### PR TITLE
[AutoPR network/resource-manager] Model ContainerNic refs under ContainerNicConfig as sub resources

### DIFF
--- a/services/network/mgmt/2018-08-01/network/models.go
+++ b/services/network/mgmt/2018-08-01/network/models.go
@@ -7256,7 +7256,7 @@ type ContainerNetworkInterfaceConfigurationPropertiesFormat struct {
 	// IPConfigurations - A list of ip configurations of the container network interface configuration.
 	IPConfigurations *[]IPConfigurationProfile `json:"ipConfigurations,omitempty"`
 	// ContainerNetworkInterfaces - A list of container network interfaces created from this container network interface configuration.
-	ContainerNetworkInterfaces *[]ContainerNetworkInterface `json:"containerNetworkInterfaces,omitempty"`
+	ContainerNetworkInterfaces *[]SubResource `json:"containerNetworkInterfaces,omitempty"`
 	// ProvisioningState - The provisioning state of the resource.
 	ProvisioningState *string `json:"provisioningState,omitempty"`
 }


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4459