### PR TITLE
storage/Client.useHTTPS should default to true when using SAS URLs

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -343,7 +343,7 @@ func NewAccountSASClient(account string, token url.Values, env azure.Environment
 
 	// Get API version and protocol from token
 	c.apiVersion = token.Get("sv")
-	c.useHTTPS = token.Get("spr") == "https"
+	c.useHTTPS = token.Get("spr") != "http"
 	return c
 }
 
@@ -384,7 +384,7 @@ func NewAccountSASClientFromEndpointToken(endpoint string, sasToken string) (Cli
 
 	// Get API version and protocol from token
 	c.apiVersion = token.Get("sv")
-	c.useHTTPS = token.Get("spr") == "https"
+	c.useHTTPS = token.Get("spr") != "http"
 	return c, nil
 }
 


### PR DESCRIPTION
Hi,
I have a blob storage that only allows access using HTTPS. When I generate a SAS URL to a container in that blob storage (using the Azure Storage Explorer), the generated SAS URL does not include the ```spr``` field. I can use the SAS URL to access the container in the Azure Storage Explorer, but neither ```NewAccountSASClient``` nor ```NewAccountSASClientFromEndpointToken```.

I could not find any documentation on the default value of the ```spr``` field, but I assume it is ```https```. Therefore I made this PR.
