### PR TITLE
fix a bug when spr parameter is missing

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -367,15 +367,13 @@ func newSASClient(accountName, baseURL string, sasToken url.Values) Client {
 		accountName:     accountName,
 		baseURL:         baseURL,
 		accountSASToken: sasToken,
+		useHTTPS:        defaultUseHTTPS,
 	}
 	c.userAgent = c.getDefaultUserAgent()
 	// Get API version and protocol from token
 	c.apiVersion = sasToken.Get("sv")
-	if sasToken.Get("spr") != "" {
-		c.useHTTPS = sasToken.Get("spr") == "https"
-	} else {
-		// SAS token generated from Storage Explorer won't carry a spr in the query, but it needs https only
-		c.useHTTPS = true
+	if spr := sasToken.Get("spr"); spr != "" {
+		c.useHTTPS = spr == "https"
 	}
 	return c
 }

--- a/storage/client.go
+++ b/storage/client.go
@@ -371,7 +371,12 @@ func newSASClient(accountName, baseURL string, sasToken url.Values) Client {
 	c.userAgent = c.getDefaultUserAgent()
 	// Get API version and protocol from token
 	c.apiVersion = sasToken.Get("sv")
-	c.useHTTPS = sasToken.Get("spr") == "https"
+	if sasToken.Get("spr") != "" {
+		c.useHTTPS = sasToken.Get("spr") == "https"
+	} else {
+		// SAS token generated from Storage Explorer won't carry a spr in the query, but it needs https only
+		c.useHTTPS = true
+	}
 	return c
 }
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -324,6 +324,19 @@ func (s *StorageClientSuite) TestNewAccountSASClientFromEndpointToken(c *chk.C) 
 	c.Assert(cli.useHTTPS, chk.Equals, false)
 }
 
+func (s *StorageClientSuite) TestNewAccountSASClientWithoutSpr(c *chk.C) {
+	values, err := url.ParseQuery("st=2019-05-22T02%3A51%3A17Z&se=2019-05-23T02%3A51%3A17Z&sp=r&sv=2018-03-28&tn=test&sig=LYD0MvtngQduTB6SSoMGsbxX8xOCUZ6eUpn%2BVKyUWlc%3D")
+	c.Assert(err, chk.IsNil)
+
+	cli := NewAccountSASClient("nstestazure", values, azure.ChinaCloud)
+
+	c.Assert(cli.accountSASToken, chk.HasLen, 6)
+	c.Assert(cli.accountName, chk.Equals, "nstestazure")
+	c.Assert(cli.baseURL, chk.Equals, "core.chinacloudapi.cn")
+	c.Assert(cli.apiVersion, chk.Equals, "2018-03-28")
+	c.Assert(cli.useHTTPS, chk.Equals, true)
+}
+
 func (s *StorageClientSuite) TestIsValidStorageAccount(c *chk.C) {
 	type test struct {
 		account  string


### PR DESCRIPTION
original [pr](https://github.com/Azure/azure-sdk-for-go/pull/4854) which carries a bunch of AutoPR and generated commit is closed. sorry for my mistake. 

the go sdk checks for [spr parameter](https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1#parameters-common-to-account-sas-and-service-sas-tokens), but when it comes to tokens generated from Storage Explorer, there is no such spr parameter, and the sdk get empty string for spr. so after compares empty string and "https", it [sets useHTTPS to false](https://github.com/Azure/azure-sdk-for-go/blob/master/storage/client.go#L374), while it actually needs to set it to true

this patch just altered that and I add a test case. the test account has been deleted to prevent malformed requests but the test case should not be influenced

it's my first PR here. tell me if there is something need to be done and i'll do it. 