### PR TITLE
[AutoPR graphrbac/data-plane] graph: identifierUris should not be required

### DIFF
--- a/services/graphrbac/1.6/graphrbac/applications.go
+++ b/services/graphrbac/1.6/graphrbac/applications.go
@@ -142,8 +142,7 @@ func (client ApplicationsClient) Create(ctx context.Context, parameters Applicat
 	}
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: parameters,
-			Constraints: []validation.Constraint{{Target: "parameters.DisplayName", Name: validation.Null, Rule: true, Chain: nil},
-				{Target: "parameters.IdentifierUris", Name: validation.Null, Rule: true, Chain: nil}}}}); err != nil {
+			Constraints: []validation.Constraint{{Target: "parameters.DisplayName", Name: validation.Null, Rule: true, Chain: nil}}}}); err != nil {
 		return result, validation.NewError("graphrbac.ApplicationsClient", "Create", err.Error())
 	}
 


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5425