### PR TITLE
Read and close response body after each retry

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -120,6 +120,7 @@ func (ds *DefaultSender) Send(c *Client, req *http.Request) (resp *http.Response
 		if err != nil || !autorest.ResponseHasStatusCode(resp, ds.ValidStatusCodes...) {
 			return resp, err
 		}
+		readAndCloseBody(resp.Body)
 		autorest.DelayForBackoff(ds.RetryDuration, attempts, req.Cancel)
 		ds.attempts = attempts
 	}


### PR DESCRIPTION
The only change here is when returned error is nil (the Response is guaranteed to contain a non-nil Body); in other cases throughout the code, readAndCloseBody is already called.

Without this fix, retries will cause connection leaks

Fixes https://github.com/Azure/azure-sdk-for-go/issues/1500

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 