### PR TITLE
Escape path when creating Canonicalized Resource for Table

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -305,7 +305,7 @@ func (c Client) buildCanonicalizedResourceTable(uri string) (string, error) {
 	cr := "/" + c.getCanonicalizedAccountName()
 
 	if len(u.Path) > 0 {
-		cr += u.Path
+		cr += u.EscapedPath()
 	}
 
 	return cr, nil

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -146,6 +146,23 @@ func (s *StorageClientSuite) Test_getStandardHeaders(c *chk.C) {
 	}
 }
 
+func (s *StorageClientSuite) Test_buildCanonicalizedResourceTable(c *chk.C) {
+	cli, err := NewBasicClient("foo", "YmFy")
+	c.Assert(err, chk.IsNil)
+
+	type test struct{ url, expected string }
+	tests := []test{
+		{"https://foo.table.core.windows.net/mytable", "/foo/mytable"},
+		{"https://foo.table.core.windows.net/mytable(PartitionKey='pkey',RowKey='rowkey%3D')", "/foo/mytable(PartitionKey='pkey',RowKey='rowkey%3D')"},
+	}
+
+	for _, i := range tests {
+		out, err := cli.buildCanonicalizedResourceTable(i.url)
+		c.Assert(err, chk.IsNil)
+		c.Assert(out, chk.Equals, i.expected)
+	}
+}
+
 func (s *StorageClientSuite) Test_buildCanonicalizedResource(c *chk.C) {
 	cli, err := NewBasicClient("foo", "YmFy")
 	c.Assert(err, chk.IsNil)


### PR DESCRIPTION
This fixes a bug where `buildCanonicalizedResourceTable` would create an
invalid string when using a PartitionKey or RowKey with a special
character in it, such as "=".

As per the documentation for creating CanonicalizedResource strings for
SharedKey and SharedKeyLite, found at:
https://msdn.microsoft.com/en-gb/library/azure/dd179428.aspx

"Any portion of the CanonicalizedResource string that is derived from
the resource's URI should be encoded exactly as it is in the URI."

`buildCanonicalizedResource` used in other places, was already using
this same method to conform to the documentation.