### PR TITLE
Release profileBuilder and storage changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## `v14.1.1`
+
+- Fixing timestamp marshalling bug in the `storage` package.
+- Updating `profileBuilder` to clear-output folders when it is run by `go generate`.
+- Tweaking Swagger -> SDK config to use "latest" instead of "nightly" and be tied to a particular version of autorest.go.
+
 ## `v14.1.0`
 
 ### Changes

--- a/profiles/2017-03-09/generate.go
+++ b/profiles/2017-03-09/generate.go
@@ -14,4 +14,4 @@
 
 package v20170309
 
-//go:generate go run ../../tools/profileBuilder/main.go list --input ./definition.go --name 2017-03-09
+//go:generate go run ../../tools/profileBuilder/main.go list --clear-output --input ./definition.txt --name 2017-03-09

--- a/profiles/latest/generate.go
+++ b/profiles/latest/generate.go
@@ -14,4 +14,4 @@
 
 package latest
 
-//go:generate go run ../../tools/profileBuilder/main.go latest --name latest
+//go:generate go run ../../tools/profileBuilder/main.go list --clear-output --name latest --input ./stableApis.txt

--- a/profiles/preview/generate.go
+++ b/profiles/preview/generate.go
@@ -14,4 +14,4 @@
 
 package preview
 
-//go:generate go run ../../tools/profileBuilder/main.go latest --name preview --preview
+//go:generate go run ../../tools/profileBuilder/main.go latest --clear-output --name preview --preview

--- a/storage/util.go
+++ b/storage/util.go
@@ -209,6 +209,11 @@ func (t *TimeRFC1123) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 	return nil
 }
 
+// MarshalXML marshals using time.RFC1123.
+func (t *TimeRFC1123) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(time.Time(*t).Format(time.RFC1123), start)
+}
+
 // returns a map of custom metadata values from the specified HTTP header
 func getMetadataFromHeaders(header http.Header) map[string]string {
 	metadata := make(map[string]string)

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -6,18 +6,18 @@
       "dep ensure",
       "go install",
       "cd ../..",
-      "go generate",
+      "go generate ./profiles/...",
       "gofmt -w ./services/",
       "gofmt -w ./profiles/"
     ],
     "autorest_options": {
-      "use": "@microsoft.azure/autorest.go@preview",
+      "use": "@microsoft.azure/autorest.go@~2",
       "go": "",
       "verbose": "",
       "sdkrel:go-sdk-folder": ".",
       "multiapi": "",
-      "package-version": "nightly",
-      "user-agent": "Azure-SDK-For-Go/nightly services"
+      "package-version": "latest",
+      "user-agent": "Azure-SDK-For-Go/latest services"
     },
     "version": "0.2.0"
   }

--- a/tools/profileBuilder/cmd/latest.go
+++ b/tools/profileBuilder/cmd/latest.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 
 	"github.com/Azure/azure-sdk-for-go/tools/profileBuilder/model"
 	"github.com/marstr/randname"
@@ -71,6 +72,14 @@ By default, this command ignores API versions that are in preview.`,
 		if latestFlags.GetBool(previewLongName) {
 			packageStrategy.Predicate = model.AcceptAll
 			outputLog.Println("Using preview versions.")
+		}
+
+		deleteLoc := path.Join(latestFlags.GetString(outputLocationLongName), latestFlags.GetString(nameLongName))
+		if viper.GetBool("clear-output") {
+			if err := model.DeleteChildDirs(deleteLoc); err != nil {
+				errLog.Print("Fatal! Unable to clear output-folder:", err)
+				return
+			}
 		}
 
 		model.BuildProfile(

--- a/tools/profileBuilder/cmd/list.go
+++ b/tools/profileBuilder/cmd/list.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 
 	"github.com/Azure/azure-sdk-for-go/tools/profileBuilder/model"
 	"github.com/marstr/randname"
@@ -69,8 +70,16 @@ $> ../model/testdata/smallProfile.txt > profileBuilder list --name small_profile
 		} else if fileHandle, err := os.Open(listFlags.GetString(inputLongName)); err == nil {
 			input = fileHandle
 		} else {
-			errLog.Printf("Unable to open file %q", listFlags.GetString(inputLongName))
+			errLog.Printf("Fatal! Unable to open file %q", listFlags.GetString(inputLongName))
 			return
+		}
+
+		deleteLoc := path.Join(listFlags.GetString(outputLocationLongName), listFlags.GetString(nameLongName))
+		if viper.GetBool("clear-output") {
+			if err := model.DeleteChildDirs(deleteLoc); err != nil {
+				errLog.Print("Fatal! Unable to clear output-folder:", err)
+				return
+			}
 		}
 
 		model.BuildProfile(

--- a/tools/profileBuilder/cmd/root.go
+++ b/tools/profileBuilder/cmd/root.go
@@ -79,8 +79,11 @@ func init() {
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.profileBuilder.yaml)")
 
+	rootCmd.PersistentFlags().BoolP("clear-output", "c", false, "Removes any directories in the output-folder before writing a profile.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Use stderr to log verbose output.")
+
 	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	viper.BindPFlag("clear-output", rootCmd.PersistentFlags().Lookup("clear-output"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/tools/profileBuilder/model/delete.go
+++ b/tools/profileBuilder/model/delete.go
@@ -1,0 +1,48 @@
+// +build go1.9
+
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+// DeleteChildDirs deletes all child directories of the directory specified by
+// `path`.
+// If it fails to delete a child, it halts execution and returns an err immediately.
+func DeleteChildDirs(dir string) (err error) {
+	var children []os.FileInfo
+
+	children, err = ioutil.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	for _, child := range children {
+		if child.IsDir() {
+			childPath := strings.Replace(path.Join(dir, child.Name()), `\`, `/`, -1)
+			err = os.RemoveAll(childPath)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}

--- a/version/version.go
+++ b/version/version.go
@@ -18,4 +18,4 @@ package version
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 // Number contains the semantic version of this SDK.
-const Number = "v14.1.0"
+const Number = "v14.1.1"


### PR DESCRIPTION
This is a roll-up of changes made in the `dev` branch.

It is necessary to get the automatic PRs working against `latest` and generating the most correct profiles.