### PR TITLE
add Slack link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ feed](https://azure.microsoft.com/updates/).
 Users may prefer to jump right in to our samples repo at
 [github.com/Azure-Samples/azure-sdk-for-go-samples][samples_repo].
 
+Questions and feedback? Chat with us in the **[#Azure SDK
+channel](https://gophers.slack.com/messages/CA7HK8EEP)** on the [Gophers
+Slack](https://gophers.slack.com/). Sign up
+[here](https://invite.slack.golangbridge.org) first if necessary.
+
+
 ## Package Updates
 
 Most packages in the SDK are generated from [Azure API specs][azure_rest_specs]


### PR DESCRIPTION
This adds a link to the azure-sdk-for-go channel in the Gophers Slack to the README.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
