### PR TITLE
Add support of PostShudownAction for shutdown vm

### DIFF
--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -209,7 +209,7 @@ func (vm VirtualMachineClient) StartRole(cloudServiceName, deploymentName, roleN
 	return vm.client.SendAzurePostRequest(requestURL, startRoleOperationBytes)
 }
 
-func (vm VirtualMachineClient) ShutdownRole(cloudServiceName, deploymentName, roleName string) (management.OperationID, error) {
+func (vm VirtualMachineClient) ShutdownRole(cloudServiceName, deploymentName, roleName string, postactions ...PostShutdownAction) (management.OperationID, error) {
 	if cloudServiceName == "" {
 		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
 	}
@@ -219,9 +219,16 @@ func (vm VirtualMachineClient) ShutdownRole(cloudServiceName, deploymentName, ro
 	if roleName == "" {
 		return "", fmt.Errorf(errParamNotSpecified, "roleName")
 	}
+	var postaction PostShutdownAction
+	if len(postactions) == 0 {
+		postaction = PostShutdownActionStopped
+	} else {
+		postaction = postactions[0]
+	}
 
 	shutdownRoleOperationBytes, err := xml.Marshal(ShutdownRoleOperation{
-		OperationType: "ShutdownRoleOperation",
+		OperationType:      "ShutdownRoleOperation",
+		PostShutdownAction: postaction,
 	})
 	if err != nil {
 		return "", err

--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -209,7 +209,7 @@ func (vm VirtualMachineClient) StartRole(cloudServiceName, deploymentName, roleN
 	return vm.client.SendAzurePostRequest(requestURL, startRoleOperationBytes)
 }
 
-func (vm VirtualMachineClient) ShutdownRole(cloudServiceName, deploymentName, roleName string, postactions ...PostShutdownAction) (management.OperationID, error) {
+func (vm VirtualMachineClient) ShutdownRole(cloudServiceName, deploymentName, roleName string, postaction PostShutdownAction) (management.OperationID, error) {
 	if cloudServiceName == "" {
 		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
 	}
@@ -218,12 +218,6 @@ func (vm VirtualMachineClient) ShutdownRole(cloudServiceName, deploymentName, ro
 	}
 	if roleName == "" {
 		return "", fmt.Errorf(errParamNotSpecified, "roleName")
-	}
-	var postaction PostShutdownAction
-	if len(postactions) == 0 {
-		postaction = PostShutdownActionStopped
-	} else {
-		postaction = postactions[0]
 	}
 
 	shutdownRoleOperationBytes, err := xml.Marshal(ShutdownRoleOperation{

--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -468,10 +468,19 @@ type StartRoleOperation struct {
 	OperationType string
 }
 
+type PostShutdownAction string
+
+// Enum values for PostShutdownAction
+const (
+	PostShutdownActionStopped            PostShutdownAction = "Stopped"
+	PostShutdownActionStoppedDeallocated PostShutdownAction = "StoppedDeallocated"
+)
+
 // ShutdownRoleOperation contains the information for shutting down a Role.
 type ShutdownRoleOperation struct {
-	XMLName       xml.Name `xml:"http://schemas.microsoft.com/windowsazure ShutdownRoleOperation"`
-	OperationType string
+	XMLName            xml.Name `xml:"http://schemas.microsoft.com/windowsazure ShutdownRoleOperation"`
+	OperationType      string
+	PostShutdownAction PostShutdownAction
 }
 
 // RestartRoleOperation contains the information for restarting a Role.

--- a/management/vmutils/integration_test.go
+++ b/management/vmutils/integration_test.go
@@ -92,7 +92,7 @@ func TestDeployPlatformOSImageCaptureRedeploy(t *testing.T) {
 
 	t.Logf("Shutting down VM: %s", vmname)
 	if err := Await(client, func() (management.OperationID, error) {
-		return vmc.ShutdownRole(vmname, vmname, vmname)
+		return vmc.ShutdownRole(vmname, vmname, vmname, vm.PostShutdownActionStopped)
 	}); err != nil {
 		t.Error(err)
 	}
@@ -162,7 +162,7 @@ func TestDeployPlatformVMImageCaptureRedeploy(t *testing.T) {
 
 	t.Logf("Shutting down VM: %s", vmname)
 	if err := Await(client, func() (management.OperationID, error) {
-		return vmc.ShutdownRole(vmname, vmname, vmname)
+		return vmc.ShutdownRole(vmname, vmname, vmname, vm.PostShutdownActionStopped)
 	}); err != nil {
 		t.Error(err)
 	}
@@ -235,7 +235,7 @@ func TestRoleStateOperations(t *testing.T) {
 
 	vmc := vm.NewClient(client)
 	if err := Await(client, func() (management.OperationID, error) {
-		return vmc.ShutdownRole(vmname, vmname, vmname)
+		return vmc.ShutdownRole(vmname, vmname, vmname, vm.PostShutdownActionStopped)
 	}); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
The implementation of Shutdown Role is incomplete: https://msdn.microsoft.com/en-us/library/azure/jj157195.aspx

The parameter PostShudownAction was not implemented