### PR TITLE
Adding ACI examples and helper code to example package

### DIFF
--- a/arm/examples/README.md
+++ b/arm/examples/README.md
@@ -1,0 +1,67 @@
+# ARM Examples in Go
+
+## Configuring your environment
+
+Install the Azure CLI tool and login using the following commands.
+
+```bash
+$ curl -L https://aka.ms/InstallAzureCli | bash
+$ exec -l $SHELL
+$ az login
+```
+
+Create a `Service Principal` for the Azure Active Directory using the following command.
+
+```bash
+$ az ad sp create-for-rbac
+{
+  "appId": "1234567-1234-1234-1234-1234567890ab",
+  "displayName": "azure-cli-2017-08-18-19-25-59",
+  "name": "http://azure-cli-2017-08-18-19-25-59",
+  "password": "1234567-1234-1234-be18-1234567890ab",
+  "tenant": "1234567-1234-1234-be18-1234567890ab"
+}
+```
+
+Translate the output from the previous command to newly exported environmental variables.
+
+**Warning**: The names of the values might change from the previous command to the environmental variables.
+Follow the chart closely.
+
+Service Principal Variable Name | Environmental variable
+--- | ---
+appId | AZURE_CLIENT_ID
+password | AZURE_CLIENT_SECRET
+tenant | AZURE_TENANT_ID
+
+Run the following command to get you Azure subscription ID.
+
+```bash
+$ az account show --query id
+"1234567-1234-1234-1234567890ab"
+```
+
+Finally export that value as an environmental variable as well.
+
+Command| Environmental variable
+--- | ---
+az account show --query id | AZURE_SUBSCRIPTION_ID
+
+**At this point you should have the following 4 environmental variables set!**
+
+```bash
+export AZURE_CLIENT_ID = "1234567-1234-1234-1234567890ab"
+export AZURE_CLIENT_SECRET = "1234567-1234-1234-1234567890ab"
+export AZURE_TENANT_ID = "1234567-1234-1234-1234567890ab"
+export AZURE_SUBSCRIPTION_ID = "1234567-1234-1234-1234567890ab"
+```
+
+## Running an example
+
+Navigate to the example you would like to run and modify any configuration for the example before running.
+
+To run the example use the following command
+
+```bash
+$ go run <example>.go
+```

--- a/arm/examples/aci/README.md
+++ b/arm/examples/aci/README.md
@@ -1,0 +1,4 @@
+# Azure Container Instances
+
+Easily run containers on Azure. [More Information](https://azure.microsoft.com/en-us/services/container-instances/).
+

--- a/arm/examples/aci/create.go
+++ b/arm/examples/aci/create.go
@@ -1,0 +1,140 @@
+package main
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/arm/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/arm/examples"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+var (
+	resourceGroupName     = "myresourcegroup"
+	resourceGroupLocation = "eastus"
+	containerGroupname    = "mycontainergroup"
+)
+
+func main() {
+
+	// -----------------------------------------------------------------------------------------------------------------
+	// Bootstrap the SDK and ensure a resource group is in place.-
+	sdk, err := examples.NewSDK()
+	examples.E(err)
+	err = sdk.EnsureResourceGroup(resourceGroupName, resourceGroupLocation)
+	examples.E(err)
+
+	//------------------------------------------------------------------------------------------------------------------
+	// Container Instance
+	containerInstance := containerinstance.NewContainerGroupsClient(sdk.Authentication.SubscriptionID)
+	containerInstance.Authorizer = autorest.NewBearerAuthorizer(sdk.Authentication.AuthenticatedToken)
+
+	// -------------------------------------------------------------------------------------------------------------
+	// Container Instance Parameters
+	parameters := containerinstance.ContainerGroup{
+		Name:     &containerGroupname,
+		Location: &resourceGroupLocation,
+		ContainerGroupProperties: &containerinstance.ContainerGroupProperties{
+
+			// Define the OsType for the container group, in this case Linux.
+			OsType: containerinstance.Linux,
+
+			// Containers is a set of Container{} structs each defined as below.
+			Containers: &[]containerinstance.Container{
+				{
+
+					Name: examples.S("golang-aci-example"),
+
+					// ---------------------------------------------------------------------------------------------
+					//
+					// Container Properties
+					//
+					// This is what ultimately will define a container for ACI.
+					//
+					//
+					// FIELD                TYPE                             ENCODING
+					// Image                *string                          `json:"image,omitempty"`
+					// Command              *[]string                        `json:"command,omitempty"`
+					// Ports                *[]ContainerPort                 `json:"ports,omitempty"`
+					// EnvironmentVariables *[]EnvironmentVariable           `json:"environmentVariables,omitempty"`
+					// InstanceView         *ContainerPropertiesInstanceView `json:"instanceView,omitempty"`
+					// Resources            *ResourceRequirements            `json:"resources,omitempty"`
+					// VolumeMounts         *[]VolumeMount                   `json:"volumeMounts,omitempty"`
+					//
+					ContainerProperties: &containerinstance.ContainerProperties{
+
+						// Use to "golang:latest" docker container.
+						Image: examples.S("golang:latest"),
+
+						// Run the three shell commands listed below.
+						Command: &[]string{"go version", "echo $GOPATH", "sleep 100"},
+
+						// Open ports to the container.
+						Ports: &[]containerinstance.ContainerPort{
+							{
+								// Expose port 8080 for the container
+								Port: examples.I32(8080),
+							},
+						},
+
+						// Define environmental variables for the container.
+						EnvironmentVariables: &[]containerinstance.EnvironmentVariable{
+							{
+
+								// Set the environmental variable $MY_KEY="MY_VALUE"
+								Name:  examples.S("MY_KEY"),
+								Value: examples.S("MY_VALUE"),
+							},
+							{
+
+								// Set the environmental variable $MY_OTHER_KEY="MY_OTHER_VALUE".
+								Name:  examples.S("MY_OTHER_KEY"),
+								Value: examples.S("MY_OTHER_VALUE"),
+							},
+						},
+
+						// Set system resource constraints for the container.
+						Resources: &containerinstance.ResourceRequirements{
+
+							// Define resource limits  for the container.
+							Limits: &containerinstance.ResourceLimits{
+
+								// Set a limit of 1GB of memory for the container.
+								MemoryInGB: examples.F64(1),
+
+								// Set a request of 1 core for the CPU for the container.
+								CPU: examples.F64(1),
+							},
+
+							// Define resource requests (nice-to-haves) for the container.
+							Requests: &containerinstance.ResourceRequests{
+
+								// Set a request of 1gb of memory for the container.
+								MemoryInGB: examples.F64(1),
+
+								// Set a request of 1 core for the CPU for the container.
+								CPU: examples.F64(1),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	newContainerGroup, err := containerInstance.CreateOrUpdate(resourceGroupName, containerGroupname, parameters)
+	examples.E(err)
+	fmt.Printf("Created container group [%s]!\n", containerGroupname)
+	examples.PrettyJSON(newContainerGroup)
+}

--- a/arm/examples/aci/delete.go
+++ b/arm/examples/aci/delete.go
@@ -1,0 +1,48 @@
+package main
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/arm/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/arm/examples"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+var (
+	resourceGroupName     = "myresourcegroup"
+	resourceGroupLocation = "eastus"
+	containerGroupname    = "mycontainergroup"
+)
+
+func main() {
+
+	// -----------------------------------------------------------------------------------------------------------------
+	// Bootstrap the SDK and ensure a resource group is in place.-
+	sdk, err := examples.NewSDK()
+	examples.E(err)
+	err = sdk.EnsureResourceGroup(resourceGroupName, resourceGroupLocation)
+	examples.E(err)
+
+	//------------------------------------------------------------------------------------------------------------------
+	// Container Instance
+	containerInstance := containerinstance.NewContainerGroupsClient(sdk.Authentication.SubscriptionID)
+	containerInstance.Authorizer = autorest.NewBearerAuthorizer(sdk.Authentication.AuthenticatedToken)
+
+	_, err = containerInstance.Delete(resourceGroupName, containerGroupname)
+	examples.E(err)
+	fmt.Printf("Deleted container group [%s]!\n", containerGroupname)
+
+}

--- a/arm/examples/sdk.go
+++ b/arm/examples/sdk.go
@@ -1,0 +1,168 @@
+package examples
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import (
+	"fmt"
+	"os"
+
+	"bytes"
+	"encoding/json"
+	"github.com/Azure/azure-sdk-for-go/arm/examples/helpers"
+	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// SDK represents a working authenticated SDK structure.
+type SDK struct {
+
+	// Authentication holds misc. authentication information for interacting with the SDK.
+	Authentication *Authentication
+}
+
+// Authentication represents the values needed to authenticate with the ARM API.
+type Authentication struct {
+
+	// ClientID is the `appId` from an Azure Service Principal.
+	ClientID string
+
+	// ClientSecret is the `password` from an Azure Service Principal.
+	ClientSecret string
+
+	// SubscriptionID is the unique Azure subscription ID to use.
+	SubscriptionID string
+
+	// TenantID is the `tenant` from an Azure Service Principal.
+	TenantID string
+
+	// HashMap is the data value some parts of the SDK will expect, and is stored here as convenience.
+	HashMap map[string]string
+
+	// AuthenticatedToken is the generated token that is needed to authenticate with each client.
+	AuthenticatedToken *adal.ServicePrincipalToken
+}
+
+func NewSDK() (*SDK, error) {
+
+	// -------------------------------------------------------------------
+	// Validation that the environment is configured correctly.
+	//
+	clientID := os.Getenv("AZURE_CLIENT_ID")
+	if clientID == "" {
+		return nil, fmt.Errorf("empty $AZURE_CLIENT_ID")
+	}
+	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+	if clientSecret == "" {
+		return nil, fmt.Errorf("empty $AZURE_CLIENT_SECRET")
+	}
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	if subscriptionID == "" {
+		return nil, fmt.Errorf("empty $AZURE_SUBSCRIPTION_ID")
+	}
+	tenantID := os.Getenv("AZURE_TENANT_ID")
+	if tenantID == "" {
+		return nil, fmt.Errorf("empty $AZURE_TENANT_ID")
+	}
+
+	// Here we build the SDK based on a user's configuration.
+	sdk := &SDK{
+		Authentication: &Authentication{
+			ClientID:       clientID,
+			ClientSecret:   clientSecret,
+			SubscriptionID: subscriptionID,
+			TenantID:       tenantID,
+			HashMap: map[string]string{
+				"AZURE_CLIENT_ID":       clientID,
+				"AZURE_CLIENT_SECRET":   clientSecret,
+				"AZURE_SUBSCRIPTION_ID": subscriptionID,
+				"AZURE_TENANT_ID":       tenantID,
+			},
+		},
+	}
+
+	// Generate an authenticated token.
+	authenticatedToken, err := helpers.NewServicePrincipalTokenFromCredentials(sdk.Authentication.HashMap, azure.PublicCloud.ResourceManagerEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	sdk.Authentication.AuthenticatedToken = authenticatedToken
+	return sdk, nil
+}
+
+// E will check if an error is nil, and exit the program in the case of an error.
+// Use this as convenience to simplify code in various examples.
+func E(err error) {
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(2)
+	}
+}
+
+// S will take an arbitrary string, and return a newly created pointer to this string.
+// Use this as convenience to simplify code in various examples.
+func S(i string) *string {
+	return &i
+}
+
+// I32 will take an arbitrary int, and return a newly created pointer to an int32.
+// Use this as convenience to simplify code in various examples.
+func I32(i int) *int32 {
+	i32 := int32(i)
+	return &i32
+}
+
+// F64 will take an arbitrary int, and return a newly created pointer to a float64.
+// Use this as convenience to simplify code in various examples.
+func F64(i int) *float64 {
+	f64 := float64(i)
+	return &f64
+}
+
+// PrettyJSON will take an arbitrarry interface{} and attempt to print the data structure out to STDOUT.
+// Use this as convenience to simplify code in various examples.
+func PrettyJSON(data interface{}) error {
+	buffer := new(bytes.Buffer)
+	encoder := json.NewEncoder(buffer)
+	encoder.SetIndent("", "\t")
+	err := encoder.Encode(data)
+	if err != nil {
+		return err
+	}
+	fmt.Println(buffer.String())
+	return nil
+}
+
+// EnsureResourceGroup will ensure that a resource group of an arbitrary name and location exists.
+// Use this as convenience to simplify code in various examples.
+func (sdk *SDK) EnsureResourceGroup(resourceGroupName, location string) error {
+	resourceGroup := resources.NewGroupsClient(sdk.Authentication.SubscriptionID)
+	resourceGroup.Authorizer = autorest.NewBearerAuthorizer(sdk.Authentication.AuthenticatedToken)
+
+	// ---------------------------------
+	// Resource Group Parameters
+	parameters := resources.Group{
+		Name:     &resourceGroupName,
+		Location: &location,
+	}
+
+	newResourceGroup, err := resourceGroup.CreateOrUpdate(resourceGroupName, parameters)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Ensured resource group [%s] exists\n", *newResourceGroup.Name)
+	return nil
+}


### PR DESCRIPTION
- The examples directory is now a proper go package, with helper code for writing easy examples moving forward.
- Adding a few `README.md` files to help explain what is going on.
- Adding CREATE and DELETE for ACI.