### PR TITLE
management/storage: Remove helpers and cleanup

### DIFF
--- a/management/storageservice/entities.go
+++ b/management/storageservice/entities.go
@@ -12,11 +12,10 @@ type StorageServiceClient struct {
 }
 
 type StorageServiceList struct {
-	XMLName         xml.Name         `xml:"StorageServices"`
-	StorageServices []StorageService `xml:"StorageService"`
+	StorageServices []StorageServiceResponse `xml:"StorageService"`
 }
 
-type StorageService struct {
+type StorageServiceResponse struct {
 	URL                      string `xml:"Url"`
 	ServiceName              string
 	StorageServiceProperties StorageServiceProperties


### PR DESCRIPTION
Fixes #68. Removed some 'special logic' containing helper methods (including `Create` in favor of `CreateAsync`).
Did some code cleanup and stopped returning pointers.

cc:@paulmey