### PR TITLE
Add breaking changes detection to travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,21 @@ go:
   - 1.10.x
   - master
 
+env:
+  matrix:
+    - MODE=default
+    - MODE=breaking
+
 matrix:
+  exclude:
+  - go: 1.8.x
+    env: MODE=breaking
+  - go: 1.9.x
+    env: MODE=breaking
+  - go: master
+    env: MODE=breaking
   allow_failures:
+    - env: MODE=breaking
     - go: master
 
 install:
@@ -17,9 +30,16 @@ install:
   - dep ensure
 
 script:
-  - bash rungas.sh
-  - grep -L -r --include *.go --exclude-dir vendor -P "Copyright (\d{4}|\(c\)) Microsoft" ./ | tee /dev/stderr | test -z "$(< /dev/stdin)"
-  - test -z "$(go build $(go list ./... | grep -v vendor) | tee /dev/stderr)"
-  - test -z "$(go fmt $(go list ./... | grep -v vendor) | tee /dev/stderr)"
-  - go vet $(go list ./... | grep -v vendor)
-  - go test $(sh ./findTestedPackages.sh)
+  - >-
+    if [[ $MODE == 'default' ]]; then
+      bash rungas.sh
+      grep -L -r --include *.go --exclude-dir vendor -P "Copyright (\d{4}|\(c\)) Microsoft" ./ | tee /dev/stderr | test -z "$(< /dev/stdin)"
+      test -z "$(go build $(go list ./... | grep -v vendor) | tee /dev/stderr)"
+      test -z "$(go fmt $(go list ./... | grep -v vendor) | tee /dev/stderr)"
+      go vet $(go list ./... | grep -v vendor)
+      go test $(sh ./findTestedPackages.sh)
+    fi
+  - >-
+    if [[ $MODE == 'breaking' ]]; then
+      go run ./tools/apidiff/main.go packages ./services FETCH_HEAD~1 FETCH_HEAD --copyrepo --breakingchanges
+    fi


### PR DESCRIPTION
Run the apidiff tool in travis to report breaking changes in a PR.  The
tool is run as an allowed failure and will return a non-zero exit code
if there are breaking changes so the task shows up as red.  The raw JSON
log will also be output to the console.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 