### PR TITLE
Fix indexer run in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ script:
   - go run ./tools/apidiff/main.go packages ./services FETCH_HEAD~1 FETCH_HEAD --copyrepo --breakingchanges || $IGNORE_BREAKING_CHANGES
   - go run ./tools/pkgchk/main.go ./services --exceptions ./tools/pkgchk/exceptions.txt
   - git diff --exit-code
-  - if [[ "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_BRANCH" == "master" ]]; then go run ./tools/indexer/main.go; fi
+  - if [[ "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_BRANCH" == "master" ]]; then go run ./tools/indexer/main.go ./services; fi

--- a/tools/indexer/main.go
+++ b/tools/indexer/main.go
@@ -26,18 +26,18 @@ import (
 
 // adds any missing SDK packages to godoc.org
 func main() {
-	dir := ""
+	// by default assume we're running from the source dir
+	// and calculate the relative path to the services directory.
+	dir := "../../services"
 	if len(os.Args) > 1 {
 		// assume second arg is source dir
 		dir = os.Args[1]
-	} else {
-		// if no args specified assume we're running from the source dir
-		// and calculate the relative path to the services directory.
-		var err error
-		dir, err = filepath.Abs("../../services")
-		if err != nil {
-			panic(err)
-		}
+	}
+
+	var err error
+	dir, err = filepath.Abs(dir)
+	if err != nil {
+		panic(err)
 	}
 
 	pkgs, err := util.GetPackagesForIndexing(dir)


### PR DESCRIPTION
Added missing directory argument to indexer.
Fixed indexer to always calculate absolute path.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
