### PR TITLE
Cleaning up hard-coded HTTP verbs.

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -435,7 +435,7 @@ func (b BlobStorageClient) ListContainers(params ListContainersParameters) (Cont
 	headers := b.client.getStandardHeaders()
 
 	var out ContainerListResponse
-	resp, err := b.client.exec("GET", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return out, err
 	}
@@ -472,7 +472,7 @@ func (b BlobStorageClient) CreateContainerIfNotExists(name string, access Contai
 }
 
 func (b BlobStorageClient) createContainer(name string, access ContainerAccessType) (*storageResponse, error) {
-	verb := "PUT"
+	verb := http.MethodPut
 	uri := b.client.getEndpoint(blobServiceName, pathForContainer(name), url.Values{"restype": {"container"}})
 
 	headers := b.client.getStandardHeaders()
@@ -485,7 +485,7 @@ func (b BlobStorageClient) createContainer(name string, access ContainerAccessTy
 // ContainerExists returns true if a container with given name exists
 // on the storage account, otherwise returns false.
 func (b BlobStorageClient) ContainerExists(name string) (bool, error) {
-	verb := "HEAD"
+	verb := http.MethodHead
 	uri := b.client.getEndpoint(blobServiceName, pathForContainer(name), url.Values{"restype": {"container"}})
 	headers := b.client.getStandardHeaders()
 
@@ -529,9 +529,9 @@ func (b BlobStorageClient) SetContainerPermissions(container string, containerPe
 	var resp *storageResponse
 	if accessPolicyXML != "" {
 		headers["Content-Length"] = strconv.Itoa(len(accessPolicyXML))
-		resp, err = b.client.exec("PUT", uri, headers, strings.NewReader(accessPolicyXML))
+		resp, err = b.client.exec(http.MethodPut, uri, headers, strings.NewReader(accessPolicyXML))
 	} else {
-		resp, err = b.client.exec("PUT", uri, headers, nil)
+		resp, err = b.client.exec(http.MethodPut, uri, headers, nil)
 	}
 
 	if err != nil {
@@ -569,7 +569,7 @@ func (b BlobStorageClient) GetContainerPermissions(container string, timeout int
 		headers[leaseID] = leaseID
 	}
 
-	resp, err := b.client.exec("GET", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -625,7 +625,7 @@ func (b BlobStorageClient) DeleteContainerIfExists(name string) (bool, error) {
 }
 
 func (b BlobStorageClient) deleteContainer(name string) (*storageResponse, error) {
-	verb := "DELETE"
+	verb := http.MethodDelete
 	uri := b.client.getEndpoint(blobServiceName, pathForContainer(name), url.Values{"restype": {"container"}})
 
 	headers := b.client.getStandardHeaders()
@@ -644,7 +644,7 @@ func (b BlobStorageClient) ListBlobs(container string, params ListBlobsParameter
 	headers := b.client.getStandardHeaders()
 
 	var out BlobListResponse
-	resp, err := b.client.exec("GET", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return out, err
 	}
@@ -657,7 +657,7 @@ func (b BlobStorageClient) ListBlobs(container string, params ListBlobsParameter
 // BlobExists returns true if a blob with given name exists on the specified
 // container of the storage account.
 func (b BlobStorageClient) BlobExists(container, name string) (bool, error) {
-	verb := "HEAD"
+	verb := http.MethodHead
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 	headers := b.client.getStandardHeaders()
 	resp, err := b.client.exec(verb, uri, headers, nil)
@@ -714,7 +714,7 @@ func (b BlobStorageClient) GetBlobRange(container, name, bytesRange string, extr
 }
 
 func (b BlobStorageClient) getBlobRange(container, name, bytesRange string, extraHeaders map[string]string) (*storageResponse, error) {
-	verb := "GET"
+	verb := http.MethodGet
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 
 	headers := b.client.getStandardHeaders()
@@ -738,7 +738,7 @@ func (b BlobStorageClient) leaseCommonPut(container string, name string, headers
 	params := url.Values{"comp": {"lease"}}
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), params)
 
-	resp, err := b.client.exec("PUT", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -765,7 +765,7 @@ func (b BlobStorageClient) SnapshotBlob(container string, name string, timeout i
 	}
 
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), params)
-	resp, err := b.client.exec("PUT", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -904,7 +904,7 @@ func (b BlobStorageClient) RenewLease(container string, name string, currentLeas
 // GetBlobProperties provides various information about the specified
 // blob. See https://msdn.microsoft.com/en-us/library/azure/dd179394.aspx
 func (b BlobStorageClient) GetBlobProperties(container, name string) (*BlobProperties, error) {
-	verb := "HEAD"
+	verb := http.MethodHead
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 
 	headers := b.client.getStandardHeaders()
@@ -977,7 +977,7 @@ func (b BlobStorageClient) SetBlobProperties(container, name string, blobHeaders
 		headers[k] = v
 	}
 
-	resp, err := b.client.exec("PUT", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return err
 	}
@@ -1006,7 +1006,7 @@ func (b BlobStorageClient) SetBlobMetadata(container, name string, metadata map[
 		headers[k] = v
 	}
 
-	resp, err := b.client.exec("PUT", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return err
 	}
@@ -1026,7 +1026,7 @@ func (b BlobStorageClient) GetBlobMetadata(container, name string) (map[string]s
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), params)
 	headers := b.client.getStandardHeaders()
 
-	resp, err := b.client.exec("GET", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1085,7 +1085,7 @@ func (b BlobStorageClient) CreateBlockBlobFromReader(container, name string, siz
 		headers[k] = v
 	}
 
-	resp, err := b.client.exec("PUT", uri, headers, blob)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, blob)
 	if err != nil {
 		return err
 	}
@@ -1122,7 +1122,7 @@ func (b BlobStorageClient) PutBlockWithLength(container, name, blockID string, s
 		headers[k] = v
 	}
 
-	resp, err := b.client.exec("PUT", uri, headers, blob)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, blob)
 	if err != nil {
 		return err
 	}
@@ -1141,7 +1141,7 @@ func (b BlobStorageClient) PutBlockList(container, name string, blocks []Block) 
 	headers := b.client.getStandardHeaders()
 	headers["Content-Length"] = fmt.Sprintf("%v", len(blockListXML))
 
-	resp, err := b.client.exec("PUT", uri, headers, strings.NewReader(blockListXML))
+	resp, err := b.client.exec(http.MethodPut, uri, headers, strings.NewReader(blockListXML))
 	if err != nil {
 		return err
 	}
@@ -1158,7 +1158,7 @@ func (b BlobStorageClient) GetBlockList(container, name string, blockType BlockL
 	headers := b.client.getStandardHeaders()
 
 	var out BlockListResponse
-	resp, err := b.client.exec("GET", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return out, err
 	}
@@ -1184,7 +1184,7 @@ func (b BlobStorageClient) PutPageBlob(container, name string, size int64, extra
 		headers[k] = v
 	}
 
-	resp, err := b.client.exec("PUT", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return err
 	}
@@ -1219,7 +1219,7 @@ func (b BlobStorageClient) PutPage(container, name string, startByte, endByte in
 	}
 	headers["Content-Length"] = fmt.Sprintf("%v", contentLength)
 
-	resp, err := b.client.exec("PUT", uri, headers, data)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, data)
 	if err != nil {
 		return err
 	}
@@ -1237,7 +1237,7 @@ func (b BlobStorageClient) GetPageRanges(container, name string) (GetPageRangesR
 	headers := b.client.getStandardHeaders()
 
 	var out GetPageRangesResponse
-	resp, err := b.client.exec("GET", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return out, err
 	}
@@ -1264,7 +1264,7 @@ func (b BlobStorageClient) PutAppendBlob(container, name string, extraHeaders ma
 		headers[k] = v
 	}
 
-	resp, err := b.client.exec("PUT", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return err
 	}
@@ -1287,7 +1287,7 @@ func (b BlobStorageClient) AppendBlock(container, name string, chunk []byte, ext
 		headers[k] = v
 	}
 
-	resp, err := b.client.exec("PUT", uri, headers, bytes.NewReader(chunk))
+	resp, err := b.client.exec(http.MethodPut, uri, headers, bytes.NewReader(chunk))
 	if err != nil {
 		return err
 	}
@@ -1322,7 +1322,7 @@ func (b BlobStorageClient) StartBlobCopy(container, name, sourceBlob string) (st
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-copy-source"] = sourceBlob
 
-	resp, err := b.client.exec("PUT", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return "", err
 	}
@@ -1357,7 +1357,7 @@ func (b BlobStorageClient) AbortBlobCopy(container, name, copyID, currentLeaseID
 		headers[leaseID] = currentLeaseID
 	}
 
-	resp, err := b.client.exec("PUT", uri, headers, nil)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return err
 	}
@@ -1425,7 +1425,7 @@ func (b BlobStorageClient) DeleteBlobIfExists(container, name string, extraHeade
 }
 
 func (b BlobStorageClient) deleteBlob(container, name string, extraHeaders map[string]string) (*storageResponse, error) {
-	verb := "DELETE"
+	verb := http.MethodDelete
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 	headers := b.client.getStandardHeaders()
 	for k, v := range extraHeaders {

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -472,24 +472,22 @@ func (b BlobStorageClient) CreateContainerIfNotExists(name string, access Contai
 }
 
 func (b BlobStorageClient) createContainer(name string, access ContainerAccessType) (*storageResponse, error) {
-	verb := http.MethodPut
 	uri := b.client.getEndpoint(blobServiceName, pathForContainer(name), url.Values{"restype": {"container"}})
 
 	headers := b.client.getStandardHeaders()
 	if access != "" {
 		headers[ContainerAccessHeader] = string(access)
 	}
-	return b.client.exec(verb, uri, headers, nil)
+	return b.client.exec(http.MethodPut, uri, headers, nil)
 }
 
 // ContainerExists returns true if a container with given name exists
 // on the storage account, otherwise returns false.
 func (b BlobStorageClient) ContainerExists(name string) (bool, error) {
-	verb := http.MethodHead
 	uri := b.client.getEndpoint(blobServiceName, pathForContainer(name), url.Values{"restype": {"container"}})
 	headers := b.client.getStandardHeaders()
 
-	resp, err := b.client.exec(verb, uri, headers, nil)
+	resp, err := b.client.exec(http.MethodHead, uri, headers, nil)
 	if resp != nil {
 		defer resp.body.Close()
 		if resp.statusCode == http.StatusOK || resp.statusCode == http.StatusNotFound {
@@ -625,11 +623,10 @@ func (b BlobStorageClient) DeleteContainerIfExists(name string) (bool, error) {
 }
 
 func (b BlobStorageClient) deleteContainer(name string) (*storageResponse, error) {
-	verb := http.MethodDelete
 	uri := b.client.getEndpoint(blobServiceName, pathForContainer(name), url.Values{"restype": {"container"}})
 
 	headers := b.client.getStandardHeaders()
-	return b.client.exec(verb, uri, headers, nil)
+	return b.client.exec(http.MethodDelete, uri, headers, nil)
 }
 
 // ListBlobs returns an object that contains list of blobs in the container,
@@ -657,10 +654,9 @@ func (b BlobStorageClient) ListBlobs(container string, params ListBlobsParameter
 // BlobExists returns true if a blob with given name exists on the specified
 // container of the storage account.
 func (b BlobStorageClient) BlobExists(container, name string) (bool, error) {
-	verb := http.MethodHead
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 	headers := b.client.getStandardHeaders()
-	resp, err := b.client.exec(verb, uri, headers, nil)
+	resp, err := b.client.exec(http.MethodHead, uri, headers, nil)
 	if resp != nil {
 		defer resp.body.Close()
 		if resp.statusCode == http.StatusOK || resp.statusCode == http.StatusNotFound {
@@ -714,7 +710,6 @@ func (b BlobStorageClient) GetBlobRange(container, name, bytesRange string, extr
 }
 
 func (b BlobStorageClient) getBlobRange(container, name, bytesRange string, extraHeaders map[string]string) (*storageResponse, error) {
-	verb := http.MethodGet
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 
 	headers := b.client.getStandardHeaders()
@@ -726,7 +721,7 @@ func (b BlobStorageClient) getBlobRange(container, name, bytesRange string, extr
 		headers[k] = v
 	}
 
-	resp, err := b.client.exec(verb, uri, headers, nil)
+	resp, err := b.client.exec(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -904,11 +899,10 @@ func (b BlobStorageClient) RenewLease(container string, name string, currentLeas
 // GetBlobProperties provides various information about the specified
 // blob. See https://msdn.microsoft.com/en-us/library/azure/dd179394.aspx
 func (b BlobStorageClient) GetBlobProperties(container, name string) (*BlobProperties, error) {
-	verb := http.MethodHead
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 
 	headers := b.client.getStandardHeaders()
-	resp, err := b.client.exec(verb, uri, headers, nil)
+	resp, err := b.client.exec(http.MethodHead, uri, headers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1425,14 +1419,13 @@ func (b BlobStorageClient) DeleteBlobIfExists(container, name string, extraHeade
 }
 
 func (b BlobStorageClient) deleteBlob(container, name string, extraHeaders map[string]string) (*storageResponse, error) {
-	verb := http.MethodDelete
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 	headers := b.client.getStandardHeaders()
 	for k, v := range extraHeaders {
 		headers[k] = v
 	}
 
-	return b.client.exec(verb, uri, headers, nil)
+	return b.client.exec(http.MethodDelete, uri, headers, nil)
 }
 
 // helper method to construct the path to a container given its name

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -1498,7 +1498,7 @@ func (b BlobStorageClient) putSingleBlockBlob(container, name string, chunk []by
 	headers["x-ms-blob-type"] = string(BlobTypeBlock)
 	headers["Content-Length"] = fmt.Sprintf("%v", len(chunk))
 
-	resp, err := b.client.exec("PUT", uri, headers, bytes.NewReader(chunk))
+	resp, err := b.client.exec(http.MethodPut, uri, headers, bytes.NewReader(chunk))
 	if err != nil {
 		return err
 	}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -156,7 +156,7 @@ func (c QueueServiceClient) SetMetadata(name string, metadata map[string]string)
 		headers[userDefinedMetadataHeaderPrefix+k] = v
 	}
 
-	resp, err := c.client.exec("PUT", uri, headers, nil)
+	resp, err := c.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (c QueueServiceClient) GetMetadata(name string) (QueueMetadataResponse, err
 	qm.UserDefinedMetadata = make(map[string]string)
 	uri := c.client.getEndpoint(queueServiceName, pathForQueue(name), url.Values{"comp": []string{"metadata"}})
 	headers := c.client.getStandardHeaders()
-	resp, err := c.client.exec("GET", uri, headers, nil)
+	resp, err := c.client.exec(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return qm, err
 	}
@@ -212,7 +212,7 @@ func (c QueueServiceClient) GetMetadata(name string) (QueueMetadataResponse, err
 func (c QueueServiceClient) CreateQueue(name string) error {
 	uri := c.client.getEndpoint(queueServiceName, pathForQueue(name), url.Values{})
 	headers := c.client.getStandardHeaders()
-	resp, err := c.client.exec("PUT", uri, headers, nil)
+	resp, err := c.client.exec(http.MethodPut, uri, headers, nil)
 	if err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func (c QueueServiceClient) CreateQueue(name string) error {
 // See https://msdn.microsoft.com/en-us/library/azure/dd179436.aspx
 func (c QueueServiceClient) DeleteQueue(name string) error {
 	uri := c.client.getEndpoint(queueServiceName, pathForQueue(name), url.Values{})
-	resp, err := c.client.exec("DELETE", uri, c.client.getStandardHeaders(), nil)
+	resp, err := c.client.exec(http.MethodDelete, uri, c.client.getStandardHeaders(), nil)
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func (c QueueServiceClient) DeleteQueue(name string) error {
 // QueueExists returns true if a queue with given name exists.
 func (c QueueServiceClient) QueueExists(name string) (bool, error) {
 	uri := c.client.getEndpoint(queueServiceName, pathForQueue(name), url.Values{"comp": {"metadata"}})
-	resp, err := c.client.exec("GET", uri, c.client.getStandardHeaders(), nil)
+	resp, err := c.client.exec(http.MethodGet, uri, c.client.getStandardHeaders(), nil)
 	if resp != nil && (resp.statusCode == http.StatusOK || resp.statusCode == http.StatusNotFound) {
 		return resp.statusCode == http.StatusOK, nil
 	}
@@ -256,7 +256,7 @@ func (c QueueServiceClient) PutMessage(queue string, message string, params PutM
 	}
 	headers := c.client.getStandardHeaders()
 	headers["Content-Length"] = strconv.Itoa(nn)
-	resp, err := c.client.exec("POST", uri, headers, body)
+	resp, err := c.client.exec(http.MethodPost, uri, headers, body)
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func (c QueueServiceClient) PutMessage(queue string, message string, params PutM
 // See https://msdn.microsoft.com/en-us/library/azure/dd179454.aspx
 func (c QueueServiceClient) ClearMessages(queue string) error {
 	uri := c.client.getEndpoint(queueServiceName, pathForQueueMessages(queue), url.Values{})
-	resp, err := c.client.exec("DELETE", uri, c.client.getStandardHeaders(), nil)
+	resp, err := c.client.exec(http.MethodDelete, uri, c.client.getStandardHeaders(), nil)
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func (c QueueServiceClient) ClearMessages(queue string) error {
 func (c QueueServiceClient) GetMessages(queue string, params GetMessagesParameters) (GetMessagesResponse, error) {
 	var r GetMessagesResponse
 	uri := c.client.getEndpoint(queueServiceName, pathForQueueMessages(queue), params.getParameters())
-	resp, err := c.client.exec("GET", uri, c.client.getStandardHeaders(), nil)
+	resp, err := c.client.exec(http.MethodGet, uri, c.client.getStandardHeaders(), nil)
 	if err != nil {
 		return r, err
 	}
@@ -300,7 +300,7 @@ func (c QueueServiceClient) GetMessages(queue string, params GetMessagesParamete
 func (c QueueServiceClient) PeekMessages(queue string, params PeekMessagesParameters) (PeekMessagesResponse, error) {
 	var r PeekMessagesResponse
 	uri := c.client.getEndpoint(queueServiceName, pathForQueueMessages(queue), params.getParameters())
-	resp, err := c.client.exec("GET", uri, c.client.getStandardHeaders(), nil)
+	resp, err := c.client.exec(http.MethodGet, uri, c.client.getStandardHeaders(), nil)
 	if err != nil {
 		return r, err
 	}
@@ -315,7 +315,7 @@ func (c QueueServiceClient) PeekMessages(queue string, params PeekMessagesParame
 func (c QueueServiceClient) DeleteMessage(queue, messageID, popReceipt string) error {
 	uri := c.client.getEndpoint(queueServiceName, pathForMessage(queue, messageID), url.Values{
 		"popreceipt": {popReceipt}})
-	resp, err := c.client.exec("DELETE", uri, c.client.getStandardHeaders(), nil)
+	resp, err := c.client.exec(http.MethodDelete, uri, c.client.getStandardHeaders(), nil)
 	if err != nil {
 		return err
 	}
@@ -335,7 +335,7 @@ func (c QueueServiceClient) UpdateMessage(queue string, messageID string, messag
 	}
 	headers := c.client.getStandardHeaders()
 	headers["Content-Length"] = fmt.Sprintf("%d", nn)
-	resp, err := c.client.exec("PUT", uri, headers, body)
+	resp, err := c.client.exec(http.MethodPut, uri, headers, body)
 	if err != nil {
 		return err
 	}

--- a/storage/table.go
+++ b/storage/table.go
@@ -45,7 +45,7 @@ func (c *TableServiceClient) QueryTables() ([]AzureTable, error) {
 	headers := c.getStandardHeaders()
 	headers["Content-Length"] = "0"
 
-	resp, err := c.client.execTable("GET", uri, headers, nil)
+	resp, err := c.client.execTable(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (c *TableServiceClient) CreateTable(table AzureTable) error {
 
 	headers["Content-Length"] = fmt.Sprintf("%d", buf.Len())
 
-	resp, err := c.client.execTable("POST", uri, headers, buf)
+	resp, err := c.client.execTable(http.MethodPost, uri, headers, buf)
 
 	if err != nil {
 		return err
@@ -114,7 +114,7 @@ func (c *TableServiceClient) DeleteTable(table AzureTable) error {
 
 	headers["Content-Length"] = "0"
 
-	resp, err := c.client.execTable("DELETE", uri, headers, nil)
+	resp, err := c.client.execTable(http.MethodDelete, uri, headers, nil)
 
 	if err != nil {
 		return err

--- a/storage/table_entities.go
+++ b/storage/table_entities.go
@@ -98,7 +98,7 @@ func (c *TableServiceClient) QueryTableEntities(tableName AzureTable, previousCo
 
 	headers["Content-Length"] = "0"
 
-	resp, err := c.client.execTable("GET", uri, headers, nil)
+	resp, err := c.client.execTable(http.MethodGet, uri, headers, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -124,7 +124,7 @@ func (c *TableServiceClient) QueryTableEntities(tableName AzureTable, previousCo
 // The function fails if there is an entity with the same
 // PartitionKey and RowKey in the table.
 func (c *TableServiceClient) InsertEntity(table AzureTable, entity TableEntity) error {
-	if sc, err := c.execTable(table, entity, false, "POST"); err != nil {
+	if sc, err := c.execTable(table, entity, false, http.MethodPost); err != nil {
 		return checkRespCode(sc, []int{http.StatusCreated})
 	}
 
@@ -165,7 +165,7 @@ func (c *TableServiceClient) execTable(table AzureTable, entity TableEntity, spe
 // one passed as parameter. The function fails if there is no entity
 // with the same PartitionKey and RowKey in the table.
 func (c *TableServiceClient) UpdateEntity(table AzureTable, entity TableEntity) error {
-	if sc, err := c.execTable(table, entity, true, "PUT"); err != nil {
+	if sc, err := c.execTable(table, entity, true, http.MethodPut); err != nil {
 		return checkRespCode(sc, []int{http.StatusNoContent})
 	}
 	return nil
@@ -205,7 +205,7 @@ func (c *TableServiceClient) DeleteEntity(table AzureTable, entity TableEntity, 
 	headers["Content-Length"] = "0"
 	headers["If-Match"] = ifMatch
 
-	resp, err := c.client.execTable("DELETE", uri, headers, nil)
+	resp, err := c.client.execTable(http.MethodDelete, uri, headers, nil)
 
 	if err != nil {
 		return err
@@ -222,7 +222,7 @@ func (c *TableServiceClient) DeleteEntity(table AzureTable, entity TableEntity, 
 // InsertOrReplaceEntity inserts an entity in the specified table
 // or replaced the existing one.
 func (c *TableServiceClient) InsertOrReplaceEntity(table AzureTable, entity TableEntity) error {
-	if sc, err := c.execTable(table, entity, true, "PUT"); err != nil {
+	if sc, err := c.execTable(table, entity, true, http.MethodPut); err != nil {
 		return checkRespCode(sc, []int{http.StatusNoContent})
 	}
 	return nil


### PR DESCRIPTION
I've updated all http-verbs to refer to consts that are defined in
golang's src/net/http/method.go

This effort was scoped to files in /storage/