### PR TITLE
[AutoPR containerservice/resource-manager] Adding customerAdminGroupId to OSA cluster swagger spec

### DIFF
--- a/services/containerservice/mgmt/2019-02-01/containerservice/models.go
+++ b/services/containerservice/mgmt/2019-02-01/containerservice/models.go
@@ -2227,6 +2227,8 @@ type OpenShiftManagedClusterAADIdentityProvider struct {
 	Secret *string `json:"secret,omitempty"`
 	// TenantID - The tenantId associated with the provider.
 	TenantID *string `json:"tenantId,omitempty"`
+	// CustomerAdminGroupID - The groupId to be granted cluster admin role.
+	CustomerAdminGroupID *string `json:"customerAdminGroupId,omitempty"`
 	// Kind - Possible values include: 'KindOpenShiftManagedClusterBaseIdentityProvider', 'KindAADIdentityProvider'
 	Kind Kind `json:"kind,omitempty"`
 }
@@ -2243,6 +2245,9 @@ func (osmcaip OpenShiftManagedClusterAADIdentityProvider) MarshalJSON() ([]byte,
 	}
 	if osmcaip.TenantID != nil {
 		objectMap["tenantId"] = osmcaip.TenantID
+	}
+	if osmcaip.CustomerAdminGroupID != nil {
+		objectMap["customerAdminGroupId"] = osmcaip.CustomerAdminGroupID
 	}
 	if osmcaip.Kind != "" {
 		objectMap["kind"] = osmcaip.Kind

--- a/services/preview/containerservice/mgmt/2018-08-01-preview/containerservice/models.go
+++ b/services/preview/containerservice/mgmt/2018-08-01-preview/containerservice/models.go
@@ -1899,6 +1899,8 @@ type OpenShiftManagedClusterAADIdentityProvider struct {
 	Secret *string `json:"secret,omitempty"`
 	// TenantID - The tenantId associated with the provider.
 	TenantID *string `json:"tenantId,omitempty"`
+	// CustomerAdminGroupID - The groupId to be granted cluster admin role.
+	CustomerAdminGroupID *string `json:"customerAdminGroupId,omitempty"`
 	// Kind - Possible values include: 'KindOpenShiftManagedClusterBaseIdentityProvider', 'KindAADIdentityProvider'
 	Kind Kind `json:"kind,omitempty"`
 }
@@ -1915,6 +1917,9 @@ func (osmcaip OpenShiftManagedClusterAADIdentityProvider) MarshalJSON() ([]byte,
 	}
 	if osmcaip.TenantID != nil {
 		objectMap["tenantId"] = osmcaip.TenantID
+	}
+	if osmcaip.CustomerAdminGroupID != nil {
+		objectMap["customerAdminGroupId"] = osmcaip.CustomerAdminGroupID
 	}
 	if osmcaip.Kind != "" {
 		objectMap["kind"] = osmcaip.Kind

--- a/services/preview/containerservice/mgmt/2018-09-30-preview/containerservice/models.go
+++ b/services/preview/containerservice/mgmt/2018-09-30-preview/containerservice/models.go
@@ -1878,6 +1878,8 @@ type OpenShiftManagedClusterAADIdentityProvider struct {
 	Secret *string `json:"secret,omitempty"`
 	// TenantID - The tenantId associated with the provider.
 	TenantID *string `json:"tenantId,omitempty"`
+	// CustomerAdminGroupID - The groupId to be granted cluster admin role.
+	CustomerAdminGroupID *string `json:"customerAdminGroupId,omitempty"`
 	// Kind - Possible values include: 'KindOpenShiftManagedClusterBaseIdentityProvider', 'KindAADIdentityProvider'
 	Kind Kind `json:"kind,omitempty"`
 }
@@ -1894,6 +1896,9 @@ func (osmcaip OpenShiftManagedClusterAADIdentityProvider) MarshalJSON() ([]byte,
 	}
 	if osmcaip.TenantID != nil {
 		objectMap["tenantId"] = osmcaip.TenantID
+	}
+	if osmcaip.CustomerAdminGroupID != nil {
+		objectMap["customerAdminGroupId"] = osmcaip.CustomerAdminGroupID
 	}
 	if osmcaip.Kind != "" {
 		objectMap["kind"] = osmcaip.Kind


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5491