### PR TITLE
fix scanner

### DIFF
--- a/tools/pkgchk/cmd/root.go
+++ b/tools/pkgchk/cmd/root.go
@@ -125,7 +125,7 @@ func loadExceptions(excepFile string) ([]string, error) {
 	exceps := []string{}
 
 	scanner := bufio.NewScanner(f)
-	for  scanner.Scan(); {
+	for scanner.Scan(); {
 		exceps = append(exceps, scanner.Text())
 	}
 	if err = scanner.Err(); err != nil {

--- a/tools/pkgchk/cmd/root.go
+++ b/tools/pkgchk/cmd/root.go
@@ -125,7 +125,7 @@ func loadExceptions(excepFile string) ([]string, error) {
 	exceps := []string{}
 
 	scanner := bufio.NewScanner(f)
-	for scanner.Scan(); {
+	for scanner.Scan() {
 		exceps = append(exceps, scanner.Text())
 	}
 	if err = scanner.Err(); err != nil {

--- a/tools/pkgchk/cmd/root.go
+++ b/tools/pkgchk/cmd/root.go
@@ -123,9 +123,15 @@ func loadExceptions(excepFile string) ([]string, error) {
 	}
 	defer f.Close()
 	exceps := []string{}
-	for scanner := bufio.NewScanner(f); scanner.Scan(); {
+
+	scanner := bufio.NewScanner(f)
+	for  scanner.Scan(); {
 		exceps = append(exceps, scanner.Text())
 	}
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+
 	return exceps, nil
 }
 


### PR DESCRIPTION
A scanner's last error should always be checked. This ensures a proper scan completes successfully.

Closing the original PR: https://github.com/Azure/azure-sdk-for-go/pull/3118 per @jhendrixMSFT in favor of this PR which is based off of the `latest` branch.