### PR TITLE
Fixes to apidiff tool.

### DIFF
--- a/tools/apidiff/cmd/root.go
+++ b/tools/apidiff/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var copyRepoFlag bool
 var onlyAdditionsFlag bool
 var onlyBreakingChangesFlag bool
 var quietFlag bool
@@ -34,6 +35,7 @@ individual packages or a set of packages under a specified directory.`,
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVarP(&copyRepoFlag, "copyrepo", "c", false, "copy the repo instead of cloning it")
 	rootCmd.PersistentFlags().BoolVarP(&onlyAdditionsFlag, "additions", "a", false, "only include additive changes in the report")
 	rootCmd.PersistentFlags().BoolVarP(&onlyBreakingChangesFlag, "breakingchanges", "b", false, "only include breaking changes in the report")
 	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "suppress console output")

--- a/tools/apidiff/delta/delta.go
+++ b/tools/apidiff/delta/delta.go
@@ -19,6 +19,7 @@ import (
 )
 
 // GetExports returns a exports.Content struct containing all exports in rhs that aren't in lhs.
+// This includes any new fields added to structs or methods added to interfaces.
 func GetExports(lhs, rhs exports.Content) exports.Content {
 	nc := exports.NewContent()
 
@@ -43,6 +44,20 @@ func GetExports(lhs, rhs exports.Content) exports.Content {
 	for n, v := range rhs.Structs {
 		if _, ok := lhs.Structs[n]; !ok {
 			nc.Structs[n] = v
+		}
+	}
+
+	structFields := GetStructFields(lhs, rhs)
+	if len(structFields) > 0 {
+		for k, v := range structFields {
+			nc.Structs[k] = v
+		}
+	}
+
+	intMethods := GetInterfaceMethods(lhs, rhs)
+	if len(intMethods) > 0 {
+		for k, v := range intMethods {
+			nc.Interfaces[k] = v
 		}
 	}
 

--- a/tools/apidiff/delta/delta_test.go
+++ b/tools/apidiff/delta/delta_test.go
@@ -94,8 +94,8 @@ func Test_GetAddedExports(t *testing.T) {
 
 	// interface
 
-	if l := len(aContent.Interfaces); l != 1 {
-		t.Logf("wrong number of interfaces added, have %v, want %v", l, 1)
+	if l := len(aContent.Interfaces); l != 2 {
+		t.Logf("wrong number of interfaces added, have %v, want %v", l, 2)
 		t.Fail()
 	}
 
@@ -103,6 +103,9 @@ func Test_GetAddedExports(t *testing.T) {
 		"NewInterface": exports.Interface{Methods: map[string]exports.Func{
 			"One": exports.Func{Params: strPtr("int")},
 			"Two": exports.Func{Returns: strPtr("error")},
+		}},
+		"SomeInterface": exports.Interface{Methods: map[string]exports.Func{
+			"NewMethod": exports.Func{Params: strPtr("string"), Returns: strPtr("bool,error")},
 		}},
 	}
 
@@ -120,8 +123,8 @@ func Test_GetAddedExports(t *testing.T) {
 
 	// struct
 
-	if l := len(aContent.Structs); l != 2 {
-		t.Logf("wrong number of structs added, have %v, want %v", l, 2)
+	if l := len(aContent.Structs); l != 4 {
+		t.Logf("wrong number of structs added, have %v, want %v", l, 4)
 		t.Fail()
 	}
 
@@ -135,6 +138,16 @@ func Test_GetAddedExports(t *testing.T) {
 				"Format":    "*string",
 				"Prefix":    "*string",
 				"Container": "*string",
+			},
+		},
+		"CreateProperties": exports.Struct{
+			Fields: map[string]string{
+				"NewField": "*float64",
+			},
+		},
+		"DeleteFuture": exports.Struct{
+			Fields: map[string]string{
+				"NewField": "string",
 			},
 		},
 	}

--- a/tools/apidiff/ioext/ioext.go
+++ b/tools/apidiff/ioext/ioext.go
@@ -1,0 +1,134 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ioext
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// CopyDir recursively copies the specified source directory tree to the
+// specified destination.  The destination directory must not exist.  Any
+// symlinks under src are ignored.
+func CopyDir(src, dst string) error {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	// verify that src is a directory
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !srcInfo.IsDir() {
+		return fmt.Errorf("source is not a directory")
+	}
+
+	// now verify that dst doesn't exist
+	_, err = os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil {
+		return fmt.Errorf("destination directory already exists")
+	}
+
+	err = os.MkdirAll(dst, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	// get the collection of directory entries under src.
+	// for each entry build its corresponding path under dst.
+	entries, err := ioutil.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		// skip symlinks
+		if entry.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			err = CopyDir(srcPath, dstPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = CopyFile(srcPath, dstPath, true)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// CopyFile copies the specified source file to the specified destination file.
+// Specify true for overwrite to overwrite the destination file if it already exits.
+func CopyFile(src, dst string, overwrite bool) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	if !overwrite {
+		// check if the file exists, if it does then return an error
+		_, err := os.Stat(dst)
+		if err != nil && !os.IsNotExist(err) {
+			return errors.New("won't overwrite destination file")
+		}
+	}
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	// flush the buffer
+	err = dstFile.Sync()
+	if err != nil {
+		return err
+	}
+
+	// copy file permissions
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	err = os.Chmod(dst, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixed a bug in breakingChanges.isEmpty() that was causing it to return
true when it should have returned false.
Convert relative package(s) path to absolute path.
Added switch "copyrep" to copy the source repo instead of cloning it;
useful for CI so things like FETCH_HEAD are preserved.
Include new struct fields and interface methods in GetExports().
Added package ioext containing various IO extension funcs.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 