### PR TITLE
ACLs now work correctly with lists

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -260,7 +260,7 @@ const (
 // lease constants.
 const (
 	leaseHeaderPrefix = "x-ms-lease-"
-	leaseID           = "x-ms-lease-id"
+	headerLeaseID     = "x-ms-lease-id"
 	leaseAction       = "x-ms-lease-action"
 	leaseBreakPeriod  = "x-ms-lease-break-period"
 	leaseDuration     = "x-ms-lease-duration"
@@ -302,13 +302,6 @@ const (
 	ContainerAccessTypeContainer ContainerAccessType = "container"
 )
 
-// ContainerAccessOptions are used when setting ACLs of containers (after creation)
-type ContainerAccessOptions struct {
-	ContainerAccess ContainerAccessType
-	Timeout         int
-	LeaseID         string
-}
-
 // ContainerAccessPolicyDetails are used for SETTING container policies
 type ContainerAccessPolicyDetails struct {
 	ID         string
@@ -321,15 +314,8 @@ type ContainerAccessPolicyDetails struct {
 
 // ContainerPermissions is used when setting permissions and Access Policies for containers.
 type ContainerPermissions struct {
-	AccessOptions ContainerAccessOptions
-	AccessPolicy  ContainerAccessPolicyDetails
-}
-
-// ContainerAccessResponse is returned for the GetContainerPermissions function.
-// This contains both the permission and access policy for the container.
-type ContainerAccessResponse struct {
-	ContainerAccess ContainerAccessType
-	AccessPolicy    SignedIdentifiers
+	AccessType     ContainerAccessType
+	AccessPolicies []ContainerAccessPolicyDetails
 }
 
 // ContainerAccessHeader references header used when setting/getting container ACL
@@ -473,44 +459,29 @@ func (b BlobStorageClient) ContainerExists(name string) (bool, error) {
 }
 
 // SetContainerPermissions sets up container permissions as per https://msdn.microsoft.com/en-us/library/azure/dd179391.aspx
-func (b BlobStorageClient) SetContainerPermissions(container string, containerPermissions ContainerPermissions) (err error) {
+func (b BlobStorageClient) SetContainerPermissions(container string, containerPermissions ContainerPermissions, timeout int, leaseID string) (err error) {
 	params := url.Values{
 		"restype": {"container"},
 		"comp":    {"acl"},
 	}
 
-	if containerPermissions.AccessOptions.Timeout > 0 {
-		params.Add("timeout", strconv.Itoa(containerPermissions.AccessOptions.Timeout))
+	if timeout > 0 {
+		params.Add("timeout", strconv.Itoa(timeout))
 	}
 
 	uri := b.client.getEndpoint(blobServiceName, pathForContainer(container), params)
 	headers := b.client.getStandardHeaders()
-	if containerPermissions.AccessOptions.ContainerAccess != "" {
-		headers[ContainerAccessHeader] = string(containerPermissions.AccessOptions.ContainerAccess)
+	if containerPermissions.AccessType != "" {
+		headers[ContainerAccessHeader] = string(containerPermissions.AccessType)
 	}
 
-	if containerPermissions.AccessOptions.LeaseID != "" {
-		headers[leaseID] = containerPermissions.AccessOptions.LeaseID
+	if leaseID != "" {
+		headers[headerLeaseID] = leaseID
 	}
 
-	var permissions = generateContainerPermissions(containerPermissions.AccessPolicy)
-
-	// generate the XML for the SharedAccessSignature if required.
-	accessPolicyXML, err := generateAccessPolicy(containerPermissions.AccessPolicy.ID,
-		containerPermissions.AccessPolicy.StartTime,
-		containerPermissions.AccessPolicy.ExpiryTime,
-		permissions)
-	if err != nil {
-		return err
-	}
-
-	var resp *storageResponse
-	if accessPolicyXML != "" {
-		headers["Content-Length"] = strconv.Itoa(len(accessPolicyXML))
-		resp, err = b.client.exec(http.MethodPut, uri, headers, strings.NewReader(accessPolicyXML))
-	} else {
-		resp, err = b.client.exec(http.MethodPut, uri, headers, nil)
-	}
+	body, length, err := generateContainerACLpayload(containerPermissions.AccessPolicies)
+	headers["Content-Length"] = fmt.Sprintf("%v", length)
+	resp, err := b.client.exec(http.MethodPut, uri, headers, body)
 
 	if err != nil {
 		return err
@@ -530,7 +501,7 @@ func (b BlobStorageClient) SetContainerPermissions(container string, containerPe
 // If timeout is 0 then it will not be passed to Azure
 // leaseID will only be passed to Azure if populated
 // Returns permissionResponse which is combined permissions and AccessPolicy
-func (b BlobStorageClient) GetContainerPermissions(container string, timeout int, leaseID string) (permissionResponse *ContainerAccessResponse, err error) {
+func (b BlobStorageClient) GetContainerPermissions(container string, timeout int, leaseID string) (permissionResponse *ContainerPermissions, err error) {
 	params := url.Values{"restype": {"container"},
 		"comp": {"acl"}}
 
@@ -542,17 +513,13 @@ func (b BlobStorageClient) GetContainerPermissions(container string, timeout int
 	headers := b.client.getStandardHeaders()
 
 	if leaseID != "" {
-		headers[leaseID] = leaseID
+		headers[headerLeaseID] = leaseID
 	}
 
 	resp, err := b.client.exec(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return nil, err
 	}
-
-	// containerAccess. Blob, Container, empty
-	containerAccess := resp.headers.Get(http.CanonicalHeaderKey(ContainerAccessHeader))
-
 	defer resp.body.Close()
 
 	var out AccessPolicy
@@ -561,11 +528,31 @@ func (b BlobStorageClient) GetContainerPermissions(container string, timeout int
 		return nil, err
 	}
 
-	permissionResponse = &ContainerAccessResponse{}
-	permissionResponse.AccessPolicy = out.SignedIdentifiersList
-	permissionResponse.ContainerAccess = ContainerAccessType(containerAccess)
+	permissionResponse = b.updateAccessPolicy(out, &resp.headers)
 
 	return permissionResponse, nil
+}
+
+func (b BlobStorageClient) updateAccessPolicy(ap AccessPolicy, headers *http.Header) *ContainerPermissions {
+	// containerAccess. Blob, Container, empty
+	containerAccess := headers.Get(http.CanonicalHeaderKey(ContainerAccessHeader))
+
+	var cp ContainerPermissions
+	cp.AccessType = ContainerAccessType(containerAccess)
+	for _, policy := range ap.SignedIdentifiersList.SignedIdentifiers {
+		capd := ContainerAccessPolicyDetails{
+			ID:         policy.ID,
+			StartTime:  policy.AccessPolicy.StartTime,
+			ExpiryTime: policy.AccessPolicy.ExpiryTime,
+		}
+		updatePermissions(&capd.CanRead, policy.AccessPolicy.Permission, "r")
+		updatePermissions(&capd.CanWrite, policy.AccessPolicy.Permission, "w")
+		updatePermissions(&capd.CanDelete, policy.AccessPolicy.Permission, "d")
+
+		cp.AccessPolicies = append(cp.AccessPolicies, capd)
+	}
+
+	return &cp
 }
 
 // DeleteContainer deletes the container with given name on the storage
@@ -779,7 +766,7 @@ func (b BlobStorageClient) AcquireLease(container string, name string, leaseTime
 		return "", err
 	}
 
-	returnedLeaseID = respHeaders.Get(http.CanonicalHeaderKey(leaseID))
+	returnedLeaseID = respHeaders.Get(http.CanonicalHeaderKey(headerLeaseID))
 
 	if returnedLeaseID != "" {
 		return returnedLeaseID, nil
@@ -830,7 +817,7 @@ func (b BlobStorageClient) breakLeaseCommon(container string, name string, heade
 func (b BlobStorageClient) ChangeLease(container string, name string, currentLeaseID string, proposedLeaseID string) (newLeaseID string, err error) {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = changeLease
-	headers[leaseID] = currentLeaseID
+	headers[headerLeaseID] = currentLeaseID
 	headers[leaseProposedID] = proposedLeaseID
 
 	respHeaders, err := b.leaseCommonPut(container, name, headers, http.StatusOK)
@@ -838,7 +825,7 @@ func (b BlobStorageClient) ChangeLease(container string, name string, currentLea
 		return "", err
 	}
 
-	newLeaseID = respHeaders.Get(http.CanonicalHeaderKey(leaseID))
+	newLeaseID = respHeaders.Get(http.CanonicalHeaderKey(headerLeaseID))
 	if newLeaseID != "" {
 		return newLeaseID, nil
 	}
@@ -850,7 +837,7 @@ func (b BlobStorageClient) ChangeLease(container string, name string, currentLea
 func (b BlobStorageClient) ReleaseLease(container string, name string, currentLeaseID string) error {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = releaseLease
-	headers[leaseID] = currentLeaseID
+	headers[headerLeaseID] = currentLeaseID
 
 	_, err := b.leaseCommonPut(container, name, headers, http.StatusOK)
 	if err != nil {
@@ -864,7 +851,7 @@ func (b BlobStorageClient) ReleaseLease(container string, name string, currentLe
 func (b BlobStorageClient) RenewLease(container string, name string, currentLeaseID string) error {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = renewLease
-	headers[leaseID] = currentLeaseID
+	headers[headerLeaseID] = currentLeaseID
 
 	_, err := b.leaseCommonPut(container, name, headers, http.StatusOK)
 	if err != nil {
@@ -1334,7 +1321,7 @@ func (b BlobStorageClient) AbortBlobCopy(container, name, copyID, currentLeaseID
 	headers["x-ms-copy-action"] = "abort"
 
 	if currentLeaseID != "" {
-		headers[leaseID] = currentLeaseID
+		headers[headerLeaseID] = currentLeaseID
 	}
 
 	resp, err := b.client.exec(http.MethodPut, uri, headers, nil)
@@ -1519,20 +1506,32 @@ func blobSASStringToSign(signedVersion, canonicalizedResource, signedExpiry, sig
 	return "", errors.New("storage: not implemented SAS for versions earlier than 2013-08-15")
 }
 
-func generateContainerPermissions(accessPolicy ContainerAccessPolicyDetails) (permissions string) {
+func generateContainerACLpayload(policies []ContainerAccessPolicyDetails) (io.Reader, int, error) {
+	sil := SignedIdentifiers{
+		SignedIdentifiers: []SignedIdentifier{},
+	}
+	for _, capd := range policies {
+		permission := capd.generateContainerPermissions()
+		signedIdentifier := convertAccessPolicyToXMLStructs(capd.ID, capd.StartTime, capd.ExpiryTime, permission)
+		sil.SignedIdentifiers = append(sil.SignedIdentifiers, signedIdentifier)
+	}
+	return xmlMarshal(sil)
+}
+
+func (capd *ContainerAccessPolicyDetails) generateContainerPermissions() (permissions string) {
 	// generate the permissions string (rwd).
 	// still want the end user API to have bool flags.
 	permissions = ""
 
-	if accessPolicy.CanRead {
+	if capd.CanRead {
 		permissions += "r"
 	}
 
-	if accessPolicy.CanWrite {
+	if capd.CanWrite {
 		permissions += "w"
 	}
 
-	if accessPolicy.CanDelete {
+	if capd.CanDelete {
 		permissions += "d"
 	}
 

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -480,7 +480,7 @@ func (b BlobStorageClient) SetContainerPermissions(container string, containerPe
 	}
 
 	body, length, err := generateContainerACLpayload(containerPermissions.AccessPolicies)
-	headers["Content-Length"] = fmt.Sprintf("%v", length)
+	headers["Content-Length"] = strconv.Itoa(length)
 	resp, err := b.client.exec(http.MethodPut, uri, headers, body)
 
 	if err != nil {
@@ -528,12 +528,12 @@ func (b BlobStorageClient) GetContainerPermissions(container string, timeout int
 		return nil, err
 	}
 
-	permissionResponse = b.updateAccessPolicy(out, &resp.headers)
+	permissionResponse = updateContainerAccessPolicy(out, &resp.headers)
 
 	return permissionResponse, nil
 }
 
-func (b BlobStorageClient) updateAccessPolicy(ap AccessPolicy, headers *http.Header) *ContainerPermissions {
+func updateContainerAccessPolicy(ap AccessPolicy, headers *http.Header) *ContainerPermissions {
 	// containerAccess. Blob, Container, empty
 	containerAccess := headers.Get(http.CanonicalHeaderKey(ContainerAccessHeader))
 

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -136,7 +136,7 @@ func (s *StorageBlobSuite) TestBlobSASURICorrectness(c *chk.C) {
 	cnt := randContainer()
 	blob := randNameWithSpecialChars(5)
 	body := []byte(randString(100))
-	expiry := time.Now().UTC().Add(time.Hour)
+	expiry := now.UTC().Add(time.Hour)
 	permissions := "r"
 
 	c.Assert(cli.CreateContainer(cnt, ContainerAccessTypePrivate), chk.IsNil)
@@ -798,9 +798,9 @@ func (s *StorageBlobSuite) TestSetBlobProperties(c *chk.C) {
 	c.Check(mPut.ContentLanguage, chk.Equals, props.ContentLanguage)
 }
 
-func (perms *ContainerPermissions) createContainerPermissions(accessType ContainerAccessType,
+func appendContainerPermission(perms ContainerPermissions, accessType ContainerAccessType,
 	ID string, start time.Time, expiry time.Time,
-	canRead bool, canWrite bool, canDelete bool) {
+	canRead bool, canWrite bool, canDelete bool) ContainerPermissions {
 
 	perms.AccessType = accessType
 
@@ -815,6 +815,7 @@ func (perms *ContainerPermissions) createContainerPermissions(accessType Contain
 		}
 		perms.AccessPolicies = append(perms.AccessPolicies, capd)
 	}
+	return perms
 }
 
 func (s *StorageBlobSuite) TestSetContainerPermissionsWithTimeoutSuccessfully(c *chk.C) {
@@ -825,7 +826,7 @@ func (s *StorageBlobSuite) TestSetContainerPermissionsWithTimeoutSuccessfully(c 
 	defer cli.deleteContainer(cnt)
 
 	perms := ContainerPermissions{}
-	perms.createContainerPermissions(ContainerAccessTypeBlob, "GolangRocksOnAzure", time.Now(), time.Now().Add(10*time.Hour), true, true, true)
+	perms = appendContainerPermission(perms, ContainerAccessTypeBlob, "GolangRocksOnAzure", now, now.Add(10*time.Hour), true, true, true)
 
 	err := cli.SetContainerPermissions(cnt, perms, 30, "")
 	c.Assert(err, chk.IsNil)
@@ -839,7 +840,7 @@ func (s *StorageBlobSuite) TestSetContainerPermissionsSuccessfully(c *chk.C) {
 	defer cli.deleteContainer(cnt)
 
 	perms := ContainerPermissions{}
-	perms.createContainerPermissions(ContainerAccessTypeBlob, "GolangRocksOnAzure", time.Now(), time.Now().Add(10*time.Hour), true, true, true)
+	perms = appendContainerPermission(perms, ContainerAccessTypeBlob, "GolangRocksOnAzure", now, now.Add(10*time.Hour), true, true, true)
 
 	err := cli.SetContainerPermissions(cnt, perms, 0, "")
 	c.Assert(err, chk.IsNil)
@@ -853,8 +854,8 @@ func (s *StorageBlobSuite) TestSetThenGetContainerPermissionsSuccessfully(c *chk
 	defer cli.deleteContainer(cnt)
 
 	perms := ContainerPermissions{}
-	perms.createContainerPermissions(ContainerAccessTypeBlob, "AutoRestIsSuperCool", time.Now(), time.Now().Add(10*time.Hour), true, true, true)
-	perms.createContainerPermissions(ContainerAccessTypeBlob, "GolangRocksOnAzure", time.Now().Add(20*time.Hour), time.Now().Add(30*time.Hour), true, false, false)
+	perms = appendContainerPermission(perms, ContainerAccessTypeBlob, "AutoRestIsSuperCool", now, now.Add(10*time.Hour), true, true, true)
+	perms = appendContainerPermission(perms, ContainerAccessTypeBlob, "GolangRocksOnAzure", now.Add(20*time.Hour), now.Add(30*time.Hour), true, false, false)
 
 	err := cli.SetContainerPermissions(cnt, perms, 0, "")
 	c.Assert(err, chk.IsNil)
@@ -894,7 +895,7 @@ func (s *StorageBlobSuite) TestSetContainerPermissionsOnlySuccessfully(c *chk.C)
 	defer cli.deleteContainer(cnt)
 
 	perms := ContainerPermissions{}
-	perms.createContainerPermissions(ContainerAccessTypeBlob, "GolangRocksOnAzure", time.Now(), time.Now().Add(10*time.Hour), true, true, true)
+	perms = appendContainerPermission(perms, ContainerAccessTypeBlob, "GolangRocksOnAzure", now, now.Add(10*time.Hour), true, true, true)
 
 	err := cli.SetContainerPermissions(cnt, perms, 0, "")
 	c.Assert(err, chk.IsNil)
@@ -908,7 +909,7 @@ func (s *StorageBlobSuite) TestSetThenGetContainerPermissionsOnlySuccessfully(c 
 	defer cli.deleteContainer(cnt)
 
 	perms := ContainerPermissions{}
-	perms.createContainerPermissions(ContainerAccessTypeBlob, "", time.Now(), time.Now().Add(10*time.Hour), true, true, true)
+	perms = appendContainerPermission(perms, ContainerAccessTypeBlob, "", now, now.Add(10*time.Hour), true, true, true)
 
 	err := cli.SetContainerPermissions(cnt, perms, 0, "")
 	c.Assert(err, chk.IsNil)
@@ -992,7 +993,7 @@ func (s *StorageBlobSuite) TestSnapshotBlobWithInvalidLease(c *chk.C) {
 	c.Assert(leaseID, chk.Not(chk.Equals), "")
 
 	extraHeaders := map[string]string{
-		headerLeaseID: "718e3c89-da3d-4201-b616-dd794b0bd7c1",
+		headerLeaseID: "GolangRocksOnAzure",
 	}
 
 	snapshotTime, err := cli.SnapshotBlob(cnt, blob, 0, extraHeaders)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	chk "gopkg.in/check.v1"
 )
@@ -16,6 +17,8 @@ func Test(t *testing.T) { chk.TestingT(t) }
 type StorageClientSuite struct{}
 
 var _ = chk.Suite(&StorageClientSuite{})
+
+var now = time.Now()
 
 // getBasicClient returns a test client from storage credentials in the env
 func getBasicClient(c *chk.C) Client {

--- a/storage/storagepolicy.go
+++ b/storage/storagepolicy.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"io/ioutil"
+	"strings"
 	"time"
 )
 
@@ -31,38 +31,17 @@ type AccessPolicy struct {
 
 // convertAccessPolicyToXMLStructs converts between AccessPolicyDetails which is a struct better for API usage to the
 // AccessPolicy struct which will get converted to XML.
-func convertAccessPolicyToXMLStructs(id string, startTime time.Time, expiryTime time.Time, permissions string) SignedIdentifiers {
-	return SignedIdentifiers{
-		SignedIdentifiers: []SignedIdentifier{
-			{
-				ID: id,
-				AccessPolicy: AccessPolicyDetailsXML{
-					StartTime:  startTime.UTC().Round(time.Second),
-					ExpiryTime: expiryTime.UTC().Round(time.Second),
-					Permission: permissions,
-				},
-			},
+func convertAccessPolicyToXMLStructs(id string, startTime time.Time, expiryTime time.Time, permissions string) SignedIdentifier {
+	return SignedIdentifier{
+		ID: id,
+		AccessPolicy: AccessPolicyDetailsXML{
+			StartTime:  startTime.UTC().Round(time.Second),
+			ExpiryTime: expiryTime.UTC().Round(time.Second),
+			Permission: permissions,
 		},
 	}
 }
 
-// generateAccessPolicy generates the XML access policy used as the payload for SetContainerPermissions.
-func generateAccessPolicy(id string, startTime time.Time, expiryTime time.Time, permissions string) (accessPolicyXML string, err error) {
-
-	if id != "" {
-		signedIdentifiers := convertAccessPolicyToXMLStructs(id, startTime, expiryTime, permissions)
-		body, _, err := xmlMarshal(signedIdentifiers)
-		if err != nil {
-			return "", err
-		}
-
-		xmlByteArray, err := ioutil.ReadAll(body)
-		if err != nil {
-			return "", err
-		}
-		accessPolicyXML = string(xmlByteArray)
-		return accessPolicyXML, nil
-	}
-
-	return "", nil
+func updatePermissions(policy *bool, permissions, permission string) {
+	*policy = strings.Contains(permissions, permission)
 }

--- a/storage/storagepolicy.go
+++ b/storage/storagepolicy.go
@@ -42,6 +42,6 @@ func convertAccessPolicyToXMLStructs(id string, startTime time.Time, expiryTime 
 	}
 }
 
-func updatePermissions(policy *bool, permissions, permission string) {
-	*policy = strings.Contains(permissions, permission)
+func updatePermissions(permissions, permission string) bool {
+	return strings.Contains(permissions, permission)
 }

--- a/storage/table.go
+++ b/storage/table.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -146,10 +146,8 @@ func (c *TableServiceClient) DeleteTable(table AzureTable) error {
 }
 
 // SetTablePermissions sets up table ACL permissions as per REST details https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/Set-Table-ACL
-func (c *TableServiceClient) SetTablePermissions(table AzureTable, accessPolicy TableAccessPolicy, timeout uint) (err error) {
-	params := url.Values{
-		"comp": {"acl"},
-	}
+func (c *TableServiceClient) SetTablePermissions(table AzureTable, policies []TableAccessPolicy, timeout uint) (err error) {
+	params := url.Values{"comp": {"acl"}}
 
 	if timeout > 0 {
 		params.Add("timeout", fmt.Sprint(timeout))
@@ -158,43 +156,38 @@ func (c *TableServiceClient) SetTablePermissions(table AzureTable, accessPolicy 
 	uri := c.client.getEndpoint(tableServiceName, string(table), params)
 	headers := c.client.getStandardHeaders()
 
-	permissions := generateTablePermissions(accessPolicy)
-
-	// generate the XML for the SharedAccessSignature if required.
-	accessPolicyXML, err := generateAccessPolicy(accessPolicy.ID,
-		accessPolicy.StartTime,
-		accessPolicy.ExpiryTime,
-		permissions)
-
+	body, length, err := generateTableACLpayload(policies)
 	if err != nil {
 		return err
 	}
+	headers["Content-Length"] = fmt.Sprintf("%v", length)
 
-	var resp *odataResponse
-	headers["Content-Length"] = strconv.Itoa(len(accessPolicyXML))
-	resp, err = c.client.execTable(http.MethodPut, uri, headers, strings.NewReader(accessPolicyXML))
-
+	resp, err := c.client.execTable(http.MethodPut, uri, headers, body)
 	if err != nil {
 		return err
 	}
+	defer resp.body.Close()
 
-	if resp != nil {
-		defer func() {
-			closeErr := resp.body.Close()
-			if closeErr != nil && err == nil {
-				err = closeErr
-			}
-		}()
-
-		if err := checkRespCode(resp.statusCode, []int{http.StatusNoContent}); err != nil {
-			return err
-		}
+	if err := checkRespCode(resp.statusCode, []int{http.StatusNoContent}); err != nil {
+		return err
 	}
 	return nil
 }
 
+func generateTableACLpayload(policies []TableAccessPolicy) (io.Reader, int, error) {
+	sil := SignedIdentifiers{
+		SignedIdentifiers: []SignedIdentifier{},
+	}
+	for _, tap := range policies {
+		permission := generateTablePermissions(&tap)
+		signedIdentifier := convertAccessPolicyToXMLStructs(tap.ID, tap.StartTime, tap.ExpiryTime, permission)
+		sil.SignedIdentifiers = append(sil.SignedIdentifiers, signedIdentifier)
+	}
+	return xmlMarshal(sil)
+}
+
 // GetTablePermissions gets the table ACL permissions, as per REST details https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-table-acl
-func (c *TableServiceClient) GetTablePermissions(table AzureTable, timeout int) (permissionResponse *AccessPolicy, err error) {
+func (c *TableServiceClient) GetTablePermissions(table AzureTable, timeout int) (permissionResponse *[]TableAccessPolicy, err error) {
 	params := url.Values{"comp": {"acl"}}
 
 	if timeout > 0 {
@@ -203,42 +196,62 @@ func (c *TableServiceClient) GetTablePermissions(table AzureTable, timeout int) 
 
 	uri := c.client.getEndpoint(tableServiceName, string(table), params)
 	headers := c.client.getStandardHeaders()
+
 	resp, err := c.client.execTable(http.MethodGet, uri, headers, nil)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.body.Close()
 
-	defer func() {
-		err = resp.body.Close()
-	}()
+	if err = checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		return nil, err
+	}
 
-	var out AccessPolicy
-	err = xmlUnmarshal(resp.body, &out.SignedIdentifiersList)
+	var ap AccessPolicy
+	err = xmlUnmarshal(resp.body, &ap.SignedIdentifiersList)
 	if err != nil {
 		return nil, err
 	}
 
-	return &out, nil
+	return updateAccessPolicy(ap), nil
 }
 
-func generateTablePermissions(accessPolicy TableAccessPolicy) (permissions string) {
+func updateAccessPolicy(ap AccessPolicy) *[]TableAccessPolicy {
+	out := []TableAccessPolicy{}
+	for _, policy := range ap.SignedIdentifiersList.SignedIdentifiers {
+		tap := TableAccessPolicy{
+			ID:         policy.ID,
+			StartTime:  policy.AccessPolicy.StartTime,
+			ExpiryTime: policy.AccessPolicy.ExpiryTime,
+		}
+		updatePermissions(&tap.CanRead, policy.AccessPolicy.Permission, "r")
+		updatePermissions(&tap.CanAppend, policy.AccessPolicy.Permission, "a")
+		updatePermissions(&tap.CanUpdate, policy.AccessPolicy.Permission, "u")
+		updatePermissions(&tap.CanDelete, policy.AccessPolicy.Permission, "d")
+
+		out = append(out, tap)
+	}
+	return &out
+}
+
+func generateTablePermissions(tap *TableAccessPolicy) (permissions string) {
 	// generate the permissions string (raud).
 	// still want the end user API to have bool flags.
 	permissions = ""
 
-	if accessPolicy.CanRead {
+	if tap.CanRead {
 		permissions += "r"
 	}
 
-	if accessPolicy.CanAppend {
+	if tap.CanAppend {
 		permissions += "a"
 	}
 
-	if accessPolicy.CanUpdate {
+	if tap.CanUpdate {
 		permissions += "u"
 	}
 
-	if accessPolicy.CanDelete {
+	if tap.CanDelete {
 		permissions += "d"
 	}
 	return permissions

--- a/storage/table.go
+++ b/storage/table.go
@@ -156,7 +156,7 @@ func (c *TableServiceClient) SetTablePermissions(table AzureTable, policies []Ta
 	uri := c.client.getEndpoint(tableServiceName, string(table), params)
 	headers := c.client.getStandardHeaders()
 
-	body, length, err := generateTableACLpayload(policies)
+	body, length, err := generateTableACLPayload(policies)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func (c *TableServiceClient) SetTablePermissions(table AzureTable, policies []Ta
 	return nil
 }
 
-func generateTableACLpayload(policies []TableAccessPolicy) (io.Reader, int, error) {
+func generateTableACLPayload(policies []TableAccessPolicy) (io.Reader, int, error) {
 	sil := SignedIdentifiers{
 		SignedIdentifiers: []SignedIdentifier{},
 	}
@@ -213,10 +213,10 @@ func (c *TableServiceClient) GetTablePermissions(table AzureTable, timeout int) 
 		return nil, err
 	}
 
-	return updateAccessPolicy(ap), nil
+	return updateTableAccessPolicy(ap), nil
 }
 
-func updateAccessPolicy(ap AccessPolicy) *[]TableAccessPolicy {
+func updateTableAccessPolicy(ap AccessPolicy) *[]TableAccessPolicy {
 	out := []TableAccessPolicy{}
 	for _, policy := range ap.SignedIdentifiersList.SignedIdentifiers {
 		tap := TableAccessPolicy{

--- a/storage/table_test.go
+++ b/storage/table_test.go
@@ -346,24 +346,24 @@ func (s *StorageBlobSuite) TestSetThenGetTablePermissionsSuccessfully(c *chk.C) 
 	c.Assert(err, chk.IsNil)
 
 	// now check policy set.
-	c.Assert(*returnedPolicies, chk.HasLen, 2)
+	c.Assert(returnedPolicies, chk.HasLen, 2)
 
 	for i := range policies {
-		c.Assert((*returnedPolicies)[i].ID, chk.Equals, policies[i].ID)
+		c.Assert(returnedPolicies[i].ID, chk.Equals, policies[i].ID)
 
 		// test timestamps down the second
 		// rounding start/expiry time original perms since the returned perms would have been rounded.
 		// so need rounded vs rounded.
-		c.Assert((*returnedPolicies)[i].StartTime.UTC().Round(time.Second).Format(time.RFC1123),
+		c.Assert(returnedPolicies[i].StartTime.UTC().Round(time.Second).Format(time.RFC1123),
 			chk.Equals, policies[i].StartTime.UTC().Round(time.Second).Format(time.RFC1123))
 
-		c.Assert((*returnedPolicies)[i].ExpiryTime.UTC().Round(time.Second).Format(time.RFC1123),
+		c.Assert(returnedPolicies[i].ExpiryTime.UTC().Round(time.Second).Format(time.RFC1123),
 			chk.Equals, policies[i].ExpiryTime.UTC().Round(time.Second).Format(time.RFC1123))
 
-		c.Assert((*returnedPolicies)[i].CanRead, chk.Equals, policies[i].CanRead)
-		c.Assert((*returnedPolicies)[i].CanAppend, chk.Equals, policies[i].CanAppend)
-		c.Assert((*returnedPolicies)[i].CanUpdate, chk.Equals, policies[i].CanUpdate)
-		c.Assert((*returnedPolicies)[i].CanDelete, chk.Equals, policies[i].CanDelete)
+		c.Assert(returnedPolicies[i].CanRead, chk.Equals, policies[i].CanRead)
+		c.Assert(returnedPolicies[i].CanAppend, chk.Equals, policies[i].CanAppend)
+		c.Assert(returnedPolicies[i].CanUpdate, chk.Equals, policies[i].CanUpdate)
+		c.Assert(returnedPolicies[i].CanDelete, chk.Equals, policies[i].CanDelete)
 
 	}
 }

--- a/storage/table_test.go
+++ b/storage/table_test.go
@@ -287,9 +287,9 @@ func randTable() string {
 	return string(bytes)
 }
 
-func (s *StorageBlobSuite) createTablePermissions(policies *[]TableAccessPolicy, ID string,
+func appendTablePermission(policies []TableAccessPolicy, ID string,
 	canRead bool, canAppend bool, canUpdate bool, canDelete bool,
-	startTime time.Time, expiryTime time.Time) {
+	startTime time.Time, expiryTime time.Time) []TableAccessPolicy {
 
 	tap := TableAccessPolicy{
 		ID:         ID,
@@ -300,7 +300,8 @@ func (s *StorageBlobSuite) createTablePermissions(policies *[]TableAccessPolicy,
 		CanUpdate:  canUpdate,
 		CanDelete:  canDelete,
 	}
-	*policies = append(*policies, tap)
+	policies = append(policies, tap)
+	return policies
 }
 
 func (s *StorageBlobSuite) TestSetTablePermissionsSuccessfully(c *chk.C) {
@@ -311,7 +312,7 @@ func (s *StorageBlobSuite) TestSetTablePermissionsSuccessfully(c *chk.C) {
 	defer cli.DeleteTable(tn)
 
 	policies := []TableAccessPolicy{}
-	s.createTablePermissions(&policies, "GolangRocksOnAzure", true, true, true, true, time.Now(), time.Now().Add(10*time.Hour))
+	policies = appendTablePermission(policies, "GolangRocksOnAzure", true, true, true, true, now, now.Add(10*time.Hour))
 
 	err = cli.SetTablePermissions(tn, policies, 0)
 	c.Assert(err, chk.IsNil)
@@ -322,7 +323,7 @@ func (s *StorageBlobSuite) TestSetTablePermissionsUnsuccessfully(c *chk.C) {
 	tn := AzureTable("nonexistingtable")
 
 	policies := []TableAccessPolicy{}
-	s.createTablePermissions(&policies, "GolangRocksOnAzure", true, true, true, true, time.Now(), time.Now().Add(10*time.Hour))
+	policies = appendTablePermission(policies, "GolangRocksOnAzure", true, true, true, true, now, now.Add(10*time.Hour))
 
 	err := cli.SetTablePermissions(tn, policies, 0)
 	c.Assert(err, chk.NotNil)
@@ -336,8 +337,8 @@ func (s *StorageBlobSuite) TestSetThenGetTablePermissionsSuccessfully(c *chk.C) 
 	defer cli.DeleteTable(tn)
 
 	policies := []TableAccessPolicy{}
-	s.createTablePermissions(&policies, "GolangRocksOnAzure", true, true, true, true, time.Now(), time.Now().Add(10*time.Hour))
-	s.createTablePermissions(&policies, "AutoRestIsSuperCool", true, true, false, true, time.Now().Add(20*time.Hour), time.Now().Add(30*time.Hour))
+	policies = appendTablePermission(policies, "GolangRocksOnAzure", true, true, true, true, now, now.Add(10*time.Hour))
+	policies = appendTablePermission(policies, "AutoRestIsSuperCool", true, true, false, true, now.Add(20*time.Hour), now.Add(30*time.Hour))
 	err = cli.SetTablePermissions(tn, policies, 0)
 	c.Assert(err, chk.IsNil)
 

--- a/storage/table_test.go
+++ b/storage/table_test.go
@@ -287,10 +287,11 @@ func randTable() string {
 	return string(bytes)
 }
 
-func (s *StorageBlobSuite) createTablePermissions(ID string, canRead bool, canAppend bool, canUpdate bool,
-	canDelete bool, startTime time.Time, expiryTime time.Time) TableAccessPolicy {
+func (s *StorageBlobSuite) createTablePermissions(policies *[]TableAccessPolicy, ID string,
+	canRead bool, canAppend bool, canUpdate bool, canDelete bool,
+	startTime time.Time, expiryTime time.Time) {
 
-	return TableAccessPolicy{
+	tap := TableAccessPolicy{
 		ID:         ID,
 		StartTime:  startTime,
 		ExpiryTime: expiryTime,
@@ -299,6 +300,7 @@ func (s *StorageBlobSuite) createTablePermissions(ID string, canRead bool, canAp
 		CanUpdate:  canUpdate,
 		CanDelete:  canDelete,
 	}
+	*policies = append(*policies, tap)
 }
 
 func (s *StorageBlobSuite) TestSetTablePermissionsSuccessfully(c *chk.C) {
@@ -308,17 +310,21 @@ func (s *StorageBlobSuite) TestSetTablePermissionsSuccessfully(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	defer cli.DeleteTable(tn)
 
-	policy := s.createTablePermissions("MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTa=", true, true, true, true, time.Now(), time.Now().Add(time.Hour*10))
-	err = cli.SetTablePermissions(tn, policy, 0)
+	policies := []TableAccessPolicy{}
+	s.createTablePermissions(&policies, "GolangRocksOnAzure", true, true, true, true, time.Now(), time.Now().Add(10*time.Hour))
+
+	err = cli.SetTablePermissions(tn, policies, 0)
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *StorageBlobSuite) TestSetTablePermissionsUnsuccessfully(c *chk.C) {
 	cli := getTableClient(c)
-
 	tn := AzureTable("nonexistingtable")
-	policy := s.createTablePermissions("MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTa=", true, true, true, true, time.Now(), time.Now().Add(10*time.Hour))
-	err := cli.SetTablePermissions(tn, policy, 0)
+
+	policies := []TableAccessPolicy{}
+	s.createTablePermissions(&policies, "GolangRocksOnAzure", true, true, true, true, time.Now(), time.Now().Add(10*time.Hour))
+
+	err := cli.SetTablePermissions(tn, policies, 0)
 	c.Assert(err, chk.NotNil)
 }
 
@@ -329,21 +335,34 @@ func (s *StorageBlobSuite) TestSetThenGetTablePermissionsSuccessfully(c *chk.C) 
 	c.Assert(err, chk.IsNil)
 	defer cli.DeleteTable(tn)
 
-	policy := s.createTablePermissions("MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTa=", true, true, true, true, time.Now(), time.Now().Add(time.Hour*10))
-	err = cli.SetTablePermissions(tn, policy, 0)
+	policies := []TableAccessPolicy{}
+	s.createTablePermissions(&policies, "GolangRocksOnAzure", true, true, true, true, time.Now(), time.Now().Add(10*time.Hour))
+	s.createTablePermissions(&policies, "AutoRestIsSuperCool", true, true, false, true, time.Now().Add(20*time.Hour), time.Now().Add(30*time.Hour))
+	err = cli.SetTablePermissions(tn, policies, 0)
 	c.Assert(err, chk.IsNil)
 
-	returnedPerms, err := cli.GetTablePermissions(tn, 0)
+	returnedPolicies, err := cli.GetTablePermissions(tn, 0)
 	c.Assert(err, chk.IsNil)
 
 	// now check policy set.
-	c.Assert(returnedPerms.SignedIdentifiersList.SignedIdentifiers, chk.HasLen, 1)
-	c.Assert(returnedPerms.SignedIdentifiersList.SignedIdentifiers[0].ID, chk.Equals, policy.ID)
+	c.Assert(*returnedPolicies, chk.HasLen, 2)
 
-	// test timestamps down the second
-	// rounding start/expiry time original perms since the returned perms would have been rounded.
-	// so need rounded vs rounded.
-	c.Assert(returnedPerms.SignedIdentifiersList.SignedIdentifiers[0].AccessPolicy.StartTime.UTC().Round(time.Second).Format(time.RFC1123), chk.Equals, policy.StartTime.UTC().Round(time.Second).Format(time.RFC1123))
-	c.Assert(returnedPerms.SignedIdentifiersList.SignedIdentifiers[0].AccessPolicy.ExpiryTime.UTC().Round(time.Second).Format(time.RFC1123), chk.Equals, policy.ExpiryTime.UTC().Round(time.Second).Format(time.RFC1123))
-	c.Assert(returnedPerms.SignedIdentifiersList.SignedIdentifiers[0].AccessPolicy.Permission, chk.Equals, "raud")
+	for i := range policies {
+		c.Assert((*returnedPolicies)[i].ID, chk.Equals, policies[i].ID)
+
+		// test timestamps down the second
+		// rounding start/expiry time original perms since the returned perms would have been rounded.
+		// so need rounded vs rounded.
+		c.Assert((*returnedPolicies)[i].StartTime.UTC().Round(time.Second).Format(time.RFC1123),
+			chk.Equals, policies[i].StartTime.UTC().Round(time.Second).Format(time.RFC1123))
+
+		c.Assert((*returnedPolicies)[i].ExpiryTime.UTC().Round(time.Second).Format(time.RFC1123),
+			chk.Equals, policies[i].ExpiryTime.UTC().Round(time.Second).Format(time.RFC1123))
+
+		c.Assert((*returnedPolicies)[i].CanRead, chk.Equals, policies[i].CanRead)
+		c.Assert((*returnedPolicies)[i].CanAppend, chk.Equals, policies[i].CanAppend)
+		c.Assert((*returnedPolicies)[i].CanUpdate, chk.Equals, policies[i].CanUpdate)
+		c.Assert((*returnedPolicies)[i].CanDelete, chk.Equals, policies[i].CanDelete)
+
+	}
 }


### PR DESCRIPTION
Found this on the way.
ACLs were working with a single permission, but they should also work with many permissions.
PTAL
@jhendrixMSFT @marstr 