### PR TITLE
Picker fixes

### DIFF
--- a/tools/apidiff/cmd/common.go
+++ b/tools/apidiff/cmd/common.go
@@ -41,6 +41,18 @@ func println(a ...interface{}) {
 	}
 }
 
+func dprintf(format string, a ...interface{}) {
+	if debugFlag {
+		printf(format, a...)
+	}
+}
+
+func dprintln(a ...interface{}) {
+	if debugFlag {
+		println(a...)
+	}
+}
+
 func vprintf(format string, a ...interface{}) {
 	if verboseFlag {
 		printf(format, a...)
@@ -161,11 +173,13 @@ func printReport(r report) error {
 		return nil
 	}
 
-	b, err := json.MarshalIndent(r, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal report: %v", err)
+	if !suppressReport {
+		b, err := json.MarshalIndent(r, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal report: %v", err)
+		}
+		println(string(b))
 	}
-	println(string(b))
 	return nil
 }
 

--- a/tools/apidiff/cmd/packages.go
+++ b/tools/apidiff/cmd/packages.go
@@ -63,15 +63,16 @@ func thePackagesCmd(args []string) (rpt CommitPkgsReport, err error) {
 
 	rpt.CommitsReports = map[string]pkgsReport{}
 	worker := func(rootDir string, cloneRepo repo.WorkingTree, baseCommit, targetCommit string) error {
+		vprintf("generating diff between %s and %s\n", baseCommit, targetCommit)
 		// get for lhs
-		vprintf("checking out base commit %s and gathering exports\n", baseCommit)
+		dprintf("checking out base commit %s and gathering exports\n", baseCommit)
 		lhs, err := getRepoContentForCommit(cloneRepo, rootDir, baseCommit)
 		if err != nil {
 			return err
 		}
 
 		// get for rhs
-		vprintf("checking out target commit %s and gathering exports\n", targetCommit)
+		dprintf("checking out target commit %s and gathering exports\n", targetCommit)
 		var rhs repoContent
 		rhs, err = getRepoContentForCommit(cloneRepo, rootDir, targetCommit)
 		if err != nil {
@@ -129,7 +130,7 @@ func getRepoContentForCommit(wt repo.WorkingTree, dir, commit string) (r repoCon
 	if err != nil {
 		return
 	}
-	if verboseFlag {
+	if debugFlag {
 		fmt.Println("found the following package directories")
 		for _, d := range pkgDirs {
 			fmt.Printf("\t%s\n", d)
@@ -150,7 +151,7 @@ type repoContent map[string]exports.Content
 func getExportsForPackages(root string, pkgDirs []string) (repoContent, error) {
 	exps := repoContent{}
 	for _, pkgDir := range pkgDirs {
-		vprintf("getting exports for %s\n", pkgDir)
+		dprintf("getting exports for %s\n", pkgDir)
 		// pkgDir = "C:\Users\somebody\AppData\Local\Temp\apidiff-1529437978\services\addons\mgmt\2017-05-15\addons"
 		// convert to package path "github.com/Azure/azure-sdk-for-go/services/analysisservices/mgmt/2016-05-16/analysisservices"
 		pkgPath := strings.Replace(pkgDir, root, "github.com/Azure/azure-sdk-for-go", -1)

--- a/tools/apidiff/cmd/root.go
+++ b/tools/apidiff/cmd/root.go
@@ -21,9 +21,11 @@ import (
 )
 
 var copyRepoFlag bool
+var debugFlag bool
 var onlyAdditionsFlag bool
 var onlyBreakingChangesFlag bool
 var quietFlag bool
+var suppressReport bool
 var verboseFlag bool
 
 var rootCmd = &cobra.Command{
@@ -36,6 +38,7 @@ individual packages or a set of packages under a specified directory.`,
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&copyRepoFlag, "copyrepo", "c", false, "copy the repo instead of cloning it")
+	rootCmd.PersistentFlags().BoolVarP(&debugFlag, "debug", "d", false, "debug output")
 	rootCmd.PersistentFlags().BoolVarP(&onlyAdditionsFlag, "additions", "a", false, "only include additive changes in the report")
 	rootCmd.PersistentFlags().BoolVarP(&onlyBreakingChangesFlag, "breakingchanges", "b", false, "only include breaking changes in the report")
 	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "suppress console output")
@@ -52,17 +55,21 @@ func Execute() {
 // CommandFlags is used to specify flags when invoking commands programatically.
 type CommandFlags struct {
 	CopyRepo            bool
+	Debug               bool
 	OnlyAdditions       bool
 	OnlyBreakingChanges bool
 	Quiet               bool
+	SuppressReport      bool
 	Verbose             bool
 }
 
 // applies the specified flags to their global equivalents
 func (cf CommandFlags) apply() {
 	copyRepoFlag = cf.CopyRepo
+	debugFlag = cf.Debug
 	onlyAdditionsFlag = cf.OnlyAdditions
 	onlyBreakingChangesFlag = cf.OnlyBreakingChanges
 	quietFlag = cf.Quiet
+	suppressReport = cf.SuppressReport
 	verboseFlag = cf.Verbose
 }

--- a/tools/apidiff/repo/repo.go
+++ b/tools/apidiff/repo/repo.go
@@ -60,6 +60,22 @@ func Get(dir string) (wt WorkingTree, err error) {
 	return
 }
 
+// Branch calls "git branch" to determine the current branch.
+func (tw WorkingTree) Branch() (string, error) {
+	cmd := exec.Command("git", "branch")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.New(string(output))
+	}
+	branches := strings.Split(string(output), "\n")
+	for _, branch := range branches {
+		if branch[0] == '*' {
+			return branch[2:], nil
+		}
+	}
+	return "", fmt.Errorf("failed to determine active branch: %s", strings.Join(branches, ","))
+}
+
 // Clone calls "git clone", cloning the working tree into the specified directory.
 // The returned WorkingTree points to the clone of the repository.
 func (wt WorkingTree) Clone(dest string) (result WorkingTree, err error) {


### PR DESCRIPTION
Added --dryrun flag to the picker tool to print what the tool would do
without actually doing it.
When creating breaking changes reports, diff each commit against its
parent even if the parent was found in the target branch.
Added more output so it's clear what the tool is doing.
Added WorkingTree.Branch() method to return the current branch.
Added debug printing and moved noisy things to it.
Added option to suppress printing apidiff report via the API.

Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.

As part of your submission, please make sure that you can make the following assertions:

 - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
 - [ ] I've tested my changes, adding unit tests where applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
 - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
 - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
 