### PR TITLE
[AutoPR containerinstance/resource-manager] Fixing Error in Naming Convention for Rows and Cols in Terminal Size

### DIFF
--- a/services/containerinstance/mgmt/2018-02-01-preview/containerinstance/models.go
+++ b/services/containerinstance/mgmt/2018-02-01-preview/containerinstance/models.go
@@ -166,10 +166,10 @@ type ContainerExecRequest struct {
 
 // ContainerExecRequestTerminalSize the size of the terminal.
 type ContainerExecRequestTerminalSize struct {
-	// Row - The row size of the terminal
-	Row *int32 `json:"row,omitempty"`
-	// Column - The column size of the terminal
-	Column *int32 `json:"column,omitempty"`
+	// Rows - The row size of the terminal
+	Rows *int32 `json:"rows,omitempty"`
+	// Cols - The column size of the terminal
+	Cols *int32 `json:"cols,omitempty"`
 }
 
 // ContainerExecResponse the information for the container exec command.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2651