### PR TITLE
[AutoPR eventhub/resource-manager] EventHub: moved VNet, IpFilter rules and Kafka from 2018-preview to 2017 API Version

### DIFF
--- a/profiles/latest/eventhub/mgmt/eventhub/models.go
+++ b/profiles/latest/eventhub/mgmt/eventhub/models.go
@@ -58,6 +58,13 @@ const (
 	Unknown         EntityStatus = original.Unknown
 )
 
+type IPAction = original.IPAction
+
+const (
+	Accept IPAction = original.Accept
+	Reject IPAction = original.Reject
+)
+
 type KeyType = original.KeyType
 
 const (
@@ -133,6 +140,11 @@ type EHNamespaceListResultIterator = original.EHNamespaceListResultIterator
 type EHNamespaceListResultPage = original.EHNamespaceListResultPage
 type EHNamespaceProperties = original.EHNamespaceProperties
 type ErrorResponse = original.ErrorResponse
+type IPFilterRule = original.IPFilterRule
+type IPFilterRuleListResult = original.IPFilterRuleListResult
+type IPFilterRuleListResultIterator = original.IPFilterRuleListResultIterator
+type IPFilterRuleListResultPage = original.IPFilterRuleListResultPage
+type IPFilterRuleProperties = original.IPFilterRuleProperties
 type ListResult = original.ListResult
 type ListResultIterator = original.ListResultIterator
 type ListResultPage = original.ListResultPage
@@ -156,6 +168,11 @@ type RegenerateAccessKeyParameters = original.RegenerateAccessKeyParameters
 type Resource = original.Resource
 type Sku = original.Sku
 type TrackedResource = original.TrackedResource
+type VirtualNetworkRule = original.VirtualNetworkRule
+type VirtualNetworkRuleListResult = original.VirtualNetworkRuleListResult
+type VirtualNetworkRuleListResultIterator = original.VirtualNetworkRuleListResultIterator
+type VirtualNetworkRuleListResultPage = original.VirtualNetworkRuleListResultPage
+type VirtualNetworkRuleProperties = original.VirtualNetworkRuleProperties
 type NamespacesClient = original.NamespacesClient
 type OperationsClient = original.OperationsClient
 type RegionsClient = original.RegionsClient
@@ -192,6 +209,9 @@ func PossibleEncodingCaptureDescriptionValues() []EncodingCaptureDescription {
 }
 func PossibleEntityStatusValues() []EntityStatus {
 	return original.PossibleEntityStatusValues()
+}
+func PossibleIPActionValues() []IPAction {
+	return original.PossibleIPActionValues()
 }
 func PossibleKeyTypeValues() []KeyType {
 	return original.PossibleKeyTypeValues()

--- a/profiles/preview/eventhub/mgmt/eventhub/models.go
+++ b/profiles/preview/eventhub/mgmt/eventhub/models.go
@@ -58,6 +58,13 @@ const (
 	Unknown         EntityStatus = original.Unknown
 )
 
+type IPAction = original.IPAction
+
+const (
+	Accept IPAction = original.Accept
+	Reject IPAction = original.Reject
+)
+
 type KeyType = original.KeyType
 
 const (
@@ -133,6 +140,11 @@ type EHNamespaceListResultIterator = original.EHNamespaceListResultIterator
 type EHNamespaceListResultPage = original.EHNamespaceListResultPage
 type EHNamespaceProperties = original.EHNamespaceProperties
 type ErrorResponse = original.ErrorResponse
+type IPFilterRule = original.IPFilterRule
+type IPFilterRuleListResult = original.IPFilterRuleListResult
+type IPFilterRuleListResultIterator = original.IPFilterRuleListResultIterator
+type IPFilterRuleListResultPage = original.IPFilterRuleListResultPage
+type IPFilterRuleProperties = original.IPFilterRuleProperties
 type ListResult = original.ListResult
 type ListResultIterator = original.ListResultIterator
 type ListResultPage = original.ListResultPage
@@ -156,6 +168,11 @@ type RegenerateAccessKeyParameters = original.RegenerateAccessKeyParameters
 type Resource = original.Resource
 type Sku = original.Sku
 type TrackedResource = original.TrackedResource
+type VirtualNetworkRule = original.VirtualNetworkRule
+type VirtualNetworkRuleListResult = original.VirtualNetworkRuleListResult
+type VirtualNetworkRuleListResultIterator = original.VirtualNetworkRuleListResultIterator
+type VirtualNetworkRuleListResultPage = original.VirtualNetworkRuleListResultPage
+type VirtualNetworkRuleProperties = original.VirtualNetworkRuleProperties
 type NamespacesClient = original.NamespacesClient
 type OperationsClient = original.OperationsClient
 type RegionsClient = original.RegionsClient
@@ -192,6 +209,9 @@ func PossibleEncodingCaptureDescriptionValues() []EncodingCaptureDescription {
 }
 func PossibleEntityStatusValues() []EntityStatus {
 	return original.PossibleEntityStatusValues()
+}
+func PossibleIPActionValues() []IPAction {
+	return original.PossibleIPActionValues()
 }
 func PossibleKeyTypeValues() []KeyType {
 	return original.PossibleKeyTypeValues()

--- a/services/eventhub/mgmt/2015-08-01/eventhub/namespaces.go
+++ b/services/eventhub/mgmt/2015-08-01/eventhub/namespaces.go
@@ -178,10 +178,6 @@ func (client NamespacesClient) CreateOrUpdateSender(req *http.Request) (future N
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
-	if err != nil {
-		return
-	}
 	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
@@ -344,10 +340,6 @@ func (client NamespacesClient) DeleteSender(req *http.Request) (future Namespace
 	var resp *http.Response
 	resp, err = autorest.SendWithSender(client, req,
 		azure.DoRetryWithRegistration(client.Client))
-	if err != nil {
-		return
-	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent))
 	if err != nil {
 		return
 	}

--- a/services/eventhub/mgmt/2017-04-01/eventhub/models.go
+++ b/services/eventhub/mgmt/2017-04-01/eventhub/models.go
@@ -87,6 +87,21 @@ func PossibleEntityStatusValues() []EntityStatus {
 	return []EntityStatus{Active, Creating, Deleting, Disabled, ReceiveDisabled, Renaming, Restoring, SendDisabled, Unknown}
 }
 
+// IPAction enumerates the values for ip action.
+type IPAction string
+
+const (
+	// Accept ...
+	Accept IPAction = "Accept"
+	// Reject ...
+	Reject IPAction = "Reject"
+)
+
+// PossibleIPActionValues returns an array of possible values for the IPAction const type.
+func PossibleIPActionValues() []IPAction {
+	return []IPAction{Accept, Reject}
+}
+
 // KeyType enumerates the values for key type.
 type KeyType string
 
@@ -1128,6 +1143,8 @@ type EHNamespaceProperties struct {
 	IsAutoInflateEnabled *bool `json:"isAutoInflateEnabled,omitempty"`
 	// MaximumThroughputUnits - Upper limit of throughput units when AutoInflate is enabled, vaule should be within 0 to 20 throughput units. ( '0' if AutoInflateEnabled = true)
 	MaximumThroughputUnits *int32 `json:"maximumThroughputUnits,omitempty"`
+	// KafkaEnabled - Value that indicates whether Kafka is enabled for eventhub namespace.
+	KafkaEnabled *bool `json:"kafkaEnabled,omitempty"`
 }
 
 // ErrorResponse error reponse indicates EventHub service is not able to process the incoming request. The reason
@@ -1137,6 +1154,200 @@ type ErrorResponse struct {
 	Code *string `json:"code,omitempty"`
 	// Message - Error message indicating why the operation failed.
 	Message *string `json:"message,omitempty"`
+}
+
+// IPFilterRule single item in a List or Get IpFilterRules operation
+type IPFilterRule struct {
+	autorest.Response `json:"-"`
+	// IPFilterRuleProperties - Properties supplied to create or update IpFilterRules
+	*IPFilterRuleProperties `json:"properties,omitempty"`
+	// ID - Resource Id
+	ID *string `json:"id,omitempty"`
+	// Name - Resource name
+	Name *string `json:"name,omitempty"`
+	// Type - Resource type
+	Type *string `json:"type,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for IPFilterRule.
+func (ifr IPFilterRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if ifr.IPFilterRuleProperties != nil {
+		objectMap["properties"] = ifr.IPFilterRuleProperties
+	}
+	if ifr.ID != nil {
+		objectMap["id"] = ifr.ID
+	}
+	if ifr.Name != nil {
+		objectMap["name"] = ifr.Name
+	}
+	if ifr.Type != nil {
+		objectMap["type"] = ifr.Type
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for IPFilterRule struct.
+func (ifr *IPFilterRule) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "properties":
+			if v != nil {
+				var IPFilterRuleProperties IPFilterRuleProperties
+				err = json.Unmarshal(*v, &IPFilterRuleProperties)
+				if err != nil {
+					return err
+				}
+				ifr.IPFilterRuleProperties = &IPFilterRuleProperties
+			}
+		case "id":
+			if v != nil {
+				var ID string
+				err = json.Unmarshal(*v, &ID)
+				if err != nil {
+					return err
+				}
+				ifr.ID = &ID
+			}
+		case "name":
+			if v != nil {
+				var name string
+				err = json.Unmarshal(*v, &name)
+				if err != nil {
+					return err
+				}
+				ifr.Name = &name
+			}
+		case "type":
+			if v != nil {
+				var typeVar string
+				err = json.Unmarshal(*v, &typeVar)
+				if err != nil {
+					return err
+				}
+				ifr.Type = &typeVar
+			}
+		}
+	}
+
+	return nil
+}
+
+// IPFilterRuleListResult the response from the List namespace operation.
+type IPFilterRuleListResult struct {
+	autorest.Response `json:"-"`
+	// Value - Result of the List IpFilter Rules operation.
+	Value *[]IPFilterRule `json:"value,omitempty"`
+	// NextLink - Link to the next set of results. Not empty if Value contains an incomplete list of IpFilter Rules
+	NextLink *string `json:"nextLink,omitempty"`
+}
+
+// IPFilterRuleListResultIterator provides access to a complete listing of IPFilterRule values.
+type IPFilterRuleListResultIterator struct {
+	i    int
+	page IPFilterRuleListResultPage
+}
+
+// Next advances to the next value.  If there was an error making
+// the request the iterator does not advance and the error is returned.
+func (iter *IPFilterRuleListResultIterator) Next() error {
+	iter.i++
+	if iter.i < len(iter.page.Values()) {
+		return nil
+	}
+	err := iter.page.Next()
+	if err != nil {
+		iter.i--
+		return err
+	}
+	iter.i = 0
+	return nil
+}
+
+// NotDone returns true if the enumeration should be started or is not yet complete.
+func (iter IPFilterRuleListResultIterator) NotDone() bool {
+	return iter.page.NotDone() && iter.i < len(iter.page.Values())
+}
+
+// Response returns the raw server response from the last page request.
+func (iter IPFilterRuleListResultIterator) Response() IPFilterRuleListResult {
+	return iter.page.Response()
+}
+
+// Value returns the current value or a zero-initialized value if the
+// iterator has advanced beyond the end of the collection.
+func (iter IPFilterRuleListResultIterator) Value() IPFilterRule {
+	if !iter.page.NotDone() {
+		return IPFilterRule{}
+	}
+	return iter.page.Values()[iter.i]
+}
+
+// IsEmpty returns true if the ListResult contains no values.
+func (ifrlr IPFilterRuleListResult) IsEmpty() bool {
+	return ifrlr.Value == nil || len(*ifrlr.Value) == 0
+}
+
+// iPFilterRuleListResultPreparer prepares a request to retrieve the next set of results.
+// It returns nil if no more results exist.
+func (ifrlr IPFilterRuleListResult) iPFilterRuleListResultPreparer() (*http.Request, error) {
+	if ifrlr.NextLink == nil || len(to.String(ifrlr.NextLink)) < 1 {
+		return nil, nil
+	}
+	return autorest.Prepare(&http.Request{},
+		autorest.AsJSON(),
+		autorest.AsGet(),
+		autorest.WithBaseURL(to.String(ifrlr.NextLink)))
+}
+
+// IPFilterRuleListResultPage contains a page of IPFilterRule values.
+type IPFilterRuleListResultPage struct {
+	fn    func(IPFilterRuleListResult) (IPFilterRuleListResult, error)
+	ifrlr IPFilterRuleListResult
+}
+
+// Next advances to the next page of values.  If there was an error making
+// the request the page does not advance and the error is returned.
+func (page *IPFilterRuleListResultPage) Next() error {
+	next, err := page.fn(page.ifrlr)
+	if err != nil {
+		return err
+	}
+	page.ifrlr = next
+	return nil
+}
+
+// NotDone returns true if the page enumeration should be started or is not yet complete.
+func (page IPFilterRuleListResultPage) NotDone() bool {
+	return !page.ifrlr.IsEmpty()
+}
+
+// Response returns the raw server response from the last page request.
+func (page IPFilterRuleListResultPage) Response() IPFilterRuleListResult {
+	return page.ifrlr
+}
+
+// Values returns the slice of values for the current page or nil if there are no values.
+func (page IPFilterRuleListResultPage) Values() []IPFilterRule {
+	if page.ifrlr.IsEmpty() {
+		return nil
+	}
+	return *page.ifrlr.Value
+}
+
+// IPFilterRuleProperties properties supplied to create or update IpFilterRules
+type IPFilterRuleProperties struct {
+	// IPMask - IP Mask
+	IPMask *string `json:"ipMask,omitempty"`
+	// Action - The IP Filter Action. Possible values include: 'Accept', 'Reject'
+	Action IPAction `json:"action,omitempty"`
+	// FilterName - IP Filter name
+	FilterName *string `json:"filterName,omitempty"`
 }
 
 // ListResult the result of the List EventHubs operation.
@@ -1845,4 +2056,194 @@ func (tr TrackedResource) MarshalJSON() ([]byte, error) {
 		objectMap["type"] = tr.Type
 	}
 	return json.Marshal(objectMap)
+}
+
+// VirtualNetworkRule single item in a List or Get VirtualNetworkRules operation
+type VirtualNetworkRule struct {
+	autorest.Response `json:"-"`
+	// VirtualNetworkRuleProperties - Properties supplied to create or update VirtualNetworkRules
+	*VirtualNetworkRuleProperties `json:"properties,omitempty"`
+	// ID - Resource Id
+	ID *string `json:"id,omitempty"`
+	// Name - Resource name
+	Name *string `json:"name,omitempty"`
+	// Type - Resource type
+	Type *string `json:"type,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for VirtualNetworkRule.
+func (vnr VirtualNetworkRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if vnr.VirtualNetworkRuleProperties != nil {
+		objectMap["properties"] = vnr.VirtualNetworkRuleProperties
+	}
+	if vnr.ID != nil {
+		objectMap["id"] = vnr.ID
+	}
+	if vnr.Name != nil {
+		objectMap["name"] = vnr.Name
+	}
+	if vnr.Type != nil {
+		objectMap["type"] = vnr.Type
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for VirtualNetworkRule struct.
+func (vnr *VirtualNetworkRule) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "properties":
+			if v != nil {
+				var virtualNetworkRuleProperties VirtualNetworkRuleProperties
+				err = json.Unmarshal(*v, &virtualNetworkRuleProperties)
+				if err != nil {
+					return err
+				}
+				vnr.VirtualNetworkRuleProperties = &virtualNetworkRuleProperties
+			}
+		case "id":
+			if v != nil {
+				var ID string
+				err = json.Unmarshal(*v, &ID)
+				if err != nil {
+					return err
+				}
+				vnr.ID = &ID
+			}
+		case "name":
+			if v != nil {
+				var name string
+				err = json.Unmarshal(*v, &name)
+				if err != nil {
+					return err
+				}
+				vnr.Name = &name
+			}
+		case "type":
+			if v != nil {
+				var typeVar string
+				err = json.Unmarshal(*v, &typeVar)
+				if err != nil {
+					return err
+				}
+				vnr.Type = &typeVar
+			}
+		}
+	}
+
+	return nil
+}
+
+// VirtualNetworkRuleListResult the response from the List namespace operation.
+type VirtualNetworkRuleListResult struct {
+	autorest.Response `json:"-"`
+	// Value - Result of the List VirtualNetwork Rules operation.
+	Value *[]VirtualNetworkRule `json:"value,omitempty"`
+	// NextLink - Link to the next set of results. Not empty if Value contains an incomplete list of VirtualNetwork Rules
+	NextLink *string `json:"nextLink,omitempty"`
+}
+
+// VirtualNetworkRuleListResultIterator provides access to a complete listing of VirtualNetworkRule values.
+type VirtualNetworkRuleListResultIterator struct {
+	i    int
+	page VirtualNetworkRuleListResultPage
+}
+
+// Next advances to the next value.  If there was an error making
+// the request the iterator does not advance and the error is returned.
+func (iter *VirtualNetworkRuleListResultIterator) Next() error {
+	iter.i++
+	if iter.i < len(iter.page.Values()) {
+		return nil
+	}
+	err := iter.page.Next()
+	if err != nil {
+		iter.i--
+		return err
+	}
+	iter.i = 0
+	return nil
+}
+
+// NotDone returns true if the enumeration should be started or is not yet complete.
+func (iter VirtualNetworkRuleListResultIterator) NotDone() bool {
+	return iter.page.NotDone() && iter.i < len(iter.page.Values())
+}
+
+// Response returns the raw server response from the last page request.
+func (iter VirtualNetworkRuleListResultIterator) Response() VirtualNetworkRuleListResult {
+	return iter.page.Response()
+}
+
+// Value returns the current value or a zero-initialized value if the
+// iterator has advanced beyond the end of the collection.
+func (iter VirtualNetworkRuleListResultIterator) Value() VirtualNetworkRule {
+	if !iter.page.NotDone() {
+		return VirtualNetworkRule{}
+	}
+	return iter.page.Values()[iter.i]
+}
+
+// IsEmpty returns true if the ListResult contains no values.
+func (vnrlr VirtualNetworkRuleListResult) IsEmpty() bool {
+	return vnrlr.Value == nil || len(*vnrlr.Value) == 0
+}
+
+// virtualNetworkRuleListResultPreparer prepares a request to retrieve the next set of results.
+// It returns nil if no more results exist.
+func (vnrlr VirtualNetworkRuleListResult) virtualNetworkRuleListResultPreparer() (*http.Request, error) {
+	if vnrlr.NextLink == nil || len(to.String(vnrlr.NextLink)) < 1 {
+		return nil, nil
+	}
+	return autorest.Prepare(&http.Request{},
+		autorest.AsJSON(),
+		autorest.AsGet(),
+		autorest.WithBaseURL(to.String(vnrlr.NextLink)))
+}
+
+// VirtualNetworkRuleListResultPage contains a page of VirtualNetworkRule values.
+type VirtualNetworkRuleListResultPage struct {
+	fn    func(VirtualNetworkRuleListResult) (VirtualNetworkRuleListResult, error)
+	vnrlr VirtualNetworkRuleListResult
+}
+
+// Next advances to the next page of values.  If there was an error making
+// the request the page does not advance and the error is returned.
+func (page *VirtualNetworkRuleListResultPage) Next() error {
+	next, err := page.fn(page.vnrlr)
+	if err != nil {
+		return err
+	}
+	page.vnrlr = next
+	return nil
+}
+
+// NotDone returns true if the page enumeration should be started or is not yet complete.
+func (page VirtualNetworkRuleListResultPage) NotDone() bool {
+	return !page.vnrlr.IsEmpty()
+}
+
+// Response returns the raw server response from the last page request.
+func (page VirtualNetworkRuleListResultPage) Response() VirtualNetworkRuleListResult {
+	return page.vnrlr
+}
+
+// Values returns the slice of values for the current page or nil if there are no values.
+func (page VirtualNetworkRuleListResultPage) Values() []VirtualNetworkRule {
+	if page.vnrlr.IsEmpty() {
+		return nil
+	}
+	return *page.vnrlr.Value
+}
+
+// VirtualNetworkRuleProperties properties supplied to create or update VirtualNetworkRules
+type VirtualNetworkRuleProperties struct {
+	// VirtualNetworkSubnetID - ARM ID of Virtual Network Subnet
+	VirtualNetworkSubnetID *string `json:"virtualNetworkSubnetId,omitempty"`
 }

--- a/services/eventhub/mgmt/2017-04-01/eventhub/namespaces.go
+++ b/services/eventhub/mgmt/2017-04-01/eventhub/namespaces.go
@@ -189,10 +189,6 @@ func (client NamespacesClient) CreateOrUpdateSender(req *http.Request) (future N
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
-	if err != nil {
-		return
-	}
 	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
@@ -297,6 +293,174 @@ func (client NamespacesClient) CreateOrUpdateAuthorizationRuleResponder(resp *ht
 	return
 }
 
+// CreateOrUpdateIPFilterRule creates or updates an IpFilterRule for a Namespace.
+// Parameters:
+// resourceGroupName - name of the resource group within the azure subscription.
+// namespaceName - the Namespace name
+// IPFilterRuleName - the IP Filter Rule name.
+// parameters - the Namespace IpFilterRule.
+func (client NamespacesClient) CreateOrUpdateIPFilterRule(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string, parameters IPFilterRule) (result IPFilterRule, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: IPFilterRuleName,
+			Constraints: []validation.Constraint{{Target: "IPFilterRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("eventhub.NamespacesClient", "CreateOrUpdateIPFilterRule", err.Error())
+	}
+
+	req, err := client.CreateOrUpdateIPFilterRulePreparer(ctx, resourceGroupName, namespaceName, IPFilterRuleName, parameters)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "CreateOrUpdateIPFilterRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CreateOrUpdateIPFilterRuleSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "CreateOrUpdateIPFilterRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateOrUpdateIPFilterRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "CreateOrUpdateIPFilterRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CreateOrUpdateIPFilterRulePreparer prepares the CreateOrUpdateIPFilterRule request.
+func (client NamespacesClient) CreateOrUpdateIPFilterRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string, parameters IPFilterRule) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"ipFilterRuleName":  autorest.Encode("path", IPFilterRuleName),
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/ipfilterrules/{ipFilterRuleName}", pathParameters),
+		autorest.WithJSON(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// CreateOrUpdateIPFilterRuleSender sends the CreateOrUpdateIPFilterRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) CreateOrUpdateIPFilterRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// CreateOrUpdateIPFilterRuleResponder handles the response to the CreateOrUpdateIPFilterRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) CreateOrUpdateIPFilterRuleResponder(resp *http.Response) (result IPFilterRule, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// CreateOrUpdateVirtualNetworkRule creates or updates an VirtualNetworkRule for a Namespace.
+// Parameters:
+// resourceGroupName - name of the resource group within the azure subscription.
+// namespaceName - the Namespace name
+// virtualNetworkRuleName - the Virtual Network Rule name.
+// parameters - the Namespace VirtualNetworkRule.
+func (client NamespacesClient) CreateOrUpdateVirtualNetworkRule(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string, parameters VirtualNetworkRule) (result VirtualNetworkRule, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: virtualNetworkRuleName,
+			Constraints: []validation.Constraint{{Target: "virtualNetworkRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("eventhub.NamespacesClient", "CreateOrUpdateVirtualNetworkRule", err.Error())
+	}
+
+	req, err := client.CreateOrUpdateVirtualNetworkRulePreparer(ctx, resourceGroupName, namespaceName, virtualNetworkRuleName, parameters)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "CreateOrUpdateVirtualNetworkRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CreateOrUpdateVirtualNetworkRuleSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "CreateOrUpdateVirtualNetworkRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateOrUpdateVirtualNetworkRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "CreateOrUpdateVirtualNetworkRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CreateOrUpdateVirtualNetworkRulePreparer prepares the CreateOrUpdateVirtualNetworkRule request.
+func (client NamespacesClient) CreateOrUpdateVirtualNetworkRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string, parameters VirtualNetworkRule) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":          autorest.Encode("path", namespaceName),
+		"resourceGroupName":      autorest.Encode("path", resourceGroupName),
+		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
+		"virtualNetworkRuleName": autorest.Encode("path", virtualNetworkRuleName),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/virtualnetworkrules/{virtualNetworkRuleName}", pathParameters),
+		autorest.WithJSON(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// CreateOrUpdateVirtualNetworkRuleSender sends the CreateOrUpdateVirtualNetworkRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) CreateOrUpdateVirtualNetworkRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// CreateOrUpdateVirtualNetworkRuleResponder handles the response to the CreateOrUpdateVirtualNetworkRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) CreateOrUpdateVirtualNetworkRuleResponder(resp *http.Response) (result VirtualNetworkRule, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // Delete deletes an existing namespace. This operation also removes all associated resources under the namespace.
 // Parameters:
 // resourceGroupName - name of the resource group within the azure subscription.
@@ -354,10 +518,6 @@ func (client NamespacesClient) DeleteSender(req *http.Request) (future Namespace
 	var resp *http.Response
 	resp, err = autorest.SendWithSender(client, req,
 		azure.DoRetryWithRegistration(client.Client))
-	if err != nil {
-		return
-	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent))
 	if err != nil {
 		return
 	}
@@ -448,6 +608,166 @@ func (client NamespacesClient) DeleteAuthorizationRuleSender(req *http.Request) 
 // DeleteAuthorizationRuleResponder handles the response to the DeleteAuthorizationRule request. The method always
 // closes the http.Response Body.
 func (client NamespacesClient) DeleteAuthorizationRuleResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
+// DeleteIPFilterRule deletes an IpFilterRule for a Namespace.
+// Parameters:
+// resourceGroupName - name of the resource group within the azure subscription.
+// namespaceName - the Namespace name
+// IPFilterRuleName - the IP Filter Rule name.
+func (client NamespacesClient) DeleteIPFilterRule(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string) (result autorest.Response, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: IPFilterRuleName,
+			Constraints: []validation.Constraint{{Target: "IPFilterRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("eventhub.NamespacesClient", "DeleteIPFilterRule", err.Error())
+	}
+
+	req, err := client.DeleteIPFilterRulePreparer(ctx, resourceGroupName, namespaceName, IPFilterRuleName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "DeleteIPFilterRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.DeleteIPFilterRuleSender(req)
+	if err != nil {
+		result.Response = resp
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "DeleteIPFilterRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.DeleteIPFilterRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "DeleteIPFilterRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// DeleteIPFilterRulePreparer prepares the DeleteIPFilterRule request.
+func (client NamespacesClient) DeleteIPFilterRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"ipFilterRuleName":  autorest.Encode("path", IPFilterRuleName),
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/ipfilterrules/{ipFilterRuleName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// DeleteIPFilterRuleSender sends the DeleteIPFilterRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) DeleteIPFilterRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// DeleteIPFilterRuleResponder handles the response to the DeleteIPFilterRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) DeleteIPFilterRuleResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
+// DeleteVirtualNetworkRule deletes an VirtualNetworkRule for a Namespace.
+// Parameters:
+// resourceGroupName - name of the resource group within the azure subscription.
+// namespaceName - the Namespace name
+// virtualNetworkRuleName - the Virtual Network Rule name.
+func (client NamespacesClient) DeleteVirtualNetworkRule(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string) (result autorest.Response, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: virtualNetworkRuleName,
+			Constraints: []validation.Constraint{{Target: "virtualNetworkRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("eventhub.NamespacesClient", "DeleteVirtualNetworkRule", err.Error())
+	}
+
+	req, err := client.DeleteVirtualNetworkRulePreparer(ctx, resourceGroupName, namespaceName, virtualNetworkRuleName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "DeleteVirtualNetworkRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.DeleteVirtualNetworkRuleSender(req)
+	if err != nil {
+		result.Response = resp
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "DeleteVirtualNetworkRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.DeleteVirtualNetworkRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "DeleteVirtualNetworkRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// DeleteVirtualNetworkRulePreparer prepares the DeleteVirtualNetworkRule request.
+func (client NamespacesClient) DeleteVirtualNetworkRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":          autorest.Encode("path", namespaceName),
+		"resourceGroupName":      autorest.Encode("path", resourceGroupName),
+		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
+		"virtualNetworkRuleName": autorest.Encode("path", virtualNetworkRuleName),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/virtualnetworkrules/{virtualNetworkRuleName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// DeleteVirtualNetworkRuleSender sends the DeleteVirtualNetworkRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) DeleteVirtualNetworkRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// DeleteVirtualNetworkRuleResponder handles the response to the DeleteVirtualNetworkRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) DeleteVirtualNetworkRuleResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -615,6 +935,87 @@ func (client NamespacesClient) GetAuthorizationRuleResponder(resp *http.Response
 	return
 }
 
+// GetIPFilterRule gets an IpFilterRule for a Namespace by rule name.
+// Parameters:
+// resourceGroupName - name of the resource group within the azure subscription.
+// namespaceName - the Namespace name
+// IPFilterRuleName - the IP Filter Rule name.
+func (client NamespacesClient) GetIPFilterRule(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string) (result IPFilterRule, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: IPFilterRuleName,
+			Constraints: []validation.Constraint{{Target: "IPFilterRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("eventhub.NamespacesClient", "GetIPFilterRule", err.Error())
+	}
+
+	req, err := client.GetIPFilterRulePreparer(ctx, resourceGroupName, namespaceName, IPFilterRuleName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "GetIPFilterRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetIPFilterRuleSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "GetIPFilterRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetIPFilterRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "GetIPFilterRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetIPFilterRulePreparer prepares the GetIPFilterRule request.
+func (client NamespacesClient) GetIPFilterRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, IPFilterRuleName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"ipFilterRuleName":  autorest.Encode("path", IPFilterRuleName),
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/ipfilterrules/{ipFilterRuleName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetIPFilterRuleSender sends the GetIPFilterRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) GetIPFilterRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// GetIPFilterRuleResponder handles the response to the GetIPFilterRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) GetIPFilterRuleResponder(resp *http.Response) (result IPFilterRule, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // GetMessagingPlan gets messaging plan for specified namespace.
 // Parameters:
 // resourceGroupName - name of the resource group within the azure subscription.
@@ -682,6 +1083,87 @@ func (client NamespacesClient) GetMessagingPlanSender(req *http.Request) (*http.
 // GetMessagingPlanResponder handles the response to the GetMessagingPlan request. The method always
 // closes the http.Response Body.
 func (client NamespacesClient) GetMessagingPlanResponder(resp *http.Response) (result MessagingPlan, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// GetVirtualNetworkRule gets an VirtualNetworkRule for a Namespace by rule name.
+// Parameters:
+// resourceGroupName - name of the resource group within the azure subscription.
+// namespaceName - the Namespace name
+// virtualNetworkRuleName - the Virtual Network Rule name.
+func (client NamespacesClient) GetVirtualNetworkRule(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string) (result VirtualNetworkRule, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}},
+		{TargetValue: virtualNetworkRuleName,
+			Constraints: []validation.Constraint{{Target: "virtualNetworkRuleName", Name: validation.MinLength, Rule: 1, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("eventhub.NamespacesClient", "GetVirtualNetworkRule", err.Error())
+	}
+
+	req, err := client.GetVirtualNetworkRulePreparer(ctx, resourceGroupName, namespaceName, virtualNetworkRuleName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "GetVirtualNetworkRule", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetVirtualNetworkRuleSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "GetVirtualNetworkRule", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetVirtualNetworkRuleResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "GetVirtualNetworkRule", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetVirtualNetworkRulePreparer prepares the GetVirtualNetworkRule request.
+func (client NamespacesClient) GetVirtualNetworkRulePreparer(ctx context.Context, resourceGroupName string, namespaceName string, virtualNetworkRuleName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":          autorest.Encode("path", namespaceName),
+		"resourceGroupName":      autorest.Encode("path", resourceGroupName),
+		"subscriptionId":         autorest.Encode("path", client.SubscriptionID),
+		"virtualNetworkRuleName": autorest.Encode("path", virtualNetworkRuleName),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/virtualnetworkrules/{virtualNetworkRuleName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetVirtualNetworkRuleSender sends the GetVirtualNetworkRule request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) GetVirtualNetworkRuleSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// GetVirtualNetworkRuleResponder handles the response to the GetVirtualNetworkRule request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) GetVirtualNetworkRuleResponder(resp *http.Response) (result VirtualNetworkRule, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -987,6 +1469,111 @@ func (client NamespacesClient) ListByResourceGroupComplete(ctx context.Context, 
 	return
 }
 
+// ListIPFilterRules gets a list of IP Filter rules for a Namespace.
+// Parameters:
+// resourceGroupName - name of the resource group within the azure subscription.
+// namespaceName - the Namespace name
+func (client NamespacesClient) ListIPFilterRules(ctx context.Context, resourceGroupName string, namespaceName string) (result IPFilterRuleListResultPage, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("eventhub.NamespacesClient", "ListIPFilterRules", err.Error())
+	}
+
+	result.fn = client.listIPFilterRulesNextResults
+	req, err := client.ListIPFilterRulesPreparer(ctx, resourceGroupName, namespaceName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "ListIPFilterRules", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListIPFilterRulesSender(req)
+	if err != nil {
+		result.ifrlr.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "ListIPFilterRules", resp, "Failure sending request")
+		return
+	}
+
+	result.ifrlr, err = client.ListIPFilterRulesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "ListIPFilterRules", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// ListIPFilterRulesPreparer prepares the ListIPFilterRules request.
+func (client NamespacesClient) ListIPFilterRulesPreparer(ctx context.Context, resourceGroupName string, namespaceName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/ipfilterrules", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListIPFilterRulesSender sends the ListIPFilterRules request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) ListIPFilterRulesSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListIPFilterRulesResponder handles the response to the ListIPFilterRules request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) ListIPFilterRulesResponder(resp *http.Response) (result IPFilterRuleListResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// listIPFilterRulesNextResults retrieves the next set of results, if any.
+func (client NamespacesClient) listIPFilterRulesNextResults(lastResults IPFilterRuleListResult) (result IPFilterRuleListResult, err error) {
+	req, err := lastResults.iPFilterRuleListResultPreparer()
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "listIPFilterRulesNextResults", nil, "Failure preparing next results request")
+	}
+	if req == nil {
+		return
+	}
+	resp, err := client.ListIPFilterRulesSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "listIPFilterRulesNextResults", resp, "Failure sending next results request")
+	}
+	result, err = client.ListIPFilterRulesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "listIPFilterRulesNextResults", resp, "Failure responding to next results request")
+	}
+	return
+}
+
+// ListIPFilterRulesComplete enumerates all values, automatically crossing page boundaries as required.
+func (client NamespacesClient) ListIPFilterRulesComplete(ctx context.Context, resourceGroupName string, namespaceName string) (result IPFilterRuleListResultIterator, err error) {
+	result.page, err = client.ListIPFilterRules(ctx, resourceGroupName, namespaceName)
+	return
+}
+
 // ListKeys gets the primary and secondary connection strings for the Namespace.
 // Parameters:
 // resourceGroupName - name of the resource group within the azure subscription.
@@ -1065,6 +1652,111 @@ func (client NamespacesClient) ListKeysResponder(resp *http.Response) (result Ac
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// ListVirtualNetworkRules gets a list of VirtualNetwork rules for a Namespace.
+// Parameters:
+// resourceGroupName - name of the resource group within the azure subscription.
+// namespaceName - the Namespace name
+func (client NamespacesClient) ListVirtualNetworkRules(ctx context.Context, resourceGroupName string, namespaceName string) (result VirtualNetworkRuleListResultPage, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: namespaceName,
+			Constraints: []validation.Constraint{{Target: "namespaceName", Name: validation.MaxLength, Rule: 50, Chain: nil},
+				{Target: "namespaceName", Name: validation.MinLength, Rule: 6, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("eventhub.NamespacesClient", "ListVirtualNetworkRules", err.Error())
+	}
+
+	result.fn = client.listVirtualNetworkRulesNextResults
+	req, err := client.ListVirtualNetworkRulesPreparer(ctx, resourceGroupName, namespaceName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "ListVirtualNetworkRules", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListVirtualNetworkRulesSender(req)
+	if err != nil {
+		result.vnrlr.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "ListVirtualNetworkRules", resp, "Failure sending request")
+		return
+	}
+
+	result.vnrlr, err = client.ListVirtualNetworkRulesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "ListVirtualNetworkRules", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// ListVirtualNetworkRulesPreparer prepares the ListVirtualNetworkRules request.
+func (client NamespacesClient) ListVirtualNetworkRulesPreparer(ctx context.Context, resourceGroupName string, namespaceName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"namespaceName":     autorest.Encode("path", namespaceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-04-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/virtualnetworkrules", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListVirtualNetworkRulesSender sends the ListVirtualNetworkRules request. The method will close the
+// http.Response Body if it receives an error.
+func (client NamespacesClient) ListVirtualNetworkRulesSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListVirtualNetworkRulesResponder handles the response to the ListVirtualNetworkRules request. The method always
+// closes the http.Response Body.
+func (client NamespacesClient) ListVirtualNetworkRulesResponder(resp *http.Response) (result VirtualNetworkRuleListResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// listVirtualNetworkRulesNextResults retrieves the next set of results, if any.
+func (client NamespacesClient) listVirtualNetworkRulesNextResults(lastResults VirtualNetworkRuleListResult) (result VirtualNetworkRuleListResult, err error) {
+	req, err := lastResults.virtualNetworkRuleListResultPreparer()
+	if err != nil {
+		return result, autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "listVirtualNetworkRulesNextResults", nil, "Failure preparing next results request")
+	}
+	if req == nil {
+		return
+	}
+	resp, err := client.ListVirtualNetworkRulesSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "listVirtualNetworkRulesNextResults", resp, "Failure sending next results request")
+	}
+	result, err = client.ListVirtualNetworkRulesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhub.NamespacesClient", "listVirtualNetworkRulesNextResults", resp, "Failure responding to next results request")
+	}
+	return
+}
+
+// ListVirtualNetworkRulesComplete enumerates all values, automatically crossing page boundaries as required.
+func (client NamespacesClient) ListVirtualNetworkRulesComplete(ctx context.Context, resourceGroupName string, namespaceName string) (result VirtualNetworkRuleListResultIterator, err error) {
+	result.page, err = client.ListVirtualNetworkRules(ctx, resourceGroupName, namespaceName)
 	return
 }
 

--- a/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub/clusters.go
+++ b/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub/clusters.go
@@ -281,10 +281,6 @@ func (client ClustersClient) PatchSender(req *http.Request) (future ClustersPatc
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
-	if err != nil {
-		return
-	}
 	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }

--- a/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub/namespaces.go
+++ b/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub/namespaces.go
@@ -118,10 +118,6 @@ func (client NamespacesClient) CreateOrUpdateSender(req *http.Request) (future N
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
-	if err != nil {
-		return
-	}
 	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
@@ -364,10 +360,6 @@ func (client NamespacesClient) DeleteSender(req *http.Request) (future Namespace
 	var resp *http.Response
 	resp, err = autorest.SendWithSender(client, req,
 		azure.DoRetryWithRegistration(client.Client))
-	if err != nil {
-		return
-	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4246