### PR TITLE
Promoted GetOSImage from tests to osimage/client

### DIFF
--- a/management/osimage/client.go
+++ b/management/osimage/client.go
@@ -4,7 +4,7 @@ package osimage
 import (
 	"encoding/xml"
 	"errors"
-	
+
 	"github.com/Azure/azure-sdk-for-go/management"
 )
 

--- a/management/osimage/client.go
+++ b/management/osimage/client.go
@@ -3,7 +3,8 @@ package osimage
 
 import (
 	"encoding/xml"
-
+	"errors"
+	
 	"github.com/Azure/azure-sdk-for-go/management"
 )
 
@@ -11,6 +12,7 @@ const (
 	azureImageListURL    = "services/images"
 	errInvalidImage      = "Can not find image %s in specified subscription, please specify another image name."
 	errParamNotSpecified = "Parameter %s is not specified."
+	errImageNotFound     = "Filter too restrictive, no images left?"
 )
 
 // NewClient is used to instantiate a new OSImageClient from an Azure client.
@@ -28,4 +30,29 @@ func (c OSImageClient) ListOSImages() (ListOSImagesResponse, error) {
 
 	err = xml.Unmarshal(response, &l)
 	return l, err
+}
+
+func (c OSImageClient) GetOSImage(filter func(OSImage) bool) (OSImage, error) {
+	allimages, err := c.ListOSImages()
+	if err != nil {
+		return OSImage{}, err
+	}
+	filtered := []OSImage{}
+	for _, im := range allimages.OSImages {
+		if filter(im) {
+			filtered = append(filtered, im)
+		}
+	}
+	if len(filtered) == 0 {
+		return OSImage{}, errors.New(errImageNotFound)
+	}
+
+	image := filtered[0]
+	for _, im := range filtered {
+		if im.PublishedDate > image.PublishedDate {
+			image = im
+		}
+	}
+
+	return image, nil
 }

--- a/management/vmutils/integration_test.go
+++ b/management/vmutils/integration_test.go
@@ -44,6 +44,15 @@ func TestVMImageList(t *testing.T) {
 	}
 }
 
+func TestFindOSImage(t *testing.T) {
+	client := testutils.GetTestClient(t)
+	osic := osimage.NewClient(client)
+	im, _ := osic.GetOSImage(func(im osimage.OSImage) bool {
+		return im.Category == "Public" && im.ImageFamily == "Windows Server 2012 R2 Datacenter"
+	})
+	t.Logf("%s -%s", im.Name, im.Description)
+}
+
 func TestDeployPlatformCaptureRedeploy(t *testing.T) {
 	client := testutils.GetTestClient(t)
 	vmname := GenerateName()
@@ -266,27 +275,10 @@ func GetOSImage(
 	filter func(osimage.OSImage) bool) osimage.OSImage {
 	t.Log("Selecting OS image")
 	osc := osimage.NewClient(client)
-	allimages, err := osc.ListOSImages()
+	image, err := osc.GetOSImage(filter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	filtered := []osimage.OSImage{}
-	for _, im := range allimages.OSImages {
-		if filter(im) {
-			filtered = append(filtered, im)
-		}
-	}
-	if len(filtered) == 0 {
-		t.Fatal("Filter too restrictive, no images left?")
-	}
-
-	image := filtered[0]
-	for _, im := range filtered {
-		if im.PublishedDate > image.PublishedDate {
-			image = im
-		}
-	}
-
 	t.Logf("Selecting image '%s'", image.Name)
 	return image
 }


### PR DESCRIPTION
Added GetOSImage as a public method in osimage/client. Allows clients to find an image based on specific criteria (e.g. ImageFamily) instead of using an image name. Promoted method from integration tests.