### PR TITLE
Replace github.com/satori/go.uuid with github.com/gofrs/uuid

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -70,6 +70,14 @@
   revision = "1ca0a4f7cbcbe61c005d1bd43fdd8bb8b71df6bc"
 
 [[projects]]
+  digest = "1:10c7813de846fa10aad0ea9bca34a3c20815d51250e48ba1a3c3c7572184aea8"
+  name = "github.com/gofrs/uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "370558f003bfe29580cd0f698d8640daccdcc45c"
+  version = "v3.1.1"
+
+[[projects]]
   digest = "1:d14365c51dd1d34d5c79833ec91413bfbb166be978724f15701e17080dc06dec"
   name = "github.com/hashicorp/hcl"
   packages = [
@@ -327,6 +335,7 @@
     "github.com/dnaeon/go-vcr/cassette",
     "github.com/dnaeon/go-vcr/recorder",
     "github.com/globalsign/mgo",
+    "github.com/gofrs/uuid",
     "github.com/marstr/collection",
     "github.com/marstr/goalias/model",
     "github.com/marstr/guid",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,10 +49,6 @@
   name = "github.com/marstr/randname"
 
 [[constraint]]
-  name = "github.com/satori/go.uuid"
-  version = "1.2.0"
-
-[[constraint]]
   name = "github.com/shopspring/decimal"
   version = "1.0.0"
 
@@ -67,3 +63,7 @@
 [[constraint]]
   branch = "v1"
   name = "gopkg.in/check.v1"
+
+[[constraint]]
+  name = "github.com/gofrs/uuid"
+  version = "3.1.1"

--- a/storage/entity.go
+++ b/storage/entity.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 // Annotating as secure for gas scanning


### PR DESCRIPTION
This PR will replace the dependency github.com/satori/go.uuid with github.com/gofrs/uuid that is a fork from the original one.

The version azure-sdk-for-go currently use do have a critical flaw when creating UUID:s. This package doesn't create UUID:s, but since it is a flawed version that is brought in, there is a risk of future bugs or bugs in projects that use azure-sdk-for-go.

Gofrs is a community-driven effort to provide maintainers for valuable projects. They forked satori/go.uuid after it appeared to be no longer maintained while exhibiting critical flaws. The fork will most likely be given more maintainer love than the original one. 

The pull request targets `master` as per suggestion by Martin Stobel @marstr on Slack.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
