### PR TITLE
[AutoPR cognitiveservices/data-plane/ContentModerator] [Cognitive Services] Update endpoint URL template for Content Moderator.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,7 @@
 
 
 [[projects]]
+  digest = "1:e222cbd536d9e0850e7297290c431aea75ba087c70d6f98525e95b9f2d02a627"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -11,52 +12,64 @@
     "autorest/date",
     "autorest/to",
     "autorest/validation",
-    "version"
+    "version",
   ]
+  pruneopts = ""
   revision = "bca49d5b51a50dc5bb17bbf6204c711c6dbded06"
   version = "v10.14.0"
 
 [[projects]]
+  digest = "1:6098222470fe0172157ce9bbef5d2200df4edde17ee649c5d6e48330e4afa4c6"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = ""
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:7f175a633086a933d1940a7e7dc2154a0070a7c25fb4a2f671f3eef1a34d1fd7"
   name = "github.com/dimchansky/utfbom"
   packages = ["."]
+  pruneopts = ""
   revision = "5448fe645cb1964ba70ac8f9f2ffe975e61a536c"
-  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e736daced8bc48a910e0634540bc5cd63f1eea1b20fed65f8d82c8ad65eb10b2"
   name = "github.com/dnaeon/go-vcr"
   packages = [
     "cassette",
-    "recorder"
+    "recorder",
   ]
+  pruneopts = ""
   revision = "8b144be0744f013a1b44386058f1fcb3ba98177d"
 
 [[projects]]
+  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = ""
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
   branch = "master"
+  digest = "1:c1e35087694b689ce1cf4f4277612b6ac0b55725fa791271ae0e3ddcd1cc0c7b"
   name = "github.com/globalsign/mgo"
   packages = [
     ".",
     "bson",
     "internal/json",
     "internal/sasl",
-    "internal/scram"
+    "internal/scram",
   ]
+  pruneopts = ""
   revision = "113d3961e7311526535a1ef7042196563d442761"
 
 [[projects]]
   branch = "master"
+  digest = "1:9b7c5846d70f425d7fe279595e32a20994c6075e87be03b5c367ed07280877c5"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -68,143 +81,187 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = ""
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:3108ec0946181c60040ff51b811908f89d03e521e2b4ade5ef5c65b3c0e911ae"
   name = "github.com/kr/pretty"
   packages = ["."]
+  pruneopts = ""
   revision = "73f6ac0b30a98e433b289500d779f50c1a6f0712"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:11b056b4421396ab14e384ab8ab8c2079b03f1e51aa5eb4d9b81f9e0d1aa8fbf"
   name = "github.com/kr/text"
   packages = ["."]
+  pruneopts = ""
   revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:961dc3b1d11f969370533390fdf203813162980c858e1dabe827b60940c909a5"
   name = "github.com/magiconair/properties"
   packages = ["."]
+  pruneopts = ""
   revision = "c2353362d570a7bfa228149c62842019201cfb71"
   version = "v1.8.0"
 
 [[projects]]
+  digest = "1:71a28fe7d86ace8e51192c97eb4fd376c27ae0ed3a6ff46b41a6da76a0785d78"
   name = "github.com/marstr/collection"
   packages = ["."]
+  pruneopts = ""
   revision = "871b1cfa2ab97d3d8f54a034280907896190c346"
   version = "v0.3.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:5a07891ac7651f2b0db3ca615f88ca80e38a41c0c9f60a6fb123b8cbe3d8d386"
   name = "github.com/marstr/goalias"
   packages = ["model"]
+  pruneopts = ""
   revision = "8dff9a14db648bfdd58d45515d3eaaee23aad078"
 
 [[projects]]
+  digest = "1:f95025d583786875a71183888acc9d0987fc96f12d4f5afab3d7558797ea1c5a"
   name = "github.com/marstr/guid"
   packages = ["."]
+  pruneopts = ""
   revision = "8bd9a64bf37eb297b492a4101fb28e80ac0b290f"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:72da3dc7eddc1f4695da12df937debc7dcf027b1c0f57ec415fdad097cef7c43"
   name = "github.com/marstr/randname"
   packages = ["."]
+  pruneopts = ""
   revision = "48a63b6052f1f9373db9388a658da30c6ab53db1"
 
 [[projects]]
   branch = "master"
+  digest = "1:99651e95333755cbe5c9768c1b80031300acca64a80870b40309202b32585a5a"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = ""
   revision = "3864e76763d94a6df2f9960b16a20a33da9f9a66"
 
 [[projects]]
   branch = "master"
+  digest = "1:f43ed2c836208c14f45158fd01577c985688a4d11cf9fd475a939819fef3b321"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
+  digest = "1:894aef961c056b6d85d12bac890bf60c44e99b46292888bfa66caf529f804457"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = ""
   revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:615c827f6a892973a587c754ae5fad7acfc4352657aff23d0238fe0ba2a154df"
   name = "github.com/shopspring/decimal"
   packages = ["."]
+  pruneopts = ""
   revision = "cd690d0c9e2447b1ef2a129a6b7b49077da89b8e"
   version = "1.1.0"
 
 [[projects]]
+  digest = "1:7ba2551c9a8de293bc575dbe2c0d862c52252d26f267f784547f059f512471c8"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem"
+    "mem",
   ]
+  pruneopts = ""
   revision = "787d034dfe70e44075ccc060d346146ef53270ad"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:d0b38ba6da419a6d4380700218eeec8623841d44a856bb57369c172fbf692ab4"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = ""
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = ""
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:104517520aab91164020ab6524a5d6b7cafc641b2e42ac6236f6ac1deac4f66a"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
+  pruneopts = ""
   revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
+  digest = "1:8e243c568f36b09031ec18dff5f7d2769dcf5ca4d624ea511c8e3197dc3d352d"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:3dab237cd3263a290d771d133fed777bb56c22e380b00ebe92e6531d5c8d3d0c"
   name = "github.com/spf13/viper"
   packages = ["."]
+  pruneopts = ""
   revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
   version = "v1.0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:cae234a803b78380e4d769db6036b9fcc8c08ed4ff862571ffc1a958edc1f629"
   name = "golang.org/x/crypto"
   packages = [
     "pkcs12",
-    "pkcs12/internal/rc2"
+    "pkcs12/internal/rc2",
   ]
+  pruneopts = ""
   revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
   branch = "master"
+  digest = "1:677e38cad6833ad266ec843739d167755eda1e6f2d8af1c63102b0426ad820db"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "ac767d655b305d4e9612f5f6e33120b9176c4ad4"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "internal/gen",
@@ -212,36 +269,66 @@
     "internal/ucd",
     "transform",
     "unicode/cldr",
-    "unicode/norm"
+    "unicode/norm",
   ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:0a7c4519ae77a3efda26ca65984efe97392362bc3c6591f23775178f785d1d59"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk"
+    "internal/fastwalk",
   ]
+  pruneopts = ""
   revision = "ded554d0681e0cba3cf074977cdc12e2c0906fe6"
 
 [[projects]]
   branch = "v1"
+  digest = "1:1d01f96bc2293b56c3dec797b8f976d7613fb30ce92bfbc994130404f7f7f031"
   name = "gopkg.in/check.v1"
   packages = ["."]
+  pruneopts = ""
   revision = "788fd78401277ebd861206a03c884797c6ec5541"
 
 [[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d76b8f370cdfbf2fbf0d0999210fb1fed0794d980a88da3df57112d5f5a439dc"
+  input-imports = [
+    "github.com/Azure/go-autorest/autorest",
+    "github.com/Azure/go-autorest/autorest/adal",
+    "github.com/Azure/go-autorest/autorest/azure",
+    "github.com/Azure/go-autorest/autorest/azure/auth",
+    "github.com/Azure/go-autorest/autorest/date",
+    "github.com/Azure/go-autorest/autorest/to",
+    "github.com/Azure/go-autorest/autorest/validation",
+    "github.com/dnaeon/go-vcr/cassette",
+    "github.com/dnaeon/go-vcr/recorder",
+    "github.com/globalsign/mgo",
+    "github.com/marstr/collection",
+    "github.com/marstr/goalias/model",
+    "github.com/marstr/guid",
+    "github.com/marstr/randname",
+    "github.com/mitchellh/go-homedir",
+    "github.com/satori/go.uuid",
+    "github.com/shopspring/decimal",
+    "github.com/spf13/cobra",
+    "github.com/spf13/viper",
+    "golang.org/x/crypto/pkcs12",
+    "golang.org/x/tools/imports",
+    "gopkg.in/check.v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/profiles/latest/cognitiveservices/contentmoderator/models.go
+++ b/profiles/latest/cognitiveservices/contentmoderator/models.go
@@ -27,24 +27,6 @@ type ListManagementImageClient = original.ListManagementImageClient
 type ListManagementImageListsClient = original.ListManagementImageListsClient
 type ListManagementTermClient = original.ListManagementTermClient
 type ListManagementTermListsClient = original.ListManagementTermListsClient
-type AzureRegionBaseURL = original.AzureRegionBaseURL
-
-const (
-	Australiaeastapicognitivemicrosoftcom  AzureRegionBaseURL = original.Australiaeastapicognitivemicrosoftcom
-	Brazilsouthapicognitivemicrosoftcom    AzureRegionBaseURL = original.Brazilsouthapicognitivemicrosoftcom
-	ContentmoderatortestazureApinet        AzureRegionBaseURL = original.ContentmoderatortestazureApinet
-	Eastasiaapicognitivemicrosoftcom       AzureRegionBaseURL = original.Eastasiaapicognitivemicrosoftcom
-	Eastus2apicognitivemicrosoftcom        AzureRegionBaseURL = original.Eastus2apicognitivemicrosoftcom
-	Eastusapicognitivemicrosoftcom         AzureRegionBaseURL = original.Eastusapicognitivemicrosoftcom
-	Northeuropeapicognitivemicrosoftcom    AzureRegionBaseURL = original.Northeuropeapicognitivemicrosoftcom
-	Southcentralusapicognitivemicrosoftcom AzureRegionBaseURL = original.Southcentralusapicognitivemicrosoftcom
-	Southeastasiaapicognitivemicrosoftcom  AzureRegionBaseURL = original.Southeastasiaapicognitivemicrosoftcom
-	Westcentralusapicognitivemicrosoftcom  AzureRegionBaseURL = original.Westcentralusapicognitivemicrosoftcom
-	Westeuropeapicognitivemicrosoftcom     AzureRegionBaseURL = original.Westeuropeapicognitivemicrosoftcom
-	Westus2apicognitivemicrosoftcom        AzureRegionBaseURL = original.Westus2apicognitivemicrosoftcom
-	Westusapicognitivemicrosoftcom         AzureRegionBaseURL = original.Westusapicognitivemicrosoftcom
-)
-
 type StatusEnum = original.StatusEnum
 
 const (
@@ -129,29 +111,26 @@ type VideoFrameBodyItemReviewerResultTagsItem = original.VideoFrameBodyItemRevie
 type ReviewsClient = original.ReviewsClient
 type TextModerationClient = original.TextModerationClient
 
-func New(baseURL AzureRegionBaseURL) BaseClient {
-	return original.New(baseURL)
+func New(endpoint string) BaseClient {
+	return original.New(endpoint)
 }
-func NewWithoutDefaults(baseURL AzureRegionBaseURL) BaseClient {
-	return original.NewWithoutDefaults(baseURL)
+func NewWithoutDefaults(endpoint string) BaseClient {
+	return original.NewWithoutDefaults(endpoint)
 }
-func NewImageModerationClient(baseURL AzureRegionBaseURL) ImageModerationClient {
-	return original.NewImageModerationClient(baseURL)
+func NewImageModerationClient(endpoint string) ImageModerationClient {
+	return original.NewImageModerationClient(endpoint)
 }
-func NewListManagementImageClient(baseURL AzureRegionBaseURL) ListManagementImageClient {
-	return original.NewListManagementImageClient(baseURL)
+func NewListManagementImageClient(endpoint string) ListManagementImageClient {
+	return original.NewListManagementImageClient(endpoint)
 }
-func NewListManagementImageListsClient(baseURL AzureRegionBaseURL) ListManagementImageListsClient {
-	return original.NewListManagementImageListsClient(baseURL)
+func NewListManagementImageListsClient(endpoint string) ListManagementImageListsClient {
+	return original.NewListManagementImageListsClient(endpoint)
 }
-func NewListManagementTermClient(baseURL AzureRegionBaseURL) ListManagementTermClient {
-	return original.NewListManagementTermClient(baseURL)
+func NewListManagementTermClient(endpoint string) ListManagementTermClient {
+	return original.NewListManagementTermClient(endpoint)
 }
-func NewListManagementTermListsClient(baseURL AzureRegionBaseURL) ListManagementTermListsClient {
-	return original.NewListManagementTermListsClient(baseURL)
-}
-func PossibleAzureRegionBaseURLValues() []AzureRegionBaseURL {
-	return original.PossibleAzureRegionBaseURLValues()
+func NewListManagementTermListsClient(endpoint string) ListManagementTermListsClient {
+	return original.NewListManagementTermListsClient(endpoint)
 }
 func PossibleStatusEnumValues() []StatusEnum {
 	return original.PossibleStatusEnumValues()
@@ -159,11 +138,11 @@ func PossibleStatusEnumValues() []StatusEnum {
 func PossibleTypeValues() []Type {
 	return original.PossibleTypeValues()
 }
-func NewReviewsClient(baseURL AzureRegionBaseURL) ReviewsClient {
-	return original.NewReviewsClient(baseURL)
+func NewReviewsClient(endpoint string) ReviewsClient {
+	return original.NewReviewsClient(endpoint)
 }
-func NewTextModerationClient(baseURL AzureRegionBaseURL) TextModerationClient {
-	return original.NewTextModerationClient(baseURL)
+func NewTextModerationClient(endpoint string) TextModerationClient {
+	return original.NewTextModerationClient(endpoint)
 }
 func UserAgent() string {
 	return original.UserAgent() + " profiles/latest"

--- a/profiles/preview/cognitiveservices/contentmoderator/models.go
+++ b/profiles/preview/cognitiveservices/contentmoderator/models.go
@@ -27,24 +27,6 @@ type ListManagementImageClient = original.ListManagementImageClient
 type ListManagementImageListsClient = original.ListManagementImageListsClient
 type ListManagementTermClient = original.ListManagementTermClient
 type ListManagementTermListsClient = original.ListManagementTermListsClient
-type AzureRegionBaseURL = original.AzureRegionBaseURL
-
-const (
-	Australiaeastapicognitivemicrosoftcom  AzureRegionBaseURL = original.Australiaeastapicognitivemicrosoftcom
-	Brazilsouthapicognitivemicrosoftcom    AzureRegionBaseURL = original.Brazilsouthapicognitivemicrosoftcom
-	ContentmoderatortestazureApinet        AzureRegionBaseURL = original.ContentmoderatortestazureApinet
-	Eastasiaapicognitivemicrosoftcom       AzureRegionBaseURL = original.Eastasiaapicognitivemicrosoftcom
-	Eastus2apicognitivemicrosoftcom        AzureRegionBaseURL = original.Eastus2apicognitivemicrosoftcom
-	Eastusapicognitivemicrosoftcom         AzureRegionBaseURL = original.Eastusapicognitivemicrosoftcom
-	Northeuropeapicognitivemicrosoftcom    AzureRegionBaseURL = original.Northeuropeapicognitivemicrosoftcom
-	Southcentralusapicognitivemicrosoftcom AzureRegionBaseURL = original.Southcentralusapicognitivemicrosoftcom
-	Southeastasiaapicognitivemicrosoftcom  AzureRegionBaseURL = original.Southeastasiaapicognitivemicrosoftcom
-	Westcentralusapicognitivemicrosoftcom  AzureRegionBaseURL = original.Westcentralusapicognitivemicrosoftcom
-	Westeuropeapicognitivemicrosoftcom     AzureRegionBaseURL = original.Westeuropeapicognitivemicrosoftcom
-	Westus2apicognitivemicrosoftcom        AzureRegionBaseURL = original.Westus2apicognitivemicrosoftcom
-	Westusapicognitivemicrosoftcom         AzureRegionBaseURL = original.Westusapicognitivemicrosoftcom
-)
-
 type StatusEnum = original.StatusEnum
 
 const (
@@ -129,29 +111,26 @@ type VideoFrameBodyItemReviewerResultTagsItem = original.VideoFrameBodyItemRevie
 type ReviewsClient = original.ReviewsClient
 type TextModerationClient = original.TextModerationClient
 
-func New(baseURL AzureRegionBaseURL) BaseClient {
-	return original.New(baseURL)
+func New(endpoint string) BaseClient {
+	return original.New(endpoint)
 }
-func NewWithoutDefaults(baseURL AzureRegionBaseURL) BaseClient {
-	return original.NewWithoutDefaults(baseURL)
+func NewWithoutDefaults(endpoint string) BaseClient {
+	return original.NewWithoutDefaults(endpoint)
 }
-func NewImageModerationClient(baseURL AzureRegionBaseURL) ImageModerationClient {
-	return original.NewImageModerationClient(baseURL)
+func NewImageModerationClient(endpoint string) ImageModerationClient {
+	return original.NewImageModerationClient(endpoint)
 }
-func NewListManagementImageClient(baseURL AzureRegionBaseURL) ListManagementImageClient {
-	return original.NewListManagementImageClient(baseURL)
+func NewListManagementImageClient(endpoint string) ListManagementImageClient {
+	return original.NewListManagementImageClient(endpoint)
 }
-func NewListManagementImageListsClient(baseURL AzureRegionBaseURL) ListManagementImageListsClient {
-	return original.NewListManagementImageListsClient(baseURL)
+func NewListManagementImageListsClient(endpoint string) ListManagementImageListsClient {
+	return original.NewListManagementImageListsClient(endpoint)
 }
-func NewListManagementTermClient(baseURL AzureRegionBaseURL) ListManagementTermClient {
-	return original.NewListManagementTermClient(baseURL)
+func NewListManagementTermClient(endpoint string) ListManagementTermClient {
+	return original.NewListManagementTermClient(endpoint)
 }
-func NewListManagementTermListsClient(baseURL AzureRegionBaseURL) ListManagementTermListsClient {
-	return original.NewListManagementTermListsClient(baseURL)
-}
-func PossibleAzureRegionBaseURLValues() []AzureRegionBaseURL {
-	return original.PossibleAzureRegionBaseURLValues()
+func NewListManagementTermListsClient(endpoint string) ListManagementTermListsClient {
+	return original.NewListManagementTermListsClient(endpoint)
 }
 func PossibleStatusEnumValues() []StatusEnum {
 	return original.PossibleStatusEnumValues()
@@ -159,11 +138,11 @@ func PossibleStatusEnumValues() []StatusEnum {
 func PossibleTypeValues() []Type {
 	return original.PossibleTypeValues()
 }
-func NewReviewsClient(baseURL AzureRegionBaseURL) ReviewsClient {
-	return original.NewReviewsClient(baseURL)
+func NewReviewsClient(endpoint string) ReviewsClient {
+	return original.NewReviewsClient(endpoint)
 }
-func NewTextModerationClient(baseURL AzureRegionBaseURL) TextModerationClient {
-	return original.NewTextModerationClient(baseURL)
+func NewTextModerationClient(endpoint string) TextModerationClient {
+	return original.NewTextModerationClient(endpoint)
 }
 func UserAgent() string {
 	return original.UserAgent() + " profiles/preview"

--- a/services/cognitiveservices/v1.0/contentmoderator/client.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/client.go
@@ -8,14 +8,6 @@
 // Text can be at most 1024 characters long.
 // If the content passed to the text API or the image API exceeds the size limits, the API will return an error code
 // that informs about the issue.
-//
-// This API is currently available in:
-//
-// * West US - westus.api.cognitive.microsoft.com
-// * East US 2 - eastus2.api.cognitive.microsoft.com
-// * West Central US - westcentralus.api.cognitive.microsoft.com
-// * West Europe - westeurope.api.cognitive.microsoft.com
-// * Southeast Asia - southeastasia.api.cognitive.microsoft.com .
 package contentmoderator
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.
@@ -42,18 +34,18 @@ import (
 // BaseClient is the base client for Contentmoderator.
 type BaseClient struct {
 	autorest.Client
-	BaseURL AzureRegionBaseURL
+	Endpoint string
 }
 
 // New creates an instance of the BaseClient client.
-func New(baseURL AzureRegionBaseURL) BaseClient {
-	return NewWithoutDefaults(baseURL)
+func New(endpoint string) BaseClient {
+	return NewWithoutDefaults(endpoint)
 }
 
 // NewWithoutDefaults creates an instance of the BaseClient client.
-func NewWithoutDefaults(baseURL AzureRegionBaseURL) BaseClient {
+func NewWithoutDefaults(endpoint string) BaseClient {
 	return BaseClient{
-		Client:  autorest.NewClientWithUserAgent(UserAgent()),
-		BaseURL: baseURL,
+		Client:   autorest.NewClientWithUserAgent(UserAgent()),
+		Endpoint: endpoint,
 	}
 }

--- a/services/cognitiveservices/v1.0/contentmoderator/imagemoderation.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/imagemoderation.go
@@ -33,21 +33,13 @@ import (
 // Text can be at most 1024 characters long.
 // If the content passed to the text API or the image API exceeds the size limits, the API will return an error code
 // that informs about the issue.
-//
-// This API is currently available in:
-//
-// * West US - westus.api.cognitive.microsoft.com
-// * East US 2 - eastus2.api.cognitive.microsoft.com
-// * West Central US - westcentralus.api.cognitive.microsoft.com
-// * West Europe - westeurope.api.cognitive.microsoft.com
-// * Southeast Asia - southeastasia.api.cognitive.microsoft.com .
 type ImageModerationClient struct {
 	BaseClient
 }
 
 // NewImageModerationClient creates an instance of the ImageModerationClient client.
-func NewImageModerationClient(baseURL AzureRegionBaseURL) ImageModerationClient {
-	return ImageModerationClient{New(baseURL)}
+func NewImageModerationClient(endpoint string) ImageModerationClient {
+	return ImageModerationClient{New(endpoint)}
 }
 
 // EvaluateFileInput returns probabilities of the image containing racy or adult content.
@@ -79,7 +71,7 @@ func (client ImageModerationClient) EvaluateFileInput(ctx context.Context, image
 // EvaluateFileInputPreparer prepares the EvaluateFileInput request.
 func (client ImageModerationClient) EvaluateFileInputPreparer(ctx context.Context, imageStream io.ReadCloser, cacheImage *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -90,7 +82,7 @@ func (client ImageModerationClient) EvaluateFileInputPreparer(ctx context.Contex
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("image/gif"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/Evaluate"),
 		autorest.WithFile(imageStream),
 		autorest.WithQueryParameters(queryParameters))
@@ -145,7 +137,7 @@ func (client ImageModerationClient) EvaluateMethod(ctx context.Context, cacheIma
 // EvaluateMethodPreparer prepares the EvaluateMethod request.
 func (client ImageModerationClient) EvaluateMethodPreparer(ctx context.Context, cacheImage *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -155,7 +147,7 @@ func (client ImageModerationClient) EvaluateMethodPreparer(ctx context.Context, 
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/Evaluate"),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -211,7 +203,7 @@ func (client ImageModerationClient) EvaluateURLInput(ctx context.Context, conten
 // EvaluateURLInputPreparer prepares the EvaluateURLInput request.
 func (client ImageModerationClient) EvaluateURLInputPreparer(ctx context.Context, contentType string, imageURL BodyModel, cacheImage *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -222,7 +214,7 @@ func (client ImageModerationClient) EvaluateURLInputPreparer(ctx context.Context
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/Evaluate"),
 		autorest.WithJSON(imageURL),
 		autorest.WithQueryParameters(queryParameters),
@@ -278,7 +270,7 @@ func (client ImageModerationClient) FindFaces(ctx context.Context, cacheImage *b
 // FindFacesPreparer prepares the FindFaces request.
 func (client ImageModerationClient) FindFacesPreparer(ctx context.Context, cacheImage *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -288,7 +280,7 @@ func (client ImageModerationClient) FindFacesPreparer(ctx context.Context, cache
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/FindFaces"),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -343,7 +335,7 @@ func (client ImageModerationClient) FindFacesFileInput(ctx context.Context, imag
 // FindFacesFileInputPreparer prepares the FindFacesFileInput request.
 func (client ImageModerationClient) FindFacesFileInputPreparer(ctx context.Context, imageStream io.ReadCloser, cacheImage *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -354,7 +346,7 @@ func (client ImageModerationClient) FindFacesFileInputPreparer(ctx context.Conte
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("image/gif"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/FindFaces"),
 		autorest.WithFile(imageStream),
 		autorest.WithQueryParameters(queryParameters))
@@ -411,7 +403,7 @@ func (client ImageModerationClient) FindFacesURLInput(ctx context.Context, conte
 // FindFacesURLInputPreparer prepares the FindFacesURLInput request.
 func (client ImageModerationClient) FindFacesURLInputPreparer(ctx context.Context, contentType string, imageURL BodyModel, cacheImage *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -422,7 +414,7 @@ func (client ImageModerationClient) FindFacesURLInputPreparer(ctx context.Contex
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/FindFaces"),
 		autorest.WithJSON(imageURL),
 		autorest.WithQueryParameters(queryParameters),
@@ -487,7 +479,7 @@ func (client ImageModerationClient) MatchFileInput(ctx context.Context, imageStr
 // MatchFileInputPreparer prepares the MatchFileInput request.
 func (client ImageModerationClient) MatchFileInputPreparer(ctx context.Context, imageStream io.ReadCloser, listID string, cacheImage *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -501,7 +493,7 @@ func (client ImageModerationClient) MatchFileInputPreparer(ctx context.Context, 
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("image/gif"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/Match"),
 		autorest.WithFile(imageStream),
 		autorest.WithQueryParameters(queryParameters))
@@ -564,7 +556,7 @@ func (client ImageModerationClient) MatchMethod(ctx context.Context, listID stri
 // MatchMethodPreparer prepares the MatchMethod request.
 func (client ImageModerationClient) MatchMethodPreparer(ctx context.Context, listID string, cacheImage *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -577,7 +569,7 @@ func (client ImageModerationClient) MatchMethodPreparer(ctx context.Context, lis
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/Match"),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -641,7 +633,7 @@ func (client ImageModerationClient) MatchURLInput(ctx context.Context, contentTy
 // MatchURLInputPreparer prepares the MatchURLInput request.
 func (client ImageModerationClient) MatchURLInputPreparer(ctx context.Context, contentType string, imageURL BodyModel, listID string, cacheImage *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -655,7 +647,7 @@ func (client ImageModerationClient) MatchURLInputPreparer(ctx context.Context, c
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/Match"),
 		autorest.WithJSON(imageURL),
 		autorest.WithQueryParameters(queryParameters),
@@ -720,7 +712,7 @@ func (client ImageModerationClient) OCRFileInput(ctx context.Context, language s
 // OCRFileInputPreparer prepares the OCRFileInput request.
 func (client ImageModerationClient) OCRFileInputPreparer(ctx context.Context, language string, imageStream io.ReadCloser, cacheImage *bool, enhanced *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{
@@ -738,7 +730,7 @@ func (client ImageModerationClient) OCRFileInputPreparer(ctx context.Context, la
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("image/gif"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/OCR"),
 		autorest.WithFile(imageStream),
 		autorest.WithQueryParameters(queryParameters))
@@ -801,7 +793,7 @@ func (client ImageModerationClient) OCRMethod(ctx context.Context, language stri
 // OCRMethodPreparer prepares the OCRMethod request.
 func (client ImageModerationClient) OCRMethodPreparer(ctx context.Context, language string, cacheImage *bool, enhanced *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{
@@ -818,7 +810,7 @@ func (client ImageModerationClient) OCRMethodPreparer(ctx context.Context, langu
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/OCR"),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -882,7 +874,7 @@ func (client ImageModerationClient) OCRURLInput(ctx context.Context, language st
 // OCRURLInputPreparer prepares the OCRURLInput request.
 func (client ImageModerationClient) OCRURLInputPreparer(ctx context.Context, language string, contentType string, imageURL BodyModel, cacheImage *bool, enhanced *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{
@@ -900,7 +892,7 @@ func (client ImageModerationClient) OCRURLInputPreparer(ctx context.Context, lan
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessImage/OCR"),
 		autorest.WithJSON(imageURL),
 		autorest.WithQueryParameters(queryParameters),

--- a/services/cognitiveservices/v1.0/contentmoderator/listmanagementimage.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/listmanagementimage.go
@@ -33,21 +33,13 @@ import (
 // Text can be at most 1024 characters long.
 // If the content passed to the text API or the image API exceeds the size limits, the API will return an error code
 // that informs about the issue.
-//
-// This API is currently available in:
-//
-// * West US - westus.api.cognitive.microsoft.com
-// * East US 2 - eastus2.api.cognitive.microsoft.com
-// * West Central US - westcentralus.api.cognitive.microsoft.com
-// * West Europe - westeurope.api.cognitive.microsoft.com
-// * Southeast Asia - southeastasia.api.cognitive.microsoft.com .
 type ListManagementImageClient struct {
 	BaseClient
 }
 
 // NewListManagementImageClient creates an instance of the ListManagementImageClient client.
-func NewListManagementImageClient(baseURL AzureRegionBaseURL) ListManagementImageClient {
-	return ListManagementImageClient{New(baseURL)}
+func NewListManagementImageClient(endpoint string) ListManagementImageClient {
+	return ListManagementImageClient{New(endpoint)}
 }
 
 // AddImage add an image to the list with list Id equal to list Id passed.
@@ -80,7 +72,7 @@ func (client ListManagementImageClient) AddImage(ctx context.Context, listID str
 // AddImagePreparer prepares the AddImage request.
 func (client ListManagementImageClient) AddImagePreparer(ctx context.Context, listID string, tag *int32, label string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -97,7 +89,7 @@ func (client ListManagementImageClient) AddImagePreparer(ctx context.Context, li
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}/images", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -154,7 +146,7 @@ func (client ListManagementImageClient) AddImageFileInput(ctx context.Context, l
 // AddImageFileInputPreparer prepares the AddImageFileInput request.
 func (client ListManagementImageClient) AddImageFileInputPreparer(ctx context.Context, listID string, imageStream io.ReadCloser, tag *int32, label string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -172,7 +164,7 @@ func (client ListManagementImageClient) AddImageFileInputPreparer(ctx context.Co
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("image/gif"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}/images", pathParameters),
 		autorest.WithFile(imageStream),
 		autorest.WithQueryParameters(queryParameters))
@@ -231,7 +223,7 @@ func (client ListManagementImageClient) AddImageURLInput(ctx context.Context, li
 // AddImageURLInputPreparer prepares the AddImageURLInput request.
 func (client ListManagementImageClient) AddImageURLInputPreparer(ctx context.Context, listID string, contentType string, imageURL BodyModel, tag *int32, label string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -249,7 +241,7 @@ func (client ListManagementImageClient) AddImageURLInputPreparer(ctx context.Con
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}/images", pathParameters),
 		autorest.WithJSON(imageURL),
 		autorest.WithQueryParameters(queryParameters),
@@ -305,7 +297,7 @@ func (client ListManagementImageClient) DeleteAllImages(ctx context.Context, lis
 // DeleteAllImagesPreparer prepares the DeleteAllImages request.
 func (client ListManagementImageClient) DeleteAllImagesPreparer(ctx context.Context, listID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -314,7 +306,7 @@ func (client ListManagementImageClient) DeleteAllImagesPreparer(ctx context.Cont
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsDelete(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}/images", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -368,7 +360,7 @@ func (client ListManagementImageClient) DeleteImage(ctx context.Context, listID 
 // DeleteImagePreparer prepares the DeleteImage request.
 func (client ListManagementImageClient) DeleteImagePreparer(ctx context.Context, listID string, imageID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -378,7 +370,7 @@ func (client ListManagementImageClient) DeleteImagePreparer(ctx context.Context,
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsDelete(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}/images/{ImageId}", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -431,7 +423,7 @@ func (client ListManagementImageClient) GetAllImageIds(ctx context.Context, list
 // GetAllImageIdsPreparer prepares the GetAllImageIds request.
 func (client ListManagementImageClient) GetAllImageIdsPreparer(ctx context.Context, listID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -440,7 +432,7 @@ func (client ListManagementImageClient) GetAllImageIdsPreparer(ctx context.Conte
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}/images", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }

--- a/services/cognitiveservices/v1.0/contentmoderator/listmanagementimagelists.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/listmanagementimagelists.go
@@ -33,21 +33,13 @@ import (
 // Text can be at most 1024 characters long.
 // If the content passed to the text API or the image API exceeds the size limits, the API will return an error code
 // that informs about the issue.
-//
-// This API is currently available in:
-//
-// * West US - westus.api.cognitive.microsoft.com
-// * East US 2 - eastus2.api.cognitive.microsoft.com
-// * West Central US - westcentralus.api.cognitive.microsoft.com
-// * West Europe - westeurope.api.cognitive.microsoft.com
-// * Southeast Asia - southeastasia.api.cognitive.microsoft.com .
 type ListManagementImageListsClient struct {
 	BaseClient
 }
 
 // NewListManagementImageListsClient creates an instance of the ListManagementImageListsClient client.
-func NewListManagementImageListsClient(baseURL AzureRegionBaseURL) ListManagementImageListsClient {
-	return ListManagementImageListsClient{New(baseURL)}
+func NewListManagementImageListsClient(endpoint string) ListManagementImageListsClient {
+	return ListManagementImageListsClient{New(endpoint)}
 }
 
 // Create creates an image list.
@@ -79,13 +71,13 @@ func (client ListManagementImageListsClient) Create(ctx context.Context, content
 // CreatePreparer prepares the Create request.
 func (client ListManagementImageListsClient) CreatePreparer(ctx context.Context, contentType string, body Body) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/lists/v1.0/imagelists"),
 		autorest.WithJSON(body),
 		autorest.WithHeader("Content-Type", autorest.String(contentType)))
@@ -140,7 +132,7 @@ func (client ListManagementImageListsClient) Delete(ctx context.Context, listID 
 // DeletePreparer prepares the Delete request.
 func (client ListManagementImageListsClient) DeletePreparer(ctx context.Context, listID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -149,7 +141,7 @@ func (client ListManagementImageListsClient) DeletePreparer(ctx context.Context,
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsDelete(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -200,12 +192,12 @@ func (client ListManagementImageListsClient) GetAllImageLists(ctx context.Contex
 // GetAllImageListsPreparer prepares the GetAllImageLists request.
 func (client ListManagementImageListsClient) GetAllImageListsPreparer(ctx context.Context) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/lists/v1.0/imagelists"))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -258,7 +250,7 @@ func (client ListManagementImageListsClient) GetDetails(ctx context.Context, lis
 // GetDetailsPreparer prepares the GetDetails request.
 func (client ListManagementImageListsClient) GetDetailsPreparer(ctx context.Context, listID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -267,7 +259,7 @@ func (client ListManagementImageListsClient) GetDetailsPreparer(ctx context.Cont
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -320,7 +312,7 @@ func (client ListManagementImageListsClient) RefreshIndexMethod(ctx context.Cont
 // RefreshIndexMethodPreparer prepares the RefreshIndexMethod request.
 func (client ListManagementImageListsClient) RefreshIndexMethodPreparer(ctx context.Context, listID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -329,7 +321,7 @@ func (client ListManagementImageListsClient) RefreshIndexMethodPreparer(ctx cont
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}/RefreshIndex", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -384,7 +376,7 @@ func (client ListManagementImageListsClient) Update(ctx context.Context, listID 
 // UpdatePreparer prepares the Update request.
 func (client ListManagementImageListsClient) UpdatePreparer(ctx context.Context, listID string, contentType string, body Body) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -394,7 +386,7 @@ func (client ListManagementImageListsClient) UpdatePreparer(ctx context.Context,
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/imagelists/{listId}", pathParameters),
 		autorest.WithJSON(body),
 		autorest.WithHeader("Content-Type", autorest.String(contentType)))

--- a/services/cognitiveservices/v1.0/contentmoderator/listmanagementterm.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/listmanagementterm.go
@@ -32,21 +32,13 @@ import (
 // Text can be at most 1024 characters long.
 // If the content passed to the text API or the image API exceeds the size limits, the API will return an error code
 // that informs about the issue.
-//
-// This API is currently available in:
-//
-// * West US - westus.api.cognitive.microsoft.com
-// * East US 2 - eastus2.api.cognitive.microsoft.com
-// * West Central US - westcentralus.api.cognitive.microsoft.com
-// * West Europe - westeurope.api.cognitive.microsoft.com
-// * Southeast Asia - southeastasia.api.cognitive.microsoft.com .
 type ListManagementTermClient struct {
 	BaseClient
 }
 
 // NewListManagementTermClient creates an instance of the ListManagementTermClient client.
-func NewListManagementTermClient(baseURL AzureRegionBaseURL) ListManagementTermClient {
-	return ListManagementTermClient{New(baseURL)}
+func NewListManagementTermClient(endpoint string) ListManagementTermClient {
+	return ListManagementTermClient{New(endpoint)}
 }
 
 // AddTerm add a term to the term list with list Id equal to list Id passed.
@@ -79,7 +71,7 @@ func (client ListManagementTermClient) AddTerm(ctx context.Context, listID strin
 // AddTermPreparer prepares the AddTerm request.
 func (client ListManagementTermClient) AddTermPreparer(ctx context.Context, listID string, term string, language string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -93,7 +85,7 @@ func (client ListManagementTermClient) AddTermPreparer(ctx context.Context, list
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/termlists/{listId}/terms/{term}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -148,7 +140,7 @@ func (client ListManagementTermClient) DeleteAllTerms(ctx context.Context, listI
 // DeleteAllTermsPreparer prepares the DeleteAllTerms request.
 func (client ListManagementTermClient) DeleteAllTermsPreparer(ctx context.Context, listID string, language string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -161,7 +153,7 @@ func (client ListManagementTermClient) DeleteAllTermsPreparer(ctx context.Contex
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsDelete(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/termlists/{listId}/terms", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -217,7 +209,7 @@ func (client ListManagementTermClient) DeleteTerm(ctx context.Context, listID st
 // DeleteTermPreparer prepares the DeleteTerm request.
 func (client ListManagementTermClient) DeleteTermPreparer(ctx context.Context, listID string, term string, language string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -231,7 +223,7 @@ func (client ListManagementTermClient) DeleteTermPreparer(ctx context.Context, l
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsDelete(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/termlists/{listId}/terms/{term}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -288,7 +280,7 @@ func (client ListManagementTermClient) GetAllTerms(ctx context.Context, listID s
 // GetAllTermsPreparer prepares the GetAllTerms request.
 func (client ListManagementTermClient) GetAllTermsPreparer(ctx context.Context, listID string, language string, offset *int32, limit *int32) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -307,7 +299,7 @@ func (client ListManagementTermClient) GetAllTermsPreparer(ctx context.Context, 
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/termlists/{listId}/terms", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))

--- a/services/cognitiveservices/v1.0/contentmoderator/listmanagementtermlists.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/listmanagementtermlists.go
@@ -32,21 +32,13 @@ import (
 // Text can be at most 1024 characters long.
 // If the content passed to the text API or the image API exceeds the size limits, the API will return an error code
 // that informs about the issue.
-//
-// This API is currently available in:
-//
-// * West US - westus.api.cognitive.microsoft.com
-// * East US 2 - eastus2.api.cognitive.microsoft.com
-// * West Central US - westcentralus.api.cognitive.microsoft.com
-// * West Europe - westeurope.api.cognitive.microsoft.com
-// * Southeast Asia - southeastasia.api.cognitive.microsoft.com .
 type ListManagementTermListsClient struct {
 	BaseClient
 }
 
 // NewListManagementTermListsClient creates an instance of the ListManagementTermListsClient client.
-func NewListManagementTermListsClient(baseURL AzureRegionBaseURL) ListManagementTermListsClient {
-	return ListManagementTermListsClient{New(baseURL)}
+func NewListManagementTermListsClient(endpoint string) ListManagementTermListsClient {
+	return ListManagementTermListsClient{New(endpoint)}
 }
 
 // Create creates a Term List
@@ -78,13 +70,13 @@ func (client ListManagementTermListsClient) Create(ctx context.Context, contentT
 // CreatePreparer prepares the Create request.
 func (client ListManagementTermListsClient) CreatePreparer(ctx context.Context, contentType string, body Body) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/lists/v1.0/termlists"),
 		autorest.WithJSON(body),
 		autorest.WithHeader("Content-Type", autorest.String(contentType)))
@@ -139,7 +131,7 @@ func (client ListManagementTermListsClient) Delete(ctx context.Context, listID s
 // DeletePreparer prepares the Delete request.
 func (client ListManagementTermListsClient) DeletePreparer(ctx context.Context, listID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -148,7 +140,7 @@ func (client ListManagementTermListsClient) DeletePreparer(ctx context.Context, 
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsDelete(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/termlists/{listId}", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -199,12 +191,12 @@ func (client ListManagementTermListsClient) GetAllTermLists(ctx context.Context)
 // GetAllTermListsPreparer prepares the GetAllTermLists request.
 func (client ListManagementTermListsClient) GetAllTermListsPreparer(ctx context.Context) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/lists/v1.0/termlists"))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -257,7 +249,7 @@ func (client ListManagementTermListsClient) GetDetails(ctx context.Context, list
 // GetDetailsPreparer prepares the GetDetails request.
 func (client ListManagementTermListsClient) GetDetailsPreparer(ctx context.Context, listID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -266,7 +258,7 @@ func (client ListManagementTermListsClient) GetDetailsPreparer(ctx context.Conte
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/termlists/{listId}", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -320,7 +312,7 @@ func (client ListManagementTermListsClient) RefreshIndexMethod(ctx context.Conte
 // RefreshIndexMethodPreparer prepares the RefreshIndexMethod request.
 func (client ListManagementTermListsClient) RefreshIndexMethodPreparer(ctx context.Context, listID string, language string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -333,7 +325,7 @@ func (client ListManagementTermListsClient) RefreshIndexMethodPreparer(ctx conte
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/termlists/{listId}/RefreshIndex", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -389,7 +381,7 @@ func (client ListManagementTermListsClient) Update(ctx context.Context, listID s
 // UpdatePreparer prepares the Update request.
 func (client ListManagementTermListsClient) UpdatePreparer(ctx context.Context, listID string, contentType string, body Body) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -399,7 +391,7 @@ func (client ListManagementTermListsClient) UpdatePreparer(ctx context.Context, 
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/lists/v1.0/termlists/{listId}", pathParameters),
 		autorest.WithJSON(body),
 		autorest.WithHeader("Content-Type", autorest.String(contentType)))

--- a/services/cognitiveservices/v1.0/contentmoderator/models.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/models.go
@@ -21,43 +21,6 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 )
 
-// AzureRegionBaseURL enumerates the values for azure region base url.
-type AzureRegionBaseURL string
-
-const (
-	// Australiaeastapicognitivemicrosoftcom ...
-	Australiaeastapicognitivemicrosoftcom AzureRegionBaseURL = "australiaeast.api.cognitive.microsoft.com"
-	// Brazilsouthapicognitivemicrosoftcom ...
-	Brazilsouthapicognitivemicrosoftcom AzureRegionBaseURL = "brazilsouth.api.cognitive.microsoft.com"
-	// ContentmoderatortestazureApinet ...
-	ContentmoderatortestazureApinet AzureRegionBaseURL = "contentmoderatortest.azure-api.net"
-	// Eastasiaapicognitivemicrosoftcom ...
-	Eastasiaapicognitivemicrosoftcom AzureRegionBaseURL = "eastasia.api.cognitive.microsoft.com"
-	// Eastus2apicognitivemicrosoftcom ...
-	Eastus2apicognitivemicrosoftcom AzureRegionBaseURL = "eastus2.api.cognitive.microsoft.com"
-	// Eastusapicognitivemicrosoftcom ...
-	Eastusapicognitivemicrosoftcom AzureRegionBaseURL = "eastus.api.cognitive.microsoft.com"
-	// Northeuropeapicognitivemicrosoftcom ...
-	Northeuropeapicognitivemicrosoftcom AzureRegionBaseURL = "northeurope.api.cognitive.microsoft.com"
-	// Southcentralusapicognitivemicrosoftcom ...
-	Southcentralusapicognitivemicrosoftcom AzureRegionBaseURL = "southcentralus.api.cognitive.microsoft.com"
-	// Southeastasiaapicognitivemicrosoftcom ...
-	Southeastasiaapicognitivemicrosoftcom AzureRegionBaseURL = "southeastasia.api.cognitive.microsoft.com"
-	// Westcentralusapicognitivemicrosoftcom ...
-	Westcentralusapicognitivemicrosoftcom AzureRegionBaseURL = "westcentralus.api.cognitive.microsoft.com"
-	// Westeuropeapicognitivemicrosoftcom ...
-	Westeuropeapicognitivemicrosoftcom AzureRegionBaseURL = "westeurope.api.cognitive.microsoft.com"
-	// Westus2apicognitivemicrosoftcom ...
-	Westus2apicognitivemicrosoftcom AzureRegionBaseURL = "westus2.api.cognitive.microsoft.com"
-	// Westusapicognitivemicrosoftcom ...
-	Westusapicognitivemicrosoftcom AzureRegionBaseURL = "westus.api.cognitive.microsoft.com"
-)
-
-// PossibleAzureRegionBaseURLValues returns an array of possible values for the AzureRegionBaseURL const type.
-func PossibleAzureRegionBaseURLValues() []AzureRegionBaseURL {
-	return []AzureRegionBaseURL{Australiaeastapicognitivemicrosoftcom, Brazilsouthapicognitivemicrosoftcom, ContentmoderatortestazureApinet, Eastasiaapicognitivemicrosoftcom, Eastus2apicognitivemicrosoftcom, Eastusapicognitivemicrosoftcom, Northeuropeapicognitivemicrosoftcom, Southcentralusapicognitivemicrosoftcom, Southeastasiaapicognitivemicrosoftcom, Westcentralusapicognitivemicrosoftcom, Westeuropeapicognitivemicrosoftcom, Westus2apicognitivemicrosoftcom, Westusapicognitivemicrosoftcom}
-}
-
 // StatusEnum enumerates the values for status enum.
 type StatusEnum string
 

--- a/services/cognitiveservices/v1.0/contentmoderator/models.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/models.go
@@ -18,6 +18,7 @@ package contentmoderator
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"encoding/json"
 	"github.com/Azure/go-autorest/autorest"
 )
 
@@ -380,10 +381,27 @@ type ImageList struct {
 
 // ImageListMetadata image List Metadata.
 type ImageListMetadata struct {
+	// AdditionalProperties - Unmatched properties from the message are deserialized this collection
+	AdditionalProperties map[string]*string `json:""`
 	// KeyOne - Optional Key value pair to describe your list.
 	KeyOne *string `json:"Key One,omitempty"`
 	// KeyTwo - Optional Key value pair to describe your list.
 	KeyTwo *string `json:"Key Two,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for ImageListMetadata.
+func (ilM ImageListMetadata) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if ilM.KeyOne != nil {
+		objectMap["Key One"] = ilM.KeyOne
+	}
+	if ilM.KeyTwo != nil {
+		objectMap["Key Two"] = ilM.KeyTwo
+	}
+	for k, v := range ilM.AdditionalProperties {
+		objectMap[k] = v
+	}
+	return json.Marshal(objectMap)
 }
 
 // IPA IP Address details.
@@ -658,10 +676,27 @@ type TermList struct {
 
 // TermListMetadata term list metadata.
 type TermListMetadata struct {
+	// AdditionalProperties - Unmatched properties from the message are deserialized this collection
+	AdditionalProperties map[string]*string `json:""`
 	// KeyOne - Optional Key value pair to describe your list.
 	KeyOne *string `json:"Key One,omitempty"`
 	// KeyTwo - Optional Key value pair to describe your list.
 	KeyTwo *string `json:"Key Two,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for TermListMetadata.
+func (tlM TermListMetadata) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if tlM.KeyOne != nil {
+		objectMap["Key One"] = tlM.KeyOne
+	}
+	if tlM.KeyTwo != nil {
+		objectMap["Key Two"] = tlM.KeyTwo
+	}
+	for k, v := range tlM.AdditionalProperties {
+		objectMap[k] = v
+	}
+	return json.Marshal(objectMap)
 }
 
 // Terms terms properties.

--- a/services/cognitiveservices/v1.0/contentmoderator/reviews.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/reviews.go
@@ -34,21 +34,13 @@ import (
 // Text can be at most 1024 characters long.
 // If the content passed to the text API or the image API exceeds the size limits, the API will return an error code
 // that informs about the issue.
-//
-// This API is currently available in:
-//
-// * West US - westus.api.cognitive.microsoft.com
-// * East US 2 - eastus2.api.cognitive.microsoft.com
-// * West Central US - westcentralus.api.cognitive.microsoft.com
-// * West Europe - westeurope.api.cognitive.microsoft.com
-// * Southeast Asia - southeastasia.api.cognitive.microsoft.com .
 type ReviewsClient struct {
 	BaseClient
 }
 
 // NewReviewsClient creates an instance of the ReviewsClient client.
-func NewReviewsClient(baseURL AzureRegionBaseURL) ReviewsClient {
-	return ReviewsClient{New(baseURL)}
+func NewReviewsClient(endpoint string) ReviewsClient {
+	return ReviewsClient{New(endpoint)}
 }
 
 // AddVideoFrame the reviews created would show up for Reviewers on your team. As Reviewers complete reviewing, results
@@ -105,7 +97,7 @@ func (client ReviewsClient) AddVideoFrame(ctx context.Context, teamName string, 
 // AddVideoFramePreparer prepares the AddVideoFrame request.
 func (client ReviewsClient) AddVideoFramePreparer(ctx context.Context, teamName string, reviewID string, timescale *int32) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -120,7 +112,7 @@ func (client ReviewsClient) AddVideoFramePreparer(ctx context.Context, teamName 
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews/{reviewId}/frames", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -181,7 +173,7 @@ func (client ReviewsClient) AddVideoFrameStream(ctx context.Context, contentType
 // AddVideoFrameStreamPreparer prepares the AddVideoFrameStream request.
 func (client ReviewsClient) AddVideoFrameStreamPreparer(ctx context.Context, contentType string, teamName string, reviewID string, frameImageZip io.ReadCloser, frameMetadata string, timescale *int32) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -201,7 +193,7 @@ func (client ReviewsClient) AddVideoFrameStreamPreparer(ctx context.Context, con
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews/{reviewId}/frames", pathParameters),
 		autorest.WithQueryParameters(queryParameters),
 		autorest.WithMultiPartFormData(formDataParameters),
@@ -269,7 +261,7 @@ func (client ReviewsClient) AddVideoFrameURL(ctx context.Context, contentType st
 // AddVideoFrameURLPreparer prepares the AddVideoFrameURL request.
 func (client ReviewsClient) AddVideoFrameURLPreparer(ctx context.Context, contentType string, teamName string, reviewID string, videoFrameBody []VideoFrameBodyItem, timescale *int32) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -285,7 +277,7 @@ func (client ReviewsClient) AddVideoFrameURLPreparer(ctx context.Context, conten
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews/{reviewId}/frames", pathParameters),
 		autorest.WithJSON(videoFrameBody),
 		autorest.WithQueryParameters(queryParameters),
@@ -343,7 +335,7 @@ func (client ReviewsClient) AddVideoTranscript(ctx context.Context, teamName str
 // AddVideoTranscriptPreparer prepares the AddVideoTranscript request.
 func (client ReviewsClient) AddVideoTranscriptPreparer(ctx context.Context, teamName string, reviewID string, vttfile io.ReadCloser) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -354,7 +346,7 @@ func (client ReviewsClient) AddVideoTranscriptPreparer(ctx context.Context, team
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("text/plain"),
 		autorest.AsPut(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews/{reviewId}/transcript", pathParameters),
 		autorest.WithFile(vttfile),
 		autorest.WithHeader("Content-Type", "text/plain"))
@@ -419,7 +411,7 @@ func (client ReviewsClient) AddVideoTranscriptModerationResult(ctx context.Conte
 // AddVideoTranscriptModerationResultPreparer prepares the AddVideoTranscriptModerationResult request.
 func (client ReviewsClient) AddVideoTranscriptModerationResultPreparer(ctx context.Context, contentType string, teamName string, reviewID string, transcriptModerationBody []TranscriptModerationBodyItem) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -430,7 +422,7 @@ func (client ReviewsClient) AddVideoTranscriptModerationResultPreparer(ctx conte
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews/{reviewId}/transcriptmoderationresult", pathParameters),
 		autorest.WithJSON(transcriptModerationBody),
 		autorest.WithHeader("Content-Type", autorest.String(contentType)))
@@ -544,7 +536,7 @@ func (client ReviewsClient) CreateJob(ctx context.Context, teamName string, cont
 // CreateJobPreparer prepares the CreateJob request.
 func (client ReviewsClient) CreateJobPreparer(ctx context.Context, teamName string, contentType string, contentID string, workflowName string, jobContentType string, content Content, callBackEndpoint string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -563,7 +555,7 @@ func (client ReviewsClient) CreateJobPreparer(ctx context.Context, teamName stri
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/jobs", pathParameters),
 		autorest.WithJSON(content),
 		autorest.WithQueryParameters(queryParameters),
@@ -652,7 +644,7 @@ func (client ReviewsClient) CreateReviews(ctx context.Context, URLContentType st
 // CreateReviewsPreparer prepares the CreateReviews request.
 func (client ReviewsClient) CreateReviewsPreparer(ctx context.Context, URLContentType string, teamName string, createReviewBody []CreateReviewBodyItem, subTeam string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -667,7 +659,7 @@ func (client ReviewsClient) CreateReviewsPreparer(ctx context.Context, URLConten
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews", pathParameters),
 		autorest.WithJSON(createReviewBody),
 		autorest.WithQueryParameters(queryParameters),
@@ -756,7 +748,7 @@ func (client ReviewsClient) CreateVideoReviews(ctx context.Context, contentType 
 // CreateVideoReviewsPreparer prepares the CreateVideoReviews request.
 func (client ReviewsClient) CreateVideoReviewsPreparer(ctx context.Context, contentType string, teamName string, createVideoReviewsBody []CreateVideoReviewsBodyItem, subTeam string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -771,7 +763,7 @@ func (client ReviewsClient) CreateVideoReviewsPreparer(ctx context.Context, cont
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews", pathParameters),
 		autorest.WithJSON(createVideoReviewsBody),
 		autorest.WithQueryParameters(queryParameters),
@@ -828,7 +820,7 @@ func (client ReviewsClient) GetJobDetails(ctx context.Context, teamName string, 
 // GetJobDetailsPreparer prepares the GetJobDetails request.
 func (client ReviewsClient) GetJobDetailsPreparer(ctx context.Context, teamName string, jobID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -838,7 +830,7 @@ func (client ReviewsClient) GetJobDetailsPreparer(ctx context.Context, teamName 
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/jobs/{JobId}", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -892,7 +884,7 @@ func (client ReviewsClient) GetReview(ctx context.Context, teamName string, revi
 // GetReviewPreparer prepares the GetReview request.
 func (client ReviewsClient) GetReviewPreparer(ctx context.Context, teamName string, reviewID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -902,7 +894,7 @@ func (client ReviewsClient) GetReviewPreparer(ctx context.Context, teamName stri
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews/{reviewId}", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -983,7 +975,7 @@ func (client ReviewsClient) GetVideoFrames(ctx context.Context, teamName string,
 // GetVideoFramesPreparer prepares the GetVideoFrames request.
 func (client ReviewsClient) GetVideoFramesPreparer(ctx context.Context, teamName string, reviewID string, startSeed *int32, noOfRecords *int32, filter string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -1004,7 +996,7 @@ func (client ReviewsClient) GetVideoFramesPreparer(ctx context.Context, teamName
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews/{reviewId}/frames", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -1059,7 +1051,7 @@ func (client ReviewsClient) PublishVideoReview(ctx context.Context, teamName str
 // PublishVideoReviewPreparer prepares the PublishVideoReview request.
 func (client ReviewsClient) PublishVideoReviewPreparer(ctx context.Context, teamName string, reviewID string) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	pathParameters := map[string]interface{}{
@@ -1069,7 +1061,7 @@ func (client ReviewsClient) PublishVideoReviewPreparer(ctx context.Context, team
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPathParameters("/contentmoderator/review/v1.0/teams/{teamName}/reviews/{reviewId}/publish", pathParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }

--- a/services/cognitiveservices/v1.0/contentmoderator/textmoderation.go
+++ b/services/cognitiveservices/v1.0/contentmoderator/textmoderation.go
@@ -33,21 +33,13 @@ import (
 // Text can be at most 1024 characters long.
 // If the content passed to the text API or the image API exceeds the size limits, the API will return an error code
 // that informs about the issue.
-//
-// This API is currently available in:
-//
-// * West US - westus.api.cognitive.microsoft.com
-// * East US 2 - eastus2.api.cognitive.microsoft.com
-// * West Central US - westcentralus.api.cognitive.microsoft.com
-// * West Europe - westeurope.api.cognitive.microsoft.com
-// * Southeast Asia - southeastasia.api.cognitive.microsoft.com .
 type TextModerationClient struct {
 	BaseClient
 }
 
 // NewTextModerationClient creates an instance of the TextModerationClient client.
-func NewTextModerationClient(baseURL AzureRegionBaseURL) TextModerationClient {
-	return TextModerationClient{New(baseURL)}
+func NewTextModerationClient(endpoint string) TextModerationClient {
+	return TextModerationClient{New(endpoint)}
 }
 
 // DetectLanguage this operation will detect the language of given input content. Returns the <a
@@ -81,13 +73,13 @@ func (client TextModerationClient) DetectLanguage(ctx context.Context, textConte
 // DetectLanguagePreparer prepares the DetectLanguage request.
 func (client TextModerationClient) DetectLanguagePreparer(ctx context.Context, textContentType string, textContent io.ReadCloser) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("text/plain"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessText/DetectLanguage"),
 		autorest.WithFile(textContent),
 		autorest.WithHeader("Content-Type", autorest.String(textContentType)))
@@ -148,7 +140,7 @@ func (client TextModerationClient) ScreenText(ctx context.Context, textContentTy
 // ScreenTextPreparer prepares the ScreenText request.
 func (client TextModerationClient) ScreenTextPreparer(ctx context.Context, textContentType string, textContent io.ReadCloser, language string, autocorrect *bool, pii *bool, listID string, classify *bool) (*http.Request, error) {
 	urlParameters := map[string]interface{}{
-		"baseUrl": client.BaseURL,
+		"Endpoint": client.Endpoint,
 	}
 
 	queryParameters := map[string]interface{}{}
@@ -177,7 +169,7 @@ func (client TextModerationClient) ScreenTextPreparer(ctx context.Context, textC
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("text/plain"),
 		autorest.AsPost(),
-		autorest.WithCustomBaseURL("https://{baseUrl}", urlParameters),
+		autorest.WithCustomBaseURL("{Endpoint}", urlParameters),
 		autorest.WithPath("/contentmoderator/moderate/v1.0/ProcessText/Screen/"),
 		autorest.WithFile(textContent),
 		autorest.WithQueryParameters(queryParameters),


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3505