### PR TITLE
Use correct uuid.NewV1() API

### DIFF
--- a/storage/table_batch.go
+++ b/storage/table_batch.go
@@ -131,15 +131,22 @@ func (t *TableBatch) MergeEntity(entity *Entity) {
 // the changesets.
 // As per document https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/performing-entity-group-transactions
 func (t *TableBatch) ExecuteBatch() error {
-
-	changesetBoundary := fmt.Sprintf("changeset_%s", uuid.NewV1().String())
+	uuidV1, err := uuid.NewV1()
+	if err != nil {
+		return err
+	}
+	changesetBoundary := fmt.Sprintf("changeset_%s", uuidV1.String())
 	uri := t.Table.tsc.client.getEndpoint(tableServiceName, "$batch", nil)
 	changesetBody, err := t.generateChangesetBody(changesetBoundary)
 	if err != nil {
 		return err
 	}
 
-	boundary := fmt.Sprintf("batch_%s", uuid.NewV1().String())
+	uuidV1, err = uuid.NewV1()
+	if err != nil {
+		return err
+	}
+	boundary := fmt.Sprintf("batch_%s", uuidV1.String())
 	body, err := generateBody(changesetBody, changesetBoundary, boundary)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR fixes invalid usage of `uuid.NewV1()`.
This method returns a value and an error, and it was used inline, like it returns a single value.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/4690