### PR TITLE
[AutoPR search/resource-manager] Azure Search: Resource Manager: Support 'None' Identity type

### DIFF
--- a/profiles/latest/search/mgmt/search/models.go
+++ b/profiles/latest/search/mgmt/search/models.go
@@ -39,6 +39,13 @@ const (
 	HighDensity HostingMode = original.HighDensity
 )
 
+type IdentityType = original.IdentityType
+
+const (
+	None           IdentityType = original.None
+	SystemAssigned IdentityType = original.SystemAssigned
+)
+
 type ProvisioningState = original.ProvisioningState
 
 const (
@@ -133,6 +140,9 @@ func PossibleAdminKeyKindValues() []AdminKeyKind {
 }
 func PossibleHostingModeValues() []HostingMode {
 	return original.PossibleHostingModeValues()
+}
+func PossibleIdentityTypeValues() []IdentityType {
+	return original.PossibleIdentityTypeValues()
 }
 func PossibleProvisioningStateValues() []ProvisioningState {
 	return original.PossibleProvisioningStateValues()

--- a/profiles/preview/search/mgmt/search/models.go
+++ b/profiles/preview/search/mgmt/search/models.go
@@ -39,6 +39,13 @@ const (
 	HighDensity HostingMode = original.HighDensity
 )
 
+type IdentityType = original.IdentityType
+
+const (
+	None           IdentityType = original.None
+	SystemAssigned IdentityType = original.SystemAssigned
+)
+
 type ProvisioningState = original.ProvisioningState
 
 const (
@@ -133,6 +140,9 @@ func PossibleAdminKeyKindValues() []AdminKeyKind {
 }
 func PossibleHostingModeValues() []HostingMode {
 	return original.PossibleHostingModeValues()
+}
+func PossibleIdentityTypeValues() []IdentityType {
+	return original.PossibleIdentityTypeValues()
 }
 func PossibleProvisioningStateValues() []ProvisioningState {
 	return original.PossibleProvisioningStateValues()

--- a/services/search/mgmt/2015-08-19/search/models.go
+++ b/services/search/mgmt/2015-08-19/search/models.go
@@ -57,6 +57,21 @@ func PossibleHostingModeValues() []HostingMode {
 	return []HostingMode{Default, HighDensity}
 }
 
+// IdentityType enumerates the values for identity type.
+type IdentityType string
+
+const (
+	// None ...
+	None IdentityType = "None"
+	// SystemAssigned ...
+	SystemAssigned IdentityType = "SystemAssigned"
+)
+
+// PossibleIdentityTypeValues returns an array of possible values for the IdentityType const type.
+func PossibleIdentityTypeValues() []IdentityType {
+	return []IdentityType{None, SystemAssigned}
+}
+
 // ProvisioningState enumerates the values for provisioning state.
 type ProvisioningState string
 
@@ -186,8 +201,8 @@ type Identity struct {
 	PrincipalID *string `json:"principalId,omitempty"`
 	// TenantID - The tenant ID of resource.
 	TenantID *string `json:"tenantId,omitempty"`
-	// Type - The identity type.
-	Type *string `json:"type,omitempty"`
+	// Type - The identity type. Possible values include: 'None', 'SystemAssigned'
+	Type IdentityType `json:"type,omitempty"`
 }
 
 // ListQueryKeysResult response containing the query API keys for a given Azure Search service.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5319