### PR TITLE
fix golint path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - curl -sSL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
 install:
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
   - dep ensure
 
 script:


### PR DESCRIPTION
Golint has been moved.

More info here -> https://github.com/golang/lint#installation and golang/lint#417