### PR TITLE
Added affinity group management support.

### DIFF
--- a/management/affinitygroup/client.go
+++ b/management/affinitygroup/client.go
@@ -1,0 +1,131 @@
+package affinitygroup
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/management"
+)
+
+const (
+	azureCreateAffinityGroupURL = "/affinitygroups"
+	azureGetAffinityGroupURL    = "/affinitygroups/%s"
+	azureListAffinityGroupsURL  = "/affinitygroups"
+	azureUpdateAffinityGroupURL = "/affinitygroups/%s"
+	azureDeleteAffinityGroupURL = "/affinitygroups/%s"
+
+	errParameterNotSpecified = "Parameter %s not specified."
+)
+
+// AffinityGroupClient simply contains a management.Client and has
+// methods for doing all affinity group-related API calls to Azure.
+type AffinityGroupClient struct {
+	mgmtClient management.Client
+}
+
+// NewClient returns an AffinityGroupClient with the given management.Client.
+func NewClient(mgmtClient management.Client) AffinityGroupClient {
+	return AffinityGroupClient{mgmtClient}
+}
+
+// CreateAffinityGroup creates a new affinity group.
+//
+// https://msdn.microsoft.com/en-us/library/azure/gg715317.aspx
+func (c AffinityGroupClient) CreateAffinityGroup(params CreateAffinityGroupParams) error {
+	params.Label = encodeLabel(params.Label)
+
+	req, err := xml.Marshal(params)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.mgmtClient.SendAzurePostRequest(azureCreateAffinityGroupURL, req)
+	return err
+}
+
+// GetAffinityGroup returns the system properties that are associated with the
+// specified affinity group.
+//
+// https://msdn.microsoft.com/en-us/library/azure/ee460789.aspx
+func (c AffinityGroupClient) GetAffinityGroup(name string) (AffinityGroup, error) {
+	var affgroup AffinityGroup
+	if name == "" {
+		return affgroup, fmt.Errorf(errParameterNotSpecified, "name")
+	}
+
+	url := fmt.Sprintf(azureGetAffinityGroupURL, name)
+	resp, err := c.mgmtClient.SendAzureGetRequest(url)
+	if err != nil {
+		return affgroup, err
+	}
+
+	err = xml.Unmarshal(resp, &affgroup)
+	affgroup.Label = decodeLabel(affgroup.Label)
+	return affgroup, err
+}
+
+// ListAffinityGroups lists the affinity groups off Azure.
+//
+// https://msdn.microsoft.com/en-us/library/azure/ee460797.aspx
+func (c AffinityGroupClient) ListAffinityGroups() (ListAffinityGroupsResponse, error) {
+	var affinitygroups ListAffinityGroupsResponse
+
+	resp, err := c.mgmtClient.SendAzureGetRequest(azureListAffinityGroupsURL)
+	if err != nil {
+		return affinitygroups, err
+	}
+
+	err = xml.Unmarshal(resp, &affinitygroups)
+
+	for i, grp := range affinitygroups.AffinityGroups {
+		affinitygroups.AffinityGroups[i].Label = decodeLabel(grp.Label)
+	}
+
+	return affinitygroups, err
+}
+
+// UpdateAffinityGroup updates the label or description for an the group.
+//
+// https://msdn.microsoft.com/en-us/library/azure/gg715316.aspx
+func (c AffinityGroupClient) UpdateAffinityGroup(name string, params UpdateAffinityGroupParams) error {
+	if name == "" {
+		return fmt.Errorf(errParameterNotSpecified, "name")
+	}
+
+	params.Label = encodeLabel(params.Label)
+	req, err := xml.Marshal(params)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf(azureUpdateAffinityGroupURL, name)
+	_, err = c.mgmtClient.SendAzurePutRequest(url, "text/xml", req)
+	return err
+}
+
+// DeleteAffinityGroup deletes the given affinity group.
+//
+// https://msdn.microsoft.com/en-us/library/azure/gg715314.aspx
+func (c AffinityGroupClient) DeleteAffinityGroup(name string) error {
+	if name == "" {
+		return fmt.Errorf(errParameterNotSpecified, name)
+	}
+
+	url := fmt.Sprintf(azureDeleteAffinityGroupURL, name)
+	_, err := c.mgmtClient.SendAzureDeleteRequest(url)
+	return err
+}
+
+// encodeLabel is a helper function which encodes the given string
+// to the base64 string which will be sent to Azure as a Label.
+func encodeLabel(label string) string {
+	return base64.StdEncoding.EncodeToString([]byte(label))
+}
+
+// decodeLabel is a helper function which decodes the base64 encoded
+// label recieved from Azure into standard encoding.
+func decodeLabel(label string) string {
+	res, _ := base64.StdEncoding.DecodeString(label)
+	return string(res)
+}

--- a/management/affinitygroup/entities.go
+++ b/management/affinitygroup/entities.go
@@ -1,0 +1,80 @@
+package affinitygroup
+
+import (
+	"encoding/xml"
+)
+
+// CreateAffinityGroupParams respresents the set of parameters required for
+// creating an affinity group creation request to Azure.
+//
+// https://msdn.microsoft.com/en-us/library/azure/gg715317.aspx
+type CreateAffinityGroupParams struct {
+	XMLName     xml.Name `xml:"http://schemas.microsoft.com/windowsazure CreateAffinityGroup"`
+	Name        string
+	Label       string
+	Description string `xml:",omitempty"`
+	Location    string
+}
+
+// HostedService is a struct containing details about a hosted service that is
+// part of an affinity group on Azure.
+type HostedService struct {
+	URL         string `xml:"Url"`
+	ServiceName string
+}
+
+// StorageService is a struct containing details about a storage  service that is
+// part of an affinity group on Azure.
+type StorageService struct {
+	URL         string `xml:"Url"`
+	ServiceName string
+}
+
+// AffinityGroup respresents the properties of an affinity group on Azure.
+//
+// https://msdn.microsoft.com/en-us/library/azure/ee460789.aspx
+type AffinityGroup struct {
+	Name            string
+	Label           string
+	Description     string
+	Location        string
+	HostedServices  []HostedService
+	StorageServices []StorageService
+	Capabilities    []string
+}
+
+// ComputeCapabilities represents the sets of capabilities of an affinity group
+// obtained from an affinity group list call to Azure.
+type ComputeCapabilities struct {
+	VirtualMachineRoleSizes []string
+	WebWorkerRoleSizes      []string
+}
+
+// AffinityGroupListResponse represents the properties obtained for each
+// affinity group listed off Azure.
+//
+// https://msdn.microsoft.com/en-us/library/azure/ee460797.aspx
+type AffinityGroupListResponse struct {
+	Name                string
+	Label               string
+	Description         string
+	Location            string
+	Capabilities        []string
+	ComputeCapabilities ComputeCapabilities
+}
+
+// ListAffinityGroupsResponse contains all the affinity groups obtained from a
+// call to the Azure API to list all affinity groups.
+type ListAffinityGroupsResponse struct {
+	AffinityGroups []AffinityGroupListResponse `xml:"AffinityGroup"`
+}
+
+// UpdateAffinityGroupParams if the set of parameters required to update an
+// affinity group on Azure.
+//
+// https://msdn.microsoft.com/en-us/library/azure/gg715316.aspx
+type UpdateAffinityGroupParams struct {
+	XMLName     xml.Name `xml:"http://schemas.microsoft.com/windowsazure UpdateAffinityGroup"`
+	Label       string   `xml:",omitempty"`
+	Description string   `xml:",omitempty"`
+}


### PR DESCRIPTION
This PR depends on the SQL client naming fix: https://github.com/Azure/azure-sdk-for-go/pull/177