### PR TITLE
Adding Go Report Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project provides various Go packages to perform operations
 on Microsoft Azure REST APIs.
 
-[![GoDoc](https://godoc.org/github.com/Azure/azure-sdk-for-go?status.svg)](https://godoc.org/github.com/Azure/azure-sdk-for-go) [![Build Status](https://travis-ci.org/Azure/azure-sdk-for-go.svg?branch=master)](https://travis-ci.org/Azure/azure-sdk-for-go)
+[![GoDoc](https://godoc.org/github.com/Azure/azure-sdk-for-go?status.svg)](https://godoc.org/github.com/Azure/azure-sdk-for-go) [![Build Status](https://travis-ci.org/Azure/azure-sdk-for-go.svg?branch=master)](https://travis-ci.org/Azure/azure-sdk-for-go) [![Go Report Card](https://goreportcard.com/badge/github.com/Azure/azure-sdk-for-go)](https://goreportcard.com/report/github.com/Azure/azure-sdk-for-go)
 
 > **NOTE:** This repository is under heavy ongoing development and
 is likely to break over time. We currently do not have any releases

--- a/management/affinitygroup/client.go
+++ b/management/affinitygroup/client.go
@@ -124,7 +124,7 @@ func encodeLabel(label string) string {
 }
 
 // decodeLabel is a helper function which decodes the base64 encoded
-// label recieved from Azure into standard encoding.
+// label received from Azure into standard encoding.
 func decodeLabel(label string) string {
 	res, _ := base64.StdEncoding.DecodeString(label)
 	return string(res)

--- a/management/publishSettings.go
+++ b/management/publishSettings.go
@@ -61,6 +61,9 @@ func ClientFromPublishSettingsDataWithConfig(data []byte, subscriptionID string,
 				}
 
 				pems, err := pkcs12.ToPEM(pfxData, "")
+				if err != nil {
+					return client, err
+				}
 
 				cert := []byte{}
 				for _, b := range pems {

--- a/management/sql/entities.go
+++ b/management/sql/entities.go
@@ -27,7 +27,7 @@ const (
 	DatabaseServerVersion12 = "12.0"
 )
 
-// DatabaseServer represents the set of data recieved from
+// DatabaseServer represents the set of data received from
 // a database server list operation.
 //
 // https://msdn.microsoft.com/en-us/library/azure/dn505702.aspx
@@ -45,7 +45,7 @@ type ListServersResponse struct {
 }
 
 // FirewallRuleCreateParams represents the set of possible
-// paramaters when creating a firewall rule on an Azure database server.
+// parameters when creating a firewall rule on an Azure database server.
 //
 // https://msdn.microsoft.com/en-us/library/azure/dn505712.aspx
 type FirewallRuleCreateParams struct {
@@ -55,7 +55,7 @@ type FirewallRuleCreateParams struct {
 	EndIPAddress   string
 }
 
-// FirewallRuleResponse represents the set of data recieved from
+// FirewallRuleResponse represents the set of data received from
 // an Azure database server firewall rule get response.
 //
 // https://msdn.microsoft.com/en-us/library/azure/dn505698.aspx

--- a/management/vmutils/integration_test.go
+++ b/management/vmutils/integration_test.go
@@ -321,6 +321,9 @@ func GetTestStorageAccount(t *testing.T, client management.Client) storage.Stora
 			t.Fatal(err)
 		}
 		sa, err = sc.GetStorageService(name)
+		if err != nil {
+			t.Fatal(err)
+		}
 	} else {
 
 		sa = ssl.StorageServices[rnd.Intn(len(ssl.StorageServices))]

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -377,7 +377,7 @@ type BlockResponse struct {
 	Size int64  `xml:"Size"`
 }
 
-// GetPageRangesResponse contains the reponse fields from
+// GetPageRangesResponse contains the response fields from
 // Get Page Ranges call.
 //
 // See https://msdn.microsoft.com/en-us/library/azure/ee691973.aspx
@@ -704,7 +704,7 @@ func (b BlobStorageClient) getBlobRange(container, name, bytesRange string, extr
 	return resp, err
 }
 
-// leasePut is common PUT code for the various aquire/release/break etc functions.
+// leasePut is common PUT code for the various acquire/release/break etc functions.
 func (b BlobStorageClient) leaseCommonPut(container string, name string, headers map[string]string, expectedStatus int) (http.Header, error) {
 	params := url.Values{"comp": {"lease"}}
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), params)
@@ -1416,7 +1416,7 @@ func pathForBlob(container, name string) string {
 }
 
 // GetBlobSASURIWithSignedIPAndProtocol creates an URL to the specified blob which contains the Shared
-// Access Signature with specified permissions and expiration time. Also includes signedIPRange and allowed procotols.
+// Access Signature with specified permissions and expiration time. Also includes signedIPRange and allowed protocols.
 // If old API version is used but no signedIP is passed (ie empty string) then this should still work.
 // We only populate the signedIP when it non-empty.
 //

--- a/storage/file.go
+++ b/storage/file.go
@@ -425,6 +425,10 @@ func (f FileServiceClient) GetFile(path string, fileRange *FileRange) (*FileStre
 	}
 
 	props, err := getFileProps(resp.headers)
+	if err != nil {
+		return nil, err
+	}
+
 	md := getFileMDFromHeaders(resp.headers)
 	return &FileStream{Body: resp.body, Properties: props, Metadata: md}, nil
 }


### PR DESCRIPTION
I added support for Go Report Card, which is a popular lint-like service that helps build confidence in folks hoping to adopt our package.

We currently have an A+ rating, but are not at 100%. I made some of the easy changes that will help bring us closer to 100. It is worth noting that I did not fix issues that are results of mistakes in swagger files (mis-spelled words) and I did not yet go add documentation to a handful of public methods that have no comment.