### PR TITLE
[AutoPR cognitiveservices/data-plane/Face] [Cogs Face] Remove Face API reference of Gender::genderless to avoid confusion.

### DIFF
--- a/profiles/latest/cognitiveservices/face/models.go
+++ b/profiles/latest/cognitiveservices/face/models.go
@@ -74,9 +74,8 @@ const (
 type Gender = original.Gender
 
 const (
-	Female     Gender = original.Female
-	Genderless Gender = original.Genderless
-	Male       Gender = original.Male
+	Female Gender = original.Female
+	Male   Gender = original.Male
 )
 
 type GlassesType = original.GlassesType

--- a/profiles/preview/cognitiveservices/face/models.go
+++ b/profiles/preview/cognitiveservices/face/models.go
@@ -74,9 +74,8 @@ const (
 type Gender = original.Gender
 
 const (
-	Female     Gender = original.Female
-	Genderless Gender = original.Genderless
-	Male       Gender = original.Male
+	Female Gender = original.Female
+	Male   Gender = original.Male
 )
 
 type GlassesType = original.GlassesType

--- a/services/cognitiveservices/v1.0/face/models.go
+++ b/services/cognitiveservices/v1.0/face/models.go
@@ -137,15 +137,13 @@ type Gender string
 const (
 	// Female ...
 	Female Gender = "female"
-	// Genderless ...
-	Genderless Gender = "genderless"
 	// Male ...
 	Male Gender = "male"
 )
 
 // PossibleGenderValues returns an array of possible values for the Gender const type.
 func PossibleGenderValues() []Gender {
-	return []Gender{Female, Genderless, Male}
+	return []Gender{Female, Male}
 }
 
 // GlassesType enumerates the values for glasses type.
@@ -306,7 +304,7 @@ type ApplySnapshotRequest struct {
 type Attributes struct {
 	// Age - Age in years
 	Age *float64 `json:"age,omitempty"`
-	// Gender - Possible gender of the face. Possible values include: 'Male', 'Female', 'Genderless'
+	// Gender - Possible gender of the face. Possible values include: 'Male', 'Female'
 	Gender Gender `json:"gender,omitempty"`
 	// Smile - Smile intensity, a number between [0,1]
 	Smile *float64 `json:"smile,omitempty"`


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5188