### PR TITLE
Updating gas to only run during CI when on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,12 @@ install:
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/Masterminds/glide
   - go get -u golang.org/x/net/context
-  - go get -u github.com/HewlettPackard/gas
   - go get -u gopkg.in/godo.v2/cmd/godo
   - export GO15VENDOREXPERIMENT=1
   - glide install
 
 script:
-  - gas -skip=*/arm/*/models.go -skip=*/management/examples/*.go -skip=*vendor* -skip=*/Gododir/* ./...
-  - gas -exclude=G101 ./arm/... ./management/examples/...
-  - gas -exclude=G204 ./Gododir/...
+  - bash rungas.sh
   - test -z "$(gofmt -s -l $(find ./arm/* -type d -print) | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w management | tee /dev/stderr)"
   - test -z "$(gofmt -s -l -w storage | tee /dev/stderr)"

--- a/rungas.sh
+++ b/rungas.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 GITBRANCH=`git rev-parse --abbrev-ref HEAD`
+#We intend to only run gas on release branches.
 if [ "master" != $GITBRANCH ]; then
     exit 0
 fi

--- a/rungas.sh
+++ b/rungas.sh
@@ -5,10 +5,10 @@ if [ "master" != $GITBRANCH ]; then
 fi
 REALEXITSTATUS=0
 go get -u github.com/HewlettPackard/gas
-gas -skip=*/arm/*/models.go -skip=*/management/examples/*.go -skip=*vendor* -skip=*/Gododir/* ./...
+gas -skip=*/arm/*/models.go -skip=*/management/examples/*.go -skip=*vendor* -skip=*/Gododir/* ./... | tee /dev/stderr
 REALEXITSTATUS=$(($REALEXITSTATUS+$?))
-gas -exclude=G101 ./arm/... ./management/examples/...
+gas -exclude=G101 ./arm/... ./management/examples/... | tee /dev/stderr
 REALEXITSTATUS=$(($REALEXITSTATUS+$?))
-gas -exclude=G204 ./Gododir/...
+gas -exclude=G204 ./Gododir/... | tee /dev/stderr
 REALEXITSTATUS=$(($REALEXITSTATUS+$?))
 exit $REALEXITSTATUS

--- a/rungas.sh
+++ b/rungas.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+GITBRANCH=`git rev-parse --abbrev-ref HEAD`
+if [ "master" != $GITBRANCH ]; then
+    exit 0
+fi
+REALEXITSTATUS=0
+go get -u github.com/HewlettPackard/gas
+gas -skip=*/arm/*/models.go -skip=*/management/examples/*.go -skip=*vendor* -skip=*/Gododir/* ./...
+REALEXITSTATUS=$(($REALEXITSTATUS+$?))
+gas -exclude=G101 ./arm/... ./management/examples/...
+REALEXITSTATUS=$(($REALEXITSTATUS+$?))
+gas -exclude=G204 ./Gododir/...
+REALEXITSTATUS=$(($REALEXITSTATUS+$?))
+exit $REALEXITSTATUS


### PR DESCRIPTION
As per issue #514, I've written a script to mask running gas unless we are on the release branch "master"

Travis is bugging out, so this PR is a copy of #521 as a mitigation.