### PR TITLE
Fixing bash script to run profileBuilder tests

### DIFF
--- a/tools/profileBuilder/test.sh
+++ b/tools/profileBuilder/test.sh
@@ -1,6 +1,5 @@
 #!bin/bash
 set -ev
-
-if [[! "${TRAVIS_GO_VERSION}" < "1.9"]]; then
+if [[ ! "${TRAVIS_GO_VERSION}" < "1.9" ]]; then
     go test -v github.com/Azure/azure-sdk-for-go/tools/profileBuilder
 fi


### PR DESCRIPTION
Bash is extremely sensitive to whitespace. The profileBuilder tests weren't getting run before this PR.