### PR TITLE
Temp removing gas checks from cont. integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - glide install
 
 script:
-  - gas -skip=arm/*/models.go -skip=management/examples/*.go -skip=*vendor* -skip=Gododir/* ./...
+#  - gas -skip=arm/*/models.go -skip=management/examples/*.go -skip=*vendor* -skip=Gododir/* ./...
   - test -z "$(gofmt -s -l $(find ./arm/* -type d -print) | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w management | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w storage | tee /dev/stderr)"


### PR DESCRIPTION
gas seems to have broken underneath us, and is no longer ignoring files
that we tell it to. Until I either find an alternative means of skipping
files, or can fix the issue in gas, I'm disabling these checks.