### PR TITLE
[AutoPR compute/resource-manager] Improve gallery swagger by improving one description and mark one param as required.

### DIFF
--- a/services/compute/mgmt/2018-06-01/compute/galleries.go
+++ b/services/compute/mgmt/2018-06-01/compute/galleries.go
@@ -43,7 +43,7 @@ func NewGalleriesClientWithBaseURI(baseURI string, subscriptionID string) Galler
 // Parameters:
 // resourceGroupName - the name of the resource group.
 // galleryName - the name of the Shared Image Gallery. The allowed characters are alphabets and numbers with
-// dots, dashes, and periods allowed in the middle. The maximum length is 80 characters.
+// dots and periods allowed in the middle. The maximum length is 80 characters.
 // gallery - parameters supplied to the create or update Shared Image Gallery operation.
 func (client GalleriesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery) (result GalleriesCreateOrUpdateFuture, err error) {
 	req, err := client.CreateOrUpdatePreparer(ctx, resourceGroupName, galleryName, gallery)


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3981