### PR TITLE
[AutoPR containerregistry/resource-manager] [ACR] Add Readonly RunErrorMessage to RunProperties

### DIFF
--- a/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
+++ b/services/containerregistry/mgmt/2018-09-01/containerregistry/models.go
@@ -3310,6 +3310,8 @@ type RunProperties struct {
 	SourceRegistryAuth *string `json:"sourceRegistryAuth,omitempty"`
 	// CustomRegistries - The list of custom registries that were logged in during this run.
 	CustomRegistries *[]string `json:"customRegistries,omitempty"`
+	// RunErrorMessage - The error message received from backend systems after the run is scheduled.
+	RunErrorMessage *string `json:"runErrorMessage,omitempty"`
 	// ProvisioningState - The provisioning state of a run. Possible values include: 'Creating', 'Updating', 'Deleting', 'Succeeded', 'Failed', 'Canceled'
 	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
 	// IsArchiveEnabled - The value that indicates whether archiving is enabled or not.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5430