### PR TITLE
[AutoPR marketplaceordering/resource-manager] Add missing MarketplaceOrdering operations to swagger

### DIFF
--- a/profiles/latest/marketplaceordering/mgmt/marketplaceordering/models.go
+++ b/profiles/latest/marketplaceordering/mgmt/marketplaceordering/models.go
@@ -34,6 +34,7 @@ type AgreementTerms = original.AgreementTerms
 type BaseClient = original.BaseClient
 type ErrorResponse = original.ErrorResponse
 type ErrorResponseError = original.ErrorResponseError
+type ListAgreementTerms = original.ListAgreementTerms
 type MarketplaceAgreementsClient = original.MarketplaceAgreementsClient
 type Operation = original.Operation
 type OperationDisplay = original.OperationDisplay

--- a/profiles/preview/marketplaceordering/mgmt/marketplaceordering/models.go
+++ b/profiles/preview/marketplaceordering/mgmt/marketplaceordering/models.go
@@ -34,6 +34,7 @@ type AgreementTerms = original.AgreementTerms
 type BaseClient = original.BaseClient
 type ErrorResponse = original.ErrorResponse
 type ErrorResponseError = original.ErrorResponseError
+type ListAgreementTerms = original.ListAgreementTerms
 type MarketplaceAgreementsClient = original.MarketplaceAgreementsClient
 type Operation = original.Operation
 type OperationDisplay = original.OperationDisplay

--- a/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/marketplaceagreements.go
+++ b/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/marketplaceagreements.go
@@ -40,6 +40,85 @@ func NewMarketplaceAgreementsClientWithBaseURI(baseURI string, subscriptionID st
 	return MarketplaceAgreementsClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
+// Cancel cancel marketplace terms.
+// Parameters:
+// publisherID - publisher identifier string of image being deployed.
+// offerID - offer identifier string of image being deployed.
+// planID - plan identifier string of image being deployed.
+func (client MarketplaceAgreementsClient) Cancel(ctx context.Context, publisherID string, offerID string, planID string) (result AgreementTerms, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/MarketplaceAgreementsClient.Cancel")
+		defer func() {
+			sc := -1
+			if result.Response.Response != nil {
+				sc = result.Response.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	req, err := client.CancelPreparer(ctx, publisherID, offerID, planID)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "Cancel", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CancelSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "Cancel", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CancelResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "Cancel", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CancelPreparer prepares the Cancel request.
+func (client MarketplaceAgreementsClient) CancelPreparer(ctx context.Context, publisherID string, offerID string, planID string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"offerId":        autorest.Encode("path", offerID),
+		"planId":         autorest.Encode("path", planID),
+		"publisherId":    autorest.Encode("path", publisherID),
+		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2015-06-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/Microsoft.MarketplaceOrdering/agreements/{publisherId}/offers/{offerId}/plans/{planId}/cancel", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// CancelSender sends the Cancel request. The method will close the
+// http.Response Body if it receives an error.
+func (client MarketplaceAgreementsClient) CancelSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// CancelResponder handles the response to the Cancel request. The method always
+// closes the http.Response Body.
+func (client MarketplaceAgreementsClient) CancelResponder(resp *http.Response) (result AgreementTerms, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // Create save marketplace terms.
 // Parameters:
 // publisherID - publisher identifier string of image being deployed.
@@ -193,6 +272,236 @@ func (client MarketplaceAgreementsClient) GetSender(req *http.Request) (*http.Re
 // GetResponder handles the response to the Get request. The method always
 // closes the http.Response Body.
 func (client MarketplaceAgreementsClient) GetResponder(resp *http.Response) (result AgreementTerms, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// GetAgreement get marketplace agreements.
+// Parameters:
+// publisherID - publisher identifier string of image being deployed.
+// offerID - offer identifier string of image being deployed.
+// planID - plan identifier string of image being deployed.
+func (client MarketplaceAgreementsClient) GetAgreement(ctx context.Context, publisherID string, offerID string, planID string) (result AgreementTerms, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/MarketplaceAgreementsClient.GetAgreement")
+		defer func() {
+			sc := -1
+			if result.Response.Response != nil {
+				sc = result.Response.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	req, err := client.GetAgreementPreparer(ctx, publisherID, offerID, planID)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "GetAgreement", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetAgreementSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "GetAgreement", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetAgreementResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "GetAgreement", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetAgreementPreparer prepares the GetAgreement request.
+func (client MarketplaceAgreementsClient) GetAgreementPreparer(ctx context.Context, publisherID string, offerID string, planID string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"offerId":        autorest.Encode("path", offerID),
+		"planId":         autorest.Encode("path", planID),
+		"publisherId":    autorest.Encode("path", publisherID),
+		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2015-06-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/Microsoft.MarketplaceOrdering/agreements/{publisherId}/offers/{offerId}/plans/{planId}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetAgreementSender sends the GetAgreement request. The method will close the
+// http.Response Body if it receives an error.
+func (client MarketplaceAgreementsClient) GetAgreementSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// GetAgreementResponder handles the response to the GetAgreement request. The method always
+// closes the http.Response Body.
+func (client MarketplaceAgreementsClient) GetAgreementResponder(resp *http.Response) (result AgreementTerms, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// List list marketplace agreements.
+func (client MarketplaceAgreementsClient) List(ctx context.Context) (result ListAgreementTerms, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/MarketplaceAgreementsClient.List")
+		defer func() {
+			sc := -1
+			if result.Response.Response != nil {
+				sc = result.Response.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	req, err := client.ListPreparer(ctx)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "List", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.ListResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "List", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// ListPreparer prepares the List request.
+func (client MarketplaceAgreementsClient) ListPreparer(ctx context.Context) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2015-06-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/Microsoft.MarketplaceOrdering/agreements", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListSender sends the List request. The method will close the
+// http.Response Body if it receives an error.
+func (client MarketplaceAgreementsClient) ListSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListResponder handles the response to the List request. The method always
+// closes the http.Response Body.
+func (client MarketplaceAgreementsClient) ListResponder(resp *http.Response) (result ListAgreementTerms, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Value),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// Sign sign marketplace terms.
+// Parameters:
+// publisherID - publisher identifier string of image being deployed.
+// offerID - offer identifier string of image being deployed.
+// planID - plan identifier string of image being deployed.
+func (client MarketplaceAgreementsClient) Sign(ctx context.Context, publisherID string, offerID string, planID string) (result AgreementTerms, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/MarketplaceAgreementsClient.Sign")
+		defer func() {
+			sc := -1
+			if result.Response.Response != nil {
+				sc = result.Response.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	req, err := client.SignPreparer(ctx, publisherID, offerID, planID)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "Sign", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.SignSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "Sign", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.SignResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "marketplaceordering.MarketplaceAgreementsClient", "Sign", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// SignPreparer prepares the Sign request.
+func (client MarketplaceAgreementsClient) SignPreparer(ctx context.Context, publisherID string, offerID string, planID string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"offerId":        autorest.Encode("path", offerID),
+		"planId":         autorest.Encode("path", planID),
+		"publisherId":    autorest.Encode("path", publisherID),
+		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2015-06-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/Microsoft.MarketplaceOrdering/agreements/{publisherId}/offers/{offerId}/plans/{planId}/sign", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// SignSender sends the Sign request. The method will close the
+// http.Response Body if it receives an error.
+func (client MarketplaceAgreementsClient) SignSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// SignResponder handles the response to the Sign request. The method always
+// closes the http.Response Body.
+func (client MarketplaceAgreementsClient) SignResponder(resp *http.Response) (result AgreementTerms, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),

--- a/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/marketplaceagreements.go
+++ b/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/marketplaceagreements.go
@@ -282,7 +282,7 @@ func (client MarketplaceAgreementsClient) GetResponder(resp *http.Response) (res
 	return
 }
 
-// GetAgreement get marketplace agreements.
+// GetAgreement get marketplace agreement.
 // Parameters:
 // publisherID - publisher identifier string of image being deployed.
 // offerID - offer identifier string of image being deployed.
@@ -361,7 +361,7 @@ func (client MarketplaceAgreementsClient) GetAgreementResponder(resp *http.Respo
 	return
 }
 
-// List list marketplace agreements.
+// List list marketplace agreements in the subscription.
 func (client MarketplaceAgreementsClient) List(ctx context.Context) (result ListAgreementTerms, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/MarketplaceAgreementsClient.List")

--- a/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/marketplaceorderingapi/interfaces.go
+++ b/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/marketplaceorderingapi/interfaces.go
@@ -24,8 +24,12 @@ import (
 
 // MarketplaceAgreementsClientAPI contains the set of methods on the MarketplaceAgreementsClient type.
 type MarketplaceAgreementsClientAPI interface {
+	Cancel(ctx context.Context, publisherID string, offerID string, planID string) (result marketplaceordering.AgreementTerms, err error)
 	Create(ctx context.Context, publisherID string, offerID string, planID string, parameters marketplaceordering.AgreementTerms) (result marketplaceordering.AgreementTerms, err error)
 	Get(ctx context.Context, publisherID string, offerID string, planID string) (result marketplaceordering.AgreementTerms, err error)
+	GetAgreement(ctx context.Context, publisherID string, offerID string, planID string) (result marketplaceordering.AgreementTerms, err error)
+	List(ctx context.Context) (result marketplaceordering.ListAgreementTerms, err error)
+	Sign(ctx context.Context, publisherID string, offerID string, planID string) (result marketplaceordering.AgreementTerms, err error)
 }
 
 var _ MarketplaceAgreementsClientAPI = (*marketplaceordering.MarketplaceAgreementsClient)(nil)

--- a/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/models.go
+++ b/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering/models.go
@@ -147,6 +147,12 @@ type ErrorResponseError struct {
 	Message *string `json:"message,omitempty"`
 }
 
+// ListAgreementTerms ...
+type ListAgreementTerms struct {
+	autorest.Response `json:"-"`
+	Value             *[]AgreementTerms `json:"value,omitempty"`
+}
+
 // Operation microsoft.MarketplaceOrdering REST API operation
 type Operation struct {
 	// Name - Operation name: {provider}/{resource}/{operation}


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5279