### PR TITLE
Service properties

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -13,13 +13,6 @@ import (
 	"time"
 )
 
-// BlobStorageClient contains operations for Microsoft Azure Blob Storage
-// Service.
-type BlobStorageClient struct {
-	client Client
-	auth   authentication
-}
-
 // A Container is an entry in ContainerListResponse.
 type Container struct {
 	Name       string              `xml:"Name"`

--- a/storage/blobserviceclient.go
+++ b/storage/blobserviceclient.go
@@ -1,0 +1,20 @@
+package storage
+
+// BlobStorageClient contains operations for Microsoft Azure Blob Storage
+// Service.
+type BlobStorageClient struct {
+	client Client
+	auth   authentication
+}
+
+// GetServiceProperties gets the properties of your storage account's blob service.
+// See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-blob-service-properties
+func (b *BlobStorageClient) GetServiceProperties() (*ServiceProperties, error) {
+	return b.client.getServiceProperties(blobServiceName, b.auth)
+}
+
+// SetServiceProperties sets the properties of your storage account's blob service.
+// See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-blob-service-properties
+func (b *BlobStorageClient) SetServiceProperties(props ServiceProperties) error {
+	return b.client.setServiceProperties(props, blobServiceName, b.auth)
+}

--- a/storage/client.go
+++ b/storage/client.go
@@ -24,7 +24,7 @@ const (
 
 	// DefaultAPIVersion is the  Azure Storage API version string used when a
 	// basic client is created.
-	DefaultAPIVersion = "2015-02-21"
+	DefaultAPIVersion = "2015-04-05"
 
 	defaultUseHTTPS = true
 

--- a/storage/fileserviceclient.go
+++ b/storage/fileserviceclient.go
@@ -149,6 +149,20 @@ func (f FileServiceClient) ListShares(params ListSharesParameters) (*ShareListRe
 	return &out, err
 }
 
+// GetServiceProperties gets the properties of your storage account's file service.
+// File service does not support logging
+// See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-file-service-properties
+func (f *FileServiceClient) GetServiceProperties() (*ServiceProperties, error) {
+	return f.client.getServiceProperties(fileServiceName, f.auth)
+}
+
+// SetServiceProperties sets the properties of your storage account's file service.
+// File service does not support logging
+// See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-file-service-properties
+func (f *FileServiceClient) SetServiceProperties(props ServiceProperties) error {
+	return f.client.setServiceProperties(props, fileServiceName, f.auth)
+}
+
 // retrieves directory or share content
 func (f FileServiceClient) listContent(path string, params url.Values, extraHeaders map[string]string) (*storageResponse, error) {
 	if err := f.checkForStorageEmulator(); err != nil {

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -15,13 +15,6 @@ const (
 	userDefinedMetadataHeaderPrefix = "X-Ms-Meta-"
 )
 
-// QueueServiceClient contains operations for Microsoft Azure Queue Storage
-// Service.
-type QueueServiceClient struct {
-	client Client
-	auth   authentication
-}
-
 func pathForQueue(queue string) string         { return fmt.Sprintf("/%s", queue) }
 func pathForQueueMessages(queue string) string { return fmt.Sprintf("/%s/messages", queue) }
 func pathForMessage(queue, name string) string { return fmt.Sprintf("/%s/messages/%s", queue, name) }

--- a/storage/queueserviceclient.go
+++ b/storage/queueserviceclient.go
@@ -1,0 +1,20 @@
+package storage
+
+// QueueServiceClient contains operations for Microsoft Azure Queue Storage
+// Service.
+type QueueServiceClient struct {
+	client Client
+	auth   authentication
+}
+
+// GetServiceProperties gets the properties of your storage account's queue service.
+// See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-queue-service-properties
+func (c *QueueServiceClient) GetServiceProperties() (*ServiceProperties, error) {
+	return c.client.getServiceProperties(queueServiceName, c.auth)
+}
+
+// SetServiceProperties sets the properties of your storage account's queue service.
+// See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-queue-service-properties
+func (c *QueueServiceClient) SetServiceProperties(props ServiceProperties) error {
+	return c.client.setServiceProperties(props, queueServiceName, c.auth)
+}

--- a/storage/storageservice.go
+++ b/storage/storageservice.go
@@ -112,7 +112,7 @@ func (c Client) setServiceProperties(props ServiceProperties, service string, au
 	if err != nil {
 		return err
 	}
-	defer resp.body.Close()
+	defer readAndCloseBody(resp.body)
 
 	return checkRespCode(resp.statusCode, []int{http.StatusAccepted})
 }

--- a/storage/storageservice.go
+++ b/storage/storageservice.go
@@ -1,0 +1,118 @@
+package storage
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// ServiceProperties represents the storage account service properties
+type ServiceProperties struct {
+	Logging       *Logging
+	HourMetrics   *Metrics
+	MinuteMetrics *Metrics
+	Cors          *Cors
+}
+
+// Logging represents the Azure Analytics Logging settings
+type Logging struct {
+	Version         string
+	Delete          bool
+	Read            bool
+	Write           bool
+	RetentionPolicy *RetentionPolicy
+}
+
+// RetentionPolicy indicates if retention is enabled and for how many days
+type RetentionPolicy struct {
+	Enabled bool
+	Days    *int
+}
+
+// Metrics provide request statistics.
+type Metrics struct {
+	Version         string
+	Enabled         bool
+	IncludeAPIs     *bool
+	RetentionPolicy *RetentionPolicy
+}
+
+// Cors includes all the CORS rules
+type Cors struct {
+	CorsRule []CorsRule
+}
+
+// CorsRule includes all settings for a Cors rule
+type CorsRule struct {
+	AllowedOrigins  string
+	AllowedMethods  string
+	MaxAgeInSeconds int
+	ExposedHeaders  string
+	AllowedHeaders  string
+}
+
+func (c Client) getServiceProperties(service string, auth authentication) (*ServiceProperties, error) {
+	query := url.Values{
+		"restype": {"service"},
+		"comp":    {"properties"},
+	}
+	uri := c.getEndpoint(service, "", query)
+	headers := c.getStandardHeaders()
+
+	resp, err := c.exec(http.MethodGet, uri, headers, nil, auth)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		return nil, err
+	}
+
+	var out ServiceProperties
+	err = xmlUnmarshal(resp.body, &out)
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c Client) setServiceProperties(props ServiceProperties, service string, auth authentication) error {
+	query := url.Values{
+		"restype": {"service"},
+		"comp":    {"properties"},
+	}
+	uri := c.getEndpoint(service, "", query)
+
+	// Ideally, StorageServiceProperties would be the output struct
+	// This is to avoid golint stuttering, while generating the correct XML
+	type StorageServiceProperties struct {
+		Logging       *Logging
+		HourMetrics   *Metrics
+		MinuteMetrics *Metrics
+		Cors          *Cors
+	}
+	input := StorageServiceProperties{
+		Logging:       props.Logging,
+		HourMetrics:   props.HourMetrics,
+		MinuteMetrics: props.MinuteMetrics,
+		Cors:          props.Cors,
+	}
+
+	body, length, err := xmlMarshal(input)
+	if err != nil {
+		return err
+	}
+
+	headers := c.getStandardHeaders()
+	headers["Content-Length"] = fmt.Sprintf("%v", length)
+
+	resp, err := c.exec(http.MethodPut, uri, headers, body, auth)
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+
+	return checkRespCode(resp.statusCode, []int{http.StatusAccepted})
+}

--- a/storage/storageservice_test.go
+++ b/storage/storageservice_test.go
@@ -1,0 +1,85 @@
+package storage
+
+import chk "gopkg.in/check.v1"
+
+type StorageSuite struct{}
+
+var _ = chk.Suite(&StorageSuite{})
+
+// This tests use the Table service, but could also use any other service
+
+func (s *StorageSuite) TestGetServiceProperties(c *chk.C) {
+	cli := getTableClient(c)
+	sp, err := cli.GetServiceProperties()
+	c.Assert(err, chk.IsNil)
+	c.Assert(sp, chk.NotNil)
+}
+
+func (s *StorageSuite) TestSetServiceProperties(c *chk.C) {
+	cli := getTableClient(c)
+
+	t := true
+	num := 7
+	rp := RetentionPolicy{
+		Enabled: true,
+		Days:    &num,
+	}
+	m := Metrics{
+		Version:         "1.0",
+		Enabled:         true,
+		IncludeAPIs:     &t,
+		RetentionPolicy: &rp,
+	}
+	spInput := ServiceProperties{
+		Logging: &Logging{
+			Version:         "1.0",
+			Delete:          true,
+			Read:            false,
+			Write:           true,
+			RetentionPolicy: &rp,
+		},
+		HourMetrics:   &m,
+		MinuteMetrics: &m,
+		Cors: &Cors{
+			CorsRule: []CorsRule{
+				{
+					AllowedOrigins:  "*",
+					AllowedMethods:  "GET,PUT",
+					MaxAgeInSeconds: 500,
+					ExposedHeaders:  "x-ms-meta-customheader,x-ms-meta-data*",
+					AllowedHeaders:  "x-ms-meta-customheader,x-ms-meta-target*",
+				},
+			},
+		},
+	}
+
+	err := cli.SetServiceProperties(spInput)
+	c.Assert(err, chk.IsNil)
+
+	spOutput, err := cli.GetServiceProperties()
+	c.Assert(err, chk.IsNil)
+	c.Assert(spOutput, chk.NotNil)
+	c.Assert(*spOutput, chk.DeepEquals, spInput)
+
+	// Back to defaults
+	defaultRP := RetentionPolicy{
+		Enabled: false,
+		Days:    nil,
+	}
+	m.Enabled = false
+	m.IncludeAPIs = nil
+	m.RetentionPolicy = &defaultRP
+	spInput.Logging.Delete = false
+	spInput.Logging.Read = false
+	spInput.Logging.Write = false
+	spInput.Logging.RetentionPolicy = &defaultRP
+	spInput.Cors = &Cors{nil}
+
+	err = cli.SetServiceProperties(spInput)
+	c.Assert(err, chk.IsNil)
+
+	spOutput, err = cli.GetServiceProperties()
+	c.Assert(err, chk.IsNil)
+	c.Assert(spOutput, chk.NotNil)
+	c.Assert(*spOutput, chk.DeepEquals, spInput)
+}

--- a/storage/table.go
+++ b/storage/table.go
@@ -11,13 +11,6 @@ import (
 	"time"
 )
 
-// TableServiceClient contains operations for Microsoft Azure Table Storage
-// Service.
-type TableServiceClient struct {
-	client Client
-	auth   authentication
-}
-
 // AzureTable is the typedef of the Azure Table name
 type AzureTable string
 

--- a/storage/tableserviceclient.go
+++ b/storage/tableserviceclient.go
@@ -1,0 +1,20 @@
+package storage
+
+// TableServiceClient contains operations for Microsoft Azure Table Storage
+// Service.
+type TableServiceClient struct {
+	client Client
+	auth   authentication
+}
+
+// GetServiceProperties gets the properties of your storage account's table service.
+// See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-table-service-properties
+func (c *TableServiceClient) GetServiceProperties() (*ServiceProperties, error) {
+	return c.client.getServiceProperties(tableServiceName, c.auth)
+}
+
+// SetServiceProperties sets the properties of your storage account's table service.
+// See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-table-service-properties
+func (c *TableServiceClient) SetServiceProperties(props ServiceProperties) error {
+	return c.client.setServiceProperties(props, tableServiceName, c.auth)
+}


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-go/issues/518
There are still some funcs missing for all services. Started with get and set service properties.
PTAL @jhendrixMSFT @marstr 