### PR TITLE
[AutoPR network/resource-manager] Adding optional traffic analytics config fields to network watcher config object for enhancing the Network Watcher cmdlets

### DIFF
--- a/services/network/mgmt/2018-01-01/network/models.go
+++ b/services/network/mgmt/2018-01-01/network/models.go
@@ -6668,12 +6668,13 @@ type ExpressRouteServiceProviderPropertiesFormat struct {
 	ProvisioningState *string `json:"provisioningState,omitempty"`
 }
 
-// FlowLogInformation information on the configuration of flow log.
+// FlowLogInformation information on the configuration of flow log and traffic analytics (optional).
 type FlowLogInformation struct {
 	autorest.Response `json:"-"`
 	// TargetResourceID - The ID of the resource to configure for flow logging.
-	TargetResourceID   *string `json:"targetResourceId,omitempty"`
-	*FlowLogProperties `json:"properties,omitempty"`
+	TargetResourceID            *string `json:"targetResourceId,omitempty"`
+	*FlowLogProperties          `json:"properties,omitempty"`
+	*TrafficAnalyticsProperties `json:"flowAnalyticsConfiguration,omitempty"`
 }
 
 // UnmarshalJSON is the custom unmarshaler for FlowLogInformation struct.
@@ -6703,6 +6704,15 @@ func (fli *FlowLogInformation) UnmarshalJSON(body []byte) error {
 				}
 				fli.FlowLogProperties = &flowLogProperties
 			}
+		case "flowAnalyticsConfiguration":
+			if v != nil {
+				var trafficAnalyticsProperties TrafficAnalyticsProperties
+				err = json.Unmarshal(*v, &trafficAnalyticsProperties)
+				if err != nil {
+					return err
+				}
+				fli.TrafficAnalyticsProperties = &trafficAnalyticsProperties
+			}
 		}
 	}
 
@@ -6718,9 +6728,10 @@ type FlowLogProperties struct {
 	RetentionPolicy *RetentionPolicyParameters `json:"retentionPolicy,omitempty"`
 }
 
-// FlowLogStatusParameters parameters that define a resource to query flow log status.
+// FlowLogStatusParameters parameters that define a resource to query flow log and traffic analytics (optional)
+// status.
 type FlowLogStatusParameters struct {
-	// TargetResourceID - The target resource where getting the flow logging status.
+	// TargetResourceID - The target resource where getting the flow logging and traffic analytics (optional) status.
 	TargetResourceID *string `json:"targetResourceId,omitempty"`
 }
 
@@ -13463,6 +13474,47 @@ type TopologyResource struct {
 	Location *string `json:"location,omitempty"`
 	// Associations - Holds the associations the resource has with other resources in the resource group.
 	Associations *[]TopologyAssociation `json:"associations,omitempty"`
+}
+
+// TrafficAnalyticsConfigurationProperties parameters that define the configuration of traffic analytics.
+type TrafficAnalyticsConfigurationProperties struct {
+	// Enabled - Flag to enable/disable traffic analytics.
+	Enabled *bool `json:"enabled,omitempty"`
+	// WorkspaceID - The resource guid of the attached workspace
+	WorkspaceID *string `json:"workspaceId,omitempty"`
+	// WorkspaceRegion - The location of the attached workspace
+	WorkspaceRegion *string `json:"workspaceRegion,omitempty"`
+	// WorkspaceResourceID - Resource Id of the attached workspace
+	WorkspaceResourceID *string `json:"workspaceResourceId,omitempty"`
+}
+
+// TrafficAnalyticsProperties parameters that define the configuration of traffic analytics.
+type TrafficAnalyticsProperties struct {
+	*TrafficAnalyticsConfigurationProperties `json:"networkWatcherFlowAnalyticsConfiguration,omitempty"`
+}
+
+// UnmarshalJSON is the custom unmarshaler for TrafficAnalyticsProperties struct.
+func (tap *TrafficAnalyticsProperties) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "networkWatcherFlowAnalyticsConfiguration":
+			if v != nil {
+				var trafficAnalyticsConfigurationProperties TrafficAnalyticsConfigurationProperties
+				err = json.Unmarshal(*v, &trafficAnalyticsConfigurationProperties)
+				if err != nil {
+					return err
+				}
+				tap.TrafficAnalyticsConfigurationProperties = &trafficAnalyticsConfigurationProperties
+			}
+		}
+	}
+
+	return nil
 }
 
 // TroubleshootingDetails information gained from troubleshooting of specified resource.

--- a/services/network/mgmt/2018-01-01/network/watchers.go
+++ b/services/network/mgmt/2018-01-01/network/watchers.go
@@ -403,10 +403,11 @@ func (client WatchersClient) GetAzureReachabilityReportResponder(resp *http.Resp
 	return
 }
 
-// GetFlowLogStatus queries status of flow log on a specified resource.
+// GetFlowLogStatus queries status of flow log and traffic analytics (optional) on a specified resource.
 //
 // resourceGroupName is the name of the network watcher resource group. networkWatcherName is the name of the
-// network watcher resource. parameters is parameters that define a resource to query flow log status.
+// network watcher resource. parameters is parameters that define a resource to query flow log and traffic
+// analytics (optional) status.
 func (client WatchersClient) GetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters) (result WatchersGetFlowLogStatusFuture, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: parameters,
@@ -1061,7 +1062,7 @@ func (client WatchersClient) ListAvailableProvidersResponder(resp *http.Response
 	return
 }
 
-// SetFlowLogConfiguration configures flow log on a specified resource.
+// SetFlowLogConfiguration configures flow log and traffic analytics (optional) on a specified resource.
 //
 // resourceGroupName is the name of the network watcher resource group. networkWatcherName is the name of the
 // network watcher resource. parameters is parameters that define the configuration of flow log.
@@ -1072,6 +1073,14 @@ func (client WatchersClient) SetFlowLogConfiguration(ctx context.Context, resour
 				{Target: "parameters.FlowLogProperties", Name: validation.Null, Rule: true,
 					Chain: []validation.Constraint{{Target: "parameters.FlowLogProperties.StorageID", Name: validation.Null, Rule: true, Chain: nil},
 						{Target: "parameters.FlowLogProperties.Enabled", Name: validation.Null, Rule: true, Chain: nil},
+					}},
+				{Target: "parameters.TrafficAnalyticsProperties", Name: validation.Null, Rule: false,
+					Chain: []validation.Constraint{{Target: "parameters.TrafficAnalyticsProperties.TrafficAnalyticsConfigurationProperties", Name: validation.Null, Rule: true,
+						Chain: []validation.Constraint{{Target: "parameters.TrafficAnalyticsProperties.TrafficAnalyticsConfigurationProperties.Enabled", Name: validation.Null, Rule: true, Chain: nil},
+							{Target: "parameters.TrafficAnalyticsProperties.TrafficAnalyticsConfigurationProperties.WorkspaceID", Name: validation.Null, Rule: true, Chain: nil},
+							{Target: "parameters.TrafficAnalyticsProperties.TrafficAnalyticsConfigurationProperties.WorkspaceRegion", Name: validation.Null, Rule: true, Chain: nil},
+							{Target: "parameters.TrafficAnalyticsProperties.TrafficAnalyticsConfigurationProperties.WorkspaceResourceID", Name: validation.Null, Rule: true, Chain: nil},
+						}},
 					}}}}}); err != nil {
 		return result, validation.NewError("network.WatchersClient", "SetFlowLogConfiguration", err.Error())
 	}


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2667