### PR TITLE
Handles error from uuid.NewV1

### DIFF
--- a/storage/table_batch.go
+++ b/storage/table_batch.go
@@ -131,14 +131,22 @@ func (t *TableBatch) MergeEntity(entity *Entity) {
 // the changesets.
 // As per document https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/performing-entity-group-transactions
 func (t *TableBatch) ExecuteBatch() error {
-	changesetBoundary := fmt.Sprintf("changeset_%s", uuid.NewV1())
+	u,err:=uuid.NewV1()
+	if err != nil {
+		return err
+	}
+	changesetBoundary := fmt.Sprintf("changeset_%s", u)
 	uri := t.Table.tsc.client.getEndpoint(tableServiceName, "$batch", nil)
 	changesetBody, err := t.generateChangesetBody(changesetBoundary)
 	if err != nil {
 		return err
 	}
 
-	boundary := fmt.Sprintf("batch_%s", uuid.NewV1())
+	u,err=uuid.NewV1()
+	if err != nil {
+		return err
+	}
+	boundary := fmt.Sprintf("batch_%s", u)
 	body, err := generateBody(changesetBody, changesetBoundary, boundary)
 	if err != nil {
 		return err


### PR DESCRIPTION
Can't do go get without this fix since uuid now returns error for NewV1.