### PR TITLE
Adding profile generation to Swagger->SDK

### DIFF
--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -1,7 +1,11 @@
 {
   "meta": {
     "after_scripts": [
-      "gofmt -w ./services/"
+      "gofmt -w ./services/",
+      "go get -u github.com/Azure/azure-sdk-for-go/tools/profileBuilder",
+      "profileBuilder -s list -l ./profiles/2017-03-09/defintion.txt -name 2017-03-09",
+      "profileBuilder -s preview -name preview",
+      "profileBuilder -s latest -name latest"
     ],
     "autorest_options": {
       "use": "@microsoft.azure/autorest.go@preview",
@@ -9,8 +13,8 @@
       "verbose": "",
       "sdkrel:go-sdk-folder": ".",
       "multiapi": "",
-      "package-version": "v12.2.1-beta",
-      "user-agent": "Azure-SDK-For-Go/v12.2.1-beta services"
+      "package-version": "nightly",
+      "user-agent": "Azure-SDK-For-Go/nightly services"
     },
     "version": "0.2.0"
   }


### PR DESCRIPTION
Profiles must be regenerated to match the regenerated services folders.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 