### PR TITLE
[AutoPR web/resource-manager] Updated the AppService Swagger to include ElasticPremium and ElasticIsolated Skus, and a new MaximumElasticWorkerCount parameter.

### DIFF
--- a/profiles/preview/web/mgmt/web/models.go
+++ b/profiles/preview/web/mgmt/web/models.go
@@ -551,14 +551,16 @@ const (
 type SkuName = original.SkuName
 
 const (
-	SkuNameBasic     SkuName = original.SkuNameBasic
-	SkuNameDynamic   SkuName = original.SkuNameDynamic
-	SkuNameFree      SkuName = original.SkuNameFree
-	SkuNameIsolated  SkuName = original.SkuNameIsolated
-	SkuNamePremium   SkuName = original.SkuNamePremium
-	SkuNamePremiumV2 SkuName = original.SkuNamePremiumV2
-	SkuNameShared    SkuName = original.SkuNameShared
-	SkuNameStandard  SkuName = original.SkuNameStandard
+	SkuNameBasic           SkuName = original.SkuNameBasic
+	SkuNameDynamic         SkuName = original.SkuNameDynamic
+	SkuNameElasticIsolated SkuName = original.SkuNameElasticIsolated
+	SkuNameElasticPremium  SkuName = original.SkuNameElasticPremium
+	SkuNameFree            SkuName = original.SkuNameFree
+	SkuNameIsolated        SkuName = original.SkuNameIsolated
+	SkuNamePremium         SkuName = original.SkuNamePremium
+	SkuNamePremiumV2       SkuName = original.SkuNamePremiumV2
+	SkuNameShared          SkuName = original.SkuNameShared
+	SkuNameStandard        SkuName = original.SkuNameStandard
 )
 
 type SolutionType = original.SolutionType

--- a/services/web/mgmt/2018-02-01/web/models.go
+++ b/services/web/mgmt/2018-02-01/web/models.go
@@ -1111,6 +1111,10 @@ const (
 	SkuNameBasic SkuName = "Basic"
 	// SkuNameDynamic ...
 	SkuNameDynamic SkuName = "Dynamic"
+	// SkuNameElasticIsolated ...
+	SkuNameElasticIsolated SkuName = "ElasticIsolated"
+	// SkuNameElasticPremium ...
+	SkuNameElasticPremium SkuName = "ElasticPremium"
 	// SkuNameFree ...
 	SkuNameFree SkuName = "Free"
 	// SkuNameIsolated ...
@@ -1127,7 +1131,7 @@ const (
 
 // PossibleSkuNameValues returns an array of possible values for the SkuName const type.
 func PossibleSkuNameValues() []SkuName {
-	return []SkuName{SkuNameBasic, SkuNameDynamic, SkuNameFree, SkuNameIsolated, SkuNamePremium, SkuNamePremiumV2, SkuNameShared, SkuNameStandard}
+	return []SkuName{SkuNameBasic, SkuNameDynamic, SkuNameElasticIsolated, SkuNameElasticPremium, SkuNameFree, SkuNameIsolated, SkuNamePremium, SkuNamePremiumV2, SkuNameShared, SkuNameStandard}
 }
 
 // SolutionType enumerates the values for solution type.
@@ -4033,6 +4037,8 @@ type AppServicePlanPatchResourceProperties struct {
 	// PerSiteScaling - If <code>true</code>, apps assigned to this App Service plan can be scaled independently.
 	// If <code>false</code>, apps assigned to this App Service plan will scale to all instances of the plan.
 	PerSiteScaling *bool `json:"perSiteScaling,omitempty"`
+	// MaximumElasticWorkerCount - Maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan
+	MaximumElasticWorkerCount *int32 `json:"maximumElasticWorkerCount,omitempty"`
 	// NumberOfSites - Number of apps assigned to this App Service plan.
 	NumberOfSites *int32 `json:"numberOfSites,omitempty"`
 	// IsSpot - If <code>true</code>, this App Service Plan owns spot instances.
@@ -4076,6 +4082,8 @@ type AppServicePlanProperties struct {
 	// PerSiteScaling - If <code>true</code>, apps assigned to this App Service plan can be scaled independently.
 	// If <code>false</code>, apps assigned to this App Service plan will scale to all instances of the plan.
 	PerSiteScaling *bool `json:"perSiteScaling,omitempty"`
+	// MaximumElasticWorkerCount - Maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan
+	MaximumElasticWorkerCount *int32 `json:"maximumElasticWorkerCount,omitempty"`
 	// NumberOfSites - Number of apps assigned to this App Service plan.
 	NumberOfSites *int32 `json:"numberOfSites,omitempty"`
 	// IsSpot - If <code>true</code>, this App Service Plan owns spot instances.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4006