### PR TITLE
Addressing issue #548

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -356,13 +356,21 @@ func (b BlobStorageClient) SnapshotBlob(container string, name string, timeout i
 
 // AcquireLease creates a lease for a blob as per https://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
 // returns leaseID acquired
+// In API Versions starting on 2012-02-12, the minimum leaseTimeInSeconds is 15, the maximum
+// non-infinite leaseTimeInSeconds is 60. To specify an infinite lease, provide the value -1.
 func (b BlobStorageClient) AcquireLease(container string, name string, leaseTimeInSeconds int, proposedLeaseID string) (returnedLeaseID string, err error) {
 	headers := b.client.getStandardHeaders()
 	headers[leaseAction] = acquireLease
 
-	if leaseTimeInSeconds > 0 {
-		headers[leaseDuration] = strconv.Itoa(leaseTimeInSeconds)
+	if leaseTimeInSeconds == -1 {
+		// Do nothing, but don't trigger the following clauses.
+	} else if leaseTimeInSeconds > 60 || b.client.apiVersion < "2012-02-12" {
+		leaseTimeInSeconds = 60
+	} else if leaseTimeInSeconds < 15 {
+		leaseTimeInSeconds = 15
 	}
+
+	headers[leaseDuration] = strconv.Itoa(leaseTimeInSeconds)
 
 	if proposedLeaseID != "" {
 		headers[leaseProposedID] = proposedLeaseID


### PR DESCRIPTION
Updating `blob.AcquireLease(...)` to ensure that leaseTimeInSeconds is
submitted within the bounds of what the Azure REST API expects. I
decided clamping the value to the min/max acceptable value was more user
friendly than throwing an error without adding too much complexity.

The real alternative to what I did was to simply remove the check
all-together and just pass through the value to Azure. The reason I
didn't do that, is that I presume Azure would adopt the same behavior I
enumerated. Having this operation done client side will allow folks who
are debugging to see the operation.