### PR TITLE
Leave file decls in their original order

### DIFF
--- a/tools/profileBuilder/model/transforms.go
+++ b/tools/profileBuilder/model/transforms.go
@@ -34,7 +34,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -200,12 +199,6 @@ func updateAliasPackageUserAgent(x interface{}, profileName string) interface{} 
 	}
 
 	*retResults = updated
-
-	file := cast.ModelFile()
-	sort.SliceStable(file.Decls, func(i, j int) bool {
-		return file.Decls[i].Pos() < file.Decls[j].Pos()
-	})
-
 	return x
 }
 
@@ -311,8 +304,6 @@ func writeAliasPackage(x interface{}, outputLocation string, outputLog, errLog *
 	outputLog.Printf("Writing File: %s", outputPath)
 
 	file := cast.ModelFile()
-
-	outputLog.Printf("Writing File: %s", outputPath)
 
 	var b bytes.Buffer
 	printer.Fprint(&b, files, file)


### PR DESCRIPTION
Don't attempt to sort the file decls, just leave them in their original
order (the generator sorts them).
Removed extra print-line for writing file.
Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 