### PR TITLE
storage: avoid transiting url.URL through string

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -221,7 +221,7 @@ func (c *Client) protectUserAgent(extraheaders map[string]string) map[string]str
 	return extraheaders
 }
 
-func (c Client) getBaseURL(service string) string {
+func (c Client) getBaseURL(service string) *url.URL {
 	scheme := "http"
 	if c.useHTTPS {
 		scheme = "https"
@@ -240,18 +240,14 @@ func (c Client) getBaseURL(service string) string {
 		host = fmt.Sprintf("%s.%s.%s", c.accountName, service, c.baseURL)
 	}
 
-	u := &url.URL{
+	return &url.URL{
 		Scheme: scheme,
-		Host:   host}
-	return u.String()
+		Host:   host,
+	}
 }
 
 func (c Client) getEndpoint(service, path string, params url.Values) string {
-	u, err := url.Parse(c.getBaseURL(service))
-	if err != nil {
-		// really should not be happening
-		panic(err)
-	}
+	u := c.getBaseURL(service)
 
 	// API doesn't accept path segments not starting with '/'
 	if !strings.HasPrefix(path, "/") {

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -80,7 +80,7 @@ func (s *StorageClientSuite) TestGetBaseURL_Basic_Https(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	c.Assert(cli.apiVersion, chk.Equals, DefaultAPIVersion)
 	c.Assert(err, chk.IsNil)
-	c.Assert(cli.getBaseURL("table"), chk.Equals, "https://foo.table.core.windows.net")
+	c.Assert(cli.getBaseURL("table").String(), chk.Equals, "https://foo.table.core.windows.net")
 }
 
 func (s *StorageClientSuite) TestGetBaseURL_Custom_NoHttps(c *chk.C) {
@@ -88,7 +88,7 @@ func (s *StorageClientSuite) TestGetBaseURL_Custom_NoHttps(c *chk.C) {
 	cli, err := NewClient("foo", "YmFy", "core.chinacloudapi.cn", apiVersion, false)
 	c.Assert(err, chk.IsNil)
 	c.Assert(cli.apiVersion, chk.Equals, apiVersion)
-	c.Assert(cli.getBaseURL("table"), chk.Equals, "http://foo.table.core.chinacloudapi.cn")
+	c.Assert(cli.getBaseURL("table").String(), chk.Equals, "http://foo.table.core.chinacloudapi.cn")
 }
 
 func (s *StorageClientSuite) TestGetBaseURL_StorageEmulator(c *chk.C) {
@@ -103,7 +103,7 @@ func (s *StorageClientSuite) TestGetBaseURL_StorageEmulator(c *chk.C) {
 	}
 	for _, i := range tests {
 		baseURL := cli.getBaseURL(i.service)
-		c.Assert(baseURL, chk.Equals, i.expected)
+		c.Assert(baseURL.String(), chk.Equals, i.expected)
 	}
 }
 


### PR DESCRIPTION
Inspired by #584, #594.

@mcardosos @jhendrixMSFT @marstr