### PR TITLE
Fix links to docs site

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@ Package sdk provides Go packages for managing and using Azure services.
 
 GitHub repo: https://github.com/Azure/azure-sdk-for-go
 
-Official documentation: https://docs.microsoft.com/go/azure
+Official documentation: https://docs.microsoft.com/azure/go
 
 API reference: https://godoc.org/github.com/Azure/azure-sdk-for-go
 


### PR DESCRIPTION
This PR updates any links in the github repo to the documentation site since old links may now 404. This PR is against the `master` branch since that is where godoc builds from, and it appears that the `docs.go` file is not contained in `latest`.

---

- [X] The purpose of this PR is explained in this or a referenced issue.
- [X] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
