### PR TITLE
Allow caller to provide headers for DeleteBlob methods.

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -914,8 +914,8 @@ func (b BlobStorageClient) waitForBlobCopy(container, name, copyID string) error
 // DeleteBlob deletes the given blob from the specified container.
 // If the blob does not exists at the time of the Delete Blob operation, it
 // returns error. See https://msdn.microsoft.com/en-us/library/azure/dd179413.aspx
-func (b BlobStorageClient) DeleteBlob(container, name string) error {
-	resp, err := b.deleteBlob(container, name)
+func (b BlobStorageClient) DeleteBlob(container, name string, extraHeaders map[string]string) error {
+	resp, err := b.deleteBlob(container, name, extraHeaders)
 	if err != nil {
 		return err
 	}
@@ -927,8 +927,8 @@ func (b BlobStorageClient) DeleteBlob(container, name string) error {
 // blob is deleted with this call, returns true. Otherwise returns false.
 //
 // See https://msdn.microsoft.com/en-us/library/azure/dd179413.aspx
-func (b BlobStorageClient) DeleteBlobIfExists(container, name string) (bool, error) {
-	resp, err := b.deleteBlob(container, name)
+func (b BlobStorageClient) DeleteBlobIfExists(container, name string, extraHeaders map[string]string) (bool, error) {
+	resp, err := b.deleteBlob(container, name, extraHeaders)
 	if resp != nil && (resp.statusCode == http.StatusAccepted || resp.statusCode == http.StatusNotFound) {
 		return resp.statusCode == http.StatusAccepted, nil
 	}
@@ -936,10 +936,13 @@ func (b BlobStorageClient) DeleteBlobIfExists(container, name string) (bool, err
 	return false, err
 }
 
-func (b BlobStorageClient) deleteBlob(container, name string) (*storageResponse, error) {
+func (b BlobStorageClient) deleteBlob(container, name string, extraHeaders map[string]string) (*storageResponse, error) {
 	verb := "DELETE"
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 	headers := b.client.getStandardHeaders()
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
 
 	return b.client.exec(verb, uri, headers, nil)
 }

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -314,32 +314,6 @@ func (s *StorageBlobSuite) TestDeleteBlobWithConditions(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	_, err = cli.GetBlob(cnt, blob)
 	c.Assert(err, chk.Not(chk.IsNil))
-
-	// Create a non-empty blob and set metadata in the hopes of
-	// triggering a "modified" event that will make an
-	// If-Unmodified-Since request give us a 412.
-	c.Assert(cli.CreateBlockBlobFromReader(cnt, blob, 1, bytes.NewReader([]byte{'-'}), nil), chk.IsNil)
-	c.Assert(cli.SetBlobMetadata(cnt, blob, map[string]string{"foo": "bar"}), chk.IsNil)
-
-	if false {
-		// "Delete if unmodified for 2 weeks" should fail
-		// without deleting (but this header seems to be
-		// ignored).
-		err = cli.DeleteBlob(cnt, blob, map[string]string{
-			"If-Unmodified-Since": time.Now().AddDate(0, 0, -14).Format(time.RFC1123),
-		})
-		c.Assert(err, chk.FitsTypeOf, UnexpectedStatusCodeError{})
-		c.Assert(err.(UnexpectedStatusCodeError).Got(), chk.Equals, http.StatusPreconditionFailed)
-		_, err = cli.GetBlob(cnt, blob)
-		c.Assert(err, chk.IsNil)
-	}
-
-	// "Delete if modified in the last 2 weeks" should succeed and delete
-	c.Assert(cli.DeleteBlob(cnt, blob, map[string]string{
-		"If-Modified-Since": time.Now().AddDate(0, 0, -14).Format(time.RFC1123),
-	}), chk.IsNil)
-	_, err = cli.GetBlob(cnt, blob)
-	c.Assert(err, chk.Not(chk.IsNil))
 }
 
 func (s *StorageBlobSuite) TestGetBlobProperties(c *chk.C) {


### PR DESCRIPTION
Same change as #257 (and other recent changes) ... but for DeleteBlob and DeleteBlobIfExists.