### PR TITLE
Major updater tool

### DIFF
--- a/tools/apidiff/repo/repo.go
+++ b/tools/apidiff/repo/repo.go
@@ -172,3 +172,25 @@ func (wt WorkingTree) ListTags(pattern string) ([]string, error) {
 	sort.Strings(tags)
 	return tags, nil
 }
+
+// Pull calls "git pull upstream branch" to update local working tree.
+func (wt WorkingTree) Pull(upstream string, branch string) error {
+	cmd := exec.Command("git", "pull", upstream, branch)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+	return nil
+}
+
+// CreateAndCheckout create and checkout to a new branch
+func (wt WorkingTree) CreateAndCheckout(branch string) error {
+	cmd := exec.Command("git", "checkout", "-b", branch)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+	return nil
+}

--- a/tools/apidiff/repo/repo.go
+++ b/tools/apidiff/repo/repo.go
@@ -174,7 +174,7 @@ func (wt WorkingTree) ListTags(pattern string) ([]string, error) {
 }
 
 // Pull calls "git pull upstream branch" to update local working tree.
-func (wt WorkingTree) Pull(upstream string, branch string) error {
+func (wt WorkingTree) Pull(upstream, branch string) error {
 	cmd := exec.Command("git", "pull", upstream, branch)
 	cmd.Dir = wt.dir
 	output, err := cmd.CombinedOutput()

--- a/tools/major-updater/cmd/afterscripts.go
+++ b/tools/major-updater/cmd/afterscripts.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/tools/major-updater/cmd/afterscripts.go
+++ b/tools/major-updater/cmd/afterscripts.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 func theAfterscriptsCommand(sdk string) error {
-	vprintln("Generating profiles...")
+	println("Generating profiles...")
 	absolutePathOfSDK, err := filepath.Abs(sdk)
 	if err != nil {
 		return fmt.Errorf("failed to get the directory of SDK: %v", err)

--- a/tools/major-updater/cmd/afterscripts.go
+++ b/tools/major-updater/cmd/afterscripts.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var afterscriptsCmd = &cobra.Command{
+	Use:   "afterscripts <SDK dir>",
+	Short: "Run afterscripts for SDK",
+	Long: `This command will run the afterscripts in SDK repo, 
+	including generation of profiles, and formatting the generated code`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		return cobra.ExactArgs(1)(cmd, args)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sdk := args[0]
+		err := theAfterscriptsCommand(sdk)
+		return err
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(afterscriptsCmd)
+}
+
+func theAfterscriptsCommand(sdk string) error {
+	vprintln("Generating profiles...")
+	absolutePathOfSDK, err := filepath.Abs(sdk)
+	if err != nil {
+		return fmt.Errorf("failed to get the directory of SDK: %v", err)
+	}
+	absolutePathOfProfiles := path.Join(absolutePathOfSDK, "profiles")
+	err = changeDir(absolutePathOfProfiles)
+	if err != nil {
+		return fmt.Errorf("failed to enter directory for profiles: %v", err)
+	}
+	c := exec.Command("go", "generate", "./...")
+	err = c.Run()
+	if err != nil {
+		return fmt.Errorf("Error occurs when generating profiles: %v", err)
+	}
+	vprintln("Formatting the whole SDK folder...")
+	err = changeDir(absolutePathOfSDK)
+	if err != nil {
+		return fmt.Errorf("failed to enter directory for SDK: %v", err)
+	}
+	c = exec.Command("gofmt", "-w", "./profiles/")
+	err = c.Run()
+	if err != nil {
+		return fmt.Errorf("Error occurs when formatting profiles: %v", err)
+	}
+	c = exec.Command("gofmt", "-w", "./services/")
+	err = c.Run()
+	if err != nil {
+		return fmt.Errorf("Error occurs when formatting the SDK folder: %v", err)
+	}
+	return nil
+}

--- a/tools/major-updater/cmd/autorest.go
+++ b/tools/major-updater/cmd/autorest.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/tools/major-updater/cmd/autorest.go
+++ b/tools/major-updater/cmd/autorest.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 func theAutorestCommand(sdk, spec string) error {
-	vprintf("Executing autorest (%d threads)\n", thread)
+	printf("Executing autorest (%d threads)\n", thread)
 	err := os.Setenv("NODE_OPTIONS", "--max-old-space-size=8192")
 	if err != nil {
 		return fmt.Errorf("failed to set environment variable: %v", err)

--- a/tools/major-updater/cmd/autorest.go
+++ b/tools/major-updater/cmd/autorest.go
@@ -66,7 +66,11 @@ func theAutorestCommand(sdk, spec string) error {
 		go worker(i, jobs, results)
 	}
 	for _, file := range files {
-		jobs <- work{filename: file, sdkFolder: absolutePathOfSDK}
+		w := work{
+			filename: file,
+			sdkFolder: absolutePathOfSDK,
+		}
+		jobs <- w
 	}
 	close(jobs)
 	for range files {

--- a/tools/major-updater/cmd/autorest.go
+++ b/tools/major-updater/cmd/autorest.go
@@ -67,7 +67,7 @@ func theAutorestCommand(sdk, spec string) error {
 	}
 	for _, file := range files {
 		w := work{
-			filename: file,
+			filename:  file,
 			sdkFolder: absolutePathOfSDK,
 		}
 		jobs <- w

--- a/tools/major-updater/cmd/autorest.go
+++ b/tools/major-updater/cmd/autorest.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var autorestCmd = &cobra.Command{
+	Use:   "autorest <SDK dir> <specs dir>",
+	Short: "Execute autorest on specs, saving generated SDK code into SDK dir",
+	Long: `This command will execute autorest on the specs dir, 
+	saving the generated SDK code into SDK dir, then runs some after-scripts`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		return cobra.ExactArgs(2)(cmd, args)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sdk := args[0]
+		spec := args[1]
+		err := theAutorestCommand(sdk, spec)
+		return err
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(autorestCmd)
+}
+
+func theAutorestCommand(sdk, spec string) error {
+	vprintf("Executing autorest (%d threads)\n", thread)
+	err := os.Setenv("NODE_OPTIONS", "--max-old-space-size=8192")
+	if err != nil {
+		return fmt.Errorf("failed to set environment variable: %v", err)
+	}
+	// get every single readme.md file in the directory
+	files, err := selectFilesWithName(absolutePathOfSpecs, readme)
+	vprintf("Found %d readme.md files\n", len(files))
+	jobs := make(chan string, 1000)
+	results := make(chan error, 1000)
+	for i := 0; i < thread; i++ {
+		go worker(i, jobs, results)
+	}
+	for _, file := range files {
+		jobs <- file
+	}
+	close(jobs)
+	for range files {
+		<-results
+	}
+	vprintln("autorest finished")
+	return nil
+}

--- a/tools/major-updater/cmd/common.go
+++ b/tools/major-updater/cmd/common.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/tools/major-updater/cmd/common.go
+++ b/tools/major-updater/cmd/common.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"bufio"
+)
+
+func printf(format string, a ...interface{}) {
+	if !quietFlag {
+		fmt.Printf(format, a...)
+	}
+}
+
+func println(a ...interface{}) {
+	if !quietFlag {
+		fmt.Println(a...)
+	}
+}
+
+func dprintf(format string, a ...interface{}) {
+	if debugFlag {
+		printf(format, a...)
+	}
+}
+
+func dprintln(a ...interface{}) {
+	if debugFlag {
+		println(a...)
+	}
+}
+
+func vprintf(format string, a ...interface{}) {
+	if verboseFlag {
+		printf(format, a...)
+	}
+}
+
+func vprintln(a ...interface{}) {
+	if verboseFlag {
+		println(a...)
+	}
+}
+
+func contains(strings []string, str string) bool {
+	for _, s := range strings {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}
+
+func startCmd(c *exec.Cmd) error {
+	stdout, err := c.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to get stdout pipe: %v", err)
+	}
+	scanner := bufio.NewScanner(stdout)
+	go func() {
+		for scanner.Scan() {
+			printf("> %s\n", scanner.Text())
+		}
+	}()
+	stderr, err := c.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("failed to get stderr pipe: %v", err)
+	}
+	scanner = bufio.NewScanner(stderr)
+	go func() {
+		for scanner.Scan() {
+			printf("> %s\n", scanner.Text())
+		}
+	}()
+	return c.Start()
+}

--- a/tools/major-updater/cmd/common.go
+++ b/tools/major-updater/cmd/common.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
-	"fmt"
-	"os/exec"
 	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 )
 
 func printf(format string, a ...interface{}) {
@@ -73,4 +75,15 @@ func startCmd(c *exec.Cmd) error {
 		}
 	}()
 	return c.Start()
+}
+
+func selectFilesWithName(path string, name string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if !info.IsDir() && info.Name() == name {
+			files = append(files, p)
+		}
+		return nil
+	})
+	return files, err
 }

--- a/tools/major-updater/cmd/common.go
+++ b/tools/major-updater/cmd/common.go
@@ -1,11 +1,7 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 )
 
 func printf(format string, a ...interface{}) {
@@ -51,39 +47,4 @@ func contains(strings []string, str string) bool {
 		}
 	}
 	return false
-}
-
-func startCmd(c *exec.Cmd) error {
-	stdout, err := c.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("failed to get stdout pipe: %v", err)
-	}
-	scanner := bufio.NewScanner(stdout)
-	go func() {
-		for scanner.Scan() {
-			printf("> %s\n", scanner.Text())
-		}
-	}()
-	stderr, err := c.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("failed to get stderr pipe: %v", err)
-	}
-	scanner = bufio.NewScanner(stderr)
-	go func() {
-		for scanner.Scan() {
-			printf("> %s\n", scanner.Text())
-		}
-	}()
-	return c.Start()
-}
-
-func selectFilesWithName(path string, name string) ([]string, error) {
-	var files []string
-	err := filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
-		if !info.IsDir() && info.Name() == name {
-			files = append(files, p)
-		}
-		return nil
-	})
-	return files, err
 }

--- a/tools/major-updater/cmd/dep.go
+++ b/tools/major-updater/cmd/dep.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/tools/major-updater/cmd/dep.go
+++ b/tools/major-updater/cmd/dep.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func theDepCommand() error {
-	vprintln("Executing dep...")
+	println("Executing dep ensure...")
 	depArgs := "ensure -update"
 	if verboseFlag {
 		depArgs += "-v"

--- a/tools/major-updater/cmd/dep.go
+++ b/tools/major-updater/cmd/dep.go
@@ -26,7 +26,7 @@ func theDepCommand() error {
 	println("Executing dep ensure...")
 	depArgs := "ensure -update"
 	if verboseFlag {
-		depArgs += "-v"
+		depArgs += " -v"
 	}
 	c := exec.Command("dep", strings.Split(depArgs, " ")...)
 	err := startCmd(c)

--- a/tools/major-updater/cmd/dep.go
+++ b/tools/major-updater/cmd/dep.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var depCmd = &cobra.Command{
+	Use:   "dep",
+	Short: "Calls dep command to execute dep ensure -update",
+	Long:  "This command will invoke the dep ensure -update command",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := theDepCommand()
+		return err
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(depCmd)
+}
+
+func theDepCommand() error {
+	vprintln("Executing dep...")
+	depArgs := "ensure -update"
+	if verboseFlag {
+		depArgs += "-v"
+	}
+	c := exec.Command("dep", strings.Split(depArgs, " ")...)
+	err := startCmd(c)
+	if err != nil {
+		return fmt.Errorf("failed to start command: %v", err)
+	}
+	return c.Wait()
+}

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -114,7 +114,7 @@ func absPaths(sdk, spec string) (string, string, error) {
 		return "", "", fmt.Errorf("failed to get directory of specification: %v", err)
 	}
 	return absSDK, absSpec, nil
-}  
+}
 
 func verboseStatus(sdk, spec string) {
 	if verboseFlag {

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
@@ -30,8 +29,8 @@ var initialBranch string
 var initialDir string
 var pattern *regexp.Regexp
 var majorVersion int
-var absolutePathOfSDK string
-var absolutePathOfSpecs string
+// var absolutePathOfSDK string
+// var absolutePathOfSpecs string
 
 var rootCmd = &cobra.Command{
 	Use:   "major-updater <SDK dir> <specification dir>",
@@ -67,33 +66,33 @@ func theCommand(args []string) error {
 	sdkDir := args[0]
 	specsDir := args[1]
 	var err error
-	absolutePathOfSDK, err = filepath.Abs(sdkDir)
-	if err != nil {
-		return fmt.Errorf("failed to get the directory of SDK: %v", err)
-	}
-	absolutePathOfSpecs, err = filepath.Abs(specsDir)
-	if err != nil {
-		return fmt.Errorf("failed to get the directory of specs: %v", err)
-	}
-	vprintf("SDK directory: %s\nSpecifications directory: %s\n", absolutePathOfSDK, absolutePathOfSpecs)
+	// absolutePathOfSDK, err = filepath.Abs(sdkDir)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to get the directory of SDK: %v", err)
+	// }
+	// absolutePathOfSpecs, err = filepath.Abs(specsDir)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to get the directory of specs: %v", err)
+	// }
+	// vprintf("SDK directory: %s\nSpecifications directory: %s\n", absolutePathOfSDK, absolutePathOfSpecs)
 	initialDir, err = os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get the initial working directory: %v", err)
 	}
-	err = changeDir(absolutePathOfSDK)
-	if err != nil {
-		return fmt.Errorf("cannot change dir to SDK folder: %v", err)
-	}
+	// err = changeDir(absolutePathOfSDK)
+	// if err != nil {
+	// 	return fmt.Errorf("cannot change dir to SDK folder: %v", err)
+	// }
 	if err = theDepCommand(); err != nil {
 		return fmt.Errorf("failed to run dep: %v", err)
 	}
-	if err = theUpdateSDKCommand(absolutePathOfSDK); err != nil {
+	if err = theUpdateSDKCommand(sdkDir); err != nil {
 		return fmt.Errorf("failed to update SDK repo: %v", err)
 	}
-	if err = theUpdateSpecsCommand(absolutePathOfSpecs); err != nil {
+	if err = theUpdateSpecsCommand(specsDir); err != nil {
 		return fmt.Errorf("failed to update specs repo: %v", err)
 	}
-	if err = theAutorestCommand(absolutePathOfSDK, absolutePathOfSpecs); err != nil {
+	if err = theAutorestCommand(sdkDir, specsDir); err != nil {
 		return fmt.Errorf("failed to execute autorest: %v", err)
 	}
 	return nil

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (
@@ -63,6 +77,7 @@ func Execute() {
 func theCommand(args []string) error {
 	sdkDir := args[0]
 	specsDir := args[1]
+	verboseStatus(sdkDir, specsDir)
 	var err error
 	initialDir, err = os.Getwd()
 	if err != nil {
@@ -79,6 +94,9 @@ func theCommand(args []string) error {
 	}
 	if err = theAutorestCommand(sdkDir, specsDir); err != nil {
 		return fmt.Errorf("failed to execute autorest: %v", err)
+	}
+	if err = theAfterscriptsCommand(sdkDir); err != nil {
+		return fmt.Errorf("failed to execute afterscripts: %v", err)
 	}
 	return nil
 }

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -3,11 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
 	"github.com/spf13/cobra"
@@ -26,8 +23,7 @@ var upstream string
 var quietFlag bool
 var debugFlag bool
 var verboseFlag bool
-var skip string
-var batch int
+var thread int
 
 // global variables
 var initialBranch string
@@ -42,10 +38,7 @@ var rootCmd = &cobra.Command{
 	Short: "Do a whole procedure of monthly regular major update",
 	Long:  `This tool will execute a procedure of releasing a new major update of the azure-sdk-for-go`,
 	Args: func(cmd *cobra.Command, args []string) error {
-		if err := cobra.ExactArgs(2)(cmd, args); err != nil {
-			return err
-		}
-		return nil
+		return cobra.ExactArgs(2)(cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := theCommand(args)
@@ -57,11 +50,10 @@ var rootCmd = &cobra.Command{
 func init() {
 	pattern = regexp.MustCompile(`^v([0-9]+)\..*$`)
 	rootCmd.PersistentFlags().StringVar(&upstream, "upstream", "origin", "specify the upstream of the SDK repo")
-	rootCmd.PersistentFlags().IntVarP(&batch, "batch", "b", 4, "batch count")
+	rootCmd.PersistentFlags().IntVarP(&thread, "thread", "t", 4, "thread count when executing autorest")
 	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "quiet output")
 	rootCmd.PersistentFlags().BoolVarP(&debugFlag, "debug", "d", false, "debug output")
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "verbose output")
-	rootCmd.PersistentFlags().StringVar(&skip, "skip", "", "skiped procedures, seprated by comma")
 }
 
 // Execute executes the specified command.
@@ -92,138 +84,19 @@ func theCommand(args []string) error {
 	if err != nil {
 		return fmt.Errorf("cannot change dir to SDK folder: %v", err)
 	}
-	skipArray := strings.Split(skip, ",")
-	if !contains(skipArray, "dep") {
-		println("Executing dep")
-		err = executeDep()
-		if err != nil {
-			return err
-		}
+	if err = theDepCommand(); err != nil {
+		return fmt.Errorf("failed to run dep: %v", err)
 	}
-	if !contains(skipArray, "sdk") && !contains(skipArray, "SDK") {
-		println("Update SDK repo...")
-		err = updateSDKRepo()
-		if err != nil {
-			return err
-		}
+	if err = theUpdateSDKCommand(absolutePathOfSDK); err != nil {
+		return fmt.Errorf("failed to update SDK repo: %v", err)
 	}
-	if !contains(skipArray, "spec") && !contains(skipArray, "specs") {
-		println("Update specs repo...")
-		err = updateSpecsRepo()
-		if err != nil {
-			return err
-		}
+	if err = theUpdateSpecsCommand(absolutePathOfSpecs); err != nil {
+		return fmt.Errorf("failed to update specs repo: %v", err)
 	}
-	println("Executing autorest...")
-	err = runAutorest()
-	return nil
-}
-
-func executeDep() error {
-	args := "ensure -update"
-	if verboseFlag {
-		args = args + " -v"
-	}
-	c := exec.Command("dep", strings.Split(args, " ")...)
-	err := startCmd(c)
-	if err != nil {
-		return err
-	}
-	return c.Wait()
-}
-
-func updateSDKRepo() error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get the current working directory: %v", err)
-	}
-	wt, err := repo.Get(cwd)
-	if err != nil {
-		return fmt.Errorf("failed to get the working tree: %v", err)
-	}
-	initialBranch, err = wt.Branch()
-	if err != nil {
-		return fmt.Errorf("failed to get the current branch: %v", err)
-	}
-	currentMajorVersion, err := findNextMajorVersionNumber(wt)
-	majorVersion = currentMajorVersion + 1
-	printf("Next major version: %d\n", majorVersion)
-	vprintf("Checking out to latest branch in %s\n", cwd)
-	err = wt.Checkout(latest)
-	if err != nil {
-		return fmt.Errorf("checkout failed: %v", err)
-	}
-	err = wt.Pull(upstream, latest)
-	if err != nil {
-		return fmt.Errorf("pull failed: %v", err)
-	}
-	printf("Checking out to new branch based on %s", latest)
-	err = createNewBranch(wt)
-	return err
-}
-
-func updateSpecsRepo() error {
-	err := changeDir(absolutePathOfSpecs)
-	if err != nil {
-		return fmt.Errorf("failed to change directory to %s: %v", absolutePathOfSpecs, err)
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get the current working directory: %v", err)
-	}
-	wt, err := repo.Get(cwd)
-	if err != nil {
-		return fmt.Errorf("failed to get the working tree: %v", err)
-	}
-	vprintf("Checking out to master branch in %s\n", cwd)
-	err = wt.Checkout(master)
-	if err != nil {
-		return fmt.Errorf("checkout failed: %v", err)
-	}
-	err = wt.Pull(specUpstream, master)
-	if err != nil {
-		return fmt.Errorf("pull failed: %v", err)
+	if err = theAutorestCommand(absolutePathOfSDK, absolutePathOfSpecs); err != nil {
+		return fmt.Errorf("failed to execute autorest: %v", err)
 	}
 	return nil
-}
-
-func runAutorest() error {
-	err := os.Setenv("NODE_OPTIONS", "--max-old-space-size=8192")
-	if err != nil {
-		return fmt.Errorf("failed to set environment variable: %v", err)
-	}
-	// get every single readme file in the directory
-	files, err := selectFilesWithName(absolutePathOfSpecs, readme)
-	vprintf("Found %d readme.md files\n", len(files))
-	jobs := make(chan string, 1000)
-	results := make(chan error, 1000)
-	for i := 0; i < batch; i++ {
-		go worker(i, jobs, results)
-	}
-	// call runAutorestSingle here in a loop
-	for _, file := range files {
-		jobs <- file
-	}
-	close(jobs)
-	for range files {
-		<-results
-	}
-	vprintln("autorest finished")
-	return nil
-}
-
-func worker(id int, jobs <-chan string, results chan<- error) {
-	for file := range jobs {
-		vprintf("worker %d is starting on file %s\n", id, file)
-		c := autorestCommand(file, absolutePathOfSDK)
-		err := c.Run()
-		if err == nil {
-			vprintf("worker %d is done with file %s\n", id, file)
-		} else {
-			printf("worker %d fails with file %s, error messages:\n%v\n", id, file, err)
-		}
-		results <- err
-	}
 }
 
 func createNewBranch(wt repo.WorkingTree) error {
@@ -248,21 +121,4 @@ func changeDir(path string) error {
 		return fmt.Errorf("failed to change directory to %s: %v", path, err)
 	}
 	return nil
-}
-
-func findNextMajorVersionNumber(wt repo.WorkingTree) (int, error) {
-	tags, err := wt.ListTags("v*")
-	if err != nil {
-		return 0, fmt.Errorf("failed to list tags: %v", err)
-	}
-	number := 0
-	for _, tag := range tags {
-		matches := pattern.FindStringSubmatch(tag)
-		cc, err := strconv.ParseInt(matches[1], 10, 16)
-		c := int(cc)
-		if err == nil && c > number {
-			number = c
-		}
-	}
-	return number, nil
 }

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -77,35 +77,48 @@ func Execute() {
 func theCommand(args []string) error {
 	sdkDir := args[0]
 	specsDir := args[1]
-	verboseStatus(sdkDir, specsDir)
-	var err error
+	absSDK, absSpec, err := absPaths(sdkDir, specsDir)
+	if err != nil {
+		return err
+	}
+	verboseStatus(absSDK, absSpec)
 	initialDir, err = os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get the initial working directory: %v", err)
 	}
-	if err = theUpdateSDKCommand(sdkDir); err != nil {
+	if err = theUpdateSDKCommand(absSDK); err != nil {
 		return fmt.Errorf("failed to update SDK repo: %v", err)
 	}
 	if err = theDepCommand(); err != nil {
 		return fmt.Errorf("failed to run dep: %v", err)
 	}
-	if err = theUpdateSpecsCommand(specsDir); err != nil {
+	if err = theUpdateSpecsCommand(absSpec); err != nil {
 		return fmt.Errorf("failed to update specs repo: %v", err)
 	}
-	if err = theAutorestCommand(sdkDir, specsDir); err != nil {
+	if err = theAutorestCommand(absSDK, absSpec); err != nil {
 		return fmt.Errorf("failed to execute autorest: %v", err)
 	}
-	if err = theAfterscriptsCommand(sdkDir); err != nil {
+	if err = theAfterscriptsCommand(absSDK); err != nil {
 		return fmt.Errorf("failed to execute afterscripts: %v", err)
 	}
 	return nil
 }
 
+func absPaths(sdk, spec string) (string, string, error) {
+	absSDK, err := filepath.Abs(sdk)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get directory of SDK: %v", err)
+	}
+	absSpec, err := filepath.Abs(spec)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get directory of specification: %v", err)
+	}
+	return absSDK, absSpec, nil
+}  
+
 func verboseStatus(sdk, spec string) {
 	if verboseFlag {
-		absSdk, _ := filepath.Abs(sdk)
-		absSpec, _ := filepath.Abs(spec)
-		vprintf("SDK directory: %s\nSpecification directory: %s\n", absSdk, absSpec)
+		vprintf("SDK directory: %s\nSpecification directory: %s\n", sdk, spec)
 	}
 }
 

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
@@ -80,6 +81,14 @@ func theCommand(args []string) error {
 		return fmt.Errorf("failed to execute autorest: %v", err)
 	}
 	return nil
+}
+
+func verboseStatus(sdk, spec string) {
+	if verboseFlag {
+		absSdk, _ := filepath.Abs(sdk)
+		absSpec, _ := filepath.Abs(spec)
+		vprintf("SDK directory: %s\nSpecification directory: %s\n", absSdk, absSpec)
+	}
 }
 
 func createNewBranch(wt repo.WorkingTree, name string) error {

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -1,0 +1,231 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/spf13/cobra"
+)
+
+const (
+	latest              = "latest"
+	master              = "master"
+	specUpstream        = "origin"
+	branchPattern       = "major-version-release-v%d.0.0"
+	autorestArgsPattern = "--use=@microsoft.azure/autorest.go@~2.1.99 %s --go --multiapi --go-sdk-folder=%s --use-onever"
+)
+
+// flags
+var upstream string
+var quietFlag bool
+var debugFlag bool
+var verboseFlag bool
+var skip []string
+var batch int
+
+// global variables
+var initialBranch string
+var initialDir string
+var pattern *regexp.Regexp
+var majorVersion int
+var absolutePathOfSDK string
+var absolutePathOfSpecs string
+
+var rootCmd = &cobra.Command{
+	Use:   "major-updater <SDK dir> <specs dir>",
+	Short: "Do a whole procedure of monthly regular major update",
+	Long:  `This tool will execute a procedure of releasing a new major update of the azure-sdk-for-go`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if err := cobra.ExactArgs(2)(cmd, args); err != nil {
+			return err
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := theCommand(args)
+		restoreDirAndBranch()
+		return err
+	},
+}
+
+func init() {
+	pattern = regexp.MustCompile(`^v([0-9]+)\..*$`)
+	rootCmd.PersistentFlags().StringVar(&upstream, "upstream", "origin", "specify the upstream of the SDK repo")
+	rootCmd.PersistentFlags().IntVarP(&batch, "batch", "b", 4, "batch count")
+	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "quiet output")
+	rootCmd.PersistentFlags().BoolVarP(&debugFlag, "debug", "d", false, "debug output")
+	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().StringArrayVarP(&skip, "skip", "s", []string{}, "skiped procedures")
+}
+
+// Execute executes the specified command.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func theCommand(args []string) error {
+	sdkDir := args[0]
+	specsDir := args[1]
+	var err error
+	initialDir, err = os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory: %v", err)
+	}
+	err = changeDir(sdkDir)
+	absolutePathOfSDK, _ = os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cannot change dir to SDK folder: %v", err)
+	}
+	if !contains(skip, "dep") {
+		println("Executing dep")
+		err = executeDep()
+		if err != nil {
+			return err
+		}
+	}
+	if !contains(skip, "sdk") {
+		println("Update SDK repo...")
+		err = updateSDKRepo()
+		if err != nil {
+			return err
+		}
+	}
+	if !contains(skip, "spec") && !contains(skip, "specs") {
+		println("Update specs repo...")
+		err = updateSpecsRepo(specsDir)
+		if err != nil {
+			return err
+		}
+	}
+	err = runAutorest()
+	return nil
+}
+
+func executeDep() error {
+	args := "ensure -update"
+	if verboseFlag {
+		args = args + " -v"
+	}
+	c := exec.Command("dep", strings.Split(args, " ")...)
+	err := startCmd(c)
+	if err != nil {
+		return err
+	}
+	return c.Wait()
+}
+
+func updateSDKRepo() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory: %v", err)
+	}
+	wt, err := repo.Get(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to get the working tree: %v", err)
+	}
+	initialBranch, err = wt.Branch()
+	if err != nil {
+		return fmt.Errorf("failed to get the current branch: %v", err)
+	}
+	currentMajorVersion, err := findNextMajorVersionNumber(wt)
+	majorVersion = currentMajorVersion + 1
+	printf("Next major version: %d\n", majorVersion)
+	vprintf("Checking out to latest branch in %s\n", cwd)
+	err = wt.Checkout(latest)
+	if err != nil {
+		return fmt.Errorf("checkout failed: %v", err)
+	}
+	err = wt.Pull(upstream, latest)
+	if err != nil {
+		return fmt.Errorf("pull failed: %v", err)
+	}
+	printf("Checking out to new branch based on %s", latest)
+	err = createNewBranch(wt)
+	return err
+}
+
+func updateSpecsRepo(cwd string) error {
+	err := changeDir(cwd)
+	absolutePathOfSpecs, _ = os.Getwd()
+	wt, err := repo.Get(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to get the working tree: %v", err)
+	}
+	vprintf("Checking out to master branch in %s\n", cwd)
+	err = wt.Checkout(master)
+	if err != nil {
+		return fmt.Errorf("checkout failed: %v", err)
+	}
+	err = wt.Pull(specUpstream, master)
+	if err != nil {
+		return fmt.Errorf("pull failed: %v", err)
+	}
+	return nil
+}
+
+func runAutorest() error {
+	err := os.Setenv("NODE_OPTIONS", "--max-old-space-size=8192")
+	if err != nil {
+		return fmt.Errorf("failed to set environment variable: %v", err)
+	}
+	// call runAutorestSingle here in a loop
+	return nil
+}
+
+func runAutorestSingle(filename string) error {
+	autorestArgs := fmt.Sprintf(autorestArgsPattern, filename, absolutePathOfSDK)
+	c := exec.Command("autorest", strings.Split(autorestArgs, " ")...)
+	err := c.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start autorest on %s: %v", filename, err)
+	}
+	return nil
+}
+
+func createNewBranch(wt repo.WorkingTree) error {
+	branchName := fmt.Sprintf(branchPattern, majorVersion)
+	vprintf("creating branch %s\n", branchName)
+	err := wt.CreateAndCheckout(branchName)
+	return err
+}
+
+func restoreDirAndBranch() {
+	if err := changeDir(initialDir); err != nil {
+		return
+	}
+	if wt, err := repo.Get(initialDir); err == nil {
+		wt.Checkout(initialBranch)
+	}
+}
+
+func changeDir(path string) error {
+	err := os.Chdir(path)
+	if err != nil {
+		return fmt.Errorf("failed to change directory to %s: %v", path, err)
+	}
+	return nil
+}
+
+func findNextMajorVersionNumber(wt repo.WorkingTree) (int, error) {
+	tags, err := wt.ListTags("v*")
+	if err != nil {
+		return 0, fmt.Errorf("failed to list tags: %v", err)
+	}
+	number := 0
+	for _, tag := range tags {
+		matches := pattern.FindStringSubmatch(tag)
+		cc, err := strconv.ParseInt(matches[1], 10, 16)
+		c := int(cc)
+		if err == nil && c > number {
+			number = c
+		}
+	}
+	return number, nil
+}

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -39,7 +39,6 @@ var rootCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := theCommand(args)
-		restoreDir()
 		return err
 	},
 }
@@ -87,10 +86,6 @@ func createNewBranch(wt repo.WorkingTree, name string) error {
 	vprintf("creating branch %s\n", name)
 	err := wt.CreateAndCheckout(name)
 	return err
-}
-
-func restoreDir() {
-	changeDir(initialDir)
 }
 
 func changeDir(path string) error {

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -29,8 +29,8 @@ var initialBranch string
 var initialDir string
 var pattern *regexp.Regexp
 var majorVersion int
-// var absolutePathOfSDK string
-// var absolutePathOfSpecs string
+
+
 
 var rootCmd = &cobra.Command{
 	Use:   "major-updater <SDK dir> <specification dir>",
@@ -66,28 +66,15 @@ func theCommand(args []string) error {
 	sdkDir := args[0]
 	specsDir := args[1]
 	var err error
-	// absolutePathOfSDK, err = filepath.Abs(sdkDir)
-	// if err != nil {
-	// 	return fmt.Errorf("failed to get the directory of SDK: %v", err)
-	// }
-	// absolutePathOfSpecs, err = filepath.Abs(specsDir)
-	// if err != nil {
-	// 	return fmt.Errorf("failed to get the directory of specs: %v", err)
-	// }
-	// vprintf("SDK directory: %s\nSpecifications directory: %s\n", absolutePathOfSDK, absolutePathOfSpecs)
 	initialDir, err = os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get the initial working directory: %v", err)
 	}
-	// err = changeDir(absolutePathOfSDK)
-	// if err != nil {
-	// 	return fmt.Errorf("cannot change dir to SDK folder: %v", err)
-	// }
-	if err = theDepCommand(); err != nil {
-		return fmt.Errorf("failed to run dep: %v", err)
-	}
 	if err = theUpdateSDKCommand(sdkDir); err != nil {
 		return fmt.Errorf("failed to update SDK repo: %v", err)
+	}
+	if err = theDepCommand(); err != nil {
+		return fmt.Errorf("failed to run dep: %v", err)
 	}
 	if err = theUpdateSpecsCommand(specsDir); err != nil {
 		return fmt.Errorf("failed to update specs repo: %v", err)
@@ -98,10 +85,9 @@ func theCommand(args []string) error {
 	return nil
 }
 
-func createNewBranch(wt repo.WorkingTree) error {
-	branchName := fmt.Sprintf(branchPattern, majorVersion)
-	vprintf("creating branch %s\n", branchName)
-	err := wt.CreateAndCheckout(branchName)
+func createNewBranch(wt repo.WorkingTree, name string) error {
+	vprintf("creating branch %s\n", name)
+	err := wt.CreateAndCheckout(name)
 	return err
 }
 

--- a/tools/major-updater/cmd/root.go
+++ b/tools/major-updater/cmd/root.go
@@ -30,8 +30,6 @@ var initialDir string
 var pattern *regexp.Regexp
 var majorVersion int
 
-
-
 var rootCmd = &cobra.Command{
 	Use:   "major-updater <SDK dir> <specification dir>",
 	Short: "Do a whole procedure of monthly regular major update",
@@ -41,7 +39,7 @@ var rootCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := theCommand(args)
-		restoreDirAndBranch()
+		restoreDir()
 		return err
 	},
 }
@@ -91,13 +89,8 @@ func createNewBranch(wt repo.WorkingTree, name string) error {
 	return err
 }
 
-func restoreDirAndBranch() {
-	if err := changeDir(initialDir); err != nil {
-		return
-	}
-	if wt, err := repo.Get(initialDir); err == nil {
-		wt.Checkout(initialBranch)
-	}
+func restoreDir() {
+	changeDir(initialDir)
 }
 
 func changeDir(path string) error {

--- a/tools/major-updater/cmd/updateSDK.go
+++ b/tools/major-updater/cmd/updateSDK.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/tools/major-updater/cmd/updateSDK.go
+++ b/tools/major-updater/cmd/updateSDK.go
@@ -17,8 +17,8 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"path/filepath"
+	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
 	"github.com/spf13/cobra"

--- a/tools/major-updater/cmd/updateSDK.go
+++ b/tools/major-updater/cmd/updateSDK.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/spf13/cobra"
+)
+
+var updateSDKCmd = &cobra.Command{
+	Use:   "updateSDK <SDK dir>",
+	Short: "Update the SDK repo on latest branch",
+	Long: `This command will checkout to latest branch in SDK repo, 
+	find next major version number based on tags, then create a new branch based on the latest branch`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		return cobra.ExactArgs(1)(cmd, args)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sdk := args[0]
+		err := theUpdateSDKCommand(sdk)
+		return err
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(updateSDKCmd)
+}
+
+func theUpdateSDKCommand(sdk string) error {
+	vprintln("Updating SDK repo...")
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory: %v", err)
+	}
+	wt, err := repo.Get(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to get the working tree: %v", err)
+	}
+	initialBranch, err = wt.Branch()
+	if err != nil {
+		return fmt.Errorf("failed to get the current branch: %v", err)
+	}
+	currentMajorVersion, err := findNextMajorVersionNumber(wt)
+	majorVersion = currentMajorVersion + 1
+	printf("Next major version: %d\n", majorVersion)
+	vprintf("Checking out to latest branch in %s\n", cwd)
+	err = wt.Checkout(latest)
+	if err != nil {
+		return fmt.Errorf("checkout failed: %v", err)
+	}
+	err = wt.Pull(upstream, latest)
+	if err != nil {
+		return fmt.Errorf("pull failed: %v", err)
+	}
+	vprintf("Checking out to new branch based on %s", latest)
+	err = createNewBranch(wt)
+	if err != nil {
+		return fmt.Errorf("checkout failed: %v", err)
+	}
+	return nil
+}
+
+func findNextMajorVersionNumber(wt repo.WorkingTree) (int, error) {
+	tags, err := wt.ListTags("v*")
+	if err != nil {
+		return 0, fmt.Errorf("failed to list tags: %v", err)
+	}
+	number := 0
+	for _, tag := range tags {
+		matches := pattern.FindStringSubmatch(tag)
+		cc, err := strconv.ParseInt(matches[1], 10, 32)
+		c := int(cc)
+		if err == nil && c > number {
+			number = c
+		}
+	}
+	return number, nil
+}

--- a/tools/major-updater/cmd/updateSDK.go
+++ b/tools/major-updater/cmd/updateSDK.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func theUpdateSDKCommand(sdk string) error {
-	vprintln("Updating SDK repo...")
+	println("Updating SDK repo...")
 	absolutePathOfSDK, err := filepath.Abs(sdk)
 	if err != nil {
 		return fmt.Errorf("failed to get the directory of SDK: %v", err)
@@ -64,7 +64,8 @@ func theUpdateSDKCommand(sdk string) error {
 		return fmt.Errorf("pull failed: %v", err)
 	}
 	vprintf("Checking out to new branch based on %s", latest)
-	err = createNewBranch(wt)
+	branchName := fmt.Sprintf(branchPattern, majorVersion)
+	err = createNewBranch(wt, branchName)
 	if err != nil {
 		return fmt.Errorf("checkout failed: %v", err)
 	}

--- a/tools/major-updater/cmd/updateSDK.go
+++ b/tools/major-updater/cmd/updateSDK.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"path/filepath"
 
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
 	"github.com/spf13/cobra"
@@ -30,6 +31,14 @@ func init() {
 
 func theUpdateSDKCommand(sdk string) error {
 	vprintln("Updating SDK repo...")
+	absolutePathOfSDK, err := filepath.Abs(sdk)
+	if err != nil {
+		return fmt.Errorf("failed to get the directory of SDK: %v", err)
+	}
+	err = changeDir(absolutePathOfSDK)
+	if err != nil {
+		return fmt.Errorf("failed to change directory to %s: %v", absolutePathOfSDK, err)
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get the current working directory: %v", err)

--- a/tools/major-updater/cmd/updateSpecs.go
+++ b/tools/major-updater/cmd/updateSpecs.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/tools/major-updater/cmd/updateSpecs.go
+++ b/tools/major-updater/cmd/updateSpecs.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
 	"github.com/spf13/cobra"
@@ -29,9 +30,13 @@ func init() {
 
 func theUpdateSpecsCommand(spec string) error {
 	vprintln("Updating specs repo...")
-	err := changeDir(spec)
+	absolutePathOfSpec, err := filepath.Abs(spec)
 	if err != nil {
-		return fmt.Errorf("failed to change directory to %s: %v", spec, err)
+		return fmt.Errorf("failed to get the directory of specs: %v", err)
+	}
+	err = changeDir(absolutePathOfSpec)
+	if err != nil {
+		return fmt.Errorf("failed to change directory to %s: %v", absolutePathOfSpec, err)
 	}
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/tools/major-updater/cmd/updateSpecs.go
+++ b/tools/major-updater/cmd/updateSpecs.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/spf13/cobra"
+)
+
+var updateSpecsCmd = &cobra.Command{
+	Use:   "updateSpec",
+	Short: "Update the specs repo on master branch",
+	Long: `This command will change the working directory to the specs folder,
+	checkout to master branch and update it`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		return cobra.ExactArgs(1)(cmd, args)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		specs := args[0]
+		err := theUpdateSpecsCommand(specs)
+		return err
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(updateSpecsCmd)
+}
+
+func theUpdateSpecsCommand(spec string) error {
+	vprintln("Updating specs repo...")
+	err := changeDir(spec)
+	if err != nil {
+		return fmt.Errorf("failed to change directory to %s: %v", spec, err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory: %v", err)
+	}
+	wt, err := repo.Get(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to get the working tree: %v", err)
+	}
+	vprintf("Checking out to master branch in %s\n", cwd)
+	err = wt.Checkout(master)
+	if err != nil {
+		return fmt.Errorf("checkout failed: %v", err)
+	}
+	err = wt.Pull(specUpstream, master)
+	if err != nil {
+		return fmt.Errorf("pull failed: %v", err)
+	}
+	return nil
+}

--- a/tools/major-updater/cmd/updateSpecs.go
+++ b/tools/major-updater/cmd/updateSpecs.go
@@ -10,7 +10,7 @@ import (
 )
 
 var updateSpecsCmd = &cobra.Command{
-	Use:   "updateSpec",
+	Use:   "updateSpec <spec dir>",
 	Short: "Update the specs repo on master branch",
 	Long: `This command will change the working directory to the specs folder,
 	checkout to master branch and update it`,
@@ -29,7 +29,7 @@ func init() {
 }
 
 func theUpdateSpecsCommand(spec string) error {
-	println("Updating specs repo...")
+	vprintln("Updating specs repo...")
 	absolutePathOfSpec, err := filepath.Abs(spec)
 	if err != nil {
 		return fmt.Errorf("failed to get the directory of specs: %v", err)
@@ -46,11 +46,12 @@ func theUpdateSpecsCommand(spec string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get the working tree: %v", err)
 	}
-	vprintf("Checking out to master branch in %s\n", cwd)
+	vprintf("Checking out to %s branch in %s\n", master, cwd)
 	err = wt.Checkout(master)
 	if err != nil {
 		return fmt.Errorf("checkout failed: %v", err)
 	}
+	vprintf("Pulling %s branch in %s\n", master, cwd)
 	err = wt.Pull(specUpstream, master)
 	if err != nil {
 		return fmt.Errorf("pull failed: %v", err)

--- a/tools/major-updater/cmd/updateSpecs.go
+++ b/tools/major-updater/cmd/updateSpecs.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 func theUpdateSpecsCommand(spec string) error {
-	vprintln("Updating specs repo...")
+	println("Updating specs repo...")
 	absolutePathOfSpec, err := filepath.Abs(spec)
 	if err != nil {
 		return fmt.Errorf("failed to get the directory of specs: %v", err)

--- a/tools/major-updater/cmd/work.go
+++ b/tools/major-updater/cmd/work.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (
@@ -28,8 +42,8 @@ func autorestCommand(file string, sdk string) *exec.Cmd {
 func worker(id int, jobs <-chan work, results chan<- error) {
 	for work := range jobs {
 		start := time.Now()
-		vprintf("worker %d is starting on file %s\n", id, work.filename)
 		c := autorestCommand(work.filename, work.sdkFolder)
+		vprintf("worker %d is starting on file %s\nparameters: %v\n", id, work.filename, c.Args)
 		output, err := c.CombinedOutput()
 		if err == nil {
 			vprintf("worker %d has done with file %s (%v)\n", id, work.filename, time.Since(start))

--- a/tools/major-updater/cmd/work.go
+++ b/tools/major-updater/cmd/work.go
@@ -30,11 +30,11 @@ func worker(id int, jobs <-chan work, results chan<- error) {
 		start := time.Now()
 		vprintf("worker %d is starting on file %s\n", id, work.filename)
 		c := autorestCommand(work.filename, work.sdkFolder)
-		err := c.Run()
+		output, err := c.CombinedOutput()
 		if err == nil {
 			vprintf("worker %d has done with file %s (%v)\n", id, work.filename, time.Since(start))
 		} else {
-			printf("worker %d fails with file %s (%v), error messages:\n%v\n", id, work.filename, time.Since(start), err)
+			printf("worker %d fails with file %s (%v), error messages:\n%v\n", id, work.filename, time.Since(start), string(output))
 		}
 		results <- err
 	}

--- a/tools/major-updater/cmd/work.go
+++ b/tools/major-updater/cmd/work.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	autorestArgsPattern = "--use=@microsoft.azure/autorest.go@~2.1.99 %s --go --multiapi --go-sdk-folder=%s --use-onever"
+)
+
+func autorestCommand(file string, sdk string) *exec.Cmd {
+	autorestArgs := fmt.Sprintf(autorestArgsPattern, file, sdk)
+	c := exec.Command("autorest", strings.Split(autorestArgs, " ")...)
+	return c
+}

--- a/tools/major-updater/cmd/work.go
+++ b/tools/major-updater/cmd/work.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -14,4 +17,53 @@ func autorestCommand(file string, sdk string) *exec.Cmd {
 	autorestArgs := fmt.Sprintf(autorestArgsPattern, file, sdk)
 	c := exec.Command("autorest", strings.Split(autorestArgs, " ")...)
 	return c
+}
+
+func worker(id int, jobs <-chan string, results chan<- error) {
+	for file := range jobs {
+		vprintf("worker %d is starting on file %s\n", id, file)
+		c := autorestCommand(file, absolutePathOfSDK)
+		err := c.Run()
+		if err == nil {
+			vprintf("worker %d is done with file %s\n", id, file)
+		} else {
+			printf("worker %d fails with file %s, error messages:\n%v\n", id, file, err)
+		}
+		results <- err
+	}
+}
+
+func startCmd(c *exec.Cmd) error {
+	stdout, err := c.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to get stdout pipe: %v", err)
+	}
+	scanner := bufio.NewScanner(stdout)
+	go func() {
+		for scanner.Scan() {
+			printf("> %s\n", scanner.Text())
+		}
+	}()
+	stderr, err := c.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("failed to get stderr pipe: %v", err)
+	}
+	scanner = bufio.NewScanner(stderr)
+	go func() {
+		for scanner.Scan() {
+			printf("> %s\n", scanner.Text())
+		}
+	}()
+	return c.Start()
+}
+
+func selectFilesWithName(path string, name string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if !info.IsDir() && info.Name() == name {
+			files = append(files, p)
+		}
+		return nil
+	})
+	return files, err
 }

--- a/tools/major-updater/main.go
+++ b/tools/major-updater/main.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import "github.com/Azure/azure-sdk-for-go/tools/major-updater/cmd"

--- a/tools/major-updater/main.go
+++ b/tools/major-updater/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/Azure/azure-sdk-for-go/tools/major-updater/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
This is a tool I wrote which tries to accumulate the major version release operations in one command

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
