### PR TITLE
[AutoPR eventgrid/data-plane] EventGrid StorageBlobCreatedEventData: Make contentLength field long instead of int to account for blob sizes greater than 2 GB.

### DIFF
--- a/services/eventgrid/2018-01-01/eventgrid/models.go
+++ b/services/eventgrid/2018-01-01/eventgrid/models.go
@@ -1917,7 +1917,7 @@ type StorageBlobCreatedEventData struct {
 	// ContentType - The content type of the blob. This is the same as what would be returned in the Content-Type header from the blob.
 	ContentType *string `json:"contentType,omitempty"`
 	// ContentLength - The size of the blob in bytes. This is the same as what would be returned in the Content-Length header from the blob.
-	ContentLength *int32 `json:"contentLength,omitempty"`
+	ContentLength *int64 `json:"contentLength,omitempty"`
 	// BlobType - The type of blob.
 	BlobType *string `json:"blobType,omitempty"`
 	// URL - The path to the blob.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5179