### PR TITLE
Bloblease

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -701,12 +701,46 @@ func (b BlobStorageClient) ChangeLease(container string, name string, currentLea
 }
 
 // ReleaseLease releases the lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
-func (b BlobStorageClient) ReleaseLease(container string, name string) error {
+func (b BlobStorageClient) ReleaseLease(container string, name string, currentLeaseID string) error {
+	params := url.Values{"comp": {"lease"}}
+	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), params)
+	headers := b.client.getStandardHeaders()
+
+	headers[leaseAction] = releaseLease
+	headers[leaseID] = currentLeaseID
+
+	resp, err := b.client.exec("PUT", uri, headers, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // RenewLease renews the lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
-func (b BlobStorageClient) RenewLease(container string, name string) error {
+func (b BlobStorageClient) RenewLease(container string, name string, currentLeaseID string) error {
+	params := url.Values{"comp": {"lease"}}
+	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), params)
+	headers := b.client.getStandardHeaders()
+
+	headers[leaseAction] = renewLease
+	headers[leaseID] = currentLeaseID
+
+	resp, err := b.client.exec("PUT", uri, headers, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -595,7 +595,7 @@ func (b BlobStorageClient) leaseCommonPut(container string, name string, headers
 	return resp.headers, nil
 }
 
-// AcquireLease gets a lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
+// AcquireLease creates a lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
 func (b BlobStorageClient) AcquireLease(container string, name string, leaseTimeInSeconds int, proposedLeaseID string) (string, error) {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = acquireLease
@@ -632,6 +632,7 @@ func (b BlobStorageClient) BreakLease(container string, name string) (int, error
 }
 
 // BreakLeaseWithBreakPeriod breaks the lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
+// breakPeriodInSeconds is used to determine how long until new lease can be created.
 func (b BlobStorageClient) BreakLeaseWithBreakPeriod(container string, name string, breakPeriodInSeconds int) (int, error) {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = breakLease

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -649,7 +648,6 @@ func (b BlobStorageClient) breakLeaseCommon(container string, name string, heade
 	}
 
 	for k, v := range respHeaders {
-		log.Println(k, v)
 
 		k = strings.ToLower(k)
 		if !strings.HasPrefix(k, strings.ToLower(leaseTime)) {

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -596,7 +596,8 @@ func (b BlobStorageClient) leaseCommonPut(container string, name string, headers
 }
 
 // AcquireLease creates a lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
-func (b BlobStorageClient) AcquireLease(container string, name string, leaseTimeInSeconds int, proposedLeaseID string) (string, error) {
+// returns leaseID acquired
+func (b BlobStorageClient) AcquireLease(container string, name string, leaseTimeInSeconds int, proposedLeaseID string) (returnedLeaseID string, err error) {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = acquireLease
 	headers[leaseProposedID] = proposedLeaseID
@@ -607,25 +608,20 @@ func (b BlobStorageClient) AcquireLease(container string, name string, leaseTime
 		return "", err
 	}
 
-	for k, v := range respHeaders {
-		k = strings.ToLower(k)
-		if len(v) == 0 || !strings.HasPrefix(k, strings.ToLower(leaseHeaderPrefix)) {
-			continue
-		}
+	returnedLeaseID = respHeaders.Get(http.CanonicalHeaderKey(leaseID))
 
-		// we only want the lease ID
-		if k == leaseID {
-			return v[0], nil
-		}
+	if returnedLeaseID != "" {
+		return returnedLeaseID, nil
 	}
 
 	// what should we return in case of HTTP 201 but no lease ID?
 	// or it just cant happen? (brave words)
-	return "", nil
+	return "", errors.New("LeaseID not returned")
 }
 
 // BreakLease breaks the lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
-func (b BlobStorageClient) BreakLease(container string, name string) (int, error) {
+// Returns the timeout remaining in the lease in seconds
+func (b BlobStorageClient) BreakLease(container string, name string) (breakTimeout int, err error) {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = breakLease
 	return b.breakLeaseCommon(container, name, headers)
@@ -633,7 +629,8 @@ func (b BlobStorageClient) BreakLease(container string, name string) (int, error
 
 // BreakLeaseWithBreakPeriod breaks the lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
 // breakPeriodInSeconds is used to determine how long until new lease can be created.
-func (b BlobStorageClient) BreakLeaseWithBreakPeriod(container string, name string, breakPeriodInSeconds int) (int, error) {
+// Returns the timeout remaining in the lease in seconds
+func (b BlobStorageClient) BreakLeaseWithBreakPeriod(container string, name string, breakPeriodInSeconds int) (breakTimeout int, err error) {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = breakLease
 	headers[leaseBreakPeriod] = strconv.Itoa(breakPeriodInSeconds)
@@ -641,32 +638,27 @@ func (b BlobStorageClient) BreakLeaseWithBreakPeriod(container string, name stri
 }
 
 // breakLeaseCommon is common code for both version of BreakLease (with and without break period)
-func (b BlobStorageClient) breakLeaseCommon(container string, name string, headers map[string]string) (int, error) {
+func (b BlobStorageClient) breakLeaseCommon(container string, name string, headers map[string]string) (breakTimeout int, err error) {
 
 	respHeaders, err := b.leaseCommonPut(container, name, headers, http.StatusAccepted)
 	if err != nil {
 		return 0, err
 	}
 
-	for k, v := range respHeaders {
-
-		k = strings.ToLower(k)
-		if !strings.HasPrefix(k, strings.ToLower(leaseTime)) {
-			continue
-		}
-
-		timeout, err := strconv.Atoi(v[0])
+	breakTimeoutStr := respHeaders.Get(http.CanonicalHeaderKey(leaseTime))
+	if breakTimeoutStr != "" {
+		breakTimeout, err = strconv.Atoi(breakTimeoutStr)
 		if err != nil {
 			return 0, err
 		}
-
-		return timeout, nil
 	}
-	return 0, nil
+
+	return breakTimeout, nil
 }
 
 // ChangeLease changes a lease ID for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
-func (b BlobStorageClient) ChangeLease(container string, name string, currentLeaseID string, proposedLeaseID string) (string, error) {
+// Returns the new LeaseID acquired
+func (b BlobStorageClient) ChangeLease(container string, name string, currentLeaseID string, proposedLeaseID string) (newLeaseID string, err error) {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = changeLease
 	headers[leaseID] = currentLeaseID
@@ -677,21 +669,12 @@ func (b BlobStorageClient) ChangeLease(container string, name string, currentLea
 		return "", err
 	}
 
-	for k, v := range respHeaders {
-		k = strings.ToLower(k)
-		if len(v) == 0 || !strings.HasPrefix(k, strings.ToLower(leaseHeaderPrefix)) {
-			continue
-		}
-
-		// we only want the lease ID
-		if k == leaseID {
-			return v[0], nil
-		}
+	newLeaseID = respHeaders.Get(http.CanonicalHeaderKey(leaseID))
+	if newLeaseID != "" {
+		return newLeaseID, nil
 	}
 
-	// what should we return in case of HTTP 201 but no lease ID?
-	// or it just cant happen? (brave words)
-	return "", nil
+	return "", errors.New("LeaseID not returned")
 }
 
 // ReleaseLease releases the lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -689,8 +689,7 @@ func (s *StorageBlobSuite) TestAcquireLeaseWithNoProposedLeaseID(c *chk.C) {
 	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
 
 	_, err := cli.AcquireLease(cnt, blob, 30, "")
-	c.Assert(err, chk.NotNil)
-
+	c.Assert(err, chk.IsNil)
 }
 
 func (s *StorageBlobSuite) TestAcquireLeaseWithProposedLeaseID(c *chk.C) {

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -689,7 +689,7 @@ func (s *StorageBlobSuite) TestAcquireLeaseWithNoProposedLeaseID(c *chk.C) {
 	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
 
 	_, err := cli.AcquireLease(cnt, blob, 30, "")
-	c.Assert(err, chk.IsNil)
+	c.Assert(err, chk.NotNil)
 }
 
 func (s *StorageBlobSuite) TestAcquireLeaseWithProposedLeaseID(c *chk.C) {

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -678,6 +678,174 @@ func (s *StorageBlobSuite) TestSetBlobProperties(c *chk.C) {
 	c.Check(mPut.ContentLanguage, chk.Equals, props.ContentLanguage)
 }
 
+func (s *StorageBlobSuite) TestAcquireLeaseWithNoProposedLeaseID(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+
+	_, err := cli.AcquireLease(cnt, blob, 30, "")
+	c.Assert(err, chk.NotNil)
+
+}
+
+func (s *StorageBlobSuite) TestAcquireLeaseWithProposedLeaseID(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+
+	proposedLeaseID := "dfe6dde8-68d5-4910-9248-c97c61768fea"
+	leaseID, err := cli.AcquireLease(cnt, blob, 30, proposedLeaseID)
+	c.Assert(err, chk.IsNil)
+	c.Assert(leaseID, chk.Equals, proposedLeaseID)
+}
+
+func (s *StorageBlobSuite) TestAcquireLeaseWithBadProposedLeaseID(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+
+	proposedLeaseID := "badbadbad"
+	_, err := cli.AcquireLease(cnt, blob, 30, proposedLeaseID)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *StorageBlobSuite) TestRenewLeaseSuccessful(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+
+	proposedLeaseID := "dfe6dde8-68d5-4910-9248-c97c61768fea"
+	leaseID, err := cli.AcquireLease(cnt, blob, 30, proposedLeaseID)
+	c.Assert(err, chk.IsNil)
+
+	err = cli.RenewLease(cnt, blob, leaseID)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *StorageBlobSuite) TestRenewLeaseAgainstNoCurrentLease(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+
+	badLeaseID := "1f812371-a41d-49e6-b123-f4b542e85144"
+	err := cli.RenewLease(cnt, blob, badLeaseID)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *StorageBlobSuite) TestChangeLeaseSuccessful(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+	proposedLeaseID := "dfe6dde8-68d5-4910-9248-c97c61768fea"
+	leaseID, err := cli.AcquireLease(cnt, blob, 30, proposedLeaseID)
+	c.Assert(err, chk.IsNil)
+
+	newProposedLeaseID := "dfe6dde8-68d5-4910-9248-c97c61768fbb"
+	newLeaseID, err := cli.ChangeLease(cnt, blob, leaseID, newProposedLeaseID)
+	c.Assert(err, chk.IsNil)
+	c.Assert(newLeaseID, chk.Equals, newProposedLeaseID)
+}
+
+func (s *StorageBlobSuite) TestChangeLeaseNotSuccessfulbadProposedLeaseID(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+	proposedLeaseID := "dfe6dde8-68d5-4910-9248-c97c61768fea"
+	leaseID, err := cli.AcquireLease(cnt, blob, 30, proposedLeaseID)
+	c.Assert(err, chk.IsNil)
+
+	newProposedLeaseID := "1f812371-a41d-49e6-b123-f4b542e"
+	_, err = cli.ChangeLease(cnt, blob, leaseID, newProposedLeaseID)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *StorageBlobSuite) TestReleaseLeaseSuccessful(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+	proposedLeaseID := "dfe6dde8-68d5-4910-9248-c97c61768fea"
+	leaseID, err := cli.AcquireLease(cnt, blob, 30, proposedLeaseID)
+	c.Assert(err, chk.IsNil)
+
+	err = cli.ReleaseLease(cnt, blob, leaseID)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *StorageBlobSuite) TestReleaseLeaseNotSuccessfulBadLeaseID(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+	proposedLeaseID := "dfe6dde8-68d5-4910-9248-c97c61768fea"
+	_, err := cli.AcquireLease(cnt, blob, 30, proposedLeaseID)
+	c.Assert(err, chk.IsNil)
+
+	err = cli.ReleaseLease(cnt, blob, "badleaseid")
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *StorageBlobSuite) TestBreakLeaseSuccessful(c *chk.C) {
+	cli := getBlobClient(c)
+	cnt := randContainer()
+
+	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
+	defer cli.deleteContainer(cnt)
+
+	blob := randName(5)
+	c.Assert(cli.putSingleBlockBlob(cnt, blob, []byte{}), chk.IsNil)
+
+	proposedLeaseID := "dfe6dde8-68d5-4910-9248-c97c61768fea"
+	_, err := cli.AcquireLease(cnt, blob, 30, proposedLeaseID)
+	c.Assert(err, chk.IsNil)
+
+	_, err = cli.BreakLease(cnt, blob)
+	c.Assert(err, chk.IsNil)
+}
+
 func (s *StorageBlobSuite) TestPutEmptyBlockBlob(c *chk.C) {
 	cli := getBlobClient(c)
 	cnt := randContainer()


### PR DESCRIPTION
Noticed in Issue 406 that blob leases hadn't been implemented in the Go client library, so thought I'd give it a go (although a long time dev am fairly new to Go).

Have added functionality for acquire, renew, change, release and break lease for blobs. I've also added in relevant tests to the blob_test.go file. 

Hope it's useful.

Thanks

Ken