### PR TITLE
[AutoPR eventgrid/resource-manager] Reverting back x-ms-azure-resource from TrackedResource definition as it is already part of the base class Resource.

### DIFF
--- a/services/eventgrid/mgmt/2018-01-01/eventgrid/eventsubscriptions.go
+++ b/services/eventgrid/mgmt/2018-01-01/eventgrid/eventsubscriptions.go
@@ -41,18 +41,17 @@ func NewEventSubscriptionsClientWithBaseURI(baseURI string, subscriptionID strin
 
 // CreateOrUpdate asynchronously creates a new event subscription or updates an existing event subscription based on
 // the specified scope.
-// Parameters:
-// scope - the identifier of the resource to which the event subscription needs to be created or updated. The
+//
+// scope is the identifier of the resource to which the event subscription needs to be created or updated. The
 // scope can be a subscription, or a resource group, or a top level resource belonging to a resource provider
 // namespace, or an EventGrid topic. For example, use '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription. Event subscription names must be between 3 and 64
-// characters in length and should use alphanumeric letters only.
-// eventSubscriptionInfo - event subscription properties containing the destination and filter information
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription. Event subscription names must
+// be between 3 and 64 characters in length and should use alphanumeric letters only. eventSubscriptionInfo is
+// event subscription properties containing the destination and filter information
 func (client EventSubscriptionsClient) CreateOrUpdate(ctx context.Context, scope string, eventSubscriptionName string, eventSubscriptionInfo EventSubscription) (result EventSubscriptionsCreateOrUpdateFuture, err error) {
 	req, err := client.CreateOrUpdatePreparer(ctx, scope, eventSubscriptionName, eventSubscriptionInfo)
 	if err != nil {
@@ -120,16 +119,15 @@ func (client EventSubscriptionsClient) CreateOrUpdateResponder(resp *http.Respon
 }
 
 // Delete delete an existing event subscription
-// Parameters:
-// scope - the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
+//
+// scope is the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
 // level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription
 func (client EventSubscriptionsClient) Delete(ctx context.Context, scope string, eventSubscriptionName string) (result EventSubscriptionsDeleteFuture, err error) {
 	req, err := client.DeletePreparer(ctx, scope, eventSubscriptionName)
 	if err != nil {
@@ -194,16 +192,15 @@ func (client EventSubscriptionsClient) DeleteResponder(resp *http.Response) (res
 }
 
 // Get get properties of an event subscription
-// Parameters:
-// scope - the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
+//
+// scope is the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
 // level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription
 func (client EventSubscriptionsClient) Get(ctx context.Context, scope string, eventSubscriptionName string) (result EventSubscription, err error) {
 	req, err := client.GetPreparer(ctx, scope, eventSubscriptionName)
 	if err != nil {
@@ -267,16 +264,15 @@ func (client EventSubscriptionsClient) GetResponder(resp *http.Response) (result
 }
 
 // GetFullURL get the full endpoint URL for an event subscription
-// Parameters:
-// scope - the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
+//
+// scope is the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
 // level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription
 func (client EventSubscriptionsClient) GetFullURL(ctx context.Context, scope string, eventSubscriptionName string) (result EventSubscriptionFullURL, err error) {
 	req, err := client.GetFullURLPreparer(ctx, scope, eventSubscriptionName)
 	if err != nil {
@@ -340,11 +336,10 @@ func (client EventSubscriptionsClient) GetFullURLResponder(resp *http.Response) 
 }
 
 // ListByResource list all event subscriptions that have been created for a specific topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// providerNamespace - namespace of the provider of the topic
-// resourceTypeName - name of the resource type
-// resourceName - name of the resource
+//
+// resourceGroupName is the name of the resource group within the user's subscription. providerNamespace is
+// namespace of the provider of the topic resourceTypeName is name of the resource type resourceName is name of the
+// resource
 func (client EventSubscriptionsClient) ListByResource(ctx context.Context, resourceGroupName string, providerNamespace string, resourceTypeName string, resourceName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListByResourcePreparer(ctx, resourceGroupName, providerNamespace, resourceTypeName, resourceName)
 	if err != nil {
@@ -411,8 +406,8 @@ func (client EventSubscriptionsClient) ListByResourceResponder(resp *http.Respon
 }
 
 // ListGlobalByResourceGroup list all global event subscriptions under a specific Azure subscription and resource group
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
+//
+// resourceGroupName is the name of the resource group within the user's subscription.
 func (client EventSubscriptionsClient) ListGlobalByResourceGroup(ctx context.Context, resourceGroupName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListGlobalByResourceGroupPreparer(ctx, resourceGroupName)
 	if err != nil {
@@ -477,9 +472,9 @@ func (client EventSubscriptionsClient) ListGlobalByResourceGroupResponder(resp *
 
 // ListGlobalByResourceGroupForTopicType list all global event subscriptions under a resource group for a specific
 // topic type.
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicTypeName - name of the topic type
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicTypeName is name of the
+// topic type
 func (client EventSubscriptionsClient) ListGlobalByResourceGroupForTopicType(ctx context.Context, resourceGroupName string, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListGlobalByResourceGroupForTopicTypePreparer(ctx, resourceGroupName, topicTypeName)
 	if err != nil {
@@ -607,8 +602,8 @@ func (client EventSubscriptionsClient) ListGlobalBySubscriptionResponder(resp *h
 
 // ListGlobalBySubscriptionForTopicType list all global event subscriptions under an Azure subscription for a topic
 // type.
-// Parameters:
-// topicTypeName - name of the topic type
+//
+// topicTypeName is name of the topic type
 func (client EventSubscriptionsClient) ListGlobalBySubscriptionForTopicType(ctx context.Context, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListGlobalBySubscriptionForTopicTypePreparer(ctx, topicTypeName)
 	if err != nil {
@@ -673,9 +668,9 @@ func (client EventSubscriptionsClient) ListGlobalBySubscriptionForTopicTypeRespo
 
 // ListRegionalByResourceGroup list all event subscriptions from the given location under a specific Azure subscription
 // and resource group
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// location - name of the location
+//
+// resourceGroupName is the name of the resource group within the user's subscription. location is name of the
+// location
 func (client EventSubscriptionsClient) ListRegionalByResourceGroup(ctx context.Context, resourceGroupName string, location string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalByResourceGroupPreparer(ctx, resourceGroupName, location)
 	if err != nil {
@@ -741,10 +736,9 @@ func (client EventSubscriptionsClient) ListRegionalByResourceGroupResponder(resp
 
 // ListRegionalByResourceGroupForTopicType list all event subscriptions from the given location under a specific Azure
 // subscription and resource group and topic type
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// location - name of the location
-// topicTypeName - name of the topic type
+//
+// resourceGroupName is the name of the resource group within the user's subscription. location is name of the
+// location topicTypeName is name of the topic type
 func (client EventSubscriptionsClient) ListRegionalByResourceGroupForTopicType(ctx context.Context, resourceGroupName string, location string, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalByResourceGroupForTopicTypePreparer(ctx, resourceGroupName, location, topicTypeName)
 	if err != nil {
@@ -810,8 +804,8 @@ func (client EventSubscriptionsClient) ListRegionalByResourceGroupForTopicTypeRe
 }
 
 // ListRegionalBySubscription list all event subscriptions from the given location under a specific Azure subscription
-// Parameters:
-// location - name of the location
+//
+// location is name of the location
 func (client EventSubscriptionsClient) ListRegionalBySubscription(ctx context.Context, location string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalBySubscriptionPreparer(ctx, location)
 	if err != nil {
@@ -876,9 +870,8 @@ func (client EventSubscriptionsClient) ListRegionalBySubscriptionResponder(resp 
 
 // ListRegionalBySubscriptionForTopicType list all event subscriptions from the given location under a specific Azure
 // subscription and topic type.
-// Parameters:
-// location - name of the location
-// topicTypeName - name of the topic type
+//
+// location is name of the location topicTypeName is name of the topic type
 func (client EventSubscriptionsClient) ListRegionalBySubscriptionForTopicType(ctx context.Context, location string, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalBySubscriptionForTopicTypePreparer(ctx, location, topicTypeName)
 	if err != nil {
@@ -943,17 +936,16 @@ func (client EventSubscriptionsClient) ListRegionalBySubscriptionForTopicTypeRes
 }
 
 // Update asynchronously updates an existing event subscription.
-// Parameters:
-// scope - the scope of existing event subscription. The scope can be a subscription, or a resource group, or a
+//
+// scope is the scope of existing event subscription. The scope can be a subscription, or a resource group, or a
 // top level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription to be created
-// eventSubscriptionUpdateParameters - updated event subscription information
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription to be created
+// eventSubscriptionUpdateParameters is updated event subscription information
 func (client EventSubscriptionsClient) Update(ctx context.Context, scope string, eventSubscriptionName string, eventSubscriptionUpdateParameters EventSubscriptionUpdateParameters) (result EventSubscriptionsUpdateFuture, err error) {
 	req, err := client.UpdatePreparer(ctx, scope, eventSubscriptionName, eventSubscriptionUpdateParameters)
 	if err != nil {

--- a/services/eventgrid/mgmt/2018-01-01/eventgrid/topics.go
+++ b/services/eventgrid/mgmt/2018-01-01/eventgrid/topics.go
@@ -41,10 +41,9 @@ func NewTopicsClientWithBaseURI(baseURI string, subscriptionID string) TopicsCli
 }
 
 // CreateOrUpdate asynchronously creates a new topic with the specified parameters.
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
-// topicInfo - topic information
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic topicInfo is topic information
 func (client TopicsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, topicName string, topicInfo Topic) (result TopicsCreateOrUpdateFuture, err error) {
 	req, err := client.CreateOrUpdatePreparer(ctx, resourceGroupName, topicName, topicInfo)
 	if err != nil {
@@ -113,9 +112,9 @@ func (client TopicsClient) CreateOrUpdateResponder(resp *http.Response) (result 
 }
 
 // Delete delete existing topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic
 func (client TopicsClient) Delete(ctx context.Context, resourceGroupName string, topicName string) (result TopicsDeleteFuture, err error) {
 	req, err := client.DeletePreparer(ctx, resourceGroupName, topicName)
 	if err != nil {
@@ -181,9 +180,9 @@ func (client TopicsClient) DeleteResponder(resp *http.Response) (result autorest
 }
 
 // Get get properties of a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic
 func (client TopicsClient) Get(ctx context.Context, resourceGroupName string, topicName string) (result Topic, err error) {
 	req, err := client.GetPreparer(ctx, resourceGroupName, topicName)
 	if err != nil {
@@ -248,8 +247,8 @@ func (client TopicsClient) GetResponder(resp *http.Response) (result Topic, err 
 }
 
 // ListByResourceGroup list all the topics under a resource group
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
+//
+// resourceGroupName is the name of the resource group within the user's subscription.
 func (client TopicsClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) (result TopicsListResult, err error) {
 	req, err := client.ListByResourceGroupPreparer(ctx, resourceGroupName)
 	if err != nil {
@@ -375,11 +374,10 @@ func (client TopicsClient) ListBySubscriptionResponder(resp *http.Response) (res
 }
 
 // ListEventTypes list event types for a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// providerNamespace - namespace of the provider of the topic
-// resourceTypeName - name of the topic type
-// resourceName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. providerNamespace is
+// namespace of the provider of the topic resourceTypeName is name of the topic type resourceName is name of the
+// topic
 func (client TopicsClient) ListEventTypes(ctx context.Context, resourceGroupName string, providerNamespace string, resourceTypeName string, resourceName string) (result EventTypesListResult, err error) {
 	req, err := client.ListEventTypesPreparer(ctx, resourceGroupName, providerNamespace, resourceTypeName, resourceName)
 	if err != nil {
@@ -446,9 +444,9 @@ func (client TopicsClient) ListEventTypesResponder(resp *http.Response) (result 
 }
 
 // ListSharedAccessKeys list the two keys used to publish to a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic
 func (client TopicsClient) ListSharedAccessKeys(ctx context.Context, resourceGroupName string, topicName string) (result TopicSharedAccessKeys, err error) {
 	req, err := client.ListSharedAccessKeysPreparer(ctx, resourceGroupName, topicName)
 	if err != nil {
@@ -513,10 +511,9 @@ func (client TopicsClient) ListSharedAccessKeysResponder(resp *http.Response) (r
 }
 
 // RegenerateKey regenerate a shared access key for a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
-// regenerateKeyRequest - request body to regenerate key
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic regenerateKeyRequest is request body to regenerate key
 func (client TopicsClient) RegenerateKey(ctx context.Context, resourceGroupName string, topicName string, regenerateKeyRequest TopicRegenerateKeyRequest) (result TopicSharedAccessKeys, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: regenerateKeyRequest,
@@ -589,10 +586,9 @@ func (client TopicsClient) RegenerateKeyResponder(resp *http.Response) (result T
 }
 
 // Update asynchronously updates a topic with the specified parameters.
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
-// topicUpdateParameters - topic update information
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic topicUpdateParameters is topic update information
 func (client TopicsClient) Update(ctx context.Context, resourceGroupName string, topicName string, topicUpdateParameters TopicUpdateParameters) (result TopicsUpdateFuture, err error) {
 	req, err := client.UpdatePreparer(ctx, resourceGroupName, topicName, topicUpdateParameters)
 	if err != nil {

--- a/services/eventgrid/mgmt/2018-01-01/eventgrid/topictypes.go
+++ b/services/eventgrid/mgmt/2018-01-01/eventgrid/topictypes.go
@@ -40,8 +40,8 @@ func NewTopicTypesClientWithBaseURI(baseURI string, subscriptionID string) Topic
 }
 
 // Get get information about a topic type
-// Parameters:
-// topicTypeName - name of the topic type
+//
+// topicTypeName is name of the topic type
 func (client TopicTypesClient) Get(ctx context.Context, topicTypeName string) (result TopicTypeInfo, err error) {
 	req, err := client.GetPreparer(ctx, topicTypeName)
 	if err != nil {
@@ -162,8 +162,8 @@ func (client TopicTypesClient) ListResponder(resp *http.Response) (result TopicT
 }
 
 // ListEventTypes list event types for a topic type
-// Parameters:
-// topicTypeName - name of the topic type
+//
+// topicTypeName is name of the topic type
 func (client TopicTypesClient) ListEventTypes(ctx context.Context, topicTypeName string) (result EventTypesListResult, err error) {
 	req, err := client.ListEventTypesPreparer(ctx, topicTypeName)
 	if err != nil {

--- a/services/preview/eventgrid/mgmt/2017-06-15-preview/eventgrid/eventsubscriptions.go
+++ b/services/preview/eventgrid/mgmt/2017-06-15-preview/eventgrid/eventsubscriptions.go
@@ -41,18 +41,17 @@ func NewEventSubscriptionsClientWithBaseURI(baseURI string, subscriptionID strin
 
 // Create asynchronously creates a new event subscription to the specified scope. Existing event subscriptions cannot
 // be updated with this API and should instead use the Update event subscription API.
-// Parameters:
-// scope - the scope of the resource to which the event subscription needs to be created. The scope can be a
+//
+// scope is the scope of the resource to which the event subscription needs to be created. The scope can be a
 // subscription, or a resource group, or a top level resource belonging to a resource provider namespace, or an
 // EventGrid topic. For example, use '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription to be created. Event subscription names must be
-// between 3 and 64 characters in length and use alphanumeric letters only.
-// eventSubscriptionInfo - event subscription properties containing the destination and filter information
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription to be created. Event
+// subscription names must be between 3 and 64 characters in length and use alphanumeric letters only.
+// eventSubscriptionInfo is event subscription properties containing the destination and filter information
 func (client EventSubscriptionsClient) Create(ctx context.Context, scope string, eventSubscriptionName string, eventSubscriptionInfo EventSubscription) (result EventSubscriptionsCreateFuture, err error) {
 	req, err := client.CreatePreparer(ctx, scope, eventSubscriptionName, eventSubscriptionInfo)
 	if err != nil {
@@ -120,16 +119,15 @@ func (client EventSubscriptionsClient) CreateResponder(resp *http.Response) (res
 }
 
 // Delete delete an existing event subscription
-// Parameters:
-// scope - the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
+//
+// scope is the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
 // level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription
 func (client EventSubscriptionsClient) Delete(ctx context.Context, scope string, eventSubscriptionName string) (result EventSubscriptionsDeleteFuture, err error) {
 	req, err := client.DeletePreparer(ctx, scope, eventSubscriptionName)
 	if err != nil {
@@ -194,16 +192,15 @@ func (client EventSubscriptionsClient) DeleteResponder(resp *http.Response) (res
 }
 
 // Get get properties of an event subscription
-// Parameters:
-// scope - the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
+//
+// scope is the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
 // level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription
 func (client EventSubscriptionsClient) Get(ctx context.Context, scope string, eventSubscriptionName string) (result EventSubscription, err error) {
 	req, err := client.GetPreparer(ctx, scope, eventSubscriptionName)
 	if err != nil {
@@ -267,16 +264,15 @@ func (client EventSubscriptionsClient) GetResponder(resp *http.Response) (result
 }
 
 // GetFullURL get the full endpoint URL for an event subscription
-// Parameters:
-// scope - the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
+//
+// scope is the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
 // level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription
 func (client EventSubscriptionsClient) GetFullURL(ctx context.Context, scope string, eventSubscriptionName string) (result EventSubscriptionFullURL, err error) {
 	req, err := client.GetFullURLPreparer(ctx, scope, eventSubscriptionName)
 	if err != nil {
@@ -340,11 +336,10 @@ func (client EventSubscriptionsClient) GetFullURLResponder(resp *http.Response) 
 }
 
 // ListByResource list all event subscriptions that have been created for a specific topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// providerNamespace - namespace of the provider of the topic
-// resourceTypeName - name of the resource type
-// resourceName - name of the resource
+//
+// resourceGroupName is the name of the resource group within the user's subscription. providerNamespace is
+// namespace of the provider of the topic resourceTypeName is name of the resource type resourceName is name of the
+// resource
 func (client EventSubscriptionsClient) ListByResource(ctx context.Context, resourceGroupName string, providerNamespace string, resourceTypeName string, resourceName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListByResourcePreparer(ctx, resourceGroupName, providerNamespace, resourceTypeName, resourceName)
 	if err != nil {
@@ -411,8 +406,8 @@ func (client EventSubscriptionsClient) ListByResourceResponder(resp *http.Respon
 }
 
 // ListGlobalByResourceGroup list all global event subscriptions under a specific Azure subscription and resource group
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
+//
+// resourceGroupName is the name of the resource group within the user's subscription.
 func (client EventSubscriptionsClient) ListGlobalByResourceGroup(ctx context.Context, resourceGroupName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListGlobalByResourceGroupPreparer(ctx, resourceGroupName)
 	if err != nil {
@@ -477,9 +472,9 @@ func (client EventSubscriptionsClient) ListGlobalByResourceGroupResponder(resp *
 
 // ListGlobalByResourceGroupForTopicType list all global event subscriptions under a resource group for a specific
 // topic type.
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicTypeName - name of the topic type
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicTypeName is name of the
+// topic type
 func (client EventSubscriptionsClient) ListGlobalByResourceGroupForTopicType(ctx context.Context, resourceGroupName string, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListGlobalByResourceGroupForTopicTypePreparer(ctx, resourceGroupName, topicTypeName)
 	if err != nil {
@@ -607,8 +602,8 @@ func (client EventSubscriptionsClient) ListGlobalBySubscriptionResponder(resp *h
 
 // ListGlobalBySubscriptionForTopicType list all global event subscriptions under an Azure subscription for a topic
 // type.
-// Parameters:
-// topicTypeName - name of the topic type
+//
+// topicTypeName is name of the topic type
 func (client EventSubscriptionsClient) ListGlobalBySubscriptionForTopicType(ctx context.Context, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListGlobalBySubscriptionForTopicTypePreparer(ctx, topicTypeName)
 	if err != nil {
@@ -673,9 +668,9 @@ func (client EventSubscriptionsClient) ListGlobalBySubscriptionForTopicTypeRespo
 
 // ListRegionalByResourceGroup list all event subscriptions from the given location under a specific Azure subscription
 // and resource group
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// location - name of the location
+//
+// resourceGroupName is the name of the resource group within the user's subscription. location is name of the
+// location
 func (client EventSubscriptionsClient) ListRegionalByResourceGroup(ctx context.Context, resourceGroupName string, location string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalByResourceGroupPreparer(ctx, resourceGroupName, location)
 	if err != nil {
@@ -741,10 +736,9 @@ func (client EventSubscriptionsClient) ListRegionalByResourceGroupResponder(resp
 
 // ListRegionalByResourceGroupForTopicType list all event subscriptions from the given location under a specific Azure
 // subscription and resource group and topic type
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// location - name of the location
-// topicTypeName - name of the topic type
+//
+// resourceGroupName is the name of the resource group within the user's subscription. location is name of the
+// location topicTypeName is name of the topic type
 func (client EventSubscriptionsClient) ListRegionalByResourceGroupForTopicType(ctx context.Context, resourceGroupName string, location string, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalByResourceGroupForTopicTypePreparer(ctx, resourceGroupName, location, topicTypeName)
 	if err != nil {
@@ -810,8 +804,8 @@ func (client EventSubscriptionsClient) ListRegionalByResourceGroupForTopicTypeRe
 }
 
 // ListRegionalBySubscription list all event subscriptions from the given location under a specific Azure subscription
-// Parameters:
-// location - name of the location
+//
+// location is name of the location
 func (client EventSubscriptionsClient) ListRegionalBySubscription(ctx context.Context, location string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalBySubscriptionPreparer(ctx, location)
 	if err != nil {
@@ -876,9 +870,8 @@ func (client EventSubscriptionsClient) ListRegionalBySubscriptionResponder(resp 
 
 // ListRegionalBySubscriptionForTopicType list all event subscriptions from the given location under a specific Azure
 // subscription and topic type.
-// Parameters:
-// location - name of the location
-// topicTypeName - name of the topic type
+//
+// location is name of the location topicTypeName is name of the topic type
 func (client EventSubscriptionsClient) ListRegionalBySubscriptionForTopicType(ctx context.Context, location string, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalBySubscriptionForTopicTypePreparer(ctx, location, topicTypeName)
 	if err != nil {
@@ -943,17 +936,16 @@ func (client EventSubscriptionsClient) ListRegionalBySubscriptionForTopicTypeRes
 }
 
 // Update asynchronously updates an existing event subscription.
-// Parameters:
-// scope - the scope of existing event subscription. The scope can be a subscription, or a resource group, or a
+//
+// scope is the scope of existing event subscription. The scope can be a subscription, or a resource group, or a
 // top level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription to be created
-// eventSubscriptionUpdateParameters - updated event subscription information
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription to be created
+// eventSubscriptionUpdateParameters is updated event subscription information
 func (client EventSubscriptionsClient) Update(ctx context.Context, scope string, eventSubscriptionName string, eventSubscriptionUpdateParameters EventSubscriptionUpdateParameters) (result EventSubscriptionsUpdateFuture, err error) {
 	req, err := client.UpdatePreparer(ctx, scope, eventSubscriptionName, eventSubscriptionUpdateParameters)
 	if err != nil {

--- a/services/preview/eventgrid/mgmt/2017-06-15-preview/eventgrid/topics.go
+++ b/services/preview/eventgrid/mgmt/2017-06-15-preview/eventgrid/topics.go
@@ -41,10 +41,9 @@ func NewTopicsClientWithBaseURI(baseURI string, subscriptionID string) TopicsCli
 }
 
 // CreateOrUpdate asynchronously creates a new topic with the specified parameters.
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
-// topicInfo - topic information
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic topicInfo is topic information
 func (client TopicsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, topicName string, topicInfo Topic) (result TopicsCreateOrUpdateFuture, err error) {
 	req, err := client.CreateOrUpdatePreparer(ctx, resourceGroupName, topicName, topicInfo)
 	if err != nil {
@@ -113,9 +112,9 @@ func (client TopicsClient) CreateOrUpdateResponder(resp *http.Response) (result 
 }
 
 // Delete delete existing topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic
 func (client TopicsClient) Delete(ctx context.Context, resourceGroupName string, topicName string) (result TopicsDeleteFuture, err error) {
 	req, err := client.DeletePreparer(ctx, resourceGroupName, topicName)
 	if err != nil {
@@ -181,9 +180,9 @@ func (client TopicsClient) DeleteResponder(resp *http.Response) (result autorest
 }
 
 // Get get properties of a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic
 func (client TopicsClient) Get(ctx context.Context, resourceGroupName string, topicName string) (result Topic, err error) {
 	req, err := client.GetPreparer(ctx, resourceGroupName, topicName)
 	if err != nil {
@@ -248,8 +247,8 @@ func (client TopicsClient) GetResponder(resp *http.Response) (result Topic, err 
 }
 
 // ListByResourceGroup list all the topics under a resource group
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
+//
+// resourceGroupName is the name of the resource group within the user's subscription.
 func (client TopicsClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) (result TopicsListResult, err error) {
 	req, err := client.ListByResourceGroupPreparer(ctx, resourceGroupName)
 	if err != nil {
@@ -375,11 +374,10 @@ func (client TopicsClient) ListBySubscriptionResponder(resp *http.Response) (res
 }
 
 // ListEventTypes list event types for a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// providerNamespace - namespace of the provider of the topic
-// resourceTypeName - name of the topic type
-// resourceName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. providerNamespace is
+// namespace of the provider of the topic resourceTypeName is name of the topic type resourceName is name of the
+// topic
 func (client TopicsClient) ListEventTypes(ctx context.Context, resourceGroupName string, providerNamespace string, resourceTypeName string, resourceName string) (result EventTypesListResult, err error) {
 	req, err := client.ListEventTypesPreparer(ctx, resourceGroupName, providerNamespace, resourceTypeName, resourceName)
 	if err != nil {
@@ -446,9 +444,9 @@ func (client TopicsClient) ListEventTypesResponder(resp *http.Response) (result 
 }
 
 // ListSharedAccessKeys list the two keys used to publish to a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic
 func (client TopicsClient) ListSharedAccessKeys(ctx context.Context, resourceGroupName string, topicName string) (result TopicSharedAccessKeys, err error) {
 	req, err := client.ListSharedAccessKeysPreparer(ctx, resourceGroupName, topicName)
 	if err != nil {
@@ -513,10 +511,9 @@ func (client TopicsClient) ListSharedAccessKeysResponder(resp *http.Response) (r
 }
 
 // RegenerateKey regenerate a shared access key for a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
-// regenerateKeyRequest - request body to regenerate key
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic regenerateKeyRequest is request body to regenerate key
 func (client TopicsClient) RegenerateKey(ctx context.Context, resourceGroupName string, topicName string, regenerateKeyRequest TopicRegenerateKeyRequest) (result TopicSharedAccessKeys, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: regenerateKeyRequest,

--- a/services/preview/eventgrid/mgmt/2017-06-15-preview/eventgrid/topictypes.go
+++ b/services/preview/eventgrid/mgmt/2017-06-15-preview/eventgrid/topictypes.go
@@ -40,8 +40,8 @@ func NewTopicTypesClientWithBaseURI(baseURI string, subscriptionID string) Topic
 }
 
 // Get get information about a topic type
-// Parameters:
-// topicTypeName - name of the topic type
+//
+// topicTypeName is name of the topic type
 func (client TopicTypesClient) Get(ctx context.Context, topicTypeName string) (result TopicTypeInfo, err error) {
 	req, err := client.GetPreparer(ctx, topicTypeName)
 	if err != nil {
@@ -162,8 +162,8 @@ func (client TopicTypesClient) ListResponder(resp *http.Response) (result TopicT
 }
 
 // ListEventTypes list event types for a topic type
-// Parameters:
-// topicTypeName - name of the topic type
+//
+// topicTypeName is name of the topic type
 func (client TopicTypesClient) ListEventTypes(ctx context.Context, topicTypeName string) (result EventTypesListResult, err error) {
 	req, err := client.ListEventTypesPreparer(ctx, topicTypeName)
 	if err != nil {

--- a/services/preview/eventgrid/mgmt/2017-09-15-preview/eventgrid/eventsubscriptions.go
+++ b/services/preview/eventgrid/mgmt/2017-09-15-preview/eventgrid/eventsubscriptions.go
@@ -41,18 +41,17 @@ func NewEventSubscriptionsClientWithBaseURI(baseURI string, subscriptionID strin
 
 // Create asynchronously creates a new event subscription to the specified scope. Existing event subscriptions cannot
 // be updated with this API and should instead use the Update event subscription API.
-// Parameters:
-// scope - the scope of the resource to which the event subscription needs to be created. The scope can be a
+//
+// scope is the scope of the resource to which the event subscription needs to be created. The scope can be a
 // subscription, or a resource group, or a top level resource belonging to a resource provider namespace, or an
 // EventGrid topic. For example, use '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription to be created. Event subscription names must be
-// between 3 and 64 characters in length and use alphanumeric letters only.
-// eventSubscriptionInfo - event subscription properties containing the destination and filter information
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription to be created. Event
+// subscription names must be between 3 and 64 characters in length and use alphanumeric letters only.
+// eventSubscriptionInfo is event subscription properties containing the destination and filter information
 func (client EventSubscriptionsClient) Create(ctx context.Context, scope string, eventSubscriptionName string, eventSubscriptionInfo EventSubscription) (result EventSubscriptionsCreateFuture, err error) {
 	req, err := client.CreatePreparer(ctx, scope, eventSubscriptionName, eventSubscriptionInfo)
 	if err != nil {
@@ -120,16 +119,15 @@ func (client EventSubscriptionsClient) CreateResponder(resp *http.Response) (res
 }
 
 // Delete delete an existing event subscription
-// Parameters:
-// scope - the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
+//
+// scope is the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
 // level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription
 func (client EventSubscriptionsClient) Delete(ctx context.Context, scope string, eventSubscriptionName string) (result EventSubscriptionsDeleteFuture, err error) {
 	req, err := client.DeletePreparer(ctx, scope, eventSubscriptionName)
 	if err != nil {
@@ -194,16 +192,15 @@ func (client EventSubscriptionsClient) DeleteResponder(resp *http.Response) (res
 }
 
 // Get get properties of an event subscription
-// Parameters:
-// scope - the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
+//
+// scope is the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
 // level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription
 func (client EventSubscriptionsClient) Get(ctx context.Context, scope string, eventSubscriptionName string) (result EventSubscription, err error) {
 	req, err := client.GetPreparer(ctx, scope, eventSubscriptionName)
 	if err != nil {
@@ -267,16 +264,15 @@ func (client EventSubscriptionsClient) GetResponder(resp *http.Response) (result
 }
 
 // GetFullURL get the full endpoint URL for an event subscription
-// Parameters:
-// scope - the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
+//
+// scope is the scope of the event subscription. The scope can be a subscription, or a resource group, or a top
 // level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription
 func (client EventSubscriptionsClient) GetFullURL(ctx context.Context, scope string, eventSubscriptionName string) (result EventSubscriptionFullURL, err error) {
 	req, err := client.GetFullURLPreparer(ctx, scope, eventSubscriptionName)
 	if err != nil {
@@ -340,11 +336,10 @@ func (client EventSubscriptionsClient) GetFullURLResponder(resp *http.Response) 
 }
 
 // ListByResource list all event subscriptions that have been created for a specific topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// providerNamespace - namespace of the provider of the topic
-// resourceTypeName - name of the resource type
-// resourceName - name of the resource
+//
+// resourceGroupName is the name of the resource group within the user's subscription. providerNamespace is
+// namespace of the provider of the topic resourceTypeName is name of the resource type resourceName is name of the
+// resource
 func (client EventSubscriptionsClient) ListByResource(ctx context.Context, resourceGroupName string, providerNamespace string, resourceTypeName string, resourceName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListByResourcePreparer(ctx, resourceGroupName, providerNamespace, resourceTypeName, resourceName)
 	if err != nil {
@@ -411,8 +406,8 @@ func (client EventSubscriptionsClient) ListByResourceResponder(resp *http.Respon
 }
 
 // ListGlobalByResourceGroup list all global event subscriptions under a specific Azure subscription and resource group
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
+//
+// resourceGroupName is the name of the resource group within the user's subscription.
 func (client EventSubscriptionsClient) ListGlobalByResourceGroup(ctx context.Context, resourceGroupName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListGlobalByResourceGroupPreparer(ctx, resourceGroupName)
 	if err != nil {
@@ -477,9 +472,9 @@ func (client EventSubscriptionsClient) ListGlobalByResourceGroupResponder(resp *
 
 // ListGlobalByResourceGroupForTopicType list all global event subscriptions under a resource group for a specific
 // topic type.
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicTypeName - name of the topic type
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicTypeName is name of the
+// topic type
 func (client EventSubscriptionsClient) ListGlobalByResourceGroupForTopicType(ctx context.Context, resourceGroupName string, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListGlobalByResourceGroupForTopicTypePreparer(ctx, resourceGroupName, topicTypeName)
 	if err != nil {
@@ -607,8 +602,8 @@ func (client EventSubscriptionsClient) ListGlobalBySubscriptionResponder(resp *h
 
 // ListGlobalBySubscriptionForTopicType list all global event subscriptions under an Azure subscription for a topic
 // type.
-// Parameters:
-// topicTypeName - name of the topic type
+//
+// topicTypeName is name of the topic type
 func (client EventSubscriptionsClient) ListGlobalBySubscriptionForTopicType(ctx context.Context, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListGlobalBySubscriptionForTopicTypePreparer(ctx, topicTypeName)
 	if err != nil {
@@ -673,9 +668,9 @@ func (client EventSubscriptionsClient) ListGlobalBySubscriptionForTopicTypeRespo
 
 // ListRegionalByResourceGroup list all event subscriptions from the given location under a specific Azure subscription
 // and resource group
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// location - name of the location
+//
+// resourceGroupName is the name of the resource group within the user's subscription. location is name of the
+// location
 func (client EventSubscriptionsClient) ListRegionalByResourceGroup(ctx context.Context, resourceGroupName string, location string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalByResourceGroupPreparer(ctx, resourceGroupName, location)
 	if err != nil {
@@ -741,10 +736,9 @@ func (client EventSubscriptionsClient) ListRegionalByResourceGroupResponder(resp
 
 // ListRegionalByResourceGroupForTopicType list all event subscriptions from the given location under a specific Azure
 // subscription and resource group and topic type
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// location - name of the location
-// topicTypeName - name of the topic type
+//
+// resourceGroupName is the name of the resource group within the user's subscription. location is name of the
+// location topicTypeName is name of the topic type
 func (client EventSubscriptionsClient) ListRegionalByResourceGroupForTopicType(ctx context.Context, resourceGroupName string, location string, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalByResourceGroupForTopicTypePreparer(ctx, resourceGroupName, location, topicTypeName)
 	if err != nil {
@@ -810,8 +804,8 @@ func (client EventSubscriptionsClient) ListRegionalByResourceGroupForTopicTypeRe
 }
 
 // ListRegionalBySubscription list all event subscriptions from the given location under a specific Azure subscription
-// Parameters:
-// location - name of the location
+//
+// location is name of the location
 func (client EventSubscriptionsClient) ListRegionalBySubscription(ctx context.Context, location string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalBySubscriptionPreparer(ctx, location)
 	if err != nil {
@@ -876,9 +870,8 @@ func (client EventSubscriptionsClient) ListRegionalBySubscriptionResponder(resp 
 
 // ListRegionalBySubscriptionForTopicType list all event subscriptions from the given location under a specific Azure
 // subscription and topic type.
-// Parameters:
-// location - name of the location
-// topicTypeName - name of the topic type
+//
+// location is name of the location topicTypeName is name of the topic type
 func (client EventSubscriptionsClient) ListRegionalBySubscriptionForTopicType(ctx context.Context, location string, topicTypeName string) (result EventSubscriptionsListResult, err error) {
 	req, err := client.ListRegionalBySubscriptionForTopicTypePreparer(ctx, location, topicTypeName)
 	if err != nil {
@@ -943,17 +936,16 @@ func (client EventSubscriptionsClient) ListRegionalBySubscriptionForTopicTypeRes
 }
 
 // Update asynchronously updates an existing event subscription.
-// Parameters:
-// scope - the scope of existing event subscription. The scope can be a subscription, or a resource group, or a
+//
+// scope is the scope of existing event subscription. The scope can be a subscription, or a resource group, or a
 // top level resource belonging to a resource provider namespace, or an EventGrid topic. For example, use
 // '/subscriptions/{subscriptionId}/' for a subscription,
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for a resource group, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
 // for a resource, and
 // '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}'
-// for an EventGrid topic.
-// eventSubscriptionName - name of the event subscription to be created
-// eventSubscriptionUpdateParameters - updated event subscription information
+// for an EventGrid topic. eventSubscriptionName is name of the event subscription to be created
+// eventSubscriptionUpdateParameters is updated event subscription information
 func (client EventSubscriptionsClient) Update(ctx context.Context, scope string, eventSubscriptionName string, eventSubscriptionUpdateParameters EventSubscriptionUpdateParameters) (result EventSubscriptionsUpdateFuture, err error) {
 	req, err := client.UpdatePreparer(ctx, scope, eventSubscriptionName, eventSubscriptionUpdateParameters)
 	if err != nil {

--- a/services/preview/eventgrid/mgmt/2017-09-15-preview/eventgrid/topics.go
+++ b/services/preview/eventgrid/mgmt/2017-09-15-preview/eventgrid/topics.go
@@ -41,10 +41,9 @@ func NewTopicsClientWithBaseURI(baseURI string, subscriptionID string) TopicsCli
 }
 
 // CreateOrUpdate asynchronously creates a new topic with the specified parameters.
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
-// topicInfo - topic information
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic topicInfo is topic information
 func (client TopicsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, topicName string, topicInfo Topic) (result TopicsCreateOrUpdateFuture, err error) {
 	req, err := client.CreateOrUpdatePreparer(ctx, resourceGroupName, topicName, topicInfo)
 	if err != nil {
@@ -113,9 +112,9 @@ func (client TopicsClient) CreateOrUpdateResponder(resp *http.Response) (result 
 }
 
 // Delete delete existing topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic
 func (client TopicsClient) Delete(ctx context.Context, resourceGroupName string, topicName string) (result TopicsDeleteFuture, err error) {
 	req, err := client.DeletePreparer(ctx, resourceGroupName, topicName)
 	if err != nil {
@@ -181,9 +180,9 @@ func (client TopicsClient) DeleteResponder(resp *http.Response) (result autorest
 }
 
 // Get get properties of a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic
 func (client TopicsClient) Get(ctx context.Context, resourceGroupName string, topicName string) (result Topic, err error) {
 	req, err := client.GetPreparer(ctx, resourceGroupName, topicName)
 	if err != nil {
@@ -248,8 +247,8 @@ func (client TopicsClient) GetResponder(resp *http.Response) (result Topic, err 
 }
 
 // ListByResourceGroup list all the topics under a resource group
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
+//
+// resourceGroupName is the name of the resource group within the user's subscription.
 func (client TopicsClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) (result TopicsListResult, err error) {
 	req, err := client.ListByResourceGroupPreparer(ctx, resourceGroupName)
 	if err != nil {
@@ -375,11 +374,10 @@ func (client TopicsClient) ListBySubscriptionResponder(resp *http.Response) (res
 }
 
 // ListEventTypes list event types for a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// providerNamespace - namespace of the provider of the topic
-// resourceTypeName - name of the topic type
-// resourceName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. providerNamespace is
+// namespace of the provider of the topic resourceTypeName is name of the topic type resourceName is name of the
+// topic
 func (client TopicsClient) ListEventTypes(ctx context.Context, resourceGroupName string, providerNamespace string, resourceTypeName string, resourceName string) (result EventTypesListResult, err error) {
 	req, err := client.ListEventTypesPreparer(ctx, resourceGroupName, providerNamespace, resourceTypeName, resourceName)
 	if err != nil {
@@ -446,9 +444,9 @@ func (client TopicsClient) ListEventTypesResponder(resp *http.Response) (result 
 }
 
 // ListSharedAccessKeys list the two keys used to publish to a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic
 func (client TopicsClient) ListSharedAccessKeys(ctx context.Context, resourceGroupName string, topicName string) (result TopicSharedAccessKeys, err error) {
 	req, err := client.ListSharedAccessKeysPreparer(ctx, resourceGroupName, topicName)
 	if err != nil {
@@ -513,10 +511,9 @@ func (client TopicsClient) ListSharedAccessKeysResponder(resp *http.Response) (r
 }
 
 // RegenerateKey regenerate a shared access key for a topic
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
-// regenerateKeyRequest - request body to regenerate key
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic regenerateKeyRequest is request body to regenerate key
 func (client TopicsClient) RegenerateKey(ctx context.Context, resourceGroupName string, topicName string, regenerateKeyRequest TopicRegenerateKeyRequest) (result TopicSharedAccessKeys, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: regenerateKeyRequest,
@@ -589,10 +586,9 @@ func (client TopicsClient) RegenerateKeyResponder(resp *http.Response) (result T
 }
 
 // Update asynchronously updates a topic with the specified parameters.
-// Parameters:
-// resourceGroupName - the name of the resource group within the user's subscription.
-// topicName - name of the topic
-// topicUpdateParameters - topic update information
+//
+// resourceGroupName is the name of the resource group within the user's subscription. topicName is name of the
+// topic topicUpdateParameters is topic update information
 func (client TopicsClient) Update(ctx context.Context, resourceGroupName string, topicName string, topicUpdateParameters TopicUpdateParameters) (result TopicsUpdateFuture, err error) {
 	req, err := client.UpdatePreparer(ctx, resourceGroupName, topicName, topicUpdateParameters)
 	if err != nil {

--- a/services/preview/eventgrid/mgmt/2017-09-15-preview/eventgrid/topictypes.go
+++ b/services/preview/eventgrid/mgmt/2017-09-15-preview/eventgrid/topictypes.go
@@ -40,8 +40,8 @@ func NewTopicTypesClientWithBaseURI(baseURI string, subscriptionID string) Topic
 }
 
 // Get get information about a topic type
-// Parameters:
-// topicTypeName - name of the topic type
+//
+// topicTypeName is name of the topic type
 func (client TopicTypesClient) Get(ctx context.Context, topicTypeName string) (result TopicTypeInfo, err error) {
 	req, err := client.GetPreparer(ctx, topicTypeName)
 	if err != nil {
@@ -162,8 +162,8 @@ func (client TopicTypesClient) ListResponder(resp *http.Response) (result TopicT
 }
 
 // ListEventTypes list event types for a topic type
-// Parameters:
-// topicTypeName - name of the topic type
+//
+// topicTypeName is name of the topic type
 func (client TopicTypesClient) ListEventTypes(ctx context.Context, topicTypeName string) (result EventTypesListResult, err error) {
 	req, err := client.ListEventTypesPreparer(ctx, topicTypeName)
 	if err != nil {


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2991