### PR TITLE
Removing `profileBuilder` portion of Swagger->SDK

### DIFF
--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -1,14 +1,7 @@
 {
   "meta": {
     "after_scripts": [
-      "dep ensure",
-      "cd ./tools/profileBuilder/",
-      "dep ensure",
-      "go install",
-      "cd ../..",
-      "go generate ./profiles/...",
-      "gofmt -w ./services/",
-      "gofmt -w ./profiles/"
+      "gofmt -w ./services/"
     ],
     "autorest_options": {
       "use": "@microsoft.azure/autorest.go@~2",

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -4,7 +4,7 @@
       "gofmt -w ./services/"
     ],
     "autorest_options": {
-      "use": "@microsoft.azure/autorest.go@~2",
+      "use": "@microsoft.azure/autorest.go@^2.1.87",
       "go": "",
       "verbose": "",
       "sdkrel:go-sdk-folder": ".",

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -4,7 +4,7 @@
       "gofmt -w ./services/"
     ],
     "autorest_options": {
-      "use": "@microsoft.azure/autorest.go@^2.1.87",
+      "use": "@microsoft.azure/autorest.go@~2.1.87",
       "go": "",
       "verbose": "",
       "sdkrel:go-sdk-folder": ".",


### PR DESCRIPTION
At the moment, we're having trouble running the profileBuilder in the
Swagger->SDK environment, because it assumes that GOPATH is set on the
machine in which it is running. Issue #1101 is tracking this and other
problems introduced by that dependency.
 