### PR TITLE
New Log Analytics Sku - PerGB2018

### DIFF
--- a/profiles/preview/operationalinsights/mgmt/operationalinsights/models.go
+++ b/profiles/preview/operationalinsights/mgmt/operationalinsights/models.go
@@ -95,6 +95,7 @@ type SkuNameEnum = original.SkuNameEnum
 
 const (
 	Free       SkuNameEnum = original.Free
+	PerGB2018  SkuNameEnum = original.PerGB2018
 	PerNode    SkuNameEnum = original.PerNode
 	Premium    SkuNameEnum = original.Premium
 	Standalone SkuNameEnum = original.Standalone

--- a/services/operationalinsights/mgmt/2015-11-01-preview/operationalinsights/models.go
+++ b/services/operationalinsights/mgmt/2015-11-01-preview/operationalinsights/models.go
@@ -96,6 +96,8 @@ type SkuNameEnum string
 const (
 	// Free ...
 	Free SkuNameEnum = "Free"
+	// PerGB2018
+	PerGB2018 SkuNameEnum = "PerGB2018"
 	// PerNode ...
 	PerNode SkuNameEnum = "PerNode"
 	// Premium ...
@@ -110,7 +112,7 @@ const (
 
 // PossibleSkuNameEnumValues returns an array of possible values for the SkuNameEnum const type.
 func PossibleSkuNameEnumValues() []SkuNameEnum {
-	return []SkuNameEnum{Free, PerNode, Premium, Standalone, Standard, Unlimited}
+	return []SkuNameEnum{Free, PerGB2018, PerNode, Premium, Standalone, Standard, Unlimited}
 }
 
 // DataSource datasources under OMS Workspace.
@@ -653,7 +655,7 @@ type SharedKeys struct {
 
 // Sku the SKU (tier) of a workspace.
 type Sku struct {
-	// Name - The name of the SKU. Possible values include: 'Free', 'Standard', 'Premium', 'Unlimited', 'PerNode', 'Standalone'
+	// Name - The name of the SKU. Possible values include: 'Free', 'Standard', 'Premium', 'Unlimited', 'PerGB2018', PerNode', 'Standalone'
 	Name SkuNameEnum `json:"name,omitempty"`
 }
 


### PR DESCRIPTION
 - [x] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
 - [x] I've tested my changes, adding unit tests where applicable.
 - [x] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 
On April 3rd, 2018 Microsoft changed the pricing tiers for Log Analytics.

https://azure.microsoft.com/en-us/blog/introducing-a-new-way-to-purchase-azure-monitoring-services/

I did some research and was able to find the new Sku name, `PerGB2018`. This is not officially documented anywhere yet that I can find. I successfully tested a deployment with the Azure RM Terraform provider using the new Sku with my forked code.

I believe the old Skus will still work if you have an older Azure subscription and have deployed Log Analytics services prior to April 3, 2018. I am unable to test this in my subscription.

