### PR TITLE
Drain response body without allocating a buffer.

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -140,7 +140,7 @@ func (b *Blob) Exists() (bool, error) {
 	headers := b.Container.bsc.client.getStandardHeaders()
 	resp, err := b.Container.bsc.client.exec(http.MethodHead, uri, headers, nil, b.Container.bsc.auth)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound {
 			return resp.StatusCode == http.StatusOK, nil
 		}
@@ -293,7 +293,7 @@ func (b *Blob) CreateSnapshot(options *SnapshotOptions) (snapshotTimestamp *time
 	if err != nil || resp == nil {
 		return nil, err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err := checkRespCode(resp, []int{http.StatusCreated}); err != nil {
 		return nil, err
@@ -340,7 +340,7 @@ func (b *Blob) GetProperties(options *GetBlobPropertiesOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err = checkRespCode(resp, []int{http.StatusOK}); err != nil {
 		return err
@@ -463,7 +463,7 @@ func (b *Blob) SetProperties(options *SetBlobPropertiesOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusOK})
 }
 
@@ -501,7 +501,7 @@ func (b *Blob) SetMetadata(options *SetBlobMetadataOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusOK})
 }
 
@@ -538,7 +538,7 @@ func (b *Blob) GetMetadata(options *GetBlobMetadataOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err := checkRespCode(resp, []int{http.StatusOK}); err != nil {
 		return err
@@ -574,7 +574,7 @@ func (b *Blob) Delete(options *DeleteBlobOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusAccepted})
 }
 
@@ -585,7 +585,7 @@ func (b *Blob) Delete(options *DeleteBlobOptions) error {
 func (b *Blob) DeleteIfExists(options *DeleteBlobOptions) (bool, error) {
 	resp, err := b.delete(options)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNotFound {
 			return resp.StatusCode == http.StatusAccepted, nil
 		}
@@ -622,7 +622,7 @@ func pathForResource(container, name string) string {
 }
 
 func (b *Blob) respondCreation(resp *http.Response, bt BlobType) error {
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	err := checkRespCode(resp, []int{http.StatusCreated})
 	if err != nil {
 		return err

--- a/storage/blockblob.go
+++ b/storage/blockblob.go
@@ -229,7 +229,7 @@ func (b *Blob) PutBlockList(blocks []Block, options *PutBlockListOptions) error 
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusCreated})
 }
 

--- a/storage/client.go
+++ b/storage/client.go
@@ -120,7 +120,7 @@ func (ds *DefaultSender) Send(c *Client, req *http.Request) (resp *http.Response
 		if err != nil || !autorest.ResponseHasStatusCode(resp, ds.ValidStatusCodes...) {
 			return resp, err
 		}
-		readAndCloseBody(resp.Body)
+		drainRespBody(resp)
 		autorest.DelayForBackoff(ds.RetryDuration, attempts, req.Cancel)
 		ds.attempts = attempts
 	}
@@ -883,6 +883,12 @@ func readAndCloseBody(body io.ReadCloser) ([]byte, error) {
 		err = nil
 	}
 	return out, err
+}
+
+// reads the response body then closes it
+func drainRespBody(resp *http.Response) {
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
 }
 
 func serviceErrFromXML(body []byte, storageErr *AzureStorageServiceError) error {

--- a/storage/client.go
+++ b/storage/client.go
@@ -120,6 +120,7 @@ func (ds *DefaultSender) Send(c *Client, req *http.Request) (resp *http.Response
 		if err != nil || !autorest.ResponseHasStatusCode(resp, ds.ValidStatusCodes...) {
 			return resp, err
 		}
+		readAndCloseBody(resp.Body)
 		autorest.DelayForBackoff(ds.RetryDuration, attempts, req.Cancel)
 		ds.attempts = attempts
 	}

--- a/storage/container.go
+++ b/storage/container.go
@@ -258,7 +258,7 @@ func (c *Container) Create(options *CreateContainerOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusCreated})
 }
 
@@ -267,7 +267,7 @@ func (c *Container) Create(options *CreateContainerOptions) error {
 func (c *Container) CreateIfNotExists(options *CreateContainerOptions) (bool, error) {
 	resp, err := c.create(options)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusConflict {
 			return resp.StatusCode == http.StatusCreated, nil
 		}
@@ -307,7 +307,7 @@ func (c *Container) Exists() (bool, error) {
 
 	resp, err := c.bsc.client.exec(http.MethodHead, uri, headers, nil, c.bsc.auth)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound {
 			return resp.StatusCode == http.StatusOK, nil
 		}
@@ -349,7 +349,7 @@ func (c *Container) SetPermissions(permissions ContainerPermissions, options *Se
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusOK})
 }
 
@@ -431,7 +431,7 @@ func (c *Container) Delete(options *DeleteContainerOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusAccepted})
 }
 
@@ -444,7 +444,7 @@ func (c *Container) Delete(options *DeleteContainerOptions) error {
 func (c *Container) DeleteIfExists(options *DeleteContainerOptions) (bool, error) {
 	resp, err := c.delete(options)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNotFound {
 			return resp.StatusCode == http.StatusAccepted, nil
 		}
@@ -535,7 +535,7 @@ func (c *Container) SetMetadata(options *ContainerMetadataOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusOK})
 }
 
@@ -563,7 +563,7 @@ func (c *Container) GetMetadata(options *ContainerMetadataOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	if err := checkRespCode(resp, []int{http.StatusOK}); err != nil {
 		return err
 	}

--- a/storage/copyblob.go
+++ b/storage/copyblob.go
@@ -110,7 +110,7 @@ func (b *Blob) StartCopy(sourceBlob string, options *CopyOptions) (string, error
 	if err != nil {
 		return "", err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err := checkRespCode(resp, []int{http.StatusAccepted, http.StatusCreated}); err != nil {
 		return "", err
@@ -152,7 +152,7 @@ func (b *Blob) AbortCopy(copyID string, options *AbortCopyOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusNoContent})
 }
 
@@ -223,7 +223,7 @@ func (b *Blob) IncrementalCopyBlob(sourceBlobURL string, snapshotTime time.Time,
 	if err != nil {
 		return "", err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err := checkRespCode(resp, []int{http.StatusAccepted}); err != nil {
 		return "", err

--- a/storage/directory.go
+++ b/storage/directory.go
@@ -107,7 +107,7 @@ func (d *Directory) CreateIfNotExists(options *FileRequestOptions) (bool, error)
 	params := prepareOptions(options)
 	resp, err := d.fsc.createResourceNoClose(d.buildPath(), resourceDirectory, params, nil)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusConflict {
 			if resp.StatusCode == http.StatusCreated {
 				d.updateEtagAndLastModified(resp.Header)
@@ -135,7 +135,7 @@ func (d *Directory) Delete(options *FileRequestOptions) error {
 func (d *Directory) DeleteIfExists(options *FileRequestOptions) (bool, error) {
 	resp, err := d.fsc.deleteResourceNoClose(d.buildPath(), resourceDirectory, options)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNotFound {
 			return resp.StatusCode == http.StatusAccepted, nil
 		}

--- a/storage/entity.go
+++ b/storage/entity.go
@@ -112,7 +112,7 @@ func (e *Entity) Get(timeout uint, ml MetadataLevel, options *GetEntityOptions) 
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err = checkRespCode(resp, []int{http.StatusOK}); err != nil {
 		return err
@@ -154,7 +154,7 @@ func (e *Entity) Insert(ml MetadataLevel, options *EntityOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if ml != EmptyPayload {
 		if err = checkRespCode(resp, []int{http.StatusCreated}); err != nil {
@@ -212,7 +212,7 @@ func (e *Entity) Delete(force bool, options *EntityOptions) error {
 		}
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err = checkRespCode(resp, []int{http.StatusNoContent}); err != nil {
 		return err
@@ -399,7 +399,7 @@ func (e *Entity) insertOr(verb string, options *EntityOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err = checkRespCode(resp, []int{http.StatusNoContent}); err != nil {
 		return err
@@ -428,7 +428,7 @@ func (e *Entity) updateMerge(force bool, verb string, options *EntityOptions) er
 		}
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err = checkRespCode(resp, []int{http.StatusNoContent}); err != nil {
 		return err

--- a/storage/file.go
+++ b/storage/file.go
@@ -187,7 +187,7 @@ func (f *File) Delete(options *FileRequestOptions) error {
 func (f *File) DeleteIfExists(options *FileRequestOptions) (bool, error) {
 	resp, err := f.fsc.deleteResourceNoClose(f.buildPath(), resourceFile, options)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNotFound {
 			return resp.StatusCode == http.StatusAccepted, nil
 		}
@@ -212,7 +212,7 @@ func (f *File) DownloadToStream(options *FileRequestOptions) (io.ReadCloser, err
 	}
 
 	if err = checkRespCode(resp, []int{http.StatusOK}); err != nil {
-		readAndCloseBody(resp.Body)
+		drainRespBody(resp)
 		return nil, err
 	}
 	return resp.Body, nil
@@ -242,7 +242,7 @@ func (f *File) DownloadRangeToStream(fileRange FileRange, options *GetFileOption
 	}
 
 	if err = checkRespCode(resp, []int{http.StatusOK, http.StatusPartialContent}); err != nil {
-		readAndCloseBody(resp.Body)
+		drainRespBody(resp)
 		return fs, err
 	}
 
@@ -375,7 +375,7 @@ func (f *File) modifyRange(bytes io.Reader, fileRange FileRange, timeout *uint, 
 	if err != nil {
 		return nil, err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return resp.Header, checkRespCode(resp, []int{http.StatusCreated})
 }
 

--- a/storage/fileserviceclient.go
+++ b/storage/fileserviceclient.go
@@ -194,7 +194,7 @@ func (f FileServiceClient) listContent(path string, params url.Values, extraHead
 	}
 
 	if err = checkRespCode(resp, []int{http.StatusOK}); err != nil {
-		readAndCloseBody(resp.Body)
+		drainRespBody(resp)
 		return nil, err
 	}
 
@@ -212,7 +212,7 @@ func (f FileServiceClient) resourceExists(path string, res resourceType) (bool, 
 
 	resp, err := f.client.exec(http.MethodHead, uri, headers, nil, f.auth)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound {
 			return resp.StatusCode == http.StatusOK, resp.Header, nil
 		}
@@ -226,7 +226,7 @@ func (f FileServiceClient) createResource(path string, res resourceType, urlPara
 	if err != nil {
 		return nil, err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return resp.Header, checkRespCode(resp, expectedResponseCodes)
 }
 
@@ -251,7 +251,7 @@ func (f FileServiceClient) getResourceHeaders(path string, comp compType, res re
 	if err != nil {
 		return nil, err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err = checkRespCode(resp, []int{http.StatusOK}); err != nil {
 		return nil, err
@@ -279,7 +279,7 @@ func (f FileServiceClient) deleteResource(path string, res resourceType, options
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusAccepted})
 }
 
@@ -323,7 +323,7 @@ func (f FileServiceClient) setResourceHeaders(path string, comp compType, res re
 	if err != nil {
 		return nil, err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	return resp.Header, checkRespCode(resp, []int{http.StatusOK})
 }

--- a/storage/leaseblob.go
+++ b/storage/leaseblob.go
@@ -53,7 +53,7 @@ func (b *Blob) leaseCommonPut(headers map[string]string, expectedStatus int, opt
 	if err != nil {
 		return nil, err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err := checkRespCode(resp, []int{expectedStatus}); err != nil {
 		return nil, err

--- a/storage/message.go
+++ b/storage/message.go
@@ -78,7 +78,7 @@ func (m *Message) Put(options *PutMessageOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	err = checkRespCode(resp, []int{http.StatusCreated})
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (m *Message) Update(options *UpdateMessageOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	m.PopReceipt = resp.Header.Get("x-ms-popreceipt")
 	nextTimeStr := resp.Header.Get("x-ms-time-next-visible")
@@ -160,7 +160,7 @@ func (m *Message) Delete(options *QueueServiceOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusNoContent})
 }
 

--- a/storage/pageblob.go
+++ b/storage/pageblob.go
@@ -121,7 +121,7 @@ func (b *Blob) modifyRange(blobRange BlobRange, bytes io.Reader, options *PutPag
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusCreated})
 }
 
@@ -160,7 +160,7 @@ func (b *Blob) GetPageRanges(options *GetPageRangesOptions) (GetPageRangesRespon
 	if err != nil {
 		return out, err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err = checkRespCode(resp, []int{http.StatusOK}); err != nil {
 		return out, err

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -91,7 +91,7 @@ func (q *Queue) Create(options *QueueServiceOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusCreated})
 }
 
@@ -111,7 +111,7 @@ func (q *Queue) Delete(options *QueueServiceOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusNoContent})
 }
 
@@ -120,7 +120,7 @@ func (q *Queue) Exists() (bool, error) {
 	uri := q.qsc.client.getEndpoint(queueServiceName, q.buildPath(), url.Values{"comp": {"metadata"}})
 	resp, err := q.qsc.client.exec(http.MethodGet, uri, q.qsc.client.getStandardHeaders(), nil, q.qsc.auth)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound {
 			return resp.StatusCode == http.StatusOK, nil
 		}
@@ -148,7 +148,7 @@ func (q *Queue) SetMetadata(options *QueueServiceOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusNoContent})
 }
 
@@ -175,7 +175,7 @@ func (q *Queue) GetMetadata(options *QueueServiceOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	if err := checkRespCode(resp, []int{http.StatusOK}); err != nil {
 		return err
@@ -314,7 +314,7 @@ func (q *Queue) ClearMessages(options *QueueServiceOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusNoContent})
 }
 
@@ -341,7 +341,7 @@ func (q *Queue) SetPermissions(permissions QueuePermissions, options *SetQueuePe
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusNoContent})
 }
 

--- a/storage/share.go
+++ b/storage/share.go
@@ -75,7 +75,7 @@ func (s *Share) CreateIfNotExists(options *FileRequestOptions) (bool, error) {
 	params := prepareOptions(options)
 	resp, err := s.fsc.createResourceNoClose(s.buildPath(), resourceShare, params, extraheaders)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusConflict {
 			if resp.StatusCode == http.StatusCreated {
 				s.updateEtagAndLastModified(resp.Header)
@@ -103,7 +103,7 @@ func (s *Share) Delete(options *FileRequestOptions) error {
 func (s *Share) DeleteIfExists(options *FileRequestOptions) (bool, error) {
 	resp, err := s.fsc.deleteResourceNoClose(s.buildPath(), resourceShare, options)
 	if resp != nil {
-		defer readAndCloseBody(resp.Body)
+		defer drainRespBody(resp)
 		if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNotFound {
 			return resp.StatusCode == http.StatusAccepted, nil
 		}

--- a/storage/storageservice.go
+++ b/storage/storageservice.go
@@ -126,6 +126,6 @@ func (c Client) setServiceProperties(props ServiceProperties, service string, au
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 	return checkRespCode(resp, []int{http.StatusAccepted})
 }

--- a/storage/table.go
+++ b/storage/table.go
@@ -186,7 +186,7 @@ func (t *Table) Delete(timeout uint, options *TableOptions) error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	return checkRespCode(resp, []int{http.StatusNoContent})
 }
@@ -269,7 +269,7 @@ func (t *Table) SetPermissions(tap []TableAccessPolicy, timeout uint, options *T
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.Body)
+	defer drainRespBody(resp)
 
 	return checkRespCode(resp, []int{http.StatusNoContent})
 }

--- a/storage/table_batch.go
+++ b/storage/table_batch.go
@@ -163,7 +163,7 @@ func (t *TableBatch) ExecuteBatch() error {
 	if err != nil {
 		return err
 	}
-	defer readAndCloseBody(resp.resp.Body)
+	defer drainRespBody(resp.resp)
 
 	if err = checkRespCode(resp.resp, []int{http.StatusAccepted}); err != nil {
 


### PR DESCRIPTION
Added func drainRespBody() that copies the HTTP response body into
nothingness then closes it, avoiding allocations.
When reading/closing the HTTP response body, for cases that don't
require the data call drainRespBody() instead of readAndCloseBody().

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 