### PR TITLE
Add changelog generation to the versioner tool

### DIFF
--- a/tools/apidiff/cmd/changelog.go
+++ b/tools/apidiff/cmd/changelog.go
@@ -53,7 +53,7 @@ func theChangelogCmd(args []string) error {
 	if err != nil {
 		return err
 	}
-	if rpt.isEmpty() {
+	if rpt.IsEmpty() {
 		return nil
 	}
 
@@ -85,7 +85,7 @@ func reportUpdatedPkgs(pr pkgsReport) {
 	fmt.Printf("### Updated Packages\n\n")
 	updated := []string{}
 	for pkgName, pkgRpt := range pr.ModifiedPackages {
-		if pkgRpt.hasAdditiveChanges() && !pkgRpt.hasBreakingChanges() {
+		if pkgRpt.HasAdditiveChanges() && !pkgRpt.HasBreakingChanges() {
 			updated = append(updated, pkgName)
 		}
 	}
@@ -99,7 +99,7 @@ func reportBreakingPkgs(pr pkgsReport) {
 	fmt.Printf("### BreakingChanges\n\n")
 	breaking := []string{}
 	for pkgName, pkgRpt := range pr.ModifiedPackages {
-		if pkgRpt.hasBreakingChanges() {
+		if pkgRpt.HasBreakingChanges() {
 			breaking = append(breaking, pkgName)
 		}
 	}

--- a/tools/apidiff/cmd/common.go
+++ b/tools/apidiff/cmd/common.go
@@ -23,10 +23,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/delta"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/ioext"
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
 )
 
 func printf(format string, a ...interface{}) {
@@ -65,31 +64,16 @@ func vprintln(a ...interface{}) {
 	}
 }
 
-// represents a set of breaking changes
-type breakingChanges struct {
-	Consts     map[string]delta.Signature    `json:"consts,omitempty"`
-	Funcs      map[string]delta.FuncSig      `json:"funcs,omitempty"`
-	Interfaces map[string]delta.InterfaceDef `json:"interfaces,omitempty"`
-	Structs    map[string]delta.StructDef    `json:"structs,omitempty"`
-	Removed    *exports.Content              `json:"removed,omitempty"`
-}
-
-// returns true if there are no breaking changes
-func (bc breakingChanges) isEmpty() bool {
-	return len(bc.Consts) == 0 && len(bc.Funcs) == 0 && len(bc.Interfaces) == 0 && len(bc.Structs) == 0 &&
-		(bc.Removed == nil || bc.Removed.IsEmpty())
-}
-
 // represents a collection of per-package reports, one for each commit hash
 type commitPkgReport struct {
-	BreakingChanges []string             `json:"breakingChanges,omitempty"`
-	CommitsReports  map[string]pkgReport `json:"deltas"`
+	BreakingChanges []string                  `json:"breakingChanges,omitempty"`
+	CommitsReports  map[string]report.Package `json:"deltas"`
 }
 
 // returns true if the report contains no data
-func (c commitPkgReport) isEmpty() bool {
+func (c commitPkgReport) IsEmpty() bool {
 	for _, rpt := range c.CommitsReports {
-		if !rpt.isEmpty() {
+		if !rpt.IsEmpty() {
 			return false
 		}
 	}
@@ -99,7 +83,7 @@ func (c commitPkgReport) isEmpty() bool {
 // returns true if the report contains breaking changes
 func (c commitPkgReport) hasBreakingChanges() bool {
 	for _, r := range c.CommitsReports {
-		if r.hasBreakingChanges() {
+		if r.HasBreakingChanges() {
 			return true
 		}
 	}
@@ -109,66 +93,19 @@ func (c commitPkgReport) hasBreakingChanges() bool {
 // returns true if the report contains additive changes
 func (c commitPkgReport) hasAdditiveChanges() bool {
 	for _, r := range c.CommitsReports {
-		if r.hasAdditiveChanges() {
+		if r.HasAdditiveChanges() {
 			return true
 		}
 	}
 	return false
 }
 
-// represents a per-package report, contains additive and breaking changes
-type pkgReport struct {
-	AdditiveChanges *exports.Content `json:"additiveChanges,omitempty"`
-	BreakingChanges *breakingChanges `json:"breakingChanges,omitempty"`
+type reportInfo interface {
+	IsEmpty() bool
 }
 
-// returns true if the package report contains breaking changes
-func (r pkgReport) hasBreakingChanges() bool {
-	return r.BreakingChanges != nil && !r.BreakingChanges.isEmpty()
-}
-
-// returns true if the package report contains additive changes
-func (r pkgReport) hasAdditiveChanges() bool {
-	return r.AdditiveChanges != nil && !r.AdditiveChanges.IsEmpty()
-}
-
-// returns true if the report contains no data
-func (r pkgReport) isEmpty() bool {
-	return (r.AdditiveChanges == nil || r.AdditiveChanges.IsEmpty()) &&
-		(r.BreakingChanges == nil || r.BreakingChanges.isEmpty())
-}
-
-// generates a package report based on the delta between lhs and rhs
-func getPkgReport(lhs, rhs exports.Content) pkgReport {
-	r := pkgReport{}
-	if !onlyBreakingChangesFlag {
-		if adds := delta.GetExports(lhs, rhs); !adds.IsEmpty() {
-			r.AdditiveChanges = &adds
-		}
-	}
-
-	if !onlyAdditionsFlag {
-		breaks := breakingChanges{}
-		breaks.Consts = delta.GetConstTypeChanges(lhs, rhs)
-		breaks.Funcs = delta.GetFuncSigChanges(lhs, rhs)
-		breaks.Interfaces = delta.GetInterfaceMethodSigChanges(lhs, rhs)
-		breaks.Structs = delta.GetStructFieldChanges(lhs, rhs)
-		if removed := delta.GetExports(rhs, lhs); !removed.IsEmpty() {
-			breaks.Removed = &removed
-		}
-		if !breaks.isEmpty() {
-			r.BreakingChanges = &breaks
-		}
-	}
-	return r
-}
-
-type report interface {
-	isEmpty() bool
-}
-
-func printReport(r report) error {
-	if r.isEmpty() {
+func printReport(r reportInfo) error {
+	if r.IsEmpty() {
 		println("no changes were found")
 		return nil
 	}
@@ -288,17 +225,17 @@ func generateReports(args []string, cln repo.WorkingTree, fn reportGenFunc) erro
 }
 
 type reportStatus interface {
-	hasBreakingChanges() bool
-	hasAdditiveChanges() bool
+	HasBreakingChanges() bool
+	HasAdditiveChanges() bool
 }
 
 // compares report status with the desired report options (breaking/additions)
 // to determine if the program should terminate with a non-zero exit code.
 func evalReportStatus(r reportStatus) {
-	if onlyBreakingChangesFlag && r.hasBreakingChanges() {
+	if onlyBreakingChangesFlag && r.HasBreakingChanges() {
 		os.Exit(1)
 	}
-	if onlyAdditionsFlag && !r.hasAdditiveChanges() {
+	if onlyAdditionsFlag && !r.HasAdditiveChanges() {
 		os.Exit(1)
 	}
 }

--- a/tools/apidiff/cmd/package.go
+++ b/tools/apidiff/cmd/package.go
@@ -24,7 +24,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var dirMode bool
+var (
+	dirMode    bool
+	asMarkdown bool
+)
 
 var packageCmd = &cobra.Command{
 	Use:   "package <package dir> (<base commit> <target commit(s)>) | (<commit sequence>)",
@@ -92,6 +95,7 @@ func thePackageCmd(args []string) (rs reportStatus, err error) {
 
 func init() {
 	packageCmd.PersistentFlags().BoolVarP(&dirMode, "directories", "i", false, "compares packages in two different directories")
+	packageCmd.PersistentFlags().BoolVarP(&asMarkdown, "markdown", "m", false, "emits the report in markdown format")
 	rootCmd.AddCommand(packageCmd)
 }
 
@@ -122,6 +126,10 @@ func packageCmdDirMode(args []string) (rs reportStatus, err error) {
 		return nil, fmt.Errorf("failed to get exports for package '%s': %s", args[1], err)
 	}
 	r := report.Generate(lhs, rhs, onlyBreakingChangesFlag, onlyAdditionsFlag)
-	err = printReport(r)
+	if asMarkdown && !suppressReport {
+		println(r.ToMarkdown())
+	} else {
+		err = printReport(r)
+	}
 	return r, err
 }

--- a/tools/apidiff/cmd/package.go
+++ b/tools/apidiff/cmd/package.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +56,7 @@ func thePackageCmd(args []string) (rs reportStatus, err error) {
 	}
 
 	var rpt commitPkgReport
-	rpt.CommitsReports = map[string]pkgReport{}
+	rpt.CommitsReports = map[string]report.Package{}
 	worker := func(pkgDir string, cloneRepo repo.WorkingTree, baseCommit, targetCommit string) error {
 		// lhs
 		vprintf("checking out base commit %s and gathering exports\n", baseCommit)
@@ -72,8 +73,8 @@ func thePackageCmd(args []string) (rs reportStatus, err error) {
 		if err != nil {
 			return err
 		}
-		r := getPkgReport(lhs, rhs)
-		if r.hasBreakingChanges() {
+		r := report.Generate(lhs, rhs, onlyBreakingChangesFlag, onlyAdditionsFlag)
+		if r.HasBreakingChanges() {
 			rpt.BreakingChanges = append(rpt.BreakingChanges, targetCommit)
 		}
 		rpt.CommitsReports[fmt.Sprintf("%s:%s", baseCommit, targetCommit)] = r
@@ -120,7 +121,7 @@ func packageCmdDirMode(args []string) (rs reportStatus, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get exports for package '%s': %s", args[1], err)
 	}
-	r := getPkgReport(lhs, rhs)
+	r := report.Generate(lhs, rhs, onlyBreakingChangesFlag, onlyAdditionsFlag)
 	err = printReport(r)
 	return r, err
 }

--- a/tools/apidiff/delta/delta.go
+++ b/tools/apidiff/delta/delta.go
@@ -35,6 +35,31 @@ func NewContent() Content {
 	}
 }
 
+// GetModifiedStructs returns the subset, if any, of structs that are modified.
+func (c Content) GetModifiedStructs() map[string]exports.Struct {
+	if len(c.CompleteStructs) == 0 {
+		return c.Structs
+	}
+	ms := map[string]exports.Struct{}
+	for k, v := range c.Structs {
+		if contains(c.CompleteStructs, k) {
+			continue
+		}
+		ms[k] = v
+	}
+	return ms
+}
+
+// returns true if sl contains x
+func contains(sl []string, x string) bool {
+	for _, s := range sl {
+		if s == x {
+			return true
+		}
+	}
+	return false
+}
+
 // GetExports returns a exports.Content struct containing all exports in rhs that aren't in lhs.
 // This includes any new fields added to structs or methods added to interfaces.
 func GetExports(lhs, rhs exports.Content) Content {

--- a/tools/apidiff/delta/delta.go
+++ b/tools/apidiff/delta/delta.go
@@ -15,13 +15,30 @@
 package delta
 
 import (
+	"sort"
+
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
 )
 
+// Content defines the set of exported constants, funcs, and structs.
+type Content struct {
+	exports.Content
+
+	// contains the names of structs that are modified in whole (i.e. new/removed)
+	CompleteStructs []string `json:"newStructs,omitempty"`
+}
+
+// NewContent returns an initialized Content object.
+func NewContent() Content {
+	return Content{
+		Content: exports.NewContent(),
+	}
+}
+
 // GetExports returns a exports.Content struct containing all exports in rhs that aren't in lhs.
 // This includes any new fields added to structs or methods added to interfaces.
-func GetExports(lhs, rhs exports.Content) exports.Content {
-	nc := exports.NewContent()
+func GetExports(lhs, rhs exports.Content) Content {
+	nc := NewContent()
 
 	for n, v := range rhs.Consts {
 		if _, ok := lhs.Consts[n]; !ok {
@@ -44,6 +61,7 @@ func GetExports(lhs, rhs exports.Content) exports.Content {
 	for n, v := range rhs.Structs {
 		if _, ok := lhs.Structs[n]; !ok {
 			nc.Structs[n] = v
+			nc.CompleteStructs = append(nc.CompleteStructs, n)
 		}
 	}
 
@@ -61,6 +79,7 @@ func GetExports(lhs, rhs exports.Content) exports.Content {
 		}
 	}
 
+	sort.Strings(nc.CompleteStructs)
 	return nc
 }
 

--- a/tools/apidiff/delta/delta_test.go
+++ b/tools/apidiff/delta/delta_test.go
@@ -212,7 +212,7 @@ func Test_GetAddedInterfaceMethods(t *testing.T) {
 
 func Test_GetNoChanges(t *testing.T) {
 	nc := delta.GetExports(nContent, nContent)
-	if !reflect.DeepEqual(nc, exports.NewContent()) {
+	if !reflect.DeepEqual(nc, delta.NewContent()) {
 		t.Log("expected empty exports")
 		t.Fail()
 	}

--- a/tools/apidiff/report/markdown.go
+++ b/tools/apidiff/report/markdown.go
@@ -154,16 +154,6 @@ func writeNewContent(p Package, md *mdWriter) {
 	writeStructs(p.AdditiveChanges, "New Structs", "New Struct Fields", md)
 }
 
-// returns true if sl contains x
-func contains(sl []string, x string) bool {
-	for _, s := range sl {
-		if s == x {
-			return true
-		}
-	}
-	return false
-}
-
 // writes out const information formatted as TypeName.ConstName
 func writeConsts(co map[string]exports.Const, subheader string, md *mdWriter) {
 	if len(co) == 0 {
@@ -212,7 +202,7 @@ func writeFuncs(funcs map[string]exports.Func, subheader string, md *mdWriter) {
 }
 
 // writes out struct information
-// sheader1 is for added/removed struct types
+// sheader1 is for added/removed struct types formatted as TypeName
 // sheader2 is for added/removed struct fields formatted as TypeName.FieldName
 func writeStructs(content *delta.Content, sheader1, sheader2 string, md *mdWriter) {
 	if len(content.Structs) == 0 {
@@ -225,14 +215,11 @@ func writeStructs(content *delta.Content, sheader1, sheader2 string, md *mdWrite
 			md.WriteLine(fmt.Sprintf("1. %s", s))
 		}
 	}
-	if len(content.Structs) > len(content.CompleteStructs) {
+	modified := content.GetModifiedStructs()
+	if len(modified) > 0 {
 		md.WriteSubheader(sheader2)
 		items := make([]string, 0, len(content.Structs)-len(content.CompleteStructs))
-		for s, f := range content.Structs {
-			// skip new/removed structs as they are reported separately
-			if contains(content.CompleteStructs, s) {
-				continue
-			}
+		for s, f := range modified {
 			for _, af := range f.AnonymousFields {
 				items = append(items, fmt.Sprintf("1. %s.%s", s, af))
 			}

--- a/tools/apidiff/report/markdown.go
+++ b/tools/apidiff/report/markdown.go
@@ -1,0 +1,248 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/delta"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+)
+
+type mdWriter struct {
+	sb strings.Builder
+	nl bool
+}
+
+func (md *mdWriter) checkNL() {
+	if md.nl {
+		md.sb.WriteString("\n")
+		md.nl = false
+	}
+}
+
+func (md *mdWriter) WriteHeader(h string) {
+	md.checkNL()
+	md.sb.WriteString("## ")
+	md.sb.WriteString(h)
+	md.sb.WriteString("\n\n")
+}
+
+func (md *mdWriter) WriteSubheader(sh string) {
+	md.checkNL()
+	md.sb.WriteString("### ")
+	md.sb.WriteString(sh)
+	md.sb.WriteString("\n\n")
+}
+
+func (md *mdWriter) WriteLine(s string) {
+	md.nl = true
+	md.sb.WriteString(s)
+	md.sb.WriteString("\n")
+}
+
+func (md *mdWriter) String() string {
+	return md.sb.String()
+}
+
+// creates a markdown-formatted report from the specified package
+func formatAsMarkdown(p Package) string {
+	md := mdWriter{}
+	writeBreakingChanges(p, &md)
+	writeNewContent(p, &md)
+	return md.String()
+}
+
+// writes all breaking changes
+func writeBreakingChanges(p Package, md *mdWriter) {
+	if !p.HasBreakingChanges() {
+		return
+	}
+	md.WriteHeader("Breaking Changes")
+	writeRemovedContent(p.BreakingChanges.Removed, md)
+	writeSigChanges(p.BreakingChanges, md)
+}
+
+// writes the subset of breaking changes pertaining to removed content
+func writeRemovedContent(removed *delta.Content, md *mdWriter) {
+	if removed == nil {
+		return
+	}
+	writeConsts(removed.Consts, "Removed Constants", md)
+	writeFuncs(removed.Funcs, "Removed Funcs", md)
+	writeStructs(removed, "Removed Structs", "Removed Struct Fields", md)
+}
+
+// writes the subset of breaking changes pertaining to signature changes
+func writeSigChanges(bc *BreakingChanges, md *mdWriter) {
+	if len(bc.Consts) == 0 && len(bc.Funcs) == 0 && len(bc.Structs) == 0 {
+		return
+	}
+	md.WriteHeader("Signature Changes")
+	if len(bc.Consts) > 0 {
+		items := make([]string, len(bc.Consts))
+		i := 0
+		for k, v := range bc.Consts {
+			items[i] = fmt.Sprintf("1. %s changed type from %s to %s", k, v.From, v.To)
+			i++
+		}
+		sort.Strings(items)
+		md.WriteSubheader("Const Types")
+		for _, item := range items {
+			md.WriteLine(item)
+		}
+	}
+	if len(bc.Funcs) > 0 {
+		// first get all the funcs so we can sort them
+		items := make([]string, len(bc.Funcs))
+		i := 0
+		for k := range bc.Funcs {
+			items[i] = k
+			i++
+		}
+		sort.Strings(items)
+		md.WriteSubheader("Funcs")
+		for _, item := range items {
+			// now add params/returns info
+			changes := bc.Funcs[item]
+			if changes.Params != nil {
+				item = fmt.Sprintf("%s\n\t- Params\n\t\t- From: %s\n\t\t- To: %s", item, changes.Params.From, changes.Params.To)
+			}
+			if changes.Returns != nil {
+				item = fmt.Sprintf("%s\n\t- Returns\n\t\t- From: %s\n\t\t- To: %s", item, changes.Returns.From, changes.Returns.To)
+			}
+			md.WriteLine(fmt.Sprintf("1. %s", item))
+		}
+	}
+	if len(bc.Structs) > 0 {
+		items := make([]string, 0, len(bc.Structs))
+		for k, v := range bc.Structs {
+			for f, d := range v.Fields {
+				items = append(items, fmt.Sprintf("1. %s.%s changed type from %s to %s", k, f, d.From, d.To))
+			}
+		}
+		sort.Strings(items)
+		md.WriteSubheader("Struct Fields")
+		for _, item := range items {
+			md.WriteLine(item)
+		}
+	}
+}
+
+// writes all new content
+func writeNewContent(p Package, md *mdWriter) {
+	if !p.HasAdditiveChanges() {
+		return
+	}
+	md.WriteHeader("New Content")
+	writeConsts(p.AdditiveChanges.Consts, "New Constants", md)
+	writeFuncs(p.AdditiveChanges.Funcs, "New Funcs", md)
+	writeStructs(p.AdditiveChanges, "New Structs", "New Struct Fields", md)
+}
+
+// returns true if sl contains x
+func contains(sl []string, x string) bool {
+	for _, s := range sl {
+		if s == x {
+			return true
+		}
+	}
+	return false
+}
+
+// writes out const information formatted as TypeName.ConstName
+func writeConsts(co map[string]exports.Const, subheader string, md *mdWriter) {
+	if len(co) == 0 {
+		return
+	}
+	items := make([]string, len(co))
+	i := 0
+	for c, t := range co {
+		items[i] = fmt.Sprintf("1. %s.%s", t.Type, c)
+		i++
+	}
+	sort.Strings(items)
+	md.WriteSubheader(subheader)
+	for _, item := range items {
+		md.WriteLine(item)
+	}
+}
+
+// writes out func information formatted as [receiver].FuncName([params]) [returns]
+func writeFuncs(funcs map[string]exports.Func, subheader string, md *mdWriter) {
+	if len(funcs) == 0 {
+		return
+	}
+	items := make([]string, len(funcs))
+	i := 0
+	for k, v := range funcs {
+		params := ""
+		if v.Params != nil {
+			params = *v.Params
+		}
+		returns := ""
+		if v.Returns != nil {
+			returns = *v.Returns
+			if strings.Index(returns, ",") > -1 {
+				returns = fmt.Sprintf("(%s)", returns)
+			}
+		}
+		items[i] = fmt.Sprintf("1. %s(%s) %s", k, params, returns)
+		i++
+	}
+	sort.Strings(items)
+	md.WriteSubheader(subheader)
+	for _, item := range items {
+		md.WriteLine(item)
+	}
+}
+
+// writes out struct information
+// sheader1 is for added/removed struct types
+// sheader2 is for added/removed struct fields formatted as TypeName.FieldName
+func writeStructs(content *delta.Content, sheader1, sheader2 string, md *mdWriter) {
+	if len(content.Structs) == 0 {
+		return
+	}
+	md.WriteHeader("Struct Changes")
+	if len(content.CompleteStructs) > 0 {
+		md.WriteSubheader(sheader1)
+		for _, s := range content.CompleteStructs {
+			md.WriteLine(fmt.Sprintf("1. %s", s))
+		}
+	}
+	if len(content.Structs) > len(content.CompleteStructs) {
+		md.WriteSubheader(sheader2)
+		items := make([]string, 0, len(content.Structs)-len(content.CompleteStructs))
+		for s, f := range content.Structs {
+			// skip new/removed structs as they are reported separately
+			if contains(content.CompleteStructs, s) {
+				continue
+			}
+			for _, af := range f.AnonymousFields {
+				items = append(items, fmt.Sprintf("1. %s.%s", s, af))
+			}
+			for f := range f.Fields {
+				items = append(items, fmt.Sprintf("1. %s.%s", s, f))
+			}
+		}
+		sort.Strings(items)
+		for _, item := range items {
+			md.WriteLine(item)
+		}
+	}
+}

--- a/tools/apidiff/report/report.go
+++ b/tools/apidiff/report/report.go
@@ -1,0 +1,84 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/delta"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+)
+
+// Package represents a per-package report that contains additive and breaking changes.
+type Package struct {
+	AdditiveChanges *exports.Content `json:"additiveChanges,omitempty"`
+	BreakingChanges *BreakingChanges `json:"breakingChanges,omitempty"`
+}
+
+// HasBreakingChanges returns true if the package report contains breaking changes.
+func (r Package) HasBreakingChanges() bool {
+	return r.BreakingChanges != nil && !r.BreakingChanges.IsEmpty()
+}
+
+// HasAdditiveChanges returns true if the package report contains additive changes.
+func (r Package) HasAdditiveChanges() bool {
+	return r.AdditiveChanges != nil && !r.AdditiveChanges.IsEmpty()
+}
+
+// IsEmpty returns true if the report contains no data (e.g. no changes in exported types).
+func (r Package) IsEmpty() bool {
+	return (r.AdditiveChanges == nil || r.AdditiveChanges.IsEmpty()) &&
+		(r.BreakingChanges == nil || r.BreakingChanges.IsEmpty())
+}
+
+// BreakingChanges represents a set of breaking changes.
+type BreakingChanges struct {
+	Consts     map[string]delta.Signature    `json:"consts,omitempty"`
+	Funcs      map[string]delta.FuncSig      `json:"funcs,omitempty"`
+	Interfaces map[string]delta.InterfaceDef `json:"interfaces,omitempty"`
+	Structs    map[string]delta.StructDef    `json:"structs,omitempty"`
+	Removed    *exports.Content              `json:"removed,omitempty"`
+}
+
+// IsEmpty returns true if there are no breaking changes.
+func (bc BreakingChanges) IsEmpty() bool {
+	return len(bc.Consts) == 0 && len(bc.Funcs) == 0 && len(bc.Interfaces) == 0 && len(bc.Structs) == 0 &&
+		(bc.Removed == nil || bc.Removed.IsEmpty())
+}
+
+// Generate generates a package report based on the delta between lhs and rhs.
+// onlyBreakingChanges - pass true to include only breaking changes in the report.
+// onlyAdditions - pass true to include only addition changes in the report.
+func Generate(lhs, rhs exports.Content, onlyBreakingChanges, onlyAdditions bool) Package {
+	r := Package{}
+	if !onlyBreakingChanges {
+		if adds := delta.GetExports(lhs, rhs); !adds.IsEmpty() {
+			r.AdditiveChanges = &adds
+		}
+	}
+
+	if !onlyAdditions {
+		breaks := BreakingChanges{}
+		breaks.Consts = delta.GetConstTypeChanges(lhs, rhs)
+		breaks.Funcs = delta.GetFuncSigChanges(lhs, rhs)
+		breaks.Interfaces = delta.GetInterfaceMethodSigChanges(lhs, rhs)
+		breaks.Structs = delta.GetStructFieldChanges(lhs, rhs)
+		if removed := delta.GetExports(rhs, lhs); !removed.IsEmpty() {
+			breaks.Removed = &removed
+		}
+		if !breaks.IsEmpty() {
+			r.BreakingChanges = &breaks
+		}
+	}
+	return r
+}

--- a/tools/apidiff/report/report.go
+++ b/tools/apidiff/report/report.go
@@ -21,7 +21,7 @@ import (
 
 // Package represents a per-package report that contains additive and breaking changes.
 type Package struct {
-	AdditiveChanges *exports.Content `json:"additiveChanges,omitempty"`
+	AdditiveChanges *delta.Content   `json:"additiveChanges,omitempty"`
 	BreakingChanges *BreakingChanges `json:"breakingChanges,omitempty"`
 }
 
@@ -47,7 +47,7 @@ type BreakingChanges struct {
 	Funcs      map[string]delta.FuncSig      `json:"funcs,omitempty"`
 	Interfaces map[string]delta.InterfaceDef `json:"interfaces,omitempty"`
 	Structs    map[string]delta.StructDef    `json:"structs,omitempty"`
-	Removed    *exports.Content              `json:"removed,omitempty"`
+	Removed    *delta.Content                `json:"removed,omitempty"`
 }
 
 // IsEmpty returns true if there are no breaking changes.
@@ -81,4 +81,12 @@ func Generate(lhs, rhs exports.Content, onlyBreakingChanges, onlyAdditions bool)
 		}
 	}
 	return r
+}
+
+// ToMarkdown creates a report of the package changes in markdown format.
+func (r Package) ToMarkdown() string {
+	if r.IsEmpty() {
+		return ""
+	}
+	return formatAsMarkdown(r)
 }

--- a/tools/versioner/cmd/root_test.go
+++ b/tools/versioner/cmd/root_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
 	"github.com/Azure/azure-sdk-for-go/tools/versioner/internal/modinfo"
 )
 
@@ -120,6 +121,16 @@ func (mock mockModInfo) BreakingChanges() bool {
 
 func (mock mockModInfo) VersionSuffix() bool {
 	return modinfo.HasVersionSuffix(mock.dir)
+}
+
+func (mock mockModInfo) NewModule() bool {
+	// not needed by tests
+	return false
+}
+
+func (mock mockModInfo) GenerateReport() report.Package {
+	// not needed by tests
+	return report.Package{}
 }
 
 func Test_calculateModuleTagMajorV1(t *testing.T) {
@@ -308,6 +319,16 @@ func cleanTestData() {
 	}
 }
 
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	} else if os.IsNotExist(err) {
+		return false
+	}
+	panic(err)
+}
+
 func Test_theCommandImplMajor(t *testing.T) {
 	cleanTestData()
 	defer cleanTestData()
@@ -343,6 +364,9 @@ go 1.12
 `
 	if !strings.EqualFold(string(b), after) {
 		t.Fatalf("bad go.mod file, expected '%s' got '%s'", after, string(b))
+	}
+	if !fileExists(filepath.Join("../testdata/scenariob/foo/v2", "CHANGELOG.md")) {
+		t.Fatal("expected changelog in scenariob")
 	}
 }
 
@@ -381,6 +405,9 @@ go 1.12
 	if !strings.EqualFold(string(b), after) {
 		t.Fatalf("bad go.mod file, expected '%s' got '%s'", after, string(b))
 	}
+	if !fileExists(filepath.Join("../testdata/scenarioa/foo", "CHANGELOG.md")) {
+		t.Fatal("expected changelog in scenarioa")
+	}
 }
 
 func Test_theCommandImplPatch(t *testing.T) {
@@ -418,6 +445,9 @@ go 1.12
 	if !strings.EqualFold(string(b), after) {
 		t.Fatalf("bad go.mod file, expected '%s' got '%s'", after, string(b))
 	}
+	if !fileExists(filepath.Join("../testdata/scenarioc/foo", "CHANGELOG.md")) {
+		t.Fatal("expected changelog in scenarioc")
+	}
 }
 
 func Test_theCommandImplNewMod(t *testing.T) {
@@ -452,5 +482,8 @@ go 1.12
 `
 	if !strings.EqualFold(string(b), after) {
 		t.Fatalf("bad go.mod file, expected '%s' got '%s'", after, string(b))
+	}
+	if fileExists(filepath.Join("../testdata/scenariof/foo", "CHANGELOG.md")) {
+		t.Fatal("unexpected changelog in scenariof")
 	}
 }

--- a/tools/versioner/internal/modinfo/modinfo.go
+++ b/tools/versioner/internal/modinfo/modinfo.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/delta"
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
 )
 
 var (
@@ -44,6 +45,8 @@ type Provider interface {
 	NewExports() bool
 	BreakingChanges() bool
 	VersionSuffix() bool
+	NewModule() bool
+	GenerateReport() report.Package
 }
 
 type module struct {
@@ -128,4 +131,14 @@ func (m module) BreakingChanges() bool {
 // VersionSuffix returns true if the module path contains a version suffix.
 func (m module) VersionSuffix() bool {
 	return verSuffixRegex.MatchString(m.dest)
+}
+
+// NewModule returns true if the module is new, i.e. v1.0.0.
+func (m module) NewModule() bool {
+	return m.lhs.IsEmpty()
+}
+
+// GenerateReport generates a package report for the module.
+func (m module) GenerateReport() report.Package {
+	return report.Generate(m.lhs, m.rhs, false, false)
 }

--- a/tools/versioner/internal/modinfo/modinfo_test.go
+++ b/tools/versioner/internal/modinfo/modinfo_test.go
@@ -139,6 +139,9 @@ func Test_ScenarioF(t *testing.T) {
 	if mod.VersionSuffix() {
 		t.Fatalf("unexpected version suffix in scenario F")
 	}
+	if !mod.NewModule() {
+		t.Fatal("expected new module in scenario F")
+	}
 	regex := regexp.MustCompile(`testdata/scenariof/foo$`)
 	if !regex.MatchString(mod.DestDir()) {
 		t.Fatalf("bad destination dir: %s", mod.DestDir())

--- a/tools/versioner/testdata/scenariod/foo/stage/foo.go
+++ b/tools/versioner/testdata/scenariod/foo/stage/foo.go
@@ -14,4 +14,5 @@
 
 package foo
 
+// breaking change on top of a v2
 func DoItOne(int) {}

--- a/tools/versioner/testdata/scenarioe/foo/stage/foo.go
+++ b/tools/versioner/testdata/scenarioe/foo/stage/foo.go
@@ -16,4 +16,5 @@ package foo
 
 func DoItOne(string) {}
 
+// additive change on top of a v2
 func DoItTwo(int) {}

--- a/tools/versioner/testdata/scenariof/foo/stage/foo.go
+++ b/tools/versioner/testdata/scenariof/foo/stage/foo.go
@@ -14,6 +14,8 @@
 
 package foo
 
+// new module
+
 func DoItOne(string) {}
 
 func DoItTwo(int) {}


### PR DESCRIPTION
Updates to existing modules will generate a changelog in the module
directory; new modules won't contain a changelog.
Refactor package report generation to its own package.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
