### PR TITLE
Add support for blobs with spaces (and other special URL characters) in the name

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -1042,6 +1042,9 @@ func (b BlobStorageClient) GetBlobSASURI(container, name string, expiry time.Tim
 	// later, the storage account name, and the resource name, and must be URL-decoded.
 	// -- https://msdn.microsoft.com/en-us/library/azure/dn140255.aspx
 
+	// We need to replace + with %2b first to avoid being treated as a space (which is correct for query strings, but not the path component).
+	canonicalizedResource = strings.Replace(canonicalizedResource, "+", "%2b", -1)
+
 	canonicalizedResource, err = url.QueryUnescape(canonicalizedResource)
 	if err != nil {
 		return "", err

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -74,7 +74,7 @@ func (s *StorageBlobSuite) TestGetBlobSASURI(c *chk.C) {
 func (s *StorageBlobSuite) TestBlobSASURICorrectness(c *chk.C) {
 	cli := getBlobClient(c)
 	cnt := randContainer()
-	blob := randName(5)
+	blob := randNameWithSpecialChars(5)
 	body := []byte(randString(100))
 	expiry := time.Now().UTC().Add(time.Hour)
 	permissions := "r"
@@ -998,6 +998,49 @@ func (b BlobStorageClient) putSingleBlockBlob(container, name string, chunk []by
 	return checkRespCode(resp.statusCode, []int{http.StatusCreated})
 }
 
+func (s *StorageBlobSuite) TestPutAppendBlobSpecialChars(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randNameWithSpecialChars(5)
+	c.Assert(cli.PutAppendBlob(cnt, blob, nil), chk.IsNil)
+
+	// Verify metadata
+	props, err := cli.GetBlobProperties(cnt, blob)
+	c.Assert(err, chk.IsNil)
+	c.Assert(props.ContentLength, chk.Equals, int64(0))
+	c.Assert(props.BlobType, chk.Equals, BlobTypeAppend)
+
+	chunk1 := []byte(randString(1024))
+	chunk2 := []byte(randString(512))
+
+	// Append first block
+	c.Assert(cli.AppendBlock(cnt, blob, chunk1, nil), chk.IsNil)
+
+	// Verify contents
+	out, err := cli.GetBlobRange(cnt, blob, fmt.Sprintf("%v-%v", 0, len(chunk1)-1), nil)
+	c.Assert(err, chk.IsNil)
+	defer out.Close()
+	blobContents, err := ioutil.ReadAll(out)
+	c.Assert(err, chk.IsNil)
+	c.Assert(blobContents, chk.DeepEquals, chunk1)
+	out.Close()
+
+	// Append second block
+	c.Assert(cli.AppendBlock(cnt, blob, chunk2, nil), chk.IsNil)
+
+	// Verify contents
+	out, err = cli.GetBlobRange(cnt, blob, fmt.Sprintf("%v-%v", 0, len(chunk1)+len(chunk2)-1), nil)
+	c.Assert(err, chk.IsNil)
+	defer out.Close()
+	blobContents, err = ioutil.ReadAll(out)
+	c.Assert(err, chk.IsNil)
+	c.Assert(blobContents, chk.DeepEquals, append(chunk1, chunk2...))
+	out.Close()
+}
+
 func randContainer() string {
 	return testContainerPrefix + randString(32-len(testContainerPrefix))
 }
@@ -1024,6 +1067,11 @@ func randBytes(n int) []byte {
 }
 
 func randName(n int) string {
-	name := randString(n) + "/" + randString(n) + "-._~:?#[]@!$&'()*,;= " + randString(n)
+	name := randString(n) + "/" + randString(n)
+	return name
+}
+
+func randNameWithSpecialChars(n int) string {
+	name := randString(n) + "/" + randString(n) + "-._~:?#[]@!$&'()*,;+= " + randString(n)
 	return name
 }

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -74,7 +74,7 @@ func (s *StorageBlobSuite) TestGetBlobSASURI(c *chk.C) {
 func (s *StorageBlobSuite) TestBlobSASURICorrectness(c *chk.C) {
 	cli := getBlobClient(c)
 	cnt := randContainer()
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	body := []byte(randString(100))
 	expiry := time.Now().UTC().Add(time.Hour)
 	permissions := "r"
@@ -213,7 +213,7 @@ func (s *StorageBlobSuite) TestDeleteContainerIfExists(c *chk.C) {
 
 func (s *StorageBlobSuite) TestBlobExists(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	cli := getBlobClient(c)
 
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypeBlob), chk.IsNil)
@@ -247,8 +247,8 @@ func (s *StorageBlobSuite) TestBlobCopy(c *chk.C) {
 
 	cli := getBlobClient(c)
 	cnt := randContainer()
-	src := randString(5) + "/" + randString(5) + " " + randString(10)
-	dst := randString(5) + "/" + randString(5) + " " + randString(10)
+	src := randName(5)
+	dst := randName(5)
 	body := []byte(randString(1024))
 
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
@@ -271,7 +271,7 @@ func (s *StorageBlobSuite) TestBlobCopy(c *chk.C) {
 
 func (s *StorageBlobSuite) TestDeleteBlobIfExists(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 
 	cli := getBlobClient(c)
 	c.Assert(cli.DeleteBlob(cnt, blob, nil), chk.NotNil)
@@ -283,7 +283,7 @@ func (s *StorageBlobSuite) TestDeleteBlobIfExists(c *chk.C) {
 
 func (s *StorageBlobSuite) TestDeleteBlobWithConditions(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 
 	cli := getBlobClient(c)
 
@@ -319,7 +319,7 @@ func (s *StorageBlobSuite) TestDeleteBlobWithConditions(c *chk.C) {
 
 func (s *StorageBlobSuite) TestGetBlobProperties(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	contents := randString(64)
 
 	cli := getBlobClient(c)
@@ -352,7 +352,7 @@ func (s *StorageBlobSuite) TestListBlobsPagination(c *chk.C) {
 	const n = 5
 	const pageSize = 2
 	for i := 0; i < n; i++ {
-		name := randString(5) + "/" + randString(5) + " " + randString(10)
+		name := randName(5)
 		c.Assert(cli.putSingleBlockBlob(cnt, name, []byte("Hello, world!")), chk.IsNil)
 		blobs = append(blobs, name)
 	}
@@ -521,7 +521,7 @@ func (s *StorageBlobSuite) TestListBlobsWithMetadata(c *chk.C) {
 
 	// Put 4 blobs with metadata
 	for i := 0; i < 4; i++ {
-		name := randString(5) + "/" + randString(5) + " " + randString(10)
+		name := randName(5)
 		c.Assert(cli.putSingleBlockBlob(cnt, name, []byte("Hello, world!")), chk.IsNil)
 		c.Assert(cli.SetBlobMetadata(cnt, name, map[string]string{
 			"Foo":     name,
@@ -534,7 +534,7 @@ func (s *StorageBlobSuite) TestListBlobsWithMetadata(c *chk.C) {
 	}
 
 	// Put one more blob with no metadata
-	blobWithoutMetadata := randString(5) + "/" + randString(5) + " " + randString(10)
+	blobWithoutMetadata := randName(5)
 	c.Assert(cli.putSingleBlockBlob(cnt, blobWithoutMetadata, []byte("Hello, world!")), chk.IsNil)
 	expectMeta[blobWithoutMetadata] = nil
 
@@ -559,7 +559,7 @@ func (s *StorageBlobSuite) TestListBlobsWithMetadata(c *chk.C) {
 // metadata, e.g., for a stub server.
 func (s *StorageBlobSuite) TestMarshalBlobMetadata(c *chk.C) {
 	buf, err := xml.Marshal(Blob{
-		Name:       randString(5) + "/" + randString(5) + " " + randString(10),
+		Name:       randName(5),
 		Properties: BlobProperties{},
 		Metadata:   BlobMetadata{"foo": "baz < waz"},
 	})
@@ -574,7 +574,7 @@ func (s *StorageBlobSuite) TestGetAndSetMetadata(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
 
 	m, err := cli.GetBlobMetadata(cnt, blob)
@@ -620,7 +620,7 @@ func (s *StorageBlobSuite) TestSetMetadataWithExtraHeaders(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
 
 	mPut := map[string]string{
@@ -653,7 +653,7 @@ func (s *StorageBlobSuite) TestPutEmptyBlockBlob(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
 
 	props, err := cli.GetBlobProperties(cnt, blob)
@@ -663,7 +663,7 @@ func (s *StorageBlobSuite) TestPutEmptyBlockBlob(c *chk.C) {
 
 func (s *StorageBlobSuite) TestGetBlobRange(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	body := "0123456789"
 
 	cli := getBlobClient(c)
@@ -698,7 +698,7 @@ func (s *StorageBlobSuite) TestCreateBlockBlobFromReader(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	name := randString(5) + "/" + randString(5) + " " + randString(10)
+	name := randName(5)
 	data := randBytes(8888)
 	c.Assert(cli.CreateBlockBlobFromReader(cnt, name, uint64(len(data)), bytes.NewReader(data), nil), chk.IsNil)
 
@@ -717,7 +717,7 @@ func (s *StorageBlobSuite) TestCreateBlockBlobFromReaderWithShortData(c *chk.C) 
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	name := randString(5) + "/" + randString(5) + " " + randString(10)
+	name := randName(5)
 	data := randBytes(8888)
 	err := cli.CreateBlockBlobFromReader(cnt, name, 9999, bytes.NewReader(data), nil)
 	c.Assert(err, chk.Not(chk.IsNil))
@@ -733,7 +733,7 @@ func (s *StorageBlobSuite) TestPutBlock(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	chunk := []byte(randString(1024))
 	blockID := base64.StdEncoding.EncodeToString([]byte("foo"))
 	c.Assert(cli.PutBlock(cnt, blob, blockID, chunk), chk.IsNil)
@@ -745,7 +745,7 @@ func (s *StorageBlobSuite) TestGetBlockList_PutBlockList(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	chunk := []byte(randString(1024))
 	blockID := base64.StdEncoding.EncodeToString([]byte("foo"))
 
@@ -787,7 +787,7 @@ func (s *StorageBlobSuite) TestCreateBlockBlob(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	c.Assert(cli.CreateBlockBlob(cnt, blob), chk.IsNil)
 
 	// Verify
@@ -803,7 +803,7 @@ func (s *StorageBlobSuite) TestPutPageBlob(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	size := int64(10 * 1024 * 1024)
 	c.Assert(cli.PutPageBlob(cnt, blob, size, nil), chk.IsNil)
 
@@ -820,7 +820,7 @@ func (s *StorageBlobSuite) TestPutPagesUpdate(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	size := int64(10 * 1024 * 1024) // larger than we'll use
 	c.Assert(cli.PutPageBlob(cnt, blob, size, nil), chk.IsNil)
 
@@ -859,7 +859,7 @@ func (s *StorageBlobSuite) TestPutPagesClear(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	size := int64(10 * 1024 * 1024) // larger than we'll use
 	c.Assert(cli.PutPageBlob(cnt, blob, size, nil), chk.IsNil)
 
@@ -885,7 +885,7 @@ func (s *StorageBlobSuite) TestGetPageRanges(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	size := int64(10 * 1024 * 1024) // larger than we'll use
 	c.Assert(cli.PutPageBlob(cnt, blob, size, nil), chk.IsNil)
 
@@ -915,7 +915,7 @@ func (s *StorageBlobSuite) TestPutAppendBlob(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	c.Assert(cli.PutAppendBlob(cnt, blob, nil), chk.IsNil)
 
 	// Verify
@@ -931,7 +931,7 @@ func (s *StorageBlobSuite) TestPutAppendBlobAppendBlocks(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(5) + "/" + randString(5) + " " + randString(10)
+	blob := randName(5)
 	c.Assert(cli.PutAppendBlob(cnt, blob, nil), chk.IsNil)
 
 	chunk1 := []byte(randString(1024))
@@ -1021,4 +1021,9 @@ func randBytes(n int) []byte {
 		panic(err)
 	}
 	return data
+}
+
+func randName(n int) string {
+	name := randString(n) + "/" + randString(n) + "-._~:?#[]@!$&'()*,;= " + randString(n)
+	return name
 }

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -213,7 +213,7 @@ func (s *StorageBlobSuite) TestDeleteContainerIfExists(c *chk.C) {
 
 func (s *StorageBlobSuite) TestBlobExists(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	cli := getBlobClient(c)
 
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypeBlob), chk.IsNil)
@@ -247,8 +247,8 @@ func (s *StorageBlobSuite) TestBlobCopy(c *chk.C) {
 
 	cli := getBlobClient(c)
 	cnt := randContainer()
-	src := randString(20)
-	dst := randString(20)
+	src := randString(5) + "/" + randString(5) + " " + randString(10)
+	dst := randString(5) + "/" + randString(5) + " " + randString(10)
 	body := []byte(randString(1024))
 
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
@@ -271,7 +271,7 @@ func (s *StorageBlobSuite) TestBlobCopy(c *chk.C) {
 
 func (s *StorageBlobSuite) TestDeleteBlobIfExists(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 
 	cli := getBlobClient(c)
 	c.Assert(cli.DeleteBlob(cnt, blob, nil), chk.NotNil)
@@ -283,7 +283,7 @@ func (s *StorageBlobSuite) TestDeleteBlobIfExists(c *chk.C) {
 
 func (s *StorageBlobSuite) TestDeleteBlobWithConditions(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 
 	cli := getBlobClient(c)
 
@@ -319,7 +319,7 @@ func (s *StorageBlobSuite) TestDeleteBlobWithConditions(c *chk.C) {
 
 func (s *StorageBlobSuite) TestGetBlobProperties(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	contents := randString(64)
 
 	cli := getBlobClient(c)
@@ -352,7 +352,7 @@ func (s *StorageBlobSuite) TestListBlobsPagination(c *chk.C) {
 	const n = 5
 	const pageSize = 2
 	for i := 0; i < n; i++ {
-		name := randString(20)
+		name := randString(5) + "/" + randString(5) + " " + randString(10)
 		c.Assert(cli.putSingleBlockBlob(cnt, name, []byte("Hello, world!")), chk.IsNil)
 		blobs = append(blobs, name)
 	}
@@ -521,7 +521,7 @@ func (s *StorageBlobSuite) TestListBlobsWithMetadata(c *chk.C) {
 
 	// Put 4 blobs with metadata
 	for i := 0; i < 4; i++ {
-		name := randString(20)
+		name := randString(5) + "/" + randString(5) + " " + randString(10)
 		c.Assert(cli.putSingleBlockBlob(cnt, name, []byte("Hello, world!")), chk.IsNil)
 		c.Assert(cli.SetBlobMetadata(cnt, name, map[string]string{
 			"Foo":     name,
@@ -534,7 +534,7 @@ func (s *StorageBlobSuite) TestListBlobsWithMetadata(c *chk.C) {
 	}
 
 	// Put one more blob with no metadata
-	blobWithoutMetadata := randString(20)
+	blobWithoutMetadata := randString(5) + "/" + randString(5) + " " + randString(10)
 	c.Assert(cli.putSingleBlockBlob(cnt, blobWithoutMetadata, []byte("Hello, world!")), chk.IsNil)
 	expectMeta[blobWithoutMetadata] = nil
 
@@ -559,7 +559,7 @@ func (s *StorageBlobSuite) TestListBlobsWithMetadata(c *chk.C) {
 // metadata, e.g., for a stub server.
 func (s *StorageBlobSuite) TestMarshalBlobMetadata(c *chk.C) {
 	buf, err := xml.Marshal(Blob{
-		Name:       randString(20),
+		Name:       randString(5) + "/" + randString(5) + " " + randString(10),
 		Properties: BlobProperties{},
 		Metadata:   BlobMetadata{"foo": "baz < waz"},
 	})
@@ -574,7 +574,7 @@ func (s *StorageBlobSuite) TestGetAndSetMetadata(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
 
 	m, err := cli.GetBlobMetadata(cnt, blob)
@@ -620,7 +620,7 @@ func (s *StorageBlobSuite) TestSetMetadataWithExtraHeaders(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
 
 	mPut := map[string]string{
@@ -653,7 +653,7 @@ func (s *StorageBlobSuite) TestPutEmptyBlockBlob(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
 
 	props, err := cli.GetBlobProperties(cnt, blob)
@@ -663,7 +663,7 @@ func (s *StorageBlobSuite) TestPutEmptyBlockBlob(c *chk.C) {
 
 func (s *StorageBlobSuite) TestGetBlobRange(c *chk.C) {
 	cnt := randContainer()
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	body := "0123456789"
 
 	cli := getBlobClient(c)
@@ -698,7 +698,7 @@ func (s *StorageBlobSuite) TestCreateBlockBlobFromReader(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	name := randString(20)
+	name := randString(5) + "/" + randString(5) + " " + randString(10)
 	data := randBytes(8888)
 	c.Assert(cli.CreateBlockBlobFromReader(cnt, name, uint64(len(data)), bytes.NewReader(data), nil), chk.IsNil)
 
@@ -717,7 +717,7 @@ func (s *StorageBlobSuite) TestCreateBlockBlobFromReaderWithShortData(c *chk.C) 
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	name := randString(20)
+	name := randString(5) + "/" + randString(5) + " " + randString(10)
 	data := randBytes(8888)
 	err := cli.CreateBlockBlobFromReader(cnt, name, 9999, bytes.NewReader(data), nil)
 	c.Assert(err, chk.Not(chk.IsNil))
@@ -733,7 +733,7 @@ func (s *StorageBlobSuite) TestPutBlock(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	chunk := []byte(randString(1024))
 	blockID := base64.StdEncoding.EncodeToString([]byte("foo"))
 	c.Assert(cli.PutBlock(cnt, blob, blockID, chunk), chk.IsNil)
@@ -745,7 +745,7 @@ func (s *StorageBlobSuite) TestGetBlockList_PutBlockList(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	chunk := []byte(randString(1024))
 	blockID := base64.StdEncoding.EncodeToString([]byte("foo"))
 
@@ -787,7 +787,7 @@ func (s *StorageBlobSuite) TestCreateBlockBlob(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	c.Assert(cli.CreateBlockBlob(cnt, blob), chk.IsNil)
 
 	// Verify
@@ -803,7 +803,7 @@ func (s *StorageBlobSuite) TestPutPageBlob(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	size := int64(10 * 1024 * 1024)
 	c.Assert(cli.PutPageBlob(cnt, blob, size, nil), chk.IsNil)
 
@@ -820,7 +820,7 @@ func (s *StorageBlobSuite) TestPutPagesUpdate(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	size := int64(10 * 1024 * 1024) // larger than we'll use
 	c.Assert(cli.PutPageBlob(cnt, blob, size, nil), chk.IsNil)
 
@@ -859,7 +859,7 @@ func (s *StorageBlobSuite) TestPutPagesClear(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	size := int64(10 * 1024 * 1024) // larger than we'll use
 	c.Assert(cli.PutPageBlob(cnt, blob, size, nil), chk.IsNil)
 
@@ -885,7 +885,7 @@ func (s *StorageBlobSuite) TestGetPageRanges(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	size := int64(10 * 1024 * 1024) // larger than we'll use
 	c.Assert(cli.PutPageBlob(cnt, blob, size, nil), chk.IsNil)
 
@@ -915,7 +915,7 @@ func (s *StorageBlobSuite) TestPutAppendBlob(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	c.Assert(cli.PutAppendBlob(cnt, blob, nil), chk.IsNil)
 
 	// Verify
@@ -931,7 +931,7 @@ func (s *StorageBlobSuite) TestPutAppendBlobAppendBlocks(c *chk.C) {
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
 	defer cli.deleteContainer(cnt)
 
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	c.Assert(cli.PutAppendBlob(cnt, blob, nil), chk.IsNil)
 
 	chunk1 := []byte(randString(1024))

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -74,7 +74,7 @@ func (s *StorageBlobSuite) TestGetBlobSASURI(c *chk.C) {
 func (s *StorageBlobSuite) TestBlobSASURICorrectness(c *chk.C) {
 	cli := getBlobClient(c)
 	cnt := randContainer()
-	blob := randString(20)
+	blob := randString(5) + "/" + randString(5) + " " + randString(10)
 	body := []byte(randString(100))
 	expiry := time.Now().UTC().Add(time.Hour)
 	permissions := "r"

--- a/storage/client.go
+++ b/storage/client.go
@@ -280,7 +280,9 @@ func (c Client) buildCanonicalizedResource(uri string) (string, error) {
 	cr := "/" + c.accountName
 
 	if len(u.Path) > 0 {
-		cr += u.Path
+		// Any portion of the CanonicalizedResource string that is derived from the resource's URI should be encoded exactly as it is in the URI.
+		// -- https://msdn.microsoft.com/en-gb/library/azure/dd179428.aspx
+		cr += u.EscapedPath()
 	}
 
 	params, err := url.ParseQuery(u.RawQuery)
@@ -343,7 +345,6 @@ func (c Client) exec(verb, url string, headers map[string]string, body io.Reader
 		return nil, err
 	}
 	headers["Authorization"] = authHeader
-
 	if err != nil {
 		return nil, err
 	}

--- a/storage/client.go
+++ b/storage/client.go
@@ -280,7 +280,8 @@ func (c Client) buildCanonicalizedResource(uri string) (string, error) {
 	cr := "/" + c.accountName
 
 	if len(u.Path) > 0 {
-		// Any portion of the CanonicalizedResource string that is derived from the resource's URI should be encoded exactly as it is in the URI.
+		// Any portion of the CanonicalizedResource string that is derived from
+		// the resource's URI should be encoded exactly as it is in the URI.
 		// -- https://msdn.microsoft.com/en-gb/library/azure/dd179428.aspx
 		cr += u.EscapedPath()
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -108,6 +108,10 @@ func (s *StorageClientSuite) Test_buildCanonicalizedResource(c *chk.C) {
 		{"https://foo.blob.core.windows.net/?comp=list", "/foo/\ncomp:list"},
 		{"https://foo.blob.core.windows.net/cnt/blob", "/foo/cnt/blob"},
 		{"https://foo.blob.core.windows.net/cnt/bl ob", "/foo/cnt/bl%20ob"},
+		{"https://foo.blob.core.windows.net/c nt/blob", "/foo/c%20nt/blob"},
+		{"https://foo.blob.core.windows.net/cnt/blob%3F%23%5B%5D%21$&%27%28%29%2A blob", "/foo/cnt/blob%3F%23%5B%5D%21$&%27%28%29%2A%20blob"},
+		{"https://foo.blob.core.windows.net/cnt/blob-._~:,@;+=blob", "/foo/cnt/blob-._~:,@;+=blob"},
+		{"https://foo.blob.core.windows.net/c nt/blob-._~:%3F%23%5B%5D@%21$&%27%28%29%2A,;+=/blob", "/foo/c%20nt/blob-._~:%3F%23%5B%5D@%21$&%27%28%29%2A,;+=/blob"},
 	}
 
 	for _, i := range tests {

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -107,6 +107,7 @@ func (s *StorageClientSuite) Test_buildCanonicalizedResource(c *chk.C) {
 		{"https://foo.blob.core.windows.net/path?a=b&c=d", "/foo/path\na:b\nc:d"},
 		{"https://foo.blob.core.windows.net/?comp=list", "/foo/\ncomp:list"},
 		{"https://foo.blob.core.windows.net/cnt/blob", "/foo/cnt/blob"},
+		{"https://foo.blob.core.windows.net/cnt/bl ob", "/foo/cnt/bl%20ob"},
 	}
 
 	for _, i := range tests {


### PR DESCRIPTION
I've updated every test that operates on a blob to check for the existence of a space, and other special URL characters. I've excluded the + (plus) character from this, as it appears to need additional special handling (as it stands in for 'space' in some parts of the URL component, but not others).  The others work as expected. 