### PR TITLE
[storage] Don't hide 404 status codes in an opaque error

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -325,7 +325,7 @@ func (c Client) exec(verb, url string, headers map[string]string, body io.Reader
 	}
 
 	statusCode := resp.StatusCode
-	if statusCode >= 400 && statusCode <= 505 {
+	if statusCode >= 400 && statusCode <= 505 && statusCode != 404 {
 		var respBody []byte
 		respBody, err = readResponseBody(resp)
 		if err != nil {


### PR DESCRIPTION
404 errors from the storage API don't provide message bodies, so don't hide these inside an opaque fmt.Errorf()