### PR TITLE
Expose the public IP address of virtual machines

### DIFF
--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -451,6 +451,7 @@ const (
 // virtual IP address for the Virtual Machine.
 type PublicIP struct {
 	Name                 string // Specifies the name of the public IP address.
+	Address              string // Specifies the IP address.
 	IdleTimeoutInMinutes int    `xml:",omitempty"` // Specifies the timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to TCP.
 }
 


### PR DESCRIPTION
The public IP name and timeout were provided, but there was no way to
get the actual address.