### PR TITLE
Ensure scanner last err is checked

### DIFF
--- a/tools/pkgchk/cmd/root.go
+++ b/tools/pkgchk/cmd/root.go
@@ -123,9 +123,15 @@ func loadExceptions(excepFile string) ([]string, error) {
 	}
 	defer f.Close()
 	exceps := []string{}
-	for scanner := bufio.NewScanner(f); scanner.Scan(); {
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
 		exceps = append(exceps, scanner.Text())
 	}
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+
 	return exceps, nil
 }
 


### PR DESCRIPTION
A scanner's last error should always be checked.  This ensures a proper scan completes successfully.