### PR TITLE
Extend the deployments so you can add custom options

### DIFF
--- a/management/publishSettings.go
+++ b/management/publishSettings.go
@@ -47,7 +47,7 @@ func ClientFromPublishSettingsFileWithConfig(filePath, subscriptionId string, co
 					return client, err
 				}
 
-				pems, err := pkcs12.ConvertToPEM(pfxData, "")
+				pems, err := pkcs12.ConvertToPEM(pfxData, nil)
 
 				cert := []byte{}
 				for _, b := range pems {

--- a/management/storageservice/client.go
+++ b/management/storageservice/client.go
@@ -12,6 +12,7 @@ import (
 const (
 	azureStorageServiceListURL         = "services/storageservices"
 	azureStorageServiceURL             = "services/storageservices/%s"
+	azureStorageServiceKeysURL         = "services/storageservices/%s/keys"
 	azureStorageAccountAvailabilityURL = "services/storageservices/operations/isavailable/%s"
 
 	azureXmlns = "http://schemas.microsoft.com/windowsazure"
@@ -88,7 +89,7 @@ func (self StorageServiceClient) GetStorageServiceKeys(serviceName string) (GetS
 		return GetStorageServiceKeysResponse{}, fmt.Errorf(errParamNotSpecified, "serviceName")
 	}
 
-	requestURL := fmt.Sprintf(azureStorageServiceURL, serviceName)
+	requestURL := fmt.Sprintf(azureStorageServiceKeysURL, serviceName)
 	data, err := self.client.SendAzureGetRequest(requestURL)
 	if err != nil {
 		return GetStorageServiceKeysResponse{}, err

--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -22,6 +22,7 @@ type DeploymentRequest struct {
 	Label          string ``            // Specifies an identifier for the deployment. The label can be up to 100 characters long. The label can be used for tracking purposes.
 	RoleList       []Role `xml:">Role"` // Contains information about the Virtual Machines that are to be deployed.
 	// Optional parameters:
+	Subnet             string          `xml:",omitempty"`                         // Specifies the name of an existing subnet to which the deployment will belong.
 	VirtualNetworkName string          `xml:",omitempty"`                         // Specifies the name of an existing virtual network to which the deployment will belong.
 	DnsServers         *[]DnsServer    `xml:"Dns>DnsServers>DnsServer,omitempty"` // Contains a list of DNS servers to associate with the Virtual Machine.
 	ReservedIPName     string          `xml:",omitempty"`                         // Specifies the name of a reserved IP address that is to be assigned to the deployment.

--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -222,8 +222,8 @@ type VirtualIP struct {
 
 // Contains the configuration sets that are used to create virtual machines.
 type Role struct {
-	RoleName                    string                        // Specifies the name for the Virtual Machine.
-	RoleType                    string                        // Specifies the type of role to use. For Virtual Machines, this must be PersistentVMRole.
+	RoleName                    string                        `xml:",omitempty"` // Specifies the name for the Virtual Machine.
+	RoleType                    string                        `xml:",omitempty"` // Specifies the type of role to use. For Virtual Machines, this must be PersistentVMRole.
 	ConfigurationSets           *[]ConfigurationSet           `xml:"ConfigurationSets>ConfigurationSet",omitempty"`
 	ResourceExtensionReferences *[]ResourceExtensionReference `xml:"ResourceExtensionReferences>ResourceExtensionReference,omitempty"`
 	VMImageName                 string                        `xml:",omitempty"`                                         // Specifies the name of the VM Image that is to be used to create the Virtual Machine. If this element is used, the ConfigurationSets element is not used.

--- a/management/vmutils/extensions_test.go
+++ b/management/vmutils/extensions_test.go
@@ -1,0 +1,45 @@
+package vmutils
+
+import (
+	"encoding/xml"
+	"testing"
+
+	vm "github.com/MSOpenTech/azure-sdk-for-go/management/virtualmachine"
+)
+
+func Test_AddAzureVMExtensionConfiguration(t *testing.T) {
+
+	role := vm.Role{}
+	AddAzureVMExtensionConfiguration(&role,
+		"nameOfExtension", "nameOfPublisher", "versionOfExtension", "nameOfReference", "state", []byte{}, []byte{})
+
+	data, err := xml.MarshalIndent(role, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected := `<Role>
+  <ResourceExtensionReferences>
+    <ResourceExtensionReference>
+      <ReferenceName>nameOfReference</ReferenceName>
+      <Publisher>nameOfPublisher</Publisher>
+      <Name>nameOfExtension</Name>
+      <Version>versionOfExtension</Version>
+      <ResourceExtensionParameterValues>
+        <ResourceExtensionParameterValue>
+          <Key>ignored</Key>
+          <Value></Value>
+          <Type>Private</Type>
+        </ResourceExtensionParameterValue>
+        <ResourceExtensionParameterValue>
+          <Key>ignored</Key>
+          <Value></Value>
+          <Type>Public</Type>
+        </ResourceExtensionParameterValue>
+      </ResourceExtensionParameterValues>
+      <State>state</State>
+    </ResourceExtensionReference>
+  </ResourceExtensionReferences>
+</Role>`; string(data) != expected {
+		t.Fatalf("Expected %q, but got %q", expected, string(data))
+	}
+}

--- a/management/vmutils/network.go
+++ b/management/vmutils/network.go
@@ -54,3 +54,21 @@ func ConfigureWithExternalPort(role *Role, name string, localport, externalport 
 		})
 	return nil
 }
+
+// ConfigureForSubnet associates the Role to a specific subnet
+func ConfigureForSubnet(role *Role, subnet string) error {
+	if role == nil {
+		return fmt.Errorf(errParamNotSpecified, "role")
+	}
+
+	role.ConfigurationSets = updateOrAddConfig(role.ConfigurationSets, ConfigurationSetTypeNetwork,
+		func(config *ConfigurationSet) {
+			if config.SubnetNames == nil {
+				config.SubnetNames = &[]string{}
+			}
+
+			*config.SubnetNames = append(*config.SubnetNames, subnet)
+		})
+
+	return nil
+}


### PR DESCRIPTION
This extension is fully backwards compatible so doesn’t change the existing API, but extends it with an additional call so you can create a deployment with some more options.

A use case example is that without this code it isn’t possible to create a deployment for a custom virtual network/subnet…