### PR TITLE
[AutoPR storage/resource-manager] Add support for identityType = "None".

### DIFF
--- a/profiles/latest/storage/mgmt/storage/models.go
+++ b/profiles/latest/storage/mgmt/storage/models.go
@@ -103,6 +103,13 @@ const (
 	Httpshttp HTTPProtocol = original.Httpshttp
 )
 
+type IdentityType = original.IdentityType
+
+const (
+	IdentityTypeNone           IdentityType = original.IdentityTypeNone
+	IdentityTypeSystemAssigned IdentityType = original.IdentityTypeSystemAssigned
+)
+
 type ImmutabilityPolicyState = original.ImmutabilityPolicyState
 
 const (
@@ -471,6 +478,9 @@ func PossibleGeoReplicationStatusValues() []GeoReplicationStatus {
 }
 func PossibleHTTPProtocolValues() []HTTPProtocol {
 	return original.PossibleHTTPProtocolValues()
+}
+func PossibleIdentityTypeValues() []IdentityType {
+	return original.PossibleIdentityTypeValues()
 }
 func PossibleImmutabilityPolicyStateValues() []ImmutabilityPolicyState {
 	return original.PossibleImmutabilityPolicyStateValues()

--- a/profiles/preview/storage/mgmt/storage/models.go
+++ b/profiles/preview/storage/mgmt/storage/models.go
@@ -103,6 +103,13 @@ const (
 	Httpshttp HTTPProtocol = original.Httpshttp
 )
 
+type IdentityType = original.IdentityType
+
+const (
+	IdentityTypeNone           IdentityType = original.IdentityTypeNone
+	IdentityTypeSystemAssigned IdentityType = original.IdentityTypeSystemAssigned
+)
+
 type ImmutabilityPolicyState = original.ImmutabilityPolicyState
 
 const (
@@ -471,6 +478,9 @@ func PossibleGeoReplicationStatusValues() []GeoReplicationStatus {
 }
 func PossibleHTTPProtocolValues() []HTTPProtocol {
 	return original.PossibleHTTPProtocolValues()
+}
+func PossibleIdentityTypeValues() []IdentityType {
+	return original.PossibleIdentityTypeValues()
 }
 func PossibleImmutabilityPolicyStateValues() []ImmutabilityPolicyState {
 	return original.PossibleImmutabilityPolicyStateValues()

--- a/services/storage/mgmt/2019-04-01/storage/accounts.go
+++ b/services/storage/mgmt/2019-04-01/storage/accounts.go
@@ -159,8 +159,6 @@ func (client AccountsClient) Create(ctx context.Context, resourceGroupName strin
 		{TargetValue: parameters,
 			Constraints: []validation.Constraint{{Target: "parameters.Sku", Name: validation.Null, Rule: true, Chain: nil},
 				{Target: "parameters.Location", Name: validation.Null, Rule: true, Chain: nil},
-				{Target: "parameters.Identity", Name: validation.Null, Rule: false,
-					Chain: []validation.Constraint{{Target: "parameters.Identity.Type", Name: validation.Null, Rule: true, Chain: nil}}},
 				{Target: "parameters.AccountPropertiesCreateParameters", Name: validation.Null, Rule: false,
 					Chain: []validation.Constraint{{Target: "parameters.AccountPropertiesCreateParameters.CustomDomain", Name: validation.Null, Rule: false,
 						Chain: []validation.Constraint{{Target: "parameters.AccountPropertiesCreateParameters.CustomDomain.Name", Name: validation.Null, Rule: true, Chain: nil}}},

--- a/services/storage/mgmt/2019-04-01/storage/models.go
+++ b/services/storage/mgmt/2019-04-01/storage/models.go
@@ -189,6 +189,21 @@ func PossibleHTTPProtocolValues() []HTTPProtocol {
 	return []HTTPProtocol{HTTPS, Httpshttp}
 }
 
+// IdentityType enumerates the values for identity type.
+type IdentityType string
+
+const (
+	// IdentityTypeNone ...
+	IdentityTypeNone IdentityType = "None"
+	// IdentityTypeSystemAssigned ...
+	IdentityTypeSystemAssigned IdentityType = "SystemAssigned"
+)
+
+// PossibleIdentityTypeValues returns an array of possible values for the IdentityType const type.
+func PossibleIdentityTypeValues() []IdentityType {
+	return []IdentityType{IdentityTypeNone, IdentityTypeSystemAssigned}
+}
+
 // ImmutabilityPolicyState enumerates the values for immutability policy state.
 type ImmutabilityPolicyState string
 
@@ -1745,8 +1760,8 @@ type Identity struct {
 	PrincipalID *string `json:"principalId,omitempty"`
 	// TenantID - READ-ONLY; The tenant ID of resource.
 	TenantID *string `json:"tenantId,omitempty"`
-	// Type - The identity type.
-	Type *string `json:"type,omitempty"`
+	// Type - The identity type. Possible values include: 'IdentityTypeSystemAssigned', 'IdentityTypeNone'
+	Type IdentityType `json:"type,omitempty"`
 }
 
 // ImmutabilityPolicy the ImmutabilityPolicy property of a blob container, including Id, resource name,


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7021