### PR TITLE
GetBlobSASURI: set expiry location to UTC

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -981,7 +981,7 @@ func (b BlobStorageClient) GetBlobSASURI(container, name string, expiry time.Tim
 	if err != nil {
 		return "", err
 	}
-	signedExpiry := expiry.Format(time.RFC3339)
+	signedExpiry := expiry.UTC().Format(time.RFC3339)
 	signedResource := "b"
 
 	stringToSign, err := blobSASStringToSign(b.client.apiVersion, canonicalizedResource, signedExpiry, signedPermissions)


### PR DESCRIPTION
GetBlobSASURI: set expiry location to UTC to meet formatting requirements of Shared Access …

https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/