### PR TITLE
[AutoPR monitor/resource-manager] Add two missing "by subscription" operations for completeness and compliance

### DIFF
--- a/services/preview/monitor/mgmt/2017-05-01-preview/insights/alertrules.go
+++ b/services/preview/monitor/mgmt/2017-05-01-preview/insights/alertrules.go
@@ -318,6 +318,68 @@ func (client AlertRulesClient) ListByResourceGroupResponder(resp *http.Response)
 	return
 }
 
+// ListBySusbscription list the alert rules within a subscription.
+func (client AlertRulesClient) ListBySusbscription(ctx context.Context) (result AlertRuleResourceCollection, err error) {
+	req, err := client.ListBySusbscriptionPreparer(ctx)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListBySusbscriptionSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.ListBySusbscriptionResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// ListBySusbscriptionPreparer prepares the ListBySusbscription request.
+func (client AlertRulesClient) ListBySusbscriptionPreparer(ctx context.Context) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2016-03-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/microsoft.insights/alertrules", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListBySusbscriptionSender sends the ListBySusbscription request. The method will close the
+// http.Response Body if it receives an error.
+func (client AlertRulesClient) ListBySusbscriptionSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListBySusbscriptionResponder handles the response to the ListBySusbscription request. The method always
+// closes the http.Response Body.
+func (client AlertRulesClient) ListBySusbscriptionResponder(resp *http.Response) (result AlertRuleResourceCollection, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // Update updates an existing AlertRuleResource. To update other fields use the CreateOrUpdate method.
 // Parameters:
 // resourceGroupName - the name of the resource group.

--- a/services/preview/monitor/mgmt/2017-05-01-preview/insights/alertrules.go
+++ b/services/preview/monitor/mgmt/2017-05-01-preview/insights/alertrules.go
@@ -318,31 +318,31 @@ func (client AlertRulesClient) ListByResourceGroupResponder(resp *http.Response)
 	return
 }
 
-// ListBySusbscription list the alert rules within a subscription.
-func (client AlertRulesClient) ListBySusbscription(ctx context.Context) (result AlertRuleResourceCollection, err error) {
-	req, err := client.ListBySusbscriptionPreparer(ctx)
+// ListBySubscription list the alert rules within a subscription.
+func (client AlertRulesClient) ListBySubscription(ctx context.Context) (result AlertRuleResourceCollection, err error) {
+	req, err := client.ListBySubscriptionPreparer(ctx)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", nil, "Failure preparing request")
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySubscription", nil, "Failure preparing request")
 		return
 	}
 
-	resp, err := client.ListBySusbscriptionSender(req)
+	resp, err := client.ListBySubscriptionSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", resp, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySubscription", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.ListBySusbscriptionResponder(resp)
+	result, err = client.ListBySubscriptionResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySubscription", resp, "Failure responding to request")
 	}
 
 	return
 }
 
-// ListBySusbscriptionPreparer prepares the ListBySusbscription request.
-func (client AlertRulesClient) ListBySusbscriptionPreparer(ctx context.Context) (*http.Request, error) {
+// ListBySubscriptionPreparer prepares the ListBySubscription request.
+func (client AlertRulesClient) ListBySubscriptionPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
@@ -360,16 +360,16 @@ func (client AlertRulesClient) ListBySusbscriptionPreparer(ctx context.Context) 
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 
-// ListBySusbscriptionSender sends the ListBySusbscription request. The method will close the
+// ListBySubscriptionSender sends the ListBySubscription request. The method will close the
 // http.Response Body if it receives an error.
-func (client AlertRulesClient) ListBySusbscriptionSender(req *http.Request) (*http.Response, error) {
+func (client AlertRulesClient) ListBySubscriptionSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client, req,
 		azure.DoRetryWithRegistration(client.Client))
 }
 
-// ListBySusbscriptionResponder handles the response to the ListBySusbscription request. The method always
+// ListBySubscriptionResponder handles the response to the ListBySubscription request. The method always
 // closes the http.Response Body.
-func (client AlertRulesClient) ListBySusbscriptionResponder(resp *http.Response) (result AlertRuleResourceCollection, err error) {
+func (client AlertRulesClient) ListBySubscriptionResponder(resp *http.Response) (result AlertRuleResourceCollection, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),

--- a/services/preview/monitor/mgmt/2017-05-01-preview/insights/autoscalesettings.go
+++ b/services/preview/monitor/mgmt/2017-05-01-preview/insights/autoscalesettings.go
@@ -345,6 +345,96 @@ func (client AutoscaleSettingsClient) ListByResourceGroupComplete(ctx context.Co
 	return
 }
 
+// ListBySubscription lists the autoscale settings for a subscription
+func (client AutoscaleSettingsClient) ListBySubscription(ctx context.Context) (result AutoscaleSettingResourceCollectionPage, err error) {
+	result.fn = client.listBySubscriptionNextResults
+	req, err := client.ListBySubscriptionPreparer(ctx)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "ListBySubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListBySubscriptionSender(req)
+	if err != nil {
+		result.asrc.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "ListBySubscription", resp, "Failure sending request")
+		return
+	}
+
+	result.asrc, err = client.ListBySubscriptionResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "ListBySubscription", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// ListBySubscriptionPreparer prepares the ListBySubscription request.
+func (client AutoscaleSettingsClient) ListBySubscriptionPreparer(ctx context.Context) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2015-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/microsoft.insights/autoscalesettings", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListBySubscriptionSender sends the ListBySubscription request. The method will close the
+// http.Response Body if it receives an error.
+func (client AutoscaleSettingsClient) ListBySubscriptionSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListBySubscriptionResponder handles the response to the ListBySubscription request. The method always
+// closes the http.Response Body.
+func (client AutoscaleSettingsClient) ListBySubscriptionResponder(resp *http.Response) (result AutoscaleSettingResourceCollection, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// listBySubscriptionNextResults retrieves the next set of results, if any.
+func (client AutoscaleSettingsClient) listBySubscriptionNextResults(lastResults AutoscaleSettingResourceCollection) (result AutoscaleSettingResourceCollection, err error) {
+	req, err := lastResults.autoscaleSettingResourceCollectionPreparer()
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "listBySubscriptionNextResults", nil, "Failure preparing next results request")
+	}
+	if req == nil {
+		return
+	}
+	resp, err := client.ListBySubscriptionSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "listBySubscriptionNextResults", resp, "Failure sending next results request")
+	}
+	result, err = client.ListBySubscriptionResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "listBySubscriptionNextResults", resp, "Failure responding to next results request")
+	}
+	return
+}
+
+// ListBySubscriptionComplete enumerates all values, automatically crossing page boundaries as required.
+func (client AutoscaleSettingsClient) ListBySubscriptionComplete(ctx context.Context) (result AutoscaleSettingResourceCollectionIterator, err error) {
+	result.page, err = client.ListBySubscription(ctx)
+	return
+}
+
 // Update updates an existing AutoscaleSettingsResource. To update other fields use the CreateOrUpdate method.
 // Parameters:
 // resourceGroupName - the name of the resource group.

--- a/services/preview/monitor/mgmt/2017-05-01-preview/insights/models.go
+++ b/services/preview/monitor/mgmt/2017-05-01-preview/insights/models.go
@@ -1311,7 +1311,8 @@ type DiagnosticSettingsCategory struct {
 
 // DiagnosticSettingsCategoryResource the diagnostic settings category resource.
 type DiagnosticSettingsCategoryResource struct {
-	autorest.Response           `json:"-"`
+	autorest.Response `json:"-"`
+	// DiagnosticSettingsCategory - The properties of a Diagnostic Settings Category.
 	*DiagnosticSettingsCategory `json:"properties,omitempty"`
 	// ID - Azure resource Id
 	ID *string `json:"id,omitempty"`
@@ -1399,7 +1400,8 @@ type DiagnosticSettingsCategoryResourceCollection struct {
 
 // DiagnosticSettingsResource the diagnostic setting resource.
 type DiagnosticSettingsResource struct {
-	autorest.Response   `json:"-"`
+	autorest.Response `json:"-"`
+	// DiagnosticSettings - Properties of a Diagnostic Settings Resource.
 	*DiagnosticSettings `json:"properties,omitempty"`
 	// ID - Azure resource Id
 	ID *string `json:"id,omitempty"`

--- a/services/preview/monitor/mgmt/2017-05-01-preview/insights/models.go
+++ b/services/preview/monitor/mgmt/2017-05-01-preview/insights/models.go
@@ -1291,6 +1291,8 @@ type AzureAppPushReceiver struct {
 type DiagnosticSettings struct {
 	// StorageAccountID - The resource ID of the storage account to which you would like to send Diagnostic Logs.
 	StorageAccountID *string `json:"storageAccountId,omitempty"`
+	// ServiceBusRuleID - The service bus rule Id of the diagnostic setting. This is here to maintain backwards compatibility.
+	ServiceBusRuleID *string `json:"serviceBusRuleId,omitempty"`
 	// EventHubAuthorizationRuleID - The resource Id for the event hub authorization rule.
 	EventHubAuthorizationRuleID *string `json:"eventHubAuthorizationRuleId,omitempty"`
 	// EventHubName - The name of the event hub. If none is specified, the default event hub will be selected.

--- a/services/preview/monitor/mgmt/2018-03-01/insights/alertrules.go
+++ b/services/preview/monitor/mgmt/2018-03-01/insights/alertrules.go
@@ -318,6 +318,68 @@ func (client AlertRulesClient) ListByResourceGroupResponder(resp *http.Response)
 	return
 }
 
+// ListBySusbscription list the alert rules within a subscription.
+func (client AlertRulesClient) ListBySusbscription(ctx context.Context) (result AlertRuleResourceCollection, err error) {
+	req, err := client.ListBySusbscriptionPreparer(ctx)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListBySusbscriptionSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.ListBySusbscriptionResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// ListBySusbscriptionPreparer prepares the ListBySusbscription request.
+func (client AlertRulesClient) ListBySusbscriptionPreparer(ctx context.Context) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2016-03-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/microsoft.insights/alertrules", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListBySusbscriptionSender sends the ListBySusbscription request. The method will close the
+// http.Response Body if it receives an error.
+func (client AlertRulesClient) ListBySusbscriptionSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListBySusbscriptionResponder handles the response to the ListBySusbscription request. The method always
+// closes the http.Response Body.
+func (client AlertRulesClient) ListBySusbscriptionResponder(resp *http.Response) (result AlertRuleResourceCollection, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // Update updates an existing AlertRuleResource. To update other fields use the CreateOrUpdate method.
 // Parameters:
 // resourceGroupName - the name of the resource group.

--- a/services/preview/monitor/mgmt/2018-03-01/insights/alertrules.go
+++ b/services/preview/monitor/mgmt/2018-03-01/insights/alertrules.go
@@ -318,31 +318,31 @@ func (client AlertRulesClient) ListByResourceGroupResponder(resp *http.Response)
 	return
 }
 
-// ListBySusbscription list the alert rules within a subscription.
-func (client AlertRulesClient) ListBySusbscription(ctx context.Context) (result AlertRuleResourceCollection, err error) {
-	req, err := client.ListBySusbscriptionPreparer(ctx)
+// ListBySubscription list the alert rules within a subscription.
+func (client AlertRulesClient) ListBySubscription(ctx context.Context) (result AlertRuleResourceCollection, err error) {
+	req, err := client.ListBySubscriptionPreparer(ctx)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", nil, "Failure preparing request")
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySubscription", nil, "Failure preparing request")
 		return
 	}
 
-	resp, err := client.ListBySusbscriptionSender(req)
+	resp, err := client.ListBySubscriptionSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", resp, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySubscription", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.ListBySusbscriptionResponder(resp)
+	result, err = client.ListBySubscriptionResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySusbscription", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "insights.AlertRulesClient", "ListBySubscription", resp, "Failure responding to request")
 	}
 
 	return
 }
 
-// ListBySusbscriptionPreparer prepares the ListBySusbscription request.
-func (client AlertRulesClient) ListBySusbscriptionPreparer(ctx context.Context) (*http.Request, error) {
+// ListBySubscriptionPreparer prepares the ListBySubscription request.
+func (client AlertRulesClient) ListBySubscriptionPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
@@ -360,16 +360,16 @@ func (client AlertRulesClient) ListBySusbscriptionPreparer(ctx context.Context) 
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 
-// ListBySusbscriptionSender sends the ListBySusbscription request. The method will close the
+// ListBySubscriptionSender sends the ListBySubscription request. The method will close the
 // http.Response Body if it receives an error.
-func (client AlertRulesClient) ListBySusbscriptionSender(req *http.Request) (*http.Response, error) {
+func (client AlertRulesClient) ListBySubscriptionSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client, req,
 		azure.DoRetryWithRegistration(client.Client))
 }
 
-// ListBySusbscriptionResponder handles the response to the ListBySusbscription request. The method always
+// ListBySubscriptionResponder handles the response to the ListBySubscription request. The method always
 // closes the http.Response Body.
-func (client AlertRulesClient) ListBySusbscriptionResponder(resp *http.Response) (result AlertRuleResourceCollection, err error) {
+func (client AlertRulesClient) ListBySubscriptionResponder(resp *http.Response) (result AlertRuleResourceCollection, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),

--- a/services/preview/monitor/mgmt/2018-03-01/insights/autoscalesettings.go
+++ b/services/preview/monitor/mgmt/2018-03-01/insights/autoscalesettings.go
@@ -345,6 +345,96 @@ func (client AutoscaleSettingsClient) ListByResourceGroupComplete(ctx context.Co
 	return
 }
 
+// ListBySubscription lists the autoscale settings for a subscription
+func (client AutoscaleSettingsClient) ListBySubscription(ctx context.Context) (result AutoscaleSettingResourceCollectionPage, err error) {
+	result.fn = client.listBySubscriptionNextResults
+	req, err := client.ListBySubscriptionPreparer(ctx)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "ListBySubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListBySubscriptionSender(req)
+	if err != nil {
+		result.asrc.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "ListBySubscription", resp, "Failure sending request")
+		return
+	}
+
+	result.asrc, err = client.ListBySubscriptionResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "ListBySubscription", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// ListBySubscriptionPreparer prepares the ListBySubscription request.
+func (client AutoscaleSettingsClient) ListBySubscriptionPreparer(ctx context.Context) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2015-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/microsoft.insights/autoscalesettings", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListBySubscriptionSender sends the ListBySubscription request. The method will close the
+// http.Response Body if it receives an error.
+func (client AutoscaleSettingsClient) ListBySubscriptionSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListBySubscriptionResponder handles the response to the ListBySubscription request. The method always
+// closes the http.Response Body.
+func (client AutoscaleSettingsClient) ListBySubscriptionResponder(resp *http.Response) (result AutoscaleSettingResourceCollection, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// listBySubscriptionNextResults retrieves the next set of results, if any.
+func (client AutoscaleSettingsClient) listBySubscriptionNextResults(lastResults AutoscaleSettingResourceCollection) (result AutoscaleSettingResourceCollection, err error) {
+	req, err := lastResults.autoscaleSettingResourceCollectionPreparer()
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "listBySubscriptionNextResults", nil, "Failure preparing next results request")
+	}
+	if req == nil {
+		return
+	}
+	resp, err := client.ListBySubscriptionSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "listBySubscriptionNextResults", resp, "Failure sending next results request")
+	}
+	result, err = client.ListBySubscriptionResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "insights.AutoscaleSettingsClient", "listBySubscriptionNextResults", resp, "Failure responding to next results request")
+	}
+	return
+}
+
+// ListBySubscriptionComplete enumerates all values, automatically crossing page boundaries as required.
+func (client AutoscaleSettingsClient) ListBySubscriptionComplete(ctx context.Context) (result AutoscaleSettingResourceCollectionIterator, err error) {
+	result.page, err = client.ListBySubscription(ctx)
+	return
+}
+
 // Update updates an existing AutoscaleSettingsResource. To update other fields use the CreateOrUpdate method.
 // Parameters:
 // resourceGroupName - the name of the resource group.

--- a/services/preview/monitor/mgmt/2018-03-01/insights/models.go
+++ b/services/preview/monitor/mgmt/2018-03-01/insights/models.go
@@ -1806,6 +1806,8 @@ type CalculateBaselineResponse struct {
 type DiagnosticSettings struct {
 	// StorageAccountID - The resource ID of the storage account to which you would like to send Diagnostic Logs.
 	StorageAccountID *string `json:"storageAccountId,omitempty"`
+	// ServiceBusRuleID - The service bus rule Id of the diagnostic setting. This is here to maintain backwards compatibility.
+	ServiceBusRuleID *string `json:"serviceBusRuleId,omitempty"`
 	// EventHubAuthorizationRuleID - The resource Id for the event hub authorization rule.
 	EventHubAuthorizationRuleID *string `json:"eventHubAuthorizationRuleId,omitempty"`
 	// EventHubName - The name of the event hub. If none is specified, the default event hub will be selected.

--- a/services/preview/monitor/mgmt/2018-03-01/insights/models.go
+++ b/services/preview/monitor/mgmt/2018-03-01/insights/models.go
@@ -509,13 +509,13 @@ func PossibleUnitValues() []Unit {
 	return []Unit{UnitBytes, UnitByteSeconds, UnitBytesPerSecond, UnitCount, UnitCountPerSecond, UnitMilliSeconds, UnitPercent, UnitSeconds, UnitUnspecified}
 }
 
-// BasicAction ...
+// BasicAction action descriptor.
 type BasicAction interface {
 	AsAlertingAction() (*AlertingAction, bool)
 	AsAction() (*Action, bool)
 }
 
-// Action ...
+// Action action descriptor.
 type Action struct {
 	// OdataType - Possible values include: 'OdataTypeAction', 'OdataTypeMicrosoftWindowsAzureManagementMonitoringAlertsModelsMicrosoftAppInsightsNexusDataContractsResourcesScheduledQueryRulesAlertingAction'
 	OdataType OdataTypeBasicAction `json:"odata.type,omitempty"`
@@ -1826,7 +1826,8 @@ type DiagnosticSettingsCategory struct {
 
 // DiagnosticSettingsCategoryResource the diagnostic settings category resource.
 type DiagnosticSettingsCategoryResource struct {
-	autorest.Response           `json:"-"`
+	autorest.Response `json:"-"`
+	// DiagnosticSettingsCategory - The properties of a Diagnostic Settings Category.
 	*DiagnosticSettingsCategory `json:"properties,omitempty"`
 	// ID - Azure resource Id
 	ID *string `json:"id,omitempty"`
@@ -1914,7 +1915,8 @@ type DiagnosticSettingsCategoryResourceCollection struct {
 
 // DiagnosticSettingsResource the diagnostic setting resource.
 type DiagnosticSettingsResource struct {
-	autorest.Response   `json:"-"`
+	autorest.Response `json:"-"`
+	// DiagnosticSettings - Properties of a Diagnostic Settings Resource.
 	*DiagnosticSettings `json:"properties,omitempty"`
 	// ID - Azure resource Id
 	ID *string `json:"id,omitempty"`
@@ -2044,6 +2046,7 @@ type EventCategoryCollection struct {
 
 // EventData the Azure event log entries are of type EventData
 type EventData struct {
+	// Authorization - The sender authorization information.
 	Authorization *SenderAuthorization `json:"authorization,omitempty"`
 	// Claims - key value pairs to identify ARM permissions.
 	Claims map[string]*string `json:"claims"`
@@ -2443,11 +2446,12 @@ type LogicAppReceiver struct {
 	CallbackURL *string `json:"callbackUrl,omitempty"`
 }
 
-// LogMetricTrigger ...
+// LogMetricTrigger a log metrics trigger descriptor.
 type LogMetricTrigger struct {
 	// ThresholdOperator - Evaluation operation for Metric -'GreaterThan' or 'LessThan' or 'Equal'. Possible values include: 'ConditionalOperatorGreaterThan', 'ConditionalOperatorLessThan', 'ConditionalOperatorEqual'
 	ThresholdOperator ConditionalOperator `json:"thresholdOperator,omitempty"`
-	Threshold         *float64            `json:"threshold,omitempty"`
+	// Threshold - The threshold of the metric trigger.
+	Threshold *float64 `json:"threshold,omitempty"`
 	// MetricTriggerType - Metric Trigger Type - 'Consecutive' or 'Total'. Possible values include: 'MetricTriggerTypeConsecutive', 'MetricTriggerTypeTotal'
 	MetricTriggerType MetricTriggerType `json:"metricTriggerType,omitempty"`
 	// MetricColumn - Evaluation of metric on a particular column
@@ -3044,7 +3048,8 @@ type Metric struct {
 // MetricAlertAction an alert action.
 type MetricAlertAction struct {
 	// ActionGroupID - the id of the action group to use.
-	ActionGroupID     *string            `json:"actionGroupId,omitempty"`
+	ActionGroupID *string `json:"actionGroupId,omitempty"`
+	// WebhookProperties - The properties of a webhook object.
 	WebhookProperties map[string]*string `json:"webhookProperties"`
 }
 
@@ -3500,6 +3505,7 @@ type MetricAlertStatusCollection struct {
 
 // MetricAlertStatusProperties an alert status properties.
 type MetricAlertStatusProperties struct {
+	// Dimensions - An object describing the type of the dimensions.
 	Dimensions map[string]*string `json:"dimensions"`
 	// Status - status value
 	Status *string `json:"status,omitempty"`
@@ -3531,7 +3537,7 @@ type MetricAvailability struct {
 	Retention *string `json:"retention,omitempty"`
 }
 
-// MetricCriteria ...
+// MetricCriteria criterion to filter metrics.
 type MetricCriteria struct {
 	// Name - Name of the criteria.
 	Name *string `json:"name,omitempty"`
@@ -3580,7 +3586,7 @@ type MetricDefinitionCollection struct {
 	Value *[]MetricDefinition `json:"value,omitempty"`
 }
 
-// MetricDimension ...
+// MetricDimension specifies a metric dimension.
 type MetricDimension struct {
 	// Name - Name of the dimension.
 	Name *string `json:"name,omitempty"`


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3285