### PR TITLE
[AutoPR monitor/resource-manager] fix documentation bug: max length of Group Short Name should be 12

### DIFF
--- a/services/monitor/mgmt/2017-05-01-preview/insights/actiongroups.go
+++ b/services/monitor/mgmt/2017-05-01-preview/insights/actiongroups.go
@@ -49,7 +49,7 @@ func (client ActionGroupsClient) CreateOrUpdate(ctx context.Context, resourceGro
 		{TargetValue: actionGroup,
 			Constraints: []validation.Constraint{{Target: "actionGroup.ActionGroup", Name: validation.Null, Rule: false,
 				Chain: []validation.Constraint{{Target: "actionGroup.ActionGroup.GroupShortName", Name: validation.Null, Rule: true,
-					Chain: []validation.Constraint{{Target: "actionGroup.ActionGroup.GroupShortName", Name: validation.MaxLength, Rule: 15, Chain: nil}}},
+					Chain: []validation.Constraint{{Target: "actionGroup.ActionGroup.GroupShortName", Name: validation.MaxLength, Rule: 12, Chain: nil}}},
 					{Target: "actionGroup.ActionGroup.Enabled", Name: validation.Null, Rule: true, Chain: nil},
 				}}}}}); err != nil {
 		return result, validation.NewError("insights.ActionGroupsClient", "CreateOrUpdate", err.Error())

--- a/services/monitor/mgmt/2018-03-01/insights/actiongroups.go
+++ b/services/monitor/mgmt/2018-03-01/insights/actiongroups.go
@@ -49,7 +49,7 @@ func (client ActionGroupsClient) CreateOrUpdate(ctx context.Context, resourceGro
 		{TargetValue: actionGroup,
 			Constraints: []validation.Constraint{{Target: "actionGroup.ActionGroup", Name: validation.Null, Rule: false,
 				Chain: []validation.Constraint{{Target: "actionGroup.ActionGroup.GroupShortName", Name: validation.Null, Rule: true,
-					Chain: []validation.Constraint{{Target: "actionGroup.ActionGroup.GroupShortName", Name: validation.MaxLength, Rule: 15, Chain: nil}}},
+					Chain: []validation.Constraint{{Target: "actionGroup.ActionGroup.GroupShortName", Name: validation.MaxLength, Rule: 12, Chain: nil}}},
 					{Target: "actionGroup.ActionGroup.Enabled", Name: validation.Null, Rule: true, Chain: nil},
 				}}}}}); err != nil {
 		return result, validation.NewError("insights.ActionGroupsClient", "CreateOrUpdate", err.Error())


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2841