### PR TITLE
[AutoPR compute/resource-manager] Adding doNotRunExtensionsOnOverprovisionedVMs property to swagger

### DIFF
--- a/services/compute/mgmt/2018-10-01/compute/models.go
+++ b/services/compute/mgmt/2018-10-01/compute/models.go
@@ -8574,6 +8574,8 @@ type VirtualMachineScaleSetProperties struct {
 	ProvisioningState *string `json:"provisioningState,omitempty"`
 	// Overprovision - Specifies whether the Virtual Machine Scale Set should be overprovisioned.
 	Overprovision *bool `json:"overprovision,omitempty"`
+	// DoNotRunExtensionsOnOverprovisionedVMs - In case of overprovisioning, determines whether extensions should be run immediately, or if they should be delayed until after overprovisioning has finished and the set of instances to keep have been selected.
+	DoNotRunExtensionsOnOverprovisionedVMs *bool `json:"doNotRunExtensionsOnOverprovisionedVMs,omitempty"`
 	// UniqueID - Specifies the ID which uniquely identifies a Virtual Machine Scale Set.
 	UniqueID *string `json:"uniqueId,omitempty"`
 	// SinglePlacementGroup - When true this limits the scale set to a single placement group, of max size 100 virtual machines.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5498