### PR TITLE
Fix build errors on earlier versions of Go.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: bdeb606eca05304f80e5577159227ae4f00a002213f353e304066c593419a31b
-updated: 2017-07-31T15:32:36.5529621-07:00
+hash: f52476dff67b66fe9fffe35b63ac0c06962fcaacd326b66820a33edf53b01a16
+updated: 2017-08-14T15:40:55.888398-07:00
 imports:
 - name: github.com/Azure/go-autorest
-  version: f6e08fe5e4d45c9a66e40196d3fed5f37331d224
+  version: 48a8154950f853ae1f2a9c409e0eb1fb71119bc8
   subpackages:
   - autorest
   - autorest/adal
@@ -11,11 +11,11 @@ imports:
   - autorest/to
   - autorest/validation
 - name: github.com/dgrijalva/jwt-go
-  version: a539ee1a749a2b895533f979515ac7e6e0f5b650
+  version: a601269ab70c205d26370c16f7c81e9017c14e04
 - name: github.com/howeyc/gopass
   version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/mattn/go-colorable
-  version: 040dd0b833b34b4182673409ada4df2853b26537
+  version: 6df6d4d004b64986bbb0d1b25945f42b44787e90
 - name: github.com/mattn/go-isatty
   version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/mgutz/ansi
@@ -35,15 +35,16 @@ imports:
 - name: github.com/shopspring/decimal
   version: 3c692774ac4c47c7a296ec96e553719dba1a68fc
 - name: golang.org/x/crypto
-  version: 558b6879de74bc843225cde5686419267ff707ca
+  version: b176d7def5d71bdd214203491f89843ed217f420
   subpackages:
   - pkcs12
   - pkcs12/internal/rc2
   - ssh/terminal
 - name: golang.org/x/sys
-  version: 0f826bdd13b500be0f1d4004938ad978fcc6031e
+  version: 2d3e384235de683634e9080b58f757466840aa48
   subpackages:
   - unix
+  - windows
 - name: gopkg.in/check.v1
   version: 20d25e2804050c1cd24a7eea1e7a6447dd0e74ec
 - name: gopkg.in/godo.v2
@@ -60,4 +61,4 @@ testImports:
   - cassette
   - recorder
 - name: gopkg.in/yaml.v2
-  version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/Azure/azure-sdk-for-go
 import:
 - package: github.com/Azure/go-autorest
-  version: ~8.1.1
+  version: ~8.2.0
   subpackages:
   - /autorest
   - autorest/azure

--- a/management/README.md
+++ b/management/README.md
@@ -1,6 +1,7 @@
-# Azure Service Management packages for Go
+# Azure Service Management packages for Go (DEPRECATED)
 
 The `github.com/Azure/azure-sdk-for-go/management` packages are used to perform operations using the Azure Service Management (ASM), aka classic deployment model. Read more about [Azure Resource Manager vs. classic deployment](https://azure.microsoft.com/documentation/articles/resource-manager-deployment-model/). Packages for Azure Resource Manager are in the [arm](../arm) folder.
+Note that this package requires Go 1.7+ to build.
 
 ## First a Sidenote: Authentication and the Azure Service Manager
 

--- a/management/affinitygroup/client.go
+++ b/management/affinitygroup/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package affinitygroup
 
 import (

--- a/management/affinitygroup/entities.go
+++ b/management/affinitygroup/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package affinitygroup
 
 import (

--- a/management/client.go
+++ b/management/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package management provides the main API client to construct other clients
 // and make requests to the Microsoft Azure Service Management REST API.
 package management

--- a/management/errors.go
+++ b/management/errors.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package management
 
 import (

--- a/management/errors_test.go
+++ b/management/errors_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package management_test
 
 import (

--- a/management/hostedservice/client.go
+++ b/management/hostedservice/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package hostedservice provides a client for Hosted Services.
 package hostedservice
 

--- a/management/hostedservice/entities.go
+++ b/management/hostedservice/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package hostedservice
 
 import (

--- a/management/http.go
+++ b/management/http.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package management
 
 import (

--- a/management/location/client.go
+++ b/management/location/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package location provides a client for Locations.
 package location
 

--- a/management/location/entities.go
+++ b/management/location/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package location
 
 import (

--- a/management/networksecuritygroup/client.go
+++ b/management/networksecuritygroup/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package networksecuritygroup provides a client for Network Security Groups.
 package networksecuritygroup
 

--- a/management/networksecuritygroup/entities.go
+++ b/management/networksecuritygroup/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package networksecuritygroup implements operations for managing network security groups
 // using the Service Management REST API
 //

--- a/management/operations.go
+++ b/management/operations.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package management
 
 import (

--- a/management/osimage/client.go
+++ b/management/osimage/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package osimage provides a client for Operating System Images.
 package osimage
 

--- a/management/osimage/entities.go
+++ b/management/osimage/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package osimage
 
 import (

--- a/management/publishSettings.go
+++ b/management/publishSettings.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package management
 
 import (

--- a/management/sql/client.go
+++ b/management/sql/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package sql
 
 import (

--- a/management/sql/entities.go
+++ b/management/sql/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package sql
 
 import (

--- a/management/storageservice/client.go
+++ b/management/storageservice/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package storageservice provides a client for Storage Services.
 package storageservice
 

--- a/management/storageservice/entities.go
+++ b/management/storageservice/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package storageservice
 
 import (

--- a/management/storageservice/entities_test.go
+++ b/management/storageservice/entities_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package storageservice
 
 import (

--- a/management/testutils/managementclient.go
+++ b/management/testutils/managementclient.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package testutils contains some test utilities for the Azure SDK
 package testutils
 

--- a/management/util.go
+++ b/management/util.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package management
 
 import (

--- a/management/version.go
+++ b/management/version.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package management
 
 var (

--- a/management/virtualmachine/client.go
+++ b/management/virtualmachine/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package virtualmachine provides a client for Virtual Machines.
 package virtualmachine
 

--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package virtualmachine
 
 import (

--- a/management/virtualmachine/entities_test.go
+++ b/management/virtualmachine/entities_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package virtualmachine
 
 import (

--- a/management/virtualmachine/resourceextensions.go
+++ b/management/virtualmachine/resourceextensions.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package virtualmachine
 
 import (

--- a/management/virtualmachine/resourceextensions_test.go
+++ b/management/virtualmachine/resourceextensions_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package virtualmachine
 
 import (

--- a/management/virtualmachinedisk/client.go
+++ b/management/virtualmachinedisk/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package virtualmachinedisk provides a client for Virtual Machine Disks.
 package virtualmachinedisk
 

--- a/management/virtualmachinedisk/entities.go
+++ b/management/virtualmachinedisk/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package virtualmachinedisk
 
 import (

--- a/management/virtualmachineimage/client.go
+++ b/management/virtualmachineimage/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package virtualmachineimage provides a client for Virtual Machine Images.
 package virtualmachineimage
 

--- a/management/virtualmachineimage/entities.go
+++ b/management/virtualmachineimage/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package virtualmachineimage
 
 import (

--- a/management/virtualmachineimage/entities_test.go
+++ b/management/virtualmachineimage/entities_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package virtualmachineimage
 
 import (

--- a/management/virtualnetwork/client.go
+++ b/management/virtualnetwork/client.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package virtualnetwork provides a client for Virtual Networks.
 package virtualnetwork
 

--- a/management/virtualnetwork/entities.go
+++ b/management/virtualnetwork/entities.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package virtualnetwork
 
 import (

--- a/management/vmutils/configurationset.go
+++ b/management/vmutils/configurationset.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/management/vmutils/datadisks.go
+++ b/management/vmutils/datadisks.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/management/vmutils/deployment.go
+++ b/management/vmutils/deployment.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/management/vmutils/extensions.go
+++ b/management/vmutils/extensions.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/management/vmutils/extensions_test.go
+++ b/management/vmutils/extensions_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/management/vmutils/integration_test.go
+++ b/management/vmutils/integration_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/management/vmutils/network.go
+++ b/management/vmutils/network.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/management/vmutils/rolesize.go
+++ b/management/vmutils/rolesize.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/management/vmutils/rolestate.go
+++ b/management/vmutils/rolestate.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/management/vmutils/vmutils.go
+++ b/management/vmutils/vmutils.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 // Package vmutils provides convenience methods for creating Virtual
 // Machine Role configurations.
 package vmutils

--- a/management/vmutils/vmutils_test.go
+++ b/management/vmutils/vmutils_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package vmutils
 
 import (

--- a/storage/client.go
+++ b/storage/client.go
@@ -403,12 +403,7 @@ func (c Client) exec(verb, url string, headers map[string]string, body io.Reader
 	// and for those that it doesn't we will handle here.
 	if body != nil && req.ContentLength < 1 {
 		if lr, ok := body.(*io.LimitedReader); ok {
-			req.ContentLength = lr.N
-			snapshot := *lr
-			req.GetBody = func() (io.ReadCloser, error) {
-				r := snapshot
-				return ioutil.NopCloser(&r), nil
-			}
+			setContentLengthFromLimitedReader(req, lr)
 		}
 	}
 

--- a/storage/table_batch_test.go
+++ b/storage/table_batch_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package storage
 
 import (

--- a/storage/util_1.7.go
+++ b/storage/util_1.7.go
@@ -1,0 +1,12 @@
+// +build !go1.8
+
+package storage
+
+import (
+	"io"
+	"net/http"
+)
+
+func setContentLengthFromLimitedReader(req *http.Request, lr *io.LimitedReader) {
+	req.ContentLength = lr.N
+}

--- a/storage/util_1.8.go
+++ b/storage/util_1.8.go
@@ -1,0 +1,18 @@
+// +build go1.8
+
+package storage
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+func setContentLengthFromLimitedReader(req *http.Request, lr *io.LimitedReader) {
+	req.ContentLength = lr.N
+	snapshot := *lr
+	req.GetBody = func() (io.ReadCloser, error) {
+		r := snapshot
+		return ioutil.NopCloser(&r), nil
+	}
+}


### PR DESCRIPTION
Add Go 1.6 and 1.7 to travis.
Refactored some 1.8-specific code into version-specific files.
Updated dependencies.
Disable table batch tests on Go 1.6; this is because the MIME multipart
writer fixed the sort order on headers starting in 1.7 so the recordings
are not comparible between 1.6 and later versions.
Add Go 1.7+ build tags to management package.
Updated README for management package indicating that it's deprecated.