### PR TITLE
Upgrading to Go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: go
 
 go:
+  - 1.8
   - 1.9
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.8
+  - 1.9
 
 install:
   - go get -u github.com/golang/lint/golint


### PR DESCRIPTION
👋 

I'm upgrading Terraform to Go 1.9 and noticed the SDK wasn't building against this yet, as such I've updated the Travis file to do this. I'm not sure if this needs to be updated anywhere else, but hopefully this is useful :)