### PR TITLE
management: Code cleanup around http.go

### DIFF
--- a/management/util.go
+++ b/management/util.go
@@ -2,11 +2,10 @@ package management
 
 import (
 	"github.com/Azure/azure-sdk-for-go/core/http"
-	"io"
+	"io/ioutil"
 )
 
-func getResponseBody(response *http.Response) []byte {
-	responseBody := make([]byte, response.ContentLength)
-	io.ReadFull(response.Body, responseBody)
-	return responseBody
+func getResponseBody(response *http.Response) ([]byte, error) {
+	defer response.Body.Close()
+	return ioutil.ReadAll(response.Body)
 }


### PR DESCRIPTION
Cleaned up repetitive code.

We're now closing the request body after reading, also switched to
`io/ioutil.ReadAll` and now we're handling errors while reading
the response body responsibly.

Changed word `requestType` to `method` , makes better sense.

Signed-off-by: Ahmet Alp Balkan

cc: @paulmey please review I might be missing some stuff.