### PR TITLE
This enables creating deployments with additional options

### DIFF
--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -1,4 +1,7 @@
-// Package virtualmachine implements operations on Azure virtual machines using the Service Management REST API
+// Package virtualmachine implements operations for managing virtual machines
+// using the Service Management REST API
+//
+// https://msdn.microsoft.com/en-us/library/azure/jj157206.aspx
 package virtualmachine
 
 import (
@@ -19,23 +22,48 @@ const (
 	errParamNotSpecified = "Parameter %s is not specified."
 )
 
-//NewClient is used to instantiate a new VmClient from an Azure client
+//NewClient is used to instantiate a new VirtualMachineClient from an Azure client
 func NewClient(client management.Client) VirtualMachineClient {
 	return VirtualMachineClient{client: client}
 }
 
-func (self VirtualMachineClient) CreateDeployment(role Role, cloudServiceName string) (management.OperationId, error) {
-	data, err := xml.Marshal(DeploymentRequest{
-		Name:           role.RoleName,
-		DeploymentSlot: "Production",
-		Label:          role.RoleName,
-		RoleList:       []Role{role}})
+// CreateDeploymentOptions can be used to create a customized deployement request
+type CreateDeploymentOptions struct {
+	DnsServers         *[]DnsServer
+	LoadBalancers      *[]LoadBalancer
+	ReservedIPName     string
+	Subnet             string
+	VirtualNetworkName string
+}
+
+// CreateDeployment creates a deployment and then creates a virtual machine
+// in the deployment based on the specified configuration.
+//
+// https://msdn.microsoft.com/en-us/library/azure/jj157194.aspx
+func (vm VirtualMachineClient) CreateDeployment(
+	role Role,
+	cloudServiceName string,
+	options CreateDeploymentOptions) (management.OperationId, error) {
+
+	req := DeploymentRequest{
+		Name:               role.RoleName,
+		DeploymentSlot:     "Production",
+		Label:              role.RoleName,
+		RoleList:           []Role{role},
+		DnsServers:         options.DnsServers,
+		LoadBalancers:      options.LoadBalancers,
+		ReservedIPName:     options.ReservedIPName,
+		Subnet:             options.Subnet,
+		VirtualNetworkName: options.VirtualNetworkName,
+	}
+
+	data, err := xml.Marshal(req)
 	if err != nil {
 		return "", err
 	}
 
 	requestURL := fmt.Sprintf(azureDeploymentListURL, cloudServiceName)
-	return self.client.SendAzurePostRequest(requestURL, data)
+	return vm.client.SendAzurePostRequest(requestURL, data)
 }
 
 func (self VirtualMachineClient) GetDeployment(cloudServiceName, deploymentName string) (DeploymentResponse, error) {

--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -22,6 +22,7 @@ type DeploymentRequest struct {
 	Label          string ``            // Specifies an identifier for the deployment. The label can be up to 100 characters long. The label can be used for tracking purposes.
 	RoleList       []Role `xml:">Role"` // Contains information about the Virtual Machines that are to be deployed.
 	// Optional parameters:
+	Subnet             string          `xml:",omitempty"`                         // Specifies the name of an existing subnet to which the deployment will belong.
 	VirtualNetworkName string          `xml:",omitempty"`                         // Specifies the name of an existing virtual network to which the deployment will belong.
 	DnsServers         *[]DnsServer    `xml:"Dns>DnsServers>DnsServer,omitempty"` // Contains a list of DNS servers to associate with the Virtual Machine.
 	ReservedIPName     string          `xml:",omitempty"`                         // Specifies the name of a reserved IP address that is to be assigned to the deployment.

--- a/management/vmutils/examples_test.go
+++ b/management/vmutils/examples_test.go
@@ -39,7 +39,7 @@ func Example() {
 	ConfigureForLinux(&role, dnsName, userName, userPassword)
 	ConfigureWithPublicSSH(&role)
 
-	operationId, err = virtualmachine.NewClient(client).CreateDeployment(role, dnsName)
+	operationId, err = virtualmachine.NewClient(client).CreateDeployment(role, dnsName, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/management/vmutils/examples_test.go
+++ b/management/vmutils/examples_test.go
@@ -23,7 +23,8 @@ func Example() {
 	}
 
 	// create hosted service
-	operationId, err := hostedservice.NewClient(client).CreateHostedService(dnsName, location, "", dnsName, "")
+	operationId, err := hostedservice.NewClient(client).
+		CreateHostedService(dnsName, location, "", dnsName, "")
 	if err != nil {
 		panic(err)
 	}
@@ -34,12 +35,16 @@ func Example() {
 
 	// create virtual machine
 	role := NewVmConfiguration(dnsName, vmSize)
-	ConfigureDeploymentFromPlatformImage(&role,
-		vmImage, fmt.Sprintf("http://%s.blob.core.windows.net/sdktest/%s.vhd", storageAccount, dnsName), "")
+	ConfigureDeploymentFromPlatformImage(
+		&role,
+		vmImage,
+		fmt.Sprintf("http://%s.blob.core.windows.net/sdktest/%s.vhd", storageAccount, dnsName),
+		"")
 	ConfigureForLinux(&role, dnsName, userName, userPassword)
 	ConfigureWithPublicSSH(&role)
 
-	operationId, err = virtualmachine.NewClient(client).CreateDeployment(role, dnsName, nil)
+	operationId, err = virtualmachine.NewClient(client).
+		CreateDeployment(role, dnsName, virtualmachine.CreateDeploymentOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/management/vmutils/integration_test.go
+++ b/management/vmutils/integration_test.go
@@ -106,7 +106,7 @@ func TestDeployPlatformCaptureRedeploy(t *testing.T) {
 
 	t.Logf("Deploying new VM from freshly captured VM image: %s", newvmname)
 	if err := Await(client, func() (management.OperationId, error) {
-		return vmc.CreateDeployment(role, vmname, nil)
+		return vmc.CreateDeployment(role, vmname, vm.CreateDeploymentOptions{})
 	}); err != nil {
 		t.Error(err)
 	}
@@ -121,7 +121,8 @@ func TestDeployFromVmImage(t *testing.T) {
 	location := sa.StorageServiceProperties.Location
 
 	im := GetVMImage(t, client, func(im vmimage.VMImage) bool {
-		return im.Name == "fb83b3509582419d99629ce476bcb5c8__SQL-Server-2014-RTM-12.0.2430.0-OLTP-ENU-Win2012R2-cy14su11"
+		return im.Name ==
+			"fb83b3509582419d99629ce476bcb5c8__SQL-Server-2014-RTM-12.0.2430.0-OLTP-ENU-Win2012R2-cy14su11"
 	})
 
 	role := NewVmConfiguration(vmname, "Standard_D4")
@@ -186,7 +187,7 @@ func createRoleConfiguration(t *testing.T, client management.Client, role vm.Rol
 	}
 
 	if err := Await(client, func() (management.OperationId, error) {
-		return vmc.CreateDeployment(role, vmname, nil)
+		return vmc.CreateDeployment(role, vmname, vm.CreateDeploymentOptions{})
 	}); err != nil {
 		t.Error(err)
 	}
@@ -256,7 +257,10 @@ func GetUserImage(t *testing.T, client management.Client, name string) osimage.O
 	})
 }
 
-func GetOSImage(t *testing.T, client management.Client, filter func(osimage.OSImage) bool) osimage.OSImage {
+func GetOSImage(
+	t *testing.T,
+	client management.Client,
+	filter func(osimage.OSImage) bool) osimage.OSImage {
 	t.Log("Selecting OS image")
 	osc := osimage.NewClient(client)
 	allimages, err := osc.GetImageList()
@@ -284,7 +288,10 @@ func GetOSImage(t *testing.T, client management.Client, filter func(osimage.OSIm
 	return image
 }
 
-func GetVMImage(t *testing.T, client management.Client, filter func(vmimage.VMImage) bool) vmimage.VMImage {
+func GetVMImage(
+	t *testing.T,
+	client management.Client,
+	filter func(vmimage.VMImage) bool) vmimage.VMImage {
 	t.Log("Selecting VM image")
 	allimages, err := vmimage.NewClient(client).GetImageList()
 	if err != nil {

--- a/management/vmutils/integration_test.go
+++ b/management/vmutils/integration_test.go
@@ -106,7 +106,7 @@ func TestDeployPlatformCaptureRedeploy(t *testing.T) {
 
 	t.Logf("Deploying new VM from freshly captured VM image: %s", newvmname)
 	if err := Await(client, func() (management.OperationId, error) {
-		return vmc.CreateDeployment(role, vmname)
+		return vmc.CreateDeployment(role, vmname, nil)
 	}); err != nil {
 		t.Error(err)
 	}
@@ -186,7 +186,7 @@ func createRoleConfiguration(t *testing.T, client management.Client, role vm.Rol
 	}
 
 	if err := Await(client, func() (management.OperationId, error) {
-		return vmc.CreateDeployment(role, vmname)
+		return vmc.CreateDeployment(role, vmname, nil)
 	}); err != nil {
 		t.Error(err)
 	}

--- a/management/vmutils/network.go
+++ b/management/vmutils/network.go
@@ -54,3 +54,21 @@ func ConfigureWithExternalPort(role *Role, name string, localport, externalport 
 		})
 	return nil
 }
+
+// ConfigureForSubnet associates the Role to a specific subnet
+func ConfigureForSubnet(role *Role, subnet string) error {
+	if role == nil {
+		return fmt.Errorf(errParamNotSpecified, "role")
+	}
+
+	role.ConfigurationSets = updateOrAddConfig(role.ConfigurationSets, ConfigurationSetTypeNetwork,
+		func(config *ConfigurationSet) {
+			if config.SubnetNames == nil {
+				config.SubnetNames = &[]string{}
+			}
+
+			*config.SubnetNames = append(*config.SubnetNames, subnet)
+		})
+
+	return nil
+}


### PR DESCRIPTION
A use case example is that without this code it isn’t possible to create a deployment for a custom virtual network/subnet…

See PR #107 for the complete story on this one.