### PR TITLE
Adding a Template to help guide new PRs.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,5 @@ As part of your submission, please make sure that you can make the following ass
  - [ ] I've added Apache 2.0 Headers to the top of any new source files.
  - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
  - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
+ - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
+ 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.
+
+As part of your submission, please make sure that you can make the following assertions:
+
+ - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
+   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
+ - [ ] I've tested my changes, adding unit tests where applicable.
+ - [ ] I've added Apache 2.0 Headers to the top of any new source files.
+ - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
+ - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).


### PR DESCRIPTION
There are a lot of submissions to the `master` branch, which will get
immediately released to folks using `go get` for that reason, we want to
always make sure that `master` stays in release quality.