### PR TITLE
Add query parameter to DeleteRole to delete disk based on boolean

### DIFF
--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -14,8 +14,7 @@ const (
 	azureListDeploymentsInSlotURL = "services/hostedservices/%s/deploymentslots/Production"
 	deleteAzureDeploymentURL = "services/hostedservices/%s/deployments/%s?comp=media"
 	azureAddRoleURL          = "services/hostedservices/%s/deployments/%s/roles"
-	azureRoleURLGetUpdate    = "services/hostedservices/%s/deployments/%s/roles/%s"
-	azureRoleURLDelete       = "services/hostedservices/%s/deployments/%s/roles/%s?comp=media"
+	azureRoleURL             = "services/hostedservices/%s/deployments/%s/roles/%s"
 	azureOperationsURL       = "services/hostedservices/%s/deployments/%s/roleinstances/%s/Operations"
 	azureRoleSizeListURL     = "rolesizes"
 
@@ -134,7 +133,7 @@ func (vm VirtualMachineClient) GetRole(cloudServiceName, deploymentName, roleNam
 
 	role := new(Role)
 
-	requestURL := fmt.Sprintf(azureRoleURLGetUpdate, cloudServiceName, deploymentName, roleName)
+	requestURL := fmt.Sprintf(azureRoleURL, cloudServiceName, deploymentName, roleName)
 	response, azureErr := vm.client.SendAzureGetRequest(requestURL)
 	if azureErr != nil {
 		return nil, azureErr
@@ -185,7 +184,7 @@ func (vm VirtualMachineClient) UpdateRole(cloudServiceName, deploymentName, role
 		return "", err
 	}
 
-	requestURL := fmt.Sprintf(azureRoleURLGetUpdate, cloudServiceName, deploymentName, roleName)
+	requestURL := fmt.Sprintf(azureRoleURL, cloudServiceName, deploymentName, roleName)
 	return vm.client.SendAzurePutRequest(requestURL, "text/xml", data)
 }
 
@@ -255,7 +254,7 @@ func (vm VirtualMachineClient) RestartRole(cloudServiceName, deploymentName, rol
 	return vm.client.SendAzurePostRequest(requestURL, restartRoleOperationBytes)
 }
 
-func (vm VirtualMachineClient) DeleteRole(cloudServiceName, deploymentName, roleName string) (management.OperationID, error) {
+func (vm VirtualMachineClient) DeleteRole(cloudServiceName, deploymentName, roleName string, deleteVHD bool) (management.OperationID, error) {
 	if cloudServiceName == "" {
 		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
 	}
@@ -266,7 +265,10 @@ func (vm VirtualMachineClient) DeleteRole(cloudServiceName, deploymentName, role
 		return "", fmt.Errorf(errParamNotSpecified, "roleName")
 	}
 
-	requestURL := fmt.Sprintf(azureRoleURLDelete, cloudServiceName, deploymentName, roleName)
+	requestURL := fmt.Sprintf(azureRoleURL, cloudServiceName, deploymentName, roleName)
+	if deleteVHD {
+		requestURL += "?comp=media"
+	}
 	return vm.client.SendAzureDeleteRequest(requestURL)
 }
 

--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -14,7 +14,8 @@ const (
 	azureListDeploymentsInSlotURL = "services/hostedservices/%s/deploymentslots/Production"
 	deleteAzureDeploymentURL = "services/hostedservices/%s/deployments/%s?comp=media"
 	azureAddRoleURL          = "services/hostedservices/%s/deployments/%s/roles"
-	azureRoleURL             = "services/hostedservices/%s/deployments/%s/roles/%s"
+	azureRoleURLGetUpdate    = "services/hostedservices/%s/deployments/%s/roles/%s"
+	azureRoleURLDelete       = "services/hostedservices/%s/deployments/%s/roles/%s?comp=media"
 	azureOperationsURL       = "services/hostedservices/%s/deployments/%s/roleinstances/%s/Operations"
 	azureRoleSizeListURL     = "rolesizes"
 
@@ -133,7 +134,7 @@ func (vm VirtualMachineClient) GetRole(cloudServiceName, deploymentName, roleNam
 
 	role := new(Role)
 
-	requestURL := fmt.Sprintf(azureRoleURL, cloudServiceName, deploymentName, roleName)
+	requestURL := fmt.Sprintf(azureRoleURLGetUpdate, cloudServiceName, deploymentName, roleName)
 	response, azureErr := vm.client.SendAzureGetRequest(requestURL)
 	if azureErr != nil {
 		return nil, azureErr
@@ -184,7 +185,7 @@ func (vm VirtualMachineClient) UpdateRole(cloudServiceName, deploymentName, role
 		return "", err
 	}
 
-	requestURL := fmt.Sprintf(azureRoleURL, cloudServiceName, deploymentName, roleName)
+	requestURL := fmt.Sprintf(azureRoleURLGetUpdate, cloudServiceName, deploymentName, roleName)
 	return vm.client.SendAzurePutRequest(requestURL, "text/xml", data)
 }
 
@@ -265,7 +266,7 @@ func (vm VirtualMachineClient) DeleteRole(cloudServiceName, deploymentName, role
 		return "", fmt.Errorf(errParamNotSpecified, "roleName")
 	}
 
-	requestURL := fmt.Sprintf(azureRoleURL, cloudServiceName, deploymentName, roleName)
+	requestURL := fmt.Sprintf(azureRoleURLDelete, cloudServiceName, deploymentName, roleName)
 	return vm.client.SendAzureDeleteRequest(requestURL)
 }
 


### PR DESCRIPTION
DeleteRole REST API (used to destroy a VM) needs a query parameter to also delete the VHD disk from storage while deleting the VM. This parameter is "comp=media". Documentation is here: https://msdn.microsoft.com/en-us/library/azure/jj157184.aspx

Without this parameter, the DeleteRole() method would only delete the VM but not the disk, thereby leaking storage dollars. Added the parameter, but made it effective only if the boolean argument is true. Thanks.

Context: I am trying to fix hashicorp/terraform#3568. In other words, I am adding the capability to manage multiple VM-s under the same Cloud Service to Terraform. Once this capability is there, we will have to also be able to destroy one VM at a time. As of now, terraform takes the shortcut of deleting the entire cloud service when deleting a VM. That works today as all terraform supports is one VM per cloud service. Hence DeleteRole() method is not called, DeleteDeployment() is called directly. But as part of the fix, I must start calling DeleteRole() to remove individual VM-s. Thus, DeleteRole() must work correctly. Hence this code change. Thanks
