### PR TITLE
Fix QueueMessage Update method

### DIFF
--- a/storage/message.go
+++ b/storage/message.go
@@ -114,7 +114,8 @@ func (m *Message) Update(options *UpdateMessageOptions) error {
 		return err
 	}
 	headers["Content-Length"] = strconv.Itoa(nn)
-
+	// visibilitytimeout is required for Update (zero or greater) so set the default here
+	query.Set("visibilitytimeout", "0")
 	if options != nil {
 		if options.VisibilityTimeout != 0 {
 			query.Set("visibilitytimeout", strconv.Itoa(options.VisibilityTimeout))


### PR DESCRIPTION
The visibilitytimeout query param is required for the update method so
include the default value of zero.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 