### PR TITLE
Fixing gas scanning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ install:
   - glide install
 
 script:
-  - gas -skip=management/examples/*.go -skip=*vendor* -skip=Gododir/* ./... | tee gas-scan.txt
-  - test -z "$(grep 'Severity:\s*HIGH' gas-scan.txt)"
+  - gas -skip=arm/*/models.go -skip=management/examples/*.go -skip=*vendor* -skip=Gododir/* ./...
   - test -z "$(gofmt -s -l $(find ./arm/* -type d -print) | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w management | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w storage | tee /dev/stderr)"

--- a/Gododir/gen.go
+++ b/Gododir/gen.go
@@ -399,7 +399,7 @@ func generate(service *service) {
 		"-pv", sdkVersion)
 	err := runner(autorest)
 	if err != nil {
-		panic(fmt.Errorf("Autorest error: %s\n", err))
+		panic(fmt.Errorf("Autorest error: %s", err))
 	}
 
 	format(service)
@@ -429,7 +429,7 @@ func format(service *service) {
 	gofmt := exec.Command("gofmt", "-w", service.Output)
 	err := runner(gofmt)
 	if err != nil {
-		panic(fmt.Errorf("gofmt error: %s\n", err))
+		panic(fmt.Errorf("gofmt error: %s", err))
 	}
 }
 
@@ -442,7 +442,7 @@ func build(service *service) {
 	gobuild := exec.Command("go", "build", service.Namespace)
 	err := runner(gobuild)
 	if err != nil {
-		panic(fmt.Errorf("go build error: %s\n", err))
+		panic(fmt.Errorf("go build error: %s", err))
 	}
 }
 
@@ -455,7 +455,7 @@ func lint(service *service) {
 	golint := exec.Command(fmt.Sprintf("%s/bin/golint", gopath), service.Namespace)
 	err := runner(golint)
 	if err != nil {
-		panic(fmt.Errorf("golint error: %s\n", err))
+		panic(fmt.Errorf("golint error: %s", err))
 	}
 }
 
@@ -468,7 +468,7 @@ func vet(service *service) {
 	govet := exec.Command("go", "vet", service.Namespace)
 	err := runner(govet)
 	if err != nil {
-		panic(fmt.Errorf("go vet error: %s\n", err))
+		panic(fmt.Errorf("go vet error: %s", err))
 	}
 }
 

--- a/arm/examples/helpers/helpers.go
+++ b/arm/examples/helpers/helpers.go
@@ -13,9 +13,9 @@ const (
 
 // ToJSON returns the passed item as a pretty-printed JSON string. If any JSON error occurs,
 // it returns the empty string.
-func ToJSON(v interface{}) string {
-	j, _ := json.MarshalIndent(v, "", "  ")
-	return string(j)
+func ToJSON(v interface{}) (string, error) {
+	j, err := json.MarshalIndent(v, "", "  ")
+	return string(j), err
 }
 
 // NewServicePrincipalTokenFromCredentials creates a new ServicePrincipalToken using values of the

--- a/storage/table_entities.go
+++ b/storage/table_entities.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 )
 
+// Anotating as secure for gas scanning
+/* #nosec */
 const (
 	partitionKeyNode                    = "PartitionKey"
 	rowKeyNode                          = "RowKey"

--- a/storage/table_entities.go
+++ b/storage/table_entities.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 )
 
-// Anotating as secure for gas scanning
+// Annotating as secure for gas scanning
 /* #nosec */
 const (
 	partitionKeyNode                    = "PartitionKey"


### PR DESCRIPTION
Mostly because of some recent updates on gas ([the update, for the curious](https://github.com/GoASTScanner/gas/commit/a3fcd96f57246314004c9c0d0e747bfd29171e57)).
Gas would skip all `models.go` generated files, another possibility is to disable rule [G101](https://github.com/GoASTScanner/gas#available-rules).
PTAL, @garimakhulbe @jhendrixMSFT @vishrutshah 