### PR TITLE
Change log level from verbose to normal

### DIFF
--- a/profiles/2017-03-09/generate.go
+++ b/profiles/2017-03-09/generate.go
@@ -14,4 +14,4 @@
 
 package v20170309
 
-//go:generate go run ../../tools/profileBuilder/main.go list --clear-output --input ./definition.json --name 2017-03-09 --output-location ./ --verbose
+//go:generate go run ../../tools/profileBuilder/main.go list --clear-output --input ./definition.json --name 2017-03-09 --output-location ./

--- a/profiles/2018-03-01/generate.go
+++ b/profiles/2018-03-01/generate.go
@@ -14,4 +14,4 @@
 
 package v20180301
 
-//go:generate go run ../../tools/profileBuilder/main.go list --clear-output --input ./definition.json --name 2018-03-01 --output-location ./ --verbose
+//go:generate go run ../../tools/profileBuilder/main.go list --clear-output --input ./definition.json --name 2018-03-01 --output-location ./

--- a/profiles/2019-03-01/generate.go
+++ b/profiles/2019-03-01/generate.go
@@ -14,4 +14,4 @@
 
 package v20180301
 
-//go:generate go run ../../tools/profileBuilder/main.go list --clear-output --input ./definition.json --name 2019-03-01 --output-location ./ --verbose
+//go:generate go run ../../tools/profileBuilder/main.go list --clear-output --input ./definition.json --name 2019-03-01 --output-location ./

--- a/profiles/latest/generate.go
+++ b/profiles/latest/generate.go
@@ -14,4 +14,4 @@
 
 package latest
 
-//go:generate go run ../../tools/profileBuilder/main.go latest --clear-output --name latest --root ../../services --output-location ./ --verbose
+//go:generate go run ../../tools/profileBuilder/main.go latest --clear-output --name latest --root ../../services --output-location ./

--- a/profiles/preview/generate.go
+++ b/profiles/preview/generate.go
@@ -14,4 +14,4 @@
 
 package preview
 
-//go:generate go run ../../tools/profileBuilder/main.go latest --clear-output --name preview --root ../../services --output-location ./ --preview --verbose
+//go:generate go run ../../tools/profileBuilder/main.go latest --clear-output --name preview --root ../../services --output-location ./ --preview

--- a/tools/profileBuilder/cmd/latest.go
+++ b/tools/profileBuilder/cmd/latest.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -64,6 +65,7 @@ By default, this command ignores API versions that are in preview.`,
 			}
 			outputRootDir = abs
 		}
+		fmt.Printf("Executes profileBuilder in %s\n", outputRootDir)
 		outputLog.Printf("Output-Location set to: %s", outputRootDir)
 
 		includePreview, err := cmd.Flags().GetBool(previewLongName)

--- a/tools/profileBuilder/cmd/list.go
+++ b/tools/profileBuilder/cmd/list.go
@@ -51,92 +51,90 @@ Example:
 $> ../model/testdata/smallProfile.txt > profileBuilder list --name small_profile
 `,
 	Args: cobra.NoArgs,
-	Run:  runCommand,
+	Run: func(cmd *cobra.Command, args []string) {
+		logWriter := ioutil.Discard
+		if verboseFlag {
+			logWriter = os.Stdout
+		}
+
+		outputLog := log.New(logWriter, "[STATUS] ", 0)
+		errLog := log.New(os.Stderr, "[ERROR] ", 0)
+
+		if !filepath.IsAbs(outputRootDir) {
+			abs, err := filepath.Abs(outputRootDir)
+			if err != nil {
+				errLog.Fatalf("failed to convert to absolute path: %v", err)
+			}
+			outputRootDir = abs
+		}
+
+		inputFile, err := cmd.Flags().GetString(inputLongName)
+		if err != nil {
+			errLog.Fatalf("failed to get %s: %v", inputLongName, err)
+		}
+
+		data, err := ioutil.ReadFile(inputFile)
+		if err != nil {
+			errLog.Fatalf("failed to read list: %v", err)
+		}
+
+		var listDef model.ListDefinition
+		err = json.Unmarshal(data, &listDef)
+		if err != nil {
+			errLog.Fatalf("failed to unmarshal JSON: %v", err)
+		}
+
+		if modulesFlag {
+			// when generating in module-aware mode a few extra things need to happen
+			// 1. find the latest module version for the profile we're working on
+			// 2. update the list of includes package to their latest module versions
+			// 3. if any includes were updated generate a new major version for this profile
+			modver, err := getLatestModVer(outputRootDir)
+			if err != nil {
+				errLog.Fatalf("failed to get module dir: %v", err)
+			}
+			updated, err := updateModuleVersions(&listDef)
+			if err != nil {
+				errLog.Fatalf("failed to update module versions: %v", err)
+			}
+			if updated {
+				// at least one include was updated, write out updated list definition
+				data, err = json.MarshalIndent(listDef, "", "  ")
+				if err != nil {
+					errLog.Fatalf("failed to marshal updated list: %v", err)
+				}
+				data = append(data, '\n')
+				err = ioutil.WriteFile(inputFile, data, 0666)
+				if err != nil {
+					errLog.Fatalf("failed to write updated list: %v", err)
+				}
+				// increment profile module major version and generate new go.mod file
+				modver = modinfo.IncrementModuleVersion(modver)
+				outputRootDir = filepath.Join(outputRootDir, modver)
+				err = generateGoMod(outputRootDir)
+				if err != nil {
+					errLog.Fatalf("failed to generate go.mod: %v", err)
+				}
+			} else if modver != "" {
+				outputRootDir = filepath.Join(outputRootDir, modver)
+			}
+		}
+		fmt.Printf("Executes profileBuilder in %s\n", outputRootDir)
+		outputLog.Printf("Output-Location set to: %s", outputRootDir)
+		if clearOutputFlag {
+			if err := dirs.DeleteChildDirs(outputRootDir); err != nil {
+				errLog.Fatalf("Unable to clear output-folder: %v", err)
+			}
+		}
+		// use recursive build to include the *api packages
+		model.BuildProfile(listDef, profileName, outputRootDir, outputLog, errLog, true, modulesFlag)
+	},
 }
 
 func init() {
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().StringP(inputLongName, inputShortName, "", inputDescription)
 	listCmd.MarkFlagRequired(inputLongName)
-}
-
-func runCommand(cmd *cobra.Command, args []string) {
-	logWriter := ioutil.Discard
-	if verboseFlag {
-		logWriter = os.Stdout
-	}
-
-	outputLog := log.New(logWriter, "[STATUS] ", 0)
-	errLog := log.New(os.Stderr, "[ERROR] ", 0)
-
-	if !filepath.IsAbs(outputRootDir) {
-		abs, err := filepath.Abs(outputRootDir)
-		if err != nil {
-			errLog.Fatalf("failed to convert to absolute path: %v", err)
-		}
-		outputRootDir = abs
-	}
-
-	inputFile, err := cmd.Flags().GetString(inputLongName)
-	if err != nil {
-		errLog.Fatalf("failed to get %s: %v", inputLongName, err)
-	}
-
-	data, err := ioutil.ReadFile(inputFile)
-	if err != nil {
-		errLog.Fatalf("failed to read list: %v", err)
-	}
-
-	var listDef model.ListDefinition
-	err = json.Unmarshal(data, &listDef)
-	if err != nil {
-		errLog.Fatalf("failed to unmarshal JSON: %v", err)
-	}
-
-	if modulesFlag {
-		// when generating in module-aware mode a few extra things need to happen
-		// 1. find the latest module version for the profile we're working on
-		// 2. update the list of includes package to their latest module versions
-		// 3. if any includes were updated generate a new major version for this profile
-		modver, err := getLatestModVer(outputRootDir)
-		if err != nil {
-			errLog.Fatalf("failed to get module dir: %v", err)
-		}
-		updated, err := updateModuleVersions(&listDef)
-		if err != nil {
-			errLog.Fatalf("failed to update module versions: %v", err)
-		}
-		if updated {
-			// at least one include was updated, write out updated list definition
-			data, err = json.MarshalIndent(listDef, "", "  ")
-			if err != nil {
-				errLog.Fatalf("failed to marshal updated list: %v", err)
-			}
-			data = append(data, '\n')
-			err = ioutil.WriteFile(inputFile, data, 0666)
-			if err != nil {
-				errLog.Fatalf("failed to write updated list: %v", err)
-			}
-			// increment profile module major version and generate new go.mod file
-			modver = modinfo.IncrementModuleVersion(modver)
-			outputRootDir = filepath.Join(outputRootDir, modver)
-			err = generateGoMod(outputRootDir)
-			if err != nil {
-				errLog.Fatalf("failed to generate go.mod: %v", err)
-			}
-		} else if modver != "" {
-			outputRootDir = filepath.Join(outputRootDir, modver)
-		}
-	}
-	fmt.Printf("Executes profileBuilder in %s\n", outputRootDir)
-	outputLog.Printf("Output-Location set to: %s", outputRootDir)
-	if clearOutputFlag {
-		if err := dirs.DeleteChildDirs(outputRootDir); err != nil {
-			errLog.Fatalf("Unable to clear output-folder: %v", err)
-		}
-	}
-	// use recursive build to include the *api packages
-	model.BuildProfile(listDef, profileName, outputRootDir, outputLog, errLog, true, modulesFlag)
 }
 
 // for each included package check if there is a newer module major version then the one specified,


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->
This will make the log of sdk automation clearer (requested by the current owner of sdk automation).

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
