### PR TITLE
[AutoPR hdinsight/resource-manager] [HDInsight] Fix syntax error in description of subDomainSuffix parameter

### DIFF
--- a/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight/models.go
+++ b/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight/models.go
@@ -199,7 +199,7 @@ type ApplicationGetHTTPSEndpoint struct {
 	DestinationPort *int32 `json:"destinationPort,omitempty"`
 	// PublicPort - The public port to connect to.
 	PublicPort *int32 `json:"publicPort,omitempty"`
-	// SubDomainSuffix - The subDomainSuffix of the application and can not greater than 3 characters.
+	// SubDomainSuffix - The subDomainSuffix of the application. It cannot be greater than 3 characters.
 	SubDomainSuffix *string `json:"subDomainSuffix,omitempty"`
 	// DisableGatewayAuth - The value indicates whether to disable GatewayAuth.
 	DisableGatewayAuth *bool `json:"disableGatewayAuth,omitempty"`

--- a/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight/models.go
+++ b/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight/models.go
@@ -199,7 +199,7 @@ type ApplicationGetHTTPSEndpoint struct {
 	DestinationPort *int32 `json:"destinationPort,omitempty"`
 	// PublicPort - The public port to connect to.
 	PublicPort *int32 `json:"publicPort,omitempty"`
-	// SubDomainSuffix - The subDomainSuffix of the application. It cannot be greater than 3 characters.
+	// SubDomainSuffix - The subDomainSuffix of the application.
 	SubDomainSuffix *string `json:"subDomainSuffix,omitempty"`
 	// DisableGatewayAuth - The value indicates whether to disable GatewayAuth.
 	DisableGatewayAuth *bool `json:"disableGatewayAuth,omitempty"`


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/6287