### PR TITLE
Typo in using oauthConfig variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ var (
 )
 
 func getServicePrincipalToken() (adal.OAuthTokenProvider, error) {
-	config, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, tenantID)
+	oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, tenantID)
 	return adal.NewServicePrincipalToken(
 		*oauthConfig,
 		clientID,


### PR DESCRIPTION
in line 111, variable name config was used to capture response from adal.NewOAuthConfig() which should be changed to oauthConfig.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [x] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [x] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [x] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [x] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 