### PR TITLE
Updating to correct scope in NewServicePrincipalTokenFromCredentials

### DIFF
--- a/arm/README.md
+++ b/arm/README.md
@@ -118,7 +118,7 @@ func checkName(name string) {
 
   ac := storage.NewAccountsClient(c["subscriptionID"])
 
-  spt, err := helpers.NewServicePrincipalTokenFromCredentials(c, azure.AzureResourceManagerScope)
+  spt, err := helpers.NewServicePrincipalTokenFromCredentials(c, azure.PublicCloud.ResourceManagerEndpoint)
   if err != nil {
     log.Fatalf("Error: %v", err)
   }


### PR DESCRIPTION
azure.AzureResourceManagerScope is not recognized as it looks like it has evolved to azure.PublicCloud.ResourceManagerEndpoint