### PR TITLE
Add support for creating Clients from a previously read settings file

### DIFF
--- a/management/publishSettings.go
+++ b/management/publishSettings.go
@@ -21,12 +21,7 @@ func ClientFromPublishSettingsData(settingsData []byte, subscriptionID string) (
 // from https://manage.windowsazure.com/publishsettings.
 // If subscriptionID is left empty, the first subscription in the string is used.
 func ClientFromPublishSettingsDataWithConfig(settingsData []byte, subscriptionID string, config ClientConfig) (client Client, err error) {
-	publishData := publishData{}
-	if err = xml.Unmarshal(settingsData, &publishData); err != nil {
-		return client, err
-	}
-
-	return clientFromPublishData(publishData, subscriptionID, config)
+	return clientFromPublishData(settingsData, subscriptionID, config)
 }
 
 // ClientFromPublishSettingsFile reads a publish settings file downloaded from https://manage.windowsazure.com/publishsettings.
@@ -47,15 +42,15 @@ func ClientFromPublishSettingsFileWithConfig(filePath, subscriptionID string, co
 		return client, err
 	}
 
+	return clientFromPublishData(publishSettingsContent, subscriptionID, config)
+}
+
+func clientFromPublishData(data []byte, subscriptionID string, config ClientConfig) (client Client, err error) {
 	publishData := publishData{}
-	if err = xml.Unmarshal(publishSettingsContent, &publishData); err != nil {
+	if err = xml.Unmarshal(data, &publishData); err != nil {
 		return client, err
 	}
 
-	return clientFromPublishData(publishData, subscriptionID, config)
-}
-
-func clientFromPublishData(publishData publishData, subscriptionID string, config ClientConfig) (client Client, err error) {
 	for _, profile := range publishData.PublishProfiles {
 		for _, sub := range profile.Subscriptions {
 			if sub.ID == subscriptionID || subscriptionID == "" {

--- a/management/publishSettings.go
+++ b/management/publishSettings.go
@@ -26,6 +26,36 @@ func ClientFromPublishSettingsDataWithConfig(settingsData []byte, subscriptionID
 		return client, err
 	}
 
+	return clientFromPublishData(publishData, subscriptionID, config)
+}
+
+// ClientFromPublishSettingsFile reads a publish settings file downloaded from https://manage.windowsazure.com/publishsettings.
+// If subscriptionID is left empty, the first subscription in the file is used.
+func ClientFromPublishSettingsFile(filePath, subscriptionID string) (client Client, err error) {
+	return ClientFromPublishSettingsFileWithConfig(filePath, subscriptionID, DefaultConfig())
+}
+
+// ClientFromPublishSettingsFileWithConfig reads a publish settings file downloaded from https://manage.windowsazure.com/publishsettings.
+// If subscriptionID is left empty, the first subscription in the file is used.
+func ClientFromPublishSettingsFileWithConfig(filePath, subscriptionID string, config ClientConfig) (client Client, err error) {
+	if filePath == "" {
+		return client, fmt.Errorf(errParamNotSpecified, "filePath")
+	}
+
+	publishSettingsContent, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return client, err
+	}
+
+	publishData := publishData{}
+	if err = xml.Unmarshal(publishSettingsContent, &publishData); err != nil {
+		return client, err
+	}
+
+	return clientFromPublishData(publishData, subscriptionID, config)
+}
+
+func clientFromPublishData(publishData publishData, subscriptionID string, config ClientConfig) (client Client, err error) {
 	for _, profile := range publishData.PublishProfiles {
 		for _, sub := range profile.Subscriptions {
 			if sub.ID == subscriptionID || subscriptionID == "" {
@@ -53,58 +83,6 @@ func ClientFromPublishSettingsDataWithConfig(settingsData []byte, subscriptionID
 	}
 
 	return client, fmt.Errorf("could not find subscription '%s' in settings provided", subscriptionID)
-}
-
-// ClientFromPublishSettingsFile reads a publish settings file downloaded from https://manage.windowsazure.com/publishsettings.
-// If subscriptionID is left empty, the first subscription in the file is used.
-func ClientFromPublishSettingsFile(filePath, subscriptionID string) (client Client, err error) {
-	return ClientFromPublishSettingsFileWithConfig(filePath, subscriptionID, DefaultConfig())
-}
-
-// ClientFromPublishSettingsFileWithConfig reads a publish settings file downloaded from https://manage.windowsazure.com/publishsettings.
-// If subscriptionID is left empty, the first subscription in the file is used.
-func ClientFromPublishSettingsFileWithConfig(filePath, subscriptionID string, config ClientConfig) (client Client, err error) {
-	if filePath == "" {
-		return client, fmt.Errorf(errParamNotSpecified, "filePath")
-	}
-
-	publishSettingsContent, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return client, err
-	}
-
-	publishData := publishData{}
-	if err = xml.Unmarshal(publishSettingsContent, &publishData); err != nil {
-		return client, err
-	}
-
-	for _, profile := range publishData.PublishProfiles {
-		for _, sub := range profile.Subscriptions {
-			if sub.ID == subscriptionID || subscriptionID == "" {
-				base64Cert := sub.ManagementCertificate
-				if base64Cert == "" {
-					base64Cert = profile.ManagementCertificate
-				}
-
-				pfxData, err := base64.StdEncoding.DecodeString(base64Cert)
-				if err != nil {
-					return client, err
-				}
-
-				pems, err := pkcs12.ConvertToPEM(pfxData, nil)
-
-				cert := []byte{}
-				for _, b := range pems {
-					cert = append(cert, pem.EncodeToMemory(b)...)
-				}
-
-				config.ManagementURL = sub.ServiceManagementURL
-				return makeClient(sub.ID, cert, config)
-			}
-		}
-	}
-
-	return client, fmt.Errorf("could not find subscription '%s' in '%s'", subscriptionID, filePath)
 }
 
 type publishSettings struct {

--- a/management/publishSettings.go
+++ b/management/publishSettings.go
@@ -10,6 +10,51 @@ import (
 	"github.com/Azure/go-pkcs12"
 )
 
+// ClientFromPublishSettingsData unmarshalls the contents of a publish settings file
+// from https://manage.windowsazure.com/publishsettings.
+// If subscriptionID is left empty, the first subscription in the file is used.
+func ClientFromPublishSettingsData(settingsData []byte, subscriptionID string) (client Client, err error) {
+	return ClientFromPublishSettingsDataWithConfig(settingsData, subscriptionID, DefaultConfig())
+}
+
+// ClientFromPublishSettingsDataWithConfig unmarshalls the contents of a publish settings file
+// from https://manage.windowsazure.com/publishsettings.
+// If subscriptionID is left empty, the first subscription in the string is used.
+func ClientFromPublishSettingsDataWithConfig(settingsData []byte, subscriptionID string, config ClientConfig) (client Client, err error) {
+	publishData := publishData{}
+	if err = xml.Unmarshal(settingsData, &publishData); err != nil {
+		return client, err
+	}
+
+	for _, profile := range publishData.PublishProfiles {
+		for _, sub := range profile.Subscriptions {
+			if sub.ID == subscriptionID || subscriptionID == "" {
+				base64Cert := sub.ManagementCertificate
+				if base64Cert == "" {
+					base64Cert = profile.ManagementCertificate
+				}
+
+				pfxData, err := base64.StdEncoding.DecodeString(base64Cert)
+				if err != nil {
+					return client, err
+				}
+
+				pems, err := pkcs12.ConvertToPEM(pfxData, nil)
+
+				cert := []byte{}
+				for _, b := range pems {
+					cert = append(cert, pem.EncodeToMemory(b)...)
+				}
+
+				config.ManagementURL = sub.ServiceManagementURL
+				return makeClient(sub.ID, cert, config)
+			}
+		}
+	}
+
+	return client, fmt.Errorf("could not find subscription '%s' in settings provided", subscriptionID)
+}
+
 // ClientFromPublishSettingsFile reads a publish settings file downloaded from https://manage.windowsazure.com/publishsettings.
 // If subscriptionID is left empty, the first subscription in the file is used.
 func ClientFromPublishSettingsFile(filePath, subscriptionID string) (client Client, err error) {


### PR DESCRIPTION
This adds support for initializing a `client` from the contents of a settings file that's stored in memory. At present, `client`s are created by supplying a file path to a settings file, but for my use case I have the contents of the file stored elsewhere, either encrypted in a database or something like [HashiCorp's Vault][1]

I originally tried modifying `ClientFromPublishSettingsFileWithConfig` to check the `filePath` parameter supplied, to see if it's valid XML and not a file path, but settled on duplicating and modifying the `ClientFromPublishSettingsFile` and `ClientFromPublishSettingsFileWithConfig` methods into `ClientFromPublishSettingsData` and `ClientFromPublishSettingsDataWithConfig`, instead. There is duplication, but I felt it was simpler to reason about. 

Example usage, borrowing from the snippet in the README:

```go
package main

import (
	"encoding/base64"
	"fmt"
	"io/ioutil"
	"log"

	"github.com/Azure/azure-sdk-for-go/management"
	"github.com/Azure/azure-sdk-for-go/management/hostedservice"
	"github.com/Azure/azure-sdk-for-go/management/virtualmachine"
	"github.com/Azure/azure-sdk-for-go/management/vmutils"
)

func main() {
	dnsName := "cts-settings-data-ex"
	storageAccount := "terraformtesting"
	location := "West US"
	vmSize := "Small"
	vmImage := "b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04-LTS-amd64-server-20140724-en-us-30GB"
	userName := "testuser"
	userPassword := "Test123"

	publishSettingsContent, err := ioutil.ReadFile("downloaded.publishsettings")
	if err != nil {
		panic(err)
	}

	client, err := management.ClientFromPublishSettingsData(publishSettingsContent, "")
	if err != nil {
		panic(err)
	}

	log.Println("Client created...")

	// create hosted service
	if err := hostedservice.NewClient(client).CreateHostedService(hostedservice.CreateHostedServiceParameters{
		ServiceName: dnsName,
		Location:    location,
		Label:       base64.StdEncoding.EncodeToString([]byte(dnsName))}); err != nil {
		panic(err)
	}

	log.Println("Service created...")

	// create virtual machine
	role := vmutils.NewVMConfiguration(dnsName, vmSize)
	vmutils.ConfigureDeploymentFromPlatformImage(
		&role,
		vmImage,
		fmt.Sprintf("http://%s.blob.core.windows.net/sdktest/%s.vhd", storageAccount, dnsName),
		"")
	vmutils.ConfigureForLinux(&role, dnsName, userName, userPassword)
	vmutils.ConfigureWithPublicSSH(&role)

	log.Println("Creating ...")
	operationID, err := virtualmachine.NewClient(client).
		CreateDeployment(role, dnsName, virtualmachine.CreateDeploymentOptions{})
	if err != nil {
		panic(err)
	}
	if err := client.WaitForOperation(operationID, nil); err != nil {
		panic(err)
	}
	log.Println("Done!")
}
```

Suggestions on naming and testing are welcome. 
Thanks!

[1]: https://vaultproject.io