### PR TITLE
[AutoPR network/resource-manager] Fix duplicate path in old Network API versions (Network January branch)

### DIFF
--- a/services/network/mgmt/2015-06-15/network/networkapi/interfaces.go
+++ b/services/network/mgmt/2015-06-15/network/networkapi/interfaces.go
@@ -206,7 +206,7 @@ type VirtualNetworkGatewayConnectionsClientAPI interface {
 	CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters network.VirtualNetworkGatewayConnection) (result network.VirtualNetworkGatewayConnectionsCreateOrUpdateFuture, err error)
 	Delete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (result network.VirtualNetworkGatewayConnectionsDeleteFuture, err error)
 	Get(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (result network.VirtualNetworkGatewayConnection, err error)
-	GetSharedKey(ctx context.Context, resourceGroupName string, connectionSharedKeyName string) (result network.ConnectionSharedKeyResult, err error)
+	GetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (result network.ConnectionSharedKeyResult, err error)
 	List(ctx context.Context, resourceGroupName string) (result network.VirtualNetworkGatewayConnectionListResultPage, err error)
 	ResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters network.ConnectionResetSharedKey) (result network.VirtualNetworkGatewayConnectionsResetSharedKeyFuture, err error)
 	SetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters network.ConnectionSharedKey) (result network.VirtualNetworkGatewayConnectionsSetSharedKeyFuture, err error)

--- a/services/network/mgmt/2015-06-15/network/virtualnetworkgatewayconnections.go
+++ b/services/network/mgmt/2015-06-15/network/virtualnetworkgatewayconnections.go
@@ -278,8 +278,8 @@ func (client VirtualNetworkGatewayConnectionsClient) GetResponder(resp *http.Res
 // virtual network gateway connection shared key through Network resource provider.
 // Parameters:
 // resourceGroupName - the name of the resource group.
-// connectionSharedKeyName - the virtual network gateway connection shared key name.
-func (client VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.Context, resourceGroupName string, connectionSharedKeyName string) (result ConnectionSharedKeyResult, err error) {
+// virtualNetworkGatewayConnectionName - the virtual network gateway connection shared key name.
+func (client VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (result ConnectionSharedKeyResult, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/VirtualNetworkGatewayConnectionsClient.GetSharedKey")
 		defer func() {
@@ -290,7 +290,7 @@ func (client VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.Co
 			tracing.EndSpan(ctx, sc, err)
 		}()
 	}
-	req, err := client.GetSharedKeyPreparer(ctx, resourceGroupName, connectionSharedKeyName)
+	req, err := client.GetSharedKeyPreparer(ctx, resourceGroupName, virtualNetworkGatewayConnectionName)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "network.VirtualNetworkGatewayConnectionsClient", "GetSharedKey", nil, "Failure preparing request")
 		return
@@ -312,11 +312,11 @@ func (client VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.Co
 }
 
 // GetSharedKeyPreparer prepares the GetSharedKey request.
-func (client VirtualNetworkGatewayConnectionsClient) GetSharedKeyPreparer(ctx context.Context, resourceGroupName string, connectionSharedKeyName string) (*http.Request, error) {
+func (client VirtualNetworkGatewayConnectionsClient) GetSharedKeyPreparer(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"connectionSharedKeyName": autorest.Encode("path", connectionSharedKeyName),
-		"resourceGroupName":       autorest.Encode("path", resourceGroupName),
-		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
+		"resourceGroupName":                   autorest.Encode("path", resourceGroupName),
+		"subscriptionId":                      autorest.Encode("path", client.SubscriptionID),
+		"virtualNetworkGatewayConnectionName": autorest.Encode("path", virtualNetworkGatewayConnectionName),
 	}
 
 	const APIVersion = "2015-06-15"
@@ -327,7 +327,7 @@ func (client VirtualNetworkGatewayConnectionsClient) GetSharedKeyPreparer(ctx co
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{connectionSharedKeyName}/sharedkey", pathParameters),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5003