### PR TITLE
management: Custom API versions and User Agent Header

### DIFF
--- a/management/http.go
+++ b/management/http.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	msVersionHeader           = "x-ms-version"
-	msVersionHeaderValue      = "2014-10-01"
+	uaHeader                  = "User-Agent"
 	contentHeader             = "Content-Type"
 	defaultContentHeaderValue = "application/xml"
 	requestIDHeader           = "X-Ms-Request-Id"
@@ -164,7 +164,7 @@ func (client *Client) createAzureRequest(url string, requestType string, content
 	var request *http.Request
 	var err error
 
-	url = fmt.Sprintf("%s/%s/%s", client.managementURL, client.publishSettings.SubscriptionID, url)
+	url = fmt.Sprintf("%s/%s/%s", client.config.ManagementURL, client.publishSettings.SubscriptionID, url)
 	if data != nil {
 		body := bytes.NewBuffer(data)
 		request, err = http.NewRequest(requestType, url, body)
@@ -176,7 +176,9 @@ func (client *Client) createAzureRequest(url string, requestType string, content
 		return nil, err
 	}
 
-	request.Header.Add(msVersionHeader, msVersionHeaderValue)
+	request.Header.Add(msVersionHeader, client.config.APIVersion)
+	request.Header.Add(uaHeader, client.config.UserAgent)
+
 	if len(contentType) > 0 {
 		request.Header.Add(contentHeader, contentType)
 	} else {

--- a/management/operations.go
+++ b/management/operations.go
@@ -69,7 +69,7 @@ func (client *Client) WaitAsyncOperation(operationID OperationID) error {
 			}
 			return fmt.Errorf("Azure Operation ID=%s has failed", operationID)
 		case OperationStatusInProgress:
-			time.Sleep(client.pollInterval)
+			time.Sleep(client.config.OperationPollInterval)
 		default:
 			return fmt.Errorf("Unknown operation status:%s (ID=%s)", operation.Status, operationID)
 		}

--- a/management/publishSettings.go
+++ b/management/publishSettings.go
@@ -13,7 +13,7 @@ import (
 // ClientFromPublishSettingsFile reads a publish settings file downloaded from https://manage.windowsazure.com/publishsettings.
 // If subscriptionID is left empty, the first subscription in the file is used.
 func ClientFromPublishSettingsFile(filePath, subscriptionID string) (client Client, err error) {
-	return ClientFromPublishSettingsFileWithConfig(filePath, subscriptionID, defaultConfig())
+	return ClientFromPublishSettingsFileWithConfig(filePath, subscriptionID, DefaultConfig())
 }
 
 // ClientFromPublishSettingsFileWithConfig reads a publish settings file downloaded from https://manage.windowsazure.com/publishsettings.


### PR DESCRIPTION
Fixes #55, #88.

Also exposed default values used to build basic client and
a `DefaultConfig` method that allows user to get a copy of
the config object (that will make it easy to construct and
override only a part of it).

Signed-off-by: Ahmet Alp Balkan
cc: @paulmey