### PR TITLE
Read deploymentID property in GetDeployment API responses

### DIFF
--- a/services/classic/management/virtualmachine/entities.go
+++ b/services/classic/management/virtualmachine/entities.go
@@ -52,6 +52,7 @@ type DeploymentResponse struct {
 
 	Name                   string
 	DeploymentSlot         string
+	PrivateID              string
 	Status                 DeploymentStatus
 	Label                  string
 	URL                    string `xml:"Url"`


### PR DESCRIPTION
Certain workflows rely on the deploymentID (a.k.a. PrivateID) from the Deployment response. 

https://docs.microsoft.com/en-us/rest/api/compute/cloudservices/rest-get-deployment
<PrivateID>identifier-of-deployment</PrivateID>  

This was missing in the entity definition