### PR TITLE
[AutoPR servicebus/resource-manager] ServiceBus: Added read-only property migrationState to MigrationConfig

### DIFF
--- a/services/servicebus/mgmt/2017-04-01/servicebus/models.go
+++ b/services/servicebus/mgmt/2017-04-01/servicebus/models.go
@@ -1016,6 +1016,8 @@ type MigrationConfigPropertiesProperties struct {
 	TargetNamespace *string `json:"targetNamespace,omitempty"`
 	// PostMigrationName - Name to access Standard Namespace after migration
 	PostMigrationName *string `json:"postMigrationName,omitempty"`
+	// MigrationState - State in which Standard to Premium Migration is, possible values : Unknown, Reverting, Completing, Initiating, Syncing, Active
+	MigrationState *string `json:"migrationState,omitempty"`
 }
 
 // MigrationConfigsCreateAndStartMigrationFuture an abstraction for monitoring and retrieving the results of a


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4008