### PR TITLE
CI: gofmt/go vet/golint for ./storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 sudo: false
 
 language: go
+
+before_script:
+  - go get -u golang.org/x/tools/cmd/vet
+  - go get -u github.com/golang/lint/golint
+
 go: tip
 script:
-    - go build -v ./...
-    - go test -v ./storage/...
-    - go test -v ./management/...
+  - test -z "$(gofmt -s -l -w management | tee /dev/stderr)"
+  - test -z "$(gofmt -s -l -w storage | tee /dev/stderr)"
+  - go build -v ./...
+  - go test -v ./storage/...
+  - test -z "$(golint ./storage     | tee /dev/stderr)"
+  - go vet ./storage
+  - go test -v ./management/...

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -49,7 +49,7 @@ func Test_blobSASStringToSign(t *testing.T) {
 }
 
 func TestGetBlobSASURI(t *testing.T) {
-	api, err := NewClient("foo", "YmFy", DefaultBaseUrl, "2013-08-15", true)
+	api, err := NewClient("foo", "YmFy", DefaultBaseURL, "2013-08-15", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,14 +124,14 @@ func TestBlobSASURICorrectness(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sasUri, err := cli.GetBlobSASURI(cnt, blob, expiry, permissions)
+	sasURI, err := cli.GetBlobSASURI(cnt, blob, expiry, permissions)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	resp, err := http.Get(sasUri)
+	resp, err := http.Get(sasURI)
 	if err != nil {
-		t.Logf("SAS URI: %s", sasUri)
+		t.Logf("SAS URI: %s", sasURI)
 		t.Fatal(err)
 	}
 
@@ -380,24 +380,24 @@ func TestBlobExists(t *testing.T) {
 	}
 }
 
-func TestGetBlobUrl(t *testing.T) {
+func TestGetBlobURL(t *testing.T) {
 	api, err := NewBasicClient("foo", "YmFy")
 	if err != nil {
 		t.Fatal(err)
 	}
 	cli := api.GetBlobService()
 
-	out := cli.GetBlobUrl("c", "nested/blob")
+	out := cli.GetBlobURL("c", "nested/blob")
 	if expected := "https://foo.blob.core.windows.net/c/nested/blob"; out != expected {
 		t.Fatalf("Wrong blob URL. Expected: '%s', got:'%s'", expected, out)
 	}
 
-	out = cli.GetBlobUrl("", "blob")
+	out = cli.GetBlobURL("", "blob")
 	if expected := "https://foo.blob.core.windows.net/$root/blob"; out != expected {
 		t.Fatalf("Wrong blob URL. Expected: '%s', got:'%s'", expected, out)
 	}
 
-	out = cli.GetBlobUrl("", "nested/blob")
+	out = cli.GetBlobURL("", "nested/blob")
 	if expected := "https://foo.blob.core.windows.net/$root/nested/blob"; out != expected {
 		t.Fatalf("Wrong blob URL. Expected: '%s', got:'%s'", expected, out)
 	}
@@ -430,7 +430,7 @@ func TestBlobCopy(t *testing.T) {
 	}
 	defer cli.DeleteBlob(cnt, src)
 
-	err = cli.CopyBlob(cnt, dst, cli.GetBlobUrl(cnt, src))
+	err = cli.CopyBlob(cnt, dst, cli.GetBlobURL(cnt, src))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -662,8 +662,8 @@ func TestPutBlock(t *testing.T) {
 
 	blob := randString(20)
 	chunk := []byte(randString(1024))
-	blockId := base64.StdEncoding.EncodeToString([]byte("foo"))
-	err = cli.PutBlock(cnt, blob, blockId, chunk)
+	blockID := base64.StdEncoding.EncodeToString([]byte("foo"))
+	err = cli.PutBlock(cnt, blob, blockID, chunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -683,10 +683,10 @@ func TestGetBlockList_PutBlockList(t *testing.T) {
 
 	blob := randString(20)
 	chunk := []byte(randString(1024))
-	blockId := base64.StdEncoding.EncodeToString([]byte("foo"))
+	blockID := base64.StdEncoding.EncodeToString([]byte("foo"))
 
 	// Put one block
-	err = cli.PutBlock(cnt, blob, blockId, chunk)
+	err = cli.PutBlock(cnt, blob, blockID, chunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -713,7 +713,7 @@ func TestGetBlockList_PutBlockList(t *testing.T) {
 	}
 
 	// Commit block list
-	err = cli.PutBlockList(cnt, blob, []Block{{blockId, BlockStatusUncommitted}})
+	err = cli.PutBlockList(cnt, blob, []Block{{blockID, BlockStatusUncommitted}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -733,7 +733,7 @@ func TestGetBlockList_PutBlockList(t *testing.T) {
 
 	// Verify the block
 	thatBlock := all.CommittedBlocks[0]
-	if expected := blockId; expected != thatBlock.Name {
+	if expected := blockID; expected != thatBlock.Name {
 		t.Fatalf("Wrong block name. Expected: %s, got: %s", expected, thatBlock.Name)
 	}
 	if expected := int64(len(chunk)); expected != thatBlock.Size {

--- a/storage/client.go
+++ b/storage/client.go
@@ -15,22 +15,28 @@ import (
 )
 
 const (
-	DefaultBaseUrl    = "core.windows.net"
-	DefaultApiVersion = "2014-02-14"
-	defaultUseHttps   = true
+	// DefaultBaseURL is the domain name used for storage requests when a
+	// default client is created.
+	DefaultBaseURL = "core.windows.net"
+
+	// DefaultAPIVersion is the  Azure Storage API version string used when a
+	// basic client is created.
+	DefaultAPIVersion = "2014-02-14"
+
+	defaultUseHTTPS = true
 
 	blobServiceName  = "blob"
 	tableServiceName = "table"
 	queueServiceName = "queue"
 )
 
-// StorageClient is the object that needs to be constructed
-// to perform operations on the storage account.
-type StorageClient struct {
+// Client is the object that needs to be constructed to perform
+// operations on the storage account.
+type Client struct {
 	accountName string
 	accountKey  []byte
-	useHttps    bool
-	baseUrl     string
+	useHTTPS    bool
+	baseURL     string
 	apiVersion  string
 }
 
@@ -40,10 +46,10 @@ type storageResponse struct {
 	body       io.ReadCloser
 }
 
-// StorageServiceError contains fields of the error response from
+// AzureStorageServiceError contains fields of the error response from
 // Azure Storage Service REST API. See https://msdn.microsoft.com/en-us/library/azure/dd179382.aspx
 // Some fields might be specific to certain calls.
-type StorageServiceError struct {
+type AzureStorageServiceError struct {
 	Code                      string `xml:"Code"`
 	Message                   string `xml:"Message"`
 	AuthenticationErrorDetail string `xml:"AuthenticationErrorDetail"`
@@ -51,25 +57,25 @@ type StorageServiceError struct {
 	QueryParameterValue       string `xml:"QueryParameterValue"`
 	Reason                    string `xml:"Reason"`
 	StatusCode                int
-	RequestId                 string
+	RequestID                 string
 }
 
-// NewBasicClient constructs a StorageClient with given storage service name
-// and key.
-func NewBasicClient(accountName, accountKey string) (StorageClient, error) {
-	return NewClient(accountName, accountKey, DefaultBaseUrl, DefaultApiVersion, defaultUseHttps)
+// NewBasicClient constructs a Client with given storage service name and
+// key.
+func NewBasicClient(accountName, accountKey string) (Client, error) {
+	return NewClient(accountName, accountKey, DefaultBaseURL, DefaultAPIVersion, defaultUseHTTPS)
 }
 
-// NewClient constructs a StorageClient. This should be used if the caller
-// wants to specify whether to use HTTPS, a specific REST API version or a
-// custom storage endpoint than Azure Public Cloud.
-func NewClient(accountName, accountKey, blobServiceBaseUrl, apiVersion string, useHttps bool) (StorageClient, error) {
-	var c StorageClient
+// NewClient constructs a Client. This should be used if the caller wants
+// to specify whether to use HTTPS, a specific REST API version or a custom
+// storage endpoint than Azure Public Cloud.
+func NewClient(accountName, accountKey, blobServiceBaseURL, apiVersion string, useHTTPS bool) (Client, error) {
+	var c Client
 	if accountName == "" {
 		return c, fmt.Errorf("azure: account name required")
 	} else if accountKey == "" {
 		return c, fmt.Errorf("azure: account key required")
-	} else if blobServiceBaseUrl == "" {
+	} else if blobServiceBaseURL == "" {
 		return c, fmt.Errorf("azure: base storage service url required")
 	}
 
@@ -78,22 +84,22 @@ func NewClient(accountName, accountKey, blobServiceBaseUrl, apiVersion string, u
 		return c, err
 	}
 
-	return StorageClient{
+	return Client{
 		accountName: accountName,
 		accountKey:  key,
-		useHttps:    useHttps,
-		baseUrl:     blobServiceBaseUrl,
+		useHTTPS:    useHTTPS,
+		baseURL:     blobServiceBaseURL,
 		apiVersion:  apiVersion,
 	}, nil
 }
 
-func (c StorageClient) getBaseUrl(service string) string {
+func (c Client) getBaseURL(service string) string {
 	scheme := "http"
-	if c.useHttps {
+	if c.useHTTPS {
 		scheme = "https"
 	}
 
-	host := fmt.Sprintf("%s.%s.%s", c.accountName, service, c.baseUrl)
+	host := fmt.Sprintf("%s.%s.%s", c.accountName, service, c.baseURL)
 
 	u := &url.URL{
 		Scheme: scheme,
@@ -101,8 +107,8 @@ func (c StorageClient) getBaseUrl(service string) string {
 	return u.String()
 }
 
-func (c StorageClient) getEndpoint(service, path string, params url.Values) string {
-	u, err := url.Parse(c.getBaseUrl(service))
+func (c Client) getEndpoint(service, path string, params url.Values) string {
+	u, err := url.Parse(c.getBaseURL(service))
 	if err != nil {
 		// really should not be happening
 		panic(err)
@@ -117,18 +123,18 @@ func (c StorageClient) getEndpoint(service, path string, params url.Values) stri
 	return u.String()
 }
 
-// GetBlobService returns a BlobStorageClient which can operate on the
-// blob service of the storage account.
-func (c StorageClient) GetBlobService() *BlobStorageClient {
+// GetBlobService returns a BlobStorageClient which can operate on the blob
+// service of the storage account.
+func (c Client) GetBlobService() *BlobStorageClient {
 	return &BlobStorageClient{c}
 }
 
-func (c StorageClient) createAuthorizationHeader(canonicalizedString string) string {
+func (c Client) createAuthorizationHeader(canonicalizedString string) string {
 	signature := c.computeHmac256(canonicalizedString)
 	return fmt.Sprintf("%s %s:%s", "SharedKey", c.accountName, signature)
 }
 
-func (c StorageClient) getAuthorizationHeader(verb, url string, headers map[string]string) (string, error) {
+func (c Client) getAuthorizationHeader(verb, url string, headers map[string]string) (string, error) {
 	canonicalizedResource, err := c.buildCanonicalizedResource(url)
 	if err != nil {
 		return "", err
@@ -138,14 +144,14 @@ func (c StorageClient) getAuthorizationHeader(verb, url string, headers map[stri
 	return c.createAuthorizationHeader(canonicalizedString), nil
 }
 
-func (c StorageClient) getStandardHeaders() map[string]string {
+func (c Client) getStandardHeaders() map[string]string {
 	return map[string]string{
 		"x-ms-version": c.apiVersion,
 		"x-ms-date":    currentTimeRfc1123Formatted(),
 	}
 }
 
-func (c StorageClient) buildCanonicalizedHeader(headers map[string]string) string {
+func (c Client) buildCanonicalizedHeader(headers map[string]string) string {
 	cm := make(map[string]string)
 
 	for k, v := range headers {
@@ -179,7 +185,7 @@ func (c StorageClient) buildCanonicalizedHeader(headers map[string]string) strin
 	return ch
 }
 
-func (c StorageClient) buildCanonicalizedResource(uri string) (string, error) {
+func (c Client) buildCanonicalizedResource(uri string) (string, error) {
 	errMsg := "buildCanonicalizedResource error: %s"
 	u, err := url.Parse(uri)
 	if err != nil {
@@ -220,7 +226,7 @@ func (c StorageClient) buildCanonicalizedResource(uri string) (string, error) {
 	return cr, nil
 }
 
-func (c StorageClient) buildCanonicalizedString(verb string, headers map[string]string, canonicalizedResource string) string {
+func (c Client) buildCanonicalizedString(verb string, headers map[string]string, canonicalizedResource string) string {
 	canonicalizedString := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s",
 		verb,
 		headers["Content-Encoding"],
@@ -240,7 +246,7 @@ func (c StorageClient) buildCanonicalizedString(verb string, headers map[string]
 	return canonicalizedString
 }
 
-func (c StorageClient) exec(verb, url string, headers map[string]string, body io.Reader) (*storageResponse, error) {
+func (c Client) exec(verb, url string, headers map[string]string, body io.Reader) (*storageResponse, error) {
 	authHeader, err := c.getAuthorizationHeader(verb, url, headers)
 	if err != nil {
 		return nil, err
@@ -271,10 +277,10 @@ func (c StorageClient) exec(verb, url string, headers map[string]string, body io
 
 		if len(respBody) == 0 {
 			// no error in response body
-			err = fmt.Errorf("storage: service returned without a response body (%s).", resp.Status)
+			err = fmt.Errorf("storage: service returned without a response body (%s)", resp.Status)
 		} else {
 			// response contains storage service error object, unmarshal
-			storageErr, errIn := serviceErrFromXml(respBody, resp.StatusCode, resp.Header.Get("x-ms-request-id"))
+			storageErr, errIn := serviceErrFromXML(respBody, resp.StatusCode, resp.Header.Get("x-ms-request-id"))
 			if err != nil { // error unmarshaling the error response
 				err = errIn
 			}
@@ -302,16 +308,16 @@ func readResponseBody(resp *http.Response) ([]byte, error) {
 	return out, err
 }
 
-func serviceErrFromXml(body []byte, statusCode int, requestId string) (StorageServiceError, error) {
-	var storageErr StorageServiceError
+func serviceErrFromXML(body []byte, statusCode int, requestID string) (AzureStorageServiceError, error) {
+	var storageErr AzureStorageServiceError
 	if err := xml.Unmarshal(body, &storageErr); err != nil {
 		return storageErr, err
 	}
 	storageErr.StatusCode = statusCode
-	storageErr.RequestId = requestId
+	storageErr.RequestID = requestID
 	return storageErr, nil
 }
 
-func (e StorageServiceError) Error() string {
-	return fmt.Sprintf("storage: remote server returned error. StatusCode=%d, ErrorCode=%s, ErrorMessage=%s, RequestId=%s", e.StatusCode, e.Code, e.Message, e.RequestId)
+func (e AzureStorageServiceError) Error() string {
+	return fmt.Sprintf("storage: remote server returned error. StatusCode=%d, ErrorCode=%s, ErrorMessage=%s, RequestId=%s", e.StatusCode, e.Code, e.Message, e.RequestID)
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -6,28 +6,28 @@ import (
 	"testing"
 )
 
-func TestGetBaseUrl_Basic_Https(t *testing.T) {
+func TestGetBaseURL_Basic_Https(t *testing.T) {
 	cli, err := NewBasicClient("foo", "YmFy")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if cli.apiVersion != DefaultApiVersion {
-		t.Fatalf("Wrong api version. Expected: '%s', got: '%s'", DefaultApiVersion, cli.apiVersion)
+	if cli.apiVersion != DefaultAPIVersion {
+		t.Fatalf("Wrong api version. Expected: '%s', got: '%s'", DefaultAPIVersion, cli.apiVersion)
 	}
 
 	if err != nil {
 		t.Fatal(err)
 	}
-	output := cli.getBaseUrl("table")
+	output := cli.getBaseURL("table")
 
 	if expected := "https://foo.table.core.windows.net"; output != expected {
 		t.Fatalf("Wrong base url. Expected: '%s', got: '%s'", expected, output)
 	}
 }
 
-func TestGetBaseUrl_Custom_NoHttps(t *testing.T) {
-	apiVersion := DefaultApiVersion
+func TestGetBaseURL_Custom_NoHttps(t *testing.T) {
+	apiVersion := DefaultAPIVersion
 	cli, err := NewClient("foo", "YmFy", "core.chinacloudapi.cn", apiVersion, false)
 	if err != nil {
 		t.Fatal(err)
@@ -37,7 +37,7 @@ func TestGetBaseUrl_Custom_NoHttps(t *testing.T) {
 		t.Fatalf("Wrong api version. Expected: '%s', got: '%s'", apiVersion, cli.apiVersion)
 	}
 
-	output := cli.getBaseUrl("table")
+	output := cli.getBaseURL("table")
 
 	if expected := "http://foo.table.core.chinacloudapi.cn"; output != expected {
 		t.Fatalf("Wrong base url. Expected: '%s', got: '%s'", expected, output)
@@ -176,14 +176,14 @@ func TestReturnsStorageServiceError(t *testing.T) {
 		t.Fatal("Service has not returned an error")
 	}
 
-	if v, ok := err.(StorageServiceError); !ok {
+	if v, ok := err.(AzureStorageServiceError); !ok {
 		t.Fatal("Cannot assert to specific error")
 	} else if v.StatusCode != 404 {
 		t.Fatalf("Expected status:%d, got: %d", 404, v.StatusCode)
 	} else if v.Code != "ContainerNotFound" {
 		t.Fatalf("Expected code: %s, got: %s", "ContainerNotFound", v.Code)
-	} else if v.RequestId == "" {
-		t.Fatalf("RequestId does not exist")
+	} else if v.RequestID == "" {
+		t.Fatalf("RequestID does not exist")
 	}
 }
 

--- a/storage/util.go
+++ b/storage/util.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func (c StorageClient) computeHmac256(message string) string {
+func (c Client) computeHmac256(message string) string {
 	h := hmac.New(sha256.New, c.accountKey)
 	h.Write([]byte(message))
 	return base64.StdEncoding.EncodeToString(h.Sum(nil))
@@ -47,7 +47,7 @@ func mergeParams(v1, v2 url.Values) url.Values {
 func prepareBlockListRequest(blocks []Block) string {
 	s := `<?xml version="1.0" encoding="utf-8"?><BlockList>`
 	for _, v := range blocks {
-		s += fmt.Sprintf("<%s>%s</%s>", v.Status, v.Id, v.Status)
+		s += fmt.Sprintf("<%s>%s</%s>", v.Status, v.ID, v.Status)
 	}
 	s += `</BlockList>`
 	return s


### PR DESCRIPTION
Took a stab at #112 by adding `gofmt`, `go vet` and `golint` checks for the `storage` pkg.

I expect the work at `management` pkg to be much more. So deferring that to some other PR.

cc: @paulmey 