### PR TITLE
Ensure content length is set when body is a io.LimitedReader.

### DIFF
--- a/storage/blockblob_test.go
+++ b/storage/blockblob_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"encoding/base64"
+	"io"
 	"io/ioutil"
 
 	chk "gopkg.in/check.v1"
@@ -131,4 +132,21 @@ func (s *BlockBlobSuite) TestPutEmptyBlockBlob(c *chk.C) {
 	err := b.GetProperties(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(b.Properties.ContentLength, chk.Not(chk.Equals), 0)
+}
+
+func (s *BlockBlobSuite) TestPutBlockWithLengthUsingLimitReader(c *chk.C) {
+	cli := getBlobClient(c)
+	rec := cli.client.appendRecorder(c)
+	defer rec.Stop()
+
+	cnt := cli.GetContainerReference(containerName(c))
+	b := cnt.GetBlobReference(blobName(c))
+	c.Assert(cnt.Create(nil), chk.IsNil)
+	defer cnt.Delete(nil)
+
+	length := 512
+	data := content(length)
+
+	lr := io.LimitReader(bytes.NewReader(data), 256)
+	c.Assert(b.PutBlockWithLength("0000", 256, lr, nil), chk.IsNil)
 }

--- a/storage/client.go
+++ b/storage/client.go
@@ -398,6 +398,20 @@ func (c Client) exec(verb, url string, headers map[string]string, body io.Reader
 		return nil, errors.New("azure/storage: error creating request: " + err.Error())
 	}
 
+	// if a body was provided ensure that the content length was set.
+	// http.NewRequest() will automatically do this for a handful of types
+	// and for those that it doesn't we will handle here.
+	if body != nil && req.ContentLength < 1 {
+		if lr, ok := body.(*io.LimitedReader); ok {
+			req.ContentLength = lr.N
+			snapshot := *lr
+			req.GetBody = func() (io.ReadCloser, error) {
+				r := snapshot
+				return ioutil.NopCloser(&r), nil
+			}
+		}
+	}
+
 	for k, v := range headers {
 		req.Header[k] = append(req.Header[k], v) // Must bypass case munging present in `Add` by using map functions directly. See https://github.com/Azure/azure-sdk-for-go/issues/645
 	}

--- a/storage/recordings/BlockBlobSuite/TestPutBlockWithLengthUsingLimitReader.yaml
+++ b/storage/recordings/BlockBlobSuite/TestPutBlockWithLengthUsingLimitReader.yaml
@@ -1,0 +1,101 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Authorization:
+      - SharedKey golangrocksonazure:FIcZtUbULA8fE5CmkoaW33GCPQW1MwoBTJq/+YjD1sk=
+      User-Agent:
+      - Go/go1.8.3 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+        blob
+      x-ms-date:
+      - Fri, 28 Jul 2017 22:46:50 GMT
+      x-ms-version:
+      - 2016-05-31
+    url: https://golangrocksonazure.blob.core.windows.net/cnt-53blockblobsuitetestputblock?restype=container
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Date:
+      - Fri, 28 Jul 2017 22:46:49 GMT
+      Etag:
+      - '"0x8D4D60A8919817B"'
+      Last-Modified:
+      - Fri, 28 Jul 2017 22:46:50 GMT
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 36facf81-0001-00a7-24f3-076d37000000
+      X-Ms-Version:
+      - 2016-05-31
+    status: 201 Created
+    code: 201
+- request:
+    body: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer feugiat
+      eleifend scelerisque. Phasellus tempor turpis eget magna pretium, et finibus
+      massa convallis. Donec eget lacinia nibh. Ut ut cursus odio. Quisque id justo
+      interdum, maximus ex a, dapi
+    form: {}
+    headers:
+      Authorization:
+      - SharedKey golangrocksonazure:3ReHF2C9N8W7jNATKW7fh7++oO8buWUDGZUhUKySRDU=
+      Content-Length:
+      - "256"
+      User-Agent:
+      - Go/go1.8.3 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+        blob
+      x-ms-date:
+      - Fri, 28 Jul 2017 22:46:50 GMT
+      x-ms-version:
+      - 2016-05-31
+    url: https://golangrocksonazure.blob.core.windows.net/cnt-53blockblobsuitetestputblock/blob/53blockblobsuitetestputblockwithlengthusinglimitreader?blockid=0000&comp=block
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Md5:
+      - jaHQUBZ1PVeS/42MY6S64Q==
+      Date:
+      - Fri, 28 Jul 2017 22:46:49 GMT
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 36facf90-0001-00a7-2ef3-076d37000000
+      X-Ms-Request-Server-Encrypted:
+      - "false"
+      X-Ms-Version:
+      - 2016-05-31
+    status: 201 Created
+    code: 201
+- request:
+    body: ""
+    form: {}
+    headers:
+      Authorization:
+      - SharedKey golangrocksonazure:B2hVRHg94wX3A9JGambw0VCy3deB73Dq5u7zGkDHon0=
+      User-Agent:
+      - Go/go1.8.3 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+        blob
+      x-ms-date:
+      - Fri, 28 Jul 2017 22:46:50 GMT
+      x-ms-version:
+      - 2016-05-31
+    url: https://golangrocksonazure.blob.core.windows.net/cnt-53blockblobsuitetestputblock?restype=container
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Fri, 28 Jul 2017 22:46:49 GMT
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 36facfa2-0001-00a7-3ef3-076d37000000
+      X-Ms-Version:
+      - 2016-05-31
+    status: 202 Accepted
+    code: 202


### PR DESCRIPTION
The ctor for http.Request will perform type assertions for a handful of
types in order to set the content length.  Unfortunately it doesn't test
for io.LimitedReader so a check has been added.
Fix for issue https://github.com/Azure/azure-sdk-for-go/issues/683