### PR TITLE
GetSASURI is more complete and has grouped params

### DIFF
--- a/storage/blobsasuri.go
+++ b/storage/blobsasuri.go
@@ -8,6 +8,9 @@ import (
 	"time"
 )
 
+// OverrideHeaders defines overridable response heaedrs in
+// a request using a SAS URI.
+// See https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
 type OverrideHeaders struct {
 	CacheControl       string
 	ContentDisposition string
@@ -16,12 +19,17 @@ type OverrideHeaders struct {
 	ContentType        string
 }
 
+// BlobSASOptions are options to construct a blob SAS
+// URI.
+// See https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
 type BlobSASOptions struct {
 	BlobSASPermissions
 	OverrideHeaders
 	SASOptions
 }
 
+// SASOptions includes options used by SAS URIs for diffrenet
+// services and resources.
 type SASOptions struct {
 	APIVersion string
 	Start      time.Time
@@ -31,6 +39,8 @@ type SASOptions struct {
 	Identifier string
 }
 
+// BlobSASPermissions includes the available permissions for
+// a blob SAS URI.
 type BlobSASPermissions struct {
 	Read   bool
 	Add    bool
@@ -39,12 +49,10 @@ type BlobSASPermissions struct {
 	Delete bool
 }
 
-// GetSASURI creates an URL to the specified blob which contains the Shared
-// Access Signature with specified permissions and expiration time. Also includes signedIPRange and allowed protocols.
-// If old API version is used but no signedIP is passed (ie empty string) then this should still work.
-// We only populate the signedIP when it non-empty.
+// GetSASURI creates an URL to the blob which contains the Shared
+// Access Signature with the specified options.
 //
-// See https://msdn.microsoft.com/en-us/library/azure/ee395415.aspx
+// See https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
 func (b *Blob) GetSASURI(options BlobSASOptions) (string, error) {
 	uri := b.GetURL()
 	signedResource := "b"

--- a/storage/blobsasuri.go
+++ b/storage/blobsasuri.go
@@ -23,12 +23,12 @@ type OverrideHeaders struct {
 // URI.
 // See https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
 type BlobSASOptions struct {
-	BlobSASPermissions
+	BlobServiceSASPermissions
 	OverrideHeaders
 	SASOptions
 }
 
-// SASOptions includes options used by SAS URIs for diffrenet
+// SASOptions includes options used by SAS URIs for different
 // services and resources.
 type SASOptions struct {
 	APIVersion string
@@ -39,14 +39,34 @@ type SASOptions struct {
 	Identifier string
 }
 
-// BlobSASPermissions includes the available permissions for
-// a blob SAS URI.
-type BlobSASPermissions struct {
+// BlobServiceSASPermissions includes the available permissions for
+// blob service SAS URI.
+type BlobServiceSASPermissions struct {
 	Read   bool
 	Add    bool
 	Create bool
 	Write  bool
 	Delete bool
+}
+
+func (p BlobServiceSASPermissions) buildString() string {
+	permissions := ""
+	if p.Read {
+		permissions += "r"
+	}
+	if p.Add {
+		permissions += "a"
+	}
+	if p.Create {
+		permissions += "c"
+	}
+	if p.Write {
+		permissions += "w"
+	}
+	if p.Delete {
+		permissions += "d"
+	}
+	return permissions
 }
 
 // GetSASURI creates an URL to the blob which contains the Shared
@@ -61,24 +81,7 @@ func (b *Blob) GetSASURI(options BlobSASOptions) (string, error) {
 		return "", err
 	}
 
-	// build permissions string
-	permissions := ""
-	if options.Read {
-		permissions += "r"
-	}
-	if options.Add {
-		permissions += "a"
-	}
-	if options.Create {
-		permissions += "c"
-	}
-	if options.Write {
-		permissions += "w"
-	}
-	if options.Delete {
-		permissions += "d"
-	}
-
+	permissions := options.BlobServiceSASPermissions.buildString()
 	return b.Container.bsc.client.commonSASURI(options.SASOptions, uri, permissions, canonicalizedResource, signedResource, options.OverrideHeaders)
 }
 

--- a/storage/blobsasuri.go
+++ b/storage/blobsasuri.go
@@ -82,10 +82,10 @@ func (b *Blob) GetSASURI(options BlobSASOptions) (string, error) {
 	}
 
 	permissions := options.BlobServiceSASPermissions.buildString()
-	return b.Container.bsc.client.commonSASURI(options.SASOptions, uri, permissions, canonicalizedResource, signedResource, options.OverrideHeaders)
+	return b.Container.bsc.client.blobAndFileSASURI(options.SASOptions, uri, permissions, canonicalizedResource, signedResource, options.OverrideHeaders)
 }
 
-func (c *Client) commonSASURI(options SASOptions, uri, permissions, canonicalizedResource, signedResource string, headers OverrideHeaders) (string, error) {
+func (c *Client) blobAndFileSASURI(options SASOptions, uri, permissions, canonicalizedResource, signedResource string, headers OverrideHeaders) (string, error) {
 	start := ""
 	if options.Start != (time.Time{}) {
 		start = options.Start.UTC().Format(time.RFC3339)

--- a/storage/blobsasuri.go
+++ b/storage/blobsasuri.go
@@ -8,25 +8,79 @@ import (
 	"time"
 )
 
-// GetSASURIWithSignedIPAndProtocol creates an URL to the specified blob which contains the Shared
+type OverrideHeaders struct {
+	CacheControl       string
+	ContentDisposition string
+	ContentEncoding    string
+	ContentLanguage    string
+	ContentType        string
+}
+
+type BlobSASOptions struct {
+	BlobSASPermissions
+	OverrideHeaders
+	SASOptions
+}
+
+type SASOptions struct {
+	APIVersion string
+	Start      time.Time
+	Expiry     time.Time
+	IP         string
+	UseHTTPS   bool
+	Identifier string
+}
+
+type BlobSASPermissions struct {
+	Read   bool
+	Add    bool
+	Create bool
+	Write  bool
+	Delete bool
+}
+
+// GetSASURI creates an URL to the specified blob which contains the Shared
 // Access Signature with specified permissions and expiration time. Also includes signedIPRange and allowed protocols.
 // If old API version is used but no signedIP is passed (ie empty string) then this should still work.
 // We only populate the signedIP when it non-empty.
 //
 // See https://msdn.microsoft.com/en-us/library/azure/ee395415.aspx
-func (b *Blob) GetSASURIWithSignedIPAndProtocol(expiry time.Time, permissions string, signedIPRange string, HTTPSOnly bool) (string, error) {
+func (b *Blob) GetSASURI(options BlobSASOptions) (string, error) {
 	uri := b.GetURL()
 	signedResource := "b"
 	canonicalizedResource, err := b.Container.bsc.client.buildCanonicalizedResource(uri, b.Container.bsc.auth)
 	if err != nil {
 		return "", err
 	}
-	return b.Container.bsc.client.commonSASURI(expiry, uri, permissions, signedIPRange, canonicalizedResource, signedResource, HTTPSOnly)
+
+	// build permissions string
+	permissions := ""
+	if options.Read {
+		permissions += "r"
+	}
+	if options.Add {
+		permissions += "a"
+	}
+	if options.Create {
+		permissions += "c"
+	}
+	if options.Write {
+		permissions += "w"
+	}
+	if options.Delete {
+		permissions += "d"
+	}
+
+	return b.Container.bsc.client.commonSASURI(options.SASOptions, uri, permissions, canonicalizedResource, signedResource, options.OverrideHeaders)
 }
 
-func (c *Client) commonSASURI(expiry time.Time, uri, permissions, signedIPRange, canonicalizedResource, signedResource string, HTTPSOnly bool) (string, error) {
+func (c *Client) commonSASURI(options SASOptions, uri, permissions, canonicalizedResource, signedResource string, headers OverrideHeaders) (string, error) {
+	start := ""
+	if options.Start != (time.Time{}) {
+		start = options.Start.UTC().Format(time.RFC3339)
+	}
 
-	signedExpiry := expiry.UTC().Format(time.RFC3339)
+	expiry := options.Expiry.UTC().Format(time.RFC3339)
 
 	// We need to replace + with %2b first to avoid being treated as a space (which is correct for query strings, but not the path component).
 	canonicalizedResource = strings.Replace(canonicalizedResource, "+", "%2b", -1)
@@ -36,10 +90,10 @@ func (c *Client) commonSASURI(expiry time.Time, uri, permissions, signedIPRange,
 	}
 
 	protocols := "https,http"
-	if HTTPSOnly {
+	if options.UseHTTPS {
 		protocols = "https"
 	}
-	stringToSign, err := blobSASStringToSign(c.apiVersion, canonicalizedResource, signedExpiry, permissions, signedIPRange, protocols)
+	stringToSign, err := blobSASStringToSign(permissions, start, expiry, canonicalizedResource, options.Identifier, options.IP, protocols, c.apiVersion, headers)
 	if err != nil {
 		return "", err
 	}
@@ -47,18 +101,26 @@ func (c *Client) commonSASURI(expiry time.Time, uri, permissions, signedIPRange,
 	sig := c.computeHmac256(stringToSign)
 	sasParams := url.Values{
 		"sv":  {c.apiVersion},
-		"se":  {signedExpiry},
+		"se":  {expiry},
 		"sr":  {signedResource},
 		"sp":  {permissions},
 		"sig": {sig},
 	}
 
+	addQueryParameter(sasParams, "st", start)
+	addQueryParameter(sasParams, "si", options.Identifier)
+
 	if c.apiVersion >= "2015-04-05" {
 		sasParams.Add("spr", protocols)
-		if signedIPRange != "" {
-			sasParams.Add("sip", signedIPRange)
-		}
+		addQueryParameter(sasParams, "sip", options.IP)
 	}
+
+	// Add override response hedaers
+	addQueryParameter(sasParams, "rscc", headers.CacheControl)
+	addQueryParameter(sasParams, "rscd", headers.ContentDisposition)
+	addQueryParameter(sasParams, "rsce", headers.ContentEncoding)
+	addQueryParameter(sasParams, "rscl", headers.ContentLanguage)
+	addQueryParameter(sasParams, "rsct", headers.ContentType)
 
 	sasURL, err := url.Parse(uri)
 	if err != nil {
@@ -68,16 +130,19 @@ func (c *Client) commonSASURI(expiry time.Time, uri, permissions, signedIPRange,
 	return sasURL.String(), nil
 }
 
-// GetSASURI creates an URL to the specified blob which contains the Shared
-// Access Signature with specified permissions and expiration time.
-//
-// See https://msdn.microsoft.com/en-us/library/azure/ee395415.aspx
-func (b *Blob) GetSASURI(expiry time.Time, permissions string) (string, error) {
-	return b.GetSASURIWithSignedIPAndProtocol(expiry, permissions, "", false)
+func addQueryParameter(query url.Values, key, value string) url.Values {
+	if value != "" {
+		query.Add(key, value)
+	}
+	return query
 }
 
-func blobSASStringToSign(signedVersion, canonicalizedResource, signedExpiry, signedPermissions string, signedIP string, protocols string) (string, error) {
-	var signedStart, signedIdentifier, rscc, rscd, rsce, rscl, rsct string
+func blobSASStringToSign(signedPermissions, signedStart, signedExpiry, canonicalizedResource, signedIdentifier, signedIP, protocols, signedVersion string, headers OverrideHeaders) (string, error) {
+	rscc := headers.CacheControl
+	rscd := headers.ContentDisposition
+	rsce := headers.ContentEncoding
+	rscl := headers.ContentLanguage
+	rsct := headers.ContentType
 
 	if signedVersion >= "2015-02-21" {
 		canonicalizedResource = "/blob" + canonicalizedResource

--- a/storage/client.go
+++ b/storage/client.go
@@ -366,6 +366,9 @@ func (c Client) getEndpoint(service, path string, params url.Values) string {
 	return u.String()
 }
 
+// AccountSASTokenOptions includes options for constructing
+// an account SAS token.
+// https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
 type AccountSASTokenOptions struct {
 	APIVersion    string
 	Services      Services
@@ -377,6 +380,7 @@ type AccountSASTokenOptions struct {
 	UseHTTPS      bool
 }
 
+// Services specify services accessible with an account SAS.
 type Services struct {
 	Blob  bool
 	Queue bool
@@ -384,12 +388,15 @@ type Services struct {
 	File  bool
 }
 
+// ResourceTypes specify the resources accesible with an
+// account SAS.
 type ResourceTypes struct {
 	Service   bool
 	Container bool
 	Object    bool
 }
 
+// Permissions specifies permissions for an accountSAS.
 type Permissions struct {
 	Read    bool
 	Write   bool

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -518,7 +518,16 @@ func (s *StorageClientSuite) Test_doRetry(c *chk.C) {
 	// Service SAS test
 	blobCli := getBlobClient(c)
 	cnt := blobCli.GetContainerReference(containerName(c))
-	sasuriString, err := cnt.GetSASURI(fixedTime, "racwdl")
+	sasuriOptions := ContainerSASOptions{}
+	sasuriOptions.Expiry = fixedTime
+	sasuriOptions.Read = true
+	sasuriOptions.Add = true
+	sasuriOptions.Create = true
+	sasuriOptions.Write = true
+	sasuriOptions.Delete = true
+	sasuriOptions.List = true
+
+	sasuriString, err := cnt.GetSASURI(sasuriOptions)
 	c.Assert(err, chk.IsNil)
 
 	sasuri, err := url.Parse(sasuriString)

--- a/storage/container.go
+++ b/storage/container.go
@@ -75,7 +75,7 @@ func (c *Container) GetSASURI(options ContainerSASOptions) (string, error) {
 		permissions += "l"
 	}
 
-	return c.bsc.client.commonSASURI(options.SASOptions, uri, permissions, canonicalizedResource, signedResource, options.OverrideHeaders)
+	return c.bsc.client.blobAndFileSASURI(options.SASOptions, uri, permissions, canonicalizedResource, signedResource, options.OverrideHeaders)
 }
 
 // ContainerProperties contains various properties of a container returned from

--- a/storage/container.go
+++ b/storage/container.go
@@ -21,6 +21,7 @@ type Container struct {
 	sasuri     url.URL
 }
 
+// Client returns the HTTP client used by the Container reference.
 func (c *Container) Client() *Client {
 	return &c.bsc.client
 }
@@ -29,6 +30,9 @@ func (c *Container) buildPath() string {
 	return fmt.Sprintf("/%s", c.Name)
 }
 
+// GetURL gets the canonical URL to the container.
+// This method does not create a publicly accessible URL if the container
+// is private and this method does not check if the blob exists.
 func (c *Container) GetURL() string {
 	container := c.Name
 	if container == "" {
@@ -37,12 +41,17 @@ func (c *Container) GetURL() string {
 	return c.bsc.client.getEndpoint(blobServiceName, pathForResource(container, ""), nil)
 }
 
+// ContainerSASOptions are options to construct a container SAS
+// URI.
+// See https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
 type ContainerSASOptions struct {
 	ContainerSASPermissions
 	OverrideHeaders
 	SASOptions
 }
 
+// ContainerSASPermissions includes the available permissions for
+// a container SAS URI.
 type ContainerSASPermissions struct {
 	Read   bool
 	Add    bool
@@ -52,6 +61,10 @@ type ContainerSASPermissions struct {
 	List   bool
 }
 
+// GetSASURI creates an URL to the container which contains the Shared
+// Access Signature with the specified options.
+//
+// See https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
 func (c *Container) GetSASURI(options ContainerSASOptions) (string, error) {
 	uri := c.GetURL()
 	signedResource := "c"

--- a/storage/container.go
+++ b/storage/container.go
@@ -53,12 +53,8 @@ type ContainerSASOptions struct {
 // ContainerSASPermissions includes the available permissions for
 // a container SAS URI.
 type ContainerSASPermissions struct {
-	Read   bool
-	Add    bool
-	Create bool
-	Write  bool
-	Delete bool
-	List   bool
+	BlobServiceSASPermissions
+	List bool
 }
 
 // GetSASURI creates an URL to the container which contains the Shared
@@ -74,22 +70,7 @@ func (c *Container) GetSASURI(options ContainerSASOptions) (string, error) {
 	}
 
 	// build permissions string
-	permissions := ""
-	if options.Read {
-		permissions += "r"
-	}
-	if options.Add {
-		permissions += "a"
-	}
-	if options.Create {
-		permissions += "c"
-	}
-	if options.Write {
-		permissions += "w"
-	}
-	if options.Delete {
-		permissions += "d"
-	}
+	permissions := options.BlobServiceSASPermissions.buildString()
 	if options.List {
 		permissions += "l"
 	}

--- a/storage/container_test.go
+++ b/storage/container_test.go
@@ -94,7 +94,16 @@ func (s *ContainerSuite) TestContainerExists(c *chk.C) {
 	c.Assert(ok, chk.Equals, true)
 
 	// Service SASURI test (funcs should fail, service SAS has not enough permissions)
-	sasuriString1, err := cnt1.GetSASURI(fixedTime, "racwdl")
+	sasuriOptions := ContainerSASOptions{}
+	sasuriOptions.Expiry = fixedTime
+	sasuriOptions.Read = true
+	sasuriOptions.Add = true
+	sasuriOptions.Create = true
+	sasuriOptions.Write = true
+	sasuriOptions.Delete = true
+	sasuriOptions.List = true
+
+	sasuriString1, err := cnt1.GetSASURI(sasuriOptions)
 	c.Assert(err, chk.IsNil)
 	sasuri1, err := url.Parse(sasuriString1)
 	c.Assert(err, chk.IsNil)
@@ -106,7 +115,7 @@ func (s *ContainerSuite) TestContainerExists(c *chk.C) {
 	c.Assert(err, chk.NotNil)
 	c.Assert(ok, chk.Equals, false)
 
-	sasuriString2, err := cnt2.GetSASURI(fixedTime, "racwdl")
+	sasuriString2, err := cnt2.GetSASURI(sasuriOptions)
 	c.Assert(err, chk.IsNil)
 	sasuri2, err := url.Parse(sasuriString2)
 	c.Assert(err, chk.IsNil)
@@ -220,7 +229,16 @@ func (s *ContainerSuite) TestListBlobsPagination(c *chk.C) {
 	listBlobsPagination(c, cnt, pageSize, blobs)
 
 	// Service SAS test
-	sasuriString, err := cnt.GetSASURI(fixedTime, "racwdl")
+	sasuriOptions := ContainerSASOptions{}
+	sasuriOptions.Expiry = fixedTime
+	sasuriOptions.Read = true
+	sasuriOptions.Add = true
+	sasuriOptions.Create = true
+	sasuriOptions.Write = true
+	sasuriOptions.Delete = true
+	sasuriOptions.List = true
+
+	sasuriString, err := cnt.GetSASURI(sasuriOptions)
 	c.Assert(err, chk.IsNil)
 	sasuri, err := url.Parse(sasuriString)
 	c.Assert(err, chk.IsNil)


### PR DESCRIPTION
GetSASURI func now receive grouped parameters
GetSASURI also includes signed identifier and overridable headers
Got rid of GetSASURIWithSignedIPAndProtocol

PTAL
@marstr @jhendrixMSFT 