### PR TITLE
blob.SetProperties fixes (Issue 765)

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -437,8 +437,8 @@ func (b *Blob) SetProperties(options *SetBlobPropertiesOptions) error {
 	uri := b.Container.bsc.client.getEndpoint(blobServiceName, b.buildPath(), params)
 
 	if b.Properties.BlobType == BlobTypePage {
-		headers = addToHeaders(headers, "x-ms-blob-content-length", fmt.Sprintf("byte %v", b.Properties.ContentLength))
-		if options != nil || options.SequenceNumberAction != nil {
+		headers = addToHeaders(headers, "x-ms-blob-content-length", fmt.Sprintf("%v", b.Properties.ContentLength))
+		if options != nil && options.SequenceNumberAction != nil {
 			headers = addToHeaders(headers, "x-ms-sequence-number-action", string(*options.SequenceNumberAction))
 			if *options.SequenceNumberAction != SequenceNumberActionIncrement {
 				headers = addToHeaders(headers, "x-ms-blob-sequence-number", fmt.Sprintf("%v", b.Properties.SequenceNumber))


### PR DESCRIPTION
SetProperties uses correct format for ContentLength header.
options.SequenceNumberAction is only accessed when options != nil.

See comments in Issue 765 for detailed description.  Hope this helps!