### PR TITLE
[AutoPR cdn/resource-manager] typo: Double word "use"

### DIFF
--- a/services/cdn/mgmt/2019-04-15/cdn/models.go
+++ b/services/cdn/mgmt/2019-04-15/cdn/models.go
@@ -5032,7 +5032,7 @@ type URLRedirectActionParameters struct {
 	DestinationProtocol DestinationProtocol `json:"destinationProtocol,omitempty"`
 	// CustomPath - The full path to redirect. Path cannot be empty and must start with /. Leave empty to use the incoming path as destination path.
 	CustomPath *string `json:"customPath,omitempty"`
-	// CustomHostname - Host to redirect. Leave empty to use use the incoming host as the destination host.
+	// CustomHostname - Host to redirect. Leave empty to use the incoming host as the destination host.
 	CustomHostname *string `json:"customHostname,omitempty"`
 	// CustomQueryString - The set of query strings to be placed in the redirect URL. Setting this value would replace any existing query string; leave empty to preserve the incoming query string. Query string must be in <key>=<value> format. ? and & will be added automatically so do not include them.
 	CustomQueryString *string `json:"customQueryString,omitempty"`


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/6192