### PR TITLE
Reuse http client used with ASM API 

### DIFF
--- a/services/classic/management/client.go
+++ b/services/classic/management/client.go
@@ -21,6 +21,7 @@ package management
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"runtime"
 	"time"
 
@@ -44,6 +45,7 @@ const (
 type client struct {
 	publishSettings publishSettings
 	config          ClientConfig
+	httpClient      *http.Client
 }
 
 // Client is the base Azure Service Management API client instance that
@@ -154,10 +156,16 @@ func makeClient(subscriptionID string, managementCert []byte, config ClientConfi
 		config.UserAgent = DefaultUserAgent
 	}
 
-	return client{
+	clientObj := client{
 		publishSettings: publishSettings,
 		config:          config,
-	}, nil
+	}
+	var err error
+	clientObj.httpClient, err = clientObj.createHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+	return clientObj, nil
 }
 
 func userAgent() string {

--- a/services/classic/management/http.go
+++ b/services/classic/management/http.go
@@ -107,7 +107,7 @@ func (client client) createHTTPClient() (*http.Client, error) {
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
-				Renegotiation: tls.RenegotiateFreelyAsClient,
+				Renegotiation: tls.RenegotiateOnceAsClient,
 				Certificates:  []tls.Certificate{cert},
 			},
 		},

--- a/services/classic/management/http.go
+++ b/services/classic/management/http.go
@@ -87,12 +87,7 @@ func (client client) sendAzureRequest(method, url, contentType string, data []by
 		return nil, fmt.Errorf(errParamNotSpecified, "url")
 	}
 
-	httpClient, err := client.createHTTPClient()
-	if err != nil {
-		return nil, err
-	}
-
-	response, err := client.sendRequest(httpClient, url, method, contentType, data, 5)
+	response, err := client.sendRequest(client.httpClient, url, method, contentType, data, 5)
 	if err != nil {
 		return nil, err
 	}
@@ -101,26 +96,22 @@ func (client client) sendAzureRequest(method, url, contentType string, data []by
 }
 
 // createHTTPClient creates an HTTP Client configured with the key pair for
-// the subscription for this client. If a client already exists, then it returns
-// the instance
+// the subscription for this client.
 func (client client) createHTTPClient() (*http.Client, error) {
-	if client.httpClient == nil {
-		cert, err := tls.X509KeyPair(client.publishSettings.SubscriptionCert, client.publishSettings.SubscriptionKey)
-		if err != nil {
-			return nil, err
-		}
-
-		client.httpClient = &http.Client{
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{
-					Renegotiation: tls.RenegotiateFreelyAsClient,
-					Certificates:  []tls.Certificate{cert},
-				},
-			},
-		}
+	cert, err := tls.X509KeyPair(client.publishSettings.SubscriptionCert, client.publishSettings.SubscriptionKey)
+	if err != nil {
+		return nil, err
 	}
-	return client.httpClient, nil
+
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				Renegotiation: tls.RenegotiateFreelyAsClient,
+				Certificates:  []tls.Certificate{cert},
+			},
+		},
+	}, nil
 }
 
 // sendRequest sends a request to the Azure management API using the given

--- a/services/classic/management/http.go
+++ b/services/classic/management/http.go
@@ -157,9 +157,9 @@ func (client client) sendRequest(httpClient *http.Client, url, requestType, cont
 				if numberOfRetries == 0 {
 					return nil, azureErr
 				}
-				if response.StatusCode == http.StatusServiceUnavailable {
+				if response.StatusCode == http.StatusServiceUnavailable || response.StatusCode == http.StatusTooManyRequests {
 					// Wait before retrying the operation
-					time.Sleep(30 * time.Second)
+					time.Sleep(client.config.OperationPollInterval)
 				}
 
 				return client.sendRequest(httpClient, url, requestType, contentType, data, numberOfRetries-1)


### PR DESCRIPTION
This PR addresses re-using the underlying httpClient when making API calls to Azure Service Management (ASM). 

It also adds some throttling when ASM returns a ServiceUnavailable response (Code: TooManyRequests, Message: Too many requests received. Retry after some time.)

