### PR TITLE
Reconcile publishSettings methods

### DIFF
--- a/management/publishSettings.go
+++ b/management/publishSettings.go
@@ -17,13 +17,6 @@ func ClientFromPublishSettingsData(settingsData []byte, subscriptionID string) (
 	return ClientFromPublishSettingsDataWithConfig(settingsData, subscriptionID, DefaultConfig())
 }
 
-// ClientFromPublishSettingsDataWithConfig unmarshalls the contents of a publish settings file
-// from https://manage.windowsazure.com/publishsettings.
-// If subscriptionID is left empty, the first subscription in the string is used.
-func ClientFromPublishSettingsDataWithConfig(settingsData []byte, subscriptionID string, config ClientConfig) (client Client, err error) {
-	return clientFromPublishData(settingsData, subscriptionID, config)
-}
-
 // ClientFromPublishSettingsFile reads a publish settings file downloaded from https://manage.windowsazure.com/publishsettings.
 // If subscriptionID is left empty, the first subscription in the file is used.
 func ClientFromPublishSettingsFile(filePath, subscriptionID string) (client Client, err error) {
@@ -42,10 +35,13 @@ func ClientFromPublishSettingsFileWithConfig(filePath, subscriptionID string, co
 		return client, err
 	}
 
-	return clientFromPublishData(publishSettingsContent, subscriptionID, config)
+	return ClientFromPublishSettingsDataWithConfig(publishSettingsContent, subscriptionID, config)
 }
 
-func clientFromPublishData(data []byte, subscriptionID string, config ClientConfig) (client Client, err error) {
+// ClientFromPublishSettingsDataWithConfig unmarshalls the contents of a publish settings file
+// from https://manage.windowsazure.com/publishsettings.
+// If subscriptionID is left empty, the first subscription in the string is used.
+func ClientFromPublishSettingsDataWithConfig(data []byte, subscriptionID string, config ClientConfig) (client Client, err error) {
 	publishData := publishData{}
 	if err = xml.Unmarshal(data, &publishData); err != nil {
 		return client, err


### PR DESCRIPTION
@catsby this is the change I was proposing in the #181. :) Implementation of `ClientFromPublishSettingsDataWithConfig` is already 100% the same with `clientFromPublishData` method and makes it obsolete.