### PR TITLE
Export maximum range and file sizes

### DIFF
--- a/storage/file.go
+++ b/storage/file.go
@@ -28,6 +28,10 @@ import (
 const fourMB = uint64(4194304)
 const oneTB = uint64(1099511627776)
 
+// Export maximum range and file sizes
+const MaxRangeSize = fourMB
+const MaxFileSize = oneTB
+
 // File represents a file on a share.
 type File struct {
 	fsc                *FileServiceClient


### PR DESCRIPTION
A very small change. Instead of users of this library having to hardcode the maximum range and file size, they should just be able to pick them from the library.

---

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [x] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] (N/A) I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] (N/A) If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] (N/A) I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 