### PR TITLE
Support os.File as body

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -15,6 +15,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"runtime"
 	"strings"
@@ -403,7 +404,12 @@ func (c Client) exec(verb, url string, headers map[string]string, body io.Reader
 	// and for those that it doesn't we will handle here.
 	if body != nil && req.ContentLength < 1 {
 		if lr, ok := body.(*io.LimitedReader); ok {
-			setContentLengthFromLimitedReader(req, lr)
+			err = setContentLengthFromLimitedReader(req, lr)
+		} else if f, ok := body.(*os.File); ok {
+			err = setContentLengthFromFile(req, f)
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/storage/util_1.7.go
+++ b/storage/util_1.7.go
@@ -5,8 +5,19 @@ package storage
 import (
 	"io"
 	"net/http"
+	"os"
 )
 
-func setContentLengthFromLimitedReader(req *http.Request, lr *io.LimitedReader) {
+func setContentLengthFromLimitedReader(req *http.Request, lr *io.LimitedReader) error {
 	req.ContentLength = lr.N
+	return nil
+}
+
+func setContentLengthFromFile(req *http.Request, f *os.File) error {
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	req.ContentLength = fi.Size()
+	return nil
 }


### PR DESCRIPTION
Trying to understand why I got authentication error when doing `WriteRange` although other calls worked, I finally found that it was using `*os.File` for `body` that didn't work. The code couldn't get the content length from it. The content length is used in the authentication signature.

This patch uses the `Stat` method to find the size of a file so that files are supported as bodies.