### PR TITLE
Refactor all slices to no longer use a pointer...

### DIFF
--- a/core/http/request_test.go
+++ b/core/http/request_test.go
@@ -398,7 +398,7 @@ func TestParseHTTPVersion(t *testing.T) {
 
 type logWrites struct {
 	t   *testing.T
-	dst []string
+	dst *[]string
 }
 
 func (l logWrites) WriteByte(c byte) error {

--- a/core/http/request_test.go
+++ b/core/http/request_test.go
@@ -398,7 +398,7 @@ func TestParseHTTPVersion(t *testing.T) {
 
 type logWrites struct {
 	t   *testing.T
-	dst *[]string
+	dst []string
 }
 
 func (l logWrites) WriteByte(c byte) error {

--- a/management/networksecuritygroup/client.go
+++ b/management/networksecuritygroup/client.go
@@ -79,18 +79,16 @@ func (sg SecurityGroupClient) GetNetworkSecurityGroup(name string) (SecurityGrou
 		return SecurityGroupResponse{}, fmt.Errorf(errParamNotSpecified, "name")
 	}
 
+	var securityGroup SecurityGroupResponse
+
 	requestURL := fmt.Sprintf(getSecurityGroupURL, name)
 	response, err := sg.client.SendAzureGetRequest(requestURL)
 	if err != nil {
-		return SecurityGroupResponse{}, err
+		return securityGroup, err
 	}
 
-	var securityGroup SecurityGroupResponse
-	if err := xml.Unmarshal(response, &securityGroup); err != nil {
-		return SecurityGroupResponse{}, err
-	}
-
-	return securityGroup, nil
+	err = xml.Unmarshal(response, &securityGroup)
+	return securityGroup, err
 }
 
 // ListNetworkSecurityGroups returns a list of the network security groups
@@ -98,17 +96,15 @@ func (sg SecurityGroupClient) GetNetworkSecurityGroup(name string) (SecurityGrou
 //
 // https://msdn.microsoft.com/en-us/library/azure/dn913815.aspx
 func (sg SecurityGroupClient) ListNetworkSecurityGroups() (SecurityGroupList, error) {
+	var securityGroups SecurityGroupList
+
 	response, err := sg.client.SendAzureGetRequest(listSecurityGroupsURL)
 	if err != nil {
-		return nil, err
+		return securityGroups, err
 	}
 
-	var securityGroups SecurityGroupList
-	if err = xml.Unmarshal(response, &securityGroups); err != nil {
-		return nil, err
-	}
-
-	return securityGroups, nil
+	err = xml.Unmarshal(response, &securityGroups)
+	return securityGroups, err
 }
 
 // AddNetworkSecurityToSubnet associates the network security group with
@@ -152,18 +148,16 @@ func (sg SecurityGroupClient) GetNetworkSecurityGroupForSubnet(
 		return SecurityGroupResponse{}, fmt.Errorf(errParamNotSpecified, "virtualNetwork")
 	}
 
+	var securityGroup SecurityGroupResponse
+
 	requestURL := fmt.Sprintf(getSecurityGroupForSubnetURL, virtualNetwork, subnet)
 	response, err := sg.client.SendAzureGetRequest(requestURL)
 	if err != nil {
-		return SecurityGroupResponse{}, err
+		return securityGroup, err
 	}
 
-	var securityGroup SecurityGroupResponse
-	if err := xml.Unmarshal(response, &securityGroup); err != nil {
-		return SecurityGroupResponse{}, err
-	}
-
-	return securityGroup, nil
+	err = xml.Unmarshal(response, &securityGroup)
+	return securityGroup, err
 }
 
 // RemoveNetworkSecurityGroupFromSubnet removes the association of the

--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -66,6 +66,7 @@ func (vm VirtualMachineClient) CreateDeployment(
 
 func (self VirtualMachineClient) GetDeployment(cloudServiceName, deploymentName string) (DeploymentResponse, error) {
 	var deployment DeploymentResponse
+
 	if cloudServiceName == "" {
 		return deployment, fmt.Errorf(errParamNotSpecified, "cloudServiceName")
 	}
@@ -80,7 +81,6 @@ func (self VirtualMachineClient) GetDeployment(cloudServiceName, deploymentName 
 	}
 
 	err := xml.Unmarshal(response, &deployment)
-
 	return deployment, err
 }
 
@@ -235,10 +235,6 @@ func (self VirtualMachineClient) GetRoleSizeList() (RoleSizeList, error) {
 	}
 
 	err = xml.Unmarshal(response, &roleSizeList)
-	if err != nil {
-		return roleSizeList, err
-	}
-
 	return roleSizeList, err
 }
 

--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -29,8 +29,8 @@ func NewClient(client management.Client) VirtualMachineClient {
 
 // CreateDeploymentOptions can be used to create a customized deployement request
 type CreateDeploymentOptions struct {
-	DnsServers         *[]DnsServer
-	LoadBalancers      *[]LoadBalancer
+	DnsServers         []DnsServer
+	LoadBalancers      []LoadBalancer
 	ReservedIPName     string
 	VirtualNetworkName string
 }

--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -53,7 +53,7 @@ type DeploymentResponse struct {
 	LoadBalancers          []LoadBalancer     `xml:">LoadBalancer"`
 	ExtendedProperties     []ExtendedProperty `xml:">ExtendedProperty"`
 	PersistentVMDowntime   PersistentVMDowntime
-	VirtualIPs             []VirtualIP `xml:">VirtualIP`
+	VirtualIPs             []VirtualIP `xml:">VirtualIP"`
 	ExtensionConfiguration string      // cloud service extensions not fully implemented
 	ReservedIPName         string
 	InternalDnsSuffix      string
@@ -224,16 +224,16 @@ type VirtualIP struct {
 type Role struct {
 	RoleName                    string                       `xml:",omitempty"` // Specifies the name for the Virtual Machine.
 	RoleType                    string                       `xml:",omitempty"` // Specifies the type of role to use. For Virtual Machines, this must be PersistentVMRole.
-	ConfigurationSets           []ConfigurationSet           `xml:"ConfigurationSets>ConfigurationSet",omitempty"`
-	ResourceExtensionReferences []ResourceExtensionReference `xml:"ResourceExtensionReferences>ResourceExtensionReference,omitempty"`
-	VMImageName                 string                       `xml:",omitempty"`                                         // Specifies the name of the VM Image that is to be used to create the Virtual Machine. If this element is used, the ConfigurationSets element is not used.
-	MediaLocation               string                       `xml:",omitempty"`                                         // Required if the Virtual Machine is being created from a published VM Image. Specifies the location of the VHD file that is created when VMImageName specifies a published VM Image.
-	AvailabilitySetName         string                       `xml:",omitempty"`                                         // Specifies the name of a collection of Virtual Machines. Virtual Machines specified in the same availability set are allocated to different nodes to maximize availability.
-	DataVirtualHardDisks        []DataVirtualHardDisk        `xml:"DataVirtualHardDisks>DataVirtualHardDisk,omitempty"` // Contains the parameters that are used to add a data disk to a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
-	OSVirtualHardDisk           *OSVirtualHardDisk           `xml:",omitempty"`                                         // Contains the parameters that are used to create the operating system disk for a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
-	RoleSize                    string                       `xml:",omitempty"`                                         // Specifies the size of the Virtual Machine. The default size is Small.
-	ProvisionGuestAgent         bool                         `xml:",omitempty"`                                         // Indicates whether the VM Agent is installed on the Virtual Machine. To run a resource extension in a Virtual Machine, this service must be installed.
-	VMImageInput                *VMImageInput                `xml:",omitempty"`                                         // When a VM Image is used to create a new PersistentVMRole, the DiskConfigurations in the VM Image are used to create new Disks for the new VM. This parameter can be used to resize the newly created Disks to a larger size than the underlying DiskConfigurations in the VM Image.
+	ConfigurationSets           []ConfigurationSet           `xml:">ConfigurationSet,omitempty"`
+	ResourceExtensionReferences []ResourceExtensionReference `xml:">ResourceExtensionReference,omitempty"`
+	VMImageName                 string                       `xml:",omitempty"`                     // Specifies the name of the VM Image that is to be used to create the Virtual Machine. If this element is used, the ConfigurationSets element is not used.
+	MediaLocation               string                       `xml:",omitempty"`                     // Required if the Virtual Machine is being created from a published VM Image. Specifies the location of the VHD file that is created when VMImageName specifies a published VM Image.
+	AvailabilitySetName         string                       `xml:",omitempty"`                     // Specifies the name of a collection of Virtual Machines. Virtual Machines specified in the same availability set are allocated to different nodes to maximize availability.
+	DataVirtualHardDisks        []DataVirtualHardDisk        `xml:">DataVirtualHardDisk,omitempty"` // Contains the parameters that are used to add a data disk to a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
+	OSVirtualHardDisk           *OSVirtualHardDisk           `xml:",omitempty"`                     // Contains the parameters that are used to create the operating system disk for a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
+	RoleSize                    string                       `xml:",omitempty"`                     // Specifies the size of the Virtual Machine. The default size is Small.
+	ProvisionGuestAgent         bool                         `xml:",omitempty"`                     // Indicates whether the VM Agent is installed on the Virtual Machine. To run a resource extension in a Virtual Machine, this service must be installed.
+	VMImageInput                *VMImageInput                `xml:",omitempty"`                     // When a VM Image is used to create a new PersistentVMRole, the DiskConfigurations in the VM Image are used to create new Disks for the new VM. This parameter can be used to resize the newly created Disks to a larger size than the underlying DiskConfigurations in the VM Image.
 
 	UseCertAuth bool   `xml:"-"`
 	CertPath    string `xml:"-"`
@@ -241,8 +241,8 @@ type Role struct {
 
 // When a VM Image is used to create a new PersistantVMRole, the DiskConfigurations in the VM Image are used to create new Disks for the new VM. This parameter can be used to resize the newly created Disks to a larger size than the underlying DiskConfigurations in the VM Image.
 type VMImageInput struct {
-	OSDiskConfiguration    *OSDiskConfiguration    `xml:",omitempty"`                                             // This corresponds to the OSDiskConfiguration of the VM Image used to create a new role. The OSDiskConfiguration element is only available using version 2014-10-01 or higher.
-	DataDiskConfigurations []DataDiskConfiguration `xml:"DataDiskConfigurations>DataDiskConfiguration,omitempty"` // This corresponds to the DataDiskConfigurations of the VM Image used to create a new role. The DataDiskConfigurations element is only available using version 2014-10-01 or higher.
+	OSDiskConfiguration    *OSDiskConfiguration    `xml:",omitempty"`                       // This corresponds to the OSDiskConfiguration of the VM Image used to create a new role. The OSDiskConfiguration element is only available using version 2014-10-01 or higher.
+	DataDiskConfigurations []DataDiskConfiguration `xml:">DataDiskConfiguration,omitempty"` // This corresponds to the DataDiskConfigurations of the VM Image used to create a new role. The DataDiskConfigurations element is only available using version 2014-10-01 or higher.
 }
 
 // Used to resize the OS disk of a new VM created from a previously saved VM image
@@ -313,15 +313,15 @@ type ConfigurationSet struct {
 	ConfigurationSetType ConfigurationSetType
 
 	// Windows provisioning:
-	ComputerName              string               `xml:",omitempty"`                                                   // Optional. Specifies the computer name for the Virtual Machine. If you do not specify a computer name, one is assigned that is a combination of the deployment name, role name, and identifying number. Computer names must be 1 to 15 characters long.
-	AdminPassword             string               `xml:",omitempty"`                                                   // Optional. Specifies the password to use for an administrator account on the Virtual Machine that is being created. If you are creating a Virtual Machine using an image, you must specify a name of an administrator account to be created on the machine using the AdminUsername element. You must use the AdminPassword element to specify the password of the administrator account that is being created. If you are creating a Virtual Machine using an existing specialized disk, this element is not used because the account should already exist on the disk.
-	EnableAutomaticUpdates    bool                 `xml:",omitempty"`                                                   // Optional. Specifies whether automatic updates are enabled for the Virtual Machine. The default value is true.
-	TimeZone                  string               `xml:",omitempty"`                                                   // Optional. Specifies the time zone for the Virtual Machine.
-	DomainJoin                *DomainJoin          `xml:",omitempty"`                                                   // Optional. Contains properties that define a domain to which the Virtual Machine will be joined.
-	StoredCertificateSettings []CertificateSetting `xml:"StoredCertificateSettings>StoredCertificateSetting,omitempty"` // Optional. Contains a list of service certificates with which to provision to the new Virtual Machine.
-	WinRMListeners            *WinRMListener       `xml:"WinRM>Listeners>Listener,omitempty"`                           // Optional. Contains configuration settings for the Windows Remote Management service on the Virtual Machine. This enables remote Windows PowerShell.
-	AdminUsername             string               `xml:",omitempty"`                                                   // Optional. Specifies the name of the administrator account that is created to access the Virtual Machine. If you are creating a Virtual Machine using an image, you must specify a name of an administrator account to be created by using this element. You must use the AdminPassword element to specify the password of the administrator account that is being created. If you are creating a Virtual Machine using an existing specialized disk, this element is not used because the account should already exist on the disk.
-	AdditionalUnattendContent string               `xml:",omitempty"`                                                   // Specifies additional base-64 encoded XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup.
+	ComputerName              string               `xml:",omitempty"`                          // Optional. Specifies the computer name for the Virtual Machine. If you do not specify a computer name, one is assigned that is a combination of the deployment name, role name, and identifying number. Computer names must be 1 to 15 characters long.
+	AdminPassword             string               `xml:",omitempty"`                          // Optional. Specifies the password to use for an administrator account on the Virtual Machine that is being created. If you are creating a Virtual Machine using an image, you must specify a name of an administrator account to be created on the machine using the AdminUsername element. You must use the AdminPassword element to specify the password of the administrator account that is being created. If you are creating a Virtual Machine using an existing specialized disk, this element is not used because the account should already exist on the disk.
+	EnableAutomaticUpdates    bool                 `xml:",omitempty"`                          // Optional. Specifies whether automatic updates are enabled for the Virtual Machine. The default value is true.
+	TimeZone                  string               `xml:",omitempty"`                          // Optional. Specifies the time zone for the Virtual Machine.
+	DomainJoin                *DomainJoin          `xml:",omitempty"`                          // Optional. Contains properties that define a domain to which the Virtual Machine will be joined.
+	StoredCertificateSettings []CertificateSetting `xml:">StoredCertificateSetting,omitempty"` // Optional. Contains a list of service certificates with which to provision to the new Virtual Machine.
+	WinRMListeners            *WinRMListener       `xml:"WinRM>Listeners>Listener,omitempty"`  // Optional. Contains configuration settings for the Windows Remote Management service on the Virtual Machine. This enables remote Windows PowerShell.
+	AdminUsername             string               `xml:",omitempty"`                          // Optional. Specifies the name of the administrator account that is created to access the Virtual Machine. If you are creating a Virtual Machine using an image, you must specify a name of an administrator account to be created by using this element. You must use the AdminPassword element to specify the password of the administrator account that is being created. If you are creating a Virtual Machine using an existing specialized disk, this element is not used because the account should already exist on the disk.
+	AdditionalUnattendContent string               `xml:",omitempty"`                          // Specifies additional base-64 encoded XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup.
 
 	// Linux provisioning:
 	HostName                         string `xml:",omitempty"` // Required. Specifies the host name for the Virtual Machine. Host names must be 1 to 64 characters long.
@@ -335,11 +335,11 @@ type ConfigurationSet struct {
 	CustomData string `xml:",omitempty"` // Specifies a base-64 encoded string of custom data.
 
 	// Network configuration:
-	InputEndpoints                []InputEndpoint `xml:"InputEndpoints>InputEndpoint,omitempty"` // Optional in NetworkConfiguration. Contains a collection of external endpoints for the Virtual Machine.
-	SubnetNames                   []string        `xml:"SubnetNames>SubnetName,omitempty"`       // Required if StaticVirtualNetworkIPAddress is specified; otherwise, optional in NetworkConfiguration. Contains a list of subnets to which the Virtual Machine will belong.
-	StaticVirtualNetworkIPAddress string          `xml:",omitempty"`                             // Specifies the internal IP address for the Virtual Machine in a Virtual Network. If you specify this element, you must also specify the SubnetNames element with only one subnet defined. The IP address specified in this element must belong to the subnet that is defined in SubnetNames and it should not be the one of the first four IP addresses or the last IP address in the subnet. Deploying web roles or worker roles into a subnet that has Virtual Machines with StaticVirtualNetworkIPAddress defined is not supported.
-	NetworkSecurityGroup          string          `xml:",omitempty"`                             // Optional in NetworkConfiguration. Represents the name of the Network Security Group that will be associated with the Virtual Machine. Network Security Group must exist in the context of subscription and be created in same region to which the virtual machine will be deployed.
-	PublicIPs                     []PublicIP      `xml:"PublicIPs>PublicIP,omitempty"`           // Contains a public IP address that can be used in addition to the default virtual IP address for the Virtual Machine.
+	InputEndpoints                []InputEndpoint `xml:">InputEndpoint,omitempty"` // Optional in NetworkConfiguration. Contains a collection of external endpoints for the Virtual Machine.
+	SubnetNames                   []string        `xml:">SubnetName,omitempty"`    // Required if StaticVirtualNetworkIPAddress is specified; otherwise, optional in NetworkConfiguration. Contains a list of subnets to which the Virtual Machine will belong.
+	StaticVirtualNetworkIPAddress string          `xml:",omitempty"`               // Specifies the internal IP address for the Virtual Machine in a Virtual Network. If you specify this element, you must also specify the SubnetNames element with only one subnet defined. The IP address specified in this element must belong to the subnet that is defined in SubnetNames and it should not be the one of the first four IP addresses or the last IP address in the subnet. Deploying web roles or worker roles into a subnet that has Virtual Machines with StaticVirtualNetworkIPAddress defined is not supported.
+	NetworkSecurityGroup          string          `xml:",omitempty"`               // Optional in NetworkConfiguration. Represents the name of the Network Security Group that will be associated with the Virtual Machine. Network Security Group must exist in the context of subscription and be created in same region to which the virtual machine will be deployed.
+	PublicIPs                     []PublicIP      `xml:">PublicIP,omitempty"`      // Contains a public IP address that can be used in addition to the default virtual IP address for the Virtual Machine.
 }
 
 type ConfigurationSetType string
@@ -389,8 +389,8 @@ const (
 
 // Specifies the SSH public keys and key pairs to use with the Virtual Machine.
 type SSH struct {
-	PublicKeys []PublicKey `xml:"PublicKeys>PublicKey"`
-	KeyPairs   []KeyPair   `xml:"KeyPairs>KeyPair"`
+	PublicKeys []PublicKey `xml:">PublicKey"`
+	KeyPairs   []KeyPair   `xml:">KeyPair"`
 }
 
 // Specifies a public SSH key.

--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -22,10 +22,10 @@ type DeploymentRequest struct {
 	Label          string ``            // Specifies an identifier for the deployment. The label can be up to 100 characters long. The label can be used for tracking purposes.
 	RoleList       []Role `xml:">Role"` // Contains information about the Virtual Machines that are to be deployed.
 	// Optional parameters:
-	VirtualNetworkName string          `xml:",omitempty"`                         // Specifies the name of an existing virtual network to which the deployment will belong.
-	DnsServers         *[]DnsServer    `xml:"Dns>DnsServers>DnsServer,omitempty"` // Contains a list of DNS servers to associate with the Virtual Machine.
-	LoadBalancers      *[]LoadBalancer `xml:">LoadBalancer,omitempty"`            // Contains a list of internal load balancers that can be assigned to input endpoints.
-	ReservedIPName     string          `xml:",omitempty"`                         // Specifies the name of a reserved IP address that is to be assigned to the deployment.
+	VirtualNetworkName string         `xml:",omitempty"`                         // Specifies the name of an existing virtual network to which the deployment will belong.
+	DnsServers         []DnsServer    `xml:"Dns>DnsServers>DnsServer,omitempty"` // Contains a list of DNS servers to associate with the Virtual Machine.
+	LoadBalancers      []LoadBalancer `xml:">LoadBalancer,omitempty"`            // Contains a list of internal load balancers that can be assigned to input endpoints.
+	ReservedIPName     string         `xml:",omitempty"`                         // Specifies the name of a reserved IP address that is to be assigned to the deployment.
 }
 
 // Type forreceiving deployment information
@@ -222,18 +222,18 @@ type VirtualIP struct {
 
 // Contains the configuration sets that are used to create virtual machines.
 type Role struct {
-	RoleName                    string                        `xml:",omitempty"` // Specifies the name for the Virtual Machine.
-	RoleType                    string                        `xml:",omitempty"` // Specifies the type of role to use. For Virtual Machines, this must be PersistentVMRole.
-	ConfigurationSets           *[]ConfigurationSet           `xml:"ConfigurationSets>ConfigurationSet",omitempty"`
-	ResourceExtensionReferences *[]ResourceExtensionReference `xml:"ResourceExtensionReferences>ResourceExtensionReference,omitempty"`
-	VMImageName                 string                        `xml:",omitempty"`                                         // Specifies the name of the VM Image that is to be used to create the Virtual Machine. If this element is used, the ConfigurationSets element is not used.
-	MediaLocation               string                        `xml:",omitempty"`                                         // Required if the Virtual Machine is being created from a published VM Image. Specifies the location of the VHD file that is created when VMImageName specifies a published VM Image.
-	AvailabilitySetName         string                        `xml:",omitempty"`                                         // Specifies the name of a collection of Virtual Machines. Virtual Machines specified in the same availability set are allocated to different nodes to maximize availability.
-	DataVirtualHardDisks        *[]DataVirtualHardDisk        `xml:"DataVirtualHardDisks>DataVirtualHardDisk,omitempty"` // Contains the parameters that are used to add a data disk to a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
-	OSVirtualHardDisk           *OSVirtualHardDisk            `xml:",omitempty"`                                         // Contains the parameters that are used to create the operating system disk for a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
-	RoleSize                    string                        `xml:",omitempty"`                                         // Specifies the size of the Virtual Machine. The default size is Small.
-	ProvisionGuestAgent         bool                          `xml:",omitempty"`                                         // Indicates whether the VM Agent is installed on the Virtual Machine. To run a resource extension in a Virtual Machine, this service must be installed.
-	VMImageInput                *VMImageInput                 `xml:",omitempty"`                                         // When a VM Image is used to create a new PersistentVMRole, the DiskConfigurations in the VM Image are used to create new Disks for the new VM. This parameter can be used to resize the newly created Disks to a larger size than the underlying DiskConfigurations in the VM Image.
+	RoleName                    string                       `xml:",omitempty"` // Specifies the name for the Virtual Machine.
+	RoleType                    string                       `xml:",omitempty"` // Specifies the type of role to use. For Virtual Machines, this must be PersistentVMRole.
+	ConfigurationSets           []ConfigurationSet           `xml:"ConfigurationSets>ConfigurationSet",omitempty"`
+	ResourceExtensionReferences []ResourceExtensionReference `xml:"ResourceExtensionReferences>ResourceExtensionReference,omitempty"`
+	VMImageName                 string                       `xml:",omitempty"`                                         // Specifies the name of the VM Image that is to be used to create the Virtual Machine. If this element is used, the ConfigurationSets element is not used.
+	MediaLocation               string                       `xml:",omitempty"`                                         // Required if the Virtual Machine is being created from a published VM Image. Specifies the location of the VHD file that is created when VMImageName specifies a published VM Image.
+	AvailabilitySetName         string                       `xml:",omitempty"`                                         // Specifies the name of a collection of Virtual Machines. Virtual Machines specified in the same availability set are allocated to different nodes to maximize availability.
+	DataVirtualHardDisks        []DataVirtualHardDisk        `xml:"DataVirtualHardDisks>DataVirtualHardDisk,omitempty"` // Contains the parameters that are used to add a data disk to a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
+	OSVirtualHardDisk           *OSVirtualHardDisk           `xml:",omitempty"`                                         // Contains the parameters that are used to create the operating system disk for a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
+	RoleSize                    string                       `xml:",omitempty"`                                         // Specifies the size of the Virtual Machine. The default size is Small.
+	ProvisionGuestAgent         bool                         `xml:",omitempty"`                                         // Indicates whether the VM Agent is installed on the Virtual Machine. To run a resource extension in a Virtual Machine, this service must be installed.
+	VMImageInput                *VMImageInput                `xml:",omitempty"`                                         // When a VM Image is used to create a new PersistentVMRole, the DiskConfigurations in the VM Image are used to create new Disks for the new VM. This parameter can be used to resize the newly created Disks to a larger size than the underlying DiskConfigurations in the VM Image.
 
 	UseCertAuth bool   `xml:"-"`
 	CertPath    string `xml:"-"`
@@ -313,15 +313,15 @@ type ConfigurationSet struct {
 	ConfigurationSetType ConfigurationSetType
 
 	// Windows provisioning:
-	ComputerName              string                `xml:",omitempty"`                                                   // Optional. Specifies the computer name for the Virtual Machine. If you do not specify a computer name, one is assigned that is a combination of the deployment name, role name, and identifying number. Computer names must be 1 to 15 characters long.
-	AdminPassword             string                `xml:",omitempty"`                                                   // Optional. Specifies the password to use for an administrator account on the Virtual Machine that is being created. If you are creating a Virtual Machine using an image, you must specify a name of an administrator account to be created on the machine using the AdminUsername element. You must use the AdminPassword element to specify the password of the administrator account that is being created. If you are creating a Virtual Machine using an existing specialized disk, this element is not used because the account should already exist on the disk.
-	EnableAutomaticUpdates    bool                  `xml:",omitempty"`                                                   // Optional. Specifies whether automatic updates are enabled for the Virtual Machine. The default value is true.
-	TimeZone                  string                `xml:",omitempty"`                                                   // Optional. Specifies the time zone for the Virtual Machine.
-	DomainJoin                *DomainJoin           `xml:",omitempty"`                                                   // Optional. Contains properties that define a domain to which the Virtual Machine will be joined.
-	StoredCertificateSettings *[]CertificateSetting `xml:"StoredCertificateSettings>StoredCertificateSetting,omitempty"` // Optional. Contains a list of service certificates with which to provision to the new Virtual Machine.
-	WinRMListeners            *WinRMListener        `xml:"WinRM>Listeners>Listener,omitempty"`                           // Optional. Contains configuration settings for the Windows Remote Management service on the Virtual Machine. This enables remote Windows PowerShell.
-	AdminUsername             string                `xml:",omitempty"`                                                   // Optional. Specifies the name of the administrator account that is created to access the Virtual Machine. If you are creating a Virtual Machine using an image, you must specify a name of an administrator account to be created by using this element. You must use the AdminPassword element to specify the password of the administrator account that is being created. If you are creating a Virtual Machine using an existing specialized disk, this element is not used because the account should already exist on the disk.
-	AdditionalUnattendContent string                `xml:",omitempty"`                                                   // Specifies additional base-64 encoded XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup.
+	ComputerName              string               `xml:",omitempty"`                                                   // Optional. Specifies the computer name for the Virtual Machine. If you do not specify a computer name, one is assigned that is a combination of the deployment name, role name, and identifying number. Computer names must be 1 to 15 characters long.
+	AdminPassword             string               `xml:",omitempty"`                                                   // Optional. Specifies the password to use for an administrator account on the Virtual Machine that is being created. If you are creating a Virtual Machine using an image, you must specify a name of an administrator account to be created on the machine using the AdminUsername element. You must use the AdminPassword element to specify the password of the administrator account that is being created. If you are creating a Virtual Machine using an existing specialized disk, this element is not used because the account should already exist on the disk.
+	EnableAutomaticUpdates    bool                 `xml:",omitempty"`                                                   // Optional. Specifies whether automatic updates are enabled for the Virtual Machine. The default value is true.
+	TimeZone                  string               `xml:",omitempty"`                                                   // Optional. Specifies the time zone for the Virtual Machine.
+	DomainJoin                *DomainJoin          `xml:",omitempty"`                                                   // Optional. Contains properties that define a domain to which the Virtual Machine will be joined.
+	StoredCertificateSettings []CertificateSetting `xml:"StoredCertificateSettings>StoredCertificateSetting,omitempty"` // Optional. Contains a list of service certificates with which to provision to the new Virtual Machine.
+	WinRMListeners            *WinRMListener       `xml:"WinRM>Listeners>Listener,omitempty"`                           // Optional. Contains configuration settings for the Windows Remote Management service on the Virtual Machine. This enables remote Windows PowerShell.
+	AdminUsername             string               `xml:",omitempty"`                                                   // Optional. Specifies the name of the administrator account that is created to access the Virtual Machine. If you are creating a Virtual Machine using an image, you must specify a name of an administrator account to be created by using this element. You must use the AdminPassword element to specify the password of the administrator account that is being created. If you are creating a Virtual Machine using an existing specialized disk, this element is not used because the account should already exist on the disk.
+	AdditionalUnattendContent string               `xml:",omitempty"`                                                   // Specifies additional base-64 encoded XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup.
 
 	// Linux provisioning:
 	HostName                         string `xml:",omitempty"` // Required. Specifies the host name for the Virtual Machine. Host names must be 1 to 64 characters long.
@@ -335,11 +335,11 @@ type ConfigurationSet struct {
 	CustomData string `xml:",omitempty"` // Specifies a base-64 encoded string of custom data.
 
 	// Network configuration:
-	InputEndpoints                *[]InputEndpoint `xml:"InputEndpoints>InputEndpoint,omitempty"` // Optional in NetworkConfiguration. Contains a collection of external endpoints for the Virtual Machine.
-	SubnetNames                   *[]string        `xml:"SubnetNames>SubnetName,omitempty"`       // Required if StaticVirtualNetworkIPAddress is specified; otherwise, optional in NetworkConfiguration. Contains a list of subnets to which the Virtual Machine will belong.
-	StaticVirtualNetworkIPAddress string           `xml:",omitempty"`                             // Specifies the internal IP address for the Virtual Machine in a Virtual Network. If you specify this element, you must also specify the SubnetNames element with only one subnet defined. The IP address specified in this element must belong to the subnet that is defined in SubnetNames and it should not be the one of the first four IP addresses or the last IP address in the subnet. Deploying web roles or worker roles into a subnet that has Virtual Machines with StaticVirtualNetworkIPAddress defined is not supported.
-	NetworkSecurityGroup          string           `xml:",omitempty"`                             // Optional in NetworkConfiguration. Represents the name of the Network Security Group that will be associated with the Virtual Machine. Network Security Group must exist in the context of subscription and be created in same region to which the virtual machine will be deployed.
-	PublicIPs                     *[]PublicIP      `xml:"PublicIPs>PublicIP,omitempty"`           // Contains a public IP address that can be used in addition to the default virtual IP address for the Virtual Machine.
+	InputEndpoints                []InputEndpoint `xml:"InputEndpoints>InputEndpoint,omitempty"` // Optional in NetworkConfiguration. Contains a collection of external endpoints for the Virtual Machine.
+	SubnetNames                   []string        `xml:"SubnetNames>SubnetName,omitempty"`       // Required if StaticVirtualNetworkIPAddress is specified; otherwise, optional in NetworkConfiguration. Contains a list of subnets to which the Virtual Machine will belong.
+	StaticVirtualNetworkIPAddress string          `xml:",omitempty"`                             // Specifies the internal IP address for the Virtual Machine in a Virtual Network. If you specify this element, you must also specify the SubnetNames element with only one subnet defined. The IP address specified in this element must belong to the subnet that is defined in SubnetNames and it should not be the one of the first four IP addresses or the last IP address in the subnet. Deploying web roles or worker roles into a subnet that has Virtual Machines with StaticVirtualNetworkIPAddress defined is not supported.
+	NetworkSecurityGroup          string          `xml:",omitempty"`                             // Optional in NetworkConfiguration. Represents the name of the Network Security Group that will be associated with the Virtual Machine. Network Security Group must exist in the context of subscription and be created in same region to which the virtual machine will be deployed.
+	PublicIPs                     []PublicIP      `xml:"PublicIPs>PublicIP,omitempty"`           // Contains a public IP address that can be used in addition to the default virtual IP address for the Virtual Machine.
 }
 
 type ConfigurationSetType string
@@ -389,8 +389,8 @@ const (
 
 // Specifies the SSH public keys and key pairs to use with the Virtual Machine.
 type SSH struct {
-	PublicKeys *[]PublicKey `xml:"PublicKeys>PublicKey"`
-	KeyPairs   *[]KeyPair   `xml:"KeyPairs>KeyPair"`
+	PublicKeys []PublicKey `xml:"PublicKeys>PublicKey"`
+	KeyPairs   []KeyPair   `xml:"KeyPairs>KeyPair"`
 }
 
 // Specifies a public SSH key.

--- a/management/virtualmachine/entities_test.go
+++ b/management/virtualmachine/entities_test.go
@@ -237,41 +237,41 @@ func TestDocumentedDeploymentRequest(t *testing.T) {
 
 	// ======
 
-	t.Logf("deployment.DnsServers[0]: %+v", (*deployment.DnsServers)[0])
-	if (*deployment.DnsServers)[0].Name != "dns-name" {
+	t.Logf("deployment.DnsServers[0]: %+v", deployment.DnsServers[0])
+	if deployment.DnsServers[0].Name != "dns-name" {
 		t.Fatalf("Expected deployment.DnsServers[0].Name=\"dns-name\", but got \"%s\"",
-			(*deployment.DnsServers)[0].Name)
+			deployment.DnsServers[0].Name)
 	}
 
 	// ======
 
-	t.Logf("deployment.LoadBalancers[0]: %+v", (*deployment.LoadBalancers)[0])
-	if (*deployment.LoadBalancers)[0].Name != "name-of-internal-load-balancer" {
+	t.Logf("deployment.LoadBalancers[0]: %+v", deployment.LoadBalancers[0])
+	if deployment.LoadBalancers[0].Name != "name-of-internal-load-balancer" {
 		t.Fatalf("Expected deployment.LoadBalancers[0].Name=\"name-of-internal-load-balancer\", but got \"%s\"",
-			(*deployment.LoadBalancers)[0].Name)
+			deployment.LoadBalancers[0].Name)
 	}
 
-	if (*deployment.LoadBalancers)[0].Type != IPAddressTypePrivate {
+	if deployment.LoadBalancers[0].Type != IPAddressTypePrivate {
 		t.Fatalf("Expected deployment.LoadBalancers[0].Type=IPAddressTypePrivate, but got \"%s\"",
-			(*deployment.LoadBalancers)[0].Type)
+			deployment.LoadBalancers[0].Type)
 	}
 
-	if (*deployment.LoadBalancers)[0].StaticVirtualNetworkIPAddress != "static-ip-address" {
+	if deployment.LoadBalancers[0].StaticVirtualNetworkIPAddress != "static-ip-address" {
 		t.Fatalf("Expected deployment.LoadBalancers[0].StaticVirtualNetworkIPAddress=\"static-ip-address\", but got \"%s\"",
-			(*deployment.LoadBalancers)[0].StaticVirtualNetworkIPAddress)
+			deployment.LoadBalancers[0].StaticVirtualNetworkIPAddress)
 	}
 
 	// ======
 
-	t.Logf("(*deployment.RoleList[0].ResourceExtensionReferences)[0]: %+v", (*deployment.RoleList[0].ResourceExtensionReferences)[0])
-	if (*deployment.RoleList[0].ResourceExtensionReferences)[0].Name != "name-of-extension" {
+	t.Logf("(*deployment.RoleList[0].ResourceExtensionReferences)[0]: %+v", deployment.RoleList[0].ResourceExtensionReferences[0])
+	if deployment.RoleList[0].ResourceExtensionReferences[0].Name != "name-of-extension" {
 		t.Fatalf("Expected (*deployment.RoleList[0].ResourceExtensionReferences)[0].Name=\"name-of-extension\", but got \"%s\"",
-			(*deployment.RoleList[0].ResourceExtensionReferences)[0].Name)
+			deployment.RoleList[0].ResourceExtensionReferences[0].Name)
 	}
 
-	if (*deployment.RoleList[0].ResourceExtensionReferences)[0].ParameterValues[0].Key != "name-of-parameter-key" {
+	if deployment.RoleList[0].ResourceExtensionReferences[0].ParameterValues[0].Key != "name-of-parameter-key" {
 		t.Fatalf("Expected (*deployment.RoleList[0].ResourceExtensionReferences)[0].ParameterValues[0].Key=\"name-of-parameter-key\", but got %v",
-			(*deployment.RoleList[0].ResourceExtensionReferences)[0].ParameterValues[0].Key)
+			deployment.RoleList[0].ResourceExtensionReferences[0].ParameterValues[0].Key)
 	}
 
 	// ======

--- a/management/vmutils/configurationset.go
+++ b/management/vmutils/configurationset.go
@@ -5,13 +5,9 @@ import (
 )
 
 func updateOrAddConfig(configs []ConfigurationSet, configType ConfigurationSetType, update func(*ConfigurationSet)) []ConfigurationSet {
-	if configs == nil {
-		configs = []ConfigurationSet{}
-	}
 	config := findConfig(configs, configType)
 	if config == nil {
-		newConfigs := append(configs, ConfigurationSet{ConfigurationSetType: configType})
-		configs = newConfigs
+		configs = append(configs, ConfigurationSet{ConfigurationSetType: configType})
 		config = findConfig(configs, configType)
 	}
 	update(config)
@@ -27,5 +23,6 @@ func findConfig(configs []ConfigurationSet, configType ConfigurationSetType) *Co
 			return &configs[i]
 		}
 	}
+
 	return nil
 }

--- a/management/vmutils/configurationset.go
+++ b/management/vmutils/configurationset.go
@@ -4,15 +4,15 @@ import (
 	. "github.com/Azure/azure-sdk-for-go/management/virtualmachine"
 )
 
-func updateOrAddConfig(configs *[]ConfigurationSet, configType ConfigurationSetType, update func(*ConfigurationSet)) *[]ConfigurationSet {
+func updateOrAddConfig(configs []ConfigurationSet, configType ConfigurationSetType, update func(*ConfigurationSet)) []ConfigurationSet {
 	if configs == nil {
-		configs = &[]ConfigurationSet{}
+		configs = []ConfigurationSet{}
 	}
-	config := findConfig(*configs, configType)
+	config := findConfig(configs, configType)
 	if config == nil {
-		newConfigs := append(*configs, ConfigurationSet{ConfigurationSetType: configType})
-		configs = &newConfigs
-		config = findConfig(*configs, configType)
+		newConfigs := append(configs, ConfigurationSet{ConfigurationSetType: configType})
+		configs = newConfigs
+		config = findConfig(configs, configType)
 	}
 	update(config)
 

--- a/management/vmutils/datadisks.go
+++ b/management/vmutils/datadisks.go
@@ -50,10 +50,10 @@ func ConfigureWithVhdDataDisk(role *Role, sourceVhdStorageUrl string, cachingTyp
 
 func appendDataDisk(role *Role, disk DataVirtualHardDisk) {
 	if role.DataVirtualHardDisks == nil {
-		role.DataVirtualHardDisks = &[]DataVirtualHardDisk{disk}
+		role.DataVirtualHardDisks = []DataVirtualHardDisk{disk}
 	} else {
-		disk.Lun = len(*role.DataVirtualHardDisks)
-		newDisks := append(*role.DataVirtualHardDisks, disk)
-		role.DataVirtualHardDisks = &newDisks
+		disk.Lun = len(role.DataVirtualHardDisks)
+		newDisks := append(role.DataVirtualHardDisks, disk)
+		role.DataVirtualHardDisks = newDisks
 	}
 }

--- a/management/vmutils/datadisks.go
+++ b/management/vmutils/datadisks.go
@@ -19,6 +19,7 @@ func ConfigureWithNewDataDisk(role *Role, label, destinationVhdStorageUrl string
 		LogicalDiskSizeInGB: sizeInGB,
 		MediaLink:           destinationVhdStorageUrl,
 	})
+
 	return nil
 }
 
@@ -32,6 +33,7 @@ func ConfigureWithExistingDataDisk(role *Role, diskname string, cachingType vmdi
 		DiskName:    diskname,
 		HostCaching: cachingType,
 	})
+
 	return nil
 }
 
@@ -45,15 +47,11 @@ func ConfigureWithVhdDataDisk(role *Role, sourceVhdStorageUrl string, cachingTyp
 		SourceMediaLink: sourceVhdStorageUrl,
 		HostCaching:     cachingType,
 	})
+
 	return nil
 }
 
 func appendDataDisk(role *Role, disk DataVirtualHardDisk) {
-	if role.DataVirtualHardDisks == nil {
-		role.DataVirtualHardDisks = []DataVirtualHardDisk{disk}
-	} else {
-		disk.Lun = len(role.DataVirtualHardDisks)
-		newDisks := append(role.DataVirtualHardDisks, disk)
-		role.DataVirtualHardDisks = newDisks
-	}
+	disk.Lun = len(role.DataVirtualHardDisks)
+	role.DataVirtualHardDisks = append(role.DataVirtualHardDisks, disk)
 }

--- a/management/vmutils/extensions.go
+++ b/management/vmutils/extensions.go
@@ -43,9 +43,9 @@ func AddAzureVMExtensionConfiguration(role *Role, name, publisher, version, refe
 	}
 
 	if role.ResourceExtensionReferences == nil {
-		role.ResourceExtensionReferences = &[]ResourceExtensionReference{extension}
+		role.ResourceExtensionReferences = []ResourceExtensionReference{extension}
 	} else {
-		*role.ResourceExtensionReferences = append(*role.ResourceExtensionReferences, extension)
+		role.ResourceExtensionReferences = append(role.ResourceExtensionReferences, extension)
 	}
 
 	return nil

--- a/management/vmutils/extensions.go
+++ b/management/vmutils/extensions.go
@@ -42,11 +42,7 @@ func AddAzureVMExtensionConfiguration(role *Role, name, publisher, version, refe
 		})
 	}
 
-	if role.ResourceExtensionReferences == nil {
-		role.ResourceExtensionReferences = []ResourceExtensionReference{extension}
-	} else {
-		role.ResourceExtensionReferences = append(role.ResourceExtensionReferences, extension)
-	}
+	role.ResourceExtensionReferences = append(role.ResourceExtensionReferences, extension)
 
 	return nil
 }

--- a/management/vmutils/extensions_test.go
+++ b/management/vmutils/extensions_test.go
@@ -18,6 +18,7 @@ func Test_AddAzureVMExtensionConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 	if expected := `<Role>
+  <ConfigurationSets></ConfigurationSets>
   <ResourceExtensionReferences>
     <ResourceExtensionReference>
       <ReferenceName>nameOfReference</ReferenceName>
@@ -39,6 +40,7 @@ func Test_AddAzureVMExtensionConfiguration(t *testing.T) {
       <State>state</State>
     </ResourceExtensionReference>
   </ResourceExtensionReferences>
+  <DataVirtualHardDisks></DataVirtualHardDisks>
 </Role>`; string(data) != expected {
 		t.Fatalf("Expected %q, but got %q", expected, string(data))
 	}

--- a/management/vmutils/network.go
+++ b/management/vmutils/network.go
@@ -42,15 +42,15 @@ func ConfigureWithExternalPort(role *Role, name string, localport, externalport 
 	role.ConfigurationSets = updateOrAddConfig(role.ConfigurationSets, ConfigurationSetTypeNetwork,
 		func(config *ConfigurationSet) {
 			if config.InputEndpoints == nil {
-				config.InputEndpoints = &[]InputEndpoint{}
+				config.InputEndpoints = []InputEndpoint{}
 			}
-			newInputEndpoints := append(*config.InputEndpoints, InputEndpoint{
+			newInputEndpoints := append(config.InputEndpoints, InputEndpoint{
 				LocalPort: localport,
 				Name:      name,
 				Port:      externalport,
 				Protocol:  protocol,
 			})
-			config.InputEndpoints = &newInputEndpoints
+			config.InputEndpoints = newInputEndpoints
 		})
 	return nil
 }
@@ -78,10 +78,10 @@ func ConfigureWithSubnet(role *Role, subnet string) error {
 	role.ConfigurationSets = updateOrAddConfig(role.ConfigurationSets, ConfigurationSetTypeNetwork,
 		func(config *ConfigurationSet) {
 			if config.SubnetNames == nil {
-				config.SubnetNames = &[]string{}
+				config.SubnetNames = []string{}
 			}
 
-			*config.SubnetNames = append(*config.SubnetNames, subnet)
+			config.SubnetNames = append(config.SubnetNames, subnet)
 		})
 
 	return nil

--- a/management/vmutils/network.go
+++ b/management/vmutils/network.go
@@ -41,17 +41,14 @@ func ConfigureWithExternalPort(role *Role, name string, localport, externalport 
 
 	role.ConfigurationSets = updateOrAddConfig(role.ConfigurationSets, ConfigurationSetTypeNetwork,
 		func(config *ConfigurationSet) {
-			if config.InputEndpoints == nil {
-				config.InputEndpoints = []InputEndpoint{}
-			}
-			newInputEndpoints := append(config.InputEndpoints, InputEndpoint{
+			config.InputEndpoints = append(config.InputEndpoints, InputEndpoint{
 				LocalPort: localport,
 				Name:      name,
 				Port:      externalport,
 				Protocol:  protocol,
 			})
-			config.InputEndpoints = newInputEndpoints
 		})
+
 	return nil
 }
 
@@ -77,10 +74,6 @@ func ConfigureWithSubnet(role *Role, subnet string) error {
 
 	role.ConfigurationSets = updateOrAddConfig(role.ConfigurationSets, ConfigurationSetTypeNetwork,
 		func(config *ConfigurationSet) {
-			if config.SubnetNames == nil {
-				config.SubnetNames = []string{}
-			}
-
 			config.SubnetNames = append(config.SubnetNames, subnet)
 		})
 

--- a/management/vmutils/rolestate.go
+++ b/management/vmutils/rolestate.go
@@ -27,5 +27,6 @@ func allInstancesInPowerState(instances []vm.RoleInstance, desiredPowerstate vm.
 			return false
 		}
 	}
+
 	return true
 }

--- a/management/vmutils/vmutils.go
+++ b/management/vmutils/vmutils.go
@@ -40,22 +40,18 @@ func ConfigureForLinux(role *Role, hostname, user, password string, sshPubkeyCer
 			}
 			if len(sshPubkeyCertificateThumbprint) != 0 {
 				config.SSH = &SSH{}
-				var keys []PublicKey
-				if config.SSH.PublicKeys == nil {
-					keys = []PublicKey{}
-				} else {
-					keys = config.SSH.PublicKeys
-				}
 				for _, k := range sshPubkeyCertificateThumbprint {
-					keys = append(keys,
+					config.SSH.PublicKeys = append(config.SSH.PublicKeys,
 						PublicKey{
 							Fingerprint: k,
 							Path:        "/home/" + user + "/.ssh/authorized_keys",
-						})
+						},
+					)
 				}
-				config.SSH.PublicKeys = keys
 			}
-		})
+		},
+	)
+
 	return nil
 }
 
@@ -75,7 +71,9 @@ func ConfigureForWindows(role *Role, hostname, user, password string, enableAuto
 			config.AdminPassword = password
 			config.EnableAutomaticUpdates = enableAutomaticUpdates
 			config.TimeZone = timeZone
-		})
+		},
+	)
+
 	return nil
 }
 
@@ -94,5 +92,6 @@ func ConfigureWindowsToJoinDomain(role *Role, username, password, domainToJoin, 
 			MachineObjectOU: machineOU,
 		}
 	}
+
 	return nil
 }

--- a/management/vmutils/vmutils.go
+++ b/management/vmutils/vmutils.go
@@ -44,7 +44,7 @@ func ConfigureForLinux(role *Role, hostname, user, password string, sshPubkeyCer
 				if config.SSH.PublicKeys == nil {
 					keys = []PublicKey{}
 				} else {
-					keys = *config.SSH.PublicKeys
+					keys = config.SSH.PublicKeys
 				}
 				for _, k := range sshPubkeyCertificateThumbprint {
 					keys = append(keys,
@@ -53,7 +53,7 @@ func ConfigureForLinux(role *Role, hostname, user, password string, sshPubkeyCer
 							Path:        "/home/" + user + "/.ssh/authorized_keys",
 						})
 				}
-				config.SSH.PublicKeys = &keys
+				config.SSH.PublicKeys = keys
 			}
 		})
 	return nil
@@ -86,7 +86,7 @@ func ConfigureWindowsToJoinDomain(role *Role, username, password, domainToJoin, 
 		return fmt.Errorf(errParamNotSpecified, "role")
 	}
 
-	winconfig := findConfig(*role.ConfigurationSets, ConfigurationSetTypeWindowsProvisioning)
+	winconfig := findConfig(role.ConfigurationSets, ConfigurationSetTypeWindowsProvisioning)
 	if winconfig != nil {
 		winconfig.DomainJoin = &DomainJoin{
 			Credentials:     Credentials{Username: username, Password: password},

--- a/management/vmutils/vmutils_test.go
+++ b/management/vmutils/vmutils_test.go
@@ -27,6 +27,7 @@ func TestNewLinuxVmRemoteImage(t *testing.T) {
   <ConfigurationSets>
     <ConfigurationSet>
       <ConfigurationSetType>LinuxProvisioningConfiguration</ConfigurationSetType>
+      <StoredCertificateSettings></StoredCertificateSettings>
       <HostName>myvm</HostName>
       <UserName>azureuser</UserName>
       <UserPassword>P@ssword</UserPassword>
@@ -38,10 +39,15 @@ func TestNewLinuxVmRemoteImage(t *testing.T) {
             <Path>/home/azureuser/.ssh/authorized_keys</Path>
           </PublicKey>
         </PublicKeys>
+        <KeyPairs></KeyPairs>
       </SSH>
+      <InputEndpoints></InputEndpoints>
+      <SubnetNames></SubnetNames>
+      <PublicIPs></PublicIPs>
     </ConfigurationSet>
     <ConfigurationSet>
       <ConfigurationSetType>NetworkConfiguration</ConfigurationSetType>
+      <StoredCertificateSettings></StoredCertificateSettings>
       <InputEndpoints>
         <InputEndpoint>
           <LocalPort>22</LocalPort>
@@ -50,8 +56,12 @@ func TestNewLinuxVmRemoteImage(t *testing.T) {
           <Protocol>TCP</Protocol>
         </InputEndpoint>
       </InputEndpoints>
+      <SubnetNames></SubnetNames>
+      <PublicIPs></PublicIPs>
     </ConfigurationSet>
   </ConfigurationSets>
+  <ResourceExtensionReferences></ResourceExtensionReferences>
+  <DataVirtualHardDisks></DataVirtualHardDisks>
   <OSVirtualHardDisk>
     <DiskName>myvm-os-disk</DiskName>
     <DiskLabel>OSDisk</DiskLabel>
@@ -86,6 +96,7 @@ func TestNewLinuxVmPlatformImage(t *testing.T) {
   <ConfigurationSets>
     <ConfigurationSet>
       <ConfigurationSetType>LinuxProvisioningConfiguration</ConfigurationSetType>
+      <StoredCertificateSettings></StoredCertificateSettings>
       <HostName>myvm</HostName>
       <UserName>azureuser</UserName>
       <SSH>
@@ -95,9 +106,15 @@ func TestNewLinuxVmPlatformImage(t *testing.T) {
             <Path>/home/azureuser/.ssh/authorized_keys</Path>
           </PublicKey>
         </PublicKeys>
+        <KeyPairs></KeyPairs>
       </SSH>
+      <InputEndpoints></InputEndpoints>
+      <SubnetNames></SubnetNames>
+      <PublicIPs></PublicIPs>
     </ConfigurationSet>
   </ConfigurationSets>
+  <ResourceExtensionReferences></ResourceExtensionReferences>
+  <DataVirtualHardDisks></DataVirtualHardDisks>
   <OSVirtualHardDisk>
     <MediaLink>http://mystorageacct.blob.core.windows.net/vhds/mybrandnewvm.vhd</MediaLink>
     <SourceImageName>b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_2_LTS-amd64-server-20150309-en-us-30GB</SourceImageName>
@@ -124,8 +141,11 @@ func TestNewVmFromVMImage(t *testing.T) {
 	expected := `<Role>
   <RoleName>restoredbackup</RoleName>
   <RoleType>PersistentVMRole</RoleType>
+  <ConfigurationSets></ConfigurationSets>
+  <ResourceExtensionReferences></ResourceExtensionReferences>
   <VMImageName>myvm-backup-20150209</VMImageName>
   <MediaLocation>http://mystorageacct.blob.core.windows.net/vhds/myoldnewvm.vhd</MediaLocation>
+  <DataVirtualHardDisks></DataVirtualHardDisks>
   <RoleSize>Standard_D1</RoleSize>
 </Role>`
 
@@ -165,9 +185,14 @@ func TestNewVmFromExistingDisk(t *testing.T) {
         </Credentials>
         <JoinDomain>redmond.corp.contoso.com</JoinDomain>
       </DomainJoin>
+      <StoredCertificateSettings></StoredCertificateSettings>
       <AdminUsername>azuser</AdminUsername>
+      <InputEndpoints></InputEndpoints>
+      <SubnetNames></SubnetNames>
+      <PublicIPs></PublicIPs>
     </ConfigurationSet>
   </ConfigurationSets>
+  <ResourceExtensionReferences></ResourceExtensionReferences>
   <DataVirtualHardDisks>
     <DataVirtualHardDisk>
       <DiskLabel>my-brand-new-disk</DiskLabel>


### PR DESCRIPTION
I've tested with this quite a lot to be sure everything still works as expected and I can confirm it does (added and removed multiple VM's, VNET's, subnets, endpoints and NSGs).

Next to it seeming a bit odd (unless very specific reason to do so) to have a pointer to a referenced type, removing the pointers for slices makes working with the package a lot nicer and more intuitive.