### PR TITLE
Remove hard dependency on GOPATH

### DIFF
--- a/tools/profileBuilder/cmd/list.go
+++ b/tools/profileBuilder/cmd/list.go
@@ -38,6 +38,12 @@ const (
 	inputDescription = "Specify a file to read for the list of packages, instead of stdin."
 )
 
+const (
+	gopathLongName    = "gopath"
+	gopathShortName   = "g"
+	gopathDescription = "The GOPATH, defaults to the environment's GOPATH if available.  If your environment doesn't set GOPATH you must specifiy it in this argument."
+)
+
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
@@ -82,8 +88,14 @@ $> ../model/testdata/smallProfile.txt > profileBuilder list --name small_profile
 			}
 		}
 
+		gopath := listFlags.GetString(gopathLongName)
+		if gopath == "" {
+			errLog.Printf("value for arg %s is empty, is your GOPATH set?", gopathLongName)
+			return
+		}
+
 		model.BuildProfile(
-			&model.ListStrategy{Reader: input},
+			&model.ListStrategy{Reader: input, Root: gopath},
 			listFlags.GetString(nameLongName),
 			listFlags.GetString(outputLocationLongName),
 			outputLog,
@@ -107,6 +119,7 @@ func init() {
 	listCmd.Flags().StringP(outputLocationLongName, outputLocationShortName, outputLocationDefault, outputLocationDescription)
 	listCmd.Flags().StringP(nameLongName, nameShortName, nameDefault, nameDescription)
 	listCmd.Flags().StringP(inputLongName, inputShortName, inputDefault, inputDescription)
+	listCmd.Flags().StringP(gopathLongName, gopathShortName, os.Getenv("GOPATH"), gopathDescription)
 
 	listFlags.BindPFlags(listCmd.Flags())
 

--- a/tools/profileBuilder/model/list.go
+++ b/tools/profileBuilder/model/list.go
@@ -19,7 +19,6 @@ package model
 import (
 	"fmt"
 	"io"
-	"os"
 	"path"
 
 	"github.com/marstr/collection"
@@ -28,9 +27,13 @@ import (
 // ListStrategy allows a mechanism for a list of packages that should be included in a profile.
 type ListStrategy struct {
 	io.Reader
+
+	// Root is the root directory of the packages.
+	Root string
 }
 
-// Enumerate reads a new line delimited list of packages names relative to $GOPATH
+// Enumerate reads a new line delimited list of packages names relative to the ListStrategy's root directory.
+// The root directory is usualy the same directory as the GOPATH environment variable.
 func (list ListStrategy) Enumerate(cancel <-chan struct{}) collection.Enumerator {
 	results := make(chan interface{})
 
@@ -45,7 +48,7 @@ func (list ListStrategy) Enumerate(cancel <-chan struct{}) collection.Enumerator
 				return
 			}
 
-			currentLine = path.Join(os.Getenv("GOPATH"), "src", currentLine)
+			currentLine = path.Join(list.Root, "src", currentLine)
 
 			select {
 			case results <- currentLine:

--- a/tools/profileBuilder/model/list_test.go
+++ b/tools/profileBuilder/model/list_test.go
@@ -56,7 +56,7 @@ func TestList_Enumerate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		subject := model.ListStrategy{Reader: tc}
+		subject := model.ListStrategy{Reader: tc, Root: gopath}
 		t.Run("", func(t *testing.T) {
 			done := make(chan struct{})
 			defer close(done)


### PR DESCRIPTION
The profile builder assumes that GOPATH will be set which might not
always be the case; this invariant has been removed.
Include package name in failure message so it can be investigated.
Moved formatting of package files to happen per package; this way it's
limited to touching files only within the current profile (before it
would touch all files which was confusing).

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 