### PR TITLE
Tweaks to profile builder.

### DIFF
--- a/tools/profileBuilder/model/transforms.go
+++ b/tools/profileBuilder/model/transforms.go
@@ -23,7 +23,6 @@ package model
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -103,12 +102,6 @@ func BuildProfile(packageList collection.Enumerable, name, outputLocation string
 		}
 	}
 	outputLog.Print(generated, " packages generated.")
-
-	if err := exec.Command("gofmt", "-w", outputLocation).Run(); err == nil {
-		outputLog.Print("Success formatting profile.")
-	} else {
-		errLog.Print("Trouble formatting profile: ", err)
-	}
 }
 
 // GetAliasPath takes an existing API Version path and a package name, and converts the path
@@ -119,7 +112,7 @@ func GetAliasPath(subject, profile string) (transformed string, err error) {
 
 	matches := packageName.FindAllStringSubmatch(subject, -1)
 	if matches == nil {
-		err = errors.New("path does not resemble a known package path")
+		err = fmt.Errorf("path '%s' does not resemble a known package path", subject)
 		return
 	}
 
@@ -325,5 +318,12 @@ func writeAliasPackage(x interface{}, outputLocation string, outputLog, errLog *
 	printer.Fprint(&b, files, file)
 	res, _ := imports.Process(outputPath, b.Bytes(), nil)
 	fmt.Fprintf(outputFile, "%s", res)
+	outputFile.Close()
+
+	if err := exec.Command("gofmt", "-w", outputPath).Run(); err == nil {
+		outputLog.Print("Success formatting profile.")
+	} else {
+		errLog.Print("Trouble formatting profile: ", err)
+	}
 	return true
 }


### PR DESCRIPTION
Include the bad path in the error message.
Close the file handle to avoid race conditions.
Moved formatting to be per file so that it only touches the contents of
the profile being generated.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 