### PR TITLE
feat(storage): allow creating clients from connection strings

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -213,7 +213,7 @@ func NewClientFromConnectionString(input string) (Client, error) {
 		case connectionStringEndpointProtocol:
 			useHTTPS = value == "https"
 		default:
-			return Client{}, fmt.Errorf("Unrecognized key in Azure storage connection string: %q", key)
+			// ignored
 		}
 	}
 

--- a/storage/client.go
+++ b/storage/client.go
@@ -53,6 +53,11 @@ const (
 	userAgentHeader = "User-Agent"
 
 	userDefinedMetadataHeaderPrefix = "x-ms-meta-"
+
+	connectionStringAccountName      = "accountname"
+	connectionStringAccountKey       = "accountkey"
+	connectionStringEndpointSuffix   = "endpointsuffix"
+	connectionStringEndpointProtocol = "defaultendpointsprotocol"
 )
 
 var (
@@ -197,17 +202,18 @@ func NewClientFromConnectionString(input string) (Client, error) {
 		}
 
 		value := pair[equalDex+1:]
-		switch strings.ToLower(pair[:equalDex]) {
-		case "accountname":
+		key := strings.ToLower(pair[:equalDex])
+		switch key {
+		case connectionStringAccountName:
 			accountName = value
-		case "accountkey":
+		case connectionStringAccountKey:
 			accountKey = value
-		case "endpointsuffix":
+		case connectionStringEndpointSuffix:
 			endpointSuffix = value
-		case "defaultendpointsprotocol":
+		case connectionStringEndpointProtocol:
 			useHTTPS = value == "https"
 		default:
-			// ignore
+			return Client{}, fmt.Errorf("Unrecognized key in Azure storage connection string: %q", key)
 		}
 	}
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -244,6 +244,20 @@ func (s *StorageClientSuite) TestNewEmulatorClient(c *chk.C) {
 	c.Assert(cli.accountKey, chk.DeepEquals, expectedKey)
 }
 
+func (s *StorageClientSuite) TestNewFromConnectionString(c *chk.C) {
+	cli, err := NewClientFromConnectionString(
+		"DefaultEndpointsProtocol=https;" +
+			"AccountName=myaccountname;" +
+			"AccountKey=" + StorageEmulatorAccountKey + ";" +
+			"EndpointSuffix=example.com")
+
+	c.Assert(err, chk.IsNil)
+	c.Assert(cli.accountName, chk.Equals, "myaccountname")
+	expectedKey, err := base64.StdEncoding.DecodeString(StorageEmulatorAccountKey)
+	c.Assert(err, chk.IsNil)
+	c.Assert(cli.accountKey, chk.DeepEquals, expectedKey)
+}
+
 func (s *StorageClientSuite) TestIsValidStorageAccount(c *chk.C) {
 	type test struct {
 		account  string


### PR DESCRIPTION
Based on the [Node.js version](https://github.com/Azure/azure-storage-node/blob/a2a26c7c70acb1eee0a77fb68fc1547145afec28/lib/common/services/servicesettings.js#L710), allows instantiating storage clients from connection strings.