### PR TITLE
Fix SAS support in storage package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## `v12.2.0-beta`
+
+### Changes
+
+#### Storage
+
+- Add support for creating a SAS client from an endpoint and SAS token.
+- Fixed bug that wasn't appending SAS token to URI query parameters in all cases.
+
 ## `v12.1.1-beta`
 
 ### Changes

--- a/arm/advisor/version.go
+++ b/arm/advisor/version.go
@@ -19,10 +19,10 @@ package advisor
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-advisor/2017-04-19"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-advisor/2017-04-19"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/analysisservices/version.go
+++ b/arm/analysisservices/version.go
@@ -19,10 +19,10 @@ package analysisservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-analysisservices/2017-08-01-beta"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-analysisservices/2017-08-01-beta"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/apimanagement/version.go
+++ b/arm/apimanagement/version.go
@@ -19,10 +19,10 @@ package apimanagement
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-apimanagement/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-apimanagement/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/appinsights/version.go
+++ b/arm/appinsights/version.go
@@ -19,10 +19,10 @@ package appinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-appinsights/2015-05-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-appinsights/2015-05-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/authorization/version.go
+++ b/arm/authorization/version.go
@@ -19,10 +19,10 @@ package authorization
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-authorization/2015-07-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-authorization/2015-07-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/automation/version.go
+++ b/arm/automation/version.go
@@ -19,10 +19,10 @@ package automation
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-automation/2015-10-31"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-automation/2015-10-31"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/batch/version.go
+++ b/arm/batch/version.go
@@ -19,10 +19,10 @@ package batch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-batch/2017-05-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-batch/2017-05-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/billing/version.go
+++ b/arm/billing/version.go
@@ -19,10 +19,10 @@ package billing
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-billing/2017-04-24-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-billing/2017-04-24-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/cdn/version.go
+++ b/arm/cdn/version.go
@@ -19,10 +19,10 @@ package cdn
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-cdn/2017-04-02"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-cdn/2017-04-02"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/cognitiveservices/version.go
+++ b/arm/cognitiveservices/version.go
@@ -19,10 +19,10 @@ package cognitiveservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-cognitiveservices/2017-04-18"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-cognitiveservices/2017-04-18"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/commerce/version.go
+++ b/arm/commerce/version.go
@@ -19,10 +19,10 @@ package commerce
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-commerce/2015-06-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-commerce/2015-06-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/compute/version.go
+++ b/arm/compute/version.go
@@ -19,10 +19,10 @@ package compute
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-compute/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-compute/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/consumption/version.go
+++ b/arm/consumption/version.go
@@ -19,10 +19,10 @@ package consumption
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-consumption/2017-04-24-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-consumption/2017-04-24-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/containerinstance/version.go
+++ b/arm/containerinstance/version.go
@@ -19,10 +19,10 @@ package containerinstance
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-containerinstance/2017-08-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-containerinstance/2017-08-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/containerregistry/version.go
+++ b/arm/containerregistry/version.go
@@ -19,10 +19,10 @@ package containerregistry
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-containerregistry/2017-10-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-containerregistry/2017-10-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/containerservice/version.go
+++ b/arm/containerservice/version.go
@@ -19,10 +19,10 @@ package containerservice
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-containerservice/2017-01-31"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-containerservice/2017-01-31"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/cosmos-db/version.go
+++ b/arm/cosmos-db/version.go
@@ -19,10 +19,10 @@ package cosmosdb
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-cosmosdb/2015-04-08"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-cosmosdb/2015-04-08"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/customer-insights/version.go
+++ b/arm/customer-insights/version.go
@@ -19,10 +19,10 @@ package customerinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-customerinsights/2017-04-26"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-customerinsights/2017-04-26"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/datalake-analytics/account/version.go
+++ b/arm/datalake-analytics/account/version.go
@@ -19,10 +19,10 @@ package account
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-account/2016-11-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-account/2016-11-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/datalake-store/account/version.go
+++ b/arm/datalake-store/account/version.go
@@ -19,10 +19,10 @@ package account
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-account/2016-11-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-account/2016-11-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/devtestlabs/version.go
+++ b/arm/devtestlabs/version.go
@@ -19,10 +19,10 @@ package devtestlabs
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-devtestlabs/2016-05-15"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-devtestlabs/2016-05-15"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/disk/version.go
+++ b/arm/disk/version.go
@@ -19,10 +19,10 @@ package disk
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-disk/2016-04-30-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-disk/2016-04-30-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/dns/version.go
+++ b/arm/dns/version.go
@@ -19,10 +19,10 @@ package dns
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-dns/2016-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-dns/2016-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/documentdb/version.go
+++ b/arm/documentdb/version.go
@@ -20,10 +20,10 @@ package documentdb
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-documentdb/2015-04-08"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-documentdb/2015-04-08"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/eventgrid/version.go
+++ b/arm/eventgrid/version.go
@@ -19,10 +19,10 @@ package eventgrid
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-eventgrid/2017-09-15-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-eventgrid/2017-09-15-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/eventhub/version.go
+++ b/arm/eventhub/version.go
@@ -19,10 +19,10 @@ package eventhub
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-eventhub/2017-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-eventhub/2017-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/graphrbac/version.go
+++ b/arm/graphrbac/version.go
@@ -19,10 +19,10 @@ package graphrbac
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-graphrbac/1.6"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-graphrbac/1.6"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/hdinsight/version.go
+++ b/arm/hdinsight/version.go
@@ -19,10 +19,10 @@ package hdinsight
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-hdinsight/2015-03-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-hdinsight/2015-03-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/insights/version.go
+++ b/arm/insights/version.go
@@ -19,10 +19,10 @@ package insights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-insights/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-insights/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/intune/version.go
+++ b/arm/intune/version.go
@@ -19,10 +19,10 @@ package intune
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-intune/2015-01-14-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-intune/2015-01-14-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/iothub/version.go
+++ b/arm/iothub/version.go
@@ -19,10 +19,10 @@ package iothub
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-iothub/2017-07-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-iothub/2017-07-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/keyvault/version.go
+++ b/arm/keyvault/version.go
@@ -19,10 +19,10 @@ package keyvault
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-keyvault/2016-10-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-keyvault/2016-10-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/logic/version.go
+++ b/arm/logic/version.go
@@ -19,10 +19,10 @@ package logic
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-logic/2016-06-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-logic/2016-06-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/machinelearning/commitmentplans/version.go
+++ b/arm/machinelearning/commitmentplans/version.go
@@ -19,10 +19,10 @@ package commitmentplans
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-commitmentplans/2016-05-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-commitmentplans/2016-05-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/machinelearning/webservices/version.go
+++ b/arm/machinelearning/webservices/version.go
@@ -19,10 +19,10 @@ package webservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-webservices/2017-01-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-webservices/2017-01-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/marketplaceordering/version.go
+++ b/arm/marketplaceordering/version.go
@@ -19,10 +19,10 @@ package marketplaceordering
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-marketplaceordering/2015-06-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-marketplaceordering/2015-06-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/mediaservices/version.go
+++ b/arm/mediaservices/version.go
@@ -19,10 +19,10 @@ package mediaservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-mediaservices/2015-10-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-mediaservices/2015-10-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/mobileengagement/version.go
+++ b/arm/mobileengagement/version.go
@@ -19,10 +19,10 @@ package mobileengagement
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-mobileengagement/2014-12-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-mobileengagement/2014-12-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/monitor/version.go
+++ b/arm/monitor/version.go
@@ -19,10 +19,10 @@ package monitor
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-monitor/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-monitor/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/mysql/version.go
+++ b/arm/mysql/version.go
@@ -19,10 +19,10 @@ package mysql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-mysql/2017-04-30-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-mysql/2017-04-30-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/network/version.go
+++ b/arm/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-network/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-network/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/notificationhubs/version.go
+++ b/arm/notificationhubs/version.go
@@ -19,10 +19,10 @@ package notificationhubs
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-notificationhubs/2017-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-notificationhubs/2017-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/operationalinsights/version.go
+++ b/arm/operationalinsights/version.go
@@ -19,10 +19,10 @@ package operationalinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-operationalinsights/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-operationalinsights/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/operationsmanagement/version.go
+++ b/arm/operationsmanagement/version.go
@@ -19,10 +19,10 @@ package operationsmanagement
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-operationsmanagement/2015-11-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-operationsmanagement/2015-11-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/postgresql/version.go
+++ b/arm/postgresql/version.go
@@ -19,10 +19,10 @@ package postgresql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-postgresql/2017-04-30-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-postgresql/2017-04-30-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/powerbiembedded/version.go
+++ b/arm/powerbiembedded/version.go
@@ -19,10 +19,10 @@ package powerbiembedded
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-powerbiembedded/2016-01-29"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-powerbiembedded/2016-01-29"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/recoveryservices/version.go
+++ b/arm/recoveryservices/version.go
@@ -19,10 +19,10 @@ package recoveryservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-recoveryservices/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-recoveryservices/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/recoveryservicesbackup/version.go
+++ b/arm/recoveryservicesbackup/version.go
@@ -19,10 +19,10 @@ package recoveryservicesbackup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-recoveryservicesbackup/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-recoveryservicesbackup/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/recoveryservicessiterecovery/version.go
+++ b/arm/recoveryservicessiterecovery/version.go
@@ -19,10 +19,10 @@ package recoveryservicessiterecovery
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-recoveryservicessiterecovery/2016-08-10"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-recoveryservicessiterecovery/2016-08-10"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/redis/version.go
+++ b/arm/redis/version.go
@@ -19,10 +19,10 @@ package redis
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-redis/2016-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-redis/2016-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/relay/version.go
+++ b/arm/relay/version.go
@@ -19,10 +19,10 @@ package relay
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-relay/2017-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-relay/2017-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/resourcehealth/version.go
+++ b/arm/resourcehealth/version.go
@@ -19,10 +19,10 @@ package resourcehealth
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-resourcehealth/2017-07-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-resourcehealth/2017-07-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/resources/features/version.go
+++ b/arm/resources/features/version.go
@@ -19,10 +19,10 @@ package features
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-features/2015-12-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-features/2015-12-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/resources/links/version.go
+++ b/arm/resources/links/version.go
@@ -19,10 +19,10 @@ package links
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-links/2016-09-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-links/2016-09-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/resources/locks/version.go
+++ b/arm/resources/locks/version.go
@@ -19,10 +19,10 @@ package locks
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-locks/2016-09-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-locks/2016-09-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/resources/managedapplications/version.go
+++ b/arm/resources/managedapplications/version.go
@@ -19,10 +19,10 @@ package managedapplications
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-managedapplications/2016-09-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-managedapplications/2016-09-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/resources/policy/version.go
+++ b/arm/resources/policy/version.go
@@ -19,10 +19,10 @@ package policy
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-policy/2016-12-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-policy/2016-12-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/resources/resources/version.go
+++ b/arm/resources/resources/version.go
@@ -19,10 +19,10 @@ package resources
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-resources/2017-05-10"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-resources/2017-05-10"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/resources/subscriptions/version.go
+++ b/arm/resources/subscriptions/version.go
@@ -19,10 +19,10 @@ package subscriptions
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-subscriptions/2016-06-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-subscriptions/2016-06-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/scheduler/version.go
+++ b/arm/scheduler/version.go
@@ -19,10 +19,10 @@ package scheduler
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-scheduler/2016-03-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-scheduler/2016-03-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/search/version.go
+++ b/arm/search/version.go
@@ -19,10 +19,10 @@ package search
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-search/2015-08-19"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-search/2015-08-19"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/servermanagement/version.go
+++ b/arm/servermanagement/version.go
@@ -19,10 +19,10 @@ package servermanagement
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-servermanagement/2016-07-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-servermanagement/2016-07-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/service-map/version.go
+++ b/arm/service-map/version.go
@@ -19,10 +19,10 @@ package servicemap
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-servicemap/2015-11-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-servicemap/2015-11-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/servicebus/version.go
+++ b/arm/servicebus/version.go
@@ -19,10 +19,10 @@ package servicebus
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-servicebus/2017-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-servicebus/2017-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/servicefabric/version.go
+++ b/arm/servicefabric/version.go
@@ -19,10 +19,10 @@ package servicefabric
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-servicefabric/2016-09-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-servicefabric/2016-09-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/sql/version.go
+++ b/arm/sql/version.go
@@ -19,10 +19,10 @@ package sql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-sql/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-sql/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/storage/version.go
+++ b/arm/storage/version.go
@@ -19,10 +19,10 @@ package storage
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-storage/2017-06-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-storage/2017-06-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/storageimportexport/version.go
+++ b/arm/storageimportexport/version.go
@@ -19,10 +19,10 @@ package storageimportexport
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-storageimportexport/2016-11-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-storageimportexport/2016-11-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/storsimple8000series/version.go
+++ b/arm/storsimple8000series/version.go
@@ -19,10 +19,10 @@ package storsimple8000series
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-storsimple8000series/2017-06-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-storsimple8000series/2017-06-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/streamanalytics/version.go
+++ b/arm/streamanalytics/version.go
@@ -19,10 +19,10 @@ package streamanalytics
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-streamanalytics/2016-03-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-streamanalytics/2016-03-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/trafficmanager/version.go
+++ b/arm/trafficmanager/version.go
@@ -19,10 +19,10 @@ package trafficmanager
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-trafficmanager/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-trafficmanager/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/visualstudio/version.go
+++ b/arm/visualstudio/version.go
@@ -19,10 +19,10 @@ package visualstudio
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-visualstudio/2014-04-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-visualstudio/2014-04-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/arm/web/version.go
+++ b/arm/web/version.go
@@ -19,10 +19,10 @@ package web
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-web/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-web/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/datalake-store/filesystem/version.go
+++ b/datalake-store/filesystem/version.go
@@ -19,10 +19,10 @@ package filesystem
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-filesystem/2016-11-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-filesystem/2016-11-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/dataplane/cognitiveservices/face/version.go
+++ b/dataplane/cognitiveservices/face/version.go
@@ -19,10 +19,10 @@ package face
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-face/1.0"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-face/1.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/dataplane/cognitiveservices/textanalytics/version.go
+++ b/dataplane/cognitiveservices/textanalytics/version.go
@@ -19,10 +19,10 @@ package textanalytics
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-textanalytics/v2.0"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-textanalytics/v2.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/dataplane/keyvault/version.go
+++ b/dataplane/keyvault/version.go
@@ -19,10 +19,10 @@ package keyvault
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-keyvault/2016-10-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-keyvault/2016-10-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/management/version.go
+++ b/management/version.go
@@ -17,5 +17,5 @@ package management
 //  limitations under the License.
 
 var (
-	sdkVersion = "v12.1.1-beta"
+	sdkVersion = "v12.2.0-beta"
 )

--- a/services/advisor/mgmt/2016-07-12-preview/advisor/version.go
+++ b/services/advisor/mgmt/2016-07-12-preview/advisor/version.go
@@ -19,10 +19,10 @@ package advisor
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/advisor/mgmt/2017-03-31/advisor/version.go
+++ b/services/advisor/mgmt/2017-03-31/advisor/version.go
@@ -19,10 +19,10 @@ package advisor
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/advisor/mgmt/2017-04-19/advisor/version.go
+++ b/services/advisor/mgmt/2017-04-19/advisor/version.go
@@ -19,10 +19,10 @@ package advisor
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/analysisservices/mgmt/2016-05-16/analysisservices/version.go
+++ b/services/analysisservices/mgmt/2016-05-16/analysisservices/version.go
@@ -19,10 +19,10 @@ package analysisservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/analysisservices/mgmt/2017-07-14/analysisservices/version.go
+++ b/services/analysisservices/mgmt/2017-07-14/analysisservices/version.go
@@ -19,10 +19,10 @@ package analysisservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/analysisservices/mgmt/2017-08-01-beta/analysisservices/version.go
+++ b/services/analysisservices/mgmt/2017-08-01-beta/analysisservices/version.go
@@ -19,10 +19,10 @@ package analysisservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/apimanagement/mgmt/2016-10-10/apimanagement/version.go
+++ b/services/apimanagement/mgmt/2016-10-10/apimanagement/version.go
@@ -19,10 +19,10 @@ package apimanagement
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/appinsights/mgmt/2015-05-01/insights/version.go
+++ b/services/appinsights/mgmt/2015-05-01/insights/version.go
@@ -19,10 +19,10 @@ package insights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/authorization/mgmt/2015-07-01/authorization/version.go
+++ b/services/authorization/mgmt/2015-07-01/authorization/version.go
@@ -19,10 +19,10 @@ package authorization
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/authorization/mgmt/2017-10-01-preview/authorization/version.go
+++ b/services/authorization/mgmt/2017-10-01-preview/authorization/version.go
@@ -19,10 +19,10 @@ package authorization
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/automation/mgmt/2015-10-31/automation/version.go
+++ b/services/automation/mgmt/2015-10-31/automation/version.go
@@ -19,10 +19,10 @@ package automation
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/batch/2017-05-01.5.0/batch/version.go
+++ b/services/batch/2017-05-01.5.0/batch/version.go
@@ -19,10 +19,10 @@ package xpackagex
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/batch/mgmt/2015-12-01/batch/version.go
+++ b/services/batch/mgmt/2015-12-01/batch/version.go
@@ -19,10 +19,10 @@ package batch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/batch/mgmt/2017-01-01/batch/version.go
+++ b/services/batch/mgmt/2017-01-01/batch/version.go
@@ -19,10 +19,10 @@ package batch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/batch/mgmt/2017-05-01/batch/version.go
+++ b/services/batch/mgmt/2017-05-01/batch/version.go
@@ -19,10 +19,10 @@ package batch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/batch/mgmt/2017-09-01/batch/version.go
+++ b/services/batch/mgmt/2017-09-01/batch/version.go
@@ -19,10 +19,10 @@ package batch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/billing/mgmt/2017-02-27-preview/billing/version.go
+++ b/services/billing/mgmt/2017-02-27-preview/billing/version.go
@@ -19,10 +19,10 @@ package billing
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/billing/mgmt/2017-04-24-preview/billing/version.go
+++ b/services/billing/mgmt/2017-04-24-preview/billing/version.go
@@ -19,10 +19,10 @@ package billing
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cdn/mgmt/2015-06-01/cdn/version.go
+++ b/services/cdn/mgmt/2015-06-01/cdn/version.go
@@ -19,10 +19,10 @@ package cdn
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cdn/mgmt/2016-04-02/cdn/version.go
+++ b/services/cdn/mgmt/2016-04-02/cdn/version.go
@@ -19,10 +19,10 @@ package cdn
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cdn/mgmt/2016-10-02/cdn/version.go
+++ b/services/cdn/mgmt/2016-10-02/cdn/version.go
@@ -19,10 +19,10 @@ package cdn
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cdn/mgmt/2017-04-02/cdn/version.go
+++ b/services/cdn/mgmt/2017-04-02/cdn/version.go
@@ -19,10 +19,10 @@ package cdn
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/luis/v2.0/runtime/version.go
+++ b/services/cognitiveservices/luis/v2.0/runtime/version.go
@@ -19,10 +19,10 @@ package runtime
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/mgmt/2016-02-01-preview/cognitiveservices/version.go
+++ b/services/cognitiveservices/mgmt/2016-02-01-preview/cognitiveservices/version.go
@@ -19,10 +19,10 @@ package cognitiveservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/mgmt/2017-04-18/cognitiveservices/version.go
+++ b/services/cognitiveservices/mgmt/2017-04-18/cognitiveservices/version.go
@@ -19,10 +19,10 @@ package cognitiveservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/computervision/version.go
+++ b/services/cognitiveservices/v1.0/computervision/version.go
@@ -19,10 +19,10 @@ package computervision
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/contentmoderator/version.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/version.go
@@ -19,10 +19,10 @@ package contentmoderator
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/customsearch/version.go
+++ b/services/cognitiveservices/v1.0/customsearch/version.go
@@ -19,10 +19,10 @@ package customsearch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/entitysearch/version.go
+++ b/services/cognitiveservices/v1.0/entitysearch/version.go
@@ -19,10 +19,10 @@ package entitysearch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/face/version.go
+++ b/services/cognitiveservices/v1.0/face/version.go
@@ -19,10 +19,10 @@ package face
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/imagesearch/version.go
+++ b/services/cognitiveservices/v1.0/imagesearch/version.go
@@ -19,10 +19,10 @@ package imagesearch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/newssearch/version.go
+++ b/services/cognitiveservices/v1.0/newssearch/version.go
@@ -19,10 +19,10 @@ package newssearch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/spellcheck/version.go
+++ b/services/cognitiveservices/v1.0/spellcheck/version.go
@@ -19,10 +19,10 @@ package spellcheck
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/videosearch/version.go
+++ b/services/cognitiveservices/v1.0/videosearch/version.go
@@ -19,10 +19,10 @@ package videosearch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v1.0/websearch/version.go
+++ b/services/cognitiveservices/v1.0/websearch/version.go
@@ -19,10 +19,10 @@ package websearch
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cognitiveservices/v2.0/textanalytics/version.go
+++ b/services/cognitiveservices/v2.0/textanalytics/version.go
@@ -19,10 +19,10 @@ package textanalytics
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/commerce/mgmt/2015-06-01-preview/commerce/version.go
+++ b/services/commerce/mgmt/2015-06-01-preview/commerce/version.go
@@ -19,10 +19,10 @@ package commerce
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/compute/mgmt/2015-06-15/compute/version.go
+++ b/services/compute/mgmt/2015-06-15/compute/version.go
@@ -19,10 +19,10 @@ package compute
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/compute/mgmt/2016-03-30/compute/version.go
+++ b/services/compute/mgmt/2016-03-30/compute/version.go
@@ -19,10 +19,10 @@ package compute
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/compute/mgmt/2016-04-30-preview/compute/version.go
+++ b/services/compute/mgmt/2016-04-30-preview/compute/version.go
@@ -19,10 +19,10 @@ package compute
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/compute/mgmt/2017-03-30/compute/version.go
+++ b/services/compute/mgmt/2017-03-30/compute/version.go
@@ -19,10 +19,10 @@ package compute
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/consumption/mgmt/2017-04-24-preview/consumption/version.go
+++ b/services/consumption/mgmt/2017-04-24-preview/consumption/version.go
@@ -19,10 +19,10 @@ package consumption
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerinstance/mgmt/2017-08-01-preview/containerinstance/version.go
+++ b/services/containerinstance/mgmt/2017-08-01-preview/containerinstance/version.go
@@ -19,10 +19,10 @@ package containerinstance
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerregistry/mgmt/2017-03-01/containerregistry/version.go
+++ b/services/containerregistry/mgmt/2017-03-01/containerregistry/version.go
@@ -19,10 +19,10 @@ package containerregistry
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerregistry/mgmt/2017-06-01-preview/containerregistry/version.go
+++ b/services/containerregistry/mgmt/2017-06-01-preview/containerregistry/version.go
@@ -19,10 +19,10 @@ package containerregistry
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerregistry/mgmt/2017-10-01/containerregistry/version.go
+++ b/services/containerregistry/mgmt/2017-10-01/containerregistry/version.go
@@ -19,10 +19,10 @@ package containerregistry
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerservice/mgmt/2015-11-01-preview/containerservice/version.go
+++ b/services/containerservice/mgmt/2015-11-01-preview/containerservice/version.go
@@ -19,10 +19,10 @@ package containerservice
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerservice/mgmt/2016-03-30/containerservice/version.go
+++ b/services/containerservice/mgmt/2016-03-30/containerservice/version.go
@@ -19,10 +19,10 @@ package containerservice
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerservice/mgmt/2016-09-30/containerservice/version.go
+++ b/services/containerservice/mgmt/2016-09-30/containerservice/version.go
@@ -19,10 +19,10 @@ package containerservice
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerservice/mgmt/2017-01-31/containerservice/version.go
+++ b/services/containerservice/mgmt/2017-01-31/containerservice/version.go
@@ -19,10 +19,10 @@ package containerservice
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerservice/mgmt/2017-07-01/containerservice/version.go
+++ b/services/containerservice/mgmt/2017-07-01/containerservice/version.go
@@ -19,10 +19,10 @@ package containerservice
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerservice/mgmt/2017-08-31/containerservice/version.go
+++ b/services/containerservice/mgmt/2017-08-31/containerservice/version.go
@@ -19,10 +19,10 @@ package containerservice
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/containerservice/mgmt/2017-09-30/containerservice/version.go
+++ b/services/containerservice/mgmt/2017-09-30/containerservice/version.go
@@ -19,10 +19,10 @@ package containerservice
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/cosmos-db/mgmt/2015-04-08/documentdb/version.go
+++ b/services/cosmos-db/mgmt/2015-04-08/documentdb/version.go
@@ -19,10 +19,10 @@ package documentdb
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/customerinsights/mgmt/2017-01-01/customerinsights/version.go
+++ b/services/customerinsights/mgmt/2017-01-01/customerinsights/version.go
@@ -19,10 +19,10 @@ package customerinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/customerinsights/mgmt/2017-04-26/customerinsights/version.go
+++ b/services/customerinsights/mgmt/2017-04-26/customerinsights/version.go
@@ -19,10 +19,10 @@ package customerinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datafactory/mgmt/2017-09-01-preview/datafactory/version.go
+++ b/services/datafactory/mgmt/2017-09-01-preview/datafactory/version.go
@@ -19,10 +19,10 @@ package datafactory
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/analytics/2015-10-01-preview/catalog/version.go
+++ b/services/datalake/analytics/2015-10-01-preview/catalog/version.go
@@ -19,10 +19,10 @@ package catalog
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/analytics/2015-11-01-preview/job/version.go
+++ b/services/datalake/analytics/2015-11-01-preview/job/version.go
@@ -19,10 +19,10 @@ package job
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/analytics/2016-03-20-preview/job/version.go
+++ b/services/datalake/analytics/2016-03-20-preview/job/version.go
@@ -19,10 +19,10 @@ package job
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/analytics/2016-11-01-preview/catalog/version.go
+++ b/services/datalake/analytics/2016-11-01-preview/catalog/version.go
@@ -19,10 +19,10 @@ package catalog
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/analytics/2016-11-01/job/version.go
+++ b/services/datalake/analytics/2016-11-01/job/version.go
@@ -19,10 +19,10 @@ package job
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/analytics/2017-09-01-preview/job/version.go
+++ b/services/datalake/analytics/2017-09-01-preview/job/version.go
@@ -19,10 +19,10 @@ package job
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/analytics/mgmt/2015-10-01-preview/account/version.go
+++ b/services/datalake/analytics/mgmt/2015-10-01-preview/account/version.go
@@ -19,10 +19,10 @@ package account
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/analytics/mgmt/2016-11-01/account/version.go
+++ b/services/datalake/analytics/mgmt/2016-11-01/account/version.go
@@ -19,10 +19,10 @@ package account
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/store/2015-10-01-preview/filesystem/version.go
+++ b/services/datalake/store/2015-10-01-preview/filesystem/version.go
@@ -19,10 +19,10 @@ package filesystem
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/store/2016-11-01/filesystem/version.go
+++ b/services/datalake/store/2016-11-01/filesystem/version.go
@@ -19,10 +19,10 @@ package filesystem
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/store/mgmt/2015-10-01-preview/account/version.go
+++ b/services/datalake/store/mgmt/2015-10-01-preview/account/version.go
@@ -19,10 +19,10 @@ package account
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/datalake/store/mgmt/2016-11-01/account/version.go
+++ b/services/datalake/store/mgmt/2016-11-01/account/version.go
@@ -19,10 +19,10 @@ package account
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/devtestlabs/mgmt/2015-05-21-preview/dtl/version.go
+++ b/services/devtestlabs/mgmt/2015-05-21-preview/dtl/version.go
@@ -19,10 +19,10 @@ package dtl
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/devtestlabs/mgmt/2016-05-15/dtl/version.go
+++ b/services/devtestlabs/mgmt/2016-05-15/dtl/version.go
@@ -19,10 +19,10 @@ package dtl
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/dns/mgmt/2015-05-04-preview/dns/version.go
+++ b/services/dns/mgmt/2015-05-04-preview/dns/version.go
@@ -19,10 +19,10 @@ package dns
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/dns/mgmt/2016-04-01/dns/version.go
+++ b/services/dns/mgmt/2016-04-01/dns/version.go
@@ -19,10 +19,10 @@ package dns
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/dns/mgmt/2017-09-01/dns/version.go
+++ b/services/dns/mgmt/2017-09-01/dns/version.go
@@ -19,10 +19,10 @@ package dns
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/domainservices/mgmt/2017-01-01/aad/version.go
+++ b/services/domainservices/mgmt/2017-01-01/aad/version.go
@@ -19,10 +19,10 @@ package aad
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/eventgrid/2018-01-01/eventgrid/version.go
+++ b/services/eventgrid/2018-01-01/eventgrid/version.go
@@ -19,10 +19,10 @@ package eventgrid
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/eventgrid/mgmt/2017-06-15-preview/eventgrid/version.go
+++ b/services/eventgrid/mgmt/2017-06-15-preview/eventgrid/version.go
@@ -19,10 +19,10 @@ package eventgrid
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/eventgrid/mgmt/2017-09-15-preview/eventgrid/version.go
+++ b/services/eventgrid/mgmt/2017-09-15-preview/eventgrid/version.go
@@ -19,10 +19,10 @@ package eventgrid
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/eventhub/mgmt/2015-08-01/eventhub/version.go
+++ b/services/eventhub/mgmt/2015-08-01/eventhub/version.go
@@ -19,10 +19,10 @@ package eventhub
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/eventhub/mgmt/2017-04-01/eventhub/version.go
+++ b/services/eventhub/mgmt/2017-04-01/eventhub/version.go
@@ -19,10 +19,10 @@ package eventhub
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/graphrbac/1.6/graphrbac/version.go
+++ b/services/graphrbac/1.6/graphrbac/version.go
@@ -19,10 +19,10 @@ package graphrbac
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/hdinsight/mgmt/2015-03-01-preview/hdinsight/version.go
+++ b/services/hdinsight/mgmt/2015-03-01-preview/hdinsight/version.go
@@ -8,10 +8,10 @@ package hdinsight
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/iothub/mgmt/2016-02-03/devices/version.go
+++ b/services/iothub/mgmt/2016-02-03/devices/version.go
@@ -19,10 +19,10 @@ package devices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/iothub/mgmt/2017-01-19/devices/version.go
+++ b/services/iothub/mgmt/2017-01-19/devices/version.go
@@ -19,10 +19,10 @@ package devices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/iothub/mgmt/2017-07-01/devices/version.go
+++ b/services/iothub/mgmt/2017-07-01/devices/version.go
@@ -19,10 +19,10 @@ package devices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/keyvault/2015-06-01/keyvault/version.go
+++ b/services/keyvault/2015-06-01/keyvault/version.go
@@ -19,10 +19,10 @@ package keyvault
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/keyvault/2016-10-01/keyvault/version.go
+++ b/services/keyvault/2016-10-01/keyvault/version.go
@@ -19,10 +19,10 @@ package keyvault
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/keyvault/mgmt/2015-06-01/keyvault/version.go
+++ b/services/keyvault/mgmt/2015-06-01/keyvault/version.go
@@ -19,10 +19,10 @@ package keyvault
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/keyvault/mgmt/2016-10-01/keyvault/version.go
+++ b/services/keyvault/mgmt/2016-10-01/keyvault/version.go
@@ -19,10 +19,10 @@ package keyvault
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/logic/mgmt/2015-02-01-preview/logic/version.go
+++ b/services/logic/mgmt/2015-02-01-preview/logic/version.go
@@ -19,10 +19,10 @@ package logic
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/logic/mgmt/2015-08-01-preview/logic/version.go
+++ b/services/logic/mgmt/2015-08-01-preview/logic/version.go
@@ -19,10 +19,10 @@ package logic
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/logic/mgmt/2016-06-01/logic/version.go
+++ b/services/logic/mgmt/2016-06-01/logic/version.go
@@ -19,10 +19,10 @@ package logic
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/machinelearning/mgmt/2016-05-01-preview/commitmentplans/version.go
+++ b/services/machinelearning/mgmt/2016-05-01-preview/commitmentplans/version.go
@@ -19,10 +19,10 @@ package commitmentplans
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/machinelearning/mgmt/2016-05-01-preview/webservices/version.go
+++ b/services/machinelearning/mgmt/2016-05-01-preview/webservices/version.go
@@ -19,10 +19,10 @@ package webservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/machinelearning/mgmt/2017-01-01/webservices/version.go
+++ b/services/machinelearning/mgmt/2017-01-01/webservices/version.go
@@ -19,10 +19,10 @@ package webservices
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/machinelearning/mgmt/2017-05-01-preview/experimentation/version.go
+++ b/services/machinelearning/mgmt/2017-05-01-preview/experimentation/version.go
@@ -19,10 +19,10 @@ package experimentation
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/machinelearning/mgmt/2017-08-01-preview/compute/version.go
+++ b/services/machinelearning/mgmt/2017-08-01-preview/compute/version.go
@@ -19,10 +19,10 @@ package compute
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/version.go
+++ b/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/version.go
@@ -19,10 +19,10 @@ package marketplaceordering
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/mediaservices/mgmt/2015-10-01/media/version.go
+++ b/services/mediaservices/mgmt/2015-10-01/media/version.go
@@ -19,10 +19,10 @@ package media
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/mobileengagement/mgmt/2014-12-01/mobileengagement/version.go
+++ b/services/mobileengagement/mgmt/2014-12-01/mobileengagement/version.go
@@ -19,10 +19,10 @@ package mobileengagement
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/monitor/mgmt/2017-05-01-preview/insights/version.go
+++ b/services/monitor/mgmt/2017-05-01-preview/insights/version.go
@@ -19,10 +19,10 @@ package insights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/msi/mgmt/2015-08-31-preview/msi/version.go
+++ b/services/msi/mgmt/2015-08-31-preview/msi/version.go
@@ -19,10 +19,10 @@ package msi
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/mysql/mgmt/2017-04-30-preview/mysql/version.go
+++ b/services/mysql/mgmt/2017-04-30-preview/mysql/version.go
@@ -19,10 +19,10 @@ package mysql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2015-05-01-preview/network/version.go
+++ b/services/network/mgmt/2015-05-01-preview/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2015-06-15/network/version.go
+++ b/services/network/mgmt/2015-06-15/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2016-03-30/network/version.go
+++ b/services/network/mgmt/2016-03-30/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2016-06-01/network/version.go
+++ b/services/network/mgmt/2016-06-01/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2016-09-01/network/version.go
+++ b/services/network/mgmt/2016-09-01/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2016-12-01/network/version.go
+++ b/services/network/mgmt/2016-12-01/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2017-03-01/network/version.go
+++ b/services/network/mgmt/2017-03-01/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2017-06-01/network/version.go
+++ b/services/network/mgmt/2017-06-01/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2017-08-01/network/version.go
+++ b/services/network/mgmt/2017-08-01/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/network/mgmt/2017-09-01/network/version.go
+++ b/services/network/mgmt/2017-09-01/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/notificationhubs/mgmt/2014-09-01/notificationhubs/version.go
+++ b/services/notificationhubs/mgmt/2014-09-01/notificationhubs/version.go
@@ -19,10 +19,10 @@ package notificationhubs
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/notificationhubs/mgmt/2016-03-01/notificationhubs/version.go
+++ b/services/notificationhubs/mgmt/2016-03-01/notificationhubs/version.go
@@ -19,10 +19,10 @@ package notificationhubs
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/notificationhubs/mgmt/2017-04-01/notificationhubs/version.go
+++ b/services/notificationhubs/mgmt/2017-04-01/notificationhubs/version.go
@@ -19,10 +19,10 @@ package notificationhubs
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/operationalinsights/mgmt/2015-03-20/operationalinsights/version.go
+++ b/services/operationalinsights/mgmt/2015-03-20/operationalinsights/version.go
@@ -19,10 +19,10 @@ package operationalinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/operationalinsights/mgmt/2015-11-01-preview/operationalinsights/version.go
+++ b/services/operationalinsights/mgmt/2015-11-01-preview/operationalinsights/version.go
@@ -19,10 +19,10 @@ package operationalinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/operationalinsights/mgmt/2015-11-01-preview/servicemap/version.go
+++ b/services/operationalinsights/mgmt/2015-11-01-preview/servicemap/version.go
@@ -19,10 +19,10 @@ package servicemap
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/operationalinsights/v1/operationalinsights/version.go
+++ b/services/operationalinsights/v1/operationalinsights/version.go
@@ -19,10 +19,10 @@ package operationalinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/operationsmanagement/mgmt/2015-11-01-preview/operationsmanagement/version.go
+++ b/services/operationsmanagement/mgmt/2015-11-01-preview/operationsmanagement/version.go
@@ -19,10 +19,10 @@ package operationsmanagement
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/postgresql/mgmt/2017-04-30-preview/postgresql/version.go
+++ b/services/postgresql/mgmt/2017-04-30-preview/postgresql/version.go
@@ -19,10 +19,10 @@ package postgresql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/powerbiembedded/mgmt/2016-01-29/powerbiembedded/version.go
+++ b/services/powerbiembedded/mgmt/2016-01-29/powerbiembedded/version.go
@@ -19,10 +19,10 @@ package powerbiembedded
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/redis/mgmt/2015-08-01/redis/version.go
+++ b/services/redis/mgmt/2015-08-01/redis/version.go
@@ -19,10 +19,10 @@ package redis
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/redis/mgmt/2016-04-01/redis/version.go
+++ b/services/redis/mgmt/2016-04-01/redis/version.go
@@ -19,10 +19,10 @@ package redis
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/redis/mgmt/2017-02-01/redis/version.go
+++ b/services/redis/mgmt/2017-02-01/redis/version.go
@@ -19,10 +19,10 @@ package redis
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/redis/mgmt/2017-10-01/cache/version.go
+++ b/services/redis/mgmt/2017-10-01/cache/version.go
@@ -19,10 +19,10 @@ package redis
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/relay/mgmt/2016-07-01/relay/version.go
+++ b/services/relay/mgmt/2016-07-01/relay/version.go
@@ -19,10 +19,10 @@ package relay
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/relay/mgmt/2017-04-01/relay/version.go
+++ b/services/relay/mgmt/2017-04-01/relay/version.go
@@ -19,10 +19,10 @@ package relay
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resourcehealth/mgmt/2015-01-01/resourcehealth/version.go
+++ b/services/resourcehealth/mgmt/2015-01-01/resourcehealth/version.go
@@ -19,10 +19,10 @@ package resourcehealth
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resourcehealth/mgmt/2017-07-01/resourcehealth/version.go
+++ b/services/resourcehealth/mgmt/2017-07-01/resourcehealth/version.go
@@ -19,10 +19,10 @@ package resourcehealth
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2015-01-01/locks/version.go
+++ b/services/resources/mgmt/2015-01-01/locks/version.go
@@ -19,10 +19,10 @@ package locks
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2015-10-01-preview/policy/version.go
+++ b/services/resources/mgmt/2015-10-01-preview/policy/version.go
@@ -19,10 +19,10 @@ package policy
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2015-11-01/resources/version.go
+++ b/services/resources/mgmt/2015-11-01/resources/version.go
@@ -19,10 +19,10 @@ package resources
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2015-11-01/subscriptions/version.go
+++ b/services/resources/mgmt/2015-11-01/subscriptions/version.go
@@ -19,10 +19,10 @@ package subscriptions
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2015-12-01/features/version.go
+++ b/services/resources/mgmt/2015-12-01/features/version.go
@@ -19,10 +19,10 @@ package features
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2016-02-01/resources/version.go
+++ b/services/resources/mgmt/2016-02-01/resources/version.go
@@ -19,10 +19,10 @@ package resources
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2016-04-01/policy/version.go
+++ b/services/resources/mgmt/2016-04-01/policy/version.go
@@ -19,10 +19,10 @@ package policy
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2016-06-01/subscriptions/version.go
+++ b/services/resources/mgmt/2016-06-01/subscriptions/version.go
@@ -19,10 +19,10 @@ package subscriptions
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2016-07-01/resources/version.go
+++ b/services/resources/mgmt/2016-07-01/resources/version.go
@@ -19,10 +19,10 @@ package resources
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2016-09-01-preview/managedapplications/version.go
+++ b/services/resources/mgmt/2016-09-01-preview/managedapplications/version.go
@@ -19,10 +19,10 @@ package managedapplications
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2016-09-01/links/version.go
+++ b/services/resources/mgmt/2016-09-01/links/version.go
@@ -19,10 +19,10 @@ package links
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2016-09-01/locks/version.go
+++ b/services/resources/mgmt/2016-09-01/locks/version.go
@@ -19,10 +19,10 @@ package locks
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2016-09-01/resources/version.go
+++ b/services/resources/mgmt/2016-09-01/resources/version.go
@@ -19,10 +19,10 @@ package resources
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2016-12-01/policy/version.go
+++ b/services/resources/mgmt/2016-12-01/policy/version.go
@@ -19,10 +19,10 @@ package policy
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2017-05-10/resources/version.go
+++ b/services/resources/mgmt/2017-05-10/resources/version.go
@@ -19,10 +19,10 @@ package resources
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2017-06-01-preview/policy/version.go
+++ b/services/resources/mgmt/2017-06-01-preview/policy/version.go
@@ -19,10 +19,10 @@ package policy
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/resources/mgmt/2017-08-31-preview/management/version.go
+++ b/services/resources/mgmt/2017-08-31-preview/management/version.go
@@ -19,10 +19,10 @@ package management
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/scheduler/mgmt/2014-08-01-preview/scheduler/version.go
+++ b/services/scheduler/mgmt/2014-08-01-preview/scheduler/version.go
@@ -19,10 +19,10 @@ package scheduler
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/scheduler/mgmt/2016-01-01/scheduler/version.go
+++ b/services/scheduler/mgmt/2016-01-01/scheduler/version.go
@@ -19,10 +19,10 @@ package scheduler
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/scheduler/mgmt/2016-03-01/scheduler/version.go
+++ b/services/scheduler/mgmt/2016-03-01/scheduler/version.go
@@ -19,10 +19,10 @@ package scheduler
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/search/2016-09-01/search/version.go
+++ b/services/search/2016-09-01/search/version.go
@@ -19,10 +19,10 @@ package search
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/search/mgmt/2015-02-28/search/version.go
+++ b/services/search/mgmt/2015-02-28/search/version.go
@@ -19,10 +19,10 @@ package search
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/search/mgmt/2015-08-19/search/version.go
+++ b/services/search/mgmt/2015-08-19/search/version.go
@@ -19,10 +19,10 @@ package search
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/servermanagement/mgmt/2015-07-01-preview/servermanagement/version.go
+++ b/services/servermanagement/mgmt/2015-07-01-preview/servermanagement/version.go
@@ -19,10 +19,10 @@ package servermanagement
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/servermanagement/mgmt/2016-07-01-preview/servermanagement/version.go
+++ b/services/servermanagement/mgmt/2016-07-01-preview/servermanagement/version.go
@@ -19,10 +19,10 @@ package servermanagement
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/servicebus/mgmt/2015-08-01/servicebus/version.go
+++ b/services/servicebus/mgmt/2015-08-01/servicebus/version.go
@@ -19,10 +19,10 @@ package servicebus
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/servicebus/mgmt/2017-04-01/servicebus/version.go
+++ b/services/servicebus/mgmt/2017-04-01/servicebus/version.go
@@ -19,10 +19,10 @@ package servicebus
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/servicefabric/1.0.0/servicefabric/version.go
+++ b/services/servicefabric/1.0.0/servicefabric/version.go
@@ -19,10 +19,10 @@ package servicefabric
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/servicefabric/5.6/servicefabric/version.go
+++ b/services/servicefabric/5.6/servicefabric/version.go
@@ -19,10 +19,10 @@ package servicefabric
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/servicefabric/6.0/servicefabric/version.go
+++ b/services/servicefabric/6.0/servicefabric/version.go
@@ -19,10 +19,10 @@ package servicefabric
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/servicefabric/mgmt/2016-09-01/servicefabric/version.go
+++ b/services/servicefabric/mgmt/2016-09-01/servicefabric/version.go
@@ -19,10 +19,10 @@ package servicefabric
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/servicefabric/mgmt/2017-07-01-preview/servicefabric/version.go
+++ b/services/servicefabric/mgmt/2017-07-01-preview/servicefabric/version.go
@@ -19,10 +19,10 @@ package servicefabric
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/sql/mgmt/2014-04-01/sql/version.go
+++ b/services/sql/mgmt/2014-04-01/sql/version.go
@@ -19,10 +19,10 @@ package sql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/sql/mgmt/2015-05-01-preview/sql/version.go
+++ b/services/sql/mgmt/2015-05-01-preview/sql/version.go
@@ -19,10 +19,10 @@ package sql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/sql/mgmt/2017-03-01-preview/sql/version.go
+++ b/services/sql/mgmt/2017-03-01-preview/sql/version.go
@@ -19,10 +19,10 @@ package sql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/storage/mgmt/2015-05-01-preview/storage/version.go
+++ b/services/storage/mgmt/2015-05-01-preview/storage/version.go
@@ -19,10 +19,10 @@ package storage
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/storage/mgmt/2015-06-15/storage/version.go
+++ b/services/storage/mgmt/2015-06-15/storage/version.go
@@ -19,10 +19,10 @@ package storage
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/storage/mgmt/2016-01-01/storage/version.go
+++ b/services/storage/mgmt/2016-01-01/storage/version.go
@@ -19,10 +19,10 @@ package storage
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/storage/mgmt/2016-05-01/storage/version.go
+++ b/services/storage/mgmt/2016-05-01/storage/version.go
@@ -19,10 +19,10 @@ package storage
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/storage/mgmt/2016-12-01/storage/version.go
+++ b/services/storage/mgmt/2016-12-01/storage/version.go
@@ -19,10 +19,10 @@ package storage
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/storage/mgmt/2017-06-01/storage/version.go
+++ b/services/storage/mgmt/2017-06-01/storage/version.go
@@ -19,10 +19,10 @@ package storage
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/storage/mgmt/2017-10-01/storage/version.go
+++ b/services/storage/mgmt/2017-10-01/storage/version.go
@@ -19,10 +19,10 @@ package storage
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta arm-storage/2017-10-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-storage/2017-10-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/storageimportexport/mgmt/2016-11-01/storageimportexport/version.go
+++ b/services/storageimportexport/mgmt/2016-11-01/storageimportexport/version.go
@@ -19,10 +19,10 @@ package storageimportexport
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/storsimple8000series/mgmt/2017-06-01/storsimple/version.go
+++ b/services/storsimple8000series/mgmt/2017-06-01/storsimple/version.go
@@ -19,10 +19,10 @@ package storsimple
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/streamanalytics/mgmt/2016-03-01/streamanalytics/version.go
+++ b/services/streamanalytics/mgmt/2016-03-01/streamanalytics/version.go
@@ -19,10 +19,10 @@ package streamanalytics
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/trafficmanager/mgmt/2015-11-01/trafficmanager/version.go
+++ b/services/trafficmanager/mgmt/2015-11-01/trafficmanager/version.go
@@ -19,10 +19,10 @@ package trafficmanager
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/trafficmanager/mgmt/2017-03-01/trafficmanager/version.go
+++ b/services/trafficmanager/mgmt/2017-03-01/trafficmanager/version.go
@@ -19,10 +19,10 @@ package trafficmanager
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/trafficmanager/mgmt/2017-05-01/trafficmanager/version.go
+++ b/services/trafficmanager/mgmt/2017-05-01/trafficmanager/version.go
@@ -19,10 +19,10 @@ package trafficmanager
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/trafficmanager/mgmt/2017-09-01-preview/trafficmanager/version.go
+++ b/services/trafficmanager/mgmt/2017-09-01-preview/trafficmanager/version.go
@@ -19,10 +19,10 @@ package trafficmanager
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/visualstudio/mgmt/2014-04-01-preview/visualstudio/version.go
+++ b/services/visualstudio/mgmt/2014-04-01-preview/visualstudio/version.go
@@ -19,10 +19,10 @@ package visualstudio
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/web/mgmt/2015-08-preview/web/version.go
+++ b/services/web/mgmt/2015-08-preview/web/version.go
@@ -19,10 +19,10 @@ package web
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/services/web/mgmt/2016-09-01/web/version.go
+++ b/services/web/mgmt/2016-09-01/web/version.go
@@ -19,10 +19,10 @@ package web
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v12.1.1-beta services"
+	return "Azure-SDK-For-Go/v12.2.0-beta services"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v12.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -310,6 +310,20 @@ func (s *StorageClientSuite) TestNewFromConnectionString(c *chk.C) {
 	c.Assert(cli.accountKey, chk.DeepEquals, expectedKey)
 }
 
+func (s *StorageClientSuite) TestNewAccountSASClientFromEndpointToken(c *chk.C) {
+	cli, err := NewAccountSASClientFromEndpointToken(
+		"http://golangrocksonazure.blob.core.windows.net",
+		"sv=2017-04-17&ss=bq&srt=sco&sp=rwdlacup&se=2018-01-09T22:32:27Z&st=2018-01-08T14:32:27Z&spr=http&sig=z8K9AiNvsQAoRQmqEgHrk3KdRfY37MxCHckGi%2BJRFDI%3D",
+	)
+
+	c.Assert(err, chk.IsNil)
+	c.Assert(cli.accountSASToken, chk.HasLen, 8)
+	c.Assert(cli.accountName, chk.Equals, "golangrocksonazure")
+	c.Assert(cli.baseURL, chk.Equals, "core.windows.net")
+	c.Assert(cli.apiVersion, chk.Equals, "2017-04-17")
+	c.Assert(cli.useHTTPS, chk.Equals, false)
+}
+
 func (s *StorageClientSuite) TestIsValidStorageAccount(c *chk.C) {
 	type test struct {
 		account  string

--- a/storage/container.go
+++ b/storage/container.go
@@ -301,9 +301,6 @@ func (c *Container) Exists() (bool, error) {
 		uri = newURI.String()
 
 	} else {
-		if c.bsc.client.isAccountSASClient() {
-			q = mergeParams(q, c.bsc.client.accountSASToken)
-		}
 		uri = c.bsc.client.getEndpoint(blobServiceName, c.buildPath(), q)
 	}
 	headers := c.bsc.client.getStandardHeaders()
@@ -489,9 +486,6 @@ func (c *Container) ListBlobs(params ListBlobsParameters) (BlobListResponse, err
 		newURI.RawQuery = q.Encode()
 		uri = newURI.String()
 	} else {
-		if c.bsc.client.isAccountSASClient() {
-			q = mergeParams(q, c.bsc.client.accountSASToken)
-		}
 		uri = c.bsc.client.getEndpoint(blobServiceName, c.buildPath(), q)
 	}
 

--- a/storage/version.go
+++ b/storage/version.go
@@ -15,5 +15,5 @@ package storage
 //  limitations under the License.
 
 var (
-	sdkVersion = "v12.1.1-beta"
+	sdkVersion = "v12.2.0-beta"
 )


### PR DESCRIPTION
Add support for creating a SAS client from an endpoint and SAS token.
Fixed bug that wasn't appending SAS token to URI query parameters in all
cases.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 