### PR TITLE
[AutoPR eventhub/resource-manager] Event Hubs: reverted removal of Messaging plan from namespace

### DIFF
--- a/services/eventhub/mgmt/2017-04-01/eventhub/models.go
+++ b/services/eventhub/mgmt/2017-04-01/eventhub/models.go
@@ -1239,6 +1239,127 @@ func (page ListResultPage) Values() []Model {
 	return *page.lr.Value
 }
 
+// MessagingPlan messaging
+type MessagingPlan struct {
+	autorest.Response        `json:"-"`
+	*MessagingPlanproperties `json:"properties,omitempty"`
+	// Location - Resource location
+	Location *string `json:"location,omitempty"`
+	// Tags - Resource tags
+	Tags map[string]*string `json:"tags"`
+	// ID - Resource Id
+	ID *string `json:"id,omitempty"`
+	// Name - Resource name
+	Name *string `json:"name,omitempty"`
+	// Type - Resource type
+	Type *string `json:"type,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for MessagingPlan.
+func (mp MessagingPlan) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if mp.MessagingPlanproperties != nil {
+		objectMap["properties"] = mp.MessagingPlanproperties
+	}
+	if mp.Location != nil {
+		objectMap["location"] = mp.Location
+	}
+	if mp.Tags != nil {
+		objectMap["tags"] = mp.Tags
+	}
+	if mp.ID != nil {
+		objectMap["id"] = mp.ID
+	}
+	if mp.Name != nil {
+		objectMap["name"] = mp.Name
+	}
+	if mp.Type != nil {
+		objectMap["type"] = mp.Type
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for MessagingPlan struct.
+func (mp *MessagingPlan) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "properties":
+			if v != nil {
+				var messagingPlanproperties MessagingPlanproperties
+				err = json.Unmarshal(*v, &messagingPlanproperties)
+				if err != nil {
+					return err
+				}
+				mp.MessagingPlanproperties = &messagingPlanproperties
+			}
+		case "location":
+			if v != nil {
+				var location string
+				err = json.Unmarshal(*v, &location)
+				if err != nil {
+					return err
+				}
+				mp.Location = &location
+			}
+		case "tags":
+			if v != nil {
+				var tags map[string]*string
+				err = json.Unmarshal(*v, &tags)
+				if err != nil {
+					return err
+				}
+				mp.Tags = tags
+			}
+		case "id":
+			if v != nil {
+				var ID string
+				err = json.Unmarshal(*v, &ID)
+				if err != nil {
+					return err
+				}
+				mp.ID = &ID
+			}
+		case "name":
+			if v != nil {
+				var name string
+				err = json.Unmarshal(*v, &name)
+				if err != nil {
+					return err
+				}
+				mp.Name = &name
+			}
+		case "type":
+			if v != nil {
+				var typeVar string
+				err = json.Unmarshal(*v, &typeVar)
+				if err != nil {
+					return err
+				}
+				mp.Type = &typeVar
+			}
+		}
+	}
+
+	return nil
+}
+
+// MessagingPlanproperties messaging Region
+type MessagingPlanproperties struct {
+	// Sku - Sku type
+	Sku *int32 `json:"sku,omitempty"`
+	// SelectedEventHubUnit - Selected event hub unit
+	SelectedEventHubUnit *int32 `json:"selectedEventHubUnit,omitempty"`
+	// UpdatedAt - The exact time the messaging plan was updated.
+	UpdatedAt *date.Time `json:"updatedAt,omitempty"`
+	// Revision - revision number
+	Revision *int64 `json:"revision,omitempty"`
+}
+
 // MessagingRegions messaging Region
 type MessagingRegions struct {
 	Properties *MessagingRegionsProperties `json:"properties,omitempty"`

--- a/services/eventhub/mgmt/2017-04-01/eventhub/namespaces.go
+++ b/services/eventhub/mgmt/2017-04-01/eventhub/namespaces.go
@@ -981,6 +981,83 @@ func (client NamespacesClient) ListKeysResponder(resp *http.Response) (result Ac
 	return
 }
 
+// MessagingPlanGet gets a description for the specified namespace.
+//
+// resourceGroupName is name of the resource group within the azure subscription. namespaceName is the Namespace
+// name
+func (client NamespacesClient) MessagingPlanGet(ctx context.Context, resourceGroupName string, namespaceName string) (result MessagingPlan, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("eventhub.NamespacesClient", "MessagingPlanGet", err.Error())
+	}
+
+	req, err := client.MessagingPlanGetPreparer(ctx, resourceGroupName, namespaceName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "MessagingPlanGet", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.MessagingPlanGetSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "MessagingPlanGet", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.MessagingPlanGetResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "MessagingPlanGet", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// MessagingPlanGetPreparer prepares the MessagingPlanGet request.
+func (client NamespacesClient) MessagingPlanGetPreparer(ctx context.Context, resourceGroupName string, namespaceName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/messagingplan", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// MessagingPlanGetSender sends the MessagingPlanGet request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) MessagingPlanGetSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// MessagingPlanGetResponder handles the response to the MessagingPlanGet request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) MessagingPlanGetResponder(resp *http.Response) (result MessagingPlan, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // RegenerateKeys regenerates the primary or secondary connection strings for the specified Namespace.
 //
 // resourceGroupName is name of the resource group within the azure subscription. namespaceName is the Namespace


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2831