### PR TITLE
Tooling fixes

### DIFF
--- a/tools/apidiff/repo/repo.go
+++ b/tools/apidiff/repo/repo.go
@@ -168,6 +168,9 @@ func (wt WorkingTree) ListTags(pattern string) ([]string, error) {
 	if err != nil {
 		return nil, errors.New(string(output))
 	}
+	if len(output) == 0 {
+		return []string{}, nil
+	}
 	tags := strings.Split(strings.TrimSpace(string(output)), "\n")
 	sort.Strings(tags)
 	return tags, nil

--- a/tools/internal/modinfo/modinfo.go
+++ b/tools/internal/modinfo/modinfo.go
@@ -206,3 +206,9 @@ func (m module) NewModule() bool {
 func (m module) GenerateReport() report.Package {
 	return report.Generate(m.lhs, m.rhs, false, false)
 }
+
+// IsValidModuleVersion returns true if the provided string is a valid module version (e.g. v1.2.3).
+func IsValidModuleVersion(v string) bool {
+	r := regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+	return r.MatchString(v)
+}

--- a/tools/internal/modinfo/modinfo_test.go
+++ b/tools/internal/modinfo/modinfo_test.go
@@ -212,3 +212,15 @@ func TestCreateModuleNameFromPathFail(t *testing.T) {
 		t.Fatalf("expected empty module name, got %s", n)
 	}
 }
+
+func TestIsValidModuleVersion(t *testing.T) {
+	if !IsValidModuleVersion("v10.21.23") {
+		t.Fatal("unexpected invalid module version")
+	}
+	if IsValidModuleVersion("1.2.3") {
+		t.Fatal("unexpected valid module version, missing v")
+	}
+	if IsValidModuleVersion("v11.563") {
+		t.Fatal("unexpected valid module version, missing patch")
+	}
+}


### PR DESCRIPTION
Return empty slice when no tags are found.
Added module version string validation.
Added optional arg 'initial module version' to versioner tool.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
