### PR TITLE
Refactor file storage APIs.

### DIFF
--- a/storage/directory.go
+++ b/storage/directory.go
@@ -1,0 +1,217 @@
+package storage
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/url"
+)
+
+// Directory represents a directory on a share.
+type Directory struct {
+	fsc        *FileServiceClient
+	Metadata   map[string]string
+	Name       string `xml:"Name"`
+	parent     *Directory
+	Properties DirectoryProperties
+	share      *Share
+}
+
+// DirectoryProperties contains various properties of a directory.
+type DirectoryProperties struct {
+	LastModified string `xml:"Last-Modified"`
+	Etag         string `xml:"Etag"`
+}
+
+// ListDirsAndFilesParameters defines the set of customizable parameters to
+// make a List Files and Directories call.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn166980.aspx
+type ListDirsAndFilesParameters struct {
+	Marker     string
+	MaxResults uint
+	Timeout    uint
+}
+
+// DirsAndFilesListResponse contains the response fields from
+// a List Files and Directories call.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn166980.aspx
+type DirsAndFilesListResponse struct {
+	XMLName     xml.Name    `xml:"EnumerationResults"`
+	Xmlns       string      `xml:"xmlns,attr"`
+	Marker      string      `xml:"Marker"`
+	MaxResults  int64       `xml:"MaxResults"`
+	Directories []Directory `xml:"Entries>Directory"`
+	Files       []File      `xml:"Entries>File"`
+	NextMarker  string      `xml:"NextMarker"`
+}
+
+// builds the complete directory path for this directory object.
+func (d *Directory) buildPath() string {
+	path := ""
+	current := d
+	for current.Name != "" {
+		path = "/" + current.Name + path
+		current = current.parent
+	}
+	return d.share.buildPath() + path
+}
+
+// Create this directory in the associated share.
+// If a directory with the same name already exists, the operation fails.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn166993.aspx
+func (d *Directory) Create() error {
+	// if this is the root directory exit early
+	if d.parent == nil {
+		return nil
+	}
+
+	headers, err := d.fsc.createResource(d.buildPath(), resourceDirectory, mergeMDIntoExtraHeaders(d.Metadata, nil))
+	if err != nil {
+		return err
+	}
+
+	d.updateEtagAndLastModified(headers)
+	return nil
+}
+
+// CreateIfNotExists creates this directory under the associated share if the
+// directory does not exists. Returns true if the directory is newly created or
+// false if the directory already exists.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn166993.aspx
+func (d *Directory) CreateIfNotExists() (bool, error) {
+	// if this is the root directory exit early
+	if d.parent == nil {
+		return false, nil
+	}
+
+	resp, err := d.fsc.createResourceNoClose(d.buildPath(), resourceDirectory, nil)
+	if resp != nil {
+		defer resp.body.Close()
+		if resp.statusCode == http.StatusCreated || resp.statusCode == http.StatusConflict {
+			if resp.statusCode == http.StatusCreated {
+				d.updateEtagAndLastModified(resp.headers)
+				return true, nil
+			}
+
+			return false, d.FetchAttributes()
+		}
+	}
+
+	return false, err
+}
+
+// Delete removes this directory.  It must be empty in order to be deleted.
+// If the directory does not exist the operation fails.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn166969.aspx
+func (d *Directory) Delete() error {
+	return d.fsc.deleteResource(d.buildPath(), resourceDirectory)
+}
+
+// DeleteIfExists removes this directory if it exists.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn166969.aspx
+func (d *Directory) DeleteIfExists() (bool, error) {
+	resp, err := d.fsc.deleteResourceNoClose(d.buildPath(), resourceDirectory)
+	if resp != nil {
+		defer resp.body.Close()
+		if resp.statusCode == http.StatusAccepted || resp.statusCode == http.StatusNotFound {
+			return resp.statusCode == http.StatusAccepted, nil
+		}
+	}
+	return false, err
+}
+
+// Exists returns true if this directory exists.
+func (d *Directory) Exists() (bool, error) {
+	exists, headers, err := d.fsc.resourceExists(d.buildPath(), resourceDirectory)
+	if exists {
+		d.updateEtagAndLastModified(headers)
+	}
+	return exists, err
+}
+
+// FetchAttributes retrieves metadata for this directory.
+func (d *Directory) FetchAttributes() error {
+	headers, err := d.fsc.getResourceHeaders(d.buildPath(), compNone, resourceDirectory, http.MethodHead)
+	if err != nil {
+		return err
+	}
+
+	d.updateEtagAndLastModified(headers)
+	d.Metadata = getMetadataFromHeaders(headers)
+
+	return nil
+}
+
+// GetDirectoryReference returns a child Directory object for this directory.
+func (d *Directory) GetDirectoryReference(name string) *Directory {
+	return &Directory{
+		fsc:    d.fsc,
+		Name:   name,
+		parent: d,
+		share:  d.share,
+	}
+}
+
+// GetFileReference returns a child File object for this directory.
+func (d *Directory) GetFileReference(name string) *File {
+	return &File{
+		fsc:    d.fsc,
+		Name:   name,
+		parent: d,
+		share:  d.share,
+	}
+}
+
+// ListDirsAndFiles returns a list of files and directories under this directory.
+// It also contains a pagination token and other response details.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn166980.aspx
+func (d *Directory) ListDirsAndFiles(params ListDirsAndFilesParameters) (*DirsAndFilesListResponse, error) {
+	q := mergeParams(params.getParameters(), getURLInitValues(compList, resourceDirectory))
+
+	resp, err := d.fsc.listContent(d.buildPath(), q, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.body.Close()
+	var out DirsAndFilesListResponse
+	err = xmlUnmarshal(resp.body, &out)
+	return &out, err
+}
+
+// SetMetadata replaces the metadata for this directory.
+//
+// Some keys may be converted to Camel-Case before sending. All keys
+// are returned in lower case by GetDirectoryMetadata. HTTP header names
+// are case-insensitive so case munging should not matter to other
+// applications either.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/mt427370.aspx
+func (d *Directory) SetMetadata() error {
+	headers, err := d.fsc.setResourceHeaders(d.buildPath(), compMetadata, resourceDirectory, mergeMDIntoExtraHeaders(d.Metadata, nil))
+	if err != nil {
+		return err
+	}
+
+	d.updateEtagAndLastModified(headers)
+	return nil
+}
+
+// updates Etag and last modified date
+func (d *Directory) updateEtagAndLastModified(headers http.Header) {
+	d.Properties.Etag = headers.Get("Etag")
+	d.Properties.LastModified = headers.Get("Last-Modified")
+}
+
+// URL gets the canonical URL to this directory.
+// This method does not create a publicly accessible URL if the directory
+// is private and this method does not check if the directory exists.
+func (d *Directory) URL() string {
+	return d.fsc.client.getEndpoint(fileServiceName, d.buildPath(), url.Values{})
+}

--- a/storage/directory_test.go
+++ b/storage/directory_test.go
@@ -1,0 +1,112 @@
+package storage
+
+import chk "gopkg.in/check.v1"
+
+type StorageDirSuite struct{}
+
+var _ = chk.Suite(&StorageDirSuite{})
+
+func (s *StorageDirSuite) TestListDirsAndFiles(c *chk.C) {
+	// create share
+	cli := getFileClient(c)
+	share := cli.GetShareReference(randShare())
+
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	root := share.GetRootDirectoryReference()
+
+	// list contents, should be empty
+	resp, err := root.ListDirsAndFiles(ListDirsAndFilesParameters{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.Directories, chk.IsNil)
+	c.Assert(resp.Files, chk.IsNil)
+
+	// create a directory and a file
+	dir := root.GetDirectoryReference("SomeDirectory")
+	file := root.GetFileReference("foo.file")
+	c.Assert(dir.Create(), chk.IsNil)
+	c.Assert(file.Create(512), chk.IsNil)
+
+	// list contents
+	resp, err = root.ListDirsAndFiles(ListDirsAndFilesParameters{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(len(resp.Directories), chk.Equals, 1)
+	c.Assert(len(resp.Files), chk.Equals, 1)
+	c.Assert(resp.Directories[0].Name, chk.Equals, dir.Name)
+	c.Assert(resp.Files[0].Name, chk.Equals, file.Name)
+
+	// delete file
+	del, err := file.DeleteIfExists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(del, chk.Equals, true)
+
+	// attempt to delete again
+	del, err = file.DeleteIfExists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(del, chk.Equals, false)
+}
+
+func (s *StorageDirSuite) TestCreateDirectory(c *chk.C) {
+	// create share
+	cli := getFileClient(c)
+	share := cli.GetShareReference(randShare())
+
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	root := share.GetRootDirectoryReference()
+
+	// directory shouldn't exist
+	dir := root.GetDirectoryReference("SomeDirectory")
+	exists, err := dir.Exists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(exists, chk.Equals, false)
+
+	// create directory
+	exists, err = dir.CreateIfNotExists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(exists, chk.Equals, true)
+
+	// try to create again, should fail
+	c.Assert(dir.Create(), chk.NotNil)
+	exists, err = dir.CreateIfNotExists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(exists, chk.Equals, false)
+
+	// check properties
+	c.Assert(dir.Properties.Etag, chk.Not(chk.Equals), "")
+	c.Assert(dir.Properties.LastModified, chk.Not(chk.Equals), "")
+
+	// delete directory and verify
+	c.Assert(dir.Delete(), chk.IsNil)
+	exists, err = dir.Exists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(exists, chk.Equals, false)
+}
+
+func (s *StorageDirSuite) TestDirectoryMetadata(c *chk.C) {
+	// create share
+	cli := getFileClient(c)
+	share := cli.GetShareReference(randShare())
+
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	root := share.GetRootDirectoryReference()
+
+	dir := root.GetDirectoryReference("testdir")
+	c.Assert(dir.Create(), chk.IsNil)
+
+	// get metadata, shouldn't be any
+	c.Assert(dir.Metadata, chk.IsNil)
+
+	// set some custom metadata
+	md := map[string]string{
+		"something": "somethingvalue",
+		"another":   "anothervalue",
+	}
+	dir.Metadata = md
+	c.Assert(dir.SetMetadata(), chk.IsNil)
+
+	// retrieve and verify
+	c.Assert(dir.FetchAttributes(), chk.IsNil)
+	c.Assert(dir.Metadata, chk.DeepEquals, md)
+}

--- a/storage/file.go
+++ b/storage/file.go
@@ -325,12 +325,11 @@ func (f *File) updateProperties(header http.Header) {
 		f.Properties.Length = size
 	}
 
+	f.updateEtagAndLastModified(header)
 	f.Properties.CacheControl = header.Get("Cache-Control")
 	f.Properties.Disposition = header.Get("Content-Disposition")
 	f.Properties.Encoding = header.Get("Content-Encoding")
-	f.Properties.Etag = header.Get("ETag")
 	f.Properties.Language = header.Get("Content-Language")
-	f.Properties.LastModified = header.Get("Last-Modified")
 	f.Properties.MD5 = header.Get("Content-MD5")
 	f.Properties.Type = header.Get("Content-Type")
 }

--- a/storage/file.go
+++ b/storage/file.go
@@ -1,118 +1,54 @@
 package storage
 
 import (
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 )
 
-// FileServiceClient contains operations for Microsoft Azure File Service.
-type FileServiceClient struct {
-	client Client
-}
+const fourMB = uint64(4194304)
+const oneTB = uint64(1099511627776)
 
-// A Share is an entry in ShareListResponse.
-type Share struct {
-	Name       string          `xml:"Name"`
-	Properties ShareProperties `xml:"Properties"`
-}
-
-// A Directory is an entry in DirsAndFilesListResponse.
-type Directory struct {
-	Name string `xml:"Name"`
-}
-
-// A File is an entry in DirsAndFilesListResponse.
+// File represents a file on a share.
 type File struct {
-	Name       string         `xml:"Name"`
+	fsc        *FileServiceClient
+	Metadata   map[string]string
+	Name       string `xml:"Name"`
+	parent     *Directory
 	Properties FileProperties `xml:"Properties"`
+	share      *Share
 }
 
-// ShareProperties contains various properties of a share returned from
-// various endpoints like ListShares.
-type ShareProperties struct {
-	LastModified string `xml:"Last-Modified"`
-	Etag         string `xml:"Etag"`
-	Quota        string `xml:"Quota"`
-}
-
-// DirectoryProperties contains various properties of a directory returned
-// from various endpoints like GetDirectoryProperties.
-type DirectoryProperties struct {
-	LastModified string `xml:"Last-Modified"`
-	Etag         string `xml:"Etag"`
-}
-
-// FileProperties contains various properties of a file returned from
-// various endpoints like ListDirsAndFiles.
+// FileProperties contains various properties of a file.
 type FileProperties struct {
-	CacheControl       string `header:"x-ms-cache-control"`
-	ContentLength      uint64 `xml:"Content-Length"`
-	ContentType        string `header:"x-ms-content-type"`
-	CopyCompletionTime string
-	CopyID             string
-	CopySource         string
-	CopyProgress       string
-	CopyStatusDesc     string
-	CopyStatus         string
-	Disposition        string `header:"x-ms-content-disposition"`
-	Encoding           string `header:"x-ms-content-encoding"`
-	Etag               string
-	Language           string `header:"x-ms-content-language"`
-	LastModified       string
-	MD5                string `header:"x-ms-content-md5"`
+	CacheControl string `header:"x-ms-cache-control"`
+	Disposition  string `header:"x-ms-content-disposition"`
+	Encoding     string `header:"x-ms-content-encoding"`
+	Etag         string
+	Language     string `header:"x-ms-content-language"`
+	LastModified string
+	Length       uint64 `xml:"Content-Length"`
+	MD5          string `header:"x-ms-content-md5"`
+	Type         string `header:"x-ms-content-type"`
+}
+
+// FileCopyState contains various properties of a file copy operation.
+type FileCopyState struct {
+	CompletionTime string
+	ID             string
+	Progress       string
+	Source         string
+	Status         string
+	StatusDesc     string
 }
 
 // FileStream contains file data returned from a call to GetFile.
 type FileStream struct {
 	Body       io.ReadCloser
-	Properties *FileProperties
-	Metadata   map[string]string
-}
-
-// ShareListResponse contains the response fields from
-// ListShares call.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn167009.aspx
-type ShareListResponse struct {
-	XMLName    xml.Name `xml:"EnumerationResults"`
-	Xmlns      string   `xml:"xmlns,attr"`
-	Prefix     string   `xml:"Prefix"`
-	Marker     string   `xml:"Marker"`
-	NextMarker string   `xml:"NextMarker"`
-	MaxResults int64    `xml:"MaxResults"`
-	Shares     []Share  `xml:"Shares>Share"`
-}
-
-// ListSharesParameters defines the set of customizable parameters to make a
-// List Shares call.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn167009.aspx
-type ListSharesParameters struct {
-	Prefix     string
-	Marker     string
-	Include    string
-	MaxResults uint
-	Timeout    uint
-}
-
-// DirsAndFilesListResponse contains the response fields from
-// a List Files and Directories call.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn166980.aspx
-type DirsAndFilesListResponse struct {
-	XMLName     xml.Name    `xml:"EnumerationResults"`
-	Xmlns       string      `xml:"xmlns,attr"`
-	Marker      string      `xml:"Marker"`
-	MaxResults  int64       `xml:"MaxResults"`
-	Directories []Directory `xml:"Entries>Directory"`
-	Files       []File      `xml:"Entries>File"`
-	NextMarker  string      `xml:"NextMarker"`
+	ContentMD5 string
 }
 
 // FileRanges contains a list of file range information for a file.
@@ -133,132 +69,140 @@ type FileRange struct {
 	End   uint64 `xml:"End"`
 }
 
-// ListDirsAndFilesParameters defines the set of customizable parameters to
-// make a List Files and Directories call.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn166980.aspx
-type ListDirsAndFilesParameters struct {
-	Marker     string
-	MaxResults uint
-	Timeout    uint
-}
-
-// ShareHeaders contains various properties of a file and is an entry
-// in SetShareProperties
-type ShareHeaders struct {
-	Quota string `header:"x-ms-share-quota"`
-}
-
-type compType string
-
-const (
-	compNone       compType = ""
-	compList       compType = "list"
-	compMetadata   compType = "metadata"
-	compProperties compType = "properties"
-	compRangeList  compType = "rangelist"
-)
-
-func (ct compType) String() string {
-	return string(ct)
-}
-
-type resourceType string
-
-const (
-	resourceDirectory resourceType = "directory"
-	resourceFile      resourceType = ""
-	resourceShare     resourceType = "share"
-)
-
-func (rt resourceType) String() string {
-	return string(rt)
-}
-
-func (p ListSharesParameters) getParameters() url.Values {
-	out := url.Values{}
-
-	if p.Prefix != "" {
-		out.Set("prefix", p.Prefix)
-	}
-	if p.Marker != "" {
-		out.Set("marker", p.Marker)
-	}
-	if p.Include != "" {
-		out.Set("include", p.Include)
-	}
-	if p.MaxResults != 0 {
-		out.Set("maxresults", fmt.Sprintf("%v", p.MaxResults))
-	}
-	if p.Timeout != 0 {
-		out.Set("timeout", fmt.Sprintf("%v", p.Timeout))
-	}
-
-	return out
-}
-
-func (p ListDirsAndFilesParameters) getParameters() url.Values {
-	out := url.Values{}
-
-	if p.Marker != "" {
-		out.Set("marker", p.Marker)
-	}
-	if p.MaxResults != 0 {
-		out.Set("maxresults", fmt.Sprintf("%v", p.MaxResults))
-	}
-	if p.Timeout != 0 {
-		out.Set("timeout", fmt.Sprintf("%v", p.Timeout))
-	}
-
-	return out
-}
-
 func (fr FileRange) String() string {
 	return fmt.Sprintf("bytes=%d-%d", fr.Start, fr.End)
 }
 
-// ToPathSegment returns the URL path segment for the specified values
-func ToPathSegment(parts ...string) string {
-	join := strings.Join(parts, "/")
-	if join[0] != '/' {
-		join = fmt.Sprintf("/%s", join)
-	}
-	return join
+// builds the complete file path for this file object
+func (f *File) buildPath() string {
+	return f.parent.buildPath() + "/" + f.Name
 }
 
-// returns url.Values for the specified types
-func getURLInitValues(comp compType, res resourceType) url.Values {
-	values := url.Values{}
-	if comp != compNone {
-		values.Set("comp", comp.String())
-	}
-	if res != resourceFile {
-		values.Set("restype", res.String())
-	}
-	return values
-}
-
-// ListDirsAndFiles returns a list of files or directories under the specified share or
-// directory.  It also contains a pagination token and other response details.
+// ClearRange releases the specified range of space in a file.
 //
-// See https://msdn.microsoft.com/en-us/library/azure/dn166980.aspx
-func (f FileServiceClient) ListDirsAndFiles(path string, params ListDirsAndFilesParameters) (DirsAndFilesListResponse, error) {
-	q := mergeParams(params.getParameters(), getURLInitValues(compList, resourceDirectory))
-
-	var out DirsAndFilesListResponse
-	resp, err := f.listContent(path, q, nil)
+// See https://msdn.microsoft.com/en-us/library/azure/dn194276.aspx
+func (f *File) ClearRange(fileRange FileRange) error {
+	headers, err := f.modifyRange(nil, fileRange, nil)
 	if err != nil {
-		return out, err
+		return err
 	}
-	defer resp.body.Close()
-	err = xmlUnmarshal(resp.body, &out)
-	return out, err
+
+	f.updateEtagAndLastModified(headers)
+	return nil
 }
 
-// ListFileRanges returns the list of valid ranges for a file.
+// Create creates a new file or replaces an existing one.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn194271.aspx
+func (f *File) Create(maxSize uint64) error {
+	if maxSize > oneTB {
+		return fmt.Errorf("max file size is 1TB")
+	}
+
+	extraHeaders := map[string]string{
+		"x-ms-content-length": strconv.FormatUint(maxSize, 10),
+		"x-ms-type":           "file",
+	}
+
+	headers, err := f.fsc.createResource(f.buildPath(), resourceFile, mergeMDIntoExtraHeaders(f.Metadata, extraHeaders))
+	if err != nil {
+		return err
+	}
+
+	f.Properties.Length = maxSize
+	f.updateEtagAndLastModified(headers)
+	return nil
+}
+
+// Delete immediately removes this file from the storage account.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn689085.aspx
+func (f *File) Delete() error {
+	return f.fsc.deleteResource(f.buildPath(), resourceFile)
+}
+
+// DeleteIfExists removes this file if it exists.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn689085.aspx
+func (f *File) DeleteIfExists() (bool, error) {
+	resp, err := f.fsc.deleteResourceNoClose(f.buildPath(), resourceFile)
+	if resp != nil {
+		defer resp.body.Close()
+		if resp.statusCode == http.StatusAccepted || resp.statusCode == http.StatusNotFound {
+			return resp.statusCode == http.StatusAccepted, nil
+		}
+	}
+	return false, err
+}
+
+// DownloadRangeToStream operation downloads the specified range of this file with optional MD5 hash.
+//
+// See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-file
+func (f *File) DownloadRangeToStream(fileRange FileRange, getContentMD5 bool) (fs FileStream, err error) {
+	if getContentMD5 && isRangeTooBig(fileRange) {
+		return fs, fmt.Errorf("must specify a range less than or equal to 4MB when getContentMD5 is true")
+	}
+
+	extraHeaders := map[string]string{
+		"Range": fileRange.String(),
+	}
+	if getContentMD5 == true {
+		extraHeaders["x-ms-range-get-content-md5"] = "true"
+	}
+
+	resp, err := f.fsc.getResourceNoClose(f.buildPath(), compNone, resourceFile, http.MethodGet, extraHeaders)
+	if err != nil {
+		return fs, err
+	}
+
+	if err = checkRespCode(resp.statusCode, []int{http.StatusOK, http.StatusPartialContent}); err != nil {
+		resp.body.Close()
+		return fs, err
+	}
+
+	fs.Body = resp.body
+	if getContentMD5 {
+		fs.ContentMD5 = resp.headers.Get("Content-MD5")
+	}
+	return fs, nil
+}
+
+// Exists returns true if this file exists.
+func (f *File) Exists() (bool, error) {
+	exists, headers, err := f.fsc.resourceExists(f.buildPath(), resourceFile)
+	if exists {
+		f.updateEtagAndLastModified(headers)
+		f.updateProperties(headers)
+	}
+	return exists, err
+}
+
+// FetchAttributes updates metadata and properties for this file.
+func (f *File) FetchAttributes() error {
+	headers, err := f.fsc.getResourceHeaders(f.buildPath(), compNone, resourceFile, http.MethodHead)
+	if err != nil {
+		return err
+	}
+
+	f.updateEtagAndLastModified(headers)
+	f.updateProperties(headers)
+	f.Metadata = getMetadataFromHeaders(headers)
+	return nil
+}
+
+// returns true if the range is larger than 4MB
+func isRangeTooBig(fileRange FileRange) bool {
+	if fileRange.End-fileRange.Start > fourMB {
+		return true
+	}
+
+	return false
+}
+
+// ListRanges returns the list of valid ranges for this file.
 //
 // See https://msdn.microsoft.com/en-us/library/azure/dn166984.aspx
-func (f FileServiceClient) ListFileRanges(path string, listRange *FileRange) (FileRanges, error) {
+func (f *File) ListRanges(listRange *FileRange) (*FileRanges, error) {
 	params := url.Values{"comp": {"rangelist"}}
 
 	// add optional range to list
@@ -268,114 +212,40 @@ func (f FileServiceClient) ListFileRanges(path string, listRange *FileRange) (Fi
 		headers["Range"] = listRange.String()
 	}
 
-	var out FileRanges
-	resp, err := f.listContent(path, params, headers)
+	resp, err := f.fsc.listContent(f.buildPath(), params, headers)
 	if err != nil {
-		return out, err
+		return nil, err
 	}
 
 	defer resp.body.Close()
 	var cl uint64
 	cl, err = strconv.ParseUint(resp.headers.Get("x-ms-content-length"), 10, 64)
 	if err != nil {
-		return out, err
+		return nil, err
 	}
 
+	var out FileRanges
 	out.ContentLength = cl
 	out.ETag = resp.headers.Get("ETag")
 	out.LastModified = resp.headers.Get("Last-Modified")
 
 	err = xmlUnmarshal(resp.body, &out)
-	return out, err
+	return &out, err
 }
 
-// ListShares returns the list of shares in a storage account along with
-// pagination token and other response details.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dd179352.aspx
-func (f FileServiceClient) ListShares(params ListSharesParameters) (ShareListResponse, error) {
-	q := mergeParams(params.getParameters(), url.Values{"comp": {"list"}})
-
-	var out ShareListResponse
-	resp, err := f.listContent("", q, nil)
-	if err != nil {
-		return out, err
-	}
-	defer resp.body.Close()
-	err = xmlUnmarshal(resp.body, &out)
-	return out, err
-}
-
-// retrieves directory or share content
-func (f FileServiceClient) listContent(path string, params url.Values, extraHeaders map[string]string) (*storageResponse, error) {
-	if err := f.checkForStorageEmulator(); err != nil {
+// modifies a range of bytes in this file
+func (f *File) modifyRange(bytes io.Reader, fileRange FileRange, contentMD5 *string) (http.Header, error) {
+	if err := f.fsc.checkForStorageEmulator(); err != nil {
 		return nil, err
-	}
-
-	uri := f.client.getEndpoint(fileServiceName, path, params)
-	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
-
-	resp, err := f.client.exec(http.MethodGet, uri, headers, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
-		resp.body.Close()
-		return nil, err
-	}
-
-	return resp, nil
-}
-
-// CreateDirectory operation creates a new directory with optional metadata in the
-// specified share. If a directory with the same name already exists, the operation fails.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn166993.aspx
-func (f FileServiceClient) CreateDirectory(path string, metadata map[string]string) error {
-	return f.createResource(path, resourceDirectory, mergeMDIntoExtraHeaders(metadata, nil))
-}
-
-// CreateFile operation creates a new file with optional metadata or replaces an existing one.
-// Note that this only initializes the file, call PutRange to add content.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn194271.aspx
-func (f FileServiceClient) CreateFile(path string, maxSize uint64, metadata map[string]string) error {
-	extraHeaders := map[string]string{
-		"x-ms-content-length": strconv.FormatUint(maxSize, 10),
-		"x-ms-type":           "file",
-	}
-	return f.createResource(path, resourceFile, mergeMDIntoExtraHeaders(metadata, extraHeaders))
-}
-
-// ClearRange releases the specified range of space in storage.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn194276.aspx
-func (f FileServiceClient) ClearRange(path string, fileRange FileRange) error {
-	return f.modifyRange(path, nil, fileRange)
-}
-
-// PutRange writes a range of bytes to a file.  Note that the length of bytes must
-// match (rangeEnd - rangeStart) + 1 with a maximum size of 4MB.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn194276.aspx
-func (f FileServiceClient) PutRange(path string, bytes io.Reader, fileRange FileRange) error {
-	return f.modifyRange(path, bytes, fileRange)
-}
-
-// modifies a range of bytes in the specified file
-func (f FileServiceClient) modifyRange(path string, bytes io.Reader, fileRange FileRange) error {
-	if err := f.checkForStorageEmulator(); err != nil {
-		return err
 	}
 	if fileRange.End < fileRange.Start {
-		return errors.New("the value for rangeEnd must be greater than or equal to rangeStart")
+		return nil, errors.New("the value for rangeEnd must be greater than or equal to rangeStart")
 	}
-	if bytes != nil && fileRange.End-fileRange.Start > 4194304 {
-		return errors.New("range cannot exceed 4MB in size")
+	if bytes != nil && isRangeTooBig(fileRange) {
+		return nil, errors.New("range cannot exceed 4MB in size")
 	}
 
-	uri := f.client.getEndpoint(fileServiceName, path, url.Values{"comp": {"range"}})
+	uri := f.fsc.client.getEndpoint(fileServiceName, f.buildPath(), url.Values{"comp": {"range"}})
 
 	// default to clear
 	write := "clear"
@@ -393,350 +263,20 @@ func (f FileServiceClient) modifyRange(path string, bytes io.Reader, fileRange F
 		"x-ms-write":     write,
 	}
 
-	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
-	resp, err := f.client.exec(http.MethodPut, uri, headers, bytes)
-	if err != nil {
-		return err
-	}
-	defer resp.body.Close()
-	return checkRespCode(resp.statusCode, []int{http.StatusCreated})
-}
-
-// GetFile operation reads or downloads a file from the system, including its
-// metadata and properties.
-//
-// See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-file
-func (f FileServiceClient) GetFile(path string, fileRange *FileRange) (*FileStream, error) {
-	var extraHeaders map[string]string
-	if fileRange != nil {
-		extraHeaders = map[string]string{
-			"Range": fileRange.String(),
-		}
+	if contentMD5 != nil {
+		extraHeaders["Content-MD5"] = *contentMD5
 	}
 
-	resp, err := f.getResourceNoClose(path, compNone, resourceFile, http.MethodGet, extraHeaders)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = checkRespCode(resp.statusCode, []int{http.StatusOK, http.StatusPartialContent}); err != nil {
-		resp.body.Close()
-		return nil, err
-	}
-
-	props, err := getFileProps(resp.headers)
-	if err != nil {
-		return nil, err
-	}
-
-	md := getFileMDFromHeaders(resp.headers)
-	return &FileStream{Body: resp.body, Properties: props, Metadata: md}, nil
-}
-
-// CreateShare operation creates a new share with optional metadata under the specified account.
-// If the share with the same name already exists, the operation fails.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn167008.aspx
-func (f FileServiceClient) CreateShare(name string, metadata map[string]string) error {
-	return f.createResource(ToPathSegment(name), resourceShare, mergeMDIntoExtraHeaders(metadata, nil))
-}
-
-// DirectoryExists returns true if the specified directory exists on the specified share.
-func (f FileServiceClient) DirectoryExists(path string) (bool, error) {
-	return f.resourceExists(path, resourceDirectory)
-}
-
-// FileExists returns true if the specified file exists.
-func (f FileServiceClient) FileExists(path string) (bool, error) {
-	return f.resourceExists(path, resourceFile)
-}
-
-// ShareExists returns true if a share with given name exists
-// on the storage account, otherwise returns false.
-func (f FileServiceClient) ShareExists(name string) (bool, error) {
-	return f.resourceExists(ToPathSegment(name), resourceShare)
-}
-
-// returns true if the specified directory or share exists
-func (f FileServiceClient) resourceExists(path string, res resourceType) (bool, error) {
-	if err := f.checkForStorageEmulator(); err != nil {
-		return false, err
-	}
-
-	uri := f.client.getEndpoint(fileServiceName, path, getURLInitValues(compNone, res))
-	headers := f.client.getStandardHeaders()
-
-	resp, err := f.client.exec(http.MethodHead, uri, headers, nil)
-	if resp != nil {
-		defer resp.body.Close()
-		if resp.statusCode == http.StatusOK || resp.statusCode == http.StatusNotFound {
-			return resp.statusCode == http.StatusOK, nil
-		}
-	}
-	return false, err
-}
-
-// GetDirectoryURL gets the canonical URL to the directory with the specified name
-// in the specified share. This method does not create a publicly accessible URL if
-// the file is private and this method does not check if the directory exists.
-func (f FileServiceClient) GetDirectoryURL(path string) string {
-	return f.client.getEndpoint(fileServiceName, path, url.Values{})
-}
-
-// GetShareURL gets the canonical URL to the share with the specified name in the
-// specified container. This method does not create a publicly accessible URL if
-// the file is private and this method does not check if the share exists.
-func (f FileServiceClient) GetShareURL(name string) string {
-	return f.client.getEndpoint(fileServiceName, ToPathSegment(name), url.Values{})
-}
-
-// CreateDirectoryIfNotExists creates a new directory on the specified share
-// if it does not exist. Returns true if directory is newly created or false
-// if the directory already exists.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn166993.aspx
-func (f FileServiceClient) CreateDirectoryIfNotExists(path string) (bool, error) {
-	resp, err := f.createResourceNoClose(path, resourceDirectory, nil)
-	if resp != nil {
-		defer resp.body.Close()
-		if resp.statusCode == http.StatusCreated || resp.statusCode == http.StatusConflict {
-			return resp.statusCode == http.StatusCreated, nil
-		}
-	}
-	return false, err
-}
-
-// CreateShareIfNotExists creates a new share under the specified account if
-// it does not exist. Returns true if container is newly created or false if
-// container already exists.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn167008.aspx
-func (f FileServiceClient) CreateShareIfNotExists(name string) (bool, error) {
-	resp, err := f.createResourceNoClose(ToPathSegment(name), resourceShare, nil)
-	if resp != nil {
-		defer resp.body.Close()
-		if resp.statusCode == http.StatusCreated || resp.statusCode == http.StatusConflict {
-			return resp.statusCode == http.StatusCreated, nil
-		}
-	}
-	return false, err
-}
-
-// creates a resource depending on the specified resource type
-func (f FileServiceClient) createResource(path string, res resourceType, extraHeaders map[string]string) error {
-	resp, err := f.createResourceNoClose(path, res, extraHeaders)
-	if err != nil {
-		return err
-	}
-	defer resp.body.Close()
-	return checkRespCode(resp.statusCode, []int{http.StatusCreated})
-}
-
-// creates a resource depending on the specified resource type, doesn't close the response body
-func (f FileServiceClient) createResourceNoClose(path string, res resourceType, extraHeaders map[string]string) (*storageResponse, error) {
-	if err := f.checkForStorageEmulator(); err != nil {
-		return nil, err
-	}
-
-	values := getURLInitValues(compNone, res)
-	uri := f.client.getEndpoint(fileServiceName, path, values)
-	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
-
-	return f.client.exec(http.MethodPut, uri, headers, nil)
-}
-
-// GetDirectoryProperties provides various information about the specified directory.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn194272.aspx
-func (f FileServiceClient) GetDirectoryProperties(path string) (*DirectoryProperties, error) {
-	headers, err := f.getResourceHeaders(path, compNone, resourceDirectory, http.MethodHead)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DirectoryProperties{
-		LastModified: headers.Get("Last-Modified"),
-		Etag:         headers.Get("Etag"),
-	}, nil
-}
-
-// GetFileProperties provides various information about the specified file.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn166971.aspx
-func (f FileServiceClient) GetFileProperties(path string) (*FileProperties, error) {
-	headers, err := f.getResourceHeaders(path, compNone, resourceFile, http.MethodHead)
-	if err != nil {
-		return nil, err
-	}
-	return getFileProps(headers)
-}
-
-// returns file properties from the specified HTTP header
-func getFileProps(header http.Header) (*FileProperties, error) {
-	size, err := strconv.ParseUint(header.Get("Content-Length"), 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	return &FileProperties{
-		CacheControl:       header.Get("Cache-Control"),
-		ContentLength:      size,
-		ContentType:        header.Get("Content-Type"),
-		CopyCompletionTime: header.Get("x-ms-copy-completion-time"),
-		CopyID:             header.Get("x-ms-copy-id"),
-		CopyProgress:       header.Get("x-ms-copy-progress"),
-		CopySource:         header.Get("x-ms-copy-source"),
-		CopyStatus:         header.Get("x-ms-copy-status"),
-		CopyStatusDesc:     header.Get("x-ms-copy-status-description"),
-		Disposition:        header.Get("Content-Disposition"),
-		Encoding:           header.Get("Content-Encoding"),
-		Etag:               header.Get("ETag"),
-		Language:           header.Get("Content-Language"),
-		LastModified:       header.Get("Last-Modified"),
-		MD5:                header.Get("Content-MD5"),
-	}, nil
-}
-
-// GetShareProperties provides various information about the specified
-// file. See https://msdn.microsoft.com/en-us/library/azure/dn689099.aspx
-func (f FileServiceClient) GetShareProperties(name string) (*ShareProperties, error) {
-	headers, err := f.getResourceHeaders(ToPathSegment(name), compNone, resourceShare, http.MethodHead)
-	if err != nil {
-		return nil, err
-	}
-	return &ShareProperties{
-		LastModified: headers.Get("Last-Modified"),
-		Etag:         headers.Get("Etag"),
-		Quota:        headers.Get("x-ms-share-quota"),
-	}, nil
-}
-
-// returns HTTP header data for the specified directory or share
-func (f FileServiceClient) getResourceHeaders(path string, comp compType, res resourceType, verb string) (http.Header, error) {
-	resp, err := f.getResourceNoClose(path, comp, res, verb, nil)
+	headers := mergeHeaders(f.fsc.client.getStandardHeaders(), extraHeaders)
+	resp, err := f.fsc.client.exec(http.MethodPut, uri, headers, bytes)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.body.Close()
-
-	if err = checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
-		return nil, err
-	}
-
-	return resp.headers, nil
+	return resp.headers, checkRespCode(resp.statusCode, []int{http.StatusCreated})
 }
 
-// gets the specified resource, doesn't close the response body
-func (f FileServiceClient) getResourceNoClose(path string, comp compType, res resourceType, verb string, extraHeaders map[string]string) (*storageResponse, error) {
-	if err := f.checkForStorageEmulator(); err != nil {
-		return nil, err
-	}
-
-	params := getURLInitValues(comp, res)
-	uri := f.client.getEndpoint(fileServiceName, path, params)
-	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
-
-	return f.client.exec(verb, uri, headers, nil)
-}
-
-// SetFileProperties operation sets system properties on the specified file.
-//
-// Some keys may be converted to Camel-Case before sending. All keys
-// are returned in lower case by SetFileProperties. HTTP header names
-// are case-insensitive so case munging should not matter to other
-// applications either.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn166975.aspx
-func (f FileServiceClient) SetFileProperties(path string, props FileProperties) error {
-	return f.setResourceHeaders(path, compProperties, resourceFile, headersFromStruct(props))
-}
-
-// SetShareProperties replaces the ShareHeaders for the specified file.
-//
-// Some keys may be converted to Camel-Case before sending. All keys
-// are returned in lower case by SetShareProperties. HTTP header names
-// are case-insensitive so case munging should not matter to other
-// applications either.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/mt427368.aspx
-func (f FileServiceClient) SetShareProperties(name string, shareHeaders ShareHeaders) error {
-	return f.setResourceHeaders(ToPathSegment(name), compProperties, resourceShare, headersFromStruct(shareHeaders))
-}
-
-// DeleteDirectory operation removes the specified empty directory.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn166969.aspx
-func (f FileServiceClient) DeleteDirectory(path string) error {
-	return f.deleteResource(path, resourceDirectory)
-}
-
-// DeleteFile operation immediately removes the file from the storage account.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn689085.aspx
-func (f FileServiceClient) DeleteFile(path string) error {
-	return f.deleteResource(path, resourceFile)
-}
-
-// DeleteShare operation marks the specified share for deletion. The share
-// and any files contained within it are later deleted during garbage
-// collection.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn689090.aspx
-func (f FileServiceClient) DeleteShare(name string) error {
-	return f.deleteResource(ToPathSegment(name), resourceShare)
-}
-
-// DeleteShareIfExists operation marks the specified share for deletion if it
-// exists. The share and any files contained within it are later deleted during
-// garbage collection. Returns true if share existed and deleted with this call,
-// false otherwise.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn689090.aspx
-func (f FileServiceClient) DeleteShareIfExists(name string) (bool, error) {
-	resp, err := f.deleteResourceNoClose(ToPathSegment(name), resourceShare)
-	if resp != nil {
-		defer resp.body.Close()
-		if resp.statusCode == http.StatusAccepted || resp.statusCode == http.StatusNotFound {
-			return resp.statusCode == http.StatusAccepted, nil
-		}
-	}
-	return false, err
-}
-
-// deletes the resource and returns the response
-func (f FileServiceClient) deleteResource(path string, res resourceType) error {
-	resp, err := f.deleteResourceNoClose(path, res)
-	if err != nil {
-		return err
-	}
-	defer resp.body.Close()
-	return checkRespCode(resp.statusCode, []int{http.StatusAccepted})
-}
-
-// deletes the resource and returns the response, doesn't close the response body
-func (f FileServiceClient) deleteResourceNoClose(path string, res resourceType) (*storageResponse, error) {
-	if err := f.checkForStorageEmulator(); err != nil {
-		return nil, err
-	}
-
-	values := getURLInitValues(compNone, res)
-	uri := f.client.getEndpoint(fileServiceName, path, values)
-	return f.client.exec(http.MethodDelete, uri, f.client.getStandardHeaders(), nil)
-}
-
-// SetDirectoryMetadata replaces the metadata for the specified directory.
-//
-// Some keys may be converted to Camel-Case before sending. All keys
-// are returned in lower case by GetDirectoryMetadata. HTTP header names
-// are case-insensitive so case munging should not matter to other
-// applications either.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/mt427370.aspx
-func (f FileServiceClient) SetDirectoryMetadata(path string, metadata map[string]string) error {
-	return f.setResourceHeaders(path, compMetadata, resourceDirectory, mergeMDIntoExtraHeaders(metadata, nil))
-}
-
-// SetFileMetadata replaces the metadata for the specified file.
+// SetMetadata replaces the metadata for this file.
 //
 // Some keys may be converted to Camel-Case before sending. All keys
 // are returned in lower case by GetFileMetadata. HTTP header names
@@ -744,136 +284,78 @@ func (f FileServiceClient) SetDirectoryMetadata(path string, metadata map[string
 // applications either.
 //
 // See https://msdn.microsoft.com/en-us/library/azure/dn689097.aspx
-func (f FileServiceClient) SetFileMetadata(path string, metadata map[string]string) error {
-	return f.setResourceHeaders(path, compMetadata, resourceFile, mergeMDIntoExtraHeaders(metadata, nil))
+func (f *File) SetMetadata() error {
+	headers, err := f.fsc.setResourceHeaders(f.buildPath(), compMetadata, resourceFile, mergeMDIntoExtraHeaders(f.Metadata, nil))
+	if err != nil {
+		return err
+	}
+
+	f.updateEtagAndLastModified(headers)
+	return nil
 }
 
-// SetShareMetadata replaces the metadata for the specified Share.
+// SetProperties sets system properties on this file.
 //
 // Some keys may be converted to Camel-Case before sending. All keys
-// are returned in lower case by GetShareMetadata. HTTP header names
+// are returned in lower case by SetFileProperties. HTTP header names
 // are case-insensitive so case munging should not matter to other
 // applications either.
 //
-// See https://msdn.microsoft.com/en-us/library/azure/dd179414.aspx
-func (f FileServiceClient) SetShareMetadata(name string, metadata map[string]string) error {
-	return f.setResourceHeaders(ToPathSegment(name), compMetadata, resourceShare, mergeMDIntoExtraHeaders(metadata, nil))
-}
-
-// merges metadata into extraHeaders and returns extraHeaders
-func mergeMDIntoExtraHeaders(metadata, extraHeaders map[string]string) map[string]string {
-	if metadata == nil && extraHeaders == nil {
-		return nil
-	}
-	if extraHeaders == nil {
-		extraHeaders = make(map[string]string)
-	}
-	for k, v := range metadata {
-		extraHeaders[userDefinedMetadataHeaderPrefix+k] = v
-	}
-	return extraHeaders
-}
-
-// merges extraHeaders into headers and returns headers
-func mergeHeaders(headers, extraHeaders map[string]string) map[string]string {
-	for k, v := range extraHeaders {
-		headers[k] = v
-	}
-	return headers
-}
-
-// sets extra header data for the specified resource
-func (f FileServiceClient) setResourceHeaders(path string, comp compType, res resourceType, extraHeaders map[string]string) error {
-	if err := f.checkForStorageEmulator(); err != nil {
-		return err
-	}
-
-	params := getURLInitValues(comp, res)
-	uri := f.client.getEndpoint(fileServiceName, path, params)
-	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
-
-	resp, err := f.client.exec(http.MethodPut, uri, headers, nil)
+// See https://msdn.microsoft.com/en-us/library/azure/dn166975.aspx
+func (f *File) SetProperties() error {
+	headers, err := f.fsc.setResourceHeaders(f.buildPath(), compProperties, resourceFile, headersFromStruct(f.Properties))
 	if err != nil {
 		return err
 	}
-	defer resp.body.Close()
 
-	return checkRespCode(resp.statusCode, []int{http.StatusOK})
+	f.updateEtagAndLastModified(headers)
+	return nil
 }
 
-// GetDirectoryMetadata returns all user-defined metadata for the specified directory.
-//
-// All metadata keys will be returned in lower case. (HTTP header
-// names are case-insensitive.)
-//
-// See https://msdn.microsoft.com/en-us/library/azure/mt427371.aspx
-func (f FileServiceClient) GetDirectoryMetadata(path string) (map[string]string, error) {
-	return f.getMetadata(path, resourceDirectory)
+// updates Etag and last modified date
+func (f *File) updateEtagAndLastModified(headers http.Header) {
+	f.Properties.Etag = headers.Get("Etag")
+	f.Properties.LastModified = headers.Get("Last-Modified")
 }
 
-// GetFileMetadata returns all user-defined metadata for the specified file.
-//
-// All metadata keys will be returned in lower case. (HTTP header
-// names are case-insensitive.)
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dn689098.aspx
-func (f FileServiceClient) GetFileMetadata(path string) (map[string]string, error) {
-	return f.getMetadata(path, resourceFile)
-}
-
-// GetShareMetadata returns all user-defined metadata for the specified share.
-//
-// All metadata keys will be returned in lower case. (HTTP header
-// names are case-insensitive.)
-//
-// See https://msdn.microsoft.com/en-us/library/azure/dd179414.aspx
-func (f FileServiceClient) GetShareMetadata(name string) (map[string]string, error) {
-	return f.getMetadata(ToPathSegment(name), resourceShare)
-}
-
-// gets metadata for the specified resource
-func (f FileServiceClient) getMetadata(path string, res resourceType) (map[string]string, error) {
-	if err := f.checkForStorageEmulator(); err != nil {
-		return nil, err
+// updates file properties from the specified HTTP header
+func (f *File) updateProperties(header http.Header) {
+	size, err := strconv.ParseUint(header.Get("Content-Length"), 10, 64)
+	if err == nil {
+		f.Properties.Length = size
 	}
 
-	headers, err := f.getResourceHeaders(path, compMetadata, res, http.MethodGet)
+	f.Properties.CacheControl = header.Get("Cache-Control")
+	f.Properties.Disposition = header.Get("Content-Disposition")
+	f.Properties.Encoding = header.Get("Content-Encoding")
+	f.Properties.Etag = header.Get("ETag")
+	f.Properties.Language = header.Get("Content-Language")
+	f.Properties.LastModified = header.Get("Last-Modified")
+	f.Properties.MD5 = header.Get("Content-MD5")
+	f.Properties.Type = header.Get("Content-Type")
+}
+
+// URL gets the canonical URL to this file.
+// This method does not create a publicly accessible URL if the file
+// is private and this method does not check if the file exists.
+func (f *File) URL() string {
+	return f.fsc.client.getEndpoint(fileServiceName, f.buildPath(), url.Values{})
+}
+
+// WriteRange writes a range of bytes to this file with an optional MD5 hash of the content.
+// Note that the length of bytes must match (rangeEnd - rangeStart) + 1 with a maximum size of 4MB.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn194276.aspx
+func (f *File) WriteRange(bytes io.Reader, fileRange FileRange, contentMD5 *string) error {
+	if bytes == nil {
+		return errors.New("bytes cannot be nil")
+	}
+
+	headers, err := f.modifyRange(bytes, fileRange, contentMD5)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return getFileMDFromHeaders(headers), nil
-}
-
-// returns a map of custom metadata values from the specified HTTP header
-func getFileMDFromHeaders(header http.Header) map[string]string {
-	metadata := make(map[string]string)
-	for k, v := range header {
-		// Can't trust CanonicalHeaderKey() to munge case
-		// reliably. "_" is allowed in identifiers:
-		// https://msdn.microsoft.com/en-us/library/azure/dd179414.aspx
-		// https://msdn.microsoft.com/library/aa664670(VS.71).aspx
-		// http://tools.ietf.org/html/rfc7230#section-3.2
-		// ...but "_" is considered invalid by
-		// CanonicalMIMEHeaderKey in
-		// https://golang.org/src/net/textproto/reader.go?s=14615:14659#L542
-		// so k can be "X-Ms-Meta-Foo" or "x-ms-meta-foo_bar".
-		k = strings.ToLower(k)
-		if len(v) == 0 || !strings.HasPrefix(k, strings.ToLower(userDefinedMetadataHeaderPrefix)) {
-			continue
-		}
-		// metadata["foo"] = content of the last X-Ms-Meta-Foo header
-		k = k[len(userDefinedMetadataHeaderPrefix):]
-		metadata[k] = v[len(v)-1]
-	}
-	return metadata
-}
-
-//checkForStorageEmulator determines if the client is setup for use with
-//Azure Storage Emulator, and returns a relevant error
-func (f FileServiceClient) checkForStorageEmulator() error {
-	if f.client.accountName == StorageEmulatorAccountName {
-		return fmt.Errorf("Error: File service is not currently supported by Azure Storage Emulator")
-	}
+	f.updateEtagAndLastModified(headers)
 	return nil
 }

--- a/storage/file_test.go
+++ b/storage/file_test.go
@@ -2,9 +2,9 @@ package storage
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/base64"
 	"io"
-	"math/rand"
-	"strconv"
 
 	chk "gopkg.in/check.v1"
 )
@@ -13,274 +13,36 @@ type StorageFileSuite struct{}
 
 var _ = chk.Suite(&StorageFileSuite{})
 
-func getFileClient(c *chk.C) FileServiceClient {
-	return getBasicClient(c).GetFileService()
-}
-
-func (s *StorageFileSuite) Test_pathSegments(c *chk.C) {
-	c.Assert(ToPathSegment("foo"), chk.Equals, "/foo")
-	c.Assert(ToPathSegment("foo", "bar"), chk.Equals, "/foo/bar")
-	c.Assert(ToPathSegment("foo", "bar", "baz"), chk.Equals, "/foo/bar/baz")
-}
-
-func (s *StorageFileSuite) TestGetURL(c *chk.C) {
-	api, err := NewBasicClient("foo", "YmFy")
-	c.Assert(err, chk.IsNil)
-	cli := api.GetFileService()
-
-	c.Assert(cli.GetShareURL("share"), chk.Equals, "https://foo.file.core.windows.net/share")
-	c.Assert(cli.GetDirectoryURL("share/dir"), chk.Equals, "https://foo.file.core.windows.net/share/dir")
-}
-
-func (s *StorageFileSuite) TestCreateShareDeleteShare(c *chk.C) {
-	cli := getFileClient(c)
-	name := randShare()
-	c.Assert(cli.CreateShare(name, nil), chk.IsNil)
-	c.Assert(cli.DeleteShare(name), chk.IsNil)
-}
-
-func (s *StorageFileSuite) TestCreateShareIfNotExists(c *chk.C) {
-	cli := getFileClient(c)
-	name := randShare()
-	defer cli.DeleteShare(name)
-
-	// First create
-	ok, err := cli.CreateShareIfNotExists(name)
-	c.Assert(err, chk.IsNil)
-	c.Assert(ok, chk.Equals, true)
-
-	// Second create, should not give errors
-	ok, err = cli.CreateShareIfNotExists(name)
-	c.Assert(err, chk.IsNil)
-	c.Assert(ok, chk.Equals, false)
-}
-
-func (s *StorageFileSuite) TestDeleteShareIfNotExists(c *chk.C) {
-	cli := getFileClient(c)
-	name := randShare()
-
-	// delete non-existing share
-	ok, err := cli.DeleteShareIfExists(name)
-	c.Assert(err, chk.IsNil)
-	c.Assert(ok, chk.Equals, false)
-
-	c.Assert(cli.CreateShare(name, nil), chk.IsNil)
-
-	// delete existing share
-	ok, err = cli.DeleteShareIfExists(name)
-	c.Assert(err, chk.IsNil)
-	c.Assert(ok, chk.Equals, true)
-}
-
-func (s *StorageFileSuite) Test_checkForStorageEmulator(c *chk.C) {
-	f := getEmulatorClient(c).GetFileService()
-	err := f.checkForStorageEmulator()
-	c.Assert(err, chk.NotNil)
-}
-
-func (s *StorageFileSuite) TestListShares(c *chk.C) {
-	cli := getFileClient(c)
-	c.Assert(deleteTestShares(cli), chk.IsNil)
-
-	name := randShare()
-
-	c.Assert(cli.CreateShare(name, nil), chk.IsNil)
-	defer cli.DeleteShare(name)
-
-	resp, err := cli.ListShares(ListSharesParameters{
-		MaxResults: 5,
-		Prefix:     testSharePrefix})
-	c.Assert(err, chk.IsNil)
-
-	c.Check(len(resp.Shares), chk.Equals, 1)
-	c.Check(resp.Shares[0].Name, chk.Equals, name)
-
-}
-
-func (s *StorageFileSuite) TestShareExists(c *chk.C) {
-	cli := getFileClient(c)
-	name := randShare()
-
-	ok, err := cli.ShareExists(name)
-	c.Assert(err, chk.IsNil)
-	c.Assert(ok, chk.Equals, false)
-
-	c.Assert(cli.CreateShare(name, nil), chk.IsNil)
-	defer cli.DeleteShare(name)
-
-	ok, err = cli.ShareExists(name)
-	c.Assert(err, chk.IsNil)
-	c.Assert(ok, chk.Equals, true)
-}
-
-func (s *StorageFileSuite) TestGetAndSetShareProperties(c *chk.C) {
-	name := randShare()
-	quota := rand.Intn(5120)
-
-	cli := getFileClient(c)
-	c.Assert(cli.CreateShare(name, nil), chk.IsNil)
-	defer cli.DeleteShare(name)
-
-	err := cli.SetShareProperties(name, ShareHeaders{Quota: strconv.Itoa(quota)})
-	c.Assert(err, chk.IsNil)
-
-	props, err := cli.GetShareProperties(name)
-	c.Assert(err, chk.IsNil)
-
-	c.Assert(props.Quota, chk.Equals, strconv.Itoa(quota))
-}
-
-func (s *StorageFileSuite) TestGetAndSetShareMetadata(c *chk.C) {
-	cli := getFileClient(c)
-	share1 := randShare()
-
-	c.Assert(cli.CreateShare(share1, nil), chk.IsNil)
-	defer cli.DeleteShare(share1)
-
-	m, err := cli.GetShareMetadata(share1)
-	c.Assert(err, chk.IsNil)
-	c.Assert(m, chk.Not(chk.Equals), nil)
-	c.Assert(len(m), chk.Equals, 0)
-
-	share2 := randShare()
-	mCreate := map[string]string{
-		"create": "data",
-	}
-	c.Assert(cli.CreateShare(share2, mCreate), chk.IsNil)
-	defer cli.DeleteShare(share2)
-
-	m, err = cli.GetShareMetadata(share2)
-	c.Assert(err, chk.IsNil)
-	c.Assert(m, chk.Not(chk.Equals), nil)
-	c.Assert(len(m), chk.Equals, 1)
-
-	mPut := map[string]string{
-		"foo":     "bar",
-		"bar_baz": "waz qux",
-	}
-
-	err = cli.SetShareMetadata(share2, mPut)
-	c.Assert(err, chk.IsNil)
-
-	m, err = cli.GetShareMetadata(share2)
-	c.Assert(err, chk.IsNil)
-	c.Check(m, chk.DeepEquals, mPut)
-
-	// Case munging
-
-	mPutUpper := map[string]string{
-		"Foo":     "different bar",
-		"bar_BAZ": "different waz qux",
-	}
-	mExpectLower := map[string]string{
-		"foo":     "different bar",
-		"bar_baz": "different waz qux",
-	}
-
-	err = cli.SetShareMetadata(share2, mPutUpper)
-	c.Assert(err, chk.IsNil)
-
-	m, err = cli.GetShareMetadata(share2)
-	c.Assert(err, chk.IsNil)
-	c.Check(m, chk.DeepEquals, mExpectLower)
-}
-
-func (s *StorageFileSuite) TestListDirsAndFiles(c *chk.C) {
-	// create share
-	cli := getFileClient(c)
-	share := randShare()
-
-	c.Assert(cli.CreateShare(share, nil), chk.IsNil)
-	defer cli.DeleteShare(share)
-
-	// list contents, should be empty
-	resp, err := cli.ListDirsAndFiles(share, ListDirsAndFilesParameters{})
-	c.Assert(err, chk.IsNil)
-	c.Assert(resp.Directories, chk.IsNil)
-	c.Assert(resp.Files, chk.IsNil)
-
-	// create a directory and a file
-	dir := "SomeDirectory"
-	file := "foo.file"
-	c.Assert(cli.CreateDirectory(ToPathSegment(share, dir), nil), chk.IsNil)
-	c.Assert(cli.CreateFile(ToPathSegment(share, file), 512, nil), chk.IsNil)
-
-	// list contents
-	resp, err = cli.ListDirsAndFiles(share, ListDirsAndFilesParameters{})
-	c.Assert(err, chk.IsNil)
-	c.Assert(len(resp.Directories), chk.Equals, 1)
-	c.Assert(len(resp.Files), chk.Equals, 1)
-	c.Assert(resp.Directories[0].Name, chk.Equals, dir)
-	c.Assert(resp.Files[0].Name, chk.Equals, file)
-}
-
-func (s *StorageFileSuite) TestCreateDirectory(c *chk.C) {
-	// create share
-	cli := getFileClient(c)
-	share := randShare()
-
-	c.Assert(cli.CreateShare(share, nil), chk.IsNil)
-	defer cli.DeleteShare(share)
-
-	// directory shouldn't exist
-	dir := ToPathSegment(share, "SomeDirectory")
-	exists, err := cli.DirectoryExists(dir)
-	c.Assert(err, chk.IsNil)
-	c.Assert(exists, chk.Equals, false)
-
-	// create directory
-	exists, err = cli.CreateDirectoryIfNotExists(dir)
-	c.Assert(err, chk.IsNil)
-	c.Assert(exists, chk.Equals, true)
-
-	// try to create again, should fail
-	c.Assert(cli.CreateDirectory(dir, nil), chk.NotNil)
-	exists, err = cli.CreateDirectoryIfNotExists(dir)
-	c.Assert(err, chk.IsNil)
-	c.Assert(exists, chk.Equals, false)
-
-	// get properties
-	var props *DirectoryProperties
-	props, err = cli.GetDirectoryProperties(dir)
-	c.Assert(props.Etag, chk.Not(chk.Equals), "")
-	c.Assert(props.LastModified, chk.Not(chk.Equals), "")
-
-	// delete directory and verify
-	c.Assert(cli.DeleteDirectory(dir), chk.IsNil)
-	exists, err = cli.DirectoryExists(dir)
-	c.Assert(err, chk.IsNil)
-	c.Assert(exists, chk.Equals, false)
-}
-
 func (s *StorageFileSuite) TestCreateFile(c *chk.C) {
 	// create share
 	cli := getFileClient(c)
-	share := randShare()
+	share := cli.GetShareReference(randShare())
 
-	c.Assert(cli.CreateShare(share, nil), chk.IsNil)
-	defer cli.DeleteShare(share)
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	root := share.GetRootDirectoryReference()
 
 	// create directory structure
-	dir1 := ToPathSegment(share, "one")
-	c.Assert(cli.CreateDirectory(dir1, nil), chk.IsNil)
-	dir2 := ToPathSegment(dir1, "two")
-	c.Assert(cli.CreateDirectory(dir2, nil), chk.IsNil)
+	dir1 := root.GetDirectoryReference("one")
+	c.Assert(dir1.Create(), chk.IsNil)
+	dir2 := dir1.GetDirectoryReference("two")
+	c.Assert(dir2.Create(), chk.IsNil)
 
 	// verify file doesn't exist
-	file := ToPathSegment(dir2, "some.file")
-	exists, err := cli.FileExists(file)
+	file := dir2.GetFileReference("some.file")
+	exists, err := file.Exists()
 	c.Assert(err, chk.IsNil)
 	c.Assert(exists, chk.Equals, false)
 
 	// create file
-	c.Assert(cli.CreateFile(file, 1024, nil), chk.IsNil)
-	exists, err = cli.FileExists(file)
+	c.Assert(file.Create(1024), chk.IsNil)
+	exists, err = file.Exists()
 	c.Assert(err, chk.IsNil)
 	c.Assert(exists, chk.Equals, true)
 
 	// delete file and verify
-	c.Assert(cli.DeleteFile(file), chk.IsNil)
-	exists, err = cli.FileExists(file)
+	c.Assert(file.Delete(), chk.IsNil)
+	exists, err = file.Exists()
 	c.Assert(err, chk.IsNil)
 	c.Assert(exists, chk.Equals, false)
 }
@@ -288,80 +50,85 @@ func (s *StorageFileSuite) TestCreateFile(c *chk.C) {
 func (s *StorageFileSuite) TestGetFile(c *chk.C) {
 	// create share
 	cli := getFileClient(c)
-	share := randShare()
+	share := cli.GetShareReference(randShare())
 
-	c.Assert(cli.CreateShare(share, nil), chk.IsNil)
-	defer cli.DeleteShare(share)
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	root := share.GetRootDirectoryReference()
 
 	// create file
 	const size = uint64(1024)
-	file := ToPathSegment(share, "some.file")
-	c.Assert(cli.CreateFile(file, size, nil), chk.IsNil)
+	byteStream, _ := newByteStream(size)
+	file := root.GetFileReference("some.file")
+	c.Assert(file.Create(size), chk.IsNil)
 
 	// fill file with some data
-	c.Assert(cli.PutRange(file, newByteStream(size), FileRange{End: size - 1}), chk.IsNil)
+	c.Assert(file.WriteRange(byteStream, FileRange{End: size - 1}, nil), chk.IsNil)
 
 	// set some metadata
 	md := map[string]string{
 		"something": "somethingvalue",
 		"another":   "anothervalue",
 	}
-	c.Assert(cli.SetFileMetadata(file, md), chk.IsNil)
+	file.Metadata = md
+	c.Assert(file.SetMetadata(), chk.IsNil)
 
 	// retrieve full file content and verify
-	stream, err := cli.GetFile(file, nil)
+	stream, err := file.DownloadRangeToStream(FileRange{Start: 0, End: size - 1}, false)
 	c.Assert(err, chk.IsNil)
 	defer stream.Body.Close()
 	var b1 [size]byte
 	count, _ := stream.Body.Read(b1[:])
 	c.Assert(count, chk.Equals, int(size))
 	var c1 [size]byte
-	newByteStream(size).Read(c1[:])
+	bs, _ := newByteStream(size)
+	bs.Read(c1[:])
 	c.Assert(b1, chk.DeepEquals, c1)
-	c.Assert(stream.Properties.ContentLength, chk.Equals, size)
-	c.Assert(stream.Metadata, chk.DeepEquals, md)
 
 	// retrieve partial file content and verify
-	stream, err = cli.GetFile(file, &FileRange{Start: size / 2, End: size - 1})
+	stream, err = file.DownloadRangeToStream(FileRange{Start: size / 2, End: size - 1}, false)
 	c.Assert(err, chk.IsNil)
 	defer stream.Body.Close()
 	var b2 [size / 2]byte
 	count, _ = stream.Body.Read(b2[:])
 	c.Assert(count, chk.Equals, int(size)/2)
 	var c2 [size / 2]byte
-	newByteStream(size / 2).Read(c2[:])
+	bs, _ = newByteStream(size / 2)
+	bs.Read(c2[:])
 	c.Assert(b2, chk.DeepEquals, c2)
 }
 
 func (s *StorageFileSuite) TestFileRanges(c *chk.C) {
 	// create share
 	cli := getFileClient(c)
-	share := randShare()
+	share := cli.GetShareReference(randShare())
 
-	c.Assert(cli.CreateShare(share, nil), chk.IsNil)
-	defer cli.DeleteShare(share)
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	root := share.GetRootDirectoryReference()
 
 	// create file
 	fileSize := uint64(4096)
-	file := ToPathSegment(share, "test.dat")
-	c.Assert(cli.CreateFile(file, fileSize, nil), chk.IsNil)
+	byteStream, _ := newByteStream(fileSize)
+	file := root.GetFileReference("test.dat")
+	c.Assert(file.Create(fileSize), chk.IsNil)
 
 	// verify there are no valid ranges
-	ranges, err := cli.ListFileRanges(file, nil)
+	ranges, err := file.ListRanges(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(ranges.ContentLength, chk.Equals, fileSize)
 	c.Assert(ranges.FileRanges, chk.IsNil)
 
 	// fill entire range and validate
-	c.Assert(cli.PutRange(file, newByteStream(fileSize), FileRange{End: fileSize - 1}), chk.IsNil)
-	ranges, err = cli.ListFileRanges(file, nil)
+	c.Assert(file.WriteRange(byteStream, FileRange{End: fileSize - 1}, nil), chk.IsNil)
+	ranges, err = file.ListRanges(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(len(ranges.FileRanges), chk.Equals, 1)
 	c.Assert((ranges.FileRanges[0].End-ranges.FileRanges[0].Start)+1, chk.Equals, fileSize)
 
 	// clear entire range and validate
-	c.Assert(cli.ClearRange(file, FileRange{End: fileSize - 1}), chk.IsNil)
-	ranges, err = cli.ListFileRanges(file, nil)
+	c.Assert(file.ClearRange(FileRange{End: fileSize - 1}), chk.IsNil)
+	ranges, err = file.ListRanges(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(ranges.FileRanges, chk.IsNil)
 
@@ -374,24 +141,25 @@ func (s *StorageFileSuite) TestFileRanges(c *chk.C) {
 	}
 
 	for _, r := range putRanges {
-		err = cli.PutRange(file, newByteStream(512), r)
+		byteStream, _ = newByteStream(512)
+		err = file.WriteRange(byteStream, r, nil)
 		c.Assert(err, chk.IsNil)
 	}
 
 	// validate all ranges
-	ranges, err = cli.ListFileRanges(file, nil)
+	ranges, err = file.ListRanges(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(ranges.FileRanges, chk.DeepEquals, putRanges)
 
 	// validate sub-ranges
-	ranges, err = cli.ListFileRanges(file, &FileRange{Start: 1000, End: 3000})
+	ranges, err = file.ListRanges(&FileRange{Start: 1000, End: 3000})
 	c.Assert(err, chk.IsNil)
 	c.Assert(ranges.FileRanges, chk.DeepEquals, putRanges[1:3])
 
 	// clear partial range and validate
-	c.Assert(cli.ClearRange(file, putRanges[0]), chk.IsNil)
-	c.Assert(cli.ClearRange(file, putRanges[2]), chk.IsNil)
-	ranges, err = cli.ListFileRanges(file, nil)
+	c.Assert(file.ClearRange(putRanges[0]), chk.IsNil)
+	c.Assert(file.ClearRange(putRanges[2]), chk.IsNil)
+	ranges, err = file.ListRanges(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(len(ranges.FileRanges), chk.Equals, 2)
 	c.Assert(ranges.FileRanges[0], chk.DeepEquals, putRanges[1])
@@ -401,19 +169,19 @@ func (s *StorageFileSuite) TestFileRanges(c *chk.C) {
 func (s *StorageFileSuite) TestFileProperties(c *chk.C) {
 	// create share
 	cli := getFileClient(c)
-	share := randShare()
+	share := cli.GetShareReference(randShare())
 
-	c.Assert(cli.CreateShare(share, nil), chk.IsNil)
-	defer cli.DeleteShare(share)
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	root := share.GetRootDirectoryReference()
 
 	fileSize := uint64(512)
-	file := ToPathSegment(share, "test.dat")
-	c.Assert(cli.CreateFile(file, fileSize, nil), chk.IsNil)
+	file := root.GetFileReference("test.dat")
+	c.Assert(file.Create(fileSize), chk.IsNil)
 
 	// get initial set of properties
-	props, err := cli.GetFileProperties(file)
-	c.Assert(err, chk.IsNil)
-	c.Assert(props.ContentLength, chk.Equals, fileSize)
+	c.Assert(file.Properties.Length, chk.Equals, fileSize)
+	c.Assert(file.Properties.Etag, chk.NotNil)
 
 	// set some file properties
 	cc := "cachecontrol"
@@ -421,135 +189,86 @@ func (s *StorageFileSuite) TestFileProperties(c *chk.C) {
 	enc := "noencoding"
 	lang := "neutral"
 	disp := "friendly"
-	props.CacheControl = cc
-	props.ContentType = ct
-	props.Disposition = disp
-	props.Encoding = enc
-	props.Language = lang
-	c.Assert(cli.SetFileProperties(file, *props), chk.IsNil)
+	file.Properties.CacheControl = cc
+	file.Properties.Type = ct
+	file.Properties.Disposition = disp
+	file.Properties.Encoding = enc
+	file.Properties.Language = lang
+	c.Assert(file.SetProperties(), chk.IsNil)
 
 	// retrieve and verify
-	props, err = cli.GetFileProperties(file)
-	c.Assert(err, chk.IsNil)
-	c.Assert(props.CacheControl, chk.Equals, cc)
-	c.Assert(props.ContentType, chk.Equals, ct)
-	c.Assert(props.Disposition, chk.Equals, disp)
-	c.Assert(props.Encoding, chk.Equals, enc)
-	c.Assert(props.Language, chk.Equals, lang)
-}
-
-func (s *StorageFileSuite) TestDirectoryMetadata(c *chk.C) {
-	// create share
-	cli := getFileClient(c)
-	share := randShare()
-
-	c.Assert(cli.CreateShare(share, nil), chk.IsNil)
-	defer cli.DeleteShare(share)
-
-	dir1 := ToPathSegment(share, "testdir1")
-	c.Assert(cli.CreateDirectory(dir1, nil), chk.IsNil)
-
-	// get metadata, shouldn't be any
-	md, err := cli.GetDirectoryMetadata(dir1)
-	c.Assert(err, chk.IsNil)
-	c.Assert(md, chk.HasLen, 0)
-
-	mCreate := map[string]string{
-		"create": "data",
-	}
-	dir2 := ToPathSegment(share, "testdir2")
-	c.Assert(cli.CreateDirectory(dir2, mCreate), chk.IsNil)
-
-	// get metadata
-	md, err = cli.GetDirectoryMetadata(dir2)
-	c.Assert(err, chk.IsNil)
-	c.Assert(md, chk.HasLen, 1)
-
-	// set some custom metadata
-	md = map[string]string{
-		"something": "somethingvalue",
-		"another":   "anothervalue",
-	}
-	c.Assert(cli.SetDirectoryMetadata(dir2, md), chk.IsNil)
-
-	// retrieve and verify
-	var mdRes map[string]string
-	mdRes, err = cli.GetDirectoryMetadata(dir2)
-	c.Assert(err, chk.IsNil)
-	c.Assert(mdRes, chk.DeepEquals, md)
+	c.Assert(file.FetchAttributes(), chk.IsNil)
+	c.Assert(file.Properties.CacheControl, chk.Equals, cc)
+	c.Assert(file.Properties.Type, chk.Equals, ct)
+	c.Assert(file.Properties.Disposition, chk.Equals, disp)
+	c.Assert(file.Properties.Encoding, chk.Equals, enc)
+	c.Assert(file.Properties.Language, chk.Equals, lang)
 }
 
 func (s *StorageFileSuite) TestFileMetadata(c *chk.C) {
 	// create share
 	cli := getFileClient(c)
-	share := randShare()
+	share := cli.GetShareReference(randShare())
 
-	c.Assert(cli.CreateShare(share, nil), chk.IsNil)
-	defer cli.DeleteShare(share)
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	root := share.GetRootDirectoryReference()
 
 	fileSize := uint64(512)
-	file1 := ToPathSegment(share, "test1.dat")
-	c.Assert(cli.CreateFile(file1, fileSize, nil), chk.IsNil)
+	file := root.GetFileReference("test.dat")
+	c.Assert(file.Create(fileSize), chk.IsNil)
 
 	// get metadata, shouldn't be any
-	md, err := cli.GetFileMetadata(file1)
-	c.Assert(err, chk.IsNil)
-	c.Assert(md, chk.HasLen, 0)
-
-	mCreate := map[string]string{
-		"create": "data",
-	}
-	file2 := ToPathSegment(share, "test2.dat")
-	c.Assert(cli.CreateFile(file2, fileSize, mCreate), chk.IsNil)
-
-	// get metadata
-	md, err = cli.GetFileMetadata(file2)
-	c.Assert(err, chk.IsNil)
-	c.Assert(md, chk.HasLen, 1)
+	c.Assert(file.Metadata, chk.HasLen, 0)
 
 	// set some custom metadata
-	md = map[string]string{
+	md := map[string]string{
 		"something": "somethingvalue",
 		"another":   "anothervalue",
 	}
-	c.Assert(cli.SetFileMetadata(file2, md), chk.IsNil)
+	file.Metadata = md
+	c.Assert(file.SetMetadata(), chk.IsNil)
 
 	// retrieve and verify
-	var mdRes map[string]string
-	mdRes, err = cli.GetFileMetadata(file2)
+	c.Assert(file.FetchAttributes(), chk.IsNil)
+	c.Assert(file.Metadata, chk.DeepEquals, md)
+}
+
+func (s *StorageFileSuite) TestFileMD5(c *chk.C) {
+	// create share
+	cli := getFileClient(c)
+	share := cli.GetShareReference(randShare())
+
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	root := share.GetRootDirectoryReference()
+
+	// create file
+	const size = uint64(1024)
+	fileSize := uint64(size)
+	file := root.GetFileReference("test.dat")
+	c.Assert(file.Create(fileSize), chk.IsNil)
+
+	// fill file with some data and MD5 hash
+	byteStream, contentMD5 := newByteStream(size)
+	c.Assert(file.WriteRange(byteStream, FileRange{End: size - 1}, &contentMD5), chk.IsNil)
+
+	// download file and verify
+	stream, err := file.DownloadRangeToStream(FileRange{Start: 0, End: size - 1}, true)
 	c.Assert(err, chk.IsNil)
-	c.Assert(mdRes, chk.DeepEquals, md)
+	defer stream.Body.Close()
+	c.Assert(stream.ContentMD5, chk.Equals, contentMD5)
 }
 
-func deleteTestShares(cli FileServiceClient) error {
-	for {
-		resp, err := cli.ListShares(ListSharesParameters{Prefix: testSharePrefix})
-		if err != nil {
-			return err
-		}
-		if len(resp.Shares) == 0 {
-			break
-		}
-		for _, c := range resp.Shares {
-			err = cli.DeleteShare(c.Name)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-const testSharePrefix = "zzzzztest"
-
-func randShare() string {
-	return testSharePrefix + randString(32-len(testSharePrefix))
-}
-
-func newByteStream(count uint64) io.Reader {
+// returns a byte stream along with a base-64 encoded MD5 hash of its contents
+func newByteStream(count uint64) (io.Reader, string) {
 	b := make([]uint8, count)
 	for i := uint64(0); i < count; i++ {
 		b[i] = 0xff
 	}
-	return bytes.NewReader(b)
+
+	// create an MD5 hash of the array
+	hash := md5.Sum(b)
+
+	return bytes.NewReader(b), base64.StdEncoding.EncodeToString(hash[:])
 }

--- a/storage/file_test.go
+++ b/storage/file_test.go
@@ -161,7 +161,7 @@ func (s *StorageFileSuite) TestFileRanges(c *chk.C) {
 	c.Assert(file.ClearRange(putRanges[2]), chk.IsNil)
 	ranges, err = file.ListRanges(nil)
 	c.Assert(err, chk.IsNil)
-	c.Assert(len(ranges.FileRanges), chk.Equals, 2)
+	c.Assert(ranges.FileRanges, chk.HasLen, 2)
 	c.Assert(ranges.FileRanges[0], chk.DeepEquals, putRanges[1])
 	c.Assert(ranges.FileRanges[1], chk.DeepEquals, putRanges[3])
 }

--- a/storage/fileserviceclient.go
+++ b/storage/fileserviceclient.go
@@ -1,0 +1,355 @@
+package storage
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// FileServiceClient contains operations for Microsoft Azure File Service.
+type FileServiceClient struct {
+	client Client
+}
+
+// ListSharesParameters defines the set of customizable parameters to make a
+// List Shares call.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn167009.aspx
+type ListSharesParameters struct {
+	Prefix     string
+	Marker     string
+	Include    string
+	MaxResults uint
+	Timeout    uint
+}
+
+// ShareListResponse contains the response fields from
+// ListShares call.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn167009.aspx
+type ShareListResponse struct {
+	XMLName    xml.Name `xml:"EnumerationResults"`
+	Xmlns      string   `xml:"xmlns,attr"`
+	Prefix     string   `xml:"Prefix"`
+	Marker     string   `xml:"Marker"`
+	NextMarker string   `xml:"NextMarker"`
+	MaxResults int64    `xml:"MaxResults"`
+	Shares     []Share  `xml:"Shares>Share"`
+}
+
+type compType string
+
+const (
+	compNone       compType = ""
+	compList       compType = "list"
+	compMetadata   compType = "metadata"
+	compProperties compType = "properties"
+	compRangeList  compType = "rangelist"
+)
+
+func (ct compType) String() string {
+	return string(ct)
+}
+
+type resourceType string
+
+const (
+	resourceDirectory resourceType = "directory"
+	resourceFile      resourceType = ""
+	resourceShare     resourceType = "share"
+)
+
+func (rt resourceType) String() string {
+	return string(rt)
+}
+
+func (p ListSharesParameters) getParameters() url.Values {
+	out := url.Values{}
+
+	if p.Prefix != "" {
+		out.Set("prefix", p.Prefix)
+	}
+	if p.Marker != "" {
+		out.Set("marker", p.Marker)
+	}
+	if p.Include != "" {
+		out.Set("include", p.Include)
+	}
+	if p.MaxResults != 0 {
+		out.Set("maxresults", fmt.Sprintf("%v", p.MaxResults))
+	}
+	if p.Timeout != 0 {
+		out.Set("timeout", fmt.Sprintf("%v", p.Timeout))
+	}
+
+	return out
+}
+
+func (p ListDirsAndFilesParameters) getParameters() url.Values {
+	out := url.Values{}
+
+	if p.Marker != "" {
+		out.Set("marker", p.Marker)
+	}
+	if p.MaxResults != 0 {
+		out.Set("maxresults", fmt.Sprintf("%v", p.MaxResults))
+	}
+	if p.Timeout != 0 {
+		out.Set("timeout", fmt.Sprintf("%v", p.Timeout))
+	}
+
+	return out
+}
+
+// returns url.Values for the specified types
+func getURLInitValues(comp compType, res resourceType) url.Values {
+	values := url.Values{}
+	if comp != compNone {
+		values.Set("comp", comp.String())
+	}
+	if res != resourceFile {
+		values.Set("restype", res.String())
+	}
+	return values
+}
+
+// GetShareReference returns a Share object for the specified share name.
+func (f FileServiceClient) GetShareReference(name string) Share {
+	return Share{
+		fsc:  &f,
+		Name: name,
+		Properties: ShareProperties{
+			Quota: -1,
+		},
+	}
+}
+
+// ListShares returns the list of shares in a storage account along with
+// pagination token and other response details.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dd179352.aspx
+func (f FileServiceClient) ListShares(params ListSharesParameters) (*ShareListResponse, error) {
+	q := mergeParams(params.getParameters(), url.Values{"comp": {"list"}})
+
+	var out ShareListResponse
+	resp, err := f.listContent("", q, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.body.Close()
+	err = xmlUnmarshal(resp.body, &out)
+
+	// assign our client to the newly created Share objects
+	for i := range out.Shares {
+		out.Shares[i].fsc = &f
+	}
+	return &out, err
+}
+
+// retrieves directory or share content
+func (f FileServiceClient) listContent(path string, params url.Values, extraHeaders map[string]string) (*storageResponse, error) {
+	if err := f.checkForStorageEmulator(); err != nil {
+		return nil, err
+	}
+
+	uri := f.client.getEndpoint(fileServiceName, path, params)
+	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
+
+	resp, err := f.client.exec(http.MethodGet, uri, headers, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		resp.body.Close()
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// returns true if the specified directory or share exists
+func (f FileServiceClient) resourceExists(path string, res resourceType) (bool, http.Header, error) {
+	if err := f.checkForStorageEmulator(); err != nil {
+		return false, nil, err
+	}
+
+	uri := f.client.getEndpoint(fileServiceName, path, getURLInitValues(compNone, res))
+	headers := f.client.getStandardHeaders()
+
+	resp, err := f.client.exec(http.MethodHead, uri, headers, nil)
+	if resp != nil {
+		defer resp.body.Close()
+		if resp.statusCode == http.StatusOK || resp.statusCode == http.StatusNotFound {
+			return resp.statusCode == http.StatusOK, resp.headers, nil
+		}
+	}
+	return false, nil, err
+}
+
+// creates a resource depending on the specified resource type
+func (f FileServiceClient) createResource(path string, res resourceType, extraHeaders map[string]string) (http.Header, error) {
+	resp, err := f.createResourceNoClose(path, res, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.body.Close()
+	return resp.headers, checkRespCode(resp.statusCode, []int{http.StatusCreated})
+}
+
+// creates a resource depending on the specified resource type, doesn't close the response body
+func (f FileServiceClient) createResourceNoClose(path string, res resourceType, extraHeaders map[string]string) (*storageResponse, error) {
+	if err := f.checkForStorageEmulator(); err != nil {
+		return nil, err
+	}
+
+	values := getURLInitValues(compNone, res)
+	uri := f.client.getEndpoint(fileServiceName, path, values)
+	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
+
+	return f.client.exec(http.MethodPut, uri, headers, nil)
+}
+
+// returns HTTP header data for the specified directory or share
+func (f FileServiceClient) getResourceHeaders(path string, comp compType, res resourceType, verb string) (http.Header, error) {
+	resp, err := f.getResourceNoClose(path, comp, res, verb, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.body.Close()
+
+	if err = checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		return nil, err
+	}
+
+	return resp.headers, nil
+}
+
+// gets the specified resource, doesn't close the response body
+func (f FileServiceClient) getResourceNoClose(path string, comp compType, res resourceType, verb string, extraHeaders map[string]string) (*storageResponse, error) {
+	if err := f.checkForStorageEmulator(); err != nil {
+		return nil, err
+	}
+
+	params := getURLInitValues(comp, res)
+	uri := f.client.getEndpoint(fileServiceName, path, params)
+	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
+
+	return f.client.exec(verb, uri, headers, nil)
+}
+
+// deletes the resource and returns the response
+func (f FileServiceClient) deleteResource(path string, res resourceType) error {
+	resp, err := f.deleteResourceNoClose(path, res)
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+	return checkRespCode(resp.statusCode, []int{http.StatusAccepted})
+}
+
+// deletes the resource and returns the response, doesn't close the response body
+func (f FileServiceClient) deleteResourceNoClose(path string, res resourceType) (*storageResponse, error) {
+	if err := f.checkForStorageEmulator(); err != nil {
+		return nil, err
+	}
+
+	values := getURLInitValues(compNone, res)
+	uri := f.client.getEndpoint(fileServiceName, path, values)
+	return f.client.exec(http.MethodDelete, uri, f.client.getStandardHeaders(), nil)
+}
+
+// merges metadata into extraHeaders and returns extraHeaders
+func mergeMDIntoExtraHeaders(metadata, extraHeaders map[string]string) map[string]string {
+	if metadata == nil && extraHeaders == nil {
+		return nil
+	}
+	if extraHeaders == nil {
+		extraHeaders = make(map[string]string)
+	}
+	for k, v := range metadata {
+		extraHeaders[userDefinedMetadataHeaderPrefix+k] = v
+	}
+	return extraHeaders
+}
+
+// merges extraHeaders into headers and returns headers
+func mergeHeaders(headers, extraHeaders map[string]string) map[string]string {
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
+	return headers
+}
+
+// sets extra header data for the specified resource
+func (f FileServiceClient) setResourceHeaders(path string, comp compType, res resourceType, extraHeaders map[string]string) (http.Header, error) {
+	if err := f.checkForStorageEmulator(); err != nil {
+		return nil, err
+	}
+
+	params := getURLInitValues(comp, res)
+	uri := f.client.getEndpoint(fileServiceName, path, params)
+	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
+
+	resp, err := f.client.exec(http.MethodPut, uri, headers, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.body.Close()
+
+	return resp.headers, checkRespCode(resp.statusCode, []int{http.StatusOK})
+}
+
+// gets metadata for the specified resource
+func (f FileServiceClient) getMetadata(path string, res resourceType) (map[string]string, error) {
+	if err := f.checkForStorageEmulator(); err != nil {
+		return nil, err
+	}
+
+	headers, err := f.getResourceHeaders(path, compMetadata, res, http.MethodGet)
+	if err != nil {
+		return nil, err
+	}
+
+	return getMetadataFromHeaders(headers), nil
+}
+
+// returns a map of custom metadata values from the specified HTTP header
+func getMetadataFromHeaders(header http.Header) map[string]string {
+	metadata := make(map[string]string)
+	for k, v := range header {
+		// Can't trust CanonicalHeaderKey() to munge case
+		// reliably. "_" is allowed in identifiers:
+		// https://msdn.microsoft.com/en-us/library/azure/dd179414.aspx
+		// https://msdn.microsoft.com/library/aa664670(VS.71).aspx
+		// http://tools.ietf.org/html/rfc7230#section-3.2
+		// ...but "_" is considered invalid by
+		// CanonicalMIMEHeaderKey in
+		// https://golang.org/src/net/textproto/reader.go?s=14615:14659#L542
+		// so k can be "X-Ms-Meta-Foo" or "x-ms-meta-foo_bar".
+		k = strings.ToLower(k)
+		if len(v) == 0 || !strings.HasPrefix(k, strings.ToLower(userDefinedMetadataHeaderPrefix)) {
+			continue
+		}
+		// metadata["foo"] = content of the last X-Ms-Meta-Foo header
+		k = k[len(userDefinedMetadataHeaderPrefix):]
+		metadata[k] = v[len(v)-1]
+	}
+
+	if len(metadata) == 0 {
+		return nil
+	}
+
+	return metadata
+}
+
+//checkForStorageEmulator determines if the client is setup for use with
+//Azure Storage Emulator, and returns a relevant error
+func (f FileServiceClient) checkForStorageEmulator() error {
+	if f.client.accountName == StorageEmulatorAccountName {
+		return fmt.Errorf("Error: File service is not currently supported by Azure Storage Emulator")
+	}
+	return nil
+}

--- a/storage/fileserviceclient.go
+++ b/storage/fileserviceclient.go
@@ -170,7 +170,7 @@ func (f FileServiceClient) listContent(path string, params url.Values, extraHead
 	return resp, nil
 }
 
-// returns true if the specified directory or share exists
+// returns true if the specified resource exists
 func (f FileServiceClient) resourceExists(path string, res resourceType) (bool, http.Header, error) {
 	if err := f.checkForStorageEmulator(); err != nil {
 		return false, nil, err

--- a/storage/share.go
+++ b/storage/share.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 )
 
-// Share represents a Azure file share.
+// Share represents an Azure file share.
 type Share struct {
 	fsc        *FileServiceClient
 	Name       string          `xml:"Name"`

--- a/storage/share.go
+++ b/storage/share.go
@@ -1,0 +1,186 @@
+package storage
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// Share represents a Azure file share.
+type Share struct {
+	fsc        *FileServiceClient
+	Name       string          `xml:"Name"`
+	Properties ShareProperties `xml:"Properties"`
+	Metadata   map[string]string
+}
+
+// ShareProperties contains various properties of a share.
+type ShareProperties struct {
+	LastModified string `xml:"Last-Modified"`
+	Etag         string `xml:"Etag"`
+	Quota        int    `xml:"Quota"`
+}
+
+// builds the complete path for this share object.
+func (s *Share) buildPath() string {
+	return fmt.Sprintf("/%s", s.Name)
+}
+
+// Create this share under the associated account.
+// If a share with the same name already exists, the operation fails.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn167008.aspx
+func (s *Share) Create() error {
+	headers, err := s.fsc.createResource(s.buildPath(), resourceShare, mergeMDIntoExtraHeaders(s.Metadata, nil))
+	if err != nil {
+		return err
+	}
+
+	s.updateEtagAndLastModified(headers)
+	return nil
+}
+
+// CreateIfNotExists creates this share under the associated account if
+// it does not exist. Returns true if the share is newly created or false if
+// the share already exists.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn167008.aspx
+func (s *Share) CreateIfNotExists() (bool, error) {
+	resp, err := s.fsc.createResourceNoClose(s.buildPath(), resourceShare, nil)
+	if resp != nil {
+		defer resp.body.Close()
+		if resp.statusCode == http.StatusCreated || resp.statusCode == http.StatusConflict {
+			if resp.statusCode == http.StatusCreated {
+				s.updateEtagAndLastModified(resp.headers)
+				return true, nil
+			}
+			return false, s.FetchAttributes()
+		}
+	}
+
+	return false, err
+}
+
+// Delete marks this share for deletion. The share along with any files
+// and directories contained within it are later deleted during garbage
+// collection.  If the share does not exist the operation fails
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn689090.aspx
+func (s *Share) Delete() error {
+	return s.fsc.deleteResource(s.buildPath(), resourceShare)
+}
+
+// DeleteIfExists operation marks this share for deletion if it exists.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn689090.aspx
+func (s *Share) DeleteIfExists() (bool, error) {
+	resp, err := s.fsc.deleteResourceNoClose(s.buildPath(), resourceShare)
+	if resp != nil {
+		defer resp.body.Close()
+		if resp.statusCode == http.StatusAccepted || resp.statusCode == http.StatusNotFound {
+			return resp.statusCode == http.StatusAccepted, nil
+		}
+	}
+	return false, err
+}
+
+// Exists returns true if this share already exists
+// on the storage account, otherwise returns false.
+func (s *Share) Exists() (bool, error) {
+	exists, headers, err := s.fsc.resourceExists(s.buildPath(), resourceShare)
+	if exists {
+		s.updateEtagAndLastModified(headers)
+		s.updateQuota(headers)
+	}
+	return exists, err
+}
+
+// FetchAttributes retrieves metadata and properties for this share.
+func (s *Share) FetchAttributes() error {
+	headers, err := s.fsc.getResourceHeaders(s.buildPath(), compNone, resourceShare, http.MethodHead)
+	if err != nil {
+		return err
+	}
+
+	s.updateEtagAndLastModified(headers)
+	s.updateQuota(headers)
+	s.Metadata = getMetadataFromHeaders(headers)
+
+	return nil
+}
+
+// GetRootDirectoryReference returns a Directory object at the root of this share.
+func (s *Share) GetRootDirectoryReference() *Directory {
+	return &Directory{
+		fsc:   s.fsc,
+		share: s,
+	}
+}
+
+// ServiceClient returns the FileServiceClient associated with this share.
+func (s *Share) ServiceClient() *FileServiceClient {
+	return s.fsc
+}
+
+// SetMetadata replaces the metadata for this share.
+//
+// Some keys may be converted to Camel-Case before sending. All keys
+// are returned in lower case by GetShareMetadata. HTTP header names
+// are case-insensitive so case munging should not matter to other
+// applications either.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dd179414.aspx
+func (s *Share) SetMetadata() error {
+	headers, err := s.fsc.setResourceHeaders(s.buildPath(), compMetadata, resourceShare, mergeMDIntoExtraHeaders(s.Metadata, nil))
+	if err != nil {
+		return err
+	}
+
+	s.updateEtagAndLastModified(headers)
+	return nil
+}
+
+// SetProperties sets system properties for this share.
+//
+// Some keys may be converted to Camel-Case before sending. All keys
+// are returned in lower case by SetShareProperties. HTTP header names
+// are case-insensitive so case munging should not matter to other
+// applications either.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/mt427368.aspx
+func (s *Share) SetProperties() error {
+	if s.Properties.Quota < 1 || s.Properties.Quota > 5120 {
+		return fmt.Errorf("invalid value %v for quota, valid values are [1, 5120]", s.Properties.Quota)
+	}
+
+	headers, err := s.fsc.setResourceHeaders(s.buildPath(), compProperties, resourceShare, map[string]string{
+		"x-ms-share-quota": strconv.Itoa(s.Properties.Quota),
+	})
+	if err != nil {
+		return err
+	}
+
+	s.updateEtagAndLastModified(headers)
+	return nil
+}
+
+// updates Etag and last modified date
+func (s *Share) updateEtagAndLastModified(headers http.Header) {
+	s.Properties.Etag = headers.Get("Etag")
+	s.Properties.LastModified = headers.Get("Last-Modified")
+}
+
+// updates quota value
+func (s *Share) updateQuota(headers http.Header) {
+	quota, err := strconv.Atoi(headers.Get("x-ms-share-quota"))
+	if err == nil {
+		s.Properties.Quota = quota
+	}
+}
+
+// URL gets the canonical URL to this share. This method does not create a publicly accessible
+// URL if the share is private and this method does not check if the share exists.
+func (s *Share) URL() string {
+	return s.fsc.client.getEndpoint(fileServiceName, s.buildPath(), url.Values{})
+}

--- a/storage/share_test.go
+++ b/storage/share_test.go
@@ -1,0 +1,188 @@
+package storage
+
+import (
+	"math/rand"
+
+	chk "gopkg.in/check.v1"
+)
+
+type StorageShareSuite struct{}
+
+var _ = chk.Suite(&StorageShareSuite{})
+
+const testSharePrefix = "zzzzztest"
+
+func randShare() string {
+	return testSharePrefix + randString(32-len(testSharePrefix))
+}
+
+func getFileClient(c *chk.C) FileServiceClient {
+	return getBasicClient(c).GetFileService()
+}
+
+func (s *StorageShareSuite) TestCreateShareDeleteShare(c *chk.C) {
+	cli := getFileClient(c)
+	share := cli.GetShareReference(randShare())
+	c.Assert(share.Create(), chk.IsNil)
+	c.Assert(share.Delete(), chk.IsNil)
+}
+
+func (s *StorageShareSuite) TestCreateShareIfNotExists(c *chk.C) {
+	cli := getFileClient(c)
+	share := cli.GetShareReference(randShare())
+
+	// First create
+	ok, err := share.CreateIfNotExists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(ok, chk.Equals, true)
+
+	// Second create, should not give errors
+	ok, err = share.CreateIfNotExists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(ok, chk.Equals, false)
+
+	// cleanup
+	share.Delete()
+}
+
+func (s *StorageShareSuite) TestDeleteShareIfNotExists(c *chk.C) {
+	cli := getFileClient(c)
+	share := cli.GetShareReference(randShare())
+
+	// delete non-existing share
+	ok, err := share.DeleteIfExists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(ok, chk.Equals, false)
+
+	c.Assert(share.Create(), chk.IsNil)
+
+	// delete existing share
+	ok, err = share.DeleteIfExists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(ok, chk.Equals, true)
+}
+
+func (s *StorageShareSuite) TestListShares(c *chk.C) {
+	cli := getFileClient(c)
+	c.Assert(deleteTestShares(cli), chk.IsNil)
+
+	name := randShare()
+	share := cli.GetShareReference(name)
+
+	c.Assert(share.Create(), chk.IsNil)
+
+	resp, err := cli.ListShares(ListSharesParameters{
+		MaxResults: 5,
+		Prefix:     testSharePrefix})
+	c.Assert(err, chk.IsNil)
+
+	c.Check(len(resp.Shares), chk.Equals, 1)
+	c.Check(resp.Shares[0].Name, chk.Equals, name)
+
+	// clean up via the retrieved share object
+	resp.Shares[0].Delete()
+}
+
+func (s *StorageShareSuite) TestShareExists(c *chk.C) {
+	cli := getFileClient(c)
+	share := cli.GetShareReference(randShare())
+
+	ok, err := share.Exists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(ok, chk.Equals, false)
+
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+
+	ok, err = share.Exists()
+	c.Assert(err, chk.IsNil)
+	c.Assert(ok, chk.Equals, true)
+}
+
+func (s *StorageShareSuite) TestGetAndSetShareProperties(c *chk.C) {
+	cli := getFileClient(c)
+	share := cli.GetShareReference(randShare())
+	quota := rand.Intn(5120)
+
+	c.Assert(share.Create(), chk.IsNil)
+	defer share.Delete()
+	c.Assert(share.Properties.LastModified, chk.Not(chk.Equals), "")
+
+	share.Properties.Quota = quota
+	err := share.SetProperties()
+	c.Assert(err, chk.IsNil)
+
+	err = share.FetchAttributes()
+	c.Assert(err, chk.IsNil)
+
+	c.Assert(share.Properties.Quota, chk.Equals, quota)
+}
+
+func (s *StorageShareSuite) TestGetAndSetShareMetadata(c *chk.C) {
+	cli := getFileClient(c)
+	share1 := cli.GetShareReference(randShare())
+
+	c.Assert(share1.Create(), chk.IsNil)
+	defer share1.Delete()
+
+	// by default there should be no metadata
+	c.Assert(share1.Metadata, chk.IsNil)
+	c.Assert(share1.FetchAttributes(), chk.IsNil)
+	c.Assert(share1.Metadata, chk.IsNil)
+
+	share2 := cli.GetShareReference(randShare())
+	c.Assert(share2.Create(), chk.IsNil)
+	defer share2.Delete()
+
+	c.Assert(share2.Metadata, chk.IsNil)
+
+	mPut := map[string]string{
+		"foo":     "bar",
+		"bar_baz": "waz qux",
+	}
+
+	share2.Metadata = mPut
+	c.Assert(share2.SetMetadata(), chk.IsNil)
+	c.Check(share2.Metadata, chk.DeepEquals, mPut)
+
+	c.Assert(share2.FetchAttributes(), chk.IsNil)
+	c.Check(share2.Metadata, chk.DeepEquals, mPut)
+
+	// Case munging
+
+	mPutUpper := map[string]string{
+		"Foo":     "different bar",
+		"bar_BAZ": "different waz qux",
+	}
+	mExpectLower := map[string]string{
+		"foo":     "different bar",
+		"bar_baz": "different waz qux",
+	}
+
+	share2.Metadata = mPutUpper
+	c.Assert(share2.SetMetadata(), chk.IsNil)
+
+	c.Check(share2.Metadata, chk.DeepEquals, mPutUpper)
+	c.Assert(share2.FetchAttributes(), chk.IsNil)
+	c.Check(share2.Metadata, chk.DeepEquals, mExpectLower)
+}
+
+func deleteTestShares(cli FileServiceClient) error {
+	for {
+		resp, err := cli.ListShares(ListSharesParameters{Prefix: testSharePrefix})
+		if err != nil {
+			return err
+		}
+		if len(resp.Shares) == 0 {
+			break
+		}
+		for _, c := range resp.Shares {
+			share := cli.GetShareReference(c.Name)
+			err = share.Delete()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Split code for shares, directories and files into their own source files;
the same refactoring was made for the test code as well.
Make CRUD APIs for shares, directories and files methods for their
respective types.
Added support for content MD5 hashes when sending/receiving file ranges.