### PR TITLE
storage: Add BlobPrefixes and Delimiter to BlobListResponse

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -88,6 +88,16 @@ type BlobListResponse struct {
 	NextMarker string   `xml:"NextMarker"`
 	MaxResults int64    `xml:"MaxResults"`
 	Blobs      []Blob   `xml:"Blobs>Blob"`
+
+	// BlobPrefix is used to traverse blobs as if it were a file system.
+	// It is returned if ListBlobsParameters.Delimiter is specified.
+	// The list here can be thought of as "folders" that may contain
+	// other folders or blobs.
+	BlobPrefixes []string `xml:"Blobs>BlobPrefix>Name"`
+
+	// Delimiter is used to traverse blobs as if it were a file system.
+	// It is returned if ListBlobsParameters.Delimiter is specified.
+	Delimiter string `xml:"Delimiter"`
 }
 
 // ListContainersParameters defines the set of customizable parameters to make a


### PR DESCRIPTION
Per the MSDN docs, BlobPrefixes and Delimiter would be required in BlobListResponse in order to traverse the blob storage as if it were a file system.

As with this example:

```
func traveseBlobs(client storage.BlobStorageClient, prefix string, depth int) {
	blobParams := storage.ListBlobsParameters{
		Delimiter: "/",
		Prefix:    prefix,
	}

	response, err := client.ListBlobs(accountContainer, blobParams)
	checkError(err)

	pad := strings.Repeat(" ", depth*2)

	// Print folders
	folders := response.BlobPrefixes
	for _, folder := range folders {
		folderWithoutParent := strings.TrimPrefix(folder, prefix)
		fmt.Printf("%sd %s\n", pad, folderWithoutParent)
		traveseBlobs(client, folder, depth+1)
	}

	// Print blob names
	blobs := response.Blobs
	for _, blob := range blobs {
		blobWithoutParent := strings.TrimPrefix(blob.Name, prefix)
		fmt.Printf("%s- %s\n", pad, blobWithoutParent)
	}
}
```

This would produce (with correct blobs in storage):

```
d root/
  d folderA/
    - fileAA.txt
    - fileAB.txt
    - fileAC.txt
  d folderB/
    d subfolderC/
      - fileBCA.txt
    - fileBA.txt
    - fileBB.txt
    - fileBC.txt
d some_folder/
  d some_subfolder/
    - xxx.txt
  - bar.txt
```