### PR TITLE
Added golint / govet to Travis CI for arm packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ before_script:
 
 go: tip
 script:
+  - test -z "$(gofmt -s -l $(find ./arm/* -type d -print) | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w management | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w storage | tee /dev/stderr)"
   - go build -v ./...
+  - test -z "$(go vet $(find ./arm/* -type d -print) | tee /dev/stderr)"
+  - test -z "$(golint ./arm/... | tee /dev/stderr)"
   - go test -v ./storage/... -check.v
   - test -z "$(golint ./storage/... | tee /dev/stderr)"
   - go vet ./storage/...

--- a/arm/CHANGELOG.md
+++ b/arm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v0.1.1-beta -------------------------------------------------------------------------------------
+
+- Improves the UserAgent string to disambiguate arm packages from others in the SDK
+- Improves setting the http.Response into generated results (reduces likelihood of a nil reference)
+- Adds gofmt, golint, and govet to Travis CI for the arm packages
+
+### Fixed Issues
+
+- https://github.com/Azure/azure-sdk-for-go/issues/196
+- https://github.com/Azure/azure-sdk-for-go/issues/213
+
 ## v0.1.0-beta -------------------------------------------------------------------------------------
 
 This release addresses the issues raised against the alpha release and adds more features. Most

--- a/arm/authorization/managementlocks.go
+++ b/arm/authorization/managementlocks.go
@@ -55,6 +55,7 @@ func (client ManagementLocksClient) CreateOrUpdateAtResourceGroupLevel(resourceG
 
 	resp, err := client.CreateOrUpdateAtResourceGroupLevelSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "CreateOrUpdateAtResourceGroupLevel", "Failure sending request")
 	}
 
@@ -123,6 +124,7 @@ func (client ManagementLocksClient) CreateOrUpdateAtResourceLevel(resourceGroupN
 
 	resp, err := client.CreateOrUpdateAtResourceLevelSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "CreateOrUpdateAtResourceLevel", "Failure sending request")
 	}
 
@@ -191,6 +193,7 @@ func (client ManagementLocksClient) CreateOrUpdateAtSubscriptionLevel(lockName s
 
 	resp, err := client.CreateOrUpdateAtSubscriptionLevelSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "CreateOrUpdateAtSubscriptionLevel", "Failure sending request")
 	}
 
@@ -253,6 +256,7 @@ func (client ManagementLocksClient) DeleteAtResourceGroupLevel(resourceGroup str
 
 	resp, err := client.DeleteAtResourceGroupLevelSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "DeleteAtResourceGroupLevel", "Failure sending request")
 	}
 
@@ -318,6 +322,7 @@ func (client ManagementLocksClient) DeleteAtResourceLevel(resourceGroupName stri
 
 	resp, err := client.DeleteAtResourceLevelSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "DeleteAtResourceLevel", "Failure sending request")
 	}
 
@@ -383,6 +388,7 @@ func (client ManagementLocksClient) DeleteAtSubscriptionLevel(lockName string) (
 
 	resp, err := client.DeleteAtSubscriptionLevelSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "DeleteAtSubscriptionLevel", "Failure sending request")
 	}
 
@@ -443,6 +449,7 @@ func (client ManagementLocksClient) Get(lockName string) (result ManagementLock,
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "Get", "Failure sending request")
 	}
 
@@ -505,6 +512,7 @@ func (client ManagementLocksClient) ListAtResourceGroupLevel(resourceGroupName s
 
 	resp, err := client.ListAtResourceGroupLevelSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "ListAtResourceGroupLevel", "Failure sending request")
 	}
 
@@ -568,6 +576,7 @@ func (client ManagementLocksClient) ListAtResourceGroupLevelNextResults(lastResu
 
 	resp, err := client.ListAtResourceGroupLevelSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "ListAtResourceGroupLevel", "Failure sending next results request request")
 	}
 
@@ -595,6 +604,7 @@ func (client ManagementLocksClient) ListAtResourceLevel(resourceGroupName string
 
 	resp, err := client.ListAtResourceLevelSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "ListAtResourceLevel", "Failure sending request")
 	}
 
@@ -662,6 +672,7 @@ func (client ManagementLocksClient) ListAtResourceLevelNextResults(lastResults M
 
 	resp, err := client.ListAtResourceLevelSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "ListAtResourceLevel", "Failure sending next results request request")
 	}
 
@@ -684,6 +695,7 @@ func (client ManagementLocksClient) ListAtSubscriptionLevel(filter string) (resu
 
 	resp, err := client.ListAtSubscriptionLevelSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "ListAtSubscriptionLevel", "Failure sending request")
 	}
 
@@ -746,6 +758,7 @@ func (client ManagementLocksClient) ListAtSubscriptionLevelNextResults(lastResul
 
 	resp, err := client.ListAtSubscriptionLevelSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "ListAtSubscriptionLevel", "Failure sending next results request request")
 	}
 
@@ -768,6 +781,7 @@ func (client ManagementLocksClient) ListNext(nextLink string) (result Management
 
 	resp, err := client.ListNextSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "ListNext", "Failure sending request")
 	}
 
@@ -825,6 +839,7 @@ func (client ManagementLocksClient) ListNextNextResults(lastResults ManagementLo
 
 	resp, err := client.ListNextSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "authorization/ManagementLocksClient", "ListNext", "Failure sending next results request request")
 	}
 

--- a/arm/authorization/version.go
+++ b/arm/authorization/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/arm/compute/availabilitysets.go
+++ b/arm/compute/availabilitysets.go
@@ -55,6 +55,7 @@ func (client AvailabilitySetsClient) CreateOrUpdate(resourceGroupName string, na
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -119,6 +120,7 @@ func (client AvailabilitySetsClient) Delete(resourceGroupName string, availabili
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "Delete", "Failure sending request")
 	}
 
@@ -181,6 +183,7 @@ func (client AvailabilitySetsClient) Get(resourceGroupName string, availabilityS
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "Get", "Failure sending request")
 	}
 
@@ -243,6 +246,7 @@ func (client AvailabilitySetsClient) List(resourceGroupName string) (result Avai
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "List", "Failure sending request")
 	}
 
@@ -306,6 +310,7 @@ func (client AvailabilitySetsClient) ListAvailableSizes(resourceGroupName string
 
 	resp, err := client.ListAvailableSizesSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/AvailabilitySetsClient", "ListAvailableSizes", "Failure sending request")
 	}
 

--- a/arm/compute/usageoperations.go
+++ b/arm/compute/usageoperations.go
@@ -53,6 +53,7 @@ func (client UsageOperationsClient) List(location string) (result ListUsagesResu
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/UsageOperationsClient", "List", "Failure sending request")
 	}
 

--- a/arm/compute/version.go
+++ b/arm/compute/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/arm/compute/virtualmachineextensionimages.go
+++ b/arm/compute/virtualmachineextensionimages.go
@@ -52,6 +52,7 @@ func (client VirtualMachineExtensionImagesClient) Get(location string, publisher
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "Get", "Failure sending request")
 	}
 
@@ -115,6 +116,7 @@ func (client VirtualMachineExtensionImagesClient) ListTypes(location string, pub
 
 	resp, err := client.ListTypesSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListTypes", "Failure sending request")
 	}
 
@@ -177,6 +179,7 @@ func (client VirtualMachineExtensionImagesClient) ListVersions(location string, 
 
 	resp, err := client.ListVersionsSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListVersions", "Failure sending request")
 	}
 

--- a/arm/compute/virtualmachineextensions.go
+++ b/arm/compute/virtualmachineextensions.go
@@ -57,6 +57,7 @@ func (client VirtualMachineExtensionsClient) CreateOrUpdate(resourceGroupName st
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -123,6 +124,7 @@ func (client VirtualMachineExtensionsClient) Delete(resourceGroupName string, vm
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "Delete", "Failure sending request")
 	}
 
@@ -188,6 +190,7 @@ func (client VirtualMachineExtensionsClient) Get(resourceGroupName string, vmNam
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "Get", "Failure sending request")
 	}
 

--- a/arm/compute/virtualmachineimages.go
+++ b/arm/compute/virtualmachineimages.go
@@ -52,6 +52,7 @@ func (client VirtualMachineImagesClient) Get(location string, publisherName stri
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "Get", "Failure sending request")
 	}
 
@@ -117,6 +118,7 @@ func (client VirtualMachineImagesClient) List(location string, publisherName str
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "List", "Failure sending request")
 	}
 
@@ -183,6 +185,7 @@ func (client VirtualMachineImagesClient) ListOffers(location string, publisherNa
 
 	resp, err := client.ListOffersSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListOffers", "Failure sending request")
 	}
 
@@ -244,6 +247,7 @@ func (client VirtualMachineImagesClient) ListPublishers(location string) (result
 
 	resp, err := client.ListPublishersSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListPublishers", "Failure sending request")
 	}
 
@@ -304,6 +308,7 @@ func (client VirtualMachineImagesClient) ListSkus(location string, publisherName
 
 	resp, err := client.ListSkusSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListSkus", "Failure sending request")
 	}
 

--- a/arm/compute/virtualmachines.go
+++ b/arm/compute/virtualmachines.go
@@ -56,6 +56,7 @@ func (client VirtualMachinesClient) Capture(resourceGroupName string, vmName str
 
 	resp, err := client.CaptureSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Capture", "Failure sending request")
 	}
 
@@ -121,6 +122,7 @@ func (client VirtualMachinesClient) CreateOrUpdate(resourceGroupName string, vmN
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -187,6 +189,7 @@ func (client VirtualMachinesClient) Deallocate(resourceGroupName string, vmName 
 
 	resp, err := client.DeallocateSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Deallocate", "Failure sending request")
 	}
 
@@ -249,6 +252,7 @@ func (client VirtualMachinesClient) Delete(resourceGroupName string, vmName stri
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Delete", "Failure sending request")
 	}
 
@@ -311,6 +315,7 @@ func (client VirtualMachinesClient) Generalize(resourceGroupName string, vmName 
 
 	resp, err := client.GeneralizeSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Generalize", "Failure sending request")
 	}
 
@@ -374,6 +379,7 @@ func (client VirtualMachinesClient) Get(resourceGroupName string, vmName string,
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Get", "Failure sending request")
 	}
 
@@ -437,6 +443,7 @@ func (client VirtualMachinesClient) List(resourceGroupName string) (result Virtu
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "List", "Failure sending request")
 	}
 
@@ -499,6 +506,7 @@ func (client VirtualMachinesClient) ListNextResults(lastResults VirtualMachineLi
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "List", "Failure sending next results request request")
 	}
 
@@ -521,6 +529,7 @@ func (client VirtualMachinesClient) ListAll() (result VirtualMachineListResult, 
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAll", "Failure sending request")
 	}
 
@@ -582,6 +591,7 @@ func (client VirtualMachinesClient) ListAllNextResults(lastResults VirtualMachin
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAll", "Failure sending next results request request")
 	}
 
@@ -606,6 +616,7 @@ func (client VirtualMachinesClient) ListAvailableSizes(resourceGroupName string,
 
 	resp, err := client.ListAvailableSizesSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "ListAvailableSizes", "Failure sending request")
 	}
 
@@ -669,6 +680,7 @@ func (client VirtualMachinesClient) PowerOff(resourceGroupName string, vmName st
 
 	resp, err := client.PowerOffSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "PowerOff", "Failure sending request")
 	}
 
@@ -731,6 +743,7 @@ func (client VirtualMachinesClient) Restart(resourceGroupName string, vmName str
 
 	resp, err := client.RestartSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Restart", "Failure sending request")
 	}
 
@@ -793,6 +806,7 @@ func (client VirtualMachinesClient) Start(resourceGroupName string, vmName strin
 
 	resp, err := client.StartSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Start", "Failure sending request")
 	}
 

--- a/arm/compute/virtualmachinesizes.go
+++ b/arm/compute/virtualmachinesizes.go
@@ -53,6 +53,7 @@ func (client VirtualMachineSizesClient) List(location string) (result VirtualMac
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineSizesClient", "List", "Failure sending request")
 	}
 

--- a/arm/examples/check.go
+++ b/arm/examples/check.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
 )
 
-func WithInspection() autorest.PrepareDecorator {
+func withInspection() autorest.PrepareDecorator {
 	return func(p autorest.Preparer) autorest.Preparer {
 		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
 			fmt.Printf("Inspecting Request: %s %s\n", r.Method, r.URL)
@@ -22,7 +22,7 @@ func WithInspection() autorest.PrepareDecorator {
 	}
 }
 
-func ByInspecting() autorest.RespondDecorator {
+func byInspecting() autorest.RespondDecorator {
 	return func(r autorest.Responder) autorest.Responder {
 		return autorest.ResponderFunc(func(resp *http.Response) error {
 			fmt.Printf("Inspecting Response: %s for %s %s\n", resp.Status, resp.Request.Method, resp.Request.URL)
@@ -48,8 +48,8 @@ func checkName(name string) {
 	ac.Sender = autorest.CreateSender(
 		autorest.WithLogging(log.New(os.Stdout, "sdk-example: ", log.LstdFlags)))
 
-	ac.RequestInspector = WithInspection()
-	ac.ResponseInspector = ByInspecting()
+	ac.RequestInspector = withInspection()
+	ac.ResponseInspector = byInspecting()
 
 	cna, err := ac.CheckNameAvailability(
 		storage.AccountCheckNameAvailabilityParameters{

--- a/arm/examples/create.go
+++ b/arm/examples/create.go
@@ -50,6 +50,7 @@ func createAccount(resourceGroup, name string) {
 			Type: to.StringPtr("Microsoft.Storage/storageAccounts")})
 	if err != nil {
 		log.Fatalf("Error: %v", err)
+		return
 	}
 	if !to.Bool(cna.NameAvailable) {
 		fmt.Printf("%s is unavailable -- try again\n", name)
@@ -70,13 +71,12 @@ func createAccount(resourceGroup, name string) {
 		if sa.Response.StatusCode != http.StatusAccepted {
 			fmt.Printf("Creation of %s.%s failed with err -- %v\n", resourceGroup, name, err)
 			return
-		} else {
-			fmt.Printf("Create initiated for %s.%s -- poll %s to check status\n",
-				resourceGroup,
-				name,
-				sa.GetPollingLocation())
-			return
 		}
+		fmt.Printf("Create initiated for %s.%s -- poll %s to check status\n",
+			resourceGroup,
+			name,
+			sa.GetPollingLocation())
+		return
 	}
 
 	fmt.Printf("Successfully created %s.%s\n\n", resourceGroup, name)

--- a/arm/features/client.go
+++ b/arm/features/client.go
@@ -65,6 +65,7 @@ func (client ManagementClient) Get(resourceProviderNamespace string, featureName
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "features/ManagementClient", "Get", "Failure sending request")
 	}
 
@@ -127,6 +128,7 @@ func (client ManagementClient) List(resourceProviderNamespace string) (result Op
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "features/ManagementClient", "List", "Failure sending request")
 	}
 
@@ -189,6 +191,7 @@ func (client ManagementClient) ListNextResults(lastResults OperationsListResult)
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "features/ManagementClient", "List", "Failure sending next results request request")
 	}
 
@@ -210,6 +213,7 @@ func (client ManagementClient) ListAll() (result OperationsListResult, ae error)
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "features/ManagementClient", "ListAll", "Failure sending request")
 	}
 
@@ -271,6 +275,7 @@ func (client ManagementClient) ListAllNextResults(lastResults OperationsListResu
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "features/ManagementClient", "ListAll", "Failure sending next results request request")
 	}
 
@@ -294,6 +299,7 @@ func (client ManagementClient) Register(resourceProviderNamespace string, featur
 
 	resp, err := client.RegisterSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "features/ManagementClient", "Register", "Failure sending request")
 	}
 

--- a/arm/features/version.go
+++ b/arm/features/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/arm/logic/version.go
+++ b/arm/logic/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/arm/logic/workflowaccesskeys.go
+++ b/arm/logic/workflowaccesskeys.go
@@ -55,6 +55,7 @@ func (client WorkflowAccessKeysClient) CreateOrUpdate(resourceGroupName string, 
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowAccessKeysClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -120,6 +121,7 @@ func (client WorkflowAccessKeysClient) Delete(resourceGroupName string, workflow
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowAccessKeysClient", "Delete", "Failure sending request")
 	}
 
@@ -183,6 +185,7 @@ func (client WorkflowAccessKeysClient) Get(resourceGroupName string, workflowNam
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowAccessKeysClient", "Get", "Failure sending request")
 	}
 
@@ -247,6 +250,7 @@ func (client WorkflowAccessKeysClient) List(resourceGroupName string, workflowNa
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowAccessKeysClient", "List", "Failure sending request")
 	}
 
@@ -311,6 +315,7 @@ func (client WorkflowAccessKeysClient) ListNextResults(lastResults WorkflowAcces
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowAccessKeysClient", "List", "Failure sending next results request request")
 	}
 
@@ -334,6 +339,7 @@ func (client WorkflowAccessKeysClient) ListSecretKeys(resourceGroupName string, 
 
 	resp, err := client.ListSecretKeysSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowAccessKeysClient", "ListSecretKeys", "Failure sending request")
 	}
 
@@ -399,6 +405,7 @@ func (client WorkflowAccessKeysClient) RegenerateSecretKey(resourceGroupName str
 
 	resp, err := client.RegenerateSecretKeySender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowAccessKeysClient", "RegenerateSecretKey", "Failure sending request")
 	}
 

--- a/arm/logic/workflowrunactions.go
+++ b/arm/logic/workflowrunactions.go
@@ -55,6 +55,7 @@ func (client WorkflowRunActionsClient) Get(resourceGroupName string, workflowNam
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowRunActionsClient", "Get", "Failure sending request")
 	}
 
@@ -121,6 +122,7 @@ func (client WorkflowRunActionsClient) List(resourceGroupName string, workflowNa
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowRunActionsClient", "List", "Failure sending request")
 	}
 
@@ -187,6 +189,7 @@ func (client WorkflowRunActionsClient) ListNextResults(lastResults WorkflowRunAc
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowRunActionsClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/logic/workflowruns.go
+++ b/arm/logic/workflowruns.go
@@ -53,6 +53,7 @@ func (client WorkflowRunsClient) Cancel(resourceGroupName string, workflowName s
 
 	resp, err := client.CancelSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowRunsClient", "Cancel", "Failure sending request")
 	}
 
@@ -116,6 +117,7 @@ func (client WorkflowRunsClient) Get(resourceGroupName string, workflowName stri
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowRunsClient", "Get", "Failure sending request")
 	}
 
@@ -181,6 +183,7 @@ func (client WorkflowRunsClient) List(resourceGroupName string, workflowName str
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowRunsClient", "List", "Failure sending request")
 	}
 
@@ -246,6 +249,7 @@ func (client WorkflowRunsClient) ListNextResults(lastResults WorkflowRunListResu
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowRunsClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/logic/workflows.go
+++ b/arm/logic/workflows.go
@@ -53,6 +53,7 @@ func (client WorkflowsClient) CreateOrUpdate(resourceGroupName string, workflowN
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -117,6 +118,7 @@ func (client WorkflowsClient) Delete(resourceGroupName string, workflowName stri
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "Delete", "Failure sending request")
 	}
 
@@ -179,6 +181,7 @@ func (client WorkflowsClient) Disable(resourceGroupName string, workflowName str
 
 	resp, err := client.DisableSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "Disable", "Failure sending request")
 	}
 
@@ -241,6 +244,7 @@ func (client WorkflowsClient) Enable(resourceGroupName string, workflowName stri
 
 	resp, err := client.EnableSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "Enable", "Failure sending request")
 	}
 
@@ -303,6 +307,7 @@ func (client WorkflowsClient) Get(resourceGroupName string, workflowName string)
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "Get", "Failure sending request")
 	}
 
@@ -366,6 +371,7 @@ func (client WorkflowsClient) ListByResourceGroup(resourceGroupName string, top 
 
 	resp, err := client.ListByResourceGroupSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "ListByResourceGroup", "Failure sending request")
 	}
 
@@ -430,6 +436,7 @@ func (client WorkflowsClient) ListByResourceGroupNextResults(lastResults Workflo
 
 	resp, err := client.ListByResourceGroupSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "ListByResourceGroup", "Failure sending next results request request")
 	}
 
@@ -453,6 +460,7 @@ func (client WorkflowsClient) ListBySubscription(top int, filter string) (result
 
 	resp, err := client.ListBySubscriptionSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "ListBySubscription", "Failure sending request")
 	}
 
@@ -516,6 +524,7 @@ func (client WorkflowsClient) ListBySubscriptionNextResults(lastResults Workflow
 
 	resp, err := client.ListBySubscriptionSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "ListBySubscription", "Failure sending next results request request")
 	}
 
@@ -539,6 +548,7 @@ func (client WorkflowsClient) Run(resourceGroupName string, workflowName string,
 
 	resp, err := client.RunSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "Run", "Failure sending request")
 	}
 
@@ -603,6 +613,7 @@ func (client WorkflowsClient) Update(resourceGroupName string, workflowName stri
 
 	resp, err := client.UpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "Update", "Failure sending request")
 	}
 
@@ -667,6 +678,7 @@ func (client WorkflowsClient) Validate(resourceGroupName string, workflowName st
 
 	resp, err := client.ValidateSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowsClient", "Validate", "Failure sending request")
 	}
 

--- a/arm/logic/workflowtriggerhistories.go
+++ b/arm/logic/workflowtriggerhistories.go
@@ -55,6 +55,7 @@ func (client WorkflowTriggerHistoriesClient) Get(resourceGroupName string, workf
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowTriggerHistoriesClient", "Get", "Failure sending request")
 	}
 
@@ -121,6 +122,7 @@ func (client WorkflowTriggerHistoriesClient) List(resourceGroupName string, work
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowTriggerHistoriesClient", "List", "Failure sending request")
 	}
 
@@ -186,6 +188,7 @@ func (client WorkflowTriggerHistoriesClient) ListNextResults(lastResults Workflo
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowTriggerHistoriesClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/logic/workflowtriggers.go
+++ b/arm/logic/workflowtriggers.go
@@ -54,6 +54,7 @@ func (client WorkflowTriggersClient) Get(resourceGroupName string, workflowName 
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowTriggersClient", "Get", "Failure sending request")
 	}
 
@@ -119,6 +120,7 @@ func (client WorkflowTriggersClient) List(resourceGroupName string, workflowName
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowTriggersClient", "List", "Failure sending request")
 	}
 
@@ -184,6 +186,7 @@ func (client WorkflowTriggersClient) ListNextResults(lastResults WorkflowTrigger
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowTriggersClient", "List", "Failure sending next results request request")
 	}
 
@@ -207,6 +210,7 @@ func (client WorkflowTriggersClient) Run(resourceGroupName string, workflowName 
 
 	resp, err := client.RunSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowTriggersClient", "Run", "Failure sending request")
 	}
 

--- a/arm/logic/workflowversions.go
+++ b/arm/logic/workflowversions.go
@@ -54,6 +54,7 @@ func (client WorkflowVersionsClient) Get(resourceGroupName string, workflowName 
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "logic/WorkflowVersionsClient", "Get", "Failure sending request")
 	}
 

--- a/arm/network/applicationgateways.go
+++ b/arm/network/applicationgateways.go
@@ -56,6 +56,7 @@ func (client ApplicationGatewaysClient) CreateOrUpdate(resourceGroupName string,
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -121,6 +122,7 @@ func (client ApplicationGatewaysClient) Delete(resourceGroupName string, applica
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Delete", "Failure sending request")
 	}
 
@@ -184,6 +186,7 @@ func (client ApplicationGatewaysClient) Get(resourceGroupName string, applicatio
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Get", "Failure sending request")
 	}
 
@@ -247,6 +250,7 @@ func (client ApplicationGatewaysClient) List(resourceGroupName string) (result A
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "List", "Failure sending request")
 	}
 
@@ -309,6 +313,7 @@ func (client ApplicationGatewaysClient) ListNextResults(lastResults ApplicationG
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "List", "Failure sending next results request request")
 	}
 
@@ -330,6 +335,7 @@ func (client ApplicationGatewaysClient) ListAll() (result ApplicationGatewayList
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "ListAll", "Failure sending request")
 	}
 
@@ -391,6 +397,7 @@ func (client ApplicationGatewaysClient) ListAllNextResults(lastResults Applicati
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "ListAll", "Failure sending next results request request")
 	}
 
@@ -415,6 +422,7 @@ func (client ApplicationGatewaysClient) Start(resourceGroupName string, applicat
 
 	resp, err := client.StartSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Start", "Failure sending request")
 	}
 
@@ -478,6 +486,7 @@ func (client ApplicationGatewaysClient) Stop(resourceGroupName string, applicati
 
 	resp, err := client.StopSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Stop", "Failure sending request")
 	}
 

--- a/arm/network/client.go
+++ b/arm/network/client.go
@@ -67,6 +67,7 @@ func (client ManagementClient) CheckDNSNameAvailability(location string, domainN
 
 	resp, err := client.CheckDNSNameAvailabilitySender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/ManagementClient", "CheckDNSNameAvailability", "Failure sending request")
 	}
 

--- a/arm/network/interfaces.go
+++ b/arm/network/interfaces.go
@@ -55,6 +55,7 @@ func (client InterfacesClient) CreateOrUpdate(resourceGroupName string, networkI
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -120,6 +121,7 @@ func (client InterfacesClient) Delete(resourceGroupName string, networkInterface
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "Delete", "Failure sending request")
 	}
 
@@ -183,6 +185,7 @@ func (client InterfacesClient) Get(resourceGroupName string, networkInterfaceNam
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "Get", "Failure sending request")
 	}
 
@@ -246,6 +249,7 @@ func (client InterfacesClient) List(resourceGroupName string) (result InterfaceL
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "List", "Failure sending request")
 	}
 
@@ -308,6 +312,7 @@ func (client InterfacesClient) ListNextResults(lastResults InterfaceListResult) 
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "List", "Failure sending next results request request")
 	}
 
@@ -329,6 +334,7 @@ func (client InterfacesClient) ListAll() (result InterfaceListResult, ae error) 
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "ListAll", "Failure sending request")
 	}
 
@@ -390,6 +396,7 @@ func (client InterfacesClient) ListAllNextResults(lastResults InterfaceListResul
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "ListAll", "Failure sending next results request request")
 	}
 

--- a/arm/network/loadbalancers.go
+++ b/arm/network/loadbalancers.go
@@ -55,6 +55,7 @@ func (client LoadBalancersClient) CreateOrUpdate(resourceGroupName string, loadB
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -119,6 +120,7 @@ func (client LoadBalancersClient) Delete(resourceGroupName string, loadBalancerN
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "Delete", "Failure sending request")
 	}
 
@@ -182,6 +184,7 @@ func (client LoadBalancersClient) Get(resourceGroupName string, loadBalancerName
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "Get", "Failure sending request")
 	}
 
@@ -245,6 +248,7 @@ func (client LoadBalancersClient) List(resourceGroupName string) (result LoadBal
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "List", "Failure sending request")
 	}
 
@@ -307,6 +311,7 @@ func (client LoadBalancersClient) ListNextResults(lastResults LoadBalancerListRe
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "List", "Failure sending next results request request")
 	}
 
@@ -328,6 +333,7 @@ func (client LoadBalancersClient) ListAll() (result LoadBalancerListResult, ae e
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "ListAll", "Failure sending request")
 	}
 
@@ -389,6 +395,7 @@ func (client LoadBalancersClient) ListAllNextResults(lastResults LoadBalancerLis
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "ListAll", "Failure sending next results request request")
 	}
 

--- a/arm/network/localnetworkgateways.go
+++ b/arm/network/localnetworkgateways.go
@@ -58,6 +58,7 @@ func (client LocalNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -123,6 +124,7 @@ func (client LocalNetworkGatewaysClient) Delete(resourceGroupName string, localN
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "Delete", "Failure sending request")
 	}
 
@@ -186,6 +188,7 @@ func (client LocalNetworkGatewaysClient) Get(resourceGroupName string, localNetw
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "Get", "Failure sending request")
 	}
 
@@ -249,6 +252,7 @@ func (client LocalNetworkGatewaysClient) List(resourceGroupName string) (result 
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "List", "Failure sending request")
 	}
 
@@ -311,6 +315,7 @@ func (client LocalNetworkGatewaysClient) ListNextResults(lastResults LocalNetwor
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/network/publicipaddresses.go
+++ b/arm/network/publicipaddresses.go
@@ -56,6 +56,7 @@ func (client PublicIPAddressesClient) CreateOrUpdate(resourceGroupName string, p
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -121,6 +122,7 @@ func (client PublicIPAddressesClient) Delete(resourceGroupName string, publicIPA
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "Delete", "Failure sending request")
 	}
 
@@ -184,6 +186,7 @@ func (client PublicIPAddressesClient) Get(resourceGroupName string, publicIPAddr
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "Get", "Failure sending request")
 	}
 
@@ -247,6 +250,7 @@ func (client PublicIPAddressesClient) List(resourceGroupName string) (result Pub
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "List", "Failure sending request")
 	}
 
@@ -309,6 +313,7 @@ func (client PublicIPAddressesClient) ListNextResults(lastResults PublicIPAddres
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "List", "Failure sending next results request request")
 	}
 
@@ -330,6 +335,7 @@ func (client PublicIPAddressesClient) ListAll() (result PublicIPAddressListResul
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "ListAll", "Failure sending request")
 	}
 
@@ -391,6 +397,7 @@ func (client PublicIPAddressesClient) ListAllNextResults(lastResults PublicIPAdd
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "ListAll", "Failure sending next results request request")
 	}
 

--- a/arm/network/securitygroups.go
+++ b/arm/network/securitygroups.go
@@ -57,6 +57,7 @@ func (client SecurityGroupsClient) CreateOrUpdate(resourceGroupName string, netw
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -122,6 +123,7 @@ func (client SecurityGroupsClient) Delete(resourceGroupName string, networkSecur
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "Delete", "Failure sending request")
 	}
 
@@ -185,6 +187,7 @@ func (client SecurityGroupsClient) Get(resourceGroupName string, networkSecurity
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "Get", "Failure sending request")
 	}
 
@@ -248,6 +251,7 @@ func (client SecurityGroupsClient) List(resourceGroupName string) (result Securi
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "List", "Failure sending request")
 	}
 
@@ -310,6 +314,7 @@ func (client SecurityGroupsClient) ListNextResults(lastResults SecurityGroupList
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "List", "Failure sending next results request request")
 	}
 
@@ -331,6 +336,7 @@ func (client SecurityGroupsClient) ListAll() (result SecurityGroupListResult, ae
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "ListAll", "Failure sending request")
 	}
 
@@ -392,6 +398,7 @@ func (client SecurityGroupsClient) ListAllNextResults(lastResults SecurityGroupL
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "ListAll", "Failure sending next results request request")
 	}
 

--- a/arm/network/securityrules.go
+++ b/arm/network/securityrules.go
@@ -58,6 +58,7 @@ func (client SecurityRulesClient) CreateOrUpdate(resourceGroupName string, netwo
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -125,6 +126,7 @@ func (client SecurityRulesClient) Delete(resourceGroupName string, networkSecuri
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "Delete", "Failure sending request")
 	}
 
@@ -190,6 +192,7 @@ func (client SecurityRulesClient) Get(resourceGroupName string, networkSecurityG
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "Get", "Failure sending request")
 	}
 
@@ -255,6 +258,7 @@ func (client SecurityRulesClient) List(resourceGroupName string, networkSecurity
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "List", "Failure sending request")
 	}
 
@@ -318,6 +322,7 @@ func (client SecurityRulesClient) ListNextResults(lastResults SecurityRuleListRe
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/network/subnets.go
+++ b/arm/network/subnets.go
@@ -54,6 +54,7 @@ func (client SubnetsClient) CreateOrUpdate(resourceGroupName string, virtualNetw
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -119,6 +120,7 @@ func (client SubnetsClient) Delete(resourceGroupName string, virtualNetworkName 
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "Delete", "Failure sending request")
 	}
 
@@ -183,6 +185,7 @@ func (client SubnetsClient) Get(resourceGroupName string, virtualNetworkName str
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "Get", "Failure sending request")
 	}
 
@@ -248,6 +251,7 @@ func (client SubnetsClient) List(resourceGroupName string, virtualNetworkName st
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "List", "Failure sending request")
 	}
 
@@ -311,6 +315,7 @@ func (client SubnetsClient) ListNextResults(lastResults SubnetListResult) (resul
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/network/usages.go
+++ b/arm/network/usages.go
@@ -50,6 +50,7 @@ func (client UsagesClient) List(location string) (result UsagesListResult, ae er
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/UsagesClient", "List", "Failure sending request")
 	}
 

--- a/arm/network/version.go
+++ b/arm/network/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/arm/network/virtualnetworkgatewayconnections.go
+++ b/arm/network/virtualnetworkgatewayconnections.go
@@ -59,6 +59,7 @@ func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdate(resourceGrou
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -126,6 +127,7 @@ func (client VirtualNetworkGatewayConnectionsClient) Delete(resourceGroupName st
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "Delete", "Failure sending request")
 	}
 
@@ -191,6 +193,7 @@ func (client VirtualNetworkGatewayConnectionsClient) Get(resourceGroupName strin
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "Get", "Failure sending request")
 	}
 
@@ -257,6 +260,7 @@ func (client VirtualNetworkGatewayConnectionsClient) GetSharedKey(resourceGroupN
 
 	resp, err := client.GetSharedKeySender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "GetSharedKey", "Failure sending request")
 	}
 
@@ -320,6 +324,7 @@ func (client VirtualNetworkGatewayConnectionsClient) List(resourceGroupName stri
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "List", "Failure sending request")
 	}
 
@@ -382,6 +387,7 @@ func (client VirtualNetworkGatewayConnectionsClient) ListNextResults(lastResults
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "List", "Failure sending next results request request")
 	}
 
@@ -411,6 +417,7 @@ func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKey(resourceGrou
 
 	resp, err := client.ResetSharedKeySender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "ResetSharedKey", "Failure sending request")
 	}
 
@@ -481,6 +488,7 @@ func (client VirtualNetworkGatewayConnectionsClient) SetSharedKey(resourceGroupN
 
 	resp, err := client.SetSharedKeySender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "SetSharedKey", "Failure sending request")
 	}
 

--- a/arm/network/virtualnetworkgateways.go
+++ b/arm/network/virtualnetworkgateways.go
@@ -58,6 +58,7 @@ func (client VirtualNetworkGatewaysClient) CreateOrUpdate(resourceGroupName stri
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -123,6 +124,7 @@ func (client VirtualNetworkGatewaysClient) Delete(resourceGroupName string, virt
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Delete", "Failure sending request")
 	}
 
@@ -186,6 +188,7 @@ func (client VirtualNetworkGatewaysClient) Get(resourceGroupName string, virtual
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Get", "Failure sending request")
 	}
 
@@ -249,6 +252,7 @@ func (client VirtualNetworkGatewaysClient) List(resourceGroupName string) (resul
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "List", "Failure sending request")
 	}
 
@@ -311,6 +315,7 @@ func (client VirtualNetworkGatewaysClient) ListNextResults(lastResults VirtualNe
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "List", "Failure sending next results request request")
 	}
 
@@ -338,6 +343,7 @@ func (client VirtualNetworkGatewaysClient) Reset(resourceGroupName string, virtu
 
 	resp, err := client.ResetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Reset", "Failure sending request")
 	}
 

--- a/arm/network/virtualnetworks.go
+++ b/arm/network/virtualnetworks.go
@@ -56,6 +56,7 @@ func (client VirtualNetworksClient) CreateOrUpdate(resourceGroupName string, vir
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -121,6 +122,7 @@ func (client VirtualNetworksClient) Delete(resourceGroupName string, virtualNetw
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "Delete", "Failure sending request")
 	}
 
@@ -184,6 +186,7 @@ func (client VirtualNetworksClient) Get(resourceGroupName string, virtualNetwork
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "Get", "Failure sending request")
 	}
 
@@ -247,6 +250,7 @@ func (client VirtualNetworksClient) List(resourceGroupName string) (result Virtu
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "List", "Failure sending request")
 	}
 
@@ -309,6 +313,7 @@ func (client VirtualNetworksClient) ListNextResults(lastResults VirtualNetworkLi
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "List", "Failure sending next results request request")
 	}
 
@@ -330,6 +335,7 @@ func (client VirtualNetworksClient) ListAll() (result VirtualNetworkListResult, 
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "ListAll", "Failure sending request")
 	}
 
@@ -391,6 +397,7 @@ func (client VirtualNetworksClient) ListAllNextResults(lastResults VirtualNetwor
 
 	resp, err := client.ListAllSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "ListAll", "Failure sending next results request request")
 	}
 

--- a/arm/resources/client.go
+++ b/arm/resources/client.go
@@ -67,6 +67,7 @@ func (client ManagementClient) CheckExistence(resourceGroupName string, resource
 
 	resp, err := client.CheckExistenceSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "CheckExistence", "Failure sending request")
 	}
 
@@ -135,6 +136,7 @@ func (client ManagementClient) CreateOrUpdate(resourceGroupName string, resource
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -204,6 +206,7 @@ func (client ManagementClient) Delete(resourceGroupName string, resourceProvider
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "Delete", "Failure sending request")
 	}
 
@@ -271,6 +274,7 @@ func (client ManagementClient) Get(resourceGroupName string, resourceProviderNam
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "Get", "Failure sending request")
 	}
 
@@ -337,6 +341,7 @@ func (client ManagementClient) List(filter string, top int) (result ListResult, 
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "List", "Failure sending request")
 	}
 
@@ -400,6 +405,7 @@ func (client ManagementClient) ListNextResults(lastResults ListResult) (result L
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "List", "Failure sending next results request request")
 	}
 
@@ -423,6 +429,7 @@ func (client ManagementClient) MoveResources(sourceResourceGroupName string, par
 
 	resp, err := client.MoveResourcesSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "resources/ManagementClient", "MoveResources", "Failure sending request")
 	}
 

--- a/arm/resources/deploymentoperations.go
+++ b/arm/resources/deploymentoperations.go
@@ -55,6 +55,7 @@ func (client DeploymentOperationsClient) Get(resourceGroupName string, deploymen
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "Get", "Failure sending request")
 	}
 
@@ -120,6 +121,7 @@ func (client DeploymentOperationsClient) List(resourceGroupName string, deployme
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "List", "Failure sending request")
 	}
 
@@ -184,6 +186,7 @@ func (client DeploymentOperationsClient) ListNextResults(lastResults DeploymentO
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentOperationsClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/resources/deployments.go
+++ b/arm/resources/deployments.go
@@ -53,6 +53,7 @@ func (client DeploymentsClient) Cancel(resourceGroupName string, deploymentName 
 
 	resp, err := client.CancelSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Cancel", "Failure sending request")
 	}
 
@@ -116,6 +117,7 @@ func (client DeploymentsClient) CreateOrUpdate(resourceGroupName string, deploym
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -180,6 +182,7 @@ func (client DeploymentsClient) Get(resourceGroupName string, deploymentName str
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Get", "Failure sending request")
 	}
 
@@ -244,6 +247,7 @@ func (client DeploymentsClient) List(resourceGroupName string, filter string, to
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "List", "Failure sending request")
 	}
 
@@ -308,6 +312,7 @@ func (client DeploymentsClient) ListNextResults(lastResults DeploymentListResult
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "List", "Failure sending next results request request")
 	}
 
@@ -332,6 +337,7 @@ func (client DeploymentsClient) Validate(resourceGroupName string, deploymentNam
 
 	resp, err := client.ValidateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Validate", "Failure sending request")
 	}
 

--- a/arm/resources/groups.go
+++ b/arm/resources/groups.go
@@ -51,6 +51,7 @@ func (client GroupsClient) CheckExistence(resourceGroupName string) (result auto
 
 	resp, err := client.CheckExistenceSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "CheckExistence", "Failure sending request")
 	}
 
@@ -113,6 +114,7 @@ func (client GroupsClient) CreateOrUpdate(resourceGroupName string, parameters G
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -177,6 +179,7 @@ func (client GroupsClient) Delete(resourceGroupName string) (result autorest.Res
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "Delete", "Failure sending request")
 	}
 
@@ -238,6 +241,7 @@ func (client GroupsClient) Get(resourceGroupName string) (result Group, ae error
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "Get", "Failure sending request")
 	}
 
@@ -300,6 +304,7 @@ func (client GroupsClient) List(filter string, top int) (result GroupListResult,
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "List", "Failure sending request")
 	}
 
@@ -363,6 +368,7 @@ func (client GroupsClient) ListNextResults(lastResults GroupListResult) (result 
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "List", "Failure sending next results request request")
 	}
 
@@ -387,6 +393,7 @@ func (client GroupsClient) ListResources(resourceGroupName string, filter string
 
 	resp, err := client.ListResourcesSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "ListResources", "Failure sending request")
 	}
 
@@ -451,6 +458,7 @@ func (client GroupsClient) ListResourcesNextResults(lastResults ListResult) (res
 
 	resp, err := client.ListResourcesSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "ListResources", "Failure sending next results request request")
 	}
 
@@ -478,6 +486,7 @@ func (client GroupsClient) Patch(resourceGroupName string, parameters Group) (re
 
 	resp, err := client.PatchSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "Patch", "Failure sending request")
 	}
 

--- a/arm/resources/provideroperationdetails.go
+++ b/arm/resources/provideroperationdetails.go
@@ -53,6 +53,7 @@ func (client ProviderOperationDetailsClient) List(resourceProviderNamespace stri
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ProviderOperationDetailsClient", "List", "Failure sending request")
 	}
 

--- a/arm/resources/providers.go
+++ b/arm/resources/providers.go
@@ -52,6 +52,7 @@ func (client ProvidersClient) Get(resourceProviderNamespace string) (result Prov
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "Get", "Failure sending request")
 	}
 
@@ -113,6 +114,7 @@ func (client ProvidersClient) List(top int) (result ProviderListResult, ae error
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "List", "Failure sending request")
 	}
 
@@ -175,6 +177,7 @@ func (client ProvidersClient) ListNextResults(lastResults ProviderListResult) (r
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "List", "Failure sending next results request request")
 	}
 
@@ -197,6 +200,7 @@ func (client ProvidersClient) Register(resourceProviderNamespace string) (result
 
 	resp, err := client.RegisterSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "Register", "Failure sending request")
 	}
 
@@ -258,6 +262,7 @@ func (client ProvidersClient) Unregister(resourceProviderNamespace string) (resu
 
 	resp, err := client.UnregisterSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/ProvidersClient", "Unregister", "Failure sending request")
 	}
 

--- a/arm/resources/tags.go
+++ b/arm/resources/tags.go
@@ -50,6 +50,7 @@ func (client TagsClient) CreateOrUpdate(tagName string) (result TagDetails, ae e
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -111,6 +112,7 @@ func (client TagsClient) CreateOrUpdateValue(tagName string, tagValue string) (r
 
 	resp, err := client.CreateOrUpdateValueSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "CreateOrUpdateValue", "Failure sending request")
 	}
 
@@ -173,6 +175,7 @@ func (client TagsClient) Delete(tagName string) (result autorest.Response, ae er
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "Delete", "Failure sending request")
 	}
 
@@ -233,6 +236,7 @@ func (client TagsClient) DeleteValue(tagName string, tagValue string) (result au
 
 	resp, err := client.DeleteValueSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "DeleteValue", "Failure sending request")
 	}
 
@@ -292,6 +296,7 @@ func (client TagsClient) List() (result TagsListResult, ae error) {
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "List", "Failure sending request")
 	}
 
@@ -353,6 +358,7 @@ func (client TagsClient) ListNextResults(lastResults TagsListResult) (result Tag
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "resources/TagsClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/resources/version.go
+++ b/arm/resources/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/arm/scheduler/jobcollections.go
+++ b/arm/scheduler/jobcollections.go
@@ -55,6 +55,7 @@ func (client JobCollectionsClient) CreateOrUpdate(resourceGroupName string, jobC
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -119,6 +120,7 @@ func (client JobCollectionsClient) Delete(resourceGroupName string, jobCollectio
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "Delete", "Failure sending request")
 	}
 
@@ -181,6 +183,7 @@ func (client JobCollectionsClient) Disable(resourceGroupName string, jobCollecti
 
 	resp, err := client.DisableSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "Disable", "Failure sending request")
 	}
 
@@ -243,6 +246,7 @@ func (client JobCollectionsClient) Enable(resourceGroupName string, jobCollectio
 
 	resp, err := client.EnableSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "Enable", "Failure sending request")
 	}
 
@@ -305,6 +309,7 @@ func (client JobCollectionsClient) Get(resourceGroupName string, jobCollectionNa
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "Get", "Failure sending request")
 	}
 
@@ -367,6 +372,7 @@ func (client JobCollectionsClient) ListByResourceGroup(resourceGroupName string)
 
 	resp, err := client.ListByResourceGroupSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "ListByResourceGroup", "Failure sending request")
 	}
 
@@ -429,6 +435,7 @@ func (client JobCollectionsClient) ListByResourceGroupNextResults(lastResults Jo
 
 	resp, err := client.ListByResourceGroupSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "ListByResourceGroup", "Failure sending next results request request")
 	}
 
@@ -449,6 +456,7 @@ func (client JobCollectionsClient) ListBySubscription() (result JobCollectionLis
 
 	resp, err := client.ListBySubscriptionSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "ListBySubscription", "Failure sending request")
 	}
 
@@ -510,6 +518,7 @@ func (client JobCollectionsClient) ListBySubscriptionNextResults(lastResults Job
 
 	resp, err := client.ListBySubscriptionSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "ListBySubscription", "Failure sending next results request request")
 	}
 
@@ -533,6 +542,7 @@ func (client JobCollectionsClient) Patch(resourceGroupName string, jobCollection
 
 	resp, err := client.PatchSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobCollectionsClient", "Patch", "Failure sending request")
 	}
 

--- a/arm/scheduler/jobs.go
+++ b/arm/scheduler/jobs.go
@@ -51,6 +51,7 @@ func (client JobsClient) CreateOrUpdate(resourceGroupName string, jobCollectionN
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobsClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -116,6 +117,7 @@ func (client JobsClient) Delete(resourceGroupName string, jobCollectionName stri
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "scheduler/JobsClient", "Delete", "Failure sending request")
 	}
 
@@ -179,6 +181,7 @@ func (client JobsClient) Get(resourceGroupName string, jobCollectionName string,
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobsClient", "Get", "Failure sending request")
 	}
 
@@ -245,6 +248,7 @@ func (client JobsClient) List(resourceGroupName string, jobCollectionName string
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobsClient", "List", "Failure sending request")
 	}
 
@@ -310,6 +314,7 @@ func (client JobsClient) ListNextResults(lastResults JobListResult) (result JobL
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobsClient", "List", "Failure sending next results request request")
 	}
 
@@ -335,6 +340,7 @@ func (client JobsClient) ListJobHistory(resourceGroupName string, jobCollectionN
 
 	resp, err := client.ListJobHistorySender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobsClient", "ListJobHistory", "Failure sending request")
 	}
 
@@ -401,6 +407,7 @@ func (client JobsClient) ListJobHistoryNextResults(lastResults JobHistoryListRes
 
 	resp, err := client.ListJobHistorySender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobsClient", "ListJobHistory", "Failure sending next results request request")
 	}
 
@@ -424,6 +431,7 @@ func (client JobsClient) Patch(resourceGroupName string, jobCollectionName strin
 
 	resp, err := client.PatchSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "scheduler/JobsClient", "Patch", "Failure sending request")
 	}
 
@@ -489,6 +497,7 @@ func (client JobsClient) Run(resourceGroupName string, jobCollectionName string,
 
 	resp, err := client.RunSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "scheduler/JobsClient", "Run", "Failure sending request")
 	}
 

--- a/arm/scheduler/version.go
+++ b/arm/scheduler/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/arm/search/adminkeys.go
+++ b/arm/search/adminkeys.go
@@ -55,6 +55,7 @@ func (client AdminKeysClient) List(resourceGroupName string, serviceName string)
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "search/AdminKeysClient", "List", "Failure sending request")
 	}
 

--- a/arm/search/querykeys.go
+++ b/arm/search/querykeys.go
@@ -54,6 +54,7 @@ func (client QueryKeysClient) List(resourceGroupName string, serviceName string)
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "search/QueryKeysClient", "List", "Failure sending request")
 	}
 

--- a/arm/search/services.go
+++ b/arm/search/services.go
@@ -57,6 +57,7 @@ func (client ServicesClient) CreateOrUpdate(resourceGroupName string, serviceNam
 
 	resp, err := client.CreateOrUpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "search/ServicesClient", "CreateOrUpdate", "Failure sending request")
 	}
 
@@ -122,6 +123,7 @@ func (client ServicesClient) Delete(resourceGroupName string, serviceName string
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "search/ServicesClient", "Delete", "Failure sending request")
 	}
 
@@ -184,6 +186,7 @@ func (client ServicesClient) List(resourceGroupName string) (result ServiceListR
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "search/ServicesClient", "List", "Failure sending request")
 	}
 

--- a/arm/search/version.go
+++ b/arm/search/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/arm/storage/accounts.go
+++ b/arm/storage/accounts.go
@@ -54,6 +54,7 @@ func (client AccountsClient) CheckNameAvailability(accountName AccountCheckNameA
 
 	resp, err := client.CheckNameAvailabilitySender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "CheckNameAvailability", "Failure sending request")
 	}
 
@@ -123,6 +124,7 @@ func (client AccountsClient) Create(resourceGroupName string, accountName string
 
 	resp, err := client.CreateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "Create", "Failure sending request")
 	}
 
@@ -189,6 +191,7 @@ func (client AccountsClient) Delete(resourceGroupName string, accountName string
 
 	resp, err := client.DeleteSender(req)
 	if err != nil {
+		result.Response = resp
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "Delete", "Failure sending request")
 	}
 
@@ -255,6 +258,7 @@ func (client AccountsClient) GetProperties(resourceGroupName string, accountName
 
 	resp, err := client.GetPropertiesSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "GetProperties", "Failure sending request")
 	}
 
@@ -316,6 +320,7 @@ func (client AccountsClient) List() (result AccountListResult, ae error) {
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "List", "Failure sending request")
 	}
 
@@ -379,6 +384,7 @@ func (client AccountsClient) ListByResourceGroup(resourceGroupName string) (resu
 
 	resp, err := client.ListByResourceGroupSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "ListByResourceGroup", "Failure sending request")
 	}
 
@@ -441,6 +447,7 @@ func (client AccountsClient) ListKeys(resourceGroupName string, accountName stri
 
 	resp, err := client.ListKeysSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "ListKeys", "Failure sending request")
 	}
 
@@ -507,6 +514,7 @@ func (client AccountsClient) RegenerateKey(resourceGroupName string, accountName
 
 	resp, err := client.RegenerateKeySender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "RegenerateKey", "Failure sending request")
 	}
 
@@ -583,6 +591,7 @@ func (client AccountsClient) Update(resourceGroupName string, accountName string
 
 	resp, err := client.UpdateSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "Update", "Failure sending request")
 	}
 

--- a/arm/storage/usageoperations.go
+++ b/arm/storage/usageoperations.go
@@ -52,6 +52,7 @@ func (client UsageOperationsClient) List() (result UsageListResult, ae error) {
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "storage/UsageOperationsClient", "List", "Failure sending request")
 	}
 

--- a/arm/storage/version.go
+++ b/arm/storage/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/arm/subscriptions/client.go
+++ b/arm/subscriptions/client.go
@@ -64,6 +64,7 @@ func (client ManagementClient) Get(subscriptionID string) (result Subscription, 
 
 	resp, err := client.GetSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "Get", "Failure sending request")
 	}
 
@@ -122,6 +123,7 @@ func (client ManagementClient) List() (result ListResult, ae error) {
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "List", "Failure sending request")
 	}
 
@@ -183,6 +185,7 @@ func (client ManagementClient) ListNextResults(lastResults ListResult) (result L
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "subscriptions/ManagementClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/subscriptions/tenants.go
+++ b/arm/subscriptions/tenants.go
@@ -49,6 +49,7 @@ func (client TenantsClient) List() (result TenantListResult, ae error) {
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "subscriptions/TenantsClient", "List", "Failure sending request")
 	}
 
@@ -110,6 +111,7 @@ func (client TenantsClient) ListNextResults(lastResults TenantListResult) (resul
 
 	resp, err := client.ListSender(req)
 	if err != nil {
+		result.Response = autorest.Response{Response: resp}
 		return result, autorest.NewErrorWithError(err, "subscriptions/TenantsClient", "List", "Failure sending next results request request")
 	}
 

--- a/arm/subscriptions/version.go
+++ b/arm/subscriptions/version.go
@@ -25,11 +25,11 @@ import (
 const (
 	major = "0"
 	minor = "1"
-	patch = "0"
+	patch = "1"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package/%s;API/%s"
+	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.


### PR DESCRIPTION
This change:

- Improves the UserAgent string to disambiguate arm packages from others in the SDK
- Improves setting the http.Response into generated results (reduces likelihood of a nil reference)
- Adds gofmt, golint, and govet to Travis CI for the arm packages

Signed-off-by: Brendan Dixon <brendand@microsoft.com>