### PR TITLE
storage: return AzureStorageServiceError for empty responses

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -428,12 +428,13 @@ func (c Client) exec(verb, url string, headers map[string]string, body io.Reader
 			return nil, err
 		}
 
+		requestID := resp.Header.Get("x-ms-request-id")
 		if len(respBody) == 0 {
-			// no error in response body
-			err = fmt.Errorf("storage: service returned without a response body (%s)", resp.Status)
+			// no error in response body, might happen in HEAD requests
+			err = serviceErrFromStatusCode(resp.StatusCode, resp.Status, requestID)
 		} else {
 			// response contains storage service error object, unmarshal
-			storageErr, errIn := serviceErrFromXML(respBody, resp.StatusCode, resp.Header.Get("x-ms-request-id"))
+			storageErr, errIn := serviceErrFromXML(respBody, resp.StatusCode, requestID)
 			if err != nil { // error unmarshaling the error response
 				err = errIn
 			}
@@ -482,8 +483,8 @@ func (c Client) execInternalJSON(verb, url string, headers map[string]string, bo
 		}
 
 		if len(respBody) == 0 {
-			// no error in response body
-			err = fmt.Errorf("storage: service returned without a response body (%d)", resp.StatusCode)
+			// no error in response body, might happen in HEAD requests
+			err = serviceErrFromStatusCode(resp.StatusCode, resp.Status, resp.Header.Get("x-ms-request-id"))
 			return respToRet, err
 		}
 		// try unmarshal as odata.error json
@@ -533,6 +534,15 @@ func serviceErrFromXML(body []byte, statusCode int, requestID string) (AzureStor
 	storageErr.StatusCode = statusCode
 	storageErr.RequestID = requestID
 	return storageErr, nil
+}
+
+func serviceErrFromStatusCode(code int, status string, requestID string) AzureStorageServiceError {
+	return AzureStorageServiceError{
+		StatusCode: code,
+		Code:       status,
+		RequestID:  requestID,
+		Message:    "no response body was available for error status code",
+	}
 }
 
 func (e AzureStorageServiceError) Error() string {

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -218,6 +218,22 @@ func (s *StorageClientSuite) TestReturnsStorageServiceError(c *chk.C) {
 	c.Assert(v.StatusCode, chk.Equals, 404)
 	c.Assert(v.Code, chk.Equals, "ContainerNotFound")
 	c.Assert(v.Code, chk.Not(chk.Equals), "")
+	c.Assert(v.RequestID, chk.Not(chk.Equals), "")
+}
+
+func (s *StorageClientSuite) TestReturnsStorageServiceError_withoutResponseBody(c *chk.C) {
+	// HEAD on non-existing blob
+	_, err := getBlobClient(c).GetBlobProperties("non-existing-blob", "non-existing-container")
+
+	c.Assert(err, chk.NotNil)
+	c.Assert(err, chk.FitsTypeOf, AzureStorageServiceError{})
+
+	v, ok := err.(AzureStorageServiceError)
+	c.Check(ok, chk.Equals, true)
+	c.Assert(v.StatusCode, chk.Equals, http.StatusNotFound)
+	c.Assert(v.Code, chk.Equals, "404 The specified container does not exist.")
+	c.Assert(v.RequestID, chk.Not(chk.Equals), "")
+	c.Assert(v.Message, chk.Equals, "no response body was available for error status code")
 }
 
 func (s *StorageClientSuite) Test_createAuthorizationHeader(c *chk.C) {


### PR DESCRIPTION
Currently, if somebody was trying to implement an `is404(error )`
for errors returned from "storage" package, they would miss
out the errors coming from HEAD requests, such as GetBlobProperties
as these responses do not have a response body that contains an error
message.

Therefore, reusing AzureStorageServiceError to return a sensible
error message that still contains the status code (int) to implement
a `err.(AzureStorageServiceError).Code==404` and the status text (str)
that contains a helpful error message instead of just "404 Not Found" with
an indicator saying "no response body was available".

That simplifies the code that would implement an is404(error) in the
downstream clients.

cc: @yuwamsft FYI