### PR TITLE
[AutoPR cognitiveservices/data-plane/TranslatorText] typo: cognitiveservices/data-plane/TranslatorText

### DIFF
--- a/services/cognitiveservices/v3.0/translatortext/translator.go
+++ b/services/cognitiveservices/v3.0/translatortext/translator.go
@@ -566,9 +566,9 @@ func (client TranslatorClient) DictionaryExamplesResponder(resp *http.Response) 
 // * `confidence`- A value between 0.0 and 1.0 which represents the "confidence" (or perhaps more accurately,
 // "probability in the training data") of that translation pair. The sum of confidence scores for one source
 // word may or may not sum to 1.0.
-// * `prefixWord-` A string giving the the word to display as a prefix of the translation. Currently, this is
-// the gendered determiner of nouns, in languages that have gendered determiners. For example, the prefix of
-// the Spanish word "mosca" is "la", since "mosca" is a feminine noun in Spanish. This is only dependent on the
+// * `prefixWord-` A string giving the word to display as a prefix of the translation. Currently, this is the
+// gendered determiner of nouns, in languages that have gendered determiners. For example, the prefix of the
+// Spanish word "mosca" is "la", since "mosca" is a feminine noun in Spanish. This is only dependent on the
 // translation, and not on the source. If there is no prefix, it will be the empty string.
 // * `backTranslations-` A list of "back translations" of the target. For example, source words that the target
 // can translate to. The list is guaranteed to contain the source word that was requested (e.g., if the source


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5484