### PR TITLE
Update profile builder to understand modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _testmain.go
 *.swp
 *~
 .DS_Store
+.vscode
 
 # ignore vendor/
 vendor/

--- a/profiles/2017-03-09/definition.json
+++ b/profiles/2017-03-09/definition.json
@@ -1,19 +1,19 @@
 {
-    "include": [
-        "../../services/storage/mgmt/2016-01-01/storage",
-        "../../services/network/mgmt/2015-06-15/network",
-        "../../services/compute/mgmt/2016-03-30/compute",
-        "../../services/keyvault/2016-10-01/keyvault",
-        "../../services/keyvault/mgmt/2016-10-01/keyvault",
-        "../../services/resources/mgmt/2015-12-01/features",
-        "../../services/resources/mgmt/2016-09-01/links",
-        "../../services/resources/mgmt/2015-01-01/locks",
-        "../../services/preview/resources/mgmt/2015-10-01-preview/policy",
-        "../../services/resources/mgmt/2016-02-01/resources",
-        "../../services/resources/mgmt/2016-06-01/subscriptions"
-    ],
-    "pathOverride": {
-        "github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2015-10-01-preview/policy": "resources/mgmt/policy",
-        "github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2015-10-01-preview/policy/policyapi": "resources/mgmt/policy/policyapi"
-    }
+  "include": [
+    "../../services/storage/mgmt/2016-01-01/storage",
+    "../../services/network/mgmt/2015-06-15/network",
+    "../../services/compute/mgmt/2016-03-30/compute",
+    "../../services/keyvault/2016-10-01/keyvault",
+    "../../services/keyvault/mgmt/2016-10-01/keyvault",
+    "../../services/resources/mgmt/2015-12-01/features",
+    "../../services/resources/mgmt/2016-09-01/links",
+    "../../services/resources/mgmt/2015-01-01/locks",
+    "../../services/preview/resources/mgmt/2015-10-01-preview/policy",
+    "../../services/resources/mgmt/2016-02-01/resources",
+    "../../services/resources/mgmt/2016-06-01/subscriptions"
+  ],
+  "pathOverride": {
+    "github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2015-10-01-preview/policy": "resources/mgmt/policy",
+    "github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2015-10-01-preview/policy/policyapi": "resources/mgmt/policy/policyapi"
+  }
 }

--- a/profiles/2018-03-01/definition.json
+++ b/profiles/2018-03-01/definition.json
@@ -1,17 +1,17 @@
 {
-    "include": [
-        "../../services/authorization/mgmt/2015-07-01/authorization",
-        "../../services/compute/mgmt/2017-03-30/compute",
-        "../../services/dns/mgmt/2016-04-01/dns",
-        "../../services/keyvault/2016-10-01/keyvault",
-        "../../services/keyvault/mgmt/2016-10-01/keyvault",
-        "../../services/network/mgmt/2017-10-01/network",
-        "../../services/resources/mgmt/2016-09-01/links",
-        "../../services/resources/mgmt/2016-09-01/locks",
-        "../../services/resources/mgmt/2016-12-01/policy",
-        "../../services/resources/mgmt/2018-02-01/resources",
-        "../../services/resources/mgmt/2016-06-01/subscriptions",
-        "../../services/storage/mgmt/2016-01-01/storage",
-        "../../services/web/mgmt/2016-09-01/web"
-    ]
+  "include": [
+    "../../services/authorization/mgmt/2015-07-01/authorization",
+    "../../services/compute/mgmt/2017-03-30/compute",
+    "../../services/dns/mgmt/2016-04-01/dns",
+    "../../services/keyvault/2016-10-01/keyvault",
+    "../../services/keyvault/mgmt/2016-10-01/keyvault",
+    "../../services/network/mgmt/2017-10-01/network",
+    "../../services/resources/mgmt/2016-09-01/links",
+    "../../services/resources/mgmt/2016-09-01/locks",
+    "../../services/resources/mgmt/2016-12-01/policy",
+    "../../services/resources/mgmt/2018-02-01/resources",
+    "../../services/resources/mgmt/2016-06-01/subscriptions",
+    "../../services/storage/mgmt/2016-01-01/storage",
+    "../../services/web/mgmt/2016-09-01/web"
+  ]
 }

--- a/profiles/2019-03-01/definition.json
+++ b/profiles/2019-03-01/definition.json
@@ -1,22 +1,22 @@
 {
-    "include": [
-        "../../services/authorization/mgmt/2015-07-01/authorization",
-        "../../services/compute/mgmt/2017-12-01/compute",
-        "../../services/dns/mgmt/2016-04-01/dns",
-        "../../services/keyvault/2016-10-01/keyvault",
-        "../../services/keyvault/mgmt/2016-10-01/keyvault",
-        "../../services/network/mgmt/2017-10-01/network",
-        "../../services/preview/monitor/mgmt/2018-03-01/insights",
-        "../../services/resources/mgmt/2016-09-01/links",
-        "../../services/resources/mgmt/2016-09-01/locks",
-        "../../services/resources/mgmt/2016-12-01/policy",
-        "../../services/resources/mgmt/2018-05-01/resources",
-        "../../services/resources/mgmt/2016-06-01/subscriptions",
-        "../../services/storage/mgmt/2017-10-01/storage",
-        "../../services/web/mgmt/2018-02-01/web"
-    ],
-    "pathOverride": {
-        "github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights": "resources/mgmt/insights",
-        "github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights/insightsapi": "resources/mgmt/insights/insightsapi"
-    }
+  "include": [
+    "../../services/authorization/mgmt/2015-07-01/authorization",
+    "../../services/compute/mgmt/2017-12-01/compute",
+    "../../services/dns/mgmt/2016-04-01/dns",
+    "../../services/keyvault/2016-10-01/keyvault",
+    "../../services/keyvault/mgmt/2016-10-01/keyvault",
+    "../../services/network/mgmt/2017-10-01/network",
+    "../../services/preview/monitor/mgmt/2018-03-01/insights",
+    "../../services/resources/mgmt/2016-09-01/links",
+    "../../services/resources/mgmt/2016-09-01/locks",
+    "../../services/resources/mgmt/2016-12-01/policy",
+    "../../services/resources/mgmt/2018-05-01/resources",
+    "../../services/resources/mgmt/2016-06-01/subscriptions",
+    "../../services/storage/mgmt/2017-10-01/storage",
+    "../../services/web/mgmt/2018-02-01/web"
+  ],
+  "pathOverride": {
+    "github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights": "resources/mgmt/insights",
+    "github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights/insightsapi": "resources/mgmt/insights/insightsapi"
+  }
 }

--- a/tools/internal/dirs/dirs.go
+++ b/tools/internal/dirs/dirs.go
@@ -1,5 +1,3 @@
-// +build go1.9
-
 // Copyright 2018 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package model
+package dirs
 
 import (
 	"io/ioutil"
@@ -22,22 +20,34 @@ import (
 	"path/filepath"
 )
 
-// DeleteChildDirs deletes all child directories in the specified directory.
-func DeleteChildDirs(dir string) error {
-	children, err := ioutil.ReadDir(dir)
+// GetSubdirs returns all of the subdirectories under current.
+// Returns an empty slice if current contains no subdirectories.
+func GetSubdirs(current string) ([]string, error) {
+	children, err := ioutil.ReadDir(current)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	for _, child := range children {
-		if child.IsDir() {
-			childPath := filepath.Join(dir, child.Name())
-			err = os.RemoveAll(childPath)
-			if err != nil {
-				return err
-			}
+	dirs := []string{}
+	for _, info := range children {
+		if info.IsDir() {
+			dirs = append(dirs, info.Name())
 		}
 	}
+	return dirs, nil
+}
 
+// DeleteChildDirs deletes all child directories in the specified directory.
+func DeleteChildDirs(dir string) error {
+	children, err := GetSubdirs(dir)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, child := range children {
+		childPath := filepath.Join(dir, child)
+		err = os.RemoveAll(childPath)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/tools/internal/dirs/dirs_test.go
+++ b/tools/internal/dirs/dirs_test.go
@@ -1,0 +1,47 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dirs
+
+import "testing"
+
+func TestGetSubdirs(t *testing.T) {
+	sd, err := GetSubdirs("../..")
+	if err != nil {
+		t.Fatalf("failed to get subdirs: %v", err)
+	}
+	if len(sd) == 0 {
+		t.Fatal("unexpected zero length subdirs")
+	}
+}
+
+func TestGetSubdirsEmpty(t *testing.T) {
+	sd, err := GetSubdirs(".")
+	if err != nil {
+		t.Fatalf("failed to get subdirs: %v", err)
+	}
+	if len(sd) != 0 {
+		t.Fatal("expected zero length subdirs")
+	}
+}
+
+func TestGetSubdirsNoExist(t *testing.T) {
+	sd, err := GetSubdirs("../thisdoesntexist")
+	if err == nil {
+		t.Fatal("expected nil error")
+	}
+	if sd != nil {
+		t.Fatal("expected nil subdirs")
+	}
+}

--- a/tools/profileBuilder/cmd/latest.go
+++ b/tools/profileBuilder/cmd/latest.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Azure/azure-sdk-for-go/tools/internal/dirs"
 	"github.com/Azure/azure-sdk-for-go/tools/profileBuilder/model"
 	"github.com/spf13/cobra"
 )
@@ -74,7 +75,7 @@ By default, this command ignores API versions that are in preview.`,
 		}
 
 		if clearOutputFlag {
-			if err := model.DeleteChildDirs(outputRootDir); err != nil {
+			if err := dirs.DeleteChildDirs(outputRootDir); err != nil {
 				errLog.Fatalf("Unable to clear output-folder: %v", err)
 			}
 		}
@@ -84,7 +85,7 @@ By default, this command ignores API versions that are in preview.`,
 		}
 		listDef, err := model.GetLatestPackages(rootDir, includePreview, outputLog)
 		// don't recursively build profiles as we already built the list of packages recursively
-		model.BuildProfile(listDef, profileName, outputRootDir, outputLog, errLog, false)
+		model.BuildProfile(listDef, profileName, outputRootDir, outputLog, errLog, false, modulesFlag)
 	},
 }
 

--- a/tools/profileBuilder/cmd/list.go
+++ b/tools/profileBuilder/cmd/list.go
@@ -86,8 +86,8 @@ $> ../model/testdata/smallProfile.txt > profileBuilder list --name small_profile
 
 		if modulesFlag {
 			// when generating in module-aware mode a few extra things need to happen
-			// 1. update the list of includes package to their latest module versions
-			// 2. find the latest module version for the profile we're working on
+			// 1. find the latest module version for the profile we're working on
+			// 2. update the list of includes package to their latest module versions
 			// 3. if any includes were updated generate a new major version for this profile
 			modver, err := getLatestModVer(outputRootDir)
 			if err != nil {
@@ -183,6 +183,7 @@ func getLatestModVer(profileDir string) (string, error) {
 // generate a go.mod file in the specified module major version directory (e.g. "profiles/foo/v2")
 // the provided module directory is used to calculate the module name.
 func generateGoMod(modDir string) error {
+	const gomodFormat = "module %s\n\ngo 1.12\n"
 	err := os.Mkdir(modDir, os.ModeDir|0644)
 	if err != nil {
 		return err
@@ -196,6 +197,6 @@ func generateGoMod(modDir string) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(gomod, "module %s\n\ngo 1.12\n", mod)
+	_, err = fmt.Fprintf(gomod, gomodFormat, mod)
 	return err
 }

--- a/tools/profileBuilder/cmd/list_test.go
+++ b/tools/profileBuilder/cmd/list_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/tools/profileBuilder/model"
+)
+
+func Test_updateModuleVersions(t *testing.T) {
+	ld := model.ListDefinition{
+		Include: []string{
+			"../../testdata/scenarioa/foo",
+			"../../testdata/scenariod/foo",
+			"../../testdata/scenarioe/foo/v2",
+		},
+	}
+	updateModuleVersions(&ld)
+	expected := []string{
+		"../../testdata/scenarioa/foo",
+		"../../testdata/scenariod/foo/v2",
+		"../../testdata/scenarioe/foo/v2",
+	}
+	if !reflect.DeepEqual(ld.Include, expected) {
+		t.Fatalf("expected '%v' got '%v'", expected, ld.Include)
+	}
+}
+
+func Test_getLatestModVer(t *testing.T) {
+	d, err := getLatestModVer("../../testdata/scenarioa/foo")
+	if err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+	if d != "" {
+		t.Fatalf("expected empty string got '%s'", d)
+	}
+	d, err = getLatestModVer("../../testdata/scenariod/foo")
+	if err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+	if d != "v2" {
+		t.Fatalf("expected 'v2' string got '%s'", d)
+	}
+}

--- a/tools/profileBuilder/cmd/root.go
+++ b/tools/profileBuilder/cmd/root.go
@@ -27,6 +27,7 @@ import (
 var (
 	clearOutputFlag bool
 	verboseFlag     bool
+	modulesFlag     bool
 	profileName     string
 	outputRootDir   string
 )
@@ -58,6 +59,7 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&clearOutputFlag, "clear-output", "c", false, "Removes any directories in the output-folder before writing a profile.")
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Use stderr to log verbose output.")
+	rootCmd.PersistentFlags().BoolVarP(&modulesFlag, "modules", "m", false, "Executes commands in modules-aware mode.")
 	rootCmd.PersistentFlags().StringVarP(&profileName, "name", "n", "", "The name that should be used to identify the profile.")
 	rootCmd.PersistentFlags().StringVarP(&outputRootDir, "output-location", "o", "", "The folder in which to output the generated profile.")
 	rootCmd.MarkPersistentFlagRequired("name")

--- a/tools/profileBuilder/model/aliasPackage.go
+++ b/tools/profileBuilder/model/aliasPackage.go
@@ -32,6 +32,7 @@ import (
 // AliasPackage is an abstraction around ast.Package to provide convenience methods for manipulating it.
 type AliasPackage ast.Package
 
+// ErrorUnexpectedToken is returned when AST parsing encounters an unexpected token, it includes the expected token.
 type ErrorUnexpectedToken struct {
 	Expected token.Token
 	Received token.Token

--- a/tools/profileBuilder/model/paths.go
+++ b/tools/profileBuilder/model/paths.go
@@ -1,0 +1,91 @@
+// +build go1.9
+
+// Copyright 2018 Microsoft Corporation and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const pkgPathRegex = `services[/\\](?P<prv>[\w\-\._/\\]+)[/\\](?P<ver>v?\d{4}-\d{2}-\d{2}[\w\.\-]*|v?\d+[\.\w\-]*)[/\\](?P<grp>[/\\\w\-\._]+)`
+
+var (
+	validPackagePath   = regexp.MustCompile(pkgPathRegex)
+	validPkgPathModVer = regexp.MustCompile(pkgPathRegex + `[/\\](?P<mod>v\d+)[/\\]?(?P<api>\w+api)?`)
+	apiPkgRegex        = regexp.MustCompile(`[/\\]\w+api$`)
+)
+
+// PathInfo provides information about a package's path.
+type PathInfo struct {
+	IsArm    bool
+	Provider string
+	Version  string
+	Group    string
+	ModVer   string
+	APIPkg   string
+}
+
+// DeconstructPath takes a full package path and deconstructs it into its constituent parts.
+func DeconstructPath(path string) (PathInfo, error) {
+	path = filepath.Clean(path)
+	// must check the module regex first, this is due to greedy regex and lack of negative look-aheads
+	matches := validPkgPathModVer.FindAllStringSubmatch(path, -1)
+	if matches == nil {
+		matches = validPackagePath.FindAllStringSubmatch(path, -1)
+	}
+	if matches == nil {
+		return PathInfo{}, fmt.Errorf("path '%s' does not resemble a known package path", path)
+	}
+
+	// matches[0][0] is the full match, we don't care about that
+	// matches[0][1] is <prv>, it might end with /mgmt due to greedy regex
+	// matches[0][2] is <ver>
+	// matches[0][3] is <grp>, it might end with /*api for non-module case due to greedy regex
+	prv := matches[0][1]
+	ver := matches[0][2]
+	grp := matches[0][3]
+	mod := ""
+	api := ""
+
+	if len(matches[0]) == 6 {
+		// this package contains a major version
+		// matches[0][4] is <mod>
+		// matches[0][5] is <api>
+		mod = matches[0][4]
+		api = matches[0][5]
+	} else if loc := apiPkgRegex.FindStringIndex(grp); loc != nil {
+		// for non-module case, if this is the *api package strip it off grp and place in api
+		api = grp[loc[0]+1:]
+		grp = grp[:loc[0]]
+	}
+
+	arm := false
+	if index := strings.LastIndex(prv, string(filepath.Separator)+armPathModifier); index > 0 {
+		prv = prv[:index]
+		arm = true
+	}
+	return PathInfo{
+		Provider: prv,
+		IsArm:    arm,
+		Version:  ver,
+		Group:    grp,
+		ModVer:   mod,
+		APIPkg:   api,
+	}, nil
+}

--- a/tools/profileBuilder/model/paths_test.go
+++ b/tools/profileBuilder/model/paths_test.go
@@ -1,0 +1,219 @@
+// +build go1.9
+
+// Copyright 2018 Microsoft Corporation and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestDeconstructPath(t *testing.T) {
+	type testcase struct {
+		name string
+		path string
+		pi   PathInfo
+	}
+	testcases := []testcase{
+		testcase{
+			name: "arm1",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "storage", "mgmt", "2016-01-01", "storage"),
+			pi: PathInfo{
+				IsArm:    true,
+				Provider: "storage",
+				Version:  "2016-01-01",
+				Group:    "storage",
+			},
+		},
+		testcase{
+			name: "arm2",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "datalake", "analytics", "mgmt", "2016-11-01", "account"),
+			pi: PathInfo{
+				IsArm:    true,
+				Provider: filepath.Join("datalake", "analytics"),
+				Version:  "2016-11-01",
+				Group:    "account",
+			},
+		},
+		testcase{
+			name: "arm3",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "datalake", "analytics", "mgmt", "2016-11-01", "account", "v2"),
+			pi: PathInfo{
+				IsArm:    true,
+				Provider: filepath.Join("datalake", "analytics"),
+				Version:  "2016-11-01",
+				Group:    "account",
+				ModVer:   "v2",
+			},
+		},
+		testcase{
+			name: "arm4",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "datalake", "analytics", "mgmt", "2016-11-01", "account", "v2", "accountapi"),
+			pi: PathInfo{
+				IsArm:    true,
+				Provider: filepath.Join("datalake", "analytics"),
+				Version:  "2016-11-01",
+				Group:    "account",
+				ModVer:   "v2",
+				APIPkg:   "accountapi",
+			},
+		},
+		testcase{
+			name: "arm5",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "storage", "mgmt", "2016-01-01", "storage", "v10"),
+			pi: PathInfo{
+				IsArm:    true,
+				Provider: "storage",
+				Version:  "2016-01-01",
+				Group:    "storage",
+				ModVer:   "v10",
+			},
+		},
+		testcase{
+			name: "arm6",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "storage", "mgmt", "2016-01-01", "storage", "v10", "storageapi"),
+			pi: PathInfo{
+				IsArm:    true,
+				Provider: "storage",
+				Version:  "2016-01-01",
+				Group:    "storage",
+				ModVer:   "v10",
+				APIPkg:   "storageapi",
+			},
+		},
+		testcase{
+			name: "arm7",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "storage", "mgmt", "2016-01-01", "storage", "storageapi"),
+			pi: PathInfo{
+				IsArm:    true,
+				Provider: "storage",
+				Version:  "2016-01-01",
+				Group:    "storage",
+				APIPkg:   "storageapi",
+			},
+		},
+		testcase{
+			name: "arm8",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "datalake", "analytics", "mgmt", "2016-11-01", "account", "accountapi"),
+			pi: PathInfo{
+				IsArm:    true,
+				Provider: filepath.Join("datalake", "analytics"),
+				Version:  "2016-11-01",
+				Group:    "account",
+				APIPkg:   "accountapi",
+			},
+		},
+		testcase{
+			name: "dataplane1",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "cognitiveservices", "v2.0", "luis", "authoring"),
+			pi: PathInfo{
+				IsArm:    false,
+				Provider: "cognitiveservices",
+				Version:  "v2.0",
+				Group:    filepath.Join("luis", "authoring"),
+			},
+		},
+		testcase{
+			name: "dataplane2",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "datalake", "analytics", "2016-11-01", "job"),
+			pi: PathInfo{
+				IsArm:    false,
+				Provider: filepath.Join("datalake", "analytics"),
+				Version:  "2016-11-01",
+				Group:    "job",
+			},
+		},
+		testcase{
+			name: "dataplane3",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "appinsights", "v1", "insights"),
+			pi: PathInfo{
+				IsArm:    false,
+				Provider: "appinsights",
+				Version:  "v1",
+				Group:    "insights",
+			},
+		},
+		testcase{
+			name: "dataplane4",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "cognitiveservices", "v2.0", "luis", "authoring", "v2"),
+			pi: PathInfo{
+				IsArm:    false,
+				Provider: "cognitiveservices",
+				Version:  "v2.0",
+				Group:    filepath.Join("luis", "authoring"),
+				ModVer:   "v2",
+			},
+		},
+		testcase{
+			name: "dataplane5",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "cognitiveservices", "v2.0", "luis", "authoring", "v2", "authoringapi"),
+			pi: PathInfo{
+				IsArm:    false,
+				Provider: "cognitiveservices",
+				Version:  "v2.0",
+				Group:    filepath.Join("luis", "authoring"),
+				ModVer:   "v2",
+				APIPkg:   "authoringapi",
+			},
+		},
+		testcase{
+			name: "dataplane6",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "appinsights", "v1", "insights", "v4"),
+			pi: PathInfo{
+				IsArm:    false,
+				Provider: "appinsights",
+				Version:  "v1",
+				Group:    "insights",
+				ModVer:   "v4",
+			},
+		},
+		testcase{
+			name: "dataplane7",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "appinsights", "v1", "insights", "insightsapi"),
+			pi: PathInfo{
+				IsArm:    false,
+				Provider: "appinsights",
+				Version:  "v1",
+				Group:    "insights",
+				APIPkg:   "insightsapi",
+			},
+		},
+		testcase{
+			name: "dataplane8",
+			path: filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "appinsights", "v1", "insights", "v4", "insightsapi"),
+			pi: PathInfo{
+				IsArm:    false,
+				Provider: "appinsights",
+				Version:  "v1",
+				Group:    "insights",
+				ModVer:   "v4",
+				APIPkg:   "insightsapi",
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := DeconstructPath(tc.path)
+			if err != nil {
+				t.Fatalf("failed to deconstruct path: %v", err)
+			}
+			if !reflect.DeepEqual(p, tc.pi) {
+				t.Fatalf("expected %+v, got %+v", tc.pi, p)
+			}
+		})
+	}
+}

--- a/tools/profileBuilder/model/transforms.go
+++ b/tools/profileBuilder/model/transforms.go
@@ -33,11 +33,12 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/tools/internal/modinfo"
 
 	"golang.org/x/tools/imports"
 )
@@ -53,10 +54,8 @@ const (
 	aliasFileName   = "models.go"
 )
 
-var packageName = regexp.MustCompile(`services[/\\](?P<provider>[\w\-\.\d_\\/]+)[/\\](?:(?P<arm>` + armPathModifier + `)[/\\])?(?P<version>v?\d{4}-\d{2}-\d{2}[\w\d\.\-]*|v?\d+[\.\d+\.\d\w\-]*)[/\\](?P<group>[/\\\w\d\-\._]+)`)
-
 // BuildProfile takes a list of packages and creates a profile
-func BuildProfile(packageList ListDefinition, name, outputLocation string, outputLog, errLog *log.Logger, recursive bool) {
+func BuildProfile(packageList ListDefinition, name, outputLocation string, outputLog, errLog *log.Logger, recursive, modules bool) {
 	// limit the number of concurrent calls to parser.ParseDir()
 	semLimit := 32
 	if runtime.GOOS == "darwin" {
@@ -119,6 +118,9 @@ func BuildProfile(packageList ListDefinition, name, outputLocation string, outpu
 					var ok bool
 					if aliasPath, ok = packageList.PathOverride[importPath]; !ok {
 						var err error
+						if modules && modinfo.HasVersionSuffix(path) {
+							path = filepath.Dir(path)
+						}
 						aliasPath, err = getAliasPath(path)
 						if err != nil {
 							errLog.Fatalf("failed to calculate alias directory: %v", err)
@@ -153,20 +155,22 @@ func getAliasPath(packageDir string) (string, error) {
 	// into this:
 	//  compute/mgmt/compute
 	// i.e. remove everything to the left of /services along with the API version
-	packageDir = strings.TrimSuffix(packageDir, string(filepath.Separator))
-	matches := packageName.FindAllStringSubmatch(packageDir, -1)
-	if matches == nil {
-		return "", fmt.Errorf("path '%s' does not resemble a known package path", packageDir)
+	pi, err := DeconstructPath(packageDir)
+	if err != nil {
+		return "", err
 	}
 
 	output := []string{
-		matches[0][1],
+		pi.Provider,
 	}
 
-	if matches[0][2] == armPathModifier {
+	if pi.IsArm {
 		output = append(output, armPathModifier)
 	}
-	output = append(output, matches[0][4])
+	output = append(output, pi.Group)
+	if pi.APIPkg != "" {
+		output = append(output, pi.APIPkg)
+	}
 
 	return filepath.Join(output...), nil
 }

--- a/tools/profileBuilder/model/transforms.go
+++ b/tools/profileBuilder/model/transforms.go
@@ -119,6 +119,7 @@ func BuildProfile(packageList ListDefinition, name, outputLocation string, outpu
 					if aliasPath, ok = packageList.PathOverride[importPath]; !ok {
 						var err error
 						if modules && modinfo.HasVersionSuffix(path) {
+							// strip off the major version dir so it's not included in the alias path
 							path = filepath.Dir(path)
 						}
 						aliasPath, err = getAliasPath(path)

--- a/tools/profileBuilder/model/transforms_test.go
+++ b/tools/profileBuilder/model/transforms_test.go
@@ -28,19 +28,35 @@ func Test_GetAliasPath(t *testing.T) {
 		expected string
 	}{
 		{
-			filepath.Join("services", "cdn", "mgmt", "2015-06-01", "cdn"),
+			filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "cdn", "mgmt", "2015-06-01", "cdn"),
 			filepath.Join("cdn", "mgmt", "cdn"),
 		},
 		{
-			filepath.Join("services", "keyvault", "2016-10-01", "keyvault"),
+			filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "cdn", "mgmt", "2015-06-01", "cdn", "cdnapi"),
+			filepath.Join("cdn", "mgmt", "cdn", "cdnapi"),
+		},
+		{
+			filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "cdn", "mgmt", "2015-06-01", "cdn", "v2"),
+			filepath.Join("cdn", "mgmt", "cdn"),
+		},
+		{
+			filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "keyvault", "2016-10-01", "keyvault"),
 			filepath.Join("keyvault", "keyvault"),
 		},
 		{
-			filepath.Join("services", "keyvault", "mgmt", "2016-10-01", "keyvault"),
+			filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "keyvault", "2016-10-01", "keyvault", "v21"),
+			filepath.Join("keyvault", "keyvault"),
+		},
+		{
+			filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "keyvault", "2016-10-01", "keyvault", "v21", "keyvaultapi"),
+			filepath.Join("keyvault", "keyvault", "keyvaultapi"),
+		},
+		{
+			filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "keyvault", "mgmt", "2016-10-01", "keyvault"),
 			filepath.Join("keyvault", "mgmt", "keyvault"),
 		},
 		{
-			filepath.Join("services", "datalake", "analytics", "2016-11-01-preview", "catalog"),
+			filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "datalake", "analytics", "2016-11-01-preview", "catalog"),
 			filepath.Join("datalake", "analytics", "catalog"),
 		},
 	}

--- a/tools/versioner/cmd/root_test.go
+++ b/tools/versioner/cmd/root_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -63,33 +62,6 @@ func Test_getTags(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("didn't find tag v10.1.0-beta")
-	}
-}
-
-func Test_sortModuleTagsBySemver(t *testing.T) {
-	before := []string{
-		"foo/v1.0.0",
-		"foo/v1.0.1",
-		"foo/v1.1.0",
-		"foo/v10.0.0",
-		"foo/v11.1.1",
-		"foo/v2.0.0",
-		"foo/v20.2.3",
-		"foo/v3.1.0",
-	}
-	sortModuleTagsBySemver(before)
-	after := []string{
-		"foo/v1.0.0",
-		"foo/v1.0.1",
-		"foo/v1.1.0",
-		"foo/v2.0.0",
-		"foo/v3.1.0",
-		"foo/v10.0.0",
-		"foo/v11.1.1",
-		"foo/v20.2.3",
-	}
-	if !reflect.DeepEqual(before, after) {
-		t.Fatalf("sort order doesn't match, expected '%v' got '%v'", after, before)
 	}
 }
 


### PR DESCRIPTION
Added 'modules' flag to profileBuilder to run in module-aware mode.  For
the latest/preview profiles this means that it will include module major
versions in its comparison algorithm.
For static profiles (i.e. 2017-03-09 etc) a new major version of an
included module will result in a new major version for that profile.
Moved some code into central packages (modinfo) to be shared across
tools.
Added additional tests to various functions.
Cleaned up white-space in profile definitions.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
