### PR TITLE
Updating gas skip paths to accomodate new globs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - glide install
 
 script:
-#  - gas -skip=arm/*/models.go -skip=management/examples/*.go -skip=*vendor* -skip=Gododir/* ./...
+  - gas -skip=*/arm/*/models.go -skip=*/management/examples/*.go -skip=*vendor* -skip=*/Gododir/* ./...
   - test -z "$(gofmt -s -l $(find ./arm/* -type d -print) | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w management | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w storage | tee /dev/stderr)"


### PR DESCRIPTION
gas changed the way their globs are resolved to no longer use
Go/filepath, but instead a package published by an individual. This
caused a change in behavior, where there must be a prefix '/' when
providing a pattern that starts with a path.