### PR TITLE
Fix Snapshot parameter format

### DIFF
--- a/storage/util.go
+++ b/storage/util.go
@@ -136,7 +136,7 @@ func addTimeout(params url.Values, timeout uint) url.Values {
 
 func addSnapshot(params url.Values, snapshot *time.Time) url.Values {
 	if snapshot != nil {
-		params.Add("snapshot", timeRfc1123Formatted(*snapshot))
+		params.Add("snapshot", snapshot.Format("2006-01-02T15:04:05.0000000Z"))
 	}
 	return params
 }


### PR DESCRIPTION
Attempting to use `Blob.Get()` to retrieve blob snapshots fails.
`addSnapshot()` is using the wrong format for the timestamp parameter.

This PR fixes `addSnapshot()` to use the correct timestamp format.