### PR TITLE
[AutoPR web/resource-manager] Fix for https://github.com/Azure/azure-rest-api-specs/issues/2907. Missed the production slot APIs earlier. 

### DIFF
--- a/services/web/mgmt/2016-09-01/web/apps.go
+++ b/services/web/mgmt/2016-09-01/web/apps.go
@@ -2635,7 +2635,7 @@ func (client AppsClient) CreateOrUpdateSourceControlSender(req *http.Request) (f
 		return
 	}
 	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
 	return
 }
 
@@ -2645,7 +2645,7 @@ func (client AppsClient) CreateOrUpdateSourceControlResponder(resp *http.Respons
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}
@@ -11298,7 +11298,7 @@ func (client AppsClient) GetSourceControlResponder(resp *http.Response) (result 
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}

--- a/services/web/mgmt/2018-02-01/web/apps.go
+++ b/services/web/mgmt/2018-02-01/web/apps.go
@@ -2615,7 +2615,7 @@ func (client AppsClient) CreateOrUpdateSourceControlSender(req *http.Request) (f
 		return
 	}
 	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
 	return
 }
 
@@ -2625,7 +2625,7 @@ func (client AppsClient) CreateOrUpdateSourceControlResponder(resp *http.Respons
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}
@@ -11580,7 +11580,7 @@ func (client AppsClient) GetSourceControlResponder(resp *http.Response) (result 
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3017