### PR TITLE
Fix SecurityGroupClient.ListNetworkSecurityGroups()

### DIFF
--- a/services/classic/management/networksecuritygroup/client.go
+++ b/services/classic/management/networksecuritygroup/client.go
@@ -109,15 +109,20 @@ func (sg SecurityGroupClient) GetNetworkSecurityGroup(name string) (SecurityGrou
 //
 // https://msdn.microsoft.com/en-us/library/azure/dn913815.aspx
 func (sg SecurityGroupClient) ListNetworkSecurityGroups() (SecurityGroupList, error) {
-	var securityGroups SecurityGroupList
+	// the list of NetworkSecurityGroup items is wrapped in a NetworkSecurityGroups
+	// element so we need an outer struct representing this element.
+	type NetworkSecurityGroups struct {
+		SecurityGroupList SecurityGroupList `xml:"http://schemas.microsoft.com/windowsazure NetworkSecurityGroup"`
+	}
+	var securityGroups NetworkSecurityGroups
 
 	response, err := sg.client.SendAzureGetRequest(listSecurityGroupsURL)
 	if err != nil {
-		return securityGroups, err
+		return securityGroups.SecurityGroupList, err
 	}
 
 	err = xml.Unmarshal(response, &securityGroups)
-	return securityGroups, err
+	return securityGroups.SecurityGroupList, err
 }
 
 // AddNetworkSecurityToSubnet associates the network security group with


### PR DESCRIPTION
The unmarshalling code didn't account for the payload being wrapped in a
NetworkSecurityGroups element; this has been fixed.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 