### PR TITLE
[AutoPR compute/resource-manager] Revert AccessUri description to make it correspond to server response

### DIFF
--- a/profiles/preview/compute/mgmt/compute/models.go
+++ b/profiles/preview/compute/mgmt/compute/models.go
@@ -562,6 +562,8 @@ const (
 )
 
 type AccessURI = original.AccessURI
+type AccessURIOutput = original.AccessURIOutput
+type AccessURIRaw = original.AccessURIRaw
 type AdditionalUnattendContent = original.AdditionalUnattendContent
 type APIEntityReference = original.APIEntityReference
 type APIError = original.APIError

--- a/services/compute/mgmt/2018-06-01/compute/models.go
+++ b/services/compute/mgmt/2018-06-01/compute/models.go
@@ -1121,6 +1121,84 @@ func PossibleVirtualMachineSizeTypesValues() []VirtualMachineSizeTypes {
 // AccessURI a disk access SAS uri.
 type AccessURI struct {
 	autorest.Response `json:"-"`
+	// AccessURIOutput - Operation output data (raw JSON)
+	*AccessURIOutput `json:"properties,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for AccessURI.
+func (au AccessURI) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if au.AccessURIOutput != nil {
+		objectMap["properties"] = au.AccessURIOutput
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for AccessURI struct.
+func (au *AccessURI) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "properties":
+			if v != nil {
+				var accessURIOutput AccessURIOutput
+				err = json.Unmarshal(*v, &accessURIOutput)
+				if err != nil {
+					return err
+				}
+				au.AccessURIOutput = &accessURIOutput
+			}
+		}
+	}
+
+	return nil
+}
+
+// AccessURIOutput azure properties, including output.
+type AccessURIOutput struct {
+	// AccessURIRaw - Operation output data (raw JSON)
+	*AccessURIRaw `json:"output,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for AccessURIOutput.
+func (auo AccessURIOutput) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if auo.AccessURIRaw != nil {
+		objectMap["output"] = auo.AccessURIRaw
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for AccessURIOutput struct.
+func (auo *AccessURIOutput) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "output":
+			if v != nil {
+				var accessURIRaw AccessURIRaw
+				err = json.Unmarshal(*v, &accessURIRaw)
+				if err != nil {
+					return err
+				}
+				auo.AccessURIRaw = &accessURIRaw
+			}
+		}
+	}
+
+	return nil
+}
+
+// AccessURIRaw a disk access SAS uri.
+type AccessURIRaw struct {
 	// AccessSAS - A SAS uri for accessing a disk.
 	AccessSAS *string `json:"accessSAS,omitempty"`
 }


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3433