### PR TITLE
Adding LeaseStatus to storage.BlobProperties

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -119,6 +119,7 @@ type BlobProperties struct {
 	CopyProgress          string   `xml:"CopyProgress"`
 	CopyCompletionTime    string   `xml:"CopyCompletionTime"`
 	CopyStatusDescription string   `xml:"CopyStatusDescription"`
+	LeaseStatus           string   `xml:"x-ms-lease-status"`
 }
 
 // BlobListResponse contains the response fields from ListBlobs call.
@@ -597,6 +598,7 @@ func (b BlobStorageClient) GetBlobProperties(container, name string) (*BlobPrope
 		CopySource:            resp.headers.Get("x-ms-copy-source"),
 		CopyStatus:            resp.headers.Get("x-ms-copy-status"),
 		BlobType:              BlobType(resp.headers.Get("x-ms-blob-type")),
+		LeaseStatus:           resp.headers.Get("x-ms-lease-status"),
 	}, nil
 }
 

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -119,7 +119,7 @@ type BlobProperties struct {
 	CopyProgress          string   `xml:"CopyProgress"`
 	CopyCompletionTime    string   `xml:"CopyCompletionTime"`
 	CopyStatusDescription string   `xml:"CopyStatusDescription"`
-	LeaseStatus           string   `xml:"x-ms-lease-status"`
+	LeaseStatus           string   `xml:"LeaseStatus"`
 }
 
 // BlobListResponse contains the response fields from ListBlobs call.


### PR DESCRIPTION
Particularly in case of a Page Blob, this property is useful in determining if the VHD is being used by a VM or not.

Tracking this enhancement as issue - #335 