### PR TITLE
[AutoPR machinelearningservices/resource-manager] [Do Not Merge] Changed machinelearning swagger for new AMLCompute type

### DIFF
--- a/services/preview/machinelearning/mgmt/2018-03-01-preview/services/machinelearningcompute.go
+++ b/services/preview/machinelearning/mgmt/2018-03-01-preview/services/machinelearningcompute.go
@@ -96,10 +96,6 @@ func (client MachineLearningComputeClient) CreateOrUpdateSender(req *http.Reques
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
-	if err != nil {
-		return
-	}
 	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
@@ -166,10 +162,6 @@ func (client MachineLearningComputeClient) DeleteSender(req *http.Request) (futu
 	var resp *http.Response
 	resp, err = autorest.SendWithSender(client, req,
 		azure.DoRetryWithRegistration(client.Client))
-	if err != nil {
-		return
-	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
 	if err != nil {
 		return
 	}
@@ -476,10 +468,6 @@ func (client MachineLearningComputeClient) SystemUpdateSender(req *http.Request)
 	var resp *http.Response
 	resp, err = autorest.SendWithSender(client, req,
 		azure.DoRetryWithRegistration(client.Client))
-	if err != nil {
-		return
-	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4344