### PR TITLE
[AutoPR marketplaceordering/resource-manager] typo: marketplaceordering/resource-manager/Microsoft.MarketplaceOrdering

### DIFF
--- a/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/models.go
+++ b/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/models.go
@@ -132,7 +132,7 @@ func (at *AgreementTerms) UnmarshalJSON(body []byte) error {
 	return nil
 }
 
-// ErrorResponse error reponse indicates Microsoft.MarketplaceOrdering service is not able to process the
+// ErrorResponse error response indicates Microsoft.MarketplaceOrdering service is not able to process the
 // incoming request. The reason is provided in the error message.
 type ErrorResponse struct {
 	// Error - The details of the error.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4711