### PR TITLE
[AutoPR iothub/resource-manager] Add DeviceStreams properties to IoTHub and modify RoutingTwin object …

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -177,6 +177,14 @@
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
@@ -324,6 +332,7 @@
     "github.com/marstr/guid",
     "github.com/marstr/randname",
     "github.com/mitchellh/go-homedir",
+    "github.com/pkg/errors",
     "github.com/satori/go.uuid",
     "github.com/shopspring/decimal",
     "github.com/spf13/cobra",


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4172