### PR TITLE
add support for extra headers in AppendBlock

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -835,7 +835,7 @@ func (b BlobStorageClient) AppendBlock(container, name string, chunk []byte, ext
 	for k, v := range extraHeaders {
 		headers[k] = v
 	}
-	
+
 	resp, err := b.client.exec("PUT", uri, headers, bytes.NewReader(chunk))
 	if err != nil {
 		return err

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -825,13 +825,17 @@ func (b BlobStorageClient) PutAppendBlob(container, name string, extraHeaders ma
 // AppendBlock appends a block to an append blob.
 //
 // See https://msdn.microsoft.com/en-us/library/azure/mt427365.aspx
-func (b BlobStorageClient) AppendBlock(container, name string, chunk []byte) error {
+func (b BlobStorageClient) AppendBlock(container, name string, chunk []byte, extraHeaders map[string]string) error {
 	path := fmt.Sprintf("%s/%s", container, name)
 	uri := b.client.getEndpoint(blobServiceName, path, url.Values{"comp": {"appendblock"}})
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-blob-type"] = string(BlobTypeAppend)
 	headers["Content-Length"] = fmt.Sprintf("%v", len(chunk))
 
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
+	
 	resp, err := b.client.exec("PUT", uri, headers, bytes.NewReader(chunk))
 	if err != nil {
 		return err

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -682,7 +682,7 @@ func (s *StorageBlobSuite) TestPutAppendBlobAppendBlocks(c *chk.C) {
 	chunk2 := []byte(randString(512))
 
 	// Append first block
-	c.Assert(cli.AppendBlock(cnt, blob, chunk1), chk.IsNil)
+	c.Assert(cli.AppendBlock(cnt, blob, chunk1, nil), chk.IsNil)
 
 	// Verify contents
 	out, err := cli.GetBlobRange(cnt, blob, fmt.Sprintf("%v-%v", 0, len(chunk1)-1))
@@ -694,7 +694,7 @@ func (s *StorageBlobSuite) TestPutAppendBlobAppendBlocks(c *chk.C) {
 	out.Close()
 
 	// Append second block
-	c.Assert(cli.AppendBlock(cnt, blob, chunk2), chk.IsNil)
+	c.Assert(cli.AppendBlock(cnt, blob, chunk2, nil), chk.IsNil)
 
 	// Verify contents
 	out, err = cli.GetBlobRange(cnt, blob, fmt.Sprintf("%v-%v", 0, len(chunk1)+len(chunk2)-1))


### PR DESCRIPTION
A couple line difference. Implementation copied from other functions in the same file. Tested locally.