### PR TITLE
storage: friendlier error for malformed key

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -132,7 +132,7 @@ func NewClient(accountName, accountKey, blobServiceBaseURL, apiVersion string, u
 
 	key, err := base64.StdEncoding.DecodeString(accountKey)
 	if err != nil {
-		return c, err
+		return c, fmt.Errorf("azure: malformed storage account key: %v", err)
 	}
 
 	return Client{

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -31,6 +31,11 @@ func getBasicClient(c *chk.C) Client {
 	return cli
 }
 
+func (s *StorageClientSuite) TestMalformedKeyError(c *chk.C) {
+	_, err := NewBasicClient("foo", "malformed")
+	c.Assert(err, chk.ErrorMatches, "azure: malformed storage account key: .*")
+}
+
 func (s *StorageClientSuite) TestGetBaseURL_Basic_Https(c *chk.C) {
 	cli, err := NewBasicClient("foo", "YmFy")
 	c.Assert(err, chk.IsNil)


### PR DESCRIPTION
This returns a better error message for malformed base64 storage account keys.

Fixes #344.
