### PR TITLE
Reduce allocations for request retry logic.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,17 +1,17 @@
-hash: fc11c273a4bfae9a077f2238a4693fa3af3d815dfc1b1e9ec75d9eb8e6428993
-updated: 2017-05-04T15:24:51.52099-07:00
+hash: 7a8f8652a17526f090124ace3974ce9bff3d6d09a83ab94841d377c1125111f7
+updated: 2017-06-12T16:27:58.5460985-07:00
 imports:
 - name: github.com/Azure/go-autorest
-  version: 58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d
+  version: ""
   subpackages:
   - autorest
+  - autorest/adal
   - autorest/azure
   - autorest/date
   - autorest/to
   - autorest/validation
-  - autorest/adal
 - name: github.com/dgrijalva/jwt-go
-  version: 2268707a8f0843315e2004ee4f1d021dc08baedf
+  version: a539ee1a749a2b895533f979515ac7e6e0f5b650
 - name: github.com/howeyc/gopass
   version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/mattn/go-colorable
@@ -33,15 +33,20 @@ imports:
 - name: github.com/satori/uuid
   version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/shopspring/decimal
-  version: 3526cd0bdb7f64e1178943b7dee81a0cc3d86a69
+  version: 16a941821474ee3986fdbeab535a68a8aa5a85d2
+- name: github.com/xtophs/azure-sdk-for-go
+  version: 76fc90689773168d2b6b8ad02e42ab60fb1359b7
+  subpackages:
+  - arm/dns
+  - arm/examples/helpers
 - name: golang.org/x/crypto
-  version: 5a033cc77e57eca05bdb50522851d29e03569cbe
+  version: e7ba82683099cae71475961448ab8f903ea77c26
   subpackages:
   - pkcs12
   - pkcs12/internal/rc2
   - ssh/terminal
 - name: golang.org/x/sys
-  version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
+  version: 0b25a408a50076fbbcae6b7ac0ea5fbb0b085e79
   subpackages:
   - unix
 - name: gopkg.in/check.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/Azure/azure-sdk-for-go
 import:
 - package: github.com/Azure/go-autorest
-  version: ~8.0.0
+  version: ~8.1.0
   subpackages:
   - /autorest
   - autorest/azure


### PR DESCRIPTION
Using ioutil.ReadAll() to read the request body can introduce a large
number of allocations increasing heap pressure.  For cases where the
content length of the request is known we can read the body into an
allocated buffer of exact size.
Update go-autorest dependency to 8.1.0 to use RetriableRequest feature.