### PR TITLE
[AutoPR containerregistry/resource-manager] [ACR] Add Readonly RunErrorMessage to RunProperties

### DIFF
--- a/services/containerregistry/mgmt/2017-10-01/containerregistry/models.go
+++ b/services/containerregistry/mgmt/2017-10-01/containerregistry/models.go
@@ -1861,6 +1861,10 @@ type Target struct {
 	URL *string `json:"url,omitempty"`
 	// Tag - The tag name.
 	Tag *string `json:"tag,omitempty"`
+	// Name - The name of the artifact.
+	Name *string `json:"name,omitempty"`
+	// Version - The version of the artifact.
+	Version *string `json:"version,omitempty"`
 }
 
 // TrustPolicy an object that represents content trust policy for a container registry.

--- a/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
+++ b/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
@@ -3310,7 +3310,7 @@ type RunProperties struct {
 	SourceRegistryAuth *string `json:"sourceRegistryAuth,omitempty"`
 	// CustomRegistries - The list of custom registries that were logged in during this run.
 	CustomRegistries *[]string `json:"customRegistries,omitempty"`
-	// RunErrorMessage - The run error message.
+	// RunErrorMessage - The error message received from backend systems after the run is scheduled.
 	RunErrorMessage *string `json:"runErrorMessage,omitempty"`
 	// ProvisioningState - The provisioning state of a run. Possible values include: 'Creating', 'Updating', 'Deleting', 'Succeeded', 'Failed', 'Canceled'
 	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`

--- a/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
+++ b/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
@@ -3639,6 +3639,10 @@ type Target struct {
 	URL *string `json:"url,omitempty"`
 	// Tag - The tag name.
 	Tag *string `json:"tag,omitempty"`
+	// Name - The name of the artifact.
+	Name *string `json:"name,omitempty"`
+	// Version - The version of the artifact.
+	Version *string `json:"version,omitempty"`
 }
 
 // Task the task that has the ARM resource and task properties.

--- a/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
+++ b/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
@@ -3310,6 +3310,8 @@ type RunProperties struct {
 	SourceRegistryAuth *string `json:"sourceRegistryAuth,omitempty"`
 	// CustomRegistries - The list of custom registries that were logged in during this run.
 	CustomRegistries *[]string `json:"customRegistries,omitempty"`
+	// RunErrorMessage - The run error message.
+	RunErrorMessage *string `json:"runErrorMessage,omitempty"`
 	// ProvisioningState - The provisioning state of a run. Possible values include: 'Creating', 'Updating', 'Deleting', 'Succeeded', 'Failed', 'Canceled'
 	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
 	// IsArchiveEnabled - The value that indicates whether archiving is enabled or not.

--- a/services/preview/containerregistry/mgmt/2018-02-01/containerregistry/models.go
+++ b/services/preview/containerregistry/mgmt/2018-02-01/containerregistry/models.go
@@ -3962,6 +3962,10 @@ type Target struct {
 	URL *string `json:"url,omitempty"`
 	// Tag - The tag name.
 	Tag *string `json:"tag,omitempty"`
+	// Name - The name of the artifact.
+	Name *string `json:"name,omitempty"`
+	// Version - The version of the artifact.
+	Version *string `json:"version,omitempty"`
 }
 
 // TrustPolicy an object that represents content trust policy for a container registry.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5430