### PR TITLE
Checking err for nil after execTable

### DIFF
--- a/storage/table_entities.go
+++ b/storage/table_entities.go
@@ -98,6 +98,10 @@ func (c *TableServiceClient) QueryTableEntities(tableName AzureTable, previousCo
 
 	resp, err := c.client.execTable("GET", uri, headers, nil)
 
+	if err != nil {
+		return nil, nil, err
+	}
+
 	contToken := extractContinuationTokenFromHeaders(resp.headers)
 
 	if err != nil {


### PR DESCRIPTION
extractContinuationTokenFromHeaders(resp.headers) panics if execTable fails, e.g. due to lack of ca-certificates package installed