### PR TITLE
Updates to apidiff tool

### DIFF
--- a/tools/apidiff/cmd/common.go
+++ b/tools/apidiff/cmd/common.go
@@ -69,6 +69,42 @@ func (bc breakingChanges) isEmpty() bool {
 		(bc.Removed == nil || bc.Removed.IsEmpty())
 }
 
+// represents a collection of per-package reports, one for each commit hash
+type commitPkgReport struct {
+	BreakingChanges []string             `json:"breakingChanges,omitempty"`
+	CommitsReports  map[string]pkgReport `json:"deltas"`
+}
+
+// returns true if the report contains no data
+func (c commitPkgReport) isEmpty() bool {
+	for _, rpt := range c.CommitsReports {
+		if !rpt.isEmpty() {
+			return false
+		}
+	}
+	return true
+}
+
+// returns true if the report contains breaking changes
+func (c commitPkgReport) hasBreakingChanges() bool {
+	for _, r := range c.CommitsReports {
+		if r.hasBreakingChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+// returns true if the report contains additive changes
+func (c commitPkgReport) hasAdditiveChanges() bool {
+	for _, r := range c.CommitsReports {
+		if r.hasAdditiveChanges() {
+			return true
+		}
+	}
+	return false
+}
+
 // represents a per-package report, contains additive and breaking changes
 type pkgReport struct {
 	AdditiveChanges *exports.Content `json:"additiveChanges,omitempty"`
@@ -134,22 +170,31 @@ func printReport(r report) error {
 	return nil
 }
 
-func processArgsAndClone(args []string) (dir string, cln repo.WorkingTree, clean func(), err error) {
+func processArgsAndClone(args []string) (cln repo.WorkingTree, err error) {
 	if onlyAdditionsFlag && onlyBreakingChangesFlag {
 		err = errors.New("flags 'additions' and 'breakingchanges' are mutually exclusive")
 		return
 	}
 
-	if len(args) < 3 {
+	// there should be at minimum two args, a directory and a
+	// sequence of commits, i.e. "d:\foo 1,2,3".  else a directory
+	// and two commits, i.e. "d:\foo 1 2" or "d:\foo 1 2,3"
+	if len(args) < 2 {
 		err = errors.New("not enough args were supplied")
 		return
 	}
 
-	dir = args[0]
+	// here args[1] should be a comma-delimited list of commits
+	if len(args) == 2 && strings.Index(args[1], ",") < 0 {
+		err = errors.New("expected a comma-delimited list of commits")
+		return
+	}
 
+	dir := args[0]
 	dir, err = filepath.Abs(dir)
 	if err != nil {
 		err = fmt.Errorf("failed to convert path '%s' to absolute path: %v", dir, err)
+		return
 	}
 
 	src, err := repo.Get(dir)
@@ -180,18 +225,53 @@ func processArgsAndClone(args []string) (dir string, cln repo.WorkingTree, clean
 		}
 	}
 
-	clean = func() {
+	// fix up pkgDir to the clone
+	args[0] = strings.Replace(dir, src.Root(), cln.Root(), 1)
+
+	return
+}
+
+type reportGenFunc func(dir string, cln repo.WorkingTree, baseCommit, targetCommit string) error
+
+func generateReports(args []string, cln repo.WorkingTree, fn reportGenFunc) error {
+	defer func() {
 		// delete clone
 		vprintln("cleaning up clone")
-		err = os.RemoveAll(cln.Root())
+		err := os.RemoveAll(cln.Root())
 		if err != nil {
 			vprintf("failed to delete temp repo: %v\n", err)
 		}
+	}()
+
+	var commits []string
+
+	// if the commits are specified as 1 2,3,4 then it means that commit 1 is
+	// always the base commit and to compare it against each target commit in
+	// the sequence.  however if it's specifed as 1,2,3,4 then the base commit
+	// is relative to the iteration, i.e. compare 1-2, 2-3, 3-4.
+	fixedBase := true
+	if len(args) == 3 {
+		commits = make([]string, 2, 2)
+		commits[0] = args[1]
+		commits[1] = args[2]
+	} else {
+		commits = strings.Split(args[1], ",")
+		fixedBase = false
 	}
 
-	// fix up pkgDir to the clone
-	dir = strings.Replace(dir, src.Root(), cln.Root(), 1)
-	return
+	for i := 0; i+1 < len(commits); i++ {
+		baseCommit := commits[i]
+		if fixedBase {
+			baseCommit = commits[0]
+		}
+		targetCommit := commits[i+1]
+
+		err := fn(args[0], cln, baseCommit, targetCommit)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type reportStatus interface {

--- a/tools/apidiff/cmd/package.go
+++ b/tools/apidiff/cmd/package.go
@@ -23,11 +23,13 @@ import (
 )
 
 var packageCmd = &cobra.Command{
-	Use:   "package [package dir] [base commit] [target commit]",
-	Short: "Generates report for the package in the specified directory.",
-	Long: `The package command generates a report for the package in the directory specified in [package dir].
-The package content in [target commit] is compared against the package content in [base commit]
-to determine what changes were introduced in [target commit].`,
+	Use:   "package <package dir> (<base commit> <target commit(s)>) | (<commit sequence>)",
+	Short: "Generates a report for the package in the specified directory containing the delta between commits.",
+	Long: `The package command generates a report for the package in the directory specified in <package dir>.
+Commits can be specified as either a base and one or more target commits or a sequence of commits.
+For a base/target pair each target commit is compared against the base commit.
+For a commit sequence each commit N in the sequence is compared against commit N+1.
+Commit sequences must be comma-delimited.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rpt, err := thePackageCmd(args)
 		if err != nil {
@@ -39,31 +41,42 @@ to determine what changes were introduced in [target commit].`,
 }
 
 // split into its own func as we can't call os.Exit from it (the defer won't get executed)
-func thePackageCmd(args []string) (rpt pkgReport, err error) {
-	pkgDir, cloneRepo, cleanupFn, err := processArgsAndClone(args)
-	if err != nil {
-		return
-	}
-	defer cleanupFn()
-
-	baseCommit := args[1]
-	targetCommit := args[2]
-
-	// lhs
-	vprintf("checking out base commit %s and gathering exports\n", baseCommit)
-	lhs, err := getContentForCommit(cloneRepo, pkgDir, baseCommit)
+func thePackageCmd(args []string) (rpt commitPkgReport, err error) {
+	cloneRepo, err := processArgsAndClone(args)
 	if err != nil {
 		return
 	}
 
-	// rhs
-	vprintf("checking out target commit %s and gathering exports\n", targetCommit)
-	rhs, err := getContentForCommit(cloneRepo, pkgDir, targetCommit)
+	rpt.CommitsReports = map[string]pkgReport{}
+	worker := func(pkgDir string, cloneRepo repo.WorkingTree, baseCommit, targetCommit string) error {
+		// lhs
+		vprintf("checking out base commit %s and gathering exports\n", baseCommit)
+		var lhs exports.Content
+		lhs, err = getContentForCommit(cloneRepo, pkgDir, baseCommit)
+		if err != nil {
+			return err
+		}
+
+		// rhs
+		vprintf("checking out target commit %s and gathering exports\n", targetCommit)
+		var rhs exports.Content
+		rhs, err = getContentForCommit(cloneRepo, pkgDir, targetCommit)
+		if err != nil {
+			return err
+		}
+		r := getPkgReport(lhs, rhs)
+		if r.hasBreakingChanges() {
+			rpt.BreakingChanges = append(rpt.BreakingChanges, targetCommit)
+		}
+		rpt.CommitsReports[fmt.Sprintf("%s:%s", baseCommit, targetCommit)] = r
+		return nil
+	}
+
+	err = generateReports(args, cloneRepo, worker)
 	if err != nil {
 		return
 	}
 
-	rpt = getPkgReport(lhs, rhs)
 	err = printReport(rpt)
 	return
 }

--- a/tools/apidiff/cmd/packages.go
+++ b/tools/apidiff/cmd/packages.go
@@ -27,11 +27,13 @@ import (
 )
 
 var packagesCmd = &cobra.Command{
-	Use:   "packages [package search dir] [base commit] [target commit]",
-	Short: "Generates report for all packages under the specified directory.",
-	Long: `The packages command generates a report for all of the packages under the directory specified in [package dir].
-The package content in [target commit] is compared against the package content in [base commit]
-to determine what changes were introduced in [target commit].`,
+	Use:   "packages <package search dir> (<base commit> <target commit(s)>) | (<commit sequence>)",
+	Short: "Generates a report for all packages under the specified directory containing the delta between commits.",
+	Long: `The packages command generates a report for all of the packages under the directory specified in <package dir>.
+Commits can be specified as either a base and one or more target commits or a sequence of commits.
+For a base/target pair each target commit is compared against the base commit.
+For a commit sequence each commit N in the sequence is compared against commit N+1.
+Commit sequences must be comma-delimited.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rpt, err := thePackagesCmd(args)
 		if err != nil {
@@ -47,32 +49,42 @@ func init() {
 }
 
 // split into its own func as we can't call os.Exit from it (the defer won't get executed)
-func thePackagesCmd(args []string) (rpt pkgsReport, err error) {
-	rootDir, cloneRepo, cleanupFn, err := processArgsAndClone(args)
-	if err != nil {
-		return
-	}
-	defer cleanupFn()
-
-	baseCommit := args[1]
-	targetCommit := args[2]
-
-	// get for lhs
-	vprintf("checking out base commit %s and gathering exports\n", baseCommit)
-	lhs, err := getRepoContentForCommit(cloneRepo, rootDir, baseCommit)
+func thePackagesCmd(args []string) (rpt commitPkgsReport, err error) {
+	cloneRepo, err := processArgsAndClone(args)
 	if err != nil {
 		return
 	}
 
-	// get for rhs
-	vprintf("checking out target commit %s and gathering exports\n", targetCommit)
-	rhs, err := getRepoContentForCommit(cloneRepo, rootDir, targetCommit)
+	rpt.CommitsReports = map[string]pkgsReport{}
+	worker := func(rootDir string, cloneRepo repo.WorkingTree, baseCommit, targetCommit string) error {
+		// get for lhs
+		vprintf("checking out base commit %s and gathering exports\n", baseCommit)
+		lhs, err := getRepoContentForCommit(cloneRepo, rootDir, baseCommit)
+		if err != nil {
+			return err
+		}
+
+		// get for rhs
+		vprintf("checking out target commit %s and gathering exports\n", targetCommit)
+		var rhs repoContent
+		rhs, err = getRepoContentForCommit(cloneRepo, rootDir, targetCommit)
+		if err != nil {
+			return err
+		}
+		r := getPkgsReport(lhs, rhs)
+		rpt.updateAffectedPackages(targetCommit, r)
+		if r.hasBreakingChanges() {
+			rpt.BreakingChanges = append(rpt.BreakingChanges, targetCommit)
+		}
+		rpt.CommitsReports[fmt.Sprintf("%s:%s", baseCommit, targetCommit)] = r
+		return nil
+	}
+
+	err = generateReports(args, cloneRepo, worker)
 	if err != nil {
 		return
 	}
 
-	// diff and report
-	rpt = getPkgsReport(lhs, rhs)
 	err = printReport(rpt)
 	return
 }
@@ -160,6 +172,68 @@ type pkgsList map[string][]string
 
 // contains a collection of package reports, it's structured as "package":"apiversion":pkgReport
 type modifiedPackages map[string]map[string]pkgReport
+
+// represents a collection of reports, one for each commit hash
+type commitPkgsReport struct {
+	AffectedPackages pkgsList              `json:"affectedPackages"`
+	BreakingChanges  []string              `json:"breakingChanges,omitempty"`
+	CommitsReports   map[string]pkgsReport `json:"deltas"`
+}
+
+// returns true if the report contains no data
+func (c commitPkgsReport) isEmpty() bool {
+	for _, r := range c.CommitsReports {
+		if !r.isEmpty() {
+			return false
+		}
+	}
+	return true
+}
+
+// returns true if the report contains breaking changes
+func (c commitPkgsReport) hasBreakingChanges() bool {
+	for _, r := range c.CommitsReports {
+		if r.hasBreakingChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+// returns true if the package contains additive changes
+func (c commitPkgsReport) hasAdditiveChanges() bool {
+	for _, r := range c.CommitsReports {
+		if r.hasAdditiveChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+// updates the collection of affected packages with the packages that were touched in the specified commit
+func (c *commitPkgsReport) updateAffectedPackages(commit string, r pkgsReport) {
+	if c.AffectedPackages == nil {
+		c.AffectedPackages = map[string][]string{}
+	}
+
+	for pkgName, apiVers := range r.AddedPackages {
+		for _, apiVer := range apiVers {
+			c.AffectedPackages[commit] = append(c.AffectedPackages[commit], fmt.Sprintf("%s/%s", pkgName, apiVer))
+		}
+	}
+
+	for pkgName, apiVers := range r.ModifiedPackages {
+		for apiVer := range apiVers {
+			c.AffectedPackages[commit] = append(c.AffectedPackages[commit], fmt.Sprintf("%s/%s", pkgName, apiVer))
+		}
+	}
+
+	for pkgName, apiVers := range r.RemovedPackages {
+		for _, apiVer := range apiVers {
+			c.AffectedPackages[commit] = append(c.AffectedPackages[commit], fmt.Sprintf("%s/%s", pkgName, apiVer))
+		}
+	}
+}
 
 // represents a complete report of added, removed, and modified packages
 type pkgsReport struct {


### PR DESCRIPTION
To support porting non-breaking changes the generated report now
includes the collection of packages impacted by commit along with a list
of commits that introduce breaking changes.
Moved the changes to a "deltas" field in the report; each entry is an
object described as "base:target" commit range.
Added support for report generation based on a sequence of commits, see
the help documentation for further details on how this works.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 