### PR TITLE
Prevent apitool from producing empty tables

### DIFF
--- a/tools/apidiff/cmd/changelog.go
+++ b/tools/apidiff/cmd/changelog.go
@@ -82,28 +82,32 @@ func reportUpdatedPkgs(pr pkgsReport) {
 	if !pr.modPkgHasAdditions {
 		return
 	}
-	fmt.Printf("### Updated Packages\n\n")
 	updated := []string{}
 	for pkgName, pkgRpt := range pr.ModifiedPackages {
 		if pkgRpt.HasAdditiveChanges() && !pkgRpt.HasBreakingChanges() {
 			updated = append(updated, pkgName)
 		}
 	}
-	createTable(createTableRows(updated))
+	if len(updated) > 0 {
+		fmt.Printf("### Updated Packages\n\n")
+		createTable(createTableRows(updated))
+	}
 }
 
 func reportBreakingPkgs(pr pkgsReport) {
 	if !pr.modPkgHasBreaking {
 		return
 	}
-	fmt.Printf("### BreakingChanges\n\n")
 	breaking := []string{}
 	for pkgName, pkgRpt := range pr.ModifiedPackages {
 		if pkgRpt.HasBreakingChanges() {
 			breaking = append(breaking, pkgName)
 		}
 	}
-	createTable(createTableRows(breaking))
+	if len(breaking) > 0 {
+		fmt.Printf("### BreakingChanges\n\n")
+		createTable(createTableRows(breaking))
+	}
 }
 
 func reportRemovedPkgs(pr pkgsReport) {


### PR DESCRIPTION
Prevent apitool from creating empty tables when there are only breaking changes but no additional changes

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
