### PR TITLE
Add primary flag to InterfaceIPConfigurationPropertiesFormat

### DIFF
--- a/services/network/mgmt/2015-06-15/network/models.go
+++ b/services/network/mgmt/2015-06-15/network/models.go
@@ -4023,6 +4023,8 @@ type InterfaceIPConfigurationPropertiesFormat struct {
 	// PrivateIPAllocationMethod - Defines how a private IP address is assigned. Possible values are: 'Static' and 'Dynamic'. Possible values include: 'Static', 'Dynamic'
 	PrivateIPAllocationMethod IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
 	Subnet                    *Subnet            `json:"subnet,omitempty"`
+	// Primary - Gets whether this is a primary customer address on the network interface.
+	Primary           *bool            `json:"primary,omitempty"`
 	PublicIPAddress           *PublicIPAddress   `json:"publicIPAddress,omitempty"`
 	ProvisioningState         *string            `json:"provisioningState,omitempty"`
 }


### PR DESCRIPTION
Primary flag is missing from InterfaceIPConfigurationPropertiesFormat struct in 2015-06-15 network model. API populates this flag but because a of bug in specs repository this flags does not get hydrated. This is a bug which has blocked Terraform efforts on Azure Stack. 
I've created a pull request to the specs repository to fix it. 
(https://github.com/Azure/azure-rest-api-specs/pull/3200)

This PR is to unblock Terradorm project while the other PR on specs repository gets through.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 