### PR TITLE
Add support to generate SAS URI for entire containers

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -1015,12 +1015,12 @@ func pathForBlob(container, name string) string {
 	return fmt.Sprintf("/%s/%s", container, name)
 }
 
-// helper method that combines pathForBlob or pathForContainer
+// helper method to construct the path to either a blob or container
 func pathForResource(container, name string) string {
 	if len(name) > 0 {
-		return pathForBlob(container, name)
+		return fmt.Sprintf("/%s/%s", container, name)
 	}
-	return pathForContainer(container)
+	return fmt.Sprintf("/%s", container)
 }
 
 // GetBlobSASURIWithSignedIPAndProtocol creates an URL to the specified blob which contains the Shared

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -238,7 +238,6 @@ func (b BlobStorageClient) BlobExists(container, name string) (bool, error) {
 // container is obtained.
 // This method does not create a publicly accessible URL if the blob or container
 // is private and this method does not check if the blob exists.
-
 func (b BlobStorageClient) GetBlobURL(container, name string) string {
 	if container == "" {
 		container = "$root"


### PR DESCRIPTION
We are using this as a dependency in Yammer's fork of hashicorp/vault which includes support for Azure Blob Storage SAS URI generation (I'll send them a PR once I get the OSS approval)

Slightly modifies GetBlobSASURI behavior to generate a URI for the entire container instead of just a single blob, if blob name isn't specified.

-- Rao Li (raol@microsoft.com)