### PR TITLE
Adding AddRole method so that this bug can be fixed: #3568

### DIFF
--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -62,6 +62,7 @@ func (vm VirtualMachineClient) CreateDeployment(
 	return vm.client.SendAzurePostRequest(requestURL, data)
 }
 
+//https://msdn.microsoft.com/en-us/library/azure/ee460804.aspx
 func (vm VirtualMachineClient) GetDeployment(cloudServiceName, deploymentName string) (DeploymentResponse, error) {
 	var deployment DeploymentResponse
 	if cloudServiceName == "" {

--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -12,6 +12,7 @@ const (
 	azureDeploymentListURL   = "services/hostedservices/%s/deployments"
 	azureDeploymentURL       = "services/hostedservices/%s/deployments/%s"
 	deleteAzureDeploymentURL = "services/hostedservices/%s/deployments/%s?comp=media"
+	azureAddRoleURL          = "services/hostedservices/%s/deployments/%s/roles"
 	azureRoleURL             = "services/hostedservices/%s/deployments/%s/roles/%s"
 	azureOperationsURL       = "services/hostedservices/%s/deployments/%s/roleinstances/%s/Operations"
 	azureRoleSizeListURL     = "rolesizes"
@@ -116,6 +117,25 @@ func (vm VirtualMachineClient) GetRole(cloudServiceName, deploymentName, roleNam
 	}
 
 	return role, nil
+}
+
+// AddRole adds a Virtual Machine to a deployment of Virtual Machines, where role name = VM name
+// See https://msdn.microsoft.com/en-us/library/azure/jj157186.aspx
+func (vm VirtualMachineClient) AddRole(cloudServiceName string, deploymentName string, role Role) (management.OperationID, error) {
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+	if deploymentName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "deploymentName")
+	}
+
+	data, err := xml.Marshal(PersistentVMRole{Role: role})
+	if err != nil {
+		return "", err
+	}
+
+	requestURL := fmt.Sprintf(azureAddRoleURL, cloudServiceName, deploymentName)
+	return vm.client.SendAzurePostRequest(requestURL, data)
 }
 
 // UpdateRole updates the configuration of the specified virtual machine


### PR DESCRIPTION
This is a pretty serious bug and limits what we can achieve with production grade deployments on Azure: https://github.com/hashicorp/terraform/issues/3568

As a first step to fix this bug, I propose that we add an "AddRole" method to azure-sdk-for-go for the virtualmachine client. This is a missing API now. Azure already has a REST API for this: https://msdn.microsoft.com/en-us/library/azure/jj157186.aspx

However, azure-sdk-for-go does not have a corresponding method that calls this REST API. Hence, we cannot add a new VM to an existing deployment or cloud service today.

Please accept this straightforward change. It is just the addition of a base method that is missing. Once accepted and merged, I plan to use it from terraform and fix the issue. Thanks again!

I have tested this method thoroughly.