### PR TITLE
Fix integration tests

### DIFF
--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -224,18 +224,18 @@ type VirtualIP struct {
 // Role contains the configuration sets that are used to create virtual
 // machines.
 type Role struct {
-	RoleName                    string                       `xml:",omitempty"` // Specifies the name for the Virtual Machine.
-	RoleType                    string                       `xml:",omitempty"` // Specifies the type of role to use. For Virtual Machines, this must be PersistentVMRole.
-	ConfigurationSets           []ConfigurationSet           `xml:"ConfigurationSets>ConfigurationSet,omitempty"`
-	ResourceExtensionReferences []ResourceExtensionReference `xml:"ResourceExtensionReferences>ResourceExtensionReference,omitempty"`
-	VMImageName                 string                       `xml:",omitempty"`                                         // Specifies the name of the VM Image that is to be used to create the Virtual Machine. If this element is used, the ConfigurationSets element is not used.
-	MediaLocation               string                       `xml:",omitempty"`                                         // Required if the Virtual Machine is being created from a published VM Image. Specifies the location of the VHD file that is created when VMImageName specifies a published VM Image.
-	AvailabilitySetName         string                       `xml:",omitempty"`                                         // Specifies the name of a collection of Virtual Machines. Virtual Machines specified in the same availability set are allocated to different nodes to maximize availability.
-	DataVirtualHardDisks        []DataVirtualHardDisk        `xml:"DataVirtualHardDisks>DataVirtualHardDisk,omitempty"` // Contains the parameters that are used to add a data disk to a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
-	OSVirtualHardDisk           *OSVirtualHardDisk           `xml:",omitempty"`                                         // Contains the parameters that are used to create the operating system disk for a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
-	RoleSize                    string                       `xml:",omitempty"`                                         // Specifies the size of the Virtual Machine. The default size is Small.
-	ProvisionGuestAgent         bool                         `xml:",omitempty"`                                         // Indicates whether the VM Agent is installed on the Virtual Machine. To run a resource extension in a Virtual Machine, this service must be installed.
-	VMImageInput                *VMImageInput                `xml:",omitempty"`                                         // When a VM Image is used to create a new PersistentVMRole, the DiskConfigurations in the VM Image are used to create new Disks for the new VM. This parameter can be used to resize the newly created Disks to a larger size than the underlying DiskConfigurations in the VM Image.
+	RoleName                    string                        `xml:",omitempty"` // Specifies the name for the Virtual Machine.
+	RoleType                    string                        `xml:",omitempty"` // Specifies the type of role to use. For Virtual Machines, this must be PersistentVMRole.
+	ConfigurationSets           []ConfigurationSet            `xml:"ConfigurationSets>ConfigurationSet,omitempty"`
+	ResourceExtensionReferences *[]ResourceExtensionReference `xml:"ResourceExtensionReferences>ResourceExtensionReference,omitempty"`
+	VMImageName                 string                        `xml:",omitempty"`                                         // Specifies the name of the VM Image that is to be used to create the Virtual Machine. If this element is used, the ConfigurationSets element is not used.
+	MediaLocation               string                        `xml:",omitempty"`                                         // Required if the Virtual Machine is being created from a published VM Image. Specifies the location of the VHD file that is created when VMImageName specifies a published VM Image.
+	AvailabilitySetName         string                        `xml:",omitempty"`                                         // Specifies the name of a collection of Virtual Machines. Virtual Machines specified in the same availability set are allocated to different nodes to maximize availability.
+	DataVirtualHardDisks        []DataVirtualHardDisk         `xml:"DataVirtualHardDisks>DataVirtualHardDisk,omitempty"` // Contains the parameters that are used to add a data disk to a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
+	OSVirtualHardDisk           *OSVirtualHardDisk            `xml:",omitempty"`                                         // Contains the parameters that are used to create the operating system disk for a Virtual Machine. If you are creating a Virtual Machine by using a VM Image, this element is not used.
+	RoleSize                    string                        `xml:",omitempty"`                                         // Specifies the size of the Virtual Machine. The default size is Small.
+	ProvisionGuestAgent         bool                          `xml:",omitempty"`                                         // Indicates whether the VM Agent is installed on the Virtual Machine. To run a resource extension in a Virtual Machine, this service must be installed.
+	VMImageInput                *VMImageInput                 `xml:",omitempty"`                                         // When a VM Image is used to create a new PersistentVMRole, the DiskConfigurations in the VM Image are used to create new Disks for the new VM. This parameter can be used to resize the newly created Disks to a larger size than the underlying DiskConfigurations in the VM Image.
 
 	UseCertAuth bool   `xml:"-"`
 	CertPath    string `xml:"-"`

--- a/management/virtualmachine/entities_test.go
+++ b/management/virtualmachine/entities_test.go
@@ -263,15 +263,16 @@ func TestDocumentedDeploymentRequest(t *testing.T) {
 
 	// ======
 
-	t.Logf("(*deployment.RoleList[0].ResourceExtensionReferences)[0]: %+v", deployment.RoleList[0].ResourceExtensionReferences[0])
-	if deployment.RoleList[0].ResourceExtensionReferences[0].Name != "name-of-extension" {
+	extensionReferences := (*deployment.RoleList[0].ResourceExtensionReferences)
+	t.Logf("(*deployment.RoleList[0].ResourceExtensionReferences)[0]: %+v", extensionReferences[0])
+	if extensionReferences[0].Name != "name-of-extension" {
 		t.Fatalf("Expected (*deployment.RoleList[0].ResourceExtensionReferences)[0].Name=\"name-of-extension\", but got \"%s\"",
-			deployment.RoleList[0].ResourceExtensionReferences[0].Name)
+			extensionReferences[0].Name)
 	}
 
-	if deployment.RoleList[0].ResourceExtensionReferences[0].ParameterValues[0].Key != "name-of-parameter-key" {
+	if extensionReferences[0].ParameterValues[0].Key != "name-of-parameter-key" {
 		t.Fatalf("Expected (*deployment.RoleList[0].ResourceExtensionReferences)[0].ParameterValues[0].Key=\"name-of-parameter-key\", but got %v",
-			deployment.RoleList[0].ResourceExtensionReferences[0].ParameterValues[0].Key)
+			extensionReferences[0].ParameterValues[0].Key)
 	}
 
 	// ======

--- a/management/vmutils/extensions.go
+++ b/management/vmutils/extensions.go
@@ -26,7 +26,7 @@ func AddAzureVMExtensionConfiguration(role *vm.Role, name, publisher, version, r
 		State:         state,
 	}
 
-	if len(privateConfigurationValue) == 0 {
+	if len(privateConfigurationValue) != 0 {
 		extension.ParameterValues = append(extension.ParameterValues, vm.ResourceExtensionParameter{
 			Key:   "ignored",
 			Value: base64.StdEncoding.EncodeToString(privateConfigurationValue),
@@ -34,7 +34,7 @@ func AddAzureVMExtensionConfiguration(role *vm.Role, name, publisher, version, r
 		})
 	}
 
-	if len(publicConfigurationValue) == 0 {
+	if len(publicConfigurationValue) != 0 {
 		extension.ParameterValues = append(extension.ParameterValues, vm.ResourceExtensionParameter{
 			Key:   "ignored",
 			Value: base64.StdEncoding.EncodeToString(publicConfigurationValue),
@@ -42,7 +42,11 @@ func AddAzureVMExtensionConfiguration(role *vm.Role, name, publisher, version, r
 		})
 	}
 
-	role.ResourceExtensionReferences = append(role.ResourceExtensionReferences, extension)
+	if role.ResourceExtensionReferences == nil {
+		role.ResourceExtensionReferences = &[]vm.ResourceExtensionReference{}
+	}
+	extensionList := append(*role.ResourceExtensionReferences, extension)
+	role.ResourceExtensionReferences = &extensionList
 	return nil
 }
 

--- a/management/vmutils/extensions_test.go
+++ b/management/vmutils/extensions_test.go
@@ -11,7 +11,7 @@ func Test_AddAzureVMExtensionConfiguration(t *testing.T) {
 
 	role := vm.Role{}
 	AddAzureVMExtensionConfiguration(&role,
-		"nameOfExtension", "nameOfPublisher", "versionOfExtension", "nameOfReference", "state", []byte{}, []byte{})
+		"nameOfExtension", "nameOfPublisher", "versionOfExtension", "nameOfReference", "state", []byte{1, 2, 3}, []byte{})
 
 	data, err := xml.MarshalIndent(role, "", "  ")
 	if err != nil {
@@ -28,12 +28,7 @@ func Test_AddAzureVMExtensionConfiguration(t *testing.T) {
       <ResourceExtensionParameterValues>
         <ResourceExtensionParameterValue>
           <Key>ignored</Key>
-          <Value></Value>
-          <Type>Private</Type>
-        </ResourceExtensionParameterValue>
-        <ResourceExtensionParameterValue>
-          <Key>ignored</Key>
-          <Value></Value>
+          <Value>AQID</Value>
           <Type>Public</Type>
         </ResourceExtensionParameterValue>
       </ResourceExtensionParameterValues>

--- a/management/vmutils/vmutils_test.go
+++ b/management/vmutils/vmutils_test.go
@@ -60,7 +60,6 @@ func TestNewLinuxVmRemoteImage(t *testing.T) {
       <PublicIPs></PublicIPs>
     </ConfigurationSet>
   </ConfigurationSets>
-  <ResourceExtensionReferences></ResourceExtensionReferences>
   <DataVirtualHardDisks></DataVirtualHardDisks>
   <OSVirtualHardDisk>
     <DiskLabel>OSDisk</DiskLabel>
@@ -113,7 +112,6 @@ func TestNewLinuxVmPlatformImage(t *testing.T) {
       <PublicIPs></PublicIPs>
     </ConfigurationSet>
   </ConfigurationSets>
-  <ResourceExtensionReferences></ResourceExtensionReferences>
   <DataVirtualHardDisks></DataVirtualHardDisks>
   <OSVirtualHardDisk>
     <MediaLink>http://mystorageacct.blob.core.windows.net/vhds/mybrandnewvm.vhd</MediaLink>
@@ -142,7 +140,6 @@ func TestNewVmFromVMImage(t *testing.T) {
   <RoleName>restoredbackup</RoleName>
   <RoleType>PersistentVMRole</RoleType>
   <ConfigurationSets></ConfigurationSets>
-  <ResourceExtensionReferences></ResourceExtensionReferences>
   <VMImageName>myvm-backup-20150209</VMImageName>
   <MediaLocation>http://mystorageacct.blob.core.windows.net/vhds/myoldnewvm.vhd</MediaLocation>
   <DataVirtualHardDisks></DataVirtualHardDisks>
@@ -192,7 +189,6 @@ func TestNewVmFromExistingDisk(t *testing.T) {
       <PublicIPs></PublicIPs>
     </ConfigurationSet>
   </ConfigurationSets>
-  <ResourceExtensionReferences></ResourceExtensionReferences>
   <DataVirtualHardDisks>
     <DataVirtualHardDisk>
       <HostCaching>ReadWrite</HostCaching>


### PR DESCRIPTION
ResourceExtensionReferences needs to be a pointer to be able to
completely omit the element from the XML, which is necessary for
deploying a VM from a VM image (TestDeployFromVmImage).

cc: @svanharmelen @ahmetalpbalkan 