### PR TITLE
[AutoPR containerservice/resource-manager] Revert node public ip support from 2019-04-01 model.

### DIFF
--- a/services/containerservice/mgmt/2019-04-30/containerservice/models.go
+++ b/services/containerservice/mgmt/2019-04-30/containerservice/models.go
@@ -1563,8 +1563,6 @@ type ManagedClusterAgentPoolProfile struct {
 	ProvisioningState *string `json:"provisioningState,omitempty"`
 	// AvailabilityZones - (PREVIEW) Availability zones for nodes. Must use VirtualMachineScaleSets AgentPoolType.
 	AvailabilityZones *[]string `json:"availabilityZones,omitempty"`
-	// EnableNodePublicIP - Enable public IP for nodes
-	EnableNodePublicIP *bool `json:"enableNodePublicIP,omitempty"`
 }
 
 // ManagedClusterAgentPoolProfileProperties properties for the container service agent pool profile.
@@ -1595,8 +1593,6 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	ProvisioningState *string `json:"provisioningState,omitempty"`
 	// AvailabilityZones - (PREVIEW) Availability zones for nodes. Must use VirtualMachineScaleSets AgentPoolType.
 	AvailabilityZones *[]string `json:"availabilityZones,omitempty"`
-	// EnableNodePublicIP - Enable public IP for nodes
-	EnableNodePublicIP *bool `json:"enableNodePublicIP,omitempty"`
 }
 
 // ManagedClusterIdentity identity for the managed cluster.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5841