### PR TITLE
Add proper support for floats in entities

### DIFF
--- a/storage/entity.go
+++ b/storage/entity.go
@@ -257,7 +257,7 @@ func (e *Entity) MarshalJSON() ([]byte, error) {
 		case int64:
 			completeMap[typeKey] = OdataInt64
 			completeMap[k] = fmt.Sprintf("%v", v)
-		case float64:
+		case float32, float64:
 			completeMap[typeKey] = OdataDouble
 			completeMap[k] = fmt.Sprintf("%v", v)
 		default:

--- a/storage/entity.go
+++ b/storage/entity.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // Annotating as secure for gas scanning
@@ -257,6 +257,9 @@ func (e *Entity) MarshalJSON() ([]byte, error) {
 		case int64:
 			completeMap[typeKey] = OdataInt64
 			completeMap[k] = fmt.Sprintf("%v", v)
+		case float64:
+			completeMap[typeKey] = OdataDouble
+			completeMap[k] = fmt.Sprintf("%v", v)
 		default:
 			completeMap[k] = v
 		}
@@ -264,7 +267,8 @@ func (e *Entity) MarshalJSON() ([]byte, error) {
 			if !(completeMap[k] == OdataBinary ||
 				completeMap[k] == OdataDateTime ||
 				completeMap[k] == OdataGUID ||
-				completeMap[k] == OdataInt64) {
+				completeMap[k] == OdataInt64 ||
+				completeMap[k] == OdataDouble) {
 				return nil, fmt.Errorf("Odata.type annotation %v value is not valid", k)
 			}
 			valueKey := strings.TrimSuffix(k, OdataTypeSuffix)
@@ -339,6 +343,12 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 					return fmt.Errorf(errorTemplate, err)
 				}
 				props[valueKey] = i
+			case OdataDouble:
+				f, err := strconv.ParseFloat(str, 64)
+				if err != nil {
+					return fmt.Errorf(errorTemplate, err)
+				}
+				props[valueKey] = f
 			default:
 				return fmt.Errorf(errorTemplate, fmt.Sprintf("%v is not supported", v))
 			}

--- a/storage/entity_test.go
+++ b/storage/entity_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	chk "gopkg.in/check.v1"
 )
 
@@ -42,7 +42,7 @@ func (s *StorageEntitySuite) TestGet(c *chk.C) {
 	entity := table.GetEntityReference("mypartitionkey", "myrowkey")
 
 	props := map[string]interface{}{
-		"AmountDue":      200.23,
+		"AmountDue":      float64(200.23),
 		"CustomerCode":   uuid.FromStringOrNil("c9da6455-213d-42c9-9a79-3e9149a57833"),
 		"CustomerSince":  time.Date(1992, time.December, 20, 21, 55, 0, 0, time.UTC),
 		"IsActive":       true,
@@ -91,7 +91,7 @@ func (s *StorageEntitySuite) TestInsert(c *chk.C) {
 	entity := table.GetEntityReference("mypartitionkey", "myrowkey")
 
 	props := map[string]interface{}{
-		"AmountDue":      200.23,
+		"AmountDue":      float64(200.23),
 		"CustomerCode":   uuid.FromStringOrNil("c9da6455-213d-42c9-9a79-3e9149a57833"),
 		"CustomerSince":  time.Date(1992, time.December, 20, 21, 55, 0, 0, time.UTC),
 		"IsActive":       true,
@@ -134,7 +134,7 @@ func (s *StorageEntitySuite) TestUpdate(c *chk.C) {
 
 	entity := table.GetEntityReference("mypartitionkey", "myrowkey")
 	entity.Properties = map[string]interface{}{
-		"AmountDue":      200.23,
+		"AmountDue":      float64(200.23),
 		"CustomerCode":   uuid.FromStringOrNil("c9da6455-213d-42c9-9a79-3e9149a57833"),
 		"CustomerSince":  time.Date(1992, time.December, 20, 21, 55, 0, 0, time.UTC),
 		"IsActive":       true,
@@ -458,7 +458,7 @@ func (s *StorageEntitySuite) TestExecuteQueryNextResults(c *chk.C) {
 }
 
 func (s *StorageEntitySuite) Test_entityMarshalJSON(c *chk.C) {
-	expected := `{"Address":"Mountain View","Age":23,"AmountDue":200.23,"Binary":"YWJjZA==","Binary@odata.type":"Edm.Binary","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}`
+	expected := `{"Address":"Mountain View","Age":23,"AmountDue":"200.23","AmountDue@odata.type":"Edm.Double","Binary":"YWJjZA==","Binary@odata.type":"Edm.Binary","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}`
 
 	entity := Entity{
 		PartitionKey: "mypartitionkey",
@@ -466,7 +466,7 @@ func (s *StorageEntitySuite) Test_entityMarshalJSON(c *chk.C) {
 		Properties: map[string]interface{}{
 			"Address":        "Mountain View",
 			"Age":            23,
-			"AmountDue":      200.23,
+			"AmountDue":      float64(200.23),
 			"Binary":         []byte("abcd"),
 			"CustomerCode":   uuid.FromStringOrNil("c9da6455-213d-42c9-9a79-3e9149a57833"),
 			"CustomerSince":  time.Date(1992, time.December, 20, 21, 55, 0, 0, time.UTC),
@@ -502,7 +502,8 @@ func (s *StorageEntitySuite) Test_entityUnmarshalJSON(c *chk.C) {
         "Timestamp@odata.type":"Edm.DateTime",
         "Address": "Mountain View",
         "Age": 23,
-        "AmountDue":200.23,
+        "AmountDue":"200.23",
+        "AmountDue@odata.type":"Edm.Double",
         "Binary@odata.type": "Edm.Binary",
         "Binary": "YWJjZA==",
         "CustomerCode@odata.type":"Edm.Guid",
@@ -521,7 +522,7 @@ func (s *StorageEntitySuite) Test_entityUnmarshalJSON(c *chk.C) {
 	expectedProperties := map[string]interface{}{
 		"Address":        "Mountain View",
 		"Age":            23,
-		"AmountDue":      200.23,
+		"AmountDue":      float64(200.23),
 		"Binary":         []byte("abcd"),
 		"CustomerCode":   uuid.FromStringOrNil("c9da6455-213d-42c9-9a79-3e9149a57833"),
 		"CustomerSince":  time.Date(1992, 12, 20, 21, 55, 0, 0, time.UTC),

--- a/storage/entity_test.go
+++ b/storage/entity_test.go
@@ -42,7 +42,7 @@ func (s *StorageEntitySuite) TestGet(c *chk.C) {
 	entity := table.GetEntityReference("mypartitionkey", "myrowkey")
 
 	props := map[string]interface{}{
-		"AmountDue":      float64(200.23),
+		"AmountDue":      float32(200.23),
 		"CustomerCode":   uuid.FromStringOrNil("c9da6455-213d-42c9-9a79-3e9149a57833"),
 		"CustomerSince":  time.Date(1992, time.December, 20, 21, 55, 0, 0, time.UTC),
 		"IsActive":       true,
@@ -91,7 +91,7 @@ func (s *StorageEntitySuite) TestInsert(c *chk.C) {
 	entity := table.GetEntityReference("mypartitionkey", "myrowkey")
 
 	props := map[string]interface{}{
-		"AmountDue":      float64(200.23),
+		"AmountDue":      float32(200.23),
 		"CustomerCode":   uuid.FromStringOrNil("c9da6455-213d-42c9-9a79-3e9149a57833"),
 		"CustomerSince":  time.Date(1992, time.December, 20, 21, 55, 0, 0, time.UTC),
 		"IsActive":       true,
@@ -134,7 +134,7 @@ func (s *StorageEntitySuite) TestUpdate(c *chk.C) {
 
 	entity := table.GetEntityReference("mypartitionkey", "myrowkey")
 	entity.Properties = map[string]interface{}{
-		"AmountDue":      float64(200.23),
+		"AmountDue":      float32(200.23),
 		"CustomerCode":   uuid.FromStringOrNil("c9da6455-213d-42c9-9a79-3e9149a57833"),
 		"CustomerSince":  time.Date(1992, time.December, 20, 21, 55, 0, 0, time.UTC),
 		"IsActive":       true,

--- a/storage/odata.go
+++ b/storage/odata.go
@@ -26,6 +26,7 @@ const (
 
 	OdataBinary   = "Edm.Binary"
 	OdataDateTime = "Edm.DateTime"
+	OdataDouble   = "Edm.Double"
 	OdataGUID     = "Edm.Guid"
 	OdataInt64    = "Edm.Int64"
 

--- a/storage/recordings/StorageEntitySuite/TestDelete.yaml
+++ b/storage/recordings/StorageEntitySuite/TestDelete.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:EZbr90rtN7p5TmCd/xfA3tm6NyuGDRnetLfXXOuS8g0=
+      - SharedKey golangrocksonazure:AwadOf1V3vU8TqGmzLVn7FmDVtcVAW6Cx89WWFDS77M=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table29storageentitysuitetestdel')
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table29storageentitysuitetestdel')
       Preference-Applied:
@@ -48,11 +47,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81af-0002-0036-56b0-0102e5000000
+      - 6d47af46-a002-00b6-770f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"PartitionKey":"pkey1","RowKey":"rowkey1"}'
     form: {}
@@ -62,7 +62,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:6p3vO/gSyANM7ODnI7G8sLaqD35pMaNot3w03ZrGIPU=
+      - SharedKey golangrocksonazure:Sm/xPFhZXBfXMnuGks6wEOyzCaY/9uphDVo+la5jYo4=
       Content-Length:
       - "43"
       Content-Type:
@@ -70,25 +70,25 @@ interactions:
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table29storageentitysuitetestdel/@Element","odata.type":"golangrocksonazure.table29storageentitysuitetestdel","odata.id":"https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel(PartitionKey=''pkey1'',RowKey=''rowkey1'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.616343Z''\"","odata.editLink":"table29storageentitysuitetestdel(PartitionKey=''pkey1'',RowKey=''rowkey1'')","PartitionKey":"pkey1","RowKey":"rowkey1","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.616343Z"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table29storageentitysuitetestdel/@Element","odata.type":"golangrocksonazure.table29storageentitysuitetestdel","odata.id":"https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel(PartitionKey=''pkey1'',RowKey=''rowkey1'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A58.796946Z''\"","odata.editLink":"table29storageentitysuitetestdel(PartitionKey=''pkey1'',RowKey=''rowkey1'')","PartitionKey":"pkey1","RowKey":"rowkey1","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:58.796946Z"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.616343Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A58.796946Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel(PartitionKey='pkey1',RowKey='rowkey1')
       Preference-Applied:
@@ -98,11 +98,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81b1-0002-0036-57b0-0102e5000000
+      - 6d47af53-a002-00b6-020f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -110,18 +111,18 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:VRhrHYGNU+UA0QTsP7GBHIS3cYumNbuvBXmESIHFsN4=
+      - SharedKey golangrocksonazure:PEK+1qI+/DqU3OkiW9phgxFrh9wysQVeuiXVCe0apKY=
       If-Match:
-      - W/"datetime'2017-07-20T23%3A34%3A05.616343Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A58.796946Z'"
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel%28PartitionKey=%27pkey1%27,%20RowKey=%27rowkey1%27%29
     method: DELETE
   response:
@@ -132,17 +133,18 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81b3-0002-0036-59b0-0102e5000000
+      - 6d47af61-a002-00b6-100f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"PartitionKey":"pkey2","RowKey":"rowkey2"}'
     form: {}
@@ -152,7 +154,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:6p3vO/gSyANM7ODnI7G8sLaqD35pMaNot3w03ZrGIPU=
+      - SharedKey golangrocksonazure:Sm/xPFhZXBfXMnuGks6wEOyzCaY/9uphDVo+la5jYo4=
       Content-Length:
       - "43"
       Content-Type:
@@ -160,12 +162,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel
     method: POST
   response:
@@ -178,9 +180,9 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel(PartitionKey='pkey2',RowKey='rowkey2')
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.6363591Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A58.8569886Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel(PartitionKey='pkey2',RowKey='rowkey2')
       Preference-Applied:
@@ -190,11 +192,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81b4-0002-0036-5ab0-0102e5000000
+      - 6d47af6d-a002-00b6-1c0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -202,39 +205,40 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:t7T32NPW6eFvJArSHI7At9hBkr5aDgZzRt4e6xyrj9I=
+      - SharedKey golangrocksonazure:2UCLyfW50Ff8Jjvhb+0j1fLrXawKhSeX3gl9IaGCjIY=
       If-Match:
       - GolangRocksOnAzure
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel%28PartitionKey=%27pkey2%27,%20RowKey=%27rowkey2%27%29
     method: DELETE
   response:
     body: '{"odata.error":{"code":"InvalidInput","message":{"lang":"en-US","value":"The
       etag value ''GolangRocksOnAzure'' specified in one of the request headers is
-      not valid. Please make sure only one etag value is specified and is valid.\nRequestId:875b81b5-0002-0036-5bb0-0102e5000000\nTime:2017-07-20T23:34:05.6553710Z"}}}'
+      not valid. Please make sure only one etag value is specified and is valid.\nRequestId:6d47af6f-a002-00b6-1e0f-018a7b000000\nTime:2019-05-02T17:47:58.8840078Z"}}}'
     headers:
       Content-Type:
       - application/json;odata=nometadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81b5-0002-0036-5bb0-0102e5000000
+      - 6d47af6f-a002-00b6-1e0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 400 Bad Request
     code: 400
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -242,18 +246,18 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:t7T32NPW6eFvJArSHI7At9hBkr5aDgZzRt4e6xyrj9I=
+      - SharedKey golangrocksonazure:2UCLyfW50Ff8Jjvhb+0j1fLrXawKhSeX3gl9IaGCjIY=
       If-Match:
       - '*'
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel%28PartitionKey=%27pkey2%27,%20RowKey=%27rowkey2%27%29
     method: DELETE
   response:
@@ -264,17 +268,18 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81b6-0002-0036-5cb0-0102e5000000
+      - 6d47af72-a002-00b6-210f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -282,16 +287,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:3d7PNy4U2GmhKomLD1O1tD8spXx9GeVbuArWtbHiJFU=
+      - SharedKey golangrocksonazure:fpFTa64ehCTQSh5HZ8fRh7ihem+/uIGosugwLe9I4aU=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table29storageentitysuitetestdel%27%29?timeout=30
     method: DELETE
   response:
@@ -302,14 +307,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81bb-0002-0036-61b0-0102e5000000
+      - 6d47af75-a002-00b6-240f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/TestExecuteQueryNextResults.yaml
+++ b/storage/recordings/StorageEntitySuite/TestExecuteQueryNextResults.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:EZbr90rtN7p5TmCd/xfA3tm6NyuGDRnetLfXXOuS8g0=
+      - SharedKey golangrocksonazure:AwadOf1V3vU8TqGmzLVn7FmDVtcVAW6Cx89WWFDS77M=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table46storageentitysuitetestexe')
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table46storageentitysuitetestexe')
       Preference-Applied:
@@ -48,11 +47,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81c1-0002-0036-65b0-0102e5000000
+      - 6d47af7e-a002-00b6-2a0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"PartitionKey":"pkey","RowKey":"r0"}'
     form: {}
@@ -62,7 +62,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:XgAFhnNhoaF6lUGEvhiAZ0dl+eJEwSCqcw6ycoY8crc=
+      - SharedKey golangrocksonazure:mGp9oA977KQ/kGipjQRVufB+9Be1WoIPvcMdGCUpwzI=
       Content-Length:
       - "37"
       Content-Type:
@@ -70,25 +70,25 @@ interactions:
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r0'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.7064077Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r0'')","PartitionKey":"pkey","RowKey":"r0","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.7064077Z"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r0'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A58.9890823Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r0'')","PartitionKey":"pkey","RowKey":"r0","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:58.9890823Z"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.7064077Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A58.9890823Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey='pkey',RowKey='r0')
       Preference-Applied:
@@ -98,11 +98,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81c3-0002-0036-66b0-0102e5000000
+      - 6d47af89-a002-00b6-340f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: '{"PartitionKey":"pkey","RowKey":"r1"}'
     form: {}
@@ -112,7 +113,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:XgAFhnNhoaF6lUGEvhiAZ0dl+eJEwSCqcw6ycoY8crc=
+      - SharedKey golangrocksonazure:mGp9oA977KQ/kGipjQRVufB+9Be1WoIPvcMdGCUpwzI=
       Content-Length:
       - "37"
       Content-Type:
@@ -120,25 +121,25 @@ interactions:
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r1'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.7164148Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r1'')","PartitionKey":"pkey","RowKey":"r1","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.7164148Z"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r1'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.021105Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r1'')","PartitionKey":"pkey","RowKey":"r1","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.021105Z"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.7164148Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.021105Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey='pkey',RowKey='r1')
       Preference-Applied:
@@ -148,11 +149,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81c4-0002-0036-67b0-0102e5000000
+      - 6d47af98-a002-00b6-430f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: '{"PartitionKey":"pkey","RowKey":"r2"}'
     form: {}
@@ -162,7 +164,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:XgAFhnNhoaF6lUGEvhiAZ0dl+eJEwSCqcw6ycoY8crc=
+      - SharedKey golangrocksonazure:mGp9oA977KQ/kGipjQRVufB+9Be1WoIPvcMdGCUpwzI=
       Content-Length:
       - "37"
       Content-Type:
@@ -170,25 +172,25 @@ interactions:
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r2'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.726422Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r2'')","PartitionKey":"pkey","RowKey":"r2","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.726422Z"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r2'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.0501256Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r2'')","PartitionKey":"pkey","RowKey":"r2","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.0501256Z"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.726422Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.0501256Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey='pkey',RowKey='r2')
       Preference-Applied:
@@ -198,11 +200,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81c8-0002-0036-6bb0-0102e5000000
+      - 6d47afaa-a002-00b6-550f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: '{"PartitionKey":"pkey","RowKey":"r3"}'
     form: {}
@@ -212,7 +215,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:XgAFhnNhoaF6lUGEvhiAZ0dl+eJEwSCqcw6ycoY8crc=
+      - SharedKey golangrocksonazure:mGp9oA977KQ/kGipjQRVufB+9Be1WoIPvcMdGCUpwzI=
       Content-Length:
       - "37"
       Content-Type:
@@ -220,25 +223,25 @@ interactions:
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r3'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.7354285Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r3'')","PartitionKey":"pkey","RowKey":"r3","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.7354285Z"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r3'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.0821484Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r3'')","PartitionKey":"pkey","RowKey":"r3","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.0821484Z"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.7354285Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.0821484Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey='pkey',RowKey='r3')
       Preference-Applied:
@@ -248,11 +251,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81ca-0002-0036-6db0-0102e5000000
+      - 6d47afbc-a002-00b6-650f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: '{"PartitionKey":"pkey","RowKey":"r4"}'
     form: {}
@@ -262,7 +266,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:XgAFhnNhoaF6lUGEvhiAZ0dl+eJEwSCqcw6ycoY8crc=
+      - SharedKey golangrocksonazure:mGp9oA977KQ/kGipjQRVufB+9Be1WoIPvcMdGCUpwzI=
       Content-Length:
       - "37"
       Content-Type:
@@ -270,25 +274,25 @@ interactions:
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r4'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.7454357Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r4'')","PartitionKey":"pkey","RowKey":"r4","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.7454357Z"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe/@Element","odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r4'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.1121701Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r4'')","PartitionKey":"pkey","RowKey":"r4","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.1121701Z"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.7454357Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.1121701Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey='pkey',RowKey='r4')
       Preference-Applied:
@@ -298,11 +302,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81cd-0002-0036-70b0-0102e5000000
+      - 6d47afc5-a002-00b6-6c0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -310,25 +315,25 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:1rFMXgyzKxIYvrKSPG8sLSiM0QbHXmkSFrBts/7dP5Q=
+      - SharedKey golangrocksonazure:/wbl8hR7cQBnUTkElwLqHLTEnTIEbbopFaECEfQU++0=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe?%24top=2&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe","value":[{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r0'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.7064077Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r0'')","PartitionKey":"pkey","RowKey":"r0","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.7064077Z"},{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r1'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.7164148Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r1'')","PartitionKey":"pkey","RowKey":"r1","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.7164148Z"}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe","value":[{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r0'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A58.9890823Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r0'')","PartitionKey":"pkey","RowKey":"r0","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:58.9890823Z"},{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r1'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.021105Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r1'')","PartitionKey":"pkey","RowKey":"r1","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.021105Z"}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
@@ -338,11 +343,12 @@ interactions:
       X-Ms-Continuation-Nextrowkey:
       - 1!4!cjI-
       X-Ms-Request-Id:
-      - 875b81ce-0002-0036-71b0-0102e5000000
+      - 6d47afc9-a002-00b6-700f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -350,25 +356,25 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:1rFMXgyzKxIYvrKSPG8sLSiM0QbHXmkSFrBts/7dP5Q=
+      - SharedKey golangrocksonazure:/wbl8hR7cQBnUTkElwLqHLTEnTIEbbopFaECEfQU++0=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe?%24top=2&NextPartitionKey=1%218%21cGtleQ--&NextRowKey=1%214%21cjI-&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe","value":[{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r2'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.726422Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r2'')","PartitionKey":"pkey","RowKey":"r2","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.726422Z"},{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r3'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.7354285Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r3'')","PartitionKey":"pkey","RowKey":"r3","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.7354285Z"}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe","value":[{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r2'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.0501256Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r2'')","PartitionKey":"pkey","RowKey":"r2","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.0501256Z"},{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r3'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.0821484Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r3'')","PartitionKey":"pkey","RowKey":"r3","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.0821484Z"}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:04 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
@@ -378,11 +384,12 @@ interactions:
       X-Ms-Continuation-Nextrowkey:
       - 1!4!cjQ-
       X-Ms-Request-Id:
-      - 875b81d0-0002-0036-73b0-0102e5000000
+      - 6d47afcb-a002-00b6-720f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -390,35 +397,36 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:1rFMXgyzKxIYvrKSPG8sLSiM0QbHXmkSFrBts/7dP5Q=
+      - SharedKey golangrocksonazure:/wbl8hR7cQBnUTkElwLqHLTEnTIEbbopFaECEfQU++0=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe?%24top=2&NextPartitionKey=1%218%21cGtleQ--&NextRowKey=1%214%21cjQ-&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe","value":[{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r4'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.7454357Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r4'')","PartitionKey":"pkey","RowKey":"r4","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.7454357Z"}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table46storageentitysuitetestexe","value":[{"odata.type":"golangrocksonazure.table46storageentitysuitetestexe","odata.id":"https://golangrocksonazure.table.core.windows.net/table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r4'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.1121701Z''\"","odata.editLink":"table46storageentitysuitetestexe(PartitionKey=''pkey'',RowKey=''r4'')","PartitionKey":"pkey","RowKey":"r4","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.1121701Z"}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81d4-0002-0036-75b0-0102e5000000
+      - 6d47afd0-a002-00b6-760f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -426,16 +434,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:7kLM103T06YElqGv9d3TDcjGoJ7Y0Z4LcgxfHm8aPw4=
+      - SharedKey golangrocksonazure:npmIvhhx/VAD/uFukULcXZ5yuhqkVPIlusRMryUhYeE=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table46storageentitysuitetestexe%27%29?timeout=30
     method: DELETE
   response:
@@ -446,14 +454,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81d6-0002-0036-77b0-0102e5000000
+      - 6d47afd5-a002-00b6-7b0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/TestGet.yaml
+++ b/storage/recordings/StorageEntitySuite/TestGet.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:EZbr90rtN7p5TmCd/xfA3tm6NyuGDRnetLfXXOuS8g0=
+      - SharedKey golangrocksonazure:AwadOf1V3vU8TqGmzLVn7FmDVtcVAW6Cx89WWFDS77M=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table26storageentitysuitetestget')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table26storageentitysuitetestget')
       Preference-Applied:
@@ -48,13 +47,14 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81dc-0002-0036-7db0-0102e5000000
+      - 6d47afdf-a002-00b6-030f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
-    body: '{"AmountDue":200.23,"CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
+    body: '{"AmountDue":"200.23","AmountDue@odata.type":"Edm.Double","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
     headers:
       Accept:
@@ -62,20 +62,20 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:QjaoU3ULO2w0cvSbOxaXelRkwqEye3ETT3g6oudzBZA=
+      - SharedKey golangrocksonazure:lltgliIbKEJykazHGj5kO8s/dwKSdBZdu9dqCWlQU2I=
       Content-Length:
-      - "323"
+      - "361"
       Content-Type:
       - application/json
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget
     method: POST
   response:
@@ -88,9 +88,9 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey='mypartitionkey',RowKey='myrowkey')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.8324981Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.259274Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey='mypartitionkey',RowKey='myrowkey')
       Preference-Applied:
@@ -100,11 +100,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81df-0002-0036-7fb0-0102e5000000
+      - 6d47afe3-a002-00b6-060f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -112,37 +113,38 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:n4L7oJ+L2DiE/USRE/mIW1bwQ1XogOx2ml+lDyvZixE=
+      - SharedKey golangrocksonazure:RvkzQjmQDS7JP4U+5PRylLyXaEPCNsvy1GWYxxsq/KU=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29?%24select=IsActive&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table26storageentitysuitetestget/@Element&$select=IsActive","odata.type":"golangrocksonazure.table26storageentitysuitetestget","odata.id":"https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.8324981Z''\"","odata.editLink":"table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","IsActive":true}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table26storageentitysuitetestget/@Element&$select=IsActive","odata.type":"golangrocksonazure.table26storageentitysuitetestget","odata.id":"https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.259274Z''\"","odata.editLink":"table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","IsActive":true}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.8324981Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.259274Z'"
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81e1-0002-0036-01b0-0102e5000000
+      - 6d47afe8-a002-00b6-0b0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -150,37 +152,38 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:n4L7oJ+L2DiE/USRE/mIW1bwQ1XogOx2ml+lDyvZixE=
+      - SharedKey golangrocksonazure:RvkzQjmQDS7JP4U+5PRylLyXaEPCNsvy1GWYxxsq/KU=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29?%24select=AmountDue%2CCustomerCode%2CCustomerSince%2CIsActive%2CNumberOfOrders&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table26storageentitysuitetestget/@Element&$select=AmountDue,CustomerCode,CustomerSince,IsActive,NumberOfOrders","odata.type":"golangrocksonazure.table26storageentitysuitetestget","odata.id":"https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.8324981Z''\"","odata.editLink":"table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table26storageentitysuitetestget/@Element&$select=AmountDue,CustomerCode,CustomerSince,IsActive,NumberOfOrders","odata.type":"golangrocksonazure.table26storageentitysuitetestget","odata.id":"https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.259274Z''\"","odata.editLink":"table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.8324981Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.259274Z'"
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81e3-0002-0036-03b0-0102e5000000
+      - 6d47afec-a002-00b6-0f0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -188,37 +191,38 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:n4L7oJ+L2DiE/USRE/mIW1bwQ1XogOx2ml+lDyvZixE=
+      - SharedKey golangrocksonazure:RvkzQjmQDS7JP4U+5PRylLyXaEPCNsvy1GWYxxsq/KU=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29?timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table26storageentitysuitetestget/@Element","odata.type":"golangrocksonazure.table26storageentitysuitetestget","odata.id":"https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.8324981Z''\"","odata.editLink":"table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.8324981Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table26storageentitysuitetestget/@Element","odata.type":"golangrocksonazure.table26storageentitysuitetestget","odata.id":"https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.259274Z''\"","odata.editLink":"table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.259274Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.8324981Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.259274Z'"
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81e4-0002-0036-04b0-0102e5000000
+      - 6d47aff0-a002-00b6-130f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -226,16 +230,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:1y0duhMkjc4p89TOsMCE01kYsEIo1cED7qhlBD1/IFA=
+      - SharedKey golangrocksonazure:jG1tfmQunTtK4DRCBQrroNhn/5dFx/dZfbanCLEoRgg=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table26storageentitysuitetestget%27%29?timeout=30
     method: DELETE
   response:
@@ -246,14 +250,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81e5-0002-0036-05b0-0102e5000000
+      - 6d47aff4-a002-00b6-170f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/TestInsert.yaml
+++ b/storage/recordings/StorageEntitySuite/TestInsert.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:EZbr90rtN7p5TmCd/xfA3tm6NyuGDRnetLfXXOuS8g0=
+      - SharedKey golangrocksonazure:AwadOf1V3vU8TqGmzLVn7FmDVtcVAW6Cx89WWFDS77M=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table29storageentitysuitetestins')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table29storageentitysuitetestins')
       Preference-Applied:
@@ -48,13 +47,14 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81e7-0002-0036-07b0-0102e5000000
+      - 6d47aff7-a002-00b6-1a0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
-    body: '{"AmountDue":200.23,"CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
+    body: '{"AmountDue":"200.23","AmountDue@odata.type":"Edm.Double","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
     headers:
       Accept:
@@ -62,20 +62,20 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:nJTyk/VW6pkVp0p0EWBNHYn1igE0AKbYBFl372P7shQ=
+      - SharedKey golangrocksonazure:dwmDR+ACR6lRETnAhyOI2eZro2YRQKwhyEiFHug913M=
       Content-Length:
-      - "323"
+      - "361"
       Content-Type:
       - application/json
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestins
     method: POST
   response:
@@ -88,9 +88,9 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='myrowkey')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.9075516Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.4303954Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='myrowkey')
       Preference-Applied:
@@ -100,13 +100,14 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81ee-0002-0036-0cb0-0102e5000000
+      - 6d47affa-a002-00b6-1c0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
-    body: '{"AmountDue":200.23,"CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey2","RowKey":"myrowkey2"}'
+    body: '{"AmountDue":"200.23","AmountDue@odata.type":"Edm.Double","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey2","RowKey":"myrowkey2"}'
     form: {}
     headers:
       Accept:
@@ -114,33 +115,33 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:nJTyk/VW6pkVp0p0EWBNHYn1igE0AKbYBFl372P7shQ=
+      - SharedKey golangrocksonazure:dwmDR+ACR6lRETnAhyOI2eZro2YRQKwhyEiFHug913M=
       Content-Length:
-      - "325"
+      - "363"
       Content-Type:
       - application/json
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestins
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table29storageentitysuitetestins/@Element","odata.type":"golangrocksonazure.table29storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestins(PartitionKey=''mypartitionkey2'',RowKey=''myrowkey2'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A05.9165584Z''\"","odata.editLink":"table29storageentitysuitetestins(PartitionKey=''mypartitionkey2'',RowKey=''myrowkey2'')","PartitionKey":"mypartitionkey2","RowKey":"myrowkey2","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:05.9165584Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table29storageentitysuitetestins/@Element","odata.type":"golangrocksonazure.table29storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestins(PartitionKey=''mypartitionkey2'',RowKey=''myrowkey2'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.4854344Z''\"","odata.editLink":"table29storageentitysuitetestins(PartitionKey=''mypartitionkey2'',RowKey=''myrowkey2'')","PartitionKey":"mypartitionkey2","RowKey":"myrowkey2","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.4854344Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.9165584Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.4854344Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestins(PartitionKey='mypartitionkey2',RowKey='myrowkey2')
       Preference-Applied:
@@ -150,11 +151,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81f3-0002-0036-11b0-0102e5000000
+      - 6d47b003-a002-00b6-250f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -162,16 +164,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:Xl7hSM6u8Fa4PpN2e3is1y9XlRgnAZAmKpBY8RF94xs=
+      - SharedKey golangrocksonazure:q71maD71+zMFukPRjezp79dA0EBt3Wc4ZEY0zWPMQuQ=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:57 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table29storageentitysuitetestins%27%29?timeout=30
     method: DELETE
   response:
@@ -182,14 +184,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81f5-0002-0036-13b0-0102e5000000
+      - 6d47b008-a002-00b6-290f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/TestInsertOrMerge.yaml
+++ b/storage/recordings/StorageEntitySuite/TestInsertOrMerge.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:EZbr90rtN7p5TmCd/xfA3tm6NyuGDRnetLfXXOuS8g0=
+      - SharedKey golangrocksonazure:EvhERFOGEgsxkYICess5C0tEAQacHWsQc6zVckwUNpc=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table36storageentitysuitetestins')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table36storageentitysuitetestins')
       Preference-Applied:
@@ -48,11 +47,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81f9-0002-0036-16b0-0102e5000000
+      - 6d47b012-a002-00b6-330f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","Name":"Luke","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -62,7 +62,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:sOJjzh//8e89L5IXHeSJFJzR4lWEElAb15cSZDWICG0=
+      - SharedKey golangrocksonazure:IRU8U7yJNgMO2Xi6+NRSJHAbBWSv9gEOEjacqOrJcj4=
       Content-Length:
       - "92"
       Content-Type:
@@ -70,12 +70,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table36storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: MERGE
   response:
@@ -86,9 +86,9 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.4985019Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.5661427Z'"
       Preference-Applied:
       - return-no-content
       Server:
@@ -96,11 +96,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81fc-0002-0036-18b0-0102e5000000
+      - 6d47b016-a002-00b6-360f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"Father":"Anakin","Mentor":"Yoda","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -110,7 +111,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:sOJjzh//8e89L5IXHeSJFJzR4lWEElAb15cSZDWICG0=
+      - SharedKey golangrocksonazure:IRU8U7yJNgMO2Xi6+NRSJHAbBWSv9gEOEjacqOrJcj4=
       Content-Length:
       - "87"
       Content-Type:
@@ -118,12 +119,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table36storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: MERGE
   response:
@@ -134,9 +135,9 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.5085092Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.5921612Z'"
       Preference-Applied:
       - return-no-content
       Server:
@@ -144,11 +145,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81fd-0002-0036-19b0-0102e5000000
+      - 6d47b019-a002-00b6-390f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -156,16 +158,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:2ucLelpLBmlJ45KnxKsHBJsYQdD6gg5dQDFUJlNVd7Q=
+      - SharedKey golangrocksonazure:tMxMGd2pmIiPljgUGKorZSWyr1L2DFV8Eyqh5NzubgU=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table36storageentitysuitetestins%27%29?timeout=30
     method: DELETE
   response:
@@ -176,14 +178,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b81ff-0002-0036-1bb0-0102e5000000
+      - 6d47b01f-a002-00b6-3f0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/TestInsertOrReplace.yaml
+++ b/storage/recordings/StorageEntitySuite/TestInsertOrReplace.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:AI3ePSpVLqD19g+mXulm9H31qjWddHbgztLq37YCVjU=
+      - SharedKey golangrocksonazure:EvhERFOGEgsxkYICess5C0tEAQacHWsQc6zVckwUNpc=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table38storageentitysuitetestins')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table38storageentitysuitetestins')
       Preference-Applied:
@@ -48,11 +47,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8205-0002-0036-21b0-0102e5000000
+      - 6d47b021-a002-00b6-410f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","HasEpicTheme":true,"Name":"Anakin","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -62,7 +62,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:wZoJdszhaWBx5PQf/22Be2fnWwDT3t18brijN39GT7k=
+      - SharedKey golangrocksonazure:K6qB3EfFJSiFobBmZIgZyUfO54b8YGJ6i4ltQpic7fA=
       Content-Length:
       - "114"
       Content-Type:
@@ -70,12 +70,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table38storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: PUT
   response:
@@ -86,9 +86,9 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.5515385Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.7032402Z'"
       Preference-Applied:
       - return-no-content
       Server:
@@ -96,11 +96,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b820a-0002-0036-25b0-0102e5000000
+      - 6d47b026-a002-00b6-450f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Organa","HasAwesomeDress":true,"Name":"Leia","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -110,7 +111,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:wZoJdszhaWBx5PQf/22Be2fnWwDT3t18brijN39GT7k=
+      - SharedKey golangrocksonazure:K6qB3EfFJSiFobBmZIgZyUfO54b8YGJ6i4ltQpic7fA=
       Content-Length:
       - "112"
       Content-Type:
@@ -118,12 +119,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table38storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: PUT
   response:
@@ -134,9 +135,9 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A05.5605446Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.728258Z'"
       Preference-Applied:
       - return-no-content
       Server:
@@ -144,11 +145,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8210-0002-0036-2bb0-0102e5000000
+      - 6d47b02a-a002-00b6-490f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -156,16 +158,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:JnnM/BD/EWVpimroWVWrozLd9kOWr/i3ogxlZofitR4=
+      - SharedKey golangrocksonazure:O5qZA2tx8/834rhkyr7009Q+LmDcFChPbiYzOk1Au+8=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table38storageentitysuitetestins%27%29?timeout=30
     method: DELETE
   response:
@@ -176,14 +178,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8212-0002-0036-2db0-0102e5000000
+      - 6d47b02f-a002-00b6-4e0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/TestMerge.yaml
+++ b/storage/recordings/StorageEntitySuite/TestMerge.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:AI3ePSpVLqD19g+mXulm9H31qjWddHbgztLq37YCVjU=
+      - SharedKey golangrocksonazure:EvhERFOGEgsxkYICess5C0tEAQacHWsQc6zVckwUNpc=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table28storageentitysuitetestmer')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table28storageentitysuitetestmer')
       Preference-Applied:
@@ -48,11 +47,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8216-0002-0036-31b0-0102e5000000
+      - 6d47b034-a002-00b6-530f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"Country":"Mexico","MalePoet":"Nezahualcoyotl","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -62,7 +62,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:/b1RTRDghnk+AFnNi7JYZjrxKf9eGRU5mK/0JDvrxcY=
+      - SharedKey golangrocksonazure:aJ866JhRwcvGMmZ7hGxvnxINCjso+o2+wEuanduB0dQ=
       Content-Length:
       - "100"
       Content-Type:
@@ -70,25 +70,25 @@ interactions:
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table28storageentitysuitetestmer/@Element","odata.type":"golangrocksonazure.table28storageentitysuitetestmer","odata.id":"https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A06.0616656Z''\"","odata.editLink":"table28storageentitysuitetestmer(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:06.0616656Z","Country":"Mexico","MalePoet":"Nezahualcoyotl"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table28storageentitysuitetestmer/@Element","odata.type":"golangrocksonazure.table28storageentitysuitetestmer","odata.id":"https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-02T17%3A47%3A59.8296787Z''\"","odata.editLink":"table28storageentitysuitetestmer(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:47:59.8296787Z","Country":"Mexico","MalePoet":"Nezahualcoyotl"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.0616656Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.8296787Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer(PartitionKey='mypartitionkey',RowKey='myrowkey')
       Preference-Applied:
@@ -98,11 +98,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b821b-0002-0036-35b0-0102e5000000
+      - 6d47b03f-a002-00b6-5d0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: '{"FemalePoet":"Sor Juana Ines de la Cruz","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -112,22 +113,22 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:jZYSxroXBs+RjeymYDVURDvZ5FfQEKvjzMTxEcvV94g=
+      - SharedKey golangrocksonazure:FrZf/3HXgmDH88wlY2iW9ezz3uoi7Pta2tdf5Bg9/I8=
       Content-Length:
       - "94"
       Content-Type:
       - application/json
       If-Match:
-      - W/"datetime'2017-07-20T23%3A34%3A06.0616656Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.8296787Z'"
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: MERGE
   response:
@@ -138,9 +139,9 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.0626656Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.8583505Z'"
       Preference-Applied:
       - return-no-content
       Server:
@@ -148,11 +149,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b821d-0002-0036-37b0-0102e5000000
+      - 6d47b044-a002-00b6-620f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FemalePoet":"Sor Juana Ines de la Cruz","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -162,7 +164,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:jZYSxroXBs+RjeymYDVURDvZ5FfQEKvjzMTxEcvV94g=
+      - SharedKey golangrocksonazure:FrZf/3HXgmDH88wlY2iW9ezz3uoi7Pta2tdf5Bg9/I8=
       Content-Length:
       - "94"
       Content-Type:
@@ -172,32 +174,33 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: MERGE
   response:
     body: '{"odata.error":{"code":"ConditionNotMet","message":{"lang":"en-US","value":"The
-      condition specified using HTTP conditional header(s) is not met.\nRequestId:875b821f-0002-0036-39b0-0102e5000000\nTime:2017-07-20T23:34:06.0896827Z"}}}'
+      condition specified using HTTP conditional header(s) is not met.\nRequestId:6d47b045-a002-00b6-630f-018a7b000000\nTime:2019-05-02T17:47:59.9057326Z"}}}'
     headers:
       Content-Type:
       - application/json;odata=nometadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b821f-0002-0036-39b0-0102e5000000
+      - 6d47b045-a002-00b6-630f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 412 Precondition Failed
     code: 412
+    duration: ""
 - request:
     body: '{"FemalePainter":"Frida Kahlo","MalePainter":"Diego Rivera","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -207,7 +210,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:jZYSxroXBs+RjeymYDVURDvZ5FfQEKvjzMTxEcvV94g=
+      - SharedKey golangrocksonazure:FrZf/3HXgmDH88wlY2iW9ezz3uoi7Pta2tdf5Bg9/I8=
       Content-Length:
       - "112"
       Content-Type:
@@ -217,12 +220,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: MERGE
   response:
@@ -233,9 +236,9 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.0636656Z'"
+      - W/"datetime'2019-05-02T17%3A47%3A59.9314024Z'"
       Preference-Applied:
       - return-no-content
       Server:
@@ -243,11 +246,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8223-0002-0036-3db0-0102e5000000
+      - 6d47b04c-a002-00b6-6a0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -255,16 +259,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:Z4CanwAtmar+XP1JYdwk9wndIDoXz9+vfoK0uhVfFno=
+      - SharedKey golangrocksonazure:WnR2KM6v+J2VqYaIH18j1NYcjD8MqkIUTUKPks5L/KY=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table28storageentitysuitetestmer%27%29?timeout=30
     method: DELETE
   response:
@@ -275,14 +279,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8227-0002-0036-41b0-0102e5000000
+      - 6d47b04e-a002-00b6-6c0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/TestUpdate.yaml
+++ b/storage/recordings/StorageEntitySuite/TestUpdate.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:AI3ePSpVLqD19g+mXulm9H31qjWddHbgztLq37YCVjU=
+      - SharedKey golangrocksonazure:EvhERFOGEgsxkYICess5C0tEAQacHWsQc6zVckwUNpc=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table29storageentitysuitetestupd')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table29storageentitysuitetestupd')
       Preference-Applied:
@@ -48,13 +47,14 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8229-0002-0036-43b0-0102e5000000
+      - 6d47b051-a002-00b6-6f0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
-    body: '{"AmountDue":200.23,"CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
+    body: '{"AmountDue":"200.23","AmountDue@odata.type":"Edm.Double","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerCode@odata.type":"Edm.Guid","CustomerSince":"1992-12-20T21:55:00Z","CustomerSince@odata.type":"Edm.DateTime","IsActive":true,"NumberOfOrders":"255","NumberOfOrders@odata.type":"Edm.Int64","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
     headers:
       Accept:
@@ -62,33 +62,33 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:OBwP+zofvIfL1l1WKfLqEJBuXVRR5S/jOGvSWmMnrac=
+      - SharedKey golangrocksonazure:/pXqwqEgbiaCgq85FTjtcVvf43zz+HzWP7zceDKZZlY=
       Content-Length:
-      - "323"
+      - "361"
       Content-Type:
       - application/json
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table29storageentitysuitetestupd/@Element","odata.type":"golangrocksonazure.table29storageentitysuitetestupd","odata.id":"https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A06.1417196Z''\"","odata.editLink":"table29storageentitysuitetestupd(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:06.1417196Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table29storageentitysuitetestupd/@Element","odata.type":"golangrocksonazure.table29storageentitysuitetestupd","odata.id":"https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-02T17%3A48%3A00.0238168Z''\"","odata.editLink":"table29storageentitysuitetestupd(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:48:00.0238168Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.1417196Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.0238168Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd(PartitionKey='mypartitionkey',RowKey='myrowkey')
       Preference-Applied:
@@ -98,11 +98,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b822b-0002-0036-44b0-0102e5000000
+      - 6d47b057-a002-00b6-740f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","HasEpicTheme":true,"Name":"Anakin","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -112,22 +113,22 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:zd7GlSbW43COv1K+UDx55rf6KiuDJKsron3WF+ihLio=
+      - SharedKey golangrocksonazure:2L6eZDzrPz7Bm5iD5VSZj5spycLlHoo4TfMW2RC4Q9A=
       Content-Length:
       - "114"
       Content-Type:
       - application/json
       If-Match:
-      - W/"datetime'2017-07-20T23%3A34%3A06.1417196Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.0238168Z'"
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: PUT
   response:
@@ -138,9 +139,9 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.1427196Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.057493Z'"
       Preference-Applied:
       - return-no-content
       Server:
@@ -148,11 +149,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b822f-0002-0036-48b0-0102e5000000
+      - 6d47b05c-a002-00b6-780f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","HasEpicTheme":true,"Name":"Anakin","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -162,7 +164,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:zd7GlSbW43COv1K+UDx55rf6KiuDJKsron3WF+ihLio=
+      - SharedKey golangrocksonazure:2L6eZDzrPz7Bm5iD5VSZj5spycLlHoo4TfMW2RC4Q9A=
       Content-Length:
       - "114"
       Content-Type:
@@ -172,32 +174,33 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: PUT
   response:
     body: '{"odata.error":{"code":"ConditionNotMet","message":{"lang":"en-US","value":"The
-      condition specified using HTTP conditional header(s) is not met.\nRequestId:875b8231-0002-0036-4ab0-0102e5000000\nTime:2017-07-20T23:34:06.1607332Z"}}}'
+      condition specified using HTTP conditional header(s) is not met.\nRequestId:6d47b060-a002-00b6-7b0f-018a7b000000\nTime:2019-05-02T17:48:00.0818575Z"}}}'
     headers:
       Content-Type:
       - application/json;odata=nometadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8231-0002-0036-4ab0-0102e5000000
+      - 6d47b060-a002-00b6-7b0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 412 Precondition Failed
     code: 412
+    duration: ""
 - request:
     body: '{"FamilyName":"Organa","HasAwesomeDress":true,"Name":"Leia","PartitionKey":"mypartitionkey","RowKey":"myrowkey"}'
     form: {}
@@ -207,7 +210,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:zd7GlSbW43COv1K+UDx55rf6KiuDJKsron3WF+ihLio=
+      - SharedKey golangrocksonazure:2L6eZDzrPz7Bm5iD5VSZj5spycLlHoo4TfMW2RC4Q9A=
       Content-Length:
       - "112"
       Content-Type:
@@ -217,12 +220,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
     method: PUT
   response:
@@ -233,9 +236,9 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.1437196Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.1065278Z'"
       Preference-Applied:
       - return-no-content
       Server:
@@ -243,11 +246,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8232-0002-0036-4bb0-0102e5000000
+      - 6d47b061-a002-00b6-7c0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -255,16 +259,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:aZmUvOVKai8L2/VkhLEnxCY9Nao6PCqJktue5/muzac=
+      - SharedKey golangrocksonazure:nahczLusnQNrjPwaKw53U1bZJHlEbnQV2VXaAK3PdOM=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table29storageentitysuitetestupd%27%29?timeout=30
     method: DELETE
   response:
@@ -275,14 +279,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8234-0002-0036-4db0-0102e5000000
+      - 6d47b066-a002-00b6-010f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/Test_InsertAndDeleteEntities.yaml
+++ b/storage/recordings/StorageEntitySuite/Test_InsertAndDeleteEntities.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:AI3ePSpVLqD19g+mXulm9H31qjWddHbgztLq37YCVjU=
+      - SharedKey golangrocksonazure:EvhERFOGEgsxkYICess5C0tEAQacHWsQc6zVckwUNpc=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table47storageentitysuitetestins')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table47storageentitysuitetestins')
       Preference-Applied:
@@ -48,11 +47,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8235-0002-0036-4eb0-0102e5000000
+      - 6d47b06f-a002-00b6-080f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","Name":"Luke","Number":3,"PartitionKey":"mypartitionkey","RowKey":"100"}'
     form: {}
@@ -62,7 +62,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:lF4Gbw3Vx6M2AoIj7k/WYDyQ3bi9Tbp9e8vD4eaE1VQ=
+      - SharedKey golangrocksonazure:8zcIcHDxGK1RK+UPwWPS65MnreXw8P0fWu0TyqXELFs=
       Content-Length:
       - "98"
       Content-Type:
@@ -70,12 +70,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins
     method: POST
   response:
@@ -88,9 +88,9 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='100')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.2097688Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.1929363Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='100')
       Preference-Applied:
@@ -100,11 +100,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8238-0002-0036-50b0-0102e5000000
+      - 6d47b073-a002-00b6-0b0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","Name":"Luke","Number":1,"PartitionKey":"mypartitionkey","RowKey":"200"}'
     form: {}
@@ -114,7 +115,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:lF4Gbw3Vx6M2AoIj7k/WYDyQ3bi9Tbp9e8vD4eaE1VQ=
+      - SharedKey golangrocksonazure:8zcIcHDxGK1RK+UPwWPS65MnreXw8P0fWu0TyqXELFs=
       Content-Length:
       - "98"
       Content-Type:
@@ -122,25 +123,25 @@ interactions:
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table47storageentitysuitetestins/@Element","odata.type":"golangrocksonazure.table47storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A06.219776Z''\"","odata.editLink":"table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:06.219776Z","FamilyName":"Skywalker","Name":"Luke","Number":1}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table47storageentitysuitetestins/@Element","odata.type":"golangrocksonazure.table47storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2019-05-02T17%3A48%3A00.2179541Z''\"","odata.editLink":"table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:48:00.2179541Z","FamilyName":"Skywalker","Name":"Luke","Number":1}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.219776Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.2179541Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='200')
       Preference-Applied:
@@ -150,11 +151,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b823a-0002-0036-52b0-0102e5000000
+      - 6d47b075-a002-00b6-0d0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -162,35 +164,36 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:OyTw86alN+gEQcOhCSkxmb55f79jXn0lsY35yf2bVc0=
+      - SharedKey golangrocksonazure:NMFEsWHZbh9bXJuGXKVl08JSaUAxb0G357H/SIooM0o=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins?%24filter=Number+eq+1&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table47storageentitysuitetestins","value":[{"odata.type":"golangrocksonazure.table47storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A06.219776Z''\"","odata.editLink":"table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:06.219776Z","FamilyName":"Skywalker","Name":"Luke","Number":1}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table47storageentitysuitetestins","value":[{"odata.type":"golangrocksonazure.table47storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2019-05-02T17%3A48%3A00.2179541Z''\"","odata.editLink":"table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:48:00.2179541Z","FamilyName":"Skywalker","Name":"Luke","Number":1}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b823b-0002-0036-53b0-0102e5000000
+      - 6d47b07b-a002-00b6-130f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -198,18 +201,18 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:rkPZo4uU/vhEmtJiJgzVlLnJWX0G5oJ3/p6VbMmaSk8=
+      - SharedKey golangrocksonazure:0ZaYtKXBkBTiFTN7MB1D6uZmJPQW5j2zb5y9PsZ0wF0=
       If-Match:
       - '*'
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27200%27%29
     method: DELETE
   response:
@@ -220,17 +223,18 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b823c-0002-0036-54b0-0102e5000000
+      - 6d47b080-a002-00b6-160f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -238,35 +242,36 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:OyTw86alN+gEQcOhCSkxmb55f79jXn0lsY35yf2bVc0=
+      - SharedKey golangrocksonazure:NMFEsWHZbh9bXJuGXKVl08JSaUAxb0G357H/SIooM0o=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins?timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table47storageentitysuitetestins","value":[{"odata.type":"golangrocksonazure.table47storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''100'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A06.2097688Z''\"","odata.editLink":"table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''100'')","PartitionKey":"mypartitionkey","RowKey":"100","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:06.2097688Z","FamilyName":"Skywalker","Name":"Luke","Number":3}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table47storageentitysuitetestins","value":[{"odata.type":"golangrocksonazure.table47storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''100'')","odata.etag":"W/\"datetime''2019-05-02T17%3A48%3A00.1929363Z''\"","odata.editLink":"table47storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''100'')","PartitionKey":"mypartitionkey","RowKey":"100","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:48:00.1929363Z","FamilyName":"Skywalker","Name":"Luke","Number":3}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b823d-0002-0036-55b0-0102e5000000
+      - 6d47b083-a002-00b6-190f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -274,16 +279,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:dj0mJIUUue6UdDG0npDXFiMqHNPb0og8f70Ih3WoLvc=
+      - SharedKey golangrocksonazure:yqLD4Lf6pICK440vl/opdPL7EAIdXnRwMz6TozGXyf0=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table47storageentitysuitetestins%27%29?timeout=30
     method: DELETE
   response:
@@ -294,14 +299,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b823e-0002-0036-56b0-0102e5000000
+      - 6d47b085-a002-00b6-1b0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/Test_InsertAndExecuteQuery.yaml
+++ b/storage/recordings/StorageEntitySuite/Test_InsertAndExecuteQuery.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:AI3ePSpVLqD19g+mXulm9H31qjWddHbgztLq37YCVjU=
+      - SharedKey golangrocksonazure:EvhERFOGEgsxkYICess5C0tEAQacHWsQc6zVckwUNpc=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table45storageentitysuitetestins')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table45storageentitysuitetestins')
       Preference-Applied:
@@ -48,11 +47,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8240-0002-0036-58b0-0102e5000000
+      - 6d47b091-a002-00b6-250f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke","PartitionKey":"mypartitionkey","RowKey":"100"}'
     form: {}
@@ -62,7 +62,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:2mQ+/toNV4Zej2Tj+dMXZvteNPWITD1yX+ejVvJukt0=
+      - SharedKey golangrocksonazure:Mln821bez6we1oqfCzI6NpUxD4QPSCkDWmhiOCm/siU=
       Content-Length:
       - "108"
       Content-Type:
@@ -70,12 +70,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table45storageentitysuitetestins
     method: POST
   response:
@@ -88,9 +88,9 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/table45storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='100')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.2918277Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.3780677Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table45storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='100')
       Preference-Applied:
@@ -100,11 +100,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8242-0002-0036-59b0-0102e5000000
+      - 6d47b09e-a002-00b6-2d0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke","PartitionKey":"mypartitionkey","RowKey":"200"}'
     form: {}
@@ -114,7 +115,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:2mQ+/toNV4Zej2Tj+dMXZvteNPWITD1yX+ejVvJukt0=
+      - SharedKey golangrocksonazure:Mln821bez6we1oqfCzI6NpUxD4QPSCkDWmhiOCm/siU=
       Content-Length:
       - "108"
       Content-Type:
@@ -122,12 +123,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table45storageentitysuitetestins
     method: POST
   response:
@@ -140,9 +141,9 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/table45storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='200')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.3028356Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.4110911Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table45storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='200')
       Preference-Applied:
@@ -152,11 +153,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8243-0002-0036-5ab0-0102e5000000
+      - 6d47b0a4-a002-00b6-330f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -164,35 +166,36 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:1PCHlLdFTrZfuJL4aBAVviq75FBLgDdZVWZtev+5adE=
+      - SharedKey golangrocksonazure:xVg7gvRHTDbq2W9eimh9vrJmZeo2kKqkMBucaVh5lLI=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table45storageentitysuitetestins?%24filter=RowKey+eq+%27200%27&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table45storageentitysuitetestins","value":[{"odata.type":"golangrocksonazure.table45storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table45storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A06.3028356Z''\"","odata.editLink":"table45storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:06.3028356Z","FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke"}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table45storageentitysuitetestins","value":[{"odata.type":"golangrocksonazure.table45storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table45storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2019-05-02T17%3A48%3A00.4110911Z''\"","odata.editLink":"table45storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:48:00.4110911Z","FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke"}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8244-0002-0036-5bb0-0102e5000000
+      - 6d47b0ab-a002-00b6-3a0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -200,16 +203,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:2np4hn/jbawvF+iCaf6ACraiW0fIVKDb/2wDtqWiv4k=
+      - SharedKey golangrocksonazure:egV+ezjnUNA13ntpG3E84nipc9eawKpR+24vWbk4SjM=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table45storageentitysuitetestins%27%29?timeout=30
     method: DELETE
   response:
@@ -220,14 +223,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8245-0002-0036-5cb0-0102e5000000
+      - 6d47b0b0-a002-00b6-3f0f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/StorageEntitySuite/Test_InsertAndGetEntities.yaml
+++ b/storage/recordings/StorageEntitySuite/Test_InsertAndGetEntities.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:AI3ePSpVLqD19g+mXulm9H31qjWddHbgztLq37YCVjU=
+      - SharedKey golangrocksonazure:EvhERFOGEgsxkYICess5C0tEAQacHWsQc6zVckwUNpc=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table44storageentitysuitetestins')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table44storageentitysuitetestins')
       Preference-Applied:
@@ -48,11 +47,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8246-0002-0036-5db0-0102e5000000
+      - 6d47b0b1-a002-00b6-400f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke","PartitionKey":"mypartitionkey","RowKey":"100"}'
     form: {}
@@ -62,7 +62,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:e7D5WTbpCj3NgfdPedQdWq5EzxzhrZMR9EF+2GAmPP4=
+      - SharedKey golangrocksonazure:a9SU3XOBN15xH5f4gq4sX5SojS8iRHsLWuAM5Ib+9t8=
       Content-Length:
       - "108"
       Content-Type:
@@ -70,12 +70,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:58 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins
     method: POST
   response:
@@ -88,9 +88,9 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='100')
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.3538744Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.5271735Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='100')
       Preference-Applied:
@@ -100,11 +100,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8248-0002-0036-5eb0-0102e5000000
+      - 6d47b0b7-a002-00b6-430f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
     body: '{"FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke","PartitionKey":"mypartitionkey","RowKey":"200"}'
     form: {}
@@ -114,7 +115,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:e7D5WTbpCj3NgfdPedQdWq5EzxzhrZMR9EF+2GAmPP4=
+      - SharedKey golangrocksonazure:i+nyrCnTHMb1p1WsgsvESCILrEf9IuP5tA0mrnqKC40=
       Content-Length:
       - "108"
       Content-Type:
@@ -122,25 +123,25 @@ interactions:
       Prefer:
       - return-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins
     method: POST
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table44storageentitysuitetestins/@Element","odata.type":"golangrocksonazure.table44storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A06.3628783Z''\"","odata.editLink":"table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:06.3628783Z","FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke"}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table44storageentitysuitetestins/@Element","odata.type":"golangrocksonazure.table44storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2019-05-02T17%3A48%3A00.5551933Z''\"","odata.editLink":"table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:48:00.5551933Z","FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke"}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Etag:
-      - W/"datetime'2017-07-20T23%3A34%3A06.3628783Z'"
+      - W/"datetime'2019-05-02T17%3A48%3A00.5551933Z'"
       Location:
       - https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins(PartitionKey='mypartitionkey',RowKey='200')
       Preference-Applied:
@@ -150,11 +151,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b824a-0002-0036-60b0-0102e5000000
+      - 6d47b0b8-a002-00b6-440f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 201 Created
     code: 201
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -162,35 +164,36 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:B6g/FdUzBvzmwMaGlafNvqTYGjV3VkZO4sof/A8EdNI=
+      - SharedKey golangrocksonazure:N/VD04LfiTQkxr7kkrrh6kVB2RYfQsx3k4G/Cq/nno8=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins?timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table44storageentitysuitetestins","value":[{"odata.type":"golangrocksonazure.table44storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''100'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A06.3538744Z''\"","odata.editLink":"table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''100'')","PartitionKey":"mypartitionkey","RowKey":"100","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:06.3538744Z","FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke"},{"odata.type":"golangrocksonazure.table44storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A06.3628783Z''\"","odata.editLink":"table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:06.3628783Z","FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke"}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table44storageentitysuitetestins","value":[{"odata.type":"golangrocksonazure.table44storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''100'')","odata.etag":"W/\"datetime''2019-05-02T17%3A48%3A00.5271735Z''\"","odata.editLink":"table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''100'')","PartitionKey":"mypartitionkey","RowKey":"100","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:48:00.5271735Z","FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke"},{"odata.type":"golangrocksonazure.table44storageentitysuitetestins","odata.id":"https://golangrocksonazure.table.core.windows.net/table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","odata.etag":"W/\"datetime''2019-05-02T17%3A48%3A00.5551933Z''\"","odata.editLink":"table44storageentitysuitetestins(PartitionKey=''mypartitionkey'',RowKey=''200'')","PartitionKey":"mypartitionkey","RowKey":"200","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:48:00.5551933Z","FamilyName":"Skywalker","HasCoolWeapon":true,"Name":"Luke"}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b824c-0002-0036-62b0-0102e5000000
+      - 6d47b0b9-a002-00b6-450f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -198,16 +201,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:oAWNszrMw6w3gjDAt0MDfoSjfk5UNPU+h9XJuz4XJPk=
+      - SharedKey golangrocksonazure:EW5mFEMlMWaTujt1I7S3dA8Kcap6Zn/mD0ife7XYT5M=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:06 GMT
+      - Thu, 02 May 2019 17:47:59 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table44storageentitysuitetestins%27%29?timeout=30
     method: DELETE
   response:
@@ -218,14 +221,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:05 GMT
+      - Thu, 02 May 2019 17:48:00 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b824d-0002-0036-63b0-0102e5000000
+      - 6d47b0ba-a002-00b6-460f-018a7b000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/TableBatchSuite/Test_BatchInsertDeleteSameEntity.yaml
+++ b/storage/recordings/TableBatchSuite/Test_BatchInsertDeleteSameEntity.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:19qYKaIWscHZl0FyBetemFrlUveL2KInnVIO+UobRUI=
+      - SharedKey golangrocksonazure:T7d3IsGXewXZ7IsMvnv7UFaRmvJyXCSgMThzTAg8F5o=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table48tablebatchsuitetestbatchi')
       Date:
-      - Thu, 20 Jul 2017 23:34:10 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table48tablebatchsuitetestbatchi')
       Preference-Applied:
@@ -48,60 +47,62 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b838c-0002-0036-03b0-0102e5000000
+      - 4711adf1-0002-0090-4b0e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
-    body: "--batch_ef29c3c4-6da3-11e7-98ad-6c3be5272b75\r\nContent-Type: multipart/mixed;
-      boundary=changeset_ef29c3c4-6da3-11e7-98ac-6c3be5272b75\r\n\r\n\r\n--changeset_ef29c3c4-6da3-11e7-98ac-6c3be5272b75\r\nContent-Transfer-Encoding:
+    body: "--batch_8a0b83eb-8f52-4b26-9daf-37484e1a5310\r\nContent-Type: multipart/mixed;
+      boundary=changeset_b99969e9-81ec-48ab-b0d7-1d31bbbe0d5d\r\n\r\n\r\n--changeset_b99969e9-81ec-48ab-b0d7-1d31bbbe0d5d\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table48tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":200.23,\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_ef29c3c4-6da3-11e7-98ac-6c3be5272b75\r\nContent-Transfer-Encoding:
+      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_b99969e9-81ec-48ab-b0d7-1d31bbbe0d5d\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nDELETE https://golangrocksonazure.table.core.windows.net/table48tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nIf-Match: *\r\nPrefer: return-no-content\r\n\r\n\r\n--changeset_ef29c3c4-6da3-11e7-98ac-6c3be5272b75--\r\n\r\n--batch_ef29c3c4-6da3-11e7-98ad-6c3be5272b75--\r\n"
+      application/json\r\nIf-Match: *\r\nPrefer: return-no-content\r\n\r\n\r\n--changeset_b99969e9-81ec-48ab-b0d7-1d31bbbe0d5d--\r\n\r\n--batch_8a0b83eb-8f52-4b26-9daf-37484e1a5310--\r\n"
     form: {}
     headers:
       Authorization:
-      - SharedKey golangrocksonazure:xpesUzw0nDp1bWkdipfYvyIor4UQFGDTXxLogQqC7Hk=
+      - SharedKey golangrocksonazure:UF7CKbZM5CaggshgXXUWWcib0045RBYNBM4Iqx6uVaU=
       Content-Type:
-      - multipart/mixed; boundary=batch_ef29c3c4-6da3-11e7-98ad-6c3be5272b75
+      - multipart/mixed; boundary=batch_8a0b83eb-8f52-4b26-9daf-37484e1a5310
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       X-Ms-Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/$batch
     method: POST
   response:
-    body: "--batchresponse_c4dd3af6-4c42-4cb6-828e-243ff21e6083\r\nContent-Type: multipart/mixed;
-      boundary=changesetresponse_88791cb4-6616-473a-8e2f-2166b7a8744c\r\n\r\n--changesetresponse_88791cb4-6616-473a-8e2f-2166b7a8744c\r\nContent-Type:
+    body: "--batchresponse_1b196260-d44f-4c48-a15f-d0321949a667\r\nContent-Type: multipart/mixed;
+      boundary=changesetresponse_0d43e739-f864-41d5-b93f-c61f85fdd8f5\r\n\r\n--changesetresponse_0d43e739-f864-41d5-b93f-c61f85fdd8f5\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 400 Bad
       Request\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nDataServiceVersion:
       3.0;\r\nContent-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\n\r\n{\"odata.error\":{\"code\":\"InvalidDuplicateRow\",\"message\":{\"lang\":\"en-US\",\"value\":\"1:The
       batch request contains multiple changes with same row key. An entity can appear
-      only once in a batch request.\\nRequestId:875b838e-0002-0036-04b0-0102e5000000\\nTime:2017-07-20T23:34:11.7237252Z\"}}}\r\n--changesetresponse_88791cb4-6616-473a-8e2f-2166b7a8744c--\r\n--batchresponse_c4dd3af6-4c42-4cb6-828e-243ff21e6083--\r\n"
+      only once in a batch request.\\nRequestId:4711ae06-0002-0090-5e0e-01c263000000\\nTime:2019-05-02T17:46:05.6836959Z\"}}}\r\n--changesetresponse_0d43e739-f864-41d5-b93f-c61f85fdd8f5--\r\n--batchresponse_1b196260-d44f-4c48-a15f-d0321949a667--\r\n"
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
-      - multipart/mixed; boundary=batchresponse_c4dd3af6-4c42-4cb6-828e-243ff21e6083
+      - multipart/mixed; boundary=batchresponse_1b196260-d44f-4c48-a15f-d0321949a667
       Date:
-      - Thu, 20 Jul 2017 23:34:10 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b838e-0002-0036-04b0-0102e5000000
+      - 4711ae06-0002-0090-5e0e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 202 Accepted
     code: 202
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -109,16 +110,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:MOsIZusDSZ3DMiB872Kyp2lKkkh8yZUUDVMgUBYMtQo=
+      - SharedKey golangrocksonazure:mRTd7MI4bRwiplc5IScZI7/Qozm7nno5jZGiuY2gA9Q=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table48tablebatchsuitetestbatchi%27%29?timeout=30
     method: DELETE
   response:
@@ -129,14 +130,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:10 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b838f-0002-0036-05b0-0102e5000000
+      - 4711ae19-0002-0090-710e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/TableBatchSuite/Test_BatchInsertMultipleEntities.yaml
+++ b/storage/recordings/TableBatchSuite/Test_BatchInsertMultipleEntities.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:19qYKaIWscHZl0FyBetemFrlUveL2KInnVIO+UobRUI=
+      - SharedKey golangrocksonazure:T7d3IsGXewXZ7IsMvnv7UFaRmvJyXCSgMThzTAg8F5o=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('tableme48tablebatchsuitetestbatc')
       Date:
-      - Thu, 20 Jul 2017 23:34:10 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('tableme48tablebatchsuitetestbatc')
       Preference-Applied:
@@ -48,61 +47,63 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8390-0002-0036-06b0-0102e5000000
+      - 4711ae28-0002-0090-800e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
-    body: "--batch_ef30a919-6da3-11e7-98ae-6c3be5272b75\r\nContent-Type: multipart/mixed;
-      boundary=changeset_ef30a919-6da3-11e7-98ad-6c3be5272b75\r\n\r\n\r\n--changeset_ef30a919-6da3-11e7-98ad-6c3be5272b75\r\nContent-Transfer-Encoding:
+    body: "--batch_2298b21d-085f-49f7-b23f-1603e12825ec\r\nContent-Type: multipart/mixed;
+      boundary=changeset_1e855f9d-09ba-4b0d-ac35-c22d5b65ba64\r\n\r\n\r\n--changeset_1e855f9d-09ba-4b0d-ac35-c22d5b65ba64\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":200.23,\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_ef30a919-6da3-11e7-98ad-6c3be5272b75\r\nContent-Transfer-Encoding:
+      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_1e855f9d-09ba-4b0d-ac35-c22d5b65ba64\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey2%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":111.23,\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey2\"}\r\n--changeset_ef30a919-6da3-11e7-98ad-6c3be5272b75--\r\n\r\n--batch_ef30a919-6da3-11e7-98ae-6c3be5272b75--\r\n"
+      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"111.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey2\"}\r\n--changeset_1e855f9d-09ba-4b0d-ac35-c22d5b65ba64--\r\n\r\n--batch_2298b21d-085f-49f7-b23f-1603e12825ec--\r\n"
     form: {}
     headers:
       Authorization:
-      - SharedKey golangrocksonazure:pIYjrohstaWPRYFMNuYVUyxlUxdq9aCRNGHAjzi/zDo=
+      - SharedKey golangrocksonazure:70WlUQToDB3k6AAiL8a2LYosa8ShylXg+mMCG+GT6tY=
       Content-Type:
-      - multipart/mixed; boundary=batch_ef30a919-6da3-11e7-98ae-6c3be5272b75
+      - multipart/mixed; boundary=batch_2298b21d-085f-49f7-b23f-1603e12825ec
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       X-Ms-Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/$batch
     method: POST
   response:
-    body: "--batchresponse_7ef4657c-3d03-4124-be07-7d71bd88808d\r\nContent-Type: multipart/mixed;
-      boundary=changesetresponse_ee6a4d77-21ad-4ba2-93f3-e410608d55e0\r\n\r\n--changesetresponse_ee6a4d77-21ad-4ba2-93f3-e410608d55e0\r\nContent-Type:
+    body: "--batchresponse_3e99b277-e37c-4fbe-8249-ff577726e12d\r\nContent-Type: multipart/mixed;
+      boundary=changesetresponse_5b24ce7d-e4fd-4f19-852f-cf45699ccfe4\r\n\r\n--changesetresponse_5b24ce7d-e4fd-4f19-852f-cf45699ccfe4\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No
       Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied:
-      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2017-07-20T23%3A34%3A11.310459Z'\"\r\n\r\n\r\n--changesetresponse_ee6a4d77-21ad-4ba2-93f3-e410608d55e0\r\nContent-Type:
+      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2019-05-02T17%3A46%3A05.8292503Z'\"\r\n\r\n\r\n--changesetresponse_5b24ce7d-e4fd-4f19-852f-cf45699ccfe4\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No
       Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied:
-      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2017-07-20T23%3A34%3A11.310459Z'\"\r\n\r\n\r\n--changesetresponse_ee6a4d77-21ad-4ba2-93f3-e410608d55e0--\r\n--batchresponse_7ef4657c-3d03-4124-be07-7d71bd88808d--\r\n"
+      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2019-05-02T17%3A46%3A05.8302514Z'\"\r\n\r\n\r\n--changesetresponse_5b24ce7d-e4fd-4f19-852f-cf45699ccfe4--\r\n--batchresponse_3e99b277-e37c-4fbe-8249-ff577726e12d--\r\n"
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
-      - multipart/mixed; boundary=batchresponse_7ef4657c-3d03-4124-be07-7d71bd88808d
+      - multipart/mixed; boundary=batchresponse_3e99b277-e37c-4fbe-8249-ff577726e12d
       Date:
-      - Thu, 20 Jul 2017 23:34:10 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8393-0002-0036-08b0-0102e5000000
+      - 4711ae36-0002-0090-0d0e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 202 Accepted
     code: 202
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -110,35 +111,36 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:GqQQaMHDx7V1Tp0qG7gPxHtyxk29oBVbUBuXA3EbKOA=
+      - SharedKey golangrocksonazure:qjwcTHwI52aLGnojizAefRMrlLpKFrdF93tUZU8XRoI=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc?%24top=2&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#tableme48tablebatchsuitetestbatc","value":[{"odata.type":"golangrocksonazure.tableme48tablebatchsuitetestbatc","odata.id":"https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A11.310459Z''\"","odata.editLink":"tableme48tablebatchsuitetestbatc(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:11.310459Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"},{"odata.type":"golangrocksonazure.tableme48tablebatchsuitetestbatc","odata.id":"https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc(PartitionKey=''mypartitionkey'',RowKey=''myrowkey2'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A11.310459Z''\"","odata.editLink":"tableme48tablebatchsuitetestbatc(PartitionKey=''mypartitionkey'',RowKey=''myrowkey2'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey2","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:11.310459Z","AmountDue":111.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#tableme48tablebatchsuitetestbatc","value":[{"odata.type":"golangrocksonazure.tableme48tablebatchsuitetestbatc","odata.id":"https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-02T17%3A46%3A05.8292503Z''\"","odata.editLink":"tableme48tablebatchsuitetestbatc(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:46:05.8292503Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"},{"odata.type":"golangrocksonazure.tableme48tablebatchsuitetestbatc","odata.id":"https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc(PartitionKey=''mypartitionkey'',RowKey=''myrowkey2'')","odata.etag":"W/\"datetime''2019-05-02T17%3A46%3A05.8302514Z''\"","odata.editLink":"tableme48tablebatchsuitetestbatc(PartitionKey=''mypartitionkey'',RowKey=''myrowkey2'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey2","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:46:05.8302514Z","AmountDue":111.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:10 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8394-0002-0036-09b0-0102e5000000
+      - 4711ae5b-0002-0090-300e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -146,16 +148,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:C2/AbzBy6EIXnncmFLw7Ihs07QehLuu4iIgB/frygq0=
+      - SharedKey golangrocksonazure:UzPuppz1TtyM7KpHwwy48cQPfsbTsdF8CFIsH1g5RhI=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27tableme48tablebatchsuitetestbatc%27%29?timeout=30
     method: DELETE
   response:
@@ -166,14 +168,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8395-0002-0036-0ab0-0102e5000000
+      - 4711ae63-0002-0090-380e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/TableBatchSuite/Test_BatchInsertSameEntryMultipleTimes.yaml
+++ b/storage/recordings/TableBatchSuite/Test_BatchInsertSameEntryMultipleTimes.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:19qYKaIWscHZl0FyBetemFrlUveL2KInnVIO+UobRUI=
+      - SharedKey golangrocksonazure:T7d3IsGXewXZ7IsMvnv7UFaRmvJyXCSgMThzTAg8F5o=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table54tablebatchsuitetestbatchi')
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table54tablebatchsuitetestbatchi')
       Preference-Applied:
@@ -48,60 +47,62 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8396-0002-0036-0bb0-0102e5000000
+      - 4711ae76-0002-0090-490e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
-    body: "--batch_ef3ab1db-6da3-11e7-98af-6c3be5272b75\r\nContent-Type: multipart/mixed;
-      boundary=changeset_ef3ab1db-6da3-11e7-98ae-6c3be5272b75\r\n\r\n\r\n--changeset_ef3ab1db-6da3-11e7-98ae-6c3be5272b75\r\nContent-Transfer-Encoding:
+    body: "--batch_7f3b70a2-3b29-4b45-937b-bcdb2d0e02b6\r\nContent-Type: multipart/mixed;
+      boundary=changeset_b018bf07-7dcc-4f67-b970-a17cdb9ab124\r\n\r\n\r\n--changeset_b018bf07-7dcc-4f67-b970-a17cdb9ab124\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table54tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":200.23,\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_ef3ab1db-6da3-11e7-98ae-6c3be5272b75\r\nContent-Transfer-Encoding:
+      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_b018bf07-7dcc-4f67-b970-a17cdb9ab124\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table54tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":200.23,\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_ef3ab1db-6da3-11e7-98ae-6c3be5272b75--\r\n\r\n--batch_ef3ab1db-6da3-11e7-98af-6c3be5272b75--\r\n"
+      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_b018bf07-7dcc-4f67-b970-a17cdb9ab124--\r\n\r\n--batch_7f3b70a2-3b29-4b45-937b-bcdb2d0e02b6--\r\n"
     form: {}
     headers:
       Authorization:
-      - SharedKey golangrocksonazure:7IdD/1Tun94lauSYsUhPnbnBnMJJpivTtin34J6VmkI=
+      - SharedKey golangrocksonazure:p3kLs9giSjTMOJTQCnctlf/av8MIQbj1mgSad30rxUU=
       Content-Type:
-      - multipart/mixed; boundary=batch_ef3ab1db-6da3-11e7-98af-6c3be5272b75
+      - multipart/mixed; boundary=batch_7f3b70a2-3b29-4b45-937b-bcdb2d0e02b6
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       X-Ms-Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/$batch
     method: POST
   response:
-    body: "--batchresponse_c968dcac-81f2-439a-95fb-f37fd0143b6f\r\nContent-Type: multipart/mixed;
-      boundary=changesetresponse_54662dc2-48d9-4e1f-b2ac-30d400756d12\r\n\r\n--changesetresponse_54662dc2-48d9-4e1f-b2ac-30d400756d12\r\nContent-Type:
+    body: "--batchresponse_e4e5bd5f-54e8-41df-a3c0-e107bab5d7d9\r\nContent-Type: multipart/mixed;
+      boundary=changesetresponse_ab19c097-7828-4a4b-b558-2fb0ab38f55e\r\n\r\n--changesetresponse_ab19c097-7828-4a4b-b558-2fb0ab38f55e\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 400 Bad
       Request\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied:
       return-no-content\r\nDataServiceVersion: 3.0;\r\nContent-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\n\r\n{\"odata.error\":{\"code\":\"InvalidDuplicateRow\",\"message\":{\"lang\":\"en-US\",\"value\":\"1:The
       batch request contains multiple changes with same row key. An entity can appear
-      only once in a batch request.\\nRequestId:875b8398-0002-0036-0cb0-0102e5000000\\nTime:2017-07-20T23:34:11.8358056Z\"}}}\r\n--changesetresponse_54662dc2-48d9-4e1f-b2ac-30d400756d12--\r\n--batchresponse_c968dcac-81f2-439a-95fb-f37fd0143b6f--\r\n"
+      only once in a batch request.\\nRequestId:4711ae87-0002-0090-590e-01c263000000\\nTime:2019-05-02T17:46:05.9458798Z\"}}}\r\n--changesetresponse_ab19c097-7828-4a4b-b558-2fb0ab38f55e--\r\n--batchresponse_e4e5bd5f-54e8-41df-a3c0-e107bab5d7d9--\r\n"
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
-      - multipart/mixed; boundary=batchresponse_c968dcac-81f2-439a-95fb-f37fd0143b6f
+      - multipart/mixed; boundary=batchresponse_e4e5bd5f-54e8-41df-a3c0-e107bab5d7d9
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8398-0002-0036-0cb0-0102e5000000
+      - 4711ae87-0002-0090-590e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 202 Accepted
     code: 202
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -109,16 +110,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:bgYxi5KDLsfPioNOqTap/xRGCPnSojDuZ2Z0a1tcZF4=
+      - SharedKey golangrocksonazure:EXvV46OUVMBp4TunwNsVR+Up4B+aVwgWsbEo0CxaS3Y=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table54tablebatchsuitetestbatchi%27%29?timeout=30
     method: DELETE
   response:
@@ -129,14 +130,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b8399-0002-0036-0db0-0102e5000000
+      - 4711ae98-0002-0090-6a0e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/TableBatchSuite/Test_BatchInsertThenDeleteDifferentBatches.yaml
+++ b/storage/recordings/TableBatchSuite/Test_BatchInsertThenDeleteDifferentBatches.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:19qYKaIWscHZl0FyBetemFrlUveL2KInnVIO+UobRUI=
+      - SharedKey golangrocksonazure:T7d3IsGXewXZ7IsMvnv7UFaRmvJyXCSgMThzTAg8F5o=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table58tablebatchsuitetestbatchi')
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table58tablebatchsuitetestbatchi')
       Preference-Applied:
@@ -48,55 +47,57 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b839a-0002-0036-0eb0-0102e5000000
+      - 4711aeaa-0002-0090-7c0e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
-    body: "--batch_ef43b2d5-6da3-11e7-98b0-6c3be5272b75\r\nContent-Type: multipart/mixed;
-      boundary=changeset_ef43b2d5-6da3-11e7-98af-6c3be5272b75\r\n\r\n\r\n--changeset_ef43b2d5-6da3-11e7-98af-6c3be5272b75\r\nContent-Transfer-Encoding:
+    body: "--batch_80adda97-ab59-4ebd-8d72-d8b2a5fd3048\r\nContent-Type: multipart/mixed;
+      boundary=changeset_605520d1-12f6-4066-87ee-dad439dfd94b\r\n\r\n\r\n--changeset_605520d1-12f6-4066-87ee-dad439dfd94b\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":200.23,\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_ef43b2d5-6da3-11e7-98af-6c3be5272b75--\r\n\r\n--batch_ef43b2d5-6da3-11e7-98b0-6c3be5272b75--\r\n"
+      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_605520d1-12f6-4066-87ee-dad439dfd94b--\r\n\r\n--batch_80adda97-ab59-4ebd-8d72-d8b2a5fd3048--\r\n"
     form: {}
     headers:
       Authorization:
-      - SharedKey golangrocksonazure:xjZfYClYVTJOJ1tU/NvPY6WWQtmkF5OqVS93aTyxTkQ=
+      - SharedKey golangrocksonazure:rH+c6DhhE3tyS4ETlPi6EXPcGRPCb5EWHAGCjw9e5U4=
       Content-Type:
-      - multipart/mixed; boundary=batch_ef43b2d5-6da3-11e7-98b0-6c3be5272b75
+      - multipart/mixed; boundary=batch_80adda97-ab59-4ebd-8d72-d8b2a5fd3048
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       X-Ms-Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/$batch
     method: POST
   response:
-    body: "--batchresponse_f1250f4a-401f-4ada-a9cb-c57703899695\r\nContent-Type: multipart/mixed;
-      boundary=changesetresponse_b3e59e13-302f-4f87-8eeb-688f3b054e6f\r\n\r\n--changesetresponse_b3e59e13-302f-4f87-8eeb-688f3b054e6f\r\nContent-Type:
+    body: "--batchresponse_5be4de5e-3b29-47d5-b0ce-6bd4f6958823\r\nContent-Type: multipart/mixed;
+      boundary=changesetresponse_80120739-b2b3-4025-88dc-5931a263e47e\r\n\r\n--changesetresponse_80120739-b2b3-4025-88dc-5931a263e47e\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No
       Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied:
-      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2017-07-20T23%3A34%3A11.4335423Z'\"\r\n\r\n\r\n--changesetresponse_b3e59e13-302f-4f87-8eeb-688f3b054e6f--\r\n--batchresponse_f1250f4a-401f-4ada-a9cb-c57703899695--\r\n"
+      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2019-05-02T17%3A46%3A06.0343962Z'\"\r\n\r\n\r\n--changesetresponse_80120739-b2b3-4025-88dc-5931a263e47e--\r\n--batchresponse_5be4de5e-3b29-47d5-b0ce-6bd4f6958823--\r\n"
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
-      - multipart/mixed; boundary=batchresponse_f1250f4a-401f-4ada-a9cb-c57703899695
+      - multipart/mixed; boundary=batchresponse_5be4de5e-3b29-47d5-b0ce-6bd4f6958823
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b839c-0002-0036-0fb0-0102e5000000
+      - 4711aec3-0002-0090-120e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 202 Accepted
     code: 202
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -104,79 +105,81 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:ATu3YuroKjhD1Fnv6SzUC5vKGd7UmQsPNPIWL8mm7FA=
+      - SharedKey golangrocksonazure:z+6CM+WuF2+vmEcso1rvMbQr9qKLrSKZDJlMj9RJ/gw=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi?%24top=2&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table58tablebatchsuitetestbatchi","value":[{"odata.type":"golangrocksonazure.table58tablebatchsuitetestbatchi","odata.id":"https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A11.4335423Z''\"","odata.editLink":"table58tablebatchsuitetestbatchi(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:11.4335423Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table58tablebatchsuitetestbatchi","value":[{"odata.type":"golangrocksonazure.table58tablebatchsuitetestbatchi","odata.id":"https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-02T17%3A46%3A06.0343962Z''\"","odata.editLink":"table58tablebatchsuitetestbatchi(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:46:06.0343962Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b839d-0002-0036-10b0-0102e5000000
+      - 4711aed9-0002-0090-280e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
-    body: "--batch_ef4693ee-6da3-11e7-98b1-6c3be5272b75\r\nContent-Type: multipart/mixed;
-      boundary=changeset_ef4693ee-6da3-11e7-98b0-6c3be5272b75\r\n\r\n\r\n--changeset_ef4693ee-6da3-11e7-98b0-6c3be5272b75\r\nContent-Transfer-Encoding:
+    body: "--batch_5bb35148-bb08-4bfc-9adf-e7f0f5b6e092\r\nContent-Type: multipart/mixed;
+      boundary=changeset_e45cb4ae-b3fb-4a25-b1a0-26727998d3b6\r\n\r\n\r\n--changeset_e45cb4ae-b3fb-4a25-b1a0-26727998d3b6\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nDELETE https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nIf-Match: *\r\nPrefer: return-no-content\r\n\r\n\r\n--changeset_ef4693ee-6da3-11e7-98b0-6c3be5272b75--\r\n\r\n--batch_ef4693ee-6da3-11e7-98b1-6c3be5272b75--\r\n"
+      application/json\r\nIf-Match: *\r\nPrefer: return-no-content\r\n\r\n\r\n--changeset_e45cb4ae-b3fb-4a25-b1a0-26727998d3b6--\r\n\r\n--batch_5bb35148-bb08-4bfc-9adf-e7f0f5b6e092--\r\n"
     form: {}
     headers:
       Authorization:
-      - SharedKey golangrocksonazure:7QMgDil3hVjeRAmKHR//MRW2CbRt5kwFsgscp6oBexY=
+      - SharedKey golangrocksonazure:5oiAcXz7usoWieXDuC0bR0F0FSvX3cOPm2dj0OO3Iv0=
       Content-Type:
-      - multipart/mixed; boundary=batch_ef4693ee-6da3-11e7-98b1-6c3be5272b75
+      - multipart/mixed; boundary=batch_5bb35148-bb08-4bfc-9adf-e7f0f5b6e092
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       X-Ms-Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/$batch
     method: POST
   response:
-    body: "--batchresponse_25ad2038-a6df-4100-923f-f0bb6c6fc612\r\nContent-Type: multipart/mixed;
-      boundary=changesetresponse_4f524076-9452-4381-a4e4-ad15fd393495\r\n\r\n--changesetresponse_4f524076-9452-4381-a4e4-ad15fd393495\r\nContent-Type:
+    body: "--batchresponse_ba653966-6da7-432f-9971-9000debc9286\r\nContent-Type: multipart/mixed;
+      boundary=changesetresponse_b84d804d-c612-46e3-b6d1-bc08a6cda813\r\n\r\n--changesetresponse_b84d804d-c612-46e3-b6d1-bc08a6cda813\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No
       Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nDataServiceVersion:
-      1.0;\r\n\r\n\r\n--changesetresponse_4f524076-9452-4381-a4e4-ad15fd393495--\r\n--batchresponse_25ad2038-a6df-4100-923f-f0bb6c6fc612--\r\n"
+      1.0;\r\n\r\n\r\n--changesetresponse_b84d804d-c612-46e3-b6d1-bc08a6cda813--\r\n--batchresponse_ba653966-6da7-432f-9971-9000debc9286--\r\n"
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
-      - multipart/mixed; boundary=batchresponse_25ad2038-a6df-4100-923f-f0bb6c6fc612
+      - multipart/mixed; boundary=batchresponse_ba653966-6da7-432f-9971-9000debc9286
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b839e-0002-0036-11b0-0102e5000000
+      - 4711aee3-0002-0090-2f0e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 202 Accepted
     code: 202
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -184,14 +187,14 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:ATu3YuroKjhD1Fnv6SzUC5vKGd7UmQsPNPIWL8mm7FA=
+      - SharedKey golangrocksonazure:z+6CM+WuF2+vmEcso1rvMbQr9qKLrSKZDJlMj9RJ/gw=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi?%24top=2&timeout=15
     method: GET
   response:
@@ -202,17 +205,18 @@ interactions:
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b839f-0002-0036-12b0-0102e5000000
+      - 4711aef3-0002-0090-3b0e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -220,16 +224,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:faE0LSu1ImrYkrsQy7aphzNJFCVEhe+3tX8Bftglj0w=
+      - SharedKey golangrocksonazure:bLqupiWQSOF+Z84XB7RH+hyi4GLu/jD7JpbafrHMAhw=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table58tablebatchsuitetestbatchi%27%29?timeout=30
     method: DELETE
   response:
@@ -240,14 +244,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b83a0-0002-0036-13b0-0102e5000000
+      - 4711aeff-0002-0090-460e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""

--- a/storage/recordings/TableBatchSuite/Test_BatchInsertThenMergeDifferentBatches.yaml
+++ b/storage/recordings/TableBatchSuite/Test_BatchInsertThenMergeDifferentBatches.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -12,7 +11,7 @@ interactions:
       Accept-Charset:
       - UTF-8
       Authorization:
-      - SharedKey golangrocksonazure:+tQ0CHBBr8KqtfNJZ9ipZgZ9CxD0Cuof10snosZI2GY=
+      - SharedKey golangrocksonazure:T7d3IsGXewXZ7IsMvnv7UFaRmvJyXCSgMThzTAg8F5o=
       Content-Length:
       - "49"
       Content-Type:
@@ -20,12 +19,12 @@ interactions:
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:12 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables?timeout=30
     method: POST
   response:
@@ -38,7 +37,7 @@ interactions:
       Dataserviceid:
       - https://golangrocksonazure.table.core.windows.net/Tables('table57tablebatchsuitetestbatchi')
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Location:
       - https://golangrocksonazure.table.core.windows.net/Tables('table57tablebatchsuitetestbatchi')
       Preference-Applied:
@@ -48,99 +47,102 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b83a1-0002-0036-14b0-0102e5000000
+      - 4711af14-0002-0090-590e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""
 - request:
-    body: "--batch_ef502eae-6da3-11e7-98b2-6c3be5272b75\r\nContent-Type: multipart/mixed;
-      boundary=changeset_ef502eae-6da3-11e7-98b1-6c3be5272b75\r\n\r\n\r\n--changeset_ef502eae-6da3-11e7-98b1-6c3be5272b75\r\nContent-Transfer-Encoding:
+    body: "--batch_40ee4d34-c711-4bd2-affc-83499e990f9b\r\nContent-Type: multipart/mixed;
+      boundary=changeset_9e4d24ec-c2ae-49fc-967e-b7558aa934a5\r\n\r\n\r\n--changeset_9e4d24ec-c2ae-49fc-967e-b7558aa934a5\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table57tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":200.23,\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_ef502eae-6da3-11e7-98b1-6c3be5272b75--\r\n\r\n--batch_ef502eae-6da3-11e7-98b2-6c3be5272b75--\r\n"
+      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_9e4d24ec-c2ae-49fc-967e-b7558aa934a5--\r\n\r\n--batch_40ee4d34-c711-4bd2-affc-83499e990f9b--\r\n"
     form: {}
     headers:
       Authorization:
-      - SharedKey golangrocksonazure:p4aDPSDWPtWHLxL0afiP2BTiTAzqqUJJsmo/+gH51VU=
+      - SharedKey golangrocksonazure:1JIF5E65rWYhRjSkWvxuQstTKTAtbxurhazXDpWf+lA=
       Content-Type:
-      - multipart/mixed; boundary=batch_ef502eae-6da3-11e7-98b2-6c3be5272b75
+      - multipart/mixed; boundary=batch_40ee4d34-c711-4bd2-affc-83499e990f9b
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       X-Ms-Date:
-      - Thu, 20 Jul 2017 23:34:12 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/$batch
     method: POST
   response:
-    body: "--batchresponse_0092b400-1327-4adb-898f-f4d6e46c73ac\r\nContent-Type: multipart/mixed;
-      boundary=changesetresponse_5825ce38-5ad0-4180-ab9b-4a6a45daab73\r\n\r\n--changesetresponse_5825ce38-5ad0-4180-ab9b-4a6a45daab73\r\nContent-Type:
+    body: "--batchresponse_59381db7-769a-46a8-a5bc-144358f70522\r\nContent-Type: multipart/mixed;
+      boundary=changesetresponse_f096b318-a873-401e-9728-2932c7d191b2\r\n\r\n--changesetresponse_f096b318-a873-401e-9728-2932c7d191b2\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No
       Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied:
-      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2017-07-20T23%3A34%3A11.5165989Z'\"\r\n\r\n\r\n--changesetresponse_5825ce38-5ad0-4180-ab9b-4a6a45daab73--\r\n--batchresponse_0092b400-1327-4adb-898f-f4d6e46c73ac--\r\n"
+      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2019-05-02T17%3A46%3A06.2095203Z'\"\r\n\r\n\r\n--changesetresponse_f096b318-a873-401e-9728-2932c7d191b2--\r\n--batchresponse_59381db7-769a-46a8-a5bc-144358f70522--\r\n"
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
-      - multipart/mixed; boundary=batchresponse_0092b400-1327-4adb-898f-f4d6e46c73ac
+      - multipart/mixed; boundary=batchresponse_59381db7-769a-46a8-a5bc-144358f70522
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b83a3-0002-0036-15b0-0102e5000000
+      - 4711af23-0002-0090-670e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 202 Accepted
     code: 202
+    duration: ""
 - request:
-    body: "--batch_ef522a6a-6da3-11e7-98b2-6c3be5272b75\r\nContent-Type: multipart/mixed;
-      boundary=changeset_ef520338-6da3-11e7-98b2-6c3be5272b75\r\n\r\n\r\n--changeset_ef520338-6da3-11e7-98b2-6c3be5272b75\r\nContent-Transfer-Encoding:
+    body: "--batch_8fa2f530-f757-4f5d-af55-53a18f8c91d5\r\nContent-Type: multipart/mixed;
+      boundary=changeset_af09e92a-c867-4096-9979-be1bad22bf85\r\n\r\n\r\n--changeset_af09e92a-c867-4096-9979-be1bad22bf85\r\nContent-Transfer-Encoding:
       binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table57tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
-      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":200.23,\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"DifferentField\":123,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_ef520338-6da3-11e7-98b2-6c3be5272b75--\r\n\r\n--batch_ef522a6a-6da3-11e7-98b2-6c3be5272b75--\r\n"
+      application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"DifferentField\":123,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_af09e92a-c867-4096-9979-be1bad22bf85--\r\n\r\n--batch_8fa2f530-f757-4f5d-af55-53a18f8c91d5--\r\n"
     form: {}
     headers:
       Authorization:
-      - SharedKey golangrocksonazure:tNel1+I2hXiwPgAE4BX1cNQDJbzRL4box0r2zilI/W0=
+      - SharedKey golangrocksonazure:4LW4DIuN+FFTZ/P3Rc9MYBePDGGDUtbEVWtrTbV8QeA=
       Content-Type:
-      - multipart/mixed; boundary=batch_ef522a6a-6da3-11e7-98b2-6c3be5272b75
+      - multipart/mixed; boundary=batch_8fa2f530-f757-4f5d-af55-53a18f8c91d5
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       X-Ms-Date:
-      - Thu, 20 Jul 2017 23:34:12 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/$batch
     method: POST
   response:
-    body: "--batchresponse_f49b1e9e-5cfc-4fd2-9e82-1a380a311169\r\nContent-Type: multipart/mixed;
-      boundary=changesetresponse_7f7984b9-5bac-401f-af1a-2636add0a36f\r\n\r\n--changesetresponse_7f7984b9-5bac-401f-af1a-2636add0a36f\r\nContent-Type:
+    body: "--batchresponse_ebcd0d35-e746-4bad-afec-e976d11abc76\r\nContent-Type: multipart/mixed;
+      boundary=changesetresponse_1d63b423-4277-44ff-ab15-4eb16282974e\r\n\r\n--changesetresponse_1d63b423-4277-44ff-ab15-4eb16282974e\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No
       Content\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\nPreference-Applied:
-      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2017-07-20T23%3A34%3A11.5276068Z'\"\r\n\r\n\r\n--changesetresponse_7f7984b9-5bac-401f-af1a-2636add0a36f--\r\n--batchresponse_f49b1e9e-5cfc-4fd2-9e82-1a380a311169--\r\n"
+      return-no-content\r\nDataServiceVersion: 3.0;\r\nETag: W/\"datetime'2019-05-02T17%3A46%3A06.2355392Z'\"\r\n\r\n\r\n--changesetresponse_1d63b423-4277-44ff-ab15-4eb16282974e--\r\n--batchresponse_ebcd0d35-e746-4bad-afec-e976d11abc76--\r\n"
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
-      - multipart/mixed; boundary=batchresponse_f49b1e9e-5cfc-4fd2-9e82-1a380a311169
+      - multipart/mixed; boundary=batchresponse_ebcd0d35-e746-4bad-afec-e976d11abc76
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b83a4-0002-0036-16b0-0102e5000000
+      - 4711af31-0002-0090-750e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 202 Accepted
     code: 202
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -148,35 +150,36 @@ interactions:
       Accept:
       - application/json;odata=fullmetadata
       Authorization:
-      - SharedKey golangrocksonazure:91TdtgFChPr0gK/hnB5RCDztq97MUR2YuMLGqTbHZQE=
+      - SharedKey golangrocksonazure:01Ua3GrDgvocTsSaIVp0om83JKzN3ws9VNej8UNOXOY=
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:12 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/table57tablebatchsuitetestbatchi?%24top=2&timeout=30
     method: GET
   response:
-    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table57tablebatchsuitetestbatchi","value":[{"odata.type":"golangrocksonazure.table57tablebatchsuitetestbatchi","odata.id":"https://golangrocksonazure.table.core.windows.net/table57tablebatchsuitetestbatchi(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2017-07-20T23%3A34%3A11.5276068Z''\"","odata.editLink":"table57tablebatchsuitetestbatchi(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2017-07-20T23:34:11.5276068Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","DifferentField":123,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}]}'
+    body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table57tablebatchsuitetestbatchi","value":[{"odata.type":"golangrocksonazure.table57tablebatchsuitetestbatchi","odata.id":"https://golangrocksonazure.table.core.windows.net/table57tablebatchsuitetestbatchi(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-02T17%3A46%3A06.2355392Z''\"","odata.editLink":"table57tablebatchsuitetestbatchi(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-02T17:46:06.2355392Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","DifferentField":123,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}]}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json;odata=fullmetadata;streaming=true;charset=utf-8
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b83a5-0002-0036-17b0-0102e5000000
+      - 4711af3e-0002-0090-020e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 200 OK
     code: 200
+    duration: ""
 - request:
     body: ""
     form: {}
@@ -184,16 +187,16 @@ interactions:
       Accept:
       - application/json;odata=nometadata
       Authorization:
-      - SharedKey golangrocksonazure:9wdQsmwPzbYol+61CfE3hgAHLI+vtwG4PMjZ6VoMtZk=
+      - SharedKey golangrocksonazure:BVYrSa/LylXVFUv/8rmBEAnGX5cszATQXVGWvGPihkQ=
       Prefer:
       - return-no-content
       User-Agent:
-      - Go/go1.9beta1 (amd64-windows) azure-storage-go/10.0.2 api-version/2016-05-31
+      - Go/go1.12.4 (amd64-darwin) azure-storage-go/latest api-version/2016-05-31
         table
       x-ms-date:
-      - Thu, 20 Jul 2017 23:34:12 GMT
+      - Thu, 02 May 2019 17:46:04 GMT
       x-ms-version:
-      - 2016-05-31
+      - "2016-05-31"
     url: https://golangrocksonazure.table.core.windows.net/Tables%28%27table57tablebatchsuitetestbatchi%27%29?timeout=30
     method: DELETE
   response:
@@ -204,14 +207,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 20 Jul 2017 23:34:11 GMT
+      - Thu, 02 May 2019 17:46:05 GMT
       Server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 875b83a6-0002-0036-18b0-0102e5000000
+      - 4711af4e-0002-0090-120e-01c263000000
       X-Ms-Version:
-      - 2016-05-31
+      - "2016-05-31"
     status: 204 No Content
     code: 204
+    duration: ""


### PR DESCRIPTION
Floating point numbers that happen to be whole numbers are
incorrectly treated as integers.  For float64 types encode them
as Edm.Double types.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
