### PR TITLE
Fix build break in storage for 'go get' consumers

### DIFF
--- a/storage/table_batch.go
+++ b/storage/table_batch.go
@@ -25,8 +25,6 @@ import (
 	"net/textproto"
 	"sort"
 	"strings"
-
-	uuid "github.com/satori/go.uuid"
 )
 
 // Operation type. Insert, Delete, Replace etc.
@@ -132,14 +130,24 @@ func (t *TableBatch) MergeEntity(entity *Entity) {
 // As per document https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/performing-entity-group-transactions
 func (t *TableBatch) ExecuteBatch() error {
 
-	changesetBoundary := fmt.Sprintf("changeset_%s", uuid.NewV1().String())
+	id, err := newUUID()
+	if err != nil {
+		return err
+	}
+
+	changesetBoundary := fmt.Sprintf("changeset_%s", id.String())
 	uri := t.Table.tsc.client.getEndpoint(tableServiceName, "$batch", nil)
 	changesetBody, err := t.generateChangesetBody(changesetBoundary)
 	if err != nil {
 		return err
 	}
 
-	boundary := fmt.Sprintf("batch_%s", uuid.NewV1().String())
+	id, err = newUUID()
+	if err != nil {
+		return err
+	}
+
+	boundary := fmt.Sprintf("batch_%s", id.String())
 	body, err := generateBody(changesetBody, changesetBoundary, boundary)
 	if err != nil {
 		return err

--- a/storage/util.go
+++ b/storage/util.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"bytes"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/xml"
@@ -29,6 +30,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 var (
@@ -241,4 +244,17 @@ func getMetadataFromHeaders(header http.Header) map[string]string {
 	}
 
 	return metadata
+}
+
+// newUUID returns a new uuid using RFC 4122 algorithm.
+func newUUID() (uuid.UUID, error) {
+	u := [16]byte{}
+	// Set all bits to randomly (or pseudo-randomly) chosen values.
+	_, err := rand.Read(u[:])
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	u[8] = (u[8]&(0xff>>2) | (0x02 << 6)) // u.setVariant(ReservedRFC4122)
+	u[6] = (u[6] & 0xF) | (uuid.V4 << 4)  // u.setVersion(V4)
+	return uuid.FromBytes(u[:])
 }


### PR DESCRIPTION
The v1.2.0 version of the go.uuid package has a different signature for
function NewV1() compared to HEAD causing build breaks for go getters.
Removed dependences on uuid.NewV1(), replaced with internal newUUID()
function taken from azure-storage-blob-go.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
