### PR TITLE
Make autorest.go version configurable.

### DIFF
--- a/tools/generator/program.go
+++ b/tools/generator/program.go
@@ -42,11 +42,16 @@ import (
 	"github.com/marstr/collection"
 )
 
+const (
+	defaultGenVer = "@microsoft.azure/autorest.go@v2.0.41"
+)
+
 var (
 	targetFiles    collection.Enumerable
 	packageVersion string
 	outputBase     string
 	logDirBase     string
+	autorestVer    string
 	errLog         *log.Logger
 	statusLog      *log.Logger
 	dryRun         bool
@@ -138,7 +143,7 @@ func main() {
 				fmt.Sprintf("--go-sdk-folder='%s'", outputBase),
 				"--verbose",
 				"--tag=" + tuple.packageName,
-				"--use=@microsoft.azure/autorest.go@v2.0.41",
+				"--use=" + autorestVer,
 			}
 
 			if packageVersion != "" {
@@ -245,6 +250,7 @@ func init() {
 	flag.BoolVar(&dryRun, "p", false, "Preview which packages would be generated instead of actaully calling autorest.")
 	flag.StringVar(&packageVersion, "version", "", "The version that should be stamped on this SDK. This should be a semver.")
 	flag.StringVar(&logDirBase, "l", getDefaultOutputBase(), logDirUsage)
+	flag.StringVar(&autorestVer, "a", defaultGenVer, "The version of the AutoRest Go code generator to use, defaults to `"+defaultGenVer+"`.")
 
 	// Override the default usage message, printing to stderr as the default one would.
 	flag.Usage = func() {


### PR DESCRIPTION
Added command flag 'a' to optionally specify autoret.go version.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 