### PR TITLE
[AutoPR containerservices/resource-manager] Remove serverAppSecret which is not required for AKS cluster updates

### DIFF
--- a/services/containerservice/mgmt/2018-03-31/containerservice/managedclusters.go
+++ b/services/containerservice/mgmt/2018-03-31/containerservice/managedclusters.go
@@ -71,7 +71,6 @@ func (client ManagedClustersClient) CreateOrUpdate(ctx context.Context, resource
 					{Target: "parameters.ManagedClusterProperties.AadProfile", Name: validation.Null, Rule: false,
 						Chain: []validation.Constraint{{Target: "parameters.ManagedClusterProperties.AadProfile.ClientAppID", Name: validation.Null, Rule: true, Chain: nil},
 							{Target: "parameters.ManagedClusterProperties.AadProfile.ServerAppID", Name: validation.Null, Rule: true, Chain: nil},
-							{Target: "parameters.ManagedClusterProperties.AadProfile.ServerAppSecret", Name: validation.Null, Rule: true, Chain: nil},
 						}},
 				}}}}}); err != nil {
 		return result, validation.NewError("containerservice.ManagedClustersClient", "CreateOrUpdate", err.Error())


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3949