### PR TITLE
fix issue where bastion ip config name wasnt marshalled to json

### DIFF
--- a/services/network/mgmt/2019-04-01/network/models.go
+++ b/services/network/mgmt/2019-04-01/network/models.go
@@ -7093,7 +7093,7 @@ func (bh *BastionHost) UnmarshalJSON(body []byte) error {
 type BastionHostIPConfiguration struct {
 	// BastionHostIPConfigurationPropertiesFormat - Represents the ip configuration associated with the resource.
 	*BastionHostIPConfigurationPropertiesFormat `json:"properties,omitempty"`
-	// Name - READ-ONLY; Name of the resource that is unique within a resource group. This name can be used to access the resource.
+	// Name - Name of the resource that is unique within a resource group. This name can be used to access the resource.
 	Name *string `json:"name,omitempty"`
 	// Etag - READ-ONLY; A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -7108,6 +7108,9 @@ func (bhic BastionHostIPConfiguration) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	if bhic.BastionHostIPConfigurationPropertiesFormat != nil {
 		objectMap["properties"] = bhic.BastionHostIPConfigurationPropertiesFormat
+	}
+	if bhic.Name != nil {
+		objectMap["name"] = bhic.Name
 	}
 	if bhic.ID != nil {
 		objectMap["id"] = bhic.ID


### PR DESCRIPTION
- [x] The purpose of this PR is explained in this or a referenced issue.

This shall marshal the "Name" property for the  &[]network.BastionHostIPConfiguration{}

- [x ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
I can't 
- [ ] Updates to [CHANGELOG.md][] are included.
- [ x] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
