### PR TITLE
[AutoPR cognitiveservices/data-plane/CustomVision/Training] typo: CustomVision/Training

### DIFF
--- a/services/cognitiveservices/v1.2/customvision/training/client.go
+++ b/services/cognitiveservices/v1.2/customvision/training/client.go
@@ -291,7 +291,7 @@ func (client BaseClient) CreateImagesFromFilesResponder(resp *http.Response) (re
 // 64 images and 20 tags.
 // Parameters:
 // projectID - the project id
-// batch - image and tag ids. Limted to 64 images and 20 tags per batch
+// batch - image and tag ids. Limited to 64 images and 20 tags per batch
 func (client BaseClient) CreateImagesFromPredictions(ctx context.Context, projectID uuid.UUID, batch ImageIDCreateBatch) (result ImageCreateSummary, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BaseClient.CreateImagesFromPredictions")
@@ -745,7 +745,7 @@ func (client BaseClient) DeleteImageRegionsResponder(resp *http.Response) (resul
 // DeleteImages sends the delete images request.
 // Parameters:
 // projectID - the project id
-// imageIds - ids of the images to be deleted. Limted to 256 images per batch
+// imageIds - ids of the images to be deleted. Limited to 256 images per batch
 func (client BaseClient) DeleteImages(ctx context.Context, projectID uuid.UUID, imageIds []string) (result autorest.Response, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BaseClient.DeleteImages")
@@ -826,7 +826,7 @@ func (client BaseClient) DeleteImagesResponder(resp *http.Response) (result auto
 // Parameters:
 // projectID - the project id
 // imageIds - image ids. Limited to 64 images
-// tagIds - tags to be deleted from the specified images. Limted to 20 tags
+// tagIds - tags to be deleted from the specified images. Limited to 20 tags
 func (client BaseClient) DeleteImageTags(ctx context.Context, projectID uuid.UUID, imageIds []string, tagIds []string) (result autorest.Response, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BaseClient.DeleteImageTags")

--- a/services/cognitiveservices/v1.2/customvision/training/models.go
+++ b/services/cognitiveservices/v1.2/customvision/training/models.go
@@ -487,7 +487,7 @@ type Project struct {
 	Settings *ProjectSettings `json:"settings,omitempty"`
 	// Created - Gets the date this project was created
 	Created *date.Time `json:"created,omitempty"`
-	// LastModified - Gets the date this project was last modifed
+	// LastModified - Gets the date this project was last modified
 	LastModified *date.Time `json:"lastModified,omitempty"`
 	// ThumbnailURI - Gets the thumbnail url representing the project
 	ThumbnailURI *string `json:"thumbnailUri,omitempty"`

--- a/services/cognitiveservices/v2.1/customvision/training/client.go
+++ b/services/cognitiveservices/v2.1/customvision/training/client.go
@@ -291,7 +291,7 @@ func (client BaseClient) CreateImagesFromFilesResponder(resp *http.Response) (re
 // 64 images and 20 tags.
 // Parameters:
 // projectID - the project id
-// batch - image and tag ids. Limted to 64 images and 20 tags per batch
+// batch - image and tag ids. Limited to 64 images and 20 tags per batch
 func (client BaseClient) CreateImagesFromPredictions(ctx context.Context, projectID uuid.UUID, batch ImageIDCreateBatch) (result ImageCreateSummary, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BaseClient.CreateImagesFromPredictions")
@@ -749,7 +749,7 @@ func (client BaseClient) DeleteImageRegionsResponder(resp *http.Response) (resul
 // DeleteImages sends the delete images request.
 // Parameters:
 // projectID - the project id
-// imageIds - ids of the images to be deleted. Limted to 256 images per batch
+// imageIds - ids of the images to be deleted. Limited to 256 images per batch
 func (client BaseClient) DeleteImages(ctx context.Context, projectID uuid.UUID, imageIds []string) (result autorest.Response, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BaseClient.DeleteImages")
@@ -830,7 +830,7 @@ func (client BaseClient) DeleteImagesResponder(resp *http.Response) (result auto
 // Parameters:
 // projectID - the project id
 // imageIds - image ids. Limited to 64 images
-// tagIds - tags to be deleted from the specified images. Limted to 20 tags
+// tagIds - tags to be deleted from the specified images. Limited to 20 tags
 func (client BaseClient) DeleteImageTags(ctx context.Context, projectID uuid.UUID, imageIds []string, tagIds []string) (result autorest.Response, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BaseClient.DeleteImageTags")

--- a/services/cognitiveservices/v2.1/customvision/training/models.go
+++ b/services/cognitiveservices/v2.1/customvision/training/models.go
@@ -505,7 +505,7 @@ type Project struct {
 	Settings *ProjectSettings `json:"settings,omitempty"`
 	// Created - Gets the date this project was created
 	Created *date.Time `json:"created,omitempty"`
-	// LastModified - Gets the date this project was last modifed
+	// LastModified - Gets the date this project was last modified
 	LastModified *date.Time `json:"lastModified,omitempty"`
 	// ThumbnailURI - Gets the thumbnail url representing the project
 	ThumbnailURI *string `json:"thumbnailUri,omitempty"`

--- a/services/cognitiveservices/v2.2/customvision/training/client.go
+++ b/services/cognitiveservices/v2.2/customvision/training/client.go
@@ -299,7 +299,7 @@ func (client BaseClient) CreateImagesFromFilesResponder(resp *http.Response) (re
 // 64 images and 20 tags.
 // Parameters:
 // projectID - the project id.
-// batch - image and tag ids. Limted to 64 images and 20 tags per batch.
+// batch - image and tag ids. Limited to 64 images and 20 tags per batch.
 func (client BaseClient) CreateImagesFromPredictions(ctx context.Context, projectID uuid.UUID, batch ImageIDCreateBatch) (result ImageCreateSummary, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BaseClient.CreateImagesFromPredictions")
@@ -785,7 +785,7 @@ func (client BaseClient) DeleteImageRegionsResponder(resp *http.Response) (resul
 // DeleteImages sends the delete images request.
 // Parameters:
 // projectID - the project id.
-// imageIds - ids of the images to be deleted. Limted to 256 images per batch.
+// imageIds - ids of the images to be deleted. Limited to 256 images per batch.
 func (client BaseClient) DeleteImages(ctx context.Context, projectID uuid.UUID, imageIds []string) (result autorest.Response, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BaseClient.DeleteImages")
@@ -870,7 +870,7 @@ func (client BaseClient) DeleteImagesResponder(resp *http.Response) (result auto
 // Parameters:
 // projectID - the project id.
 // imageIds - image ids. Limited to 64 images.
-// tagIds - tags to be deleted from the specified images. Limted to 20 tags.
+// tagIds - tags to be deleted from the specified images. Limited to 20 tags.
 func (client BaseClient) DeleteImageTags(ctx context.Context, projectID uuid.UUID, imageIds []string, tagIds []string) (result autorest.Response, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BaseClient.DeleteImageTags")

--- a/services/cognitiveservices/v2.2/customvision/training/models.go
+++ b/services/cognitiveservices/v2.2/customvision/training/models.go
@@ -549,7 +549,7 @@ type Project struct {
 	Settings *ProjectSettings `json:"settings,omitempty"`
 	// Created - Gets the date this project was created.
 	Created *date.Time `json:"created,omitempty"`
-	// LastModified - Gets the date this project was last modifed.
+	// LastModified - Gets the date this project was last modified.
 	LastModified *date.Time `json:"lastModified,omitempty"`
 	// ThumbnailURI - Gets the thumbnail url representing the project.
 	ThumbnailURI *string `json:"thumbnailUri,omitempty"`


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4817