### PR TITLE
Support asm cloud services (Targeting latest branch)

### DIFF
--- a/services/classic/management/virtualmachine/client.go
+++ b/services/classic/management/virtualmachine/client.go
@@ -25,14 +25,18 @@ import (
 )
 
 const (
-	azureDeploymentListURL        = "services/hostedservices/%s/deployments"
-	azureDeploymentURL            = "services/hostedservices/%s/deployments/%s"
-	azureListDeploymentsInSlotURL = "services/hostedservices/%s/deploymentslots/Production"
-	deleteAzureDeploymentURL      = "services/hostedservices/%s/deployments/%s?comp=media"
-	azureAddRoleURL               = "services/hostedservices/%s/deployments/%s/roles"
-	azureRoleURL                  = "services/hostedservices/%s/deployments/%s/roles/%s"
-	azureOperationsURL            = "services/hostedservices/%s/deployments/%s/roleinstances/%s/Operations"
-	azureRoleSizeListURL          = "rolesizes"
+	azureDeploymentListURL                    = "services/hostedservices/%s/deployments"
+	azureDeploymentURL                        = "services/hostedservices/%s/deployments/%s"
+	azureUpdateDeploymentURL                  = "services/hostedservices/%s/deployments/%s?comp=%s"
+	azureDeploymentSlotSwapURL                = "services/hostedservices/%s"
+	azureDeploymentSlotURL                    = "services/hostedservices/%s/deploymentslots/%s"
+	azureUpdateDeploymentSlotConfigurationURL = "services/hostedservices/%s/deploymentslots/%s?comp=%s"
+	deleteAzureDeploymentURL                  = "services/hostedservices/%s/deployments/%s?comp=media"
+	azureDeleteDeploymentBySlotURL            = "services/hostedservices/%s/deploymentslots/%s"
+	azureAddRoleURL                           = "services/hostedservices/%s/deployments/%s/roles"
+	azureRoleURL                              = "services/hostedservices/%s/deployments/%s/roles/%s"
+	azureOperationsURL                        = "services/hostedservices/%s/deployments/%s/roleinstances/%s/Operations"
+	azureRoleSizeListURL                      = "rolesizes"
 
 	errParamNotSpecified = "Parameter %s is not specified."
 )
@@ -79,6 +83,224 @@ func (vm VirtualMachineClient) CreateDeployment(
 	return vm.client.SendAzurePostRequest(requestURL, data)
 }
 
+// CreateDeploymentFromPackageOptions can be used to create a customized deployement request
+type CreateDeploymentFromPackageOptions struct {
+	Name                   string
+	PackageURL             string
+	Label                  string
+	Configuration          string
+	StartDeployment        bool
+	TreatWarningsAsError   bool
+	ExtendedProperties     []ExtendedProperty
+	ExtensionConfiguration ExtensionConfiguration
+}
+
+// CreateDeploymentRequest is the type for creating a deployment of a cloud service package
+// in the deployment based on the specified configuration. See
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-create-deployment
+type CreateDeploymentRequest struct {
+	XMLName xml.Name `xml:"http://schemas.microsoft.com/windowsazure CreateDeployment"`
+	// Required parameters:
+	Name          string ``                 // Specifies the name of the deployment.
+	PackageURL    string `xml:"PackageUrl"` // Specifies a URL that refers to the location of the service package in the Blob service. The service package can be located either in a storage account beneath the same subscription or a Shared Access Signature (SAS) URI from any storage account.
+	Label         string ``                 // Specifies an identifier for the deployment that is base-64 encoded. The identifier can be up to 100 characters in length. It is recommended that the label be unique within the subscription. The label can be used for your tracking purposes.
+	Configuration string ``                 // Specifies the base-64 encoded service configuration file for the deployment.
+	// Optional parameters:
+	StartDeployment        bool                   ``                                  // Indicates whether to start the deployment immediately after it is created. The default value is false
+	TreatWarningsAsError   bool                   ``                                  // Indicates whether to treat package validation warnings as errors. The default value is false. If set to true, the Created Deployment operation fails if there are validation warnings on the service package.
+	ExtendedProperties     []ExtendedProperty     `xml:">ExtendedProperty,omitempty"` // Array of ExtendedProprties. Each extended property must have both a defined name and value. You can have a maximum of 25 extended property name and value pairs.
+	ExtensionConfiguration ExtensionConfiguration `xml:",omitempty"`
+}
+
+// CreateDeploymentFromPackage creates a deployment from a cloud services package (.cspkg) and configuration file (.cscfg)
+func (vm VirtualMachineClient) CreateDeploymentFromPackage(
+	cloudServiceName string,
+	deploymentSlot DeploymentSlot,
+	options CreateDeploymentFromPackageOptions) (management.OperationID, error) {
+
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+
+	req := CreateDeploymentRequest{
+		Name:                   options.Name,
+		Label:                  options.Label,
+		Configuration:          options.Configuration,
+		PackageURL:             options.PackageURL,
+		StartDeployment:        options.StartDeployment,
+		TreatWarningsAsError:   options.TreatWarningsAsError,
+		ExtendedProperties:     options.ExtendedProperties,
+		ExtensionConfiguration: options.ExtensionConfiguration,
+	}
+
+	data, err := xml.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+
+	requestURL := fmt.Sprintf(azureDeploymentSlotURL, cloudServiceName, deploymentSlot)
+	return vm.client.SendAzurePostRequest(requestURL, data)
+}
+
+// SwapDeploymentRequest is the type used for specifying information to swap the deployments in
+// a cloud service
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-swap-deployment
+type SwapDeploymentRequest struct {
+	XMLName xml.Name `xml:"http://schemas.microsoft.com/windowsazure Swap"`
+	// Required parameters:
+	Production       string
+	SourceDeployment string
+}
+
+// SwapDeployment initiates a virtual IP address swap between the staging and production deployment environments for a service.
+// If the service is currently running in the staging environment, it will be swapped to the production environment.
+// If it is running in the production environment, it will be swapped to staging.
+func (vm VirtualMachineClient) SwapDeployment(
+	cloudServiceName string) (management.OperationID, error) {
+
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+
+	productionDeploymentName, err := vm.GetDeploymentNameForSlot(cloudServiceName, DeploymentSlotProduction)
+	if err != nil {
+		return "", err
+	}
+
+	stagingDeploymentName, err := vm.GetDeploymentNameForSlot(cloudServiceName, DeploymentSlotStaging)
+	if err != nil {
+		return "", err
+	}
+
+	req := SwapDeploymentRequest{
+		Production:       productionDeploymentName,
+		SourceDeployment: stagingDeploymentName,
+	}
+
+	data, err := xml.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+
+	requestURL := fmt.Sprintf(azureDeploymentSlotSwapURL, cloudServiceName)
+	return vm.client.SendAzurePostRequest(requestURL, data)
+}
+
+// ChangeDeploymentConfigurationRequestOptions can be used to update configuration of a deployment
+type ChangeDeploymentConfigurationRequestOptions struct {
+	Mode                   UpgradeType
+	Configuration          string
+	TreatWarningsAsError   bool
+	ExtendedProperties     []ExtendedProperty
+	ExtensionConfiguration ExtensionConfiguration
+}
+
+// ChangeDeploymentConfigurationRequest is the type for changing the configuration of a deployment of a cloud service p
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-change-deployment-configuration
+type ChangeDeploymentConfigurationRequest struct {
+	XMLName xml.Name `xml:"http://schemas.microsoft.com/windowsazure ChangeConfiguration"`
+	// Required parameters:
+	Configuration string `` // Specifies the base-64 encoded service configuration file for the deployment.
+	// Optional parameters:
+	Mode                   UpgradeType            ``                                  // Specifies the type of Upgrade (Auto | Manual | Simultaneous) .
+	TreatWarningsAsError   bool                   ``                                  // Indicates whether to treat package validation warnings as errors. The default value is false. If set to true, the Created Deployment operation fails if there are validation warnings on the service package.
+	ExtendedProperties     []ExtendedProperty     `xml:">ExtendedProperty,omitempty"` // Array of ExtendedProprties. Each extended property must have both a defined name and value. You can have a maximum of 25 extended property name and value pairs.
+	ExtensionConfiguration ExtensionConfiguration `xml:",omitempty"`
+}
+
+// ChangeDeploymentConfiguration updates the configuration for a deployment from a configuration file (.cscfg)
+func (vm VirtualMachineClient) ChangeDeploymentConfiguration(
+	cloudServiceName string,
+	deploymentSlot DeploymentSlot,
+	options ChangeDeploymentConfigurationRequestOptions) (management.OperationID, error) {
+
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+
+	req := ChangeDeploymentConfigurationRequest{
+		Mode:                   options.Mode,
+		Configuration:          options.Configuration,
+		TreatWarningsAsError:   options.TreatWarningsAsError,
+		ExtendedProperties:     options.ExtendedProperties,
+		ExtensionConfiguration: options.ExtensionConfiguration,
+	}
+	if req.Mode == "" {
+		req.Mode = UpgradeTypeAuto
+	}
+
+	data, err := xml.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+
+	requestURL := fmt.Sprintf(azureUpdateDeploymentSlotConfigurationURL, cloudServiceName, deploymentSlot, "config")
+	return vm.client.SendAzurePostRequest(requestURL, data)
+}
+
+// UpdateDeploymentStatusRequest is the type used to make UpdateDeploymentStatus requests
+type UpdateDeploymentStatusRequest struct {
+	XMLName xml.Name `xml:"http://schemas.microsoft.com/windowsazure UpdateDeploymentStatus"`
+	// Required parameters:
+	Status string
+}
+
+// UpdateDeploymentStatus changes the running status of a deployment. The status of a deployment can be running or suspended.
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-update-deployment-status
+func (vm VirtualMachineClient) UpdateDeploymentStatus(
+	cloudServiceName string,
+	deploymentSlot DeploymentSlot,
+	status string) (management.OperationID, error) {
+
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+
+	if status != "Running" && status != "Suspended" {
+		return "", fmt.Errorf("Invalid status provided")
+	}
+
+	req := UpdateDeploymentStatusRequest{
+		Status: status,
+	}
+
+	data, err := xml.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+
+	requestURL := fmt.Sprintf(azureUpdateDeploymentSlotConfigurationURL, cloudServiceName, deploymentSlot, "status")
+	return vm.client.SendAzurePostRequest(requestURL, data)
+}
+
+// UpdateDeploymentStatusByName changes the running status of a deployment. The status of a deployment can be running or suspended.
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-update-deployment-status
+func (vm VirtualMachineClient) UpdateDeploymentStatusByName(
+	cloudServiceName string,
+	deploymentName string,
+	status string) (management.OperationID, error) {
+
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+
+	if status != "Running" && status != "Suspended" {
+		return "", fmt.Errorf("Invalid status provided")
+	}
+
+	req := UpdateDeploymentStatusRequest{
+		Status: status,
+	}
+
+	data, err := xml.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+
+	requestURL := fmt.Sprintf(azureUpdateDeploymentURL, cloudServiceName, deploymentName, "status")
+	return vm.client.SendAzurePostRequest(requestURL, data)
+}
+
 // GetDeploymentName queries an existing Azure cloud service for the name of the Deployment,
 // if any, in its 'Production' slot (the only slot possible). If none exists, it returns empty
 // string but no error
@@ -89,7 +311,33 @@ func (vm VirtualMachineClient) GetDeploymentName(cloudServiceName string) (strin
 	if cloudServiceName == "" {
 		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
 	}
-	requestURL := fmt.Sprintf(azureListDeploymentsInSlotURL, cloudServiceName)
+	requestURL := fmt.Sprintf(azureDeploymentSlotURL, cloudServiceName, "Production")
+	response, err := vm.client.SendAzureGetRequest(requestURL)
+	if err != nil {
+		if management.IsResourceNotFoundError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	err = xml.Unmarshal(response, &deployment)
+	if err != nil {
+		return "", err
+	}
+
+	return deployment.Name, nil
+}
+
+// GetDeploymentNameForSlot queries an existing Azure cloud service for the name of the Deployment,
+// in a given slot. If none exists, it returns empty
+// string but no error
+//
+//https://msdn.microsoft.com/en-us/library/azure/ee460804.aspx
+func (vm VirtualMachineClient) GetDeploymentNameForSlot(cloudServiceName string, deploymentSlot DeploymentSlot) (string, error) {
+	var deployment DeploymentResponse
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+	requestURL := fmt.Sprintf(azureDeploymentSlotURL, cloudServiceName, deploymentSlot)
 	response, err := vm.client.SendAzureGetRequest(requestURL)
 	if err != nil {
 		if management.IsResourceNotFoundError(err) {
@@ -123,6 +371,25 @@ func (vm VirtualMachineClient) GetDeployment(cloudServiceName, deploymentName st
 	return deployment, err
 }
 
+// GetDeploymentBySlot used to retrieve deployment events for a single deployment slot (staging or production)
+func (vm VirtualMachineClient) GetDeploymentBySlot(cloudServiceName string, deploymentSlot DeploymentSlot) (DeploymentResponse, error) {
+	var deployment DeploymentResponse
+	if cloudServiceName == "" {
+		return deployment, fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+	if deploymentSlot == "" {
+		return deployment, fmt.Errorf(errParamNotSpecified, "deploymentSlot")
+	}
+	requestURL := fmt.Sprintf(azureDeploymentSlotURL, cloudServiceName, deploymentSlot)
+	response, azureErr := vm.client.SendAzureGetRequest(requestURL)
+	if azureErr != nil {
+		return deployment, azureErr
+	}
+
+	err := xml.Unmarshal(response, &deployment)
+	return deployment, err
+}
+
 func (vm VirtualMachineClient) DeleteDeployment(cloudServiceName, deploymentName string) (management.OperationID, error) {
 	if cloudServiceName == "" {
 		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
@@ -132,6 +399,18 @@ func (vm VirtualMachineClient) DeleteDeployment(cloudServiceName, deploymentName
 	}
 
 	requestURL := fmt.Sprintf(deleteAzureDeploymentURL, cloudServiceName, deploymentName)
+	return vm.client.SendAzureDeleteRequest(requestURL)
+}
+
+func (vm VirtualMachineClient) DeleteDeploymentBySlot(cloudServiceName string, deploymentSlot DeploymentSlot) (management.OperationID, error) {
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+	if deploymentSlot == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "deploymentSlot")
+	}
+
+	requestURL := fmt.Sprintf(azureDeleteDeploymentBySlotURL, cloudServiceName, deploymentSlot)
 	return vm.client.SendAzureDeleteRequest(requestURL)
 }
 

--- a/services/classic/management/virtualmachine/client.go
+++ b/services/classic/management/virtualmachine/client.go
@@ -307,24 +307,7 @@ func (vm VirtualMachineClient) UpdateDeploymentStatusByName(
 //
 //https://msdn.microsoft.com/en-us/library/azure/ee460804.aspx
 func (vm VirtualMachineClient) GetDeploymentName(cloudServiceName string) (string, error) {
-	var deployment DeploymentResponse
-	if cloudServiceName == "" {
-		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
-	}
-	requestURL := fmt.Sprintf(azureDeploymentSlotURL, cloudServiceName, "Production")
-	response, err := vm.client.SendAzureGetRequest(requestURL)
-	if err != nil {
-		if management.IsResourceNotFoundError(err) {
-			return "", nil
-		}
-		return "", err
-	}
-	err = xml.Unmarshal(response, &deployment)
-	if err != nil {
-		return "", err
-	}
-
-	return deployment.Name, nil
+	return vm.GetDeploymentNameForSlot(cloudServiceName, DeploymentSlotProduction)
 }
 
 // GetDeploymentNameForSlot queries an existing Azure cloud service for the name of the Deployment,

--- a/services/classic/management/virtualmachine/entities.go
+++ b/services/classic/management/virtualmachine/entities.go
@@ -71,7 +71,7 @@ type DeploymentResponse struct {
 	ExtendedProperties     []ExtendedProperty `xml:">ExtendedProperty"`
 	PersistentVMDowntime   PersistentVMDowntime
 	VirtualIPs             []VirtualIP `xml:">VirtualIP"`
-	ExtensionConfiguration string      // cloud service extensions not fully implemented
+	ExtensionConfiguration ExtensionConfiguration
 	ReservedIPName         string
 	InternalDNSSuffix      string `xml:"InternalDnsSuffix"`
 }
@@ -87,6 +87,16 @@ const (
 	DeploymentStatusSuspending             DeploymentStatus = "Suspending"
 	DeploymentStatusDeploying              DeploymentStatus = "Deploying"
 	DeploymentStatusDeleting               DeploymentStatus = "Deleting"
+)
+
+// DeploymentSlot for cloud services are either Production or Staging Slots
+type DeploymentSlot string
+
+const (
+	// DeploymentSlotProduction represents the Production slot of a cloud service
+	DeploymentSlotProduction DeploymentSlot = "Production"
+	// DeploymentSlotStaging represents the Staging slot of a cloud service
+	DeploymentSlotStaging DeploymentSlot = "Staging"
 )
 
 type RoleInstance struct {
@@ -278,6 +288,26 @@ type DataDiskConfiguration struct {
 	OSDiskConfiguration
 	Name string // The Name of the DataDiskConfiguration being referenced to.
 
+}
+
+// ExtensionConfiguration Contains extensions that are added to the cloud service.
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-get-deployment#bk_extensionconfig
+type ExtensionConfiguration struct {
+	NamedRoles []NamedRole `xml:"NamedRoles>Role,omitempty"`
+}
+
+// NamedRole specifies a list of extensions that are applied to specific roles in a deployment.
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-get-deployment#bk_namedroles
+type NamedRole struct {
+	RoleName   string      `xml:",omitempty"`
+	Extensions []Extension `xml:"Extensions>Extension,omitempty"`
+}
+
+// Extension Specifies an extension that is to be deployed to a role in a cloud service.
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-get-deployment#bk_extension
+type Extension struct {
+	ID    string `xml:"Id"`
+	State string
 }
 
 // ResourceExtensionReference contains a collection of resource extensions that

--- a/services/classic/management/virtualmachine/resourceextensions.go
+++ b/services/classic/management/virtualmachine/resourceextensions.go
@@ -18,10 +18,15 @@ package virtualmachine
 
 import (
 	"encoding/xml"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/classic/management"
 )
 
 const (
-	azureResourceExtensionsURL = "services/resourceextensions"
+	azureResourceExtensionsURL     = "services/resourceextensions"
+	azureCloudServiceExtensionsURL = "services/hostedservices/%s/extensions"
+	azureCloudServiceExtensionURL  = "services/hostedservices/%s/extensions/%s"
 )
 
 // GetResourceExtensions lists the resource extensions that are available to add
@@ -38,4 +43,141 @@ func (c VirtualMachineClient) GetResourceExtensions() (extensions []ResourceExte
 	err = xml.Unmarshal(data, &response)
 	extensions = response.List
 	return
+}
+
+// Extensions is a list of extensions returned by the ListExtensions response
+type Extensions struct {
+	XMLName    xml.Name        `xml:"http://schemas.microsoft.com/windowsazure Extensions"`
+	Extensions []ExtensionInfo `xml:"Extension"`
+}
+
+// ExtensionInfo defined the type retured by GetExtension
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-get-extension
+type ExtensionInfo struct {
+	XMLName                     xml.Name `xml:"http://schemas.microsoft.com/windowsazure Extension"`
+	ProviderNameSpace           string
+	Type                        string
+	ID                          string `xml:"Id"`
+	Version                     string
+	Thumbprint                  string
+	PublicConfigurationSchema   string
+	ThumbprintAlgorithm         string
+	IsJSONExtension             bool `xml:"IsJsonExtension"`
+	DisallowMajorVersionUpgrade bool
+}
+
+// GetExtension retrieves information about a specified extension that was added to a cloud service.
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-get-extension
+func (c VirtualMachineClient) GetExtension(cloudServiceName string, extensionID string) (extension ExtensionInfo, err error) {
+
+	if cloudServiceName == "" {
+		return ExtensionInfo{}, fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+	if extensionID == "" {
+		return ExtensionInfo{}, fmt.Errorf(errParamNotSpecified, "extensionID")
+	}
+
+	requestURL := fmt.Sprintf(azureCloudServiceExtensionURL, cloudServiceName, extensionID)
+	data, err := c.client.SendAzureGetRequest(requestURL)
+	if err != nil {
+		return ExtensionInfo{}, err
+	}
+	err = xml.Unmarshal(data, &extension)
+	return
+}
+
+// ListExtensions lists all of the extensions that were added to a cloud service.
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-list-extensions
+func (c VirtualMachineClient) ListExtensions(cloudServiceName string) (extensions []ExtensionInfo, err error) {
+
+	if cloudServiceName == "" {
+		return []ExtensionInfo{}, fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+
+	requestURL := fmt.Sprintf(azureCloudServiceExtensionsURL, cloudServiceName)
+	data, err := c.client.SendAzureGetRequest(requestURL)
+	if err != nil {
+		return []ExtensionInfo{}, err
+	}
+	var response Extensions
+	err = xml.Unmarshal(data, &response)
+	extensions = response.Extensions
+	return
+}
+
+// AddExtensionOptions defines the options available for adding extensions to a cloud service
+type AddExtensionOptions struct {
+	ProviderNameSpace    string
+	Type                 string
+	ID                   string
+	Thumbprint           string
+	ThumbprintAlgorithm  string
+	PublicConfiguration  string
+	PrivateConfiguration string
+	Version              string
+}
+
+// AddExtensionRequest is the type used to submit AddExtension requests
+type AddExtensionRequest struct {
+	XMLName              xml.Name `xml:"http://schemas.microsoft.com/windowsazure Extension"`
+	ProviderNameSpace    string
+	Type                 string
+	ID                   string `xml:"Id"`
+	Thumbprint           string
+	ThumbprintAlgorithm  string
+	PublicConfiguration  string
+	PrivateConfiguration string
+	Version              string
+}
+
+// AddExtension addes an extension to the cloud service
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-add-extension
+func (c VirtualMachineClient) AddExtension(cloudServiceName string, options AddExtensionOptions) (management.OperationID, error) {
+
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+	if options.ID == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "options.ID")
+	}
+	if options.ProviderNameSpace == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "options.ProviderNameSpace")
+	}
+	if options.Type == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "options.Type")
+	}
+
+	req := AddExtensionRequest{
+		ProviderNameSpace:    options.ProviderNameSpace,
+		Type:                 options.Type,
+		ID:                   options.ID,
+		Thumbprint:           options.Thumbprint,
+		ThumbprintAlgorithm:  options.ThumbprintAlgorithm,
+		PublicConfiguration:  options.PublicConfiguration,
+		PrivateConfiguration: options.PrivateConfiguration,
+		Version:              options.Version,
+	}
+
+	data, err := xml.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+
+	requestURL := fmt.Sprintf(azureCloudServiceExtensionsURL, cloudServiceName)
+	return c.client.SendAzurePostRequest(requestURL, data)
+}
+
+// DeleteExtension deletes the specified extension from a cloud service.
+// https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-delete-extension
+func (c VirtualMachineClient) DeleteExtension(cloudServiceName string, extensionID string) (management.OperationID, error) {
+
+	if cloudServiceName == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "cloudServiceName")
+	}
+	if extensionID == "" {
+		return "", fmt.Errorf(errParamNotSpecified, "extensionID")
+	}
+
+	requestURL := fmt.Sprintf(azureCloudServiceExtensionURL, cloudServiceName, extensionID)
+	return c.client.SendAzureDeleteRequest(requestURL)
 }


### PR DESCRIPTION
Several large enterprises still extensively use Azure PaaS V1 (Cloud Services a.k.a. Web/Worker Roles) through the classic management API (ASM). These are early adopters of the Azure cloud platform and will take singificant migration effort to move to newer Compute options available via Azure Resource Manager (ARM).
Newer cross platform automation options (azure cli, Az Powershell Module) do not provide support for ASM, which makes it non feasible to run on non windows environment (e.g:- Linux Containers as part of CI/CD).
This pull request wraps the ASM API and adds support for the common workflows such as deploying cloud service packages to production or staging slots of a cloud service and performing blue/green style deployment with VIP Swap. It also adds support for managing extensions for cloud services which are needed for enabling extension such as PaaS Diagnostics (a.k.a. WAD a.k.a. Windows Azure Diagnostics) and Microsoft AntiMalware extensions.

Targeting latest branch