### PR TITLE
v32.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## `v32.4.0`
+
+### Updated Packages
+
+| Package Name | API Version |
+| -----------: | :---------: |
+| datamigration | 2018-07-15-preview |
+
 ## `v32.3.0`
 
 ### BreakingChanges

--- a/services/preview/datamigration/mgmt/2018-07-15-preview/datamigration/models.go
+++ b/services/preview/datamigration/mgmt/2018-07-15-preview/datamigration/models.go
@@ -10414,6 +10414,8 @@ func (moadfpsstp *MigrateOracleAzureDbForPostgreSQLSyncTaskProperties) Unmarshal
 // MigrateOracleAzureDbPostgreSQLSyncDatabaseInput database specific information for Oracle to Azure
 // Database for PostgreSQL migration task inputs
 type MigrateOracleAzureDbPostgreSQLSyncDatabaseInput struct {
+	// CaseManipulation - How to handle object name casing: either Preserve or ToLower
+	CaseManipulation *string `json:"caseManipulation,omitempty"`
 	// Name - Name of the migration pipeline
 	Name *string `json:"name,omitempty"`
 	// SchemaName - Name of the source schema
@@ -10433,6 +10435,9 @@ type MigrateOracleAzureDbPostgreSQLSyncDatabaseInput struct {
 // MarshalJSON is the custom marshaler for MigrateOracleAzureDbPostgreSQLSyncDatabaseInput.
 func (moadpssdi MigrateOracleAzureDbPostgreSQLSyncDatabaseInput) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
+	if moadpssdi.CaseManipulation != nil {
+		objectMap["caseManipulation"] = moadpssdi.CaseManipulation
+	}
 	if moadpssdi.Name != nil {
 		objectMap["name"] = moadpssdi.Name
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -18,4 +18,4 @@ package version
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 // Number contains the semantic version of this SDK.
-const Number = "v32.3.0"
+const Number = "v32.4.0"


### PR DESCRIPTION
This pull request releases minor version v32.4.0

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
