### PR TITLE
Add doc string clarifying the encoding requirements for KeyOperationParameters.Value

### DIFF
--- a/services/keyvault/2016-10-01/keyvault/models.go
+++ b/services/keyvault/2016-10-01/keyvault/models.go
@@ -1737,7 +1737,8 @@ type KeyOperationResult struct {
 type KeyOperationsParameters struct {
 	// Algorithm - algorithm identifier. Possible values include: 'RSAOAEP', 'RSAOAEP256', 'RSA15'
 	Algorithm JSONWebKeyEncryptionAlgorithm `json:"alg,omitempty"`
-	Value     *string                       `json:"value,omitempty"`
+	// Value - an unpadded, url-encoded base-64 encoded string (see encoding/base64.RawURLEncoding)
+	Value *string `json:"value,omitempty"`
 }
 
 // KeyProperties properties of the key pair backing a certificate.


### PR DESCRIPTION
To spare others the confused debugging when using `base64.StdEncoding`, this PR adds documentation about how to properly encode `KeyOperationParameter.Value`.

(If I hadn't found [this](https://github.com/Azure/azure-sdk-for-go/issues/764#issuecomment-332951711) comment, I'd never understood what was happening)