### PR TITLE
add customdata to configuration set

### DIFF
--- a/clients/vmClient/entities.go
+++ b/clients/vmClient/entities.go
@@ -100,6 +100,7 @@ type ConfigurationSet struct {
 	DisableSshPasswordAuthentication bool
 	InputEndpoints                   InputEndpoints `xml:",omitempty"`
 	SSH                              SSH            `xml:",omitempty"`
+	CustomData                       string         `xml:",omitempty"`
 }
 
 type SSH struct {


### PR DESCRIPTION
This adds the ability to set CustomData in the `LinuxProvisioningConfiguration` set.  I didn't add anything to `AddAzureLinuxProvisioningConfig` although I think that would be a better user experience.  I will leave that decision to you :)

Signed-off-by: Evan Hazlett ejhazlett@gmail.com
