### PR TITLE
[AutoPR containerregistry/resource-manager] allow specifying credentials for source registry on import image

### DIFF
--- a/profiles/latest/containerregistry/mgmt/containerregistry/models.go
+++ b/profiles/latest/containerregistry/mgmt/containerregistry/models.go
@@ -116,6 +116,7 @@ type EventRequestMessage = original.EventRequestMessage
 type EventResponseMessage = original.EventResponseMessage
 type ImportImageParameters = original.ImportImageParameters
 type ImportSource = original.ImportSource
+type ImportSourceCredentials = original.ImportSourceCredentials
 type OperationDefinition = original.OperationDefinition
 type OperationDisplayDefinition = original.OperationDisplayDefinition
 type OperationListResult = original.OperationListResult

--- a/profiles/preview/containerregistry/mgmt/containerregistry/models.go
+++ b/profiles/preview/containerregistry/mgmt/containerregistry/models.go
@@ -256,6 +256,7 @@ type ImageDescriptor = original.ImageDescriptor
 type ImageUpdateTrigger = original.ImageUpdateTrigger
 type ImportImageParameters = original.ImportImageParameters
 type ImportSource = original.ImportSource
+type ImportSourceCredentials = original.ImportSourceCredentials
 type OperationDefinition = original.OperationDefinition
 type OperationDisplayDefinition = original.OperationDisplayDefinition
 type OperationListResult = original.OperationListResult

--- a/profiles/preview/preview/containerregistry/mgmt/containerregistry/models.go
+++ b/profiles/preview/preview/containerregistry/mgmt/containerregistry/models.go
@@ -249,6 +249,7 @@ type ImageDescriptor = original.ImageDescriptor
 type ImageUpdateTrigger = original.ImageUpdateTrigger
 type ImportImageParameters = original.ImportImageParameters
 type ImportSource = original.ImportSource
+type ImportSourceCredentials = original.ImportSourceCredentials
 type OperationDefinition = original.OperationDefinition
 type OperationDisplayDefinition = original.OperationDisplayDefinition
 type OperationListResult = original.OperationListResult

--- a/services/containerregistry/mgmt/2017-10-01/containerregistry/models.go
+++ b/services/containerregistry/mgmt/2017-10-01/containerregistry/models.go
@@ -443,13 +443,23 @@ type ImportImageParameters struct {
 type ImportSource struct {
 	// ResourceID - The resource identifier of the source Azure Container Registry.
 	ResourceID *string `json:"resourceId,omitempty"`
-	// RegistryURI - The address of the source registry.
+	// RegistryURI - The address of the source registry (e.g. 'mcr.microsoft.com').
 	RegistryURI *string `json:"registryUri,omitempty"`
+	// Credentials - Credentials used when importing from a registry uri.
+	Credentials *ImportSourceCredentials `json:"credentials,omitempty"`
 	// SourceImage - Repository name of the source image.
 	// Specify an image by repository ('hello-world'). This will use the 'latest' tag.
 	// Specify an image by tag ('hello-world:latest').
 	// Specify an image by sha256-based manifest digest ('hello-world@sha256:abc123').
 	SourceImage *string `json:"sourceImage,omitempty"`
+}
+
+// ImportSourceCredentials ...
+type ImportSourceCredentials struct {
+	// Username - The username to authenticate with the source registry.
+	Username *string `json:"username,omitempty"`
+	// Password - The password used to authenticate with the source registry.
+	Password *string `json:"password,omitempty"`
 }
 
 // OperationDefinition the definition of a container registry operation.

--- a/services/containerregistry/mgmt/2017-10-01/containerregistry/registries.go
+++ b/services/containerregistry/mgmt/2017-10-01/containerregistry/registries.go
@@ -372,7 +372,10 @@ func (client RegistriesClient) ImportImage(ctx context.Context, resourceGroupNam
 				{Target: "registryName", Name: validation.Pattern, Rule: `^[a-zA-Z0-9]*$`, Chain: nil}}},
 		{TargetValue: parameters,
 			Constraints: []validation.Constraint{{Target: "parameters.Source", Name: validation.Null, Rule: true,
-				Chain: []validation.Constraint{{Target: "parameters.Source.SourceImage", Name: validation.Null, Rule: true, Chain: nil}}}}}}); err != nil {
+				Chain: []validation.Constraint{{Target: "parameters.Source.Credentials", Name: validation.Null, Rule: false,
+					Chain: []validation.Constraint{{Target: "parameters.Source.Credentials.Password", Name: validation.Null, Rule: true, Chain: nil}}},
+					{Target: "parameters.Source.SourceImage", Name: validation.Null, Rule: true, Chain: nil},
+				}}}}}); err != nil {
 		return result, validation.NewError("containerregistry.RegistriesClient", "ImportImage", err.Error())
 	}
 

--- a/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
+++ b/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
@@ -1474,13 +1474,23 @@ type ImportImageParameters struct {
 type ImportSource struct {
 	// ResourceID - The resource identifier of the source Azure Container Registry.
 	ResourceID *string `json:"resourceId,omitempty"`
-	// RegistryURI - The address of the source registry.
+	// RegistryURI - The address of the source registry (e.g. 'mcr.microsoft.com').
 	RegistryURI *string `json:"registryUri,omitempty"`
+	// Credentials - Credentials used when importing from a registry uri.
+	Credentials *ImportSourceCredentials `json:"credentials,omitempty"`
 	// SourceImage - Repository name of the source image.
 	// Specify an image by repository ('hello-world'). This will use the 'latest' tag.
 	// Specify an image by tag ('hello-world:latest').
 	// Specify an image by sha256-based manifest digest ('hello-world@sha256:abc123').
 	SourceImage *string `json:"sourceImage,omitempty"`
+}
+
+// ImportSourceCredentials ...
+type ImportSourceCredentials struct {
+	// Username - The username to authenticate with the source registry.
+	Username *string `json:"username,omitempty"`
+	// Password - The password used to authenticate with the source registry.
+	Password *string `json:"password,omitempty"`
 }
 
 // OperationDefinition the definition of a container registry operation.

--- a/services/containerregistry/mgmt/2018-09-01/containerregistry/registries.go
+++ b/services/containerregistry/mgmt/2018-09-01/containerregistry/registries.go
@@ -447,7 +447,10 @@ func (client RegistriesClient) ImportImage(ctx context.Context, resourceGroupNam
 				{Target: "registryName", Name: validation.Pattern, Rule: `^[a-zA-Z0-9]*$`, Chain: nil}}},
 		{TargetValue: parameters,
 			Constraints: []validation.Constraint{{Target: "parameters.Source", Name: validation.Null, Rule: true,
-				Chain: []validation.Constraint{{Target: "parameters.Source.SourceImage", Name: validation.Null, Rule: true, Chain: nil}}}}}}); err != nil {
+				Chain: []validation.Constraint{{Target: "parameters.Source.Credentials", Name: validation.Null, Rule: false,
+					Chain: []validation.Constraint{{Target: "parameters.Source.Credentials.Password", Name: validation.Null, Rule: true, Chain: nil}}},
+					{Target: "parameters.Source.SourceImage", Name: validation.Null, Rule: true, Chain: nil},
+				}}}}}); err != nil {
 		return result, validation.NewError("containerregistry.RegistriesClient", "ImportImage", err.Error())
 	}
 

--- a/services/preview/containerregistry/mgmt/2018-02-01/containerregistry/models.go
+++ b/services/preview/containerregistry/mgmt/2018-02-01/containerregistry/models.go
@@ -2109,13 +2109,23 @@ type ImportImageParameters struct {
 type ImportSource struct {
 	// ResourceID - The resource identifier of the source Azure Container Registry.
 	ResourceID *string `json:"resourceId,omitempty"`
-	// RegistryURI - The address of the source registry.
+	// RegistryURI - The address of the source registry (e.g. 'mcr.microsoft.com').
 	RegistryURI *string `json:"registryUri,omitempty"`
+	// Credentials - Credentials used when importing from a registry uri.
+	Credentials *ImportSourceCredentials `json:"credentials,omitempty"`
 	// SourceImage - Repository name of the source image.
 	// Specify an image by repository ('hello-world'). This will use the 'latest' tag.
 	// Specify an image by tag ('hello-world:latest').
 	// Specify an image by sha256-based manifest digest ('hello-world@sha256:abc123').
 	SourceImage *string `json:"sourceImage,omitempty"`
+}
+
+// ImportSourceCredentials ...
+type ImportSourceCredentials struct {
+	// Username - The username to authenticate with the source registry.
+	Username *string `json:"username,omitempty"`
+	// Password - The password used to authenticate with the source registry.
+	Password *string `json:"password,omitempty"`
 }
 
 // OperationDefinition the definition of a container registry operation.

--- a/services/preview/containerregistry/mgmt/2018-02-01/containerregistry/registries.go
+++ b/services/preview/containerregistry/mgmt/2018-02-01/containerregistry/registries.go
@@ -447,7 +447,10 @@ func (client RegistriesClient) ImportImage(ctx context.Context, resourceGroupNam
 				{Target: "registryName", Name: validation.Pattern, Rule: `^[a-zA-Z0-9]*$`, Chain: nil}}},
 		{TargetValue: parameters,
 			Constraints: []validation.Constraint{{Target: "parameters.Source", Name: validation.Null, Rule: true,
-				Chain: []validation.Constraint{{Target: "parameters.Source.SourceImage", Name: validation.Null, Rule: true, Chain: nil}}}}}}); err != nil {
+				Chain: []validation.Constraint{{Target: "parameters.Source.Credentials", Name: validation.Null, Rule: false,
+					Chain: []validation.Constraint{{Target: "parameters.Source.Credentials.Password", Name: validation.Null, Rule: true, Chain: nil}}},
+					{Target: "parameters.Source.SourceImage", Name: validation.Null, Rule: true, Chain: nil},
+				}}}}}); err != nil {
 		return result, validation.NewError("containerregistry.RegistriesClient", "ImportImage", err.Error())
 	}
 


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4049