### PR TITLE
Fix table query continuation token

### DIFF
--- a/storage/table.go
+++ b/storage/table.go
@@ -355,8 +355,12 @@ func (t *Table) queryEntities(uri string, headers map[string]string, ml Metadata
 			return nil, err
 		}
 		v := originalURI.Query()
-		v.Set(nextPartitionKeyQueryParameter, contToken.NextPartitionKey)
-		v.Set(nextRowKeyQueryParameter, contToken.NextRowKey)
+		if contToken.NextPartitionKey != "" {
+			v.Set(nextPartitionKeyQueryParameter, contToken.NextPartitionKey)
+		}
+		if contToken.NextRowKey != "" {
+			v.Set(nextRowKeyQueryParameter, contToken.NextRowKey)
+		}
 		newURI := t.tsc.client.getEndpoint(tableServiceName, t.buildPath(), v)
 		entities.NextLink = &newURI
 		entities.ml = ml
@@ -371,7 +375,7 @@ func extractContinuationTokenFromHeaders(h http.Header) *continuationToken {
 		NextRowKey:       h.Get(headerNextRowKey),
 	}
 
-	if ct.NextPartitionKey != "" && ct.NextRowKey != "" {
+	if ct.NextPartitionKey != "" || ct.NextRowKey != "" {
 		return &ct
 	}
 	return nil


### PR DESCRIPTION
Azure Storage table query may return results with non-empty `x-ms-continuation-NextPartitionKey` but empty `x-ms-continuation-NextRowKey`, see https://docs.microsoft.com/en-us/rest/api/storageservices/query-timeout-and-pagination

The current Go SDK implementation couldn't follow the continuation token for these cases.

Reference to .NET implementation https://github.com/Azure/azure-storage-net/blob/fdc07726910ead3281b14b2769a92b2fea68bd97/Lib/Common/Table/TableContinuationToken.cs

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
