### PR TITLE
Add picker tool for cherry-picking commits

### DIFF
--- a/tools/apidiff/cmd/common.go
+++ b/tools/apidiff/cmd/common.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -203,7 +202,7 @@ func processArgsAndClone(args []string) (cln repo.WorkingTree, err error) {
 		return
 	}
 
-	tempRepoDir := path.Join(os.TempDir(), fmt.Sprintf("apidiff-%v", time.Now().Unix()))
+	tempRepoDir := filepath.Join(os.TempDir(), fmt.Sprintf("apidiff-%v", time.Now().Unix()))
 	if copyRepoFlag {
 		vprintf("copying '%s' into '%s'...\n", src.Root(), tempRepoDir)
 		err = ioext.CopyDir(src.Root(), tempRepoDir)

--- a/tools/apidiff/cmd/packages.go
+++ b/tools/apidiff/cmd/packages.go
@@ -48,8 +48,14 @@ func init() {
 	rootCmd.AddCommand(packagesCmd)
 }
 
+// ExecPackagesCmd is the programmatic interface for the packages command.
+func ExecPackagesCmd(pkgDir string, commitSeq string, flags CommandFlags) (CommitPkgsReport, error) {
+	flags.apply()
+	return thePackagesCmd([]string{pkgDir, commitSeq})
+}
+
 // split into its own func as we can't call os.Exit from it (the defer won't get executed)
-func thePackagesCmd(args []string) (rpt commitPkgsReport, err error) {
+func thePackagesCmd(args []string) (rpt CommitPkgsReport, err error) {
 	cloneRepo, err := processArgsAndClone(args)
 	if err != nil {
 		return
@@ -173,15 +179,15 @@ type pkgsList map[string][]string
 // contains a collection of package reports, it's structured as "package":"apiversion":pkgReport
 type modifiedPackages map[string]map[string]pkgReport
 
-// represents a collection of reports, one for each commit hash
-type commitPkgsReport struct {
+// CommitPkgsReport represents a collection of reports, one for each commit hash.
+type CommitPkgsReport struct {
 	AffectedPackages pkgsList              `json:"affectedPackages"`
 	BreakingChanges  []string              `json:"breakingChanges,omitempty"`
 	CommitsReports   map[string]pkgsReport `json:"deltas"`
 }
 
 // returns true if the report contains no data
-func (c commitPkgsReport) isEmpty() bool {
+func (c CommitPkgsReport) isEmpty() bool {
 	for _, r := range c.CommitsReports {
 		if !r.isEmpty() {
 			return false
@@ -191,7 +197,7 @@ func (c commitPkgsReport) isEmpty() bool {
 }
 
 // returns true if the report contains breaking changes
-func (c commitPkgsReport) hasBreakingChanges() bool {
+func (c CommitPkgsReport) hasBreakingChanges() bool {
 	for _, r := range c.CommitsReports {
 		if r.hasBreakingChanges() {
 			return true
@@ -201,7 +207,7 @@ func (c commitPkgsReport) hasBreakingChanges() bool {
 }
 
 // returns true if the package contains additive changes
-func (c commitPkgsReport) hasAdditiveChanges() bool {
+func (c CommitPkgsReport) hasAdditiveChanges() bool {
 	for _, r := range c.CommitsReports {
 		if r.hasAdditiveChanges() {
 			return true
@@ -211,7 +217,7 @@ func (c commitPkgsReport) hasAdditiveChanges() bool {
 }
 
 // updates the collection of affected packages with the packages that were touched in the specified commit
-func (c *commitPkgsReport) updateAffectedPackages(commit string, r pkgsReport) {
+func (c *CommitPkgsReport) updateAffectedPackages(commit string, r pkgsReport) {
 	if c.AffectedPackages == nil {
 		c.AffectedPackages = map[string][]string{}
 	}

--- a/tools/apidiff/cmd/root.go
+++ b/tools/apidiff/cmd/root.go
@@ -48,3 +48,21 @@ func Execute() {
 		os.Exit(-1)
 	}
 }
+
+// CommandFlags is used to specify flags when invoking commands programatically.
+type CommandFlags struct {
+	CopyRepo            bool
+	OnlyAdditions       bool
+	OnlyBreakingChanges bool
+	Quiet               bool
+	Verbose             bool
+}
+
+// applies the specified flags to their global equivalents
+func (cf CommandFlags) apply() {
+	copyRepoFlag = cf.CopyRepo
+	onlyAdditionsFlag = cf.OnlyAdditions
+	onlyBreakingChangesFlag = cf.OnlyBreakingChanges
+	quietFlag = cf.Quiet
+	verboseFlag = cf.Verbose
+}

--- a/tools/picker/cmd/root.go
+++ b/tools/picker/cmd/root.go
@@ -1,0 +1,170 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	apidiff "github.com/Azure/azure-sdk-for-go/tools/apidiff/cmd"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "picker <from> <to>",
+	Short: "Cherry-picks commits with non-breaking changes between two branches.",
+	Long: `This tool will find the list of commits in branch <from> that are not in
+branch <to>, and for each commit found it will cherry-pick it into <to> if
+the commit contains no breaking changes.  If a cherry-pick contains a merge
+conflict the process will pause so the conflicts can be resolved.
+NOTE: running this tool will modify your working tree!`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return theCommand(args)
+	},
+}
+
+// Execute executes the specified command.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(-1)
+	}
+}
+
+func theCommand(args []string) error {
+	if len(args) < 2 {
+		return errors.New("not enough arguments were supplied")
+	}
+
+	from := args[0]
+	to := args[1]
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory: %v", err)
+	}
+
+	wt, err := repo.Get(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to get the working tree: %v", err)
+	}
+
+	// checkout "from" branch
+	fmt.Printf("checking out branch '%s' to get list of candidate commits for cherry-picking\n", from)
+	err = wt.Checkout(from)
+	if err != nil {
+		return fmt.Errorf("checkout failed: %v", err)
+	}
+
+	commits, err := wt.Cherry(to)
+	if err != nil {
+		return fmt.Errorf("the command 'git cherry' failed: %v", err)
+	}
+
+	// for each commit, if it wasn't found in the "to" branch add it to the candidate list
+	candidates := []string{}
+	for _, commit := range commits {
+		if !commit.Found {
+			candidates = append(candidates, commit.Hash)
+		}
+	}
+
+	if len(candidates) == 0 {
+		fmt.Println("didn't find any candidate commits")
+		return nil
+	}
+
+	fmt.Printf("found %v candidate commits, looking for breaking changes...\n", len(candidates))
+
+	// generate report to find the breaking changes
+	report, err := apidiff.ExecPackagesCmd(filepath.Join(wt.Root(), "services"),
+		fmt.Sprintf("%s~1,%s", candidates[0], strings.Join(candidates, ",")),
+		apidiff.CommandFlags{Quiet: true})
+	if err != nil {
+		return fmt.Errorf("failed to obtain the breaking changes report: %v", err)
+	}
+
+	forPicking := pruneCandidates(candidates, report)
+	if len(forPicking) == 0 {
+		fmt.Println("didn't find any commits to cherry-pick")
+		return nil
+	}
+
+	// now cherry-pick the commits
+	fmt.Printf("checking out branch '%s' to begin cherry-picking\n", to)
+	err = wt.Checkout(to)
+	if err != nil {
+		return fmt.Errorf("checkout failed: %v", err)
+	}
+
+	for _, commit := range forPicking {
+		fmt.Printf("cherry-picking commit %s\n", commit)
+		err = wt.CherryPick(commit)
+		if err != nil {
+			fmt.Printf("there was an error: %v\n", err)
+			fmt.Println("if this is due to a merge conflict fix the conflict then press ENTER to continue cherry-picking, else press CTRL-C to abort")
+			dummy := ""
+			fmt.Scanln(&dummy)
+		}
+	}
+	return nil
+}
+
+// performs a linear search of ss, looking for s
+func contains(ss []string, s string) bool {
+	for i := range ss {
+		if ss[i] == s {
+			return true
+		}
+	}
+	return false
+}
+
+// removes commits and decendents thereof that contain breaking changes
+func pruneCandidates(candidates []string, report apidiff.CommitPkgsReport) []string {
+	pkgsToSkip := map[string]string{}
+	forPicking := []string{}
+	for _, commit := range candidates {
+		if contains(report.BreakingChanges, commit) {
+			fmt.Printf("omitting %s as it contains breaking changes\n", commit)
+			// add the affected packages to the collection of packages to skip
+			for _, pkg := range report.AffectedPackages[commit] {
+				if _, ok := pkgsToSkip[pkg]; !ok {
+					pkgsToSkip[pkg] = commit
+				}
+			}
+			continue
+		}
+
+		// check the packages impacted by this commit, if any of them are in
+		// the list of packages to skip then this commit can't be cherry-picked
+		include := true
+		for _, pkg := range report.AffectedPackages[commit] {
+			if _, ok := pkgsToSkip[pkg]; ok {
+				include = false
+				fmt.Printf("omitting %s as it's an aggregate of breaking changes commit %s\n", commit, pkgsToSkip[pkg])
+				break
+			}
+		}
+
+		if include {
+			forPicking = append(forPicking, commit)
+		}
+	}
+	return forPicking
+}

--- a/tools/picker/main.go
+++ b/tools/picker/main.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "github.com/Azure/azure-sdk-for-go/tools/picker/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
The picker tool is used to cherry-pick non-breaking changes from one
branch to another.  Note that this tool will mutate the state of your
working tree.
Added ExecPackagesCmd() for programmatically invoking the packages
command and exported the type of the report it returns.
Added Cherry() and CherryPick() to the repo package.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 