### PR TITLE
[AutoPR monitor/resource-manager] BUG fix: Fixing type of MetricValue.Count to be double instead of the incorrect int64 it had before

### DIFF
--- a/services/preview/monitor/mgmt/2017-05-01-preview/insights/activitylogs.go
+++ b/services/preview/monitor/mgmt/2017-05-01-preview/insights/activitylogs.go
@@ -42,18 +42,18 @@ func NewActivityLogsClientWithBaseURI(baseURI string, subscriptionID string) Act
 
 // List provides the list of records from the activity logs.
 // Parameters:
-// filter - reduces the set of data collected.<br>The **$filter** argument is very restricted and allows only
-// the following patterns.<br>- *List events for a resource group*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq
-// 'resourceGroupName'.<br>- *List events for resource*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceUri eq
-// 'resourceURI'.<br>- *List events for a subscription in a time range*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a
-// resource provider*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and resourceProvider eq 'resourceProviderName'.<br>- *List events for a
-// correlation Id*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and correlationId eq 'correlationID'.<br><br>**NOTE**: No other syntax is
-// allowed.
+// filter - reduces the set of data collected.<br>This argument is required and it also requires at least the
+// start date/time.<br>The **$filter** argument is very restricted and allows only the following patterns.<br>-
+// *List events for a resource group*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and
+// eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq 'resourceGroupName'.<br>- *List
+// events for resource*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z' and resourceUri eq 'resourceURI'.<br>- *List events for a subscription in a
+// time range*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a resource provider*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceProvider eq
+// 'resourceProviderName'.<br>- *List events for a correlation Id*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and correlationId eq
+// 'correlationID'.<br><br>**NOTE**: No other syntax is allowed.
 // selectParameter - used to fetch events with only the given properties.<br>The **$select** argument is a
 // comma separated list of property names to be returned. Possible values are: *authorization*, *claims*,
 // *correlationId*, *description*, *eventDataId*, *eventName*, *eventTimestamp*, *httpRequest*, *level*,
@@ -100,10 +100,8 @@ func (client ActivityLogsClient) ListPreparer(ctx context.Context, filter string
 
 	const APIVersion = "2015-04-01"
 	queryParameters := map[string]interface{}{
+		"$filter":     autorest.Encode("query", filter),
 		"api-version": APIVersion,
-	}
-	if len(filter) > 0 {
-		queryParameters["$filter"] = autorest.Encode("query", filter)
 	}
 	if len(selectParameter) > 0 {
 		queryParameters["$select"] = autorest.Encode("query", selectParameter)

--- a/services/preview/monitor/mgmt/2018-03-01/insights/activitylogs.go
+++ b/services/preview/monitor/mgmt/2018-03-01/insights/activitylogs.go
@@ -42,18 +42,18 @@ func NewActivityLogsClientWithBaseURI(baseURI string, subscriptionID string) Act
 
 // List provides the list of records from the activity logs.
 // Parameters:
-// filter - reduces the set of data collected.<br>The **$filter** argument is very restricted and allows only
-// the following patterns.<br>- *List events for a resource group*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq
-// 'resourceGroupName'.<br>- *List events for resource*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceUri eq
-// 'resourceURI'.<br>- *List events for a subscription in a time range*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a
-// resource provider*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and resourceProvider eq 'resourceProviderName'.<br>- *List events for a
-// correlation Id*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and correlationId eq 'correlationID'.<br><br>**NOTE**: No other syntax is
-// allowed.
+// filter - reduces the set of data collected.<br>This argument is required and it also requires at least the
+// start date/time.<br>The **$filter** argument is very restricted and allows only the following patterns.<br>-
+// *List events for a resource group*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and
+// eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq 'resourceGroupName'.<br>- *List
+// events for resource*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z' and resourceUri eq 'resourceURI'.<br>- *List events for a subscription in a
+// time range*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a resource provider*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceProvider eq
+// 'resourceProviderName'.<br>- *List events for a correlation Id*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and correlationId eq
+// 'correlationID'.<br><br>**NOTE**: No other syntax is allowed.
 // selectParameter - used to fetch events with only the given properties.<br>The **$select** argument is a
 // comma separated list of property names to be returned. Possible values are: *authorization*, *claims*,
 // *correlationId*, *description*, *eventDataId*, *eventName*, *eventTimestamp*, *httpRequest*, *level*,
@@ -100,10 +100,8 @@ func (client ActivityLogsClient) ListPreparer(ctx context.Context, filter string
 
 	const APIVersion = "2015-04-01"
 	queryParameters := map[string]interface{}{
+		"$filter":     autorest.Encode("query", filter),
 		"api-version": APIVersion,
-	}
-	if len(filter) > 0 {
-		queryParameters["$filter"] = autorest.Encode("query", filter)
 	}
 	if len(selectParameter) > 0 {
 		queryParameters["$select"] = autorest.Encode("query", selectParameter)

--- a/services/preview/monitor/mgmt/2018-03-01/insights/models.go
+++ b/services/preview/monitor/mgmt/2018-03-01/insights/models.go
@@ -4261,7 +4261,7 @@ type MetricValue struct {
 	// Total - the sum of all of the values in the time range.
 	Total *float64 `json:"total,omitempty"`
 	// Count - the number of samples in the time range. Can be used to determine the number of values that contributed to the average value.
-	Count *int64 `json:"count,omitempty"`
+	Count *float64 `json:"count,omitempty"`
 }
 
 // BasicMultiMetricCriteria the types of conditions for a multi resource alert.

--- a/services/preview/monitor/mgmt/2018-09-01/insights/activitylogs.go
+++ b/services/preview/monitor/mgmt/2018-09-01/insights/activitylogs.go
@@ -42,18 +42,18 @@ func NewActivityLogsClientWithBaseURI(baseURI string, subscriptionID string) Act
 
 // List provides the list of records from the activity logs.
 // Parameters:
-// filter - reduces the set of data collected.<br>The **$filter** argument is very restricted and allows only
-// the following patterns.<br>- *List events for a resource group*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq
-// 'resourceGroupName'.<br>- *List events for resource*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceUri eq
-// 'resourceURI'.<br>- *List events for a subscription in a time range*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a
-// resource provider*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and resourceProvider eq 'resourceProviderName'.<br>- *List events for a
-// correlation Id*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and correlationId eq 'correlationID'.<br><br>**NOTE**: No other syntax is
-// allowed.
+// filter - reduces the set of data collected.<br>This argument is required and it also requires at least the
+// start date/time.<br>The **$filter** argument is very restricted and allows only the following patterns.<br>-
+// *List events for a resource group*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and
+// eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq 'resourceGroupName'.<br>- *List
+// events for resource*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z' and resourceUri eq 'resourceURI'.<br>- *List events for a subscription in a
+// time range*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a resource provider*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceProvider eq
+// 'resourceProviderName'.<br>- *List events for a correlation Id*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and correlationId eq
+// 'correlationID'.<br><br>**NOTE**: No other syntax is allowed.
 // selectParameter - used to fetch events with only the given properties.<br>The **$select** argument is a
 // comma separated list of property names to be returned. Possible values are: *authorization*, *claims*,
 // *correlationId*, *description*, *eventDataId*, *eventName*, *eventTimestamp*, *httpRequest*, *level*,
@@ -100,10 +100,8 @@ func (client ActivityLogsClient) ListPreparer(ctx context.Context, filter string
 
 	const APIVersion = "2015-04-01"
 	queryParameters := map[string]interface{}{
+		"$filter":     autorest.Encode("query", filter),
 		"api-version": APIVersion,
-	}
-	if len(filter) > 0 {
-		queryParameters["$filter"] = autorest.Encode("query", filter)
 	}
 	if len(selectParameter) > 0 {
 		queryParameters["$select"] = autorest.Encode("query", selectParameter)

--- a/services/preview/monitor/mgmt/2018-09-01/insights/models.go
+++ b/services/preview/monitor/mgmt/2018-09-01/insights/models.go
@@ -4296,7 +4296,7 @@ type MetricValue struct {
 	// Total - the sum of all of the values in the time range.
 	Total *float64 `json:"total,omitempty"`
 	// Count - the number of samples in the time range. Can be used to determine the number of values that contributed to the average value.
-	Count *int64 `json:"count,omitempty"`
+	Count *float64 `json:"count,omitempty"`
 }
 
 // BasicMultiMetricCriteria the types of conditions for a multi resource alert.

--- a/services/preview/monitor/mgmt/2018-11-01-preview/insights/activitylogs.go
+++ b/services/preview/monitor/mgmt/2018-11-01-preview/insights/activitylogs.go
@@ -42,18 +42,18 @@ func NewActivityLogsClientWithBaseURI(baseURI string, subscriptionID string) Act
 
 // List provides the list of records from the activity logs.
 // Parameters:
-// filter - reduces the set of data collected.<br>The **$filter** argument is very restricted and allows only
-// the following patterns.<br>- *List events for a resource group*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq
-// 'resourceGroupName'.<br>- *List events for resource*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceUri eq
-// 'resourceURI'.<br>- *List events for a subscription in a time range*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a
-// resource provider*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and resourceProvider eq 'resourceProviderName'.<br>- *List events for a
-// correlation Id*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and correlationId eq 'correlationID'.<br><br>**NOTE**: No other syntax is
-// allowed.
+// filter - reduces the set of data collected.<br>This argument is required and it also requires at least the
+// start date/time.<br>The **$filter** argument is very restricted and allows only the following patterns.<br>-
+// *List events for a resource group*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and
+// eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq 'resourceGroupName'.<br>- *List
+// events for resource*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z' and resourceUri eq 'resourceURI'.<br>- *List events for a subscription in a
+// time range*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a resource provider*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceProvider eq
+// 'resourceProviderName'.<br>- *List events for a correlation Id*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and correlationId eq
+// 'correlationID'.<br><br>**NOTE**: No other syntax is allowed.
 // selectParameter - used to fetch events with only the given properties.<br>The **$select** argument is a
 // comma separated list of property names to be returned. Possible values are: *authorization*, *claims*,
 // *correlationId*, *description*, *eventDataId*, *eventName*, *eventTimestamp*, *httpRequest*, *level*,
@@ -100,10 +100,8 @@ func (client ActivityLogsClient) ListPreparer(ctx context.Context, filter string
 
 	const APIVersion = "2015-04-01"
 	queryParameters := map[string]interface{}{
+		"$filter":     autorest.Encode("query", filter),
 		"api-version": APIVersion,
-	}
-	if len(filter) > 0 {
-		queryParameters["$filter"] = autorest.Encode("query", filter)
 	}
 	if len(selectParameter) > 0 {
 		queryParameters["$select"] = autorest.Encode("query", selectParameter)

--- a/services/preview/monitor/mgmt/2018-11-01-preview/insights/models.go
+++ b/services/preview/monitor/mgmt/2018-11-01-preview/insights/models.go
@@ -4342,7 +4342,7 @@ type MetricValue struct {
 	// Total - the sum of all of the values in the time range.
 	Total *float64 `json:"total,omitempty"`
 	// Count - the number of samples in the time range. Can be used to determine the number of values that contributed to the average value.
-	Count *int64 `json:"count,omitempty"`
+	Count *float64 `json:"count,omitempty"`
 }
 
 // BasicMultiMetricCriteria the types of conditions for a multi resource alert.

--- a/services/preview/monitor/mgmt/2019-03-01/insights/activitylogs.go
+++ b/services/preview/monitor/mgmt/2019-03-01/insights/activitylogs.go
@@ -42,18 +42,18 @@ func NewActivityLogsClientWithBaseURI(baseURI string, subscriptionID string) Act
 
 // List provides the list of records from the activity logs.
 // Parameters:
-// filter - reduces the set of data collected.<br>The **$filter** argument is very restricted and allows only
-// the following patterns.<br>- *List events for a resource group*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq
-// 'resourceGroupName'.<br>- *List events for resource*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceUri eq
-// 'resourceURI'.<br>- *List events for a subscription in a time range*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a
-// resource provider*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and resourceProvider eq 'resourceProviderName'.<br>- *List events for a
-// correlation Id*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and correlationId eq 'correlationID'.<br><br>**NOTE**: No other syntax is
-// allowed.
+// filter - reduces the set of data collected.<br>This argument is required and it also requires at least the
+// start date/time.<br>The **$filter** argument is very restricted and allows only the following patterns.<br>-
+// *List events for a resource group*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and
+// eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq 'resourceGroupName'.<br>- *List
+// events for resource*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z' and resourceUri eq 'resourceURI'.<br>- *List events for a subscription in a
+// time range*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a resource provider*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceProvider eq
+// 'resourceProviderName'.<br>- *List events for a correlation Id*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and correlationId eq
+// 'correlationID'.<br><br>**NOTE**: No other syntax is allowed.
 // selectParameter - used to fetch events with only the given properties.<br>The **$select** argument is a
 // comma separated list of property names to be returned. Possible values are: *authorization*, *claims*,
 // *correlationId*, *description*, *eventDataId*, *eventName*, *eventTimestamp*, *httpRequest*, *level*,
@@ -100,10 +100,8 @@ func (client ActivityLogsClient) ListPreparer(ctx context.Context, filter string
 
 	const APIVersion = "2015-04-01"
 	queryParameters := map[string]interface{}{
+		"$filter":     autorest.Encode("query", filter),
 		"api-version": APIVersion,
-	}
-	if len(filter) > 0 {
-		queryParameters["$filter"] = autorest.Encode("query", filter)
 	}
 	if len(selectParameter) > 0 {
 		queryParameters["$select"] = autorest.Encode("query", selectParameter)

--- a/services/preview/monitor/mgmt/2019-03-01/insights/models.go
+++ b/services/preview/monitor/mgmt/2019-03-01/insights/models.go
@@ -4404,7 +4404,7 @@ type MetricValue struct {
 	// Total - the sum of all of the values in the time range.
 	Total *float64 `json:"total,omitempty"`
 	// Count - the number of samples in the time range. Can be used to determine the number of values that contributed to the average value.
-	Count *int64 `json:"count,omitempty"`
+	Count *float64 `json:"count,omitempty"`
 }
 
 // BasicMultiMetricCriteria the types of conditions for a multi resource alert.

--- a/services/preview/monitor/mgmt/2019-06-01/insights/activitylogs.go
+++ b/services/preview/monitor/mgmt/2019-06-01/insights/activitylogs.go
@@ -42,18 +42,18 @@ func NewActivityLogsClientWithBaseURI(baseURI string, subscriptionID string) Act
 
 // List provides the list of records from the activity logs.
 // Parameters:
-// filter - reduces the set of data collected.<br>The **$filter** argument is very restricted and allows only
-// the following patterns.<br>- *List events for a resource group*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq
-// 'resourceGroupName'.<br>- *List events for resource*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceUri eq
-// 'resourceURI'.<br>- *List events for a subscription in a time range*: $filter=eventTimestamp ge
-// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a
-// resource provider*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and resourceProvider eq 'resourceProviderName'.<br>- *List events for a
-// correlation Id*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
-// '2014-07-20T04:36:37.6407898Z' and correlationId eq 'correlationID'.<br><br>**NOTE**: No other syntax is
-// allowed.
+// filter - reduces the set of data collected.<br>This argument is required and it also requires at least the
+// start date/time.<br>The **$filter** argument is very restricted and allows only the following patterns.<br>-
+// *List events for a resource group*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and
+// eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName eq 'resourceGroupName'.<br>- *List
+// events for resource*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z' and resourceUri eq 'resourceURI'.<br>- *List events for a subscription in a
+// time range*: $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and eventTimestamp le
+// '2014-07-20T04:36:37.6407898Z'.<br>- *List events for a resource provider*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceProvider eq
+// 'resourceProviderName'.<br>- *List events for a correlation Id*: $filter=eventTimestamp ge
+// '2014-07-16T04:36:37.6407898Z' and eventTimestamp le '2014-07-20T04:36:37.6407898Z' and correlationId eq
+// 'correlationID'.<br><br>**NOTE**: No other syntax is allowed.
 // selectParameter - used to fetch events with only the given properties.<br>The **$select** argument is a
 // comma separated list of property names to be returned. Possible values are: *authorization*, *claims*,
 // *correlationId*, *description*, *eventDataId*, *eventName*, *eventTimestamp*, *httpRequest*, *level*,
@@ -100,10 +100,8 @@ func (client ActivityLogsClient) ListPreparer(ctx context.Context, filter string
 
 	const APIVersion = "2015-04-01"
 	queryParameters := map[string]interface{}{
+		"$filter":     autorest.Encode("query", filter),
 		"api-version": APIVersion,
-	}
-	if len(filter) > 0 {
-		queryParameters["$filter"] = autorest.Encode("query", filter)
 	}
 	if len(selectParameter) > 0 {
 		queryParameters["$select"] = autorest.Encode("query", selectParameter)

--- a/services/preview/monitor/mgmt/2019-06-01/insights/models.go
+++ b/services/preview/monitor/mgmt/2019-06-01/insights/models.go
@@ -4404,7 +4404,7 @@ type MetricValue struct {
 	// Total - the sum of all of the values in the time range.
 	Total *float64 `json:"total,omitempty"`
 	// Count - the number of samples in the time range. Can be used to determine the number of values that contributed to the average value.
-	Count *int64 `json:"count,omitempty"`
+	Count *float64 `json:"count,omitempty"`
 }
 
 // BasicMultiMetricCriteria the types of conditions for a multi resource alert.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/6485