### PR TITLE
[backport:master] add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report bugs in Azure Go SDK packages.
+---
+
+### Bug Report
+
+<!--
+Thank you for opening a bug report. For faster processing, please include:
+-->
+
+* import path of package in question, e.g. `.../services/compute/mgmt/2018-06-01/compute`
+* SDK version e.g. `master`, `latest`, `18.1.0`
+    * Specify the exact commit if possible; one way to get this is the REVISION
+      column output by `dep status "github.com/Azure/azure-sdk-for-go`.
+* output of `go version`
+
+<!--
+and please describe:
+-->
+
+* What happened?
+* What did you expect or want to happen?
+* How can we reproduce it?
+* Anything we should know about your environment.
+
+<!--
+Thanks!
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature Request
+about: Request new features for the Go SDK.
+---
+
+### Feature Request
+
+<!--
+To help us better serve you, describe the feature you'd like and how it will help you.
+-->
+
+

--- a/.github/ISSUE_TEMPLATE/service_package_request.md
+++ b/.github/ISSUE_TEMPLATE/service_package_request.md
@@ -1,0 +1,17 @@
+---
+name: Service Package Request
+about: Seeking a package or feature for a service in Azure.
+---
+
+### Service Package Request
+
+<!--
+Please describe the service you seek support for, including a link to docs or
+other libraries.
+
+If you need this package for use in a downstream framework like Terraform or
+Kubernetes please link any related issues from those projects.
+
+Thanks and looking forward to serving you!
+-->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,16 @@
-Thanks you for your contribution to the Azure-SDK-for-Go! We will triage and review it as quickly as we can.
+<!--
+Thank you for contributing to the Azure SDK for Go.
 
-As part of your submission, please make sure that you can make the following assertions:
+Please verify the following before submitting your PR, thank you!
+-->
 
- - [ ] I'm not making changes to Auto-Generated files which will just get erased next time there's a release.
-   - If that's what you want to do, consider making a contribution here: https://github.com/Azure/autorest.go
- - [ ] I've tested my changes, adding unit tests where applicable.
- - [ ] I've added Apache 2.0 Headers to the top of any new source files.
- - [ ] I'm submitting this PR to the `dev` branch, or I'm fixing a bug that warrants its own release and I'm targeting the `master` branch.
- - [ ] If I'm targeting the `master` branch, I've also added a note to [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/master/README.md).
- - [ ] I've mentioned any relevant open issues in this PR, making clear the context for the contribution.
+- [ ] The purpose of this PR is explained in this or a referenced issue.
+- [ ] The PR does not update generated files.
+   - These files are managed by the codegen framework at [Azure/autorest.go][].
+- [ ] The PR targets the `latest` branch.
+- [ ] Tests are included and/or updated for code changes.
+- [ ] Updates to [CHANGELOG.md][] are included.
+- [ ] Apache v2 license headers are included in each file.
  
+[Azure/autorest.go]: https://github.com/Azure/autorest.go
+[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md


### PR DESCRIPTION
Backport of #2204, lands cleanly :). I think the process once someone approves would be to land in master and tag a new patch (0.0.**++x**) release. @jhendrixMSFT can you confirm? Thanks!