### PR TITLE
Format previous snapshot time as RFC3339.

### DIFF
--- a/storage/pageblob.go
+++ b/storage/pageblob.go
@@ -147,7 +147,7 @@ func (b *Blob) GetPageRanges(options *GetPageRangesOptions) (GetPageRangesRespon
 		params = addTimeout(params, options.Timeout)
 		params = addSnapshot(params, options.Snapshot)
 		if options.PreviousSnapshot != nil {
-			params.Add("prevsnapshot", timeRfc1123Formatted(*options.PreviousSnapshot))
+			params.Add("prevsnapshot", timeRFC3339Formatted(*options.PreviousSnapshot))
 		}
 		if options.Range != nil {
 			headers["Range"] = options.Range.String()

--- a/storage/util.go
+++ b/storage/util.go
@@ -71,6 +71,10 @@ func timeRfc1123Formatted(t time.Time) string {
 	return t.Format(http.TimeFormat)
 }
 
+func timeRFC3339Formatted(t time.Time) string {
+	return t.Format("2006-01-02T15:04:05.0000000Z")
+}
+
 func mergeParams(v1, v2 url.Values) url.Values {
 	out := url.Values{}
 	for k, v := range v1 {
@@ -172,7 +176,7 @@ func addTimeout(params url.Values, timeout uint) url.Values {
 
 func addSnapshot(params url.Values, snapshot *time.Time) url.Values {
 	if snapshot != nil {
-		params.Add("snapshot", snapshot.Format("2006-01-02T15:04:05.0000000Z"))
+		params.Add("snapshot", timeRFC3339Formatted(*snapshot))
 	}
 	return params
 }


### PR DESCRIPTION
The previous snapshot time query param is supposed to be in RFC3339
format.  Moved formatting code to its own function.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [x] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [x] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [x] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 