### PR TITLE
Adding telemetry to storage dataplane

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -688,6 +688,7 @@ func (b BlobStorageClient) GetBlobRange(container, name, bytesRange string, extr
 func (b BlobStorageClient) getBlobRange(container, name, bytesRange string, extraHeaders map[string]string) (*storageResponse, error) {
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
 
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	if bytesRange != "" {
 		headers["Range"] = fmt.Sprintf("bytes=%s", bytesRange)
@@ -724,6 +725,7 @@ func (b BlobStorageClient) leaseCommonPut(container string, name string, headers
 
 // SnapshotBlob creates a snapshot for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691971.aspx
 func (b BlobStorageClient) SnapshotBlob(container string, name string, timeout int, extraHeaders map[string]string) (snapshotTimestamp *time.Time, err error) {
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	params := url.Values{"comp": {"snapshot"}}
 
@@ -967,6 +969,8 @@ func (b BlobStorageClient) SetBlobProperties(container, name string, blobHeaders
 func (b BlobStorageClient) SetBlobMetadata(container, name string, metadata map[string]string, extraHeaders map[string]string) error {
 	params := url.Values{"comp": {"metadata"}}
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), params)
+	metadata = b.client.protectUserAgent(metadata)
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	for k, v := range metadata {
 		headers[userDefinedMetadataHeaderPrefix+k] = v
@@ -1047,6 +1051,7 @@ func (b BlobStorageClient) CreateBlockBlob(container, name string) error {
 func (b BlobStorageClient) CreateBlockBlobFromReader(container, name string, size uint64, blob io.Reader, extraHeaders map[string]string) error {
 	path := fmt.Sprintf("%s/%s", container, name)
 	uri := b.client.getEndpoint(blobServiceName, path, url.Values{})
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-blob-type"] = string(BlobTypeBlock)
 	headers["Content-Length"] = fmt.Sprintf("%d", size)
@@ -1084,6 +1089,7 @@ func (b BlobStorageClient) PutBlock(container, name, blockID string, chunk []byt
 // See https://msdn.microsoft.com/en-us/library/azure/dd135726.aspx
 func (b BlobStorageClient) PutBlockWithLength(container, name, blockID string, size uint64, blob io.Reader, extraHeaders map[string]string) error {
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{"comp": {"block"}, "blockid": {blockID}})
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-blob-type"] = string(BlobTypeBlock)
 	headers["Content-Length"] = fmt.Sprintf("%v", size)
@@ -1146,6 +1152,7 @@ func (b BlobStorageClient) GetBlockList(container, name string, blockType BlockL
 func (b BlobStorageClient) PutPageBlob(container, name string, size int64, extraHeaders map[string]string) error {
 	path := fmt.Sprintf("%s/%s", container, name)
 	uri := b.client.getEndpoint(blobServiceName, path, url.Values{})
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-blob-type"] = string(BlobTypePage)
 	headers["x-ms-blob-content-length"] = fmt.Sprintf("%v", size)
@@ -1171,6 +1178,7 @@ func (b BlobStorageClient) PutPageBlob(container, name string, size int64, extra
 func (b BlobStorageClient) PutPage(container, name string, startByte, endByte int64, writeType PageWriteType, chunk []byte, extraHeaders map[string]string) error {
 	path := fmt.Sprintf("%s/%s", container, name)
 	uri := b.client.getEndpoint(blobServiceName, path, url.Values{"comp": {"page"}})
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-blob-type"] = string(BlobTypePage)
 	headers["x-ms-page-write"] = string(writeType)
@@ -1227,6 +1235,7 @@ func (b BlobStorageClient) GetPageRanges(container, name string) (GetPageRangesR
 func (b BlobStorageClient) PutAppendBlob(container, name string, extraHeaders map[string]string) error {
 	path := fmt.Sprintf("%s/%s", container, name)
 	uri := b.client.getEndpoint(blobServiceName, path, url.Values{})
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-blob-type"] = string(BlobTypeAppend)
 
@@ -1249,6 +1258,7 @@ func (b BlobStorageClient) PutAppendBlob(container, name string, extraHeaders ma
 func (b BlobStorageClient) AppendBlock(container, name string, chunk []byte, extraHeaders map[string]string) error {
 	path := fmt.Sprintf("%s/%s", container, name)
 	uri := b.client.getEndpoint(blobServiceName, path, url.Values{"comp": {"appendblock"}})
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	headers["x-ms-blob-type"] = string(BlobTypeAppend)
 	headers["Content-Length"] = fmt.Sprintf("%v", len(chunk))
@@ -1396,6 +1406,7 @@ func (b BlobStorageClient) DeleteBlobIfExists(container, name string, extraHeade
 
 func (b BlobStorageClient) deleteBlob(container, name string, extraHeaders map[string]string) (*storageResponse, error) {
 	uri := b.client.getEndpoint(blobServiceName, pathForBlob(container, name), url.Values{})
+	extraHeaders = b.client.protectUserAgent(extraHeaders)
 	headers := b.client.getStandardHeaders()
 	for k, v := range extraHeaders {
 		headers[k] = v

--- a/storage/client.go
+++ b/storage/client.go
@@ -171,7 +171,7 @@ func NewClient(accountName, accountKey, blobServiceBaseURL, apiVersion string, u
 }
 
 func (c Client) getDefaultUserAgent() string {
-	return fmt.Sprintf("Go/%s (%s-%s) Azure-SDK-for-Go/%s storage-dataplane/%s",
+	return fmt.Sprintf("Go/%s (%s-%s) Azure-SDK-For-Go/%s storage-dataplane/%s",
 		runtime.Version(),
 		runtime.GOARCH,
 		runtime.GOOS,

--- a/storage/client.go
+++ b/storage/client.go
@@ -181,8 +181,12 @@ func (c Client) getDefaultUserAgent() string {
 }
 
 // AddToUserAgent adds an extension to the current user agent
-func (c *Client) AddToUserAgent(extension string) {
-	c.userAgent = fmt.Sprintf("%s %s", c.userAgent, extension)
+func (c *Client) AddToUserAgent(extension string) error {
+	if extension != "" {
+		c.userAgent = fmt.Sprintf("%s %s", c.userAgent, extension)
+		return nil
+	}
+	return fmt.Errorf("Extension was empty, User Agent stayed as %s", c.userAgent)
 }
 
 // protectUserAgent is used in funcs that include extraheaders as a parameter.
@@ -245,8 +249,8 @@ func (c Client) getEndpoint(service, path string, params url.Values) string {
 // GetBlobService returns a BlobStorageClient which can operate on the blob
 // service of the storage account.
 func (c Client) GetBlobService() BlobStorageClient {
-	c.AddToUserAgent(blobServiceName)
 	b := BlobStorageClient{c}
+	b.client.AddToUserAgent(blobServiceName)
 	return b
 }
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -283,8 +283,12 @@ func (s *StorageClientSuite) TestAddToUserAgent(c *chk.C) {
 
 	ua := cli.getDefaultUserAgent()
 
-	cli.AddToUserAgent("bar")
+	err = cli.AddToUserAgent("bar")
+	c.Assert(err, chk.IsNil)
 	c.Assert(cli.userAgent, chk.Equals, ua+" bar")
+
+	err = cli.AddToUserAgent("")
+	c.Assert(err, chk.NotNil)
 }
 
 func (s *StorageClientSuite) Test_protectUserAgent(c *chk.C) {

--- a/storage/file.go
+++ b/storage/file.go
@@ -313,6 +313,7 @@ func (f FileServiceClient) listContent(path string, params url.Values, extraHead
 	}
 
 	uri := f.client.getEndpoint(fileServiceName, path, params)
+	extraHeaders = f.client.protectUserAgent(extraHeaders)
 	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
 
 	resp, err := f.client.exec(http.MethodGet, uri, headers, nil)
@@ -540,6 +541,7 @@ func (f FileServiceClient) createResourceNoClose(path string, res resourceType, 
 
 	values := getURLInitValues(compNone, res)
 	uri := f.client.getEndpoint(fileServiceName, path, values)
+	extraHeaders = f.client.protectUserAgent(extraHeaders)
 	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
 
 	return f.client.exec(http.MethodPut, uri, headers, nil)
@@ -634,6 +636,7 @@ func (f FileServiceClient) getResourceNoClose(path string, comp compType, res re
 
 	params := getURLInitValues(comp, res)
 	uri := f.client.getEndpoint(fileServiceName, path, params)
+	extraHeaders = f.client.protectUserAgent(extraHeaders)
 	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
 
 	return f.client.exec(verb, uri, headers, nil)
@@ -790,6 +793,7 @@ func (f FileServiceClient) setResourceHeaders(path string, comp compType, res re
 
 	params := getURLInitValues(comp, res)
 	uri := f.client.getEndpoint(fileServiceName, path, params)
+	extraHeaders = f.client.protectUserAgent(extraHeaders)
 	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
 
 	resp, err := f.client.exec(http.MethodPut, uri, headers, nil)

--- a/storage/fileserviceclient.go
+++ b/storage/fileserviceclient.go
@@ -155,6 +155,7 @@ func (f FileServiceClient) listContent(path string, params url.Values, extraHead
 	}
 
 	uri := f.client.getEndpoint(fileServiceName, path, params)
+	extraHeaders = f.client.protectUserAgent(extraHeaders)
 	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
 
 	resp, err := f.client.exec(http.MethodGet, uri, headers, nil)
@@ -207,6 +208,7 @@ func (f FileServiceClient) createResourceNoClose(path string, res resourceType, 
 
 	values := getURLInitValues(compNone, res)
 	uri := f.client.getEndpoint(fileServiceName, path, values)
+	extraHeaders = f.client.protectUserAgent(extraHeaders)
 	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
 
 	return f.client.exec(http.MethodPut, uri, headers, nil)
@@ -235,6 +237,7 @@ func (f FileServiceClient) getResourceNoClose(path string, comp compType, res re
 
 	params := getURLInitValues(comp, res)
 	uri := f.client.getEndpoint(fileServiceName, path, params)
+	extraHeaders = f.client.protectUserAgent(extraHeaders)
 	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
 
 	return f.client.exec(verb, uri, headers, nil)
@@ -291,6 +294,7 @@ func (f FileServiceClient) setResourceHeaders(path string, comp compType, res re
 
 	params := getURLInitValues(comp, res)
 	uri := f.client.getEndpoint(fileServiceName, path, params)
+	extraHeaders = f.client.protectUserAgent(extraHeaders)
 	headers := mergeHeaders(f.client.getStandardHeaders(), extraHeaders)
 
 	resp, err := f.client.exec(http.MethodPut, uri, headers, nil)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -151,6 +151,7 @@ type QueueMetadataResponse struct {
 // See https://msdn.microsoft.com/en-us/library/azure/dd179348.aspx
 func (c QueueServiceClient) SetMetadata(name string, metadata map[string]string) error {
 	uri := c.client.getEndpoint(queueServiceName, pathForQueue(name), url.Values{"comp": []string{"metadata"}})
+	metadata = c.client.protectUserAgent(metadata)
 	headers := c.client.getStandardHeaders()
 	for k, v := range metadata {
 		headers[userDefinedMetadataHeaderPrefix+k] = v

--- a/storage/table.go
+++ b/storage/table.go
@@ -48,6 +48,7 @@ func (c *TableServiceClient) getStandardHeaders() map[string]string {
 		"Accept":         "application/json;odata=nometadata",
 		"Accept-Charset": "UTF-8",
 		"Content-Type":   "application/json",
+		userAgentHeader:  c.client.userAgent,
 	}
 }
 

--- a/storage/version.go
+++ b/storage/version.go
@@ -1,0 +1,5 @@
+package storage
+
+var (
+	sdkVersion = "7.0.1-beta"
+)


### PR DESCRIPTION
Taking some cool ideas from the [Ruby SDK telemetry](https://github.com/Azure/azure-sdk-for-ruby/pull/543), users can append more info to the User Agent using the `AddToUserAgent` func.
The User-Agent header follows this format...
```
Go/[version] ([arch]-[OS]) Azure-SDK-for-Go/[version] storage-dataplane/[APIversion] [storageService]
```
... and would look like this...
```
Go/go1.7 (amd64-windows) Azure-SDK-for-Go/7.0.1-beta storage-dataplane/2015-02-21 queue
```

PTAL
@salameer @kirthik @vishrutshah @marstr @jhendrixMSFT 