### PR TITLE
[AutoPR eventgrid/data-plane] EventGrid Dataplane: Added schemas corresponding to SubscriptionValidationEvent/Response and SubscriptionDeletedEvent

### DIFF
--- a/profiles/latest/eventgrid/eventgrid/models.go
+++ b/profiles/latest/eventgrid/eventgrid/models.go
@@ -49,6 +49,9 @@ type ServiceBusActiveMessagesAvailableWithNoListenersEventData = original.Servic
 type ServiceBusDeadletterMessagesAvailableWithNoListenersEventData = original.ServiceBusDeadletterMessagesAvailableWithNoListenersEventData
 type StorageBlobCreatedEventData = original.StorageBlobCreatedEventData
 type StorageBlobDeletedEventData = original.StorageBlobDeletedEventData
+type SubscriptionDeletedEventData = original.SubscriptionDeletedEventData
+type SubscriptionValidationEventData = original.SubscriptionValidationEventData
+type SubscriptionValidationResponse = original.SubscriptionValidationResponse
 
 func New() BaseClient {
 	return original.New()

--- a/profiles/preview/eventgrid/eventgrid/models.go
+++ b/profiles/preview/eventgrid/eventgrid/models.go
@@ -49,6 +49,9 @@ type ServiceBusActiveMessagesAvailableWithNoListenersEventData = original.Servic
 type ServiceBusDeadletterMessagesAvailableWithNoListenersEventData = original.ServiceBusDeadletterMessagesAvailableWithNoListenersEventData
 type StorageBlobCreatedEventData = original.StorageBlobCreatedEventData
 type StorageBlobDeletedEventData = original.StorageBlobDeletedEventData
+type SubscriptionDeletedEventData = original.SubscriptionDeletedEventData
+type SubscriptionValidationEventData = original.SubscriptionValidationEventData
+type SubscriptionValidationResponse = original.SubscriptionValidationResponse
 
 func New() BaseClient {
 	return original.New()

--- a/services/eventgrid/2018-01-01/eventgrid/models.go
+++ b/services/eventgrid/2018-01-01/eventgrid/models.go
@@ -514,3 +514,27 @@ type StorageBlobDeletedEventData struct {
 	// StorageDiagnostics - For service use only. Diagnostic data occasionally included by the Azure Storage service. This property should be ignored by event consumers.
 	StorageDiagnostics interface{} `json:"storageDiagnostics,omitempty"`
 }
+
+// SubscriptionDeletedEventData schema of the Data property of an EventGridEvent for a
+// Microsoft.EventGrid.SubscriptionDeletedEvent.
+type SubscriptionDeletedEventData struct {
+	// EventSubscriptionID - The Azure resource ID of the deleted event subscription.
+	EventSubscriptionID *string `json:"eventSubscriptionId,omitempty"`
+}
+
+// SubscriptionValidationEventData schema of the Data property of an EventGridEvent for a
+// Microsoft.EventGrid.SubscriptionValidationEvent.
+type SubscriptionValidationEventData struct {
+	// ValidationCode - The validation code sent by Azure Event Grid to validate an event subscription. To complete the validation handshake, the subscriber must either respond with this validation code as part of the validation response, or perform a GET request on the validationUrl (available starting version 2018-05-01-preview).
+	ValidationCode *string `json:"validationCode,omitempty"`
+	// ValidationURL - The validation URL sent by Azure Event Grid (available starting version 2018-05-01-preview). To complete the validation handshake, the subscriber must either respond with the validationCode as part of the validation response, or perform a GET request on the validationUrl (available starting version 2018-05-01-preview).
+	ValidationURL *string `json:"validationUrl,omitempty"`
+}
+
+// SubscriptionValidationResponse to complete an event subscription validation handshake, a subscriber can use
+// either the validationCode or the validationUrl received in a SubscriptionValidationEvent. When the
+// validationCode is used, the SubscriptionValidationResponse can be used to build the response.
+type SubscriptionValidationResponse struct {
+	// ValidationResponse - The validation response sent by the subscriber to Azure Event Grid to complete the validation of an event subscription.
+	ValidationResponse *string `json:"validationResponse,omitempty"`
+}


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3061