### PR TITLE
Fix table entities error checking

### DIFF
--- a/storage/table_entities.go
+++ b/storage/table_entities.go
@@ -124,11 +124,12 @@ func (c *TableServiceClient) QueryTableEntities(tableName AzureTable, previousCo
 // The function fails if there is an entity with the same
 // PartitionKey and RowKey in the table.
 func (c *TableServiceClient) InsertEntity(table AzureTable, entity TableEntity) error {
-	if sc, err := c.execTable(table, entity, false, http.MethodPost); err != nil {
-		return checkRespCode(sc, []int{http.StatusCreated})
+	sc, err := c.execTable(table, entity, false, http.MethodPost)
+	if err != nil {
+		return err
 	}
 
-	return nil
+	return checkRespCode(sc, []int{http.StatusCreated})
 }
 
 func (c *TableServiceClient) execTable(table AzureTable, entity TableEntity, specifyKeysInURL bool, method string) (int, error) {
@@ -162,10 +163,12 @@ func (c *TableServiceClient) execTable(table AzureTable, entity TableEntity, spe
 // one passed as parameter. The function fails if there is no entity
 // with the same PartitionKey and RowKey in the table.
 func (c *TableServiceClient) UpdateEntity(table AzureTable, entity TableEntity) error {
-	if sc, err := c.execTable(table, entity, true, http.MethodPut); err != nil {
-		return checkRespCode(sc, []int{http.StatusNoContent})
+	sc, err := c.execTable(table, entity, true, http.MethodPut)
+	if err != nil {
+		return err
 	}
-	return nil
+
+	return checkRespCode(sc, []int{http.StatusNoContent})
 }
 
 // MergeEntity merges the contents of an entity with the
@@ -173,10 +176,12 @@ func (c *TableServiceClient) UpdateEntity(table AzureTable, entity TableEntity) 
 // The function fails if there is no entity
 // with the same PartitionKey and RowKey in the table.
 func (c *TableServiceClient) MergeEntity(table AzureTable, entity TableEntity) error {
-	if sc, err := c.execTable(table, entity, true, "MERGE"); err != nil {
-		return checkRespCode(sc, []int{http.StatusNoContent})
+	sc, err := c.execTable(table, entity, true, "MERGE")
+	if err != nil {
+		return err
 	}
-	return nil
+
+	return checkRespCode(sc, []int{http.StatusNoContent})
 }
 
 // DeleteEntityWithoutCheck deletes the entity matching by
@@ -219,19 +224,23 @@ func (c *TableServiceClient) DeleteEntity(table AzureTable, entity TableEntity, 
 // InsertOrReplaceEntity inserts an entity in the specified table
 // or replaced the existing one.
 func (c *TableServiceClient) InsertOrReplaceEntity(table AzureTable, entity TableEntity) error {
-	if sc, err := c.execTable(table, entity, true, http.MethodPut); err != nil {
-		return checkRespCode(sc, []int{http.StatusNoContent})
+	sc, err := c.execTable(table, entity, true, http.MethodPut)
+	if err != nil {
+		return err
 	}
-	return nil
+
+	return checkRespCode(sc, []int{http.StatusNoContent})
 }
 
 // InsertOrMergeEntity inserts an entity in the specified table
 // or merges the existing one.
 func (c *TableServiceClient) InsertOrMergeEntity(table AzureTable, entity TableEntity) error {
-	if sc, err := c.execTable(table, entity, true, "MERGE"); err != nil {
-		return checkRespCode(sc, []int{http.StatusNoContent})
+	sc, err := c.execTable(table, entity, true, "MERGE")
+	if err != nil {
+		return err
 	}
-	return nil
+
+	return checkRespCode(sc, []int{http.StatusNoContent})
 }
 
 func injectPartitionAndRowKeys(entity TableEntity, buf *bytes.Buffer) error {

--- a/storage/table_test.go
+++ b/storage/table_test.go
@@ -77,6 +77,16 @@ func (s *StorageBlobSuite) Test_InsertEntities(c *chk.C) {
 	}
 }
 
+func (s *StorageBlobSuite) Test_InsertEntitiesRandomTableFails(c *chk.C) {
+	cli := getTableClient(c)
+
+	tn := AzureTable(randTable())
+
+	ce := &CustomEntity{Name: "Luke", Surname: "Skywalker", Number: 1543, PKey: "pkey", RKey: "5"}
+	err := cli.InsertEntity(tn, ce)
+	c.Assert(err, chk.NotNil)
+}
+
 func (s *StorageBlobSuite) Test_InsertOrReplaceEntities(c *chk.C) {
 	cli := getTableClient(c)
 


### PR DESCRIPTION
There is a nasty bug in the current TableService code that results in some errors being silently dropped.

The following functions are only checking the response code if a call to `c.execTable` returns an error:

* `InsertEntity`
* `UpdateEntity`
* `InsertOrReplaceEntity`
* `InsertOrMergeEntity`

In some cases calls to `c.execTable` can fail without returning errors. In particular, it calls `client.execInternalJSON`,  which does return an error for bad status codes with no response body (https://github.com/Azure/azure-sdk-for-go/blob/master/storage/client.go#L414). However if there is some response body, it then unmarshals it, and only returns an error if this unmarshalling fails (https://github.com/Azure/azure-sdk-for-go/blob/master/storage/client.go#L420).

It is unclear if this behaviour (for `execInternalJSON`) is intentional or not, so this PR just makes sure that the response code is checked at all times. It also adds a new test verifying that trying to insert entities into nonexistent tables should fail as expected.