### PR TITLE
Adding missing import that wasn't caught in last pull-request.

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"encoding/base64"
+	"net/http"
 	"net/url"
 	"os"
 	"testing"


### PR DESCRIPTION
Issue 485 masked the issue because it appeared that gas was the only
cause of failure in the integration tests.