### PR TITLE
Adding call to `gofmt` once a profile is generated

### DIFF
--- a/tools/profileBuilder/program.go
+++ b/tools/profileBuilder/program.go
@@ -38,6 +38,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -257,8 +258,13 @@ func main() {
 			generated++
 		}
 	}
-
 	outputLog.Print(generated, " packages generated.")
+
+	if err := exec.Command("gofmt", "-w", outputLocation).Run(); err == nil {
+		outputLog.Print("Success formatting profile.")
+	} else {
+		errLog.Print("Trouble formatting profile: ", err)
+	}
 
 }
 


### PR DESCRIPTION
This will prevent profiles built with the profile Builder from ever failing CI after #853 is merged.

---

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [x] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [x] I've tested my changes, adding unit tests where applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [x] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [x] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 