### PR TITLE
Use Copy function to avoid lock contention when using a Regexp in multiple goroutines.

### DIFF
--- a/tools/generator/program.go
+++ b/tools/generator/program.go
@@ -109,12 +109,12 @@ func main() {
 						return
 					}
 
-					matches := goConfigPattern.FindAllStringSubmatch(string(targetContents), -1)
+					matches := goConfigPattern.Copy().FindAllStringSubmatch(string(targetContents), -1)
 
 					if len(matches) == 0 {
 						statusLog.Printf("Skipping %q because there were no package tags with go configuration found.", subject.(string))
 					} else {
-						packageMatches := packageConfigPattern.FindAllStringSubmatch(string(targetContents), -1)
+						packageMatches := packageConfigPattern.Copy().FindAllStringSubmatch(string(targetContents), -1)
 						outputAPIFolders := map[string]string{}
 
 						for _, submatch := range matches {


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md

----

## What is the PR?

The Regexp provides Copy function since go1.6 or later.

We should use it when using a Regexp in multiple goroutines to avoid lock contention.

## CHANGELOG.md wasn't updated

I believe I don't need to update the CHANGELOG.md because it's not an essential file.