### PR TITLE
add github.com/mitchellh/go-homedir

### DIFF
--- a/clients/vmClient/vmClient.go
+++ b/clients/vmClient/vmClient.go
@@ -11,11 +11,12 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path"
 	"strings"
 	"time"
 	"unicode"
+
+	homedir "github.com/mitchellh/go-homedir"
 
 	azure "github.com/MSOpenTech/azure-sdk-for-go"
 	"github.com/MSOpenTech/azure-sdk-for-go/clients/imageClient"
@@ -557,12 +558,12 @@ func createDockerPublicConfig(dockerPort int) string {
 }
 
 func createDockerPrivateConfig(dockerCertDir string) (string, error) {
-	usr, err := user.Current()
+	homeDir, err := homedir.Dir()
 	if err != nil {
 		return "", err
 	}
 
-	certDir := path.Join(usr.HomeDir, dockerCertDir)
+	certDir := path.Join(homeDir, dockerCertDir)
 
 	if _, err := os.Stat(certDir); err == nil {
 		fmt.Println(dockerDirExistsMessage)

--- a/publishSettings.go
+++ b/publishSettings.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path"
+
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 var settings publishSettings = publishSettings{}
@@ -140,12 +141,12 @@ func getActiveSubscription(publishSettingsContent []byte) (subscription, error) 
 }
 
 func getAzureDir() (string, error) {
-	usr, err := user.Current()
+	homeDir, err := homedir.Dir()
 	if err != nil {
 		return "", err
 	}
 
-	azureDir := path.Join(usr.HomeDir, ".azure")
+	azureDir := path.Join(homeDir, ".azure")
 	//Create azure dir if does not exists
 	if _, err := os.Stat(azureDir); os.IsNotExist(err) {
 		mkdirErr := os.Mkdir(azureDir, 0644)


### PR DESCRIPTION
Since azure-sdk-for-go is being vendored in docker, we need to drop os/user to allow for cross-compilation.  After these changes, I can send a PR to bfirsh/host-management to vendor mitchellh/go-homedir in docker as well.
