### PR TITLE
[AutoPR servicebus/resource-manager] Service Bus: moved VNet and IpFilter rules from 2018-preview to 2017 API version

### DIFF
--- a/profiles/latest/servicebus/mgmt/servicebus/models.go
+++ b/profiles/latest/servicebus/mgmt/servicebus/models.go
@@ -65,6 +65,13 @@ const (
 	FilterTypeSQLFilter         FilterType = original.FilterTypeSQLFilter
 )
 
+type IPAction = original.IPAction
+
+const (
+	Accept IPAction = original.Accept
+	Reject IPAction = original.Reject
+)
+
 type KeyType = original.KeyType
 
 const (
@@ -135,6 +142,11 @@ type EventHubListResult = original.EventHubListResult
 type EventHubListResultIterator = original.EventHubListResultIterator
 type EventHubListResultPage = original.EventHubListResultPage
 type EventhubProperties = original.EventhubProperties
+type IPFilterRule = original.IPFilterRule
+type IPFilterRuleListResult = original.IPFilterRuleListResult
+type IPFilterRuleListResultIterator = original.IPFilterRuleListResultIterator
+type IPFilterRuleListResultPage = original.IPFilterRuleListResultPage
+type IPFilterRuleProperties = original.IPFilterRuleProperties
 type MessageCountDetails = original.MessageCountDetails
 type MigrationConfigListResult = original.MigrationConfigListResult
 type MigrationConfigListResultIterator = original.MigrationConfigListResultIterator
@@ -192,6 +204,11 @@ type SBTopicProperties = original.SBTopicProperties
 type SQLFilter = original.SQLFilter
 type SQLRuleAction = original.SQLRuleAction
 type TrackedResource = original.TrackedResource
+type VirtualNetworkRule = original.VirtualNetworkRule
+type VirtualNetworkRuleListResult = original.VirtualNetworkRuleListResult
+type VirtualNetworkRuleListResultIterator = original.VirtualNetworkRuleListResultIterator
+type VirtualNetworkRuleListResultPage = original.VirtualNetworkRuleListResultPage
+type VirtualNetworkRuleProperties = original.VirtualNetworkRuleProperties
 type NamespacesClient = original.NamespacesClient
 type OperationsClient = original.OperationsClient
 type PremiumMessagingRegionsClient = original.PremiumMessagingRegionsClient
@@ -236,6 +253,9 @@ func PossibleEntityStatusValues() []EntityStatus {
 }
 func PossibleFilterTypeValues() []FilterType {
 	return original.PossibleFilterTypeValues()
+}
+func PossibleIPActionValues() []IPAction {
+	return original.PossibleIPActionValues()
 }
 func PossibleKeyTypeValues() []KeyType {
 	return original.PossibleKeyTypeValues()

--- a/profiles/latest/servicebus/mgmt/servicebus/models.go
+++ b/profiles/latest/servicebus/mgmt/servicebus/models.go
@@ -87,12 +87,6 @@ const (
 	Succeeded ProvisioningStateDR = original.Succeeded
 )
 
-type ReplicationType = original.ReplicationType
-
-const (
-	MetadataReplication ReplicationType = original.MetadataReplication
-)
-
 type RoleDisasterRecovery = original.RoleDisasterRecovery
 
 const (
@@ -268,9 +262,6 @@ func PossibleKeyTypeValues() []KeyType {
 }
 func PossibleProvisioningStateDRValues() []ProvisioningStateDR {
 	return original.PossibleProvisioningStateDRValues()
-}
-func PossibleReplicationTypeValues() []ReplicationType {
-	return original.PossibleReplicationTypeValues()
 }
 func PossibleRoleDisasterRecoveryValues() []RoleDisasterRecovery {
 	return original.PossibleRoleDisasterRecoveryValues()

--- a/profiles/latest/servicebus/mgmt/servicebus/models.go
+++ b/profiles/latest/servicebus/mgmt/servicebus/models.go
@@ -87,6 +87,12 @@ const (
 	Succeeded ProvisioningStateDR = original.Succeeded
 )
 
+type ReplicationType = original.ReplicationType
+
+const (
+	MetadataReplication ReplicationType = original.MetadataReplication
+)
+
 type RoleDisasterRecovery = original.RoleDisasterRecovery
 
 const (
@@ -262,6 +268,9 @@ func PossibleKeyTypeValues() []KeyType {
 }
 func PossibleProvisioningStateDRValues() []ProvisioningStateDR {
 	return original.PossibleProvisioningStateDRValues()
+}
+func PossibleReplicationTypeValues() []ReplicationType {
+	return original.PossibleReplicationTypeValues()
 }
 func PossibleRoleDisasterRecoveryValues() []RoleDisasterRecovery {
 	return original.PossibleRoleDisasterRecoveryValues()

--- a/profiles/preview/servicebus/mgmt/servicebus/models.go
+++ b/profiles/preview/servicebus/mgmt/servicebus/models.go
@@ -65,6 +65,13 @@ const (
 	FilterTypeSQLFilter         FilterType = original.FilterTypeSQLFilter
 )
 
+type IPAction = original.IPAction
+
+const (
+	Accept IPAction = original.Accept
+	Reject IPAction = original.Reject
+)
+
 type KeyType = original.KeyType
 
 const (
@@ -135,6 +142,11 @@ type EventHubListResult = original.EventHubListResult
 type EventHubListResultIterator = original.EventHubListResultIterator
 type EventHubListResultPage = original.EventHubListResultPage
 type EventhubProperties = original.EventhubProperties
+type IPFilterRule = original.IPFilterRule
+type IPFilterRuleListResult = original.IPFilterRuleListResult
+type IPFilterRuleListResultIterator = original.IPFilterRuleListResultIterator
+type IPFilterRuleListResultPage = original.IPFilterRuleListResultPage
+type IPFilterRuleProperties = original.IPFilterRuleProperties
 type MessageCountDetails = original.MessageCountDetails
 type MigrationConfigListResult = original.MigrationConfigListResult
 type MigrationConfigListResultIterator = original.MigrationConfigListResultIterator
@@ -192,6 +204,11 @@ type SBTopicProperties = original.SBTopicProperties
 type SQLFilter = original.SQLFilter
 type SQLRuleAction = original.SQLRuleAction
 type TrackedResource = original.TrackedResource
+type VirtualNetworkRule = original.VirtualNetworkRule
+type VirtualNetworkRuleListResult = original.VirtualNetworkRuleListResult
+type VirtualNetworkRuleListResultIterator = original.VirtualNetworkRuleListResultIterator
+type VirtualNetworkRuleListResultPage = original.VirtualNetworkRuleListResultPage
+type VirtualNetworkRuleProperties = original.VirtualNetworkRuleProperties
 type NamespacesClient = original.NamespacesClient
 type OperationsClient = original.OperationsClient
 type PremiumMessagingRegionsClient = original.PremiumMessagingRegionsClient
@@ -236,6 +253,9 @@ func PossibleEntityStatusValues() []EntityStatus {
 }
 func PossibleFilterTypeValues() []FilterType {
 	return original.PossibleFilterTypeValues()
+}
+func PossibleIPActionValues() []IPAction {
+	return original.PossibleIPActionValues()
 }
 func PossibleKeyTypeValues() []KeyType {
 	return original.PossibleKeyTypeValues()

--- a/profiles/preview/servicebus/mgmt/servicebus/models.go
+++ b/profiles/preview/servicebus/mgmt/servicebus/models.go
@@ -87,12 +87,6 @@ const (
 	Succeeded ProvisioningStateDR = original.Succeeded
 )
 
-type ReplicationType = original.ReplicationType
-
-const (
-	MetadataReplication ReplicationType = original.MetadataReplication
-)
-
 type RoleDisasterRecovery = original.RoleDisasterRecovery
 
 const (
@@ -268,9 +262,6 @@ func PossibleKeyTypeValues() []KeyType {
 }
 func PossibleProvisioningStateDRValues() []ProvisioningStateDR {
 	return original.PossibleProvisioningStateDRValues()
-}
-func PossibleReplicationTypeValues() []ReplicationType {
-	return original.PossibleReplicationTypeValues()
 }
 func PossibleRoleDisasterRecoveryValues() []RoleDisasterRecovery {
 	return original.PossibleRoleDisasterRecoveryValues()

--- a/profiles/preview/servicebus/mgmt/servicebus/models.go
+++ b/profiles/preview/servicebus/mgmt/servicebus/models.go
@@ -87,6 +87,12 @@ const (
 	Succeeded ProvisioningStateDR = original.Succeeded
 )
 
+type ReplicationType = original.ReplicationType
+
+const (
+	MetadataReplication ReplicationType = original.MetadataReplication
+)
+
 type RoleDisasterRecovery = original.RoleDisasterRecovery
 
 const (
@@ -262,6 +268,9 @@ func PossibleKeyTypeValues() []KeyType {
 }
 func PossibleProvisioningStateDRValues() []ProvisioningStateDR {
 	return original.PossibleProvisioningStateDRValues()
+}
+func PossibleReplicationTypeValues() []ReplicationType {
+	return original.PossibleReplicationTypeValues()
 }
 func PossibleRoleDisasterRecoveryValues() []RoleDisasterRecovery {
 	return original.PossibleRoleDisasterRecoveryValues()

--- a/services/servicebus/mgmt/2015-08-01/servicebus/namespaces.go
+++ b/services/servicebus/mgmt/2015-08-01/servicebus/namespaces.go
@@ -175,10 +175,6 @@ func (client NamespacesClient) CreateOrUpdateSender(req *http.Request) (future N
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
-	if err != nil {
-		return
-	}
 	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
@@ -341,10 +337,6 @@ func (client NamespacesClient) DeleteSender(req *http.Request) (future Namespace
 	var resp *http.Response
 	resp, err = autorest.SendWithSender(client, req,
 		azure.DoRetryWithRegistration(client.Client))
-	if err != nil {
-		return
-	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent))
 	if err != nil {
 		return
 	}

--- a/services/servicebus/mgmt/2017-04-01/servicebus/migrationconfigs.go
+++ b/services/servicebus/mgmt/2017-04-01/servicebus/migrationconfigs.go
@@ -189,10 +189,6 @@ func (client MigrationConfigsClient) CreateAndStartMigrationSender(req *http.Req
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
-	if err != nil {
-		return
-	}
 	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }

--- a/services/servicebus/mgmt/2017-04-01/servicebus/models.go
+++ b/services/servicebus/mgmt/2017-04-01/servicebus/models.go
@@ -102,6 +102,21 @@ func PossibleFilterTypeValues() []FilterType {
 	return []FilterType{FilterTypeCorrelationFilter, FilterTypeSQLFilter}
 }
 
+// IPAction enumerates the values for ip action.
+type IPAction string
+
+const (
+	// Accept ...
+	Accept IPAction = "Accept"
+	// Reject ...
+	Reject IPAction = "Reject"
+)
+
+// PossibleIPActionValues returns an array of possible values for the IPAction const type.
+func PossibleIPActionValues() []IPAction {
+	return []IPAction{Accept, Reject}
+}
+
 // KeyType enumerates the values for key type.
 type KeyType string
 
@@ -806,6 +821,200 @@ type EventhubProperties struct {
 	Status EntityStatus `json:"status,omitempty"`
 	// CaptureDescription - Properties of capture description
 	CaptureDescription *CaptureDescription `json:"captureDescription,omitempty"`
+}
+
+// IPFilterRule single item in a List or Get IpFilterRules operation
+type IPFilterRule struct {
+	autorest.Response `json:"-"`
+	// IPFilterRuleProperties - Properties supplied to create or update IpFilterRules
+	*IPFilterRuleProperties `json:"properties,omitempty"`
+	// ID - Resource Id
+	ID *string `json:"id,omitempty"`
+	// Name - Resource name
+	Name *string `json:"name,omitempty"`
+	// Type - Resource type
+	Type *string `json:"type,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for IPFilterRule.
+func (ifr IPFilterRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if ifr.IPFilterRuleProperties != nil {
+		objectMap["properties"] = ifr.IPFilterRuleProperties
+	}
+	if ifr.ID != nil {
+		objectMap["id"] = ifr.ID
+	}
+	if ifr.Name != nil {
+		objectMap["name"] = ifr.Name
+	}
+	if ifr.Type != nil {
+		objectMap["type"] = ifr.Type
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for IPFilterRule struct.
+func (ifr *IPFilterRule) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "properties":
+			if v != nil {
+				var IPFilterRuleProperties IPFilterRuleProperties
+				err = json.Unmarshal(*v, &IPFilterRuleProperties)
+				if err != nil {
+					return err
+				}
+				ifr.IPFilterRuleProperties = &IPFilterRuleProperties
+			}
+		case "id":
+			if v != nil {
+				var ID string
+				err = json.Unmarshal(*v, &ID)
+				if err != nil {
+					return err
+				}
+				ifr.ID = &ID
+			}
+		case "name":
+			if v != nil {
+				var name string
+				err = json.Unmarshal(*v, &name)
+				if err != nil {
+					return err
+				}
+				ifr.Name = &name
+			}
+		case "type":
+			if v != nil {
+				var typeVar string
+				err = json.Unmarshal(*v, &typeVar)
+				if err != nil {
+					return err
+				}
+				ifr.Type = &typeVar
+			}
+		}
+	}
+
+	return nil
+}
+
+// IPFilterRuleListResult the response from the List namespace operation.
+type IPFilterRuleListResult struct {
+	autorest.Response `json:"-"`
+	// Value - Result of the List IpFilter Rules operation.
+	Value *[]IPFilterRule `json:"value,omitempty"`
+	// NextLink - Link to the next set of results. Not empty if Value contains an incomplete list of IpFilter Rules
+	NextLink *string `json:"nextLink,omitempty"`
+}
+
+// IPFilterRuleListResultIterator provides access to a complete listing of IPFilterRule values.
+type IPFilterRuleListResultIterator struct {
+	i    int
+	page IPFilterRuleListResultPage
+}
+
+// Next advances to the next value.  If there was an error making
+// the request the iterator does not advance and the error is returned.
+func (iter *IPFilterRuleListResultIterator) Next() error {
+	iter.i++
+	if iter.i < len(iter.page.Values()) {
+		return nil
+	}
+	err := iter.page.Next()
+	if err != nil {
+		iter.i--
+		return err
+	}
+	iter.i = 0
+	return nil
+}
+
+// NotDone returns true if the enumeration should be started or is not yet complete.
+func (iter IPFilterRuleListResultIterator) NotDone() bool {
+	return iter.page.NotDone() && iter.i < len(iter.page.Values())
+}
+
+// Response returns the raw server response from the last page request.
+func (iter IPFilterRuleListResultIterator) Response() IPFilterRuleListResult {
+	return iter.page.Response()
+}
+
+// Value returns the current value or a zero-initialized value if the
+// iterator has advanced beyond the end of the collection.
+func (iter IPFilterRuleListResultIterator) Value() IPFilterRule {
+	if !iter.page.NotDone() {
+		return IPFilterRule{}
+	}
+	return iter.page.Values()[iter.i]
+}
+
+// IsEmpty returns true if the ListResult contains no values.
+func (ifrlr IPFilterRuleListResult) IsEmpty() bool {
+	return ifrlr.Value == nil || len(*ifrlr.Value) == 0
+}
+
+// iPFilterRuleListResultPreparer prepares a request to retrieve the next set of results.
+// It returns nil if no more results exist.
+func (ifrlr IPFilterRuleListResult) iPFilterRuleListResultPreparer() (*http.Request, error) {
+	if ifrlr.NextLink == nil || len(to.String(ifrlr.NextLink)) < 1 {
+		return nil, nil
+	}
+	return autorest.Prepare(&http.Request{},
+		autorest.AsJSON(),
+		autorest.AsGet(),
+		autorest.WithBaseURL(to.String(ifrlr.NextLink)))
+}
+
+// IPFilterRuleListResultPage contains a page of IPFilterRule values.
+type IPFilterRuleListResultPage struct {
+	fn    func(IPFilterRuleListResult) (IPFilterRuleListResult, error)
+	ifrlr IPFilterRuleListResult
+}
+
+// Next advances to the next page of values.  If there was an error making
+// the request the page does not advance and the error is returned.
+func (page *IPFilterRuleListResultPage) Next() error {
+	next, err := page.fn(page.ifrlr)
+	if err != nil {
+		return err
+	}
+	page.ifrlr = next
+	return nil
+}
+
+// NotDone returns true if the page enumeration should be started or is not yet complete.
+func (page IPFilterRuleListResultPage) NotDone() bool {
+	return !page.ifrlr.IsEmpty()
+}
+
+// Response returns the raw server response from the last page request.
+func (page IPFilterRuleListResultPage) Response() IPFilterRuleListResult {
+	return page.ifrlr
+}
+
+// Values returns the slice of values for the current page or nil if there are no values.
+func (page IPFilterRuleListResultPage) Values() []IPFilterRule {
+	if page.ifrlr.IsEmpty() {
+		return nil
+	}
+	return *page.ifrlr.Value
+}
+
+// IPFilterRuleProperties properties supplied to create or update IpFilterRules
+type IPFilterRuleProperties struct {
+	// IPMask - IP Mask
+	IPMask *string `json:"ipMask,omitempty"`
+	// Action - The IP Filter Action. Possible values include: 'Accept', 'Reject'
+	Action IPAction `json:"action,omitempty"`
+	// FilterName - IP Filter name
+	FilterName *string `json:"filterName,omitempty"`
 }
 
 // MessageCountDetails message Count Details.
@@ -2911,4 +3120,194 @@ func (tr TrackedResource) MarshalJSON() ([]byte, error) {
 		objectMap["type"] = tr.Type
 	}
 	return json.Marshal(objectMap)
+}
+
+// VirtualNetworkRule single item in a List or Get VirtualNetworkRules operation
+type VirtualNetworkRule struct {
+	autorest.Response `json:"-"`
+	// VirtualNetworkRuleProperties - Properties supplied to create or update VirtualNetworkRules
+	*VirtualNetworkRuleProperties `json:"properties,omitempty"`
+	// ID - Resource Id
+	ID *string `json:"id,omitempty"`
+	// Name - Resource name
+	Name *string `json:"name,omitempty"`
+	// Type - Resource type
+	Type *string `json:"type,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for VirtualNetworkRule.
+func (vnr VirtualNetworkRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if vnr.VirtualNetworkRuleProperties != nil {
+		objectMap["properties"] = vnr.VirtualNetworkRuleProperties
+	}
+	if vnr.ID != nil {
+		objectMap["id"] = vnr.ID
+	}
+	if vnr.Name != nil {
+		objectMap["name"] = vnr.Name
+	}
+	if vnr.Type != nil {
+		objectMap["type"] = vnr.Type
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for VirtualNetworkRule struct.
+func (vnr *VirtualNetworkRule) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "properties":
+			if v != nil {
+				var virtualNetworkRuleProperties VirtualNetworkRuleProperties
+				err = json.Unmarshal(*v, &virtualNetworkRuleProperties)
+				if err != nil {
+					return err
+				}
+				vnr.VirtualNetworkRuleProperties = &virtualNetworkRuleProperties
+			}
+		case "id":
+			if v != nil {
+				var ID string
+				err = json.Unmarshal(*v, &ID)
+				if err != nil {
+					return err
+				}
+				vnr.ID = &ID
+			}
+		case "name":
+			if v != nil {
+				var name string
+				err = json.Unmarshal(*v, &name)
+				if err != nil {
+					return err
+				}
+				vnr.Name = &name
+			}
+		case "type":
+			if v != nil {
+				var typeVar string
+				err = json.Unmarshal(*v, &typeVar)
+				if err != nil {
+					return err
+				}
+				vnr.Type = &typeVar
+			}
+		}
+	}
+
+	return nil
+}
+
+// VirtualNetworkRuleListResult the response from the List namespace operation.
+type VirtualNetworkRuleListResult struct {
+	autorest.Response `json:"-"`
+	// Value - Result of the List VirtualNetwork Rules operation.
+	Value *[]VirtualNetworkRule `json:"value,omitempty"`
+	// NextLink - Link to the next set of results. Not empty if Value contains an incomplete list of VirtualNetwork Rules
+	NextLink *string `json:"nextLink,omitempty"`
+}
+
+// VirtualNetworkRuleListResultIterator provides access to a complete listing of VirtualNetworkRule values.
+type VirtualNetworkRuleListResultIterator struct {
+	i    int
+	page VirtualNetworkRuleListResultPage
+}
+
+// Next advances to the next value.  If there was an error making
+// the request the iterator does not advance and the error is returned.
+func (iter *VirtualNetworkRuleListResultIterator) Next() error {
+	iter.i++
+	if iter.i < len(iter.page.Values()) {
+		return nil
+	}
+	err := iter.page.Next()
+	if err != nil {
+		iter.i--
+		return err
+	}
+	iter.i = 0
+	return nil
+}
+
+// NotDone returns true if the enumeration should be started or is not yet complete.
+func (iter VirtualNetworkRuleListResultIterator) NotDone() bool {
+	return iter.page.NotDone() && iter.i < len(iter.page.Values())
+}
+
+// Response returns the raw server response from the last page request.
+func (iter VirtualNetworkRuleListResultIterator) Response() VirtualNetworkRuleListResult {
+	return iter.page.Response()
+}
+
+// Value returns the current value or a zero-initialized value if the
+// iterator has advanced beyond the end of the collection.
+func (iter VirtualNetworkRuleListResultIterator) Value() VirtualNetworkRule {
+	if !iter.page.NotDone() {
+		return VirtualNetworkRule{}
+	}
+	return iter.page.Values()[iter.i]
+}
+
+// IsEmpty returns true if the ListResult contains no values.
+func (vnrlr VirtualNetworkRuleListResult) IsEmpty() bool {
+	return vnrlr.Value == nil || len(*vnrlr.Value) == 0
+}
+
+// virtualNetworkRuleListResultPreparer prepares a request to retrieve the next set of results.
+// It returns nil if no more results exist.
+func (vnrlr VirtualNetworkRuleListResult) virtualNetworkRuleListResultPreparer() (*http.Request, error) {
+	if vnrlr.NextLink == nil || len(to.String(vnrlr.NextLink)) < 1 {
+		return nil, nil
+	}
+	return autorest.Prepare(&http.Request{},
+		autorest.AsJSON(),
+		autorest.AsGet(),
+		autorest.WithBaseURL(to.String(vnrlr.NextLink)))
+}
+
+// VirtualNetworkRuleListResultPage contains a page of VirtualNetworkRule values.
+type VirtualNetworkRuleListResultPage struct {
+	fn    func(VirtualNetworkRuleListResult) (VirtualNetworkRuleListResult, error)
+	vnrlr VirtualNetworkRuleListResult
+}
+
+// Next advances to the next page of values.  If there was an error making
+// the request the page does not advance and the error is returned.
+func (page *VirtualNetworkRuleListResultPage) Next() error {
+	next, err := page.fn(page.vnrlr)
+	if err != nil {
+		return err
+	}
+	page.vnrlr = next
+	return nil
+}
+
+// NotDone returns true if the page enumeration should be started or is not yet complete.
+func (page VirtualNetworkRuleListResultPage) NotDone() bool {
+	return !page.vnrlr.IsEmpty()
+}
+
+// Response returns the raw server response from the last page request.
+func (page VirtualNetworkRuleListResultPage) Response() VirtualNetworkRuleListResult {
+	return page.vnrlr
+}
+
+// Values returns the slice of values for the current page or nil if there are no values.
+func (page VirtualNetworkRuleListResultPage) Values() []VirtualNetworkRule {
+	if page.vnrlr.IsEmpty() {
+		return nil
+	}
+	return *page.vnrlr.Value
+}
+
+// VirtualNetworkRuleProperties properties supplied to create or update VirtualNetworkRules
+type VirtualNetworkRuleProperties struct {
+	// VirtualNetworkSubnetID - Resource ID of Virtual Network Subnet
+	VirtualNetworkSubnetID *string `json:"virtualNetworkSubnetId,omitempty"`
 }

--- a/services/servicebus/mgmt/2017-04-01/servicebus/models.go
+++ b/services/servicebus/mgmt/2017-04-01/servicebus/models.go
@@ -149,19 +149,6 @@ func PossibleProvisioningStateDRValues() []ProvisioningStateDR {
 	return []ProvisioningStateDR{Accepted, Failed, Succeeded}
 }
 
-// ReplicationType enumerates the values for replication type.
-type ReplicationType string
-
-const (
-	// MetadataReplication ...
-	MetadataReplication ReplicationType = "MetadataReplication"
-)
-
-// PossibleReplicationTypeValues returns an array of possible values for the ReplicationType const type.
-func PossibleReplicationTypeValues() []ReplicationType {
-	return []ReplicationType{MetadataReplication}
-}
-
 // RoleDisasterRecovery enumerates the values for role disaster recovery.
 type RoleDisasterRecovery string
 
@@ -463,8 +450,6 @@ type ArmDisasterRecoveryProperties struct {
 	AlternateName *string `json:"alternateName,omitempty"`
 	// Role - role of namespace in GEO DR - possible values 'Primary' or 'PrimaryNotReplicating' or 'Secondary'. Possible values include: 'Primary', 'PrimaryNotReplicating', 'Secondary'
 	Role RoleDisasterRecovery `json:"role,omitempty"`
-	// Type - Replication Type on the Alias(Disaster Recovery configurations). Possible values include: 'MetadataReplication'
-	Type ReplicationType `json:"type,omitempty"`
 }
 
 // AuthorizationRuleProperties authorizationRule properties.

--- a/services/servicebus/mgmt/2017-04-01/servicebus/models.go
+++ b/services/servicebus/mgmt/2017-04-01/servicebus/models.go
@@ -149,6 +149,19 @@ func PossibleProvisioningStateDRValues() []ProvisioningStateDR {
 	return []ProvisioningStateDR{Accepted, Failed, Succeeded}
 }
 
+// ReplicationType enumerates the values for replication type.
+type ReplicationType string
+
+const (
+	// MetadataReplication ...
+	MetadataReplication ReplicationType = "MetadataReplication"
+)
+
+// PossibleReplicationTypeValues returns an array of possible values for the ReplicationType const type.
+func PossibleReplicationTypeValues() []ReplicationType {
+	return []ReplicationType{MetadataReplication}
+}
+
 // RoleDisasterRecovery enumerates the values for role disaster recovery.
 type RoleDisasterRecovery string
 
@@ -450,6 +463,8 @@ type ArmDisasterRecoveryProperties struct {
 	AlternateName *string `json:"alternateName,omitempty"`
 	// Role - role of namespace in GEO DR - possible values 'Primary' or 'PrimaryNotReplicating' or 'Secondary'. Possible values include: 'Primary', 'PrimaryNotReplicating', 'Secondary'
 	Role RoleDisasterRecovery `json:"role,omitempty"`
+	// Type - Replication Type on the Alias(Disaster Recovery configurations). Possible values include: 'MetadataReplication'
+	Type ReplicationType `json:"type,omitempty"`
 }
 
 // AuthorizationRuleProperties authorizationRule properties.

--- a/services/servicebus/mgmt/2017-04-01/servicebus/namespaces.go
+++ b/services/servicebus/mgmt/2017-04-01/servicebus/namespaces.go
@@ -173,10 +173,6 @@ func (client NamespacesClient) CreateOrUpdateSender(req *http.Request) (future N
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
-	if err != nil {
-		return
-	}
 	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
@@ -282,6 +278,174 @@ func (client NamespacesClient) CreateOrUpdateAuthorizationRuleResponder(resp *ht
 	return
 }
 
+// CreateOrUpdateIPFilterRule creates or updates an IpFilterRule for a Namespace.
+// Parameters:
+// resourceGroupName - name of the Resource group within the Azure subscription.
+// namespaceName - the namespace name
+// IPFilterRuleName - the IP Filter Rule name.
+// parameters - the Namespace IpFilterRule.
+func (client NamespacesClient) CreateOrUpdateIPFilterRule(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string, parameters IPFilterRule) (result IPFilterRule, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: IPFilterRuleName,
+			Constraints: []validation.Constraint{{Target: "IPFilterRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("servicebus.NamespacesClient", "CreateOrUpdateIPFilterRule", err.Error())
+	}
+
+	req, err := client.CreateOrUpdateIPFilterRulePreparer(ctx, resourceGroupName, namespaceName, IPFilterRuleName, parameters)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "CreateOrUpdateIPFilterRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CreateOrUpdateIPFilterRuleSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "CreateOrUpdateIPFilterRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateOrUpdateIPFilterRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "CreateOrUpdateIPFilterRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CreateOrUpdateIPFilterRulePreparer prepares the CreateOrUpdateIPFilterRule request.
+func (client NamespacesClient) CreateOrUpdateIPFilterRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string, parameters IPFilterRule) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"ipFilterRuleName":  autorest.Encode("path", IPFilterRuleName),
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/ipfilterrules/{ipFilterRuleName}", pathParameters),
+		autorest.WithJSON(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// CreateOrUpdateIPFilterRuleSender sends the CreateOrUpdateIPFilterRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) CreateOrUpdateIPFilterRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// CreateOrUpdateIPFilterRuleResponder handles the response to the CreateOrUpdateIPFilterRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) CreateOrUpdateIPFilterRuleResponder(resp *http.Response) (result IPFilterRule, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// CreateOrUpdateVirtualNetworkRule creates or updates an VirtualNetworkRule for a Namespace.
+// Parameters:
+// resourceGroupName - name of the Resource group within the Azure subscription.
+// namespaceName - the namespace name
+// virtualNetworkRuleName - the Virtual Network Rule name.
+// parameters - the Namespace VirtualNetworkRule.
+func (client NamespacesClient) CreateOrUpdateVirtualNetworkRule(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string, parameters VirtualNetworkRule) (result VirtualNetworkRule, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: virtualNetworkRuleName,
+			Constraints: []validation.Constraint{{Target: "virtualNetworkRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("servicebus.NamespacesClient", "CreateOrUpdateVirtualNetworkRule", err.Error())
+	}
+
+	req, err := client.CreateOrUpdateVirtualNetworkRulePreparer(ctx, resourceGroupName, namespaceName, virtualNetworkRuleName, parameters)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "CreateOrUpdateVirtualNetworkRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CreateOrUpdateVirtualNetworkRuleSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "CreateOrUpdateVirtualNetworkRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateOrUpdateVirtualNetworkRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "CreateOrUpdateVirtualNetworkRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CreateOrUpdateVirtualNetworkRulePreparer prepares the CreateOrUpdateVirtualNetworkRule request.
+func (client NamespacesClient) CreateOrUpdateVirtualNetworkRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string, parameters VirtualNetworkRule) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":          autorest.Encode("path", namespaceName),
+		"resourceGroupName":      autorest.Encode("path", resourceGroupName),
+		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
+		"virtualNetworkRuleName": autorest.Encode("path", virtualNetworkRuleName),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/virtualnetworkrules/{virtualNetworkRuleName}", pathParameters),
+		autorest.WithJSON(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// CreateOrUpdateVirtualNetworkRuleSender sends the CreateOrUpdateVirtualNetworkRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) CreateOrUpdateVirtualNetworkRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// CreateOrUpdateVirtualNetworkRuleResponder handles the response to the CreateOrUpdateVirtualNetworkRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) CreateOrUpdateVirtualNetworkRuleResponder(resp *http.Response) (result VirtualNetworkRule, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // Delete deletes an existing namespace. This operation also removes all associated resources under the namespace.
 // Parameters:
 // resourceGroupName - name of the Resource group within the Azure subscription.
@@ -339,10 +503,6 @@ func (client NamespacesClient) DeleteSender(req *http.Request) (future Namespace
 	var resp *http.Response
 	resp, err = autorest.SendWithSender(client, req,
 		azure.DoRetryWithRegistration(client.Client))
-	if err != nil {
-		return
-	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent))
 	if err != nil {
 		return
 	}
@@ -434,6 +594,166 @@ func (client NamespacesClient) DeleteAuthorizationRuleSender(req *http.Request) 
 // DeleteAuthorizationRuleResponder handles the response to the DeleteAuthorizationRule request. The method always
 // closes the http.Response Body.
 func (client NamespacesClient) DeleteAuthorizationRuleResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
+// DeleteIPFilterRule deletes an IpFilterRule for a Namespace.
+// Parameters:
+// resourceGroupName - name of the Resource group within the Azure subscription.
+// namespaceName - the namespace name
+// IPFilterRuleName - the IP Filter Rule name.
+func (client NamespacesClient) DeleteIPFilterRule(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string) (result autorest.Response, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: IPFilterRuleName,
+			Constraints: []validation.Constraint{{Target: "IPFilterRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("servicebus.NamespacesClient", "DeleteIPFilterRule", err.Error())
+	}
+
+	req, err := client.DeleteIPFilterRulePreparer(ctx, resourceGroupName, namespaceName, IPFilterRuleName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "DeleteIPFilterRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.DeleteIPFilterRuleSender(req)
+	if err != nil {
+		result.Response = resp
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "DeleteIPFilterRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.DeleteIPFilterRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "DeleteIPFilterRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// DeleteIPFilterRulePreparer prepares the DeleteIPFilterRule request.
+func (client NamespacesClient) DeleteIPFilterRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"ipFilterRuleName":  autorest.Encode("path", IPFilterRuleName),
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/ipfilterrules/{ipFilterRuleName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// DeleteIPFilterRuleSender sends the DeleteIPFilterRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) DeleteIPFilterRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// DeleteIPFilterRuleResponder handles the response to the DeleteIPFilterRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) DeleteIPFilterRuleResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
+// DeleteVirtualNetworkRule deletes an VirtualNetworkRule for a Namespace.
+// Parameters:
+// resourceGroupName - name of the Resource group within the Azure subscription.
+// namespaceName - the namespace name
+// virtualNetworkRuleName - the Virtual Network Rule name.
+func (client NamespacesClient) DeleteVirtualNetworkRule(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string) (result autorest.Response, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: virtualNetworkRuleName,
+			Constraints: []validation.Constraint{{Target: "virtualNetworkRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("servicebus.NamespacesClient", "DeleteVirtualNetworkRule", err.Error())
+	}
+
+	req, err := client.DeleteVirtualNetworkRulePreparer(ctx, resourceGroupName, namespaceName, virtualNetworkRuleName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "DeleteVirtualNetworkRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.DeleteVirtualNetworkRuleSender(req)
+	if err != nil {
+		result.Response = resp
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "DeleteVirtualNetworkRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.DeleteVirtualNetworkRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "DeleteVirtualNetworkRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// DeleteVirtualNetworkRulePreparer prepares the DeleteVirtualNetworkRule request.
+func (client NamespacesClient) DeleteVirtualNetworkRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":          autorest.Encode("path", namespaceName),
+		"resourceGroupName":      autorest.Encode("path", resourceGroupName),
+		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
+		"virtualNetworkRuleName": autorest.Encode("path", virtualNetworkRuleName),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/virtualnetworkrules/{virtualNetworkRuleName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// DeleteVirtualNetworkRuleSender sends the DeleteVirtualNetworkRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) DeleteVirtualNetworkRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// DeleteVirtualNetworkRuleResponder handles the response to the DeleteVirtualNetworkRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) DeleteVirtualNetworkRuleResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -592,6 +912,168 @@ func (client NamespacesClient) GetAuthorizationRuleSender(req *http.Request) (*h
 // GetAuthorizationRuleResponder handles the response to the GetAuthorizationRule request. The method always
 // closes the http.Response Body.
 func (client NamespacesClient) GetAuthorizationRuleResponder(resp *http.Response) (result SBAuthorizationRule, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// GetIPFilterRule gets an IpFilterRule for a Namespace by rule name.
+// Parameters:
+// resourceGroupName - name of the Resource group within the Azure subscription.
+// namespaceName - the namespace name
+// IPFilterRuleName - the IP Filter Rule name.
+func (client NamespacesClient) GetIPFilterRule(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string) (result IPFilterRule, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: IPFilterRuleName,
+			Constraints: []validation.Constraint{{Target: "IPFilterRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("servicebus.NamespacesClient", "GetIPFilterRule", err.Error())
+	}
+
+	req, err := client.GetIPFilterRulePreparer(ctx, resourceGroupName, namespaceName, IPFilterRuleName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "GetIPFilterRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetIPFilterRuleSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "GetIPFilterRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetIPFilterRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "GetIPFilterRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetIPFilterRulePreparer prepares the GetIPFilterRule request.
+func (client NamespacesClient) GetIPFilterRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"ipFilterRuleName":  autorest.Encode("path", IPFilterRuleName),
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/ipfilterrules/{ipFilterRuleName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetIPFilterRuleSender sends the GetIPFilterRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) GetIPFilterRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// GetIPFilterRuleResponder handles the response to the GetIPFilterRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) GetIPFilterRuleResponder(resp *http.Response) (result IPFilterRule, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// GetVirtualNetworkRule gets an VirtualNetworkRule for a Namespace by rule name.
+// Parameters:
+// resourceGroupName - name of the Resource group within the Azure subscription.
+// namespaceName - the namespace name
+// virtualNetworkRuleName - the Virtual Network Rule name.
+func (client NamespacesClient) GetVirtualNetworkRule(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string) (result VirtualNetworkRule, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: virtualNetworkRuleName,
+			Constraints: []validation.Constraint{{Target: "virtualNetworkRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("servicebus.NamespacesClient", "GetVirtualNetworkRule", err.Error())
+	}
+
+	req, err := client.GetVirtualNetworkRulePreparer(ctx, resourceGroupName, namespaceName, virtualNetworkRuleName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "GetVirtualNetworkRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetVirtualNetworkRuleSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "GetVirtualNetworkRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetVirtualNetworkRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "GetVirtualNetworkRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetVirtualNetworkRulePreparer prepares the GetVirtualNetworkRule request.
+func (client NamespacesClient) GetVirtualNetworkRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":          autorest.Encode("path", namespaceName),
+		"resourceGroupName":      autorest.Encode("path", resourceGroupName),
+		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
+		"virtualNetworkRuleName": autorest.Encode("path", virtualNetworkRuleName),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/virtualnetworkrules/{virtualNetworkRuleName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetVirtualNetworkRuleSender sends the GetVirtualNetworkRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) GetVirtualNetworkRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// GetVirtualNetworkRuleResponder handles the response to the GetVirtualNetworkRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) GetVirtualNetworkRuleResponder(resp *http.Response) (result VirtualNetworkRule, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -897,6 +1379,111 @@ func (client NamespacesClient) ListByResourceGroupComplete(ctx context.Context, 
 	return
 }
 
+// ListIPFilterRules gets a list of IP Filter rules for a Namespace.
+// Parameters:
+// resourceGroupName - name of the Resource group within the Azure subscription.
+// namespaceName - the namespace name
+func (client NamespacesClient) ListIPFilterRules(ctx context.Context, resourceGroupName string, namespaceName string) (result IPFilterRuleListResultPage, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("servicebus.NamespacesClient", "ListIPFilterRules", err.Error())
+	}
+
+	result.fn = client.listIPFilterRulesNextResults
+	req, err := client.ListIPFilterRulesPreparer(ctx, resourceGroupName, namespaceName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "ListIPFilterRules", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListIPFilterRulesSender(req)
+	if err != nil {
+		result.ifrlr.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "ListIPFilterRules", resp, "Failure sending request")
+		return
+	}
+
+	result.ifrlr, err = client.ListIPFilterRulesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "ListIPFilterRules", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// ListIPFilterRulesPreparer prepares the ListIPFilterRules request.
+func (client NamespacesClient) ListIPFilterRulesPreparer(ctx context.Context, resourceGroupName string, namespaceName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/ipfilterrules", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListIPFilterRulesSender sends the ListIPFilterRules request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) ListIPFilterRulesSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListIPFilterRulesResponder handles the response to the ListIPFilterRules request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) ListIPFilterRulesResponder(resp *http.Response) (result IPFilterRuleListResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// listIPFilterRulesNextResults retrieves the next set of results, if any.
+func (client NamespacesClient) listIPFilterRulesNextResults(lastResults IPFilterRuleListResult) (result IPFilterRuleListResult, err error) {
+	req, err := lastResults.iPFilterRuleListResultPreparer()
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "listIPFilterRulesNextResults", nil, "Failure preparing next results request")
+	}
+	if req == nil {
+		return
+	}
+	resp, err := client.ListIPFilterRulesSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "listIPFilterRulesNextResults", resp, "Failure sending next results request")
+	}
+	result, err = client.ListIPFilterRulesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "listIPFilterRulesNextResults", resp, "Failure responding to next results request")
+	}
+	return
+}
+
+// ListIPFilterRulesComplete enumerates all values, automatically crossing page boundaries as required.
+func (client NamespacesClient) ListIPFilterRulesComplete(ctx context.Context, resourceGroupName string, namespaceName string) (result IPFilterRuleListResultIterator, err error) {
+	result.page, err = client.ListIPFilterRules(ctx, resourceGroupName, namespaceName)
+	return
+}
+
 // ListKeys gets the primary and secondary connection strings for the namespace.
 // Parameters:
 // resourceGroupName - name of the Resource group within the Azure subscription.
@@ -976,6 +1563,111 @@ func (client NamespacesClient) ListKeysResponder(resp *http.Response) (result Ac
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// ListVirtualNetworkRules gets a list of VirtualNetwork rules for a Namespace.
+// Parameters:
+// resourceGroupName - name of the Resource group within the Azure subscription.
+// namespaceName - the namespace name
+func (client NamespacesClient) ListVirtualNetworkRules(ctx context.Context, resourceGroupName string, namespaceName string) (result VirtualNetworkRuleListResultPage, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("servicebus.NamespacesClient", "ListVirtualNetworkRules", err.Error())
+	}
+
+	result.fn = client.listVirtualNetworkRulesNextResults
+	req, err := client.ListVirtualNetworkRulesPreparer(ctx, resourceGroupName, namespaceName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "ListVirtualNetworkRules", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListVirtualNetworkRulesSender(req)
+	if err != nil {
+		result.vnrlr.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "ListVirtualNetworkRules", resp, "Failure sending request")
+		return
+	}
+
+	result.vnrlr, err = client.ListVirtualNetworkRulesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "ListVirtualNetworkRules", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// ListVirtualNetworkRulesPreparer prepares the ListVirtualNetworkRules request.
+func (client NamespacesClient) ListVirtualNetworkRulesPreparer(ctx context.Context, resourceGroupName string, namespaceName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/virtualnetworkrules", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListVirtualNetworkRulesSender sends the ListVirtualNetworkRules request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) ListVirtualNetworkRulesSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListVirtualNetworkRulesResponder handles the response to the ListVirtualNetworkRules request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) ListVirtualNetworkRulesResponder(resp *http.Response) (result VirtualNetworkRuleListResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// listVirtualNetworkRulesNextResults retrieves the next set of results, if any.
+func (client NamespacesClient) listVirtualNetworkRulesNextResults(lastResults VirtualNetworkRuleListResult) (result VirtualNetworkRuleListResult, err error) {
+	req, err := lastResults.virtualNetworkRuleListResultPreparer()
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "listVirtualNetworkRulesNextResults", nil, "Failure preparing next results request")
+	}
+	if req == nil {
+		return
+	}
+	resp, err := client.ListVirtualNetworkRulesSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "listVirtualNetworkRulesNextResults", resp, "Failure sending next results request")
+	}
+	result, err = client.ListVirtualNetworkRulesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "servicebus.NamespacesClient", "listVirtualNetworkRulesNextResults", resp, "Failure responding to next results request")
+	}
+	return
+}
+
+// ListVirtualNetworkRulesComplete enumerates all values, automatically crossing page boundaries as required.
+func (client NamespacesClient) ListVirtualNetworkRulesComplete(ctx context.Context, resourceGroupName string, namespaceName string) (result VirtualNetworkRuleListResultIterator, err error) {
+	result.page, err = client.ListVirtualNetworkRules(ctx, resourceGroupName, namespaceName)
 	return
 }
 


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4245