### PR TITLE
Queue metadata with userdefined

### DIFF
--- a/storage/queue.go
+++ b/storage/queue.go
@@ -6,6 +6,13 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
+)
+
+const (
+	// casing is per Golang's http.Header canonicalizing the header names.
+	approximateMessagesCountHeader  = "X-Ms-Approximate-Messages-Count"
+	userDefinedMetadataHeaderPrefix = "X-Ms-Meta-"
 )
 
 // QueueServiceClient contains operations for Microsoft Azure Queue Storage
@@ -109,6 +116,77 @@ type PeekMessageResponse struct {
 	ExpirationTime string `xml:"ExpirationTime"`
 	DequeueCount   int    `xml:"DequeueCount"`
 	MessageText    string `xml:"MessageText"`
+}
+
+// QueueMetadataResponse represents user defined metadata and queue
+// properties on a specific queue.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dd179384.aspx
+type QueueMetadataResponse struct {
+	ApproximateMessageCount int
+	UserDefinedMetadata     map[string]string
+}
+
+// SetMetadata operation sets user-defined metadata on the specified queue.
+// Metadata is associated with the queue as name-value pairs.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dd179348.aspx
+func (c QueueServiceClient) SetMetadata(name string, metadata map[string]string) error {
+	uri := c.client.getEndpoint(queueServiceName, pathForQueue(name), url.Values{"comp": []string{"metadata"}})
+	headers := c.client.getStandardHeaders()
+	headers["Content-Length"] = "0"
+	for k, v := range metadata {
+		headers[userDefinedMetadataHeaderPrefix+k] = v
+	}
+
+	resp, err := c.client.exec("PUT", uri, headers, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+
+	return checkRespCode(resp.statusCode, []int{http.StatusNoContent})
+}
+
+// GetMetadata operation retrieves user-defined metadata and queue
+// properties on the specified queue. Metadata is associated with
+// the queue as name-values pairs.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dd179384.aspx
+//
+// Because the way Golang's http client (and http.Header in particular)
+// canonicalize header names, the returned metadata names would always
+// be all lower case.
+func (c QueueServiceClient) GetMetadata(name string) (QueueMetadataResponse, error) {
+	qm := QueueMetadataResponse{}
+	qm.UserDefinedMetadata = make(map[string]string)
+	uri := c.client.getEndpoint(queueServiceName, pathForQueue(name), url.Values{"comp": []string{"metadata"}})
+	headers := c.client.getStandardHeaders()
+	resp, err := c.client.exec("GET", uri, headers, nil)
+	if err != nil {
+		return qm, err
+	}
+	defer resp.body.Close()
+
+	for k, v := range resp.headers {
+		if len(v) != 1 {
+			return qm, fmt.Errorf("Unexpected number of values (%d) in response header '%s'", len(v), k)
+		}
+
+		value := v[0]
+
+		if k == approximateMessagesCountHeader {
+			qm.ApproximateMessageCount, err = strconv.Atoi(value)
+			if err != nil {
+				return qm, fmt.Errorf("Unexpected value in response header '%s': '%s' ", k, value)
+			}
+		} else if strings.HasPrefix(k, userDefinedMetadataHeaderPrefix) {
+			name := strings.TrimPrefix(k, userDefinedMetadataHeaderPrefix)
+			qm.UserDefinedMetadata[strings.ToLower(name)] = value
+		}
+	}
+
+	return qm, checkRespCode(resp.statusCode, []int{http.StatusOK})
 }
 
 // CreateQueue operation creates a queue under the given account.

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"time"
+
 	chk "gopkg.in/check.v1"
 )
 
@@ -29,6 +31,45 @@ func (s *StorageQueueSuite) TestCreateQueue_DeleteQueue(c *chk.C) {
 	name := randString(20)
 	c.Assert(cli.CreateQueue(name), chk.IsNil)
 	c.Assert(cli.DeleteQueue(name), chk.IsNil)
+}
+
+func (s *StorageQueueSuite) Test_GetMetadata_GetApproximateCount(c *chk.C) {
+	cli := getQueueClient(c)
+	name := randString(20)
+	c.Assert(cli.CreateQueue(name), chk.IsNil)
+	defer cli.DeleteQueue(name)
+
+	qm, err := cli.GetMetadata(name)
+	c.Assert(err, chk.IsNil)
+	c.Assert(qm.ApproximateMessageCount, chk.Equals, 0)
+
+	for ix := 0; ix < 3; ix++ {
+		err = cli.PutMessage(name, "foobar", PutMessageParameters{})
+		c.Assert(err, chk.IsNil)
+	}
+	time.Sleep(1 * time.Second)
+
+	qm, err = cli.GetMetadata(name)
+	c.Assert(err, chk.IsNil)
+	c.Assert(qm.ApproximateMessageCount, chk.Equals, 3)
+}
+
+func (s *StorageQueueSuite) Test_SetMetadataGetMetadata_Roundtrips(c *chk.C) {
+	cli := getQueueClient(c)
+	name := randString(20)
+	c.Assert(cli.CreateQueue(name), chk.IsNil)
+	defer cli.DeleteQueue(name)
+
+	metadata := make(map[string]string)
+	metadata["Foo1"] = "bar1"
+	metadata["fooBaz"] = "bar"
+	err := cli.SetMetadata(name, metadata)
+	c.Assert(err, chk.IsNil)
+
+	qm, err := cli.GetMetadata(name)
+	c.Assert(err, chk.IsNil)
+	c.Assert(qm.UserDefinedMetadata["foo1"], chk.Equals, "bar1")
+	c.Assert(qm.UserDefinedMetadata["foobaz"], chk.Equals, "bar")
 }
 
 func (s *StorageQueueSuite) TestQueueExists(c *chk.C) {


### PR DESCRIPTION
this one include #201 and add support for SetMetadata and to deal with user defined fields.
It is separate as implementation is less obvious so if this is not the way the team wants to go with user-defined data, it would be easier to only accept the other, straight-forward patch.