### PR TITLE
[AutoPR mariadb/resource-manager] typo: mariadb/resource-manager/Microsoft.DBforMariaDB

### DIFF
--- a/services/preview/mariadb/mgmt/2018-06-01-preview/mariadb/models.go
+++ b/services/preview/mariadb/mgmt/2018-06-01-preview/mariadb/models.go
@@ -1569,7 +1569,7 @@ func (future *ServersUpdateFuture) Result(client ServersClient) (s Server, err e
 	return
 }
 
-// ServerUpdateParameters parameters allowd to update for a server.
+// ServerUpdateParameters parameters allowed to update for a server.
 type ServerUpdateParameters struct {
 	// Sku - The SKU (pricing tier) of the server.
 	Sku *Sku `json:"sku,omitempty"`


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4710