### PR TITLE
management: check x509 decoding errors

### DIFF
--- a/management/http.go
+++ b/management/http.go
@@ -70,7 +70,10 @@ func (client client) sendAzureRequest(method, url, contentType string, data []by
 		return nil, fmt.Errorf(errParamNotSpecified, "url")
 	}
 
-	httpClient := client.createHTTPClient()
+	httpClient, err := client.createHTTPClient()
+	if err != nil {
+		return nil, err
+	}
 
 	response, err := client.sendRequest(httpClient, url, method, contentType, data, 5)
 	if err != nil {
@@ -82,8 +85,12 @@ func (client client) sendAzureRequest(method, url, contentType string, data []by
 
 // createHTTPClient creates an HTTP Client configured with the key pair for
 // the subscription for this client.
-func (client client) createHTTPClient() *http.Client {
-	cert, _ := tls.X509KeyPair(client.publishSettings.SubscriptionCert, client.publishSettings.SubscriptionKey)
+func (client client) createHTTPClient() (*http.Client, error) {
+	cert, err := tls.X509KeyPair(client.publishSettings.SubscriptionCert, client.publishSettings.SubscriptionKey)
+	if err != nil {
+		return nil, err
+	}
+
 	return &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
@@ -92,7 +99,7 @@ func (client client) createHTTPClient() *http.Client {
 				Certificates:  []tls.Certificate{cert},
 			},
 		},
-	}
+	}, nil
 }
 
 // sendRequest sends a request to the Azure management API using the given


### PR DESCRIPTION
errors should not be ignored in this codebase, and https://github.com/kisielk/errcheck should probably be run over the whole repo.

this caused a hard to debug auth problem where i mishandled certificate decoding from `azureProfile.json` from the CLI.