### PR TITLE
Add encrypted storage key for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  secure: "FFgOmjPVglBgZPUeDjPXWs0HTjNOSjLDuTjrOS156z49oa/JtY28eSDZTtUwTW/Mw9pTGkVc0BtaMdDRI+MTZh30rOOEtFJrjF1y5HhCkw6+s0L2SAOZEoUviJTD/+wqtE7ZNYGRnMJ9svu437IXQTtsxmQjMcwmVOmQBNwP+0c="
+
 sudo: false
 
 language: go


### PR DESCRIPTION
We are currently leaking our storage key on Travis.

This commit adds the secondary storage key to the .travis.yml file in an encrypted format (encrypted with the public portion of a key pair Travis creates for our repo; they keep the private key).

Travis smartly prevents pull requests from receiving encrypted data. Otherwise Jane Schmane could send a PR that just reads the environment variable and POSTs it to her server.

This means that storage tests will always fail for PRs. Or, it means we disable storage tests in that scenario on pull requests (Travis gives us an env variable for pull requests). That option makes me quite nervous, because it means that Travis is no longer 100% authoritative on whether or not the commit is safe to merge. Green on Travis for a PR would no longer mean "100% test pass", it would mean "100% test pass except storage tests which may or may not pass".

I'm trying to find out if there's a way to tell Travis that it's okay to give the credential out. This is a pattern I've seen on larger repos. PRs aren't automatically built, but rather they wait until a Collaborator comes along and leaves a comment that a bot reads and then submits the CI build. It would be smart of Travis to give us Collaborators a way of saying "Travis, please retest this with the encrypted environment variables now that I've code reviewed this for obvious malicious intent.

I have a support ticket open with Travis to try to understand what our options are.