### PR TITLE
[AutoPR automation/resource-manager] fix: Double word "the" in automation

### DIFF
--- a/services/automation/mgmt/2015-10-31/automation/dsccompilationjob.go
+++ b/services/automation/mgmt/2015-10-31/automation/dsccompilationjob.go
@@ -46,7 +46,7 @@ func NewDscCompilationJobClientWithBaseURI(baseURI string, subscriptionID string
 // Parameters:
 // resourceGroupName - name of an Azure Resource group.
 // automationAccountName - the name of the automation account.
-// compilationJobID - the the DSC configuration Id.
+// compilationJobID - the DSC configuration Id.
 // parameters - the parameters supplied to the create compilation job operation.
 func (client DscCompilationJobClient) Create(ctx context.Context, resourceGroupName string, automationAccountName string, compilationJobID uuid.UUID, parameters DscCompilationJobCreateParameters) (result DscCompilationJob, err error) {
 	if tracing.IsEnabled() {

--- a/services/automation/mgmt/2015-10-31/automation/dscconfiguration.go
+++ b/services/automation/mgmt/2015-10-31/automation/dscconfiguration.go
@@ -405,7 +405,7 @@ func (client DscConfigurationClient) GetContentResponder(resp *http.Response) (r
 // automationAccountName - the name of the automation account.
 // filter - the filter to apply on the operation.
 // skip - the number of rows to skip.
-// top - the the number of rows to take.
+// top - the number of rows to take.
 // inlinecount - return total rows.
 func (client DscConfigurationClient) ListByAutomationAccount(ctx context.Context, resourceGroupName string, automationAccountName string, filter string, skip *int32, top *int32, inlinecount string) (result DscConfigurationListResultPage, err error) {
 	if tracing.IsEnabled() {

--- a/services/preview/automation/mgmt/2017-05-15-preview/automation/dsccompilationjob.go
+++ b/services/preview/automation/mgmt/2017-05-15-preview/automation/dsccompilationjob.go
@@ -46,7 +46,7 @@ func NewDscCompilationJobClientWithBaseURI(baseURI string, subscriptionID string
 // Parameters:
 // resourceGroupName - name of an Azure Resource group.
 // automationAccountName - the name of the automation account.
-// compilationJobID - the the DSC configuration Id.
+// compilationJobID - the DSC configuration Id.
 // parameters - the parameters supplied to the create compilation job operation.
 func (client DscCompilationJobClient) Create(ctx context.Context, resourceGroupName string, automationAccountName string, compilationJobID uuid.UUID, parameters DscCompilationJobCreateParameters) (result DscCompilationJob, err error) {
 	if tracing.IsEnabled() {

--- a/services/preview/automation/mgmt/2017-05-15-preview/automation/dscconfiguration.go
+++ b/services/preview/automation/mgmt/2017-05-15-preview/automation/dscconfiguration.go
@@ -405,7 +405,7 @@ func (client DscConfigurationClient) GetContentResponder(resp *http.Response) (r
 // automationAccountName - the name of the automation account.
 // filter - the filter to apply on the operation.
 // skip - the number of rows to skip.
-// top - the the number of rows to take.
+// top - the number of rows to take.
 // inlinecount - return total rows.
 func (client DscConfigurationClient) ListByAutomationAccount(ctx context.Context, resourceGroupName string, automationAccountName string, filter string, skip *int32, top *int32, inlinecount string) (result DscConfigurationListResultPage, err error) {
 	if tracing.IsEnabled() {

--- a/services/preview/automation/mgmt/2018-01-15-preview/automation/dsccompilationjob.go
+++ b/services/preview/automation/mgmt/2018-01-15-preview/automation/dsccompilationjob.go
@@ -46,7 +46,7 @@ func NewDscCompilationJobClientWithBaseURI(baseURI string, subscriptionID string
 // Parameters:
 // resourceGroupName - name of an Azure Resource group.
 // automationAccountName - the name of the automation account.
-// compilationJobName - the the DSC configuration Id.
+// compilationJobName - the DSC configuration Id.
 // parameters - the parameters supplied to the create compilation job operation.
 func (client DscCompilationJobClient) Create(ctx context.Context, resourceGroupName string, automationAccountName string, compilationJobName string, parameters DscCompilationJobCreateParameters) (result DscCompilationJobCreateFuture, err error) {
 	if tracing.IsEnabled() {
@@ -139,7 +139,7 @@ func (client DscCompilationJobClient) CreateResponder(resp *http.Response) (resu
 // Parameters:
 // resourceGroupName - name of an Azure Resource group.
 // automationAccountName - the name of the automation account.
-// compilationJobName - the the DSC configuration Id.
+// compilationJobName - the DSC configuration Id.
 func (client DscCompilationJobClient) Get(ctx context.Context, resourceGroupName string, automationAccountName string, compilationJobName string) (result DscCompilationJob, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/DscCompilationJobClient.Get")

--- a/services/preview/automation/mgmt/2018-01-15-preview/automation/dscconfiguration.go
+++ b/services/preview/automation/mgmt/2018-01-15-preview/automation/dscconfiguration.go
@@ -405,7 +405,7 @@ func (client DscConfigurationClient) GetContentResponder(resp *http.Response) (r
 // automationAccountName - the name of the automation account.
 // filter - the filter to apply on the operation.
 // skip - the number of rows to skip.
-// top - the the number of rows to take.
+// top - the number of rows to take.
 // inlinecount - return total rows.
 func (client DscConfigurationClient) ListByAutomationAccount(ctx context.Context, resourceGroupName string, automationAccountName string, filter string, skip *int32, top *int32, inlinecount string) (result DscConfigurationListResultPage, err error) {
 	if tracing.IsEnabled() {

--- a/services/preview/automation/mgmt/2018-01-15-preview/automation/dscnode.go
+++ b/services/preview/automation/mgmt/2018-01-15-preview/automation/dscnode.go
@@ -221,7 +221,7 @@ func (client DscNodeClient) GetResponder(resp *http.Response) (result DscNode, e
 // automationAccountName - the name of the automation account.
 // filter - the filter to apply on the operation.
 // skip - the number of rows to skip.
-// top - the the number of rows to take.
+// top - the number of rows to take.
 // inlinecount - return total rows.
 func (client DscNodeClient) ListByAutomationAccount(ctx context.Context, resourceGroupName string, automationAccountName string, filter string, skip *int32, top *int32, inlinecount string) (result DscNodeListResultPage, err error) {
 	if tracing.IsEnabled() {

--- a/services/preview/automation/mgmt/2018-01-15-preview/automation/dscnodeconfiguration.go
+++ b/services/preview/automation/mgmt/2018-01-15-preview/automation/dscnodeconfiguration.go
@@ -320,7 +320,7 @@ func (client DscNodeConfigurationClient) GetResponder(resp *http.Response) (resu
 // automationAccountName - the name of the automation account.
 // filter - the filter to apply on the operation.
 // skip - the number of rows to skip.
-// top - the the number of rows to take.
+// top - the number of rows to take.
 // inlinecount - return total rows.
 func (client DscNodeConfigurationClient) ListByAutomationAccount(ctx context.Context, resourceGroupName string, automationAccountName string, filter string, skip *int32, top *int32, inlinecount string) (result DscNodeConfigurationListResultPage, err error) {
 	if tracing.IsEnabled() {

--- a/services/preview/automation/mgmt/2018-06-30-preview/automation/dsccompilationjob.go
+++ b/services/preview/automation/mgmt/2018-06-30-preview/automation/dsccompilationjob.go
@@ -46,7 +46,7 @@ func NewDscCompilationJobClientWithBaseURI(baseURI string, subscriptionID string
 // Parameters:
 // resourceGroupName - name of an Azure Resource group.
 // automationAccountName - the name of the automation account.
-// compilationJobName - the the DSC configuration Id.
+// compilationJobName - the DSC configuration Id.
 // parameters - the parameters supplied to the create compilation job operation.
 func (client DscCompilationJobClient) Create(ctx context.Context, resourceGroupName string, automationAccountName string, compilationJobName string, parameters DscCompilationJobCreateParameters) (result DscCompilationJobCreateFuture, err error) {
 	if tracing.IsEnabled() {
@@ -139,7 +139,7 @@ func (client DscCompilationJobClient) CreateResponder(resp *http.Response) (resu
 // Parameters:
 // resourceGroupName - name of an Azure Resource group.
 // automationAccountName - the name of the automation account.
-// compilationJobName - the the DSC configuration Id.
+// compilationJobName - the DSC configuration Id.
 func (client DscCompilationJobClient) Get(ctx context.Context, resourceGroupName string, automationAccountName string, compilationJobName string) (result DscCompilationJob, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/DscCompilationJobClient.Get")

--- a/services/preview/automation/mgmt/2018-06-30-preview/automation/dscconfiguration.go
+++ b/services/preview/automation/mgmt/2018-06-30-preview/automation/dscconfiguration.go
@@ -405,7 +405,7 @@ func (client DscConfigurationClient) GetContentResponder(resp *http.Response) (r
 // automationAccountName - the name of the automation account.
 // filter - the filter to apply on the operation.
 // skip - the number of rows to skip.
-// top - the the number of rows to take.
+// top - the number of rows to take.
 // inlinecount - return total rows.
 func (client DscConfigurationClient) ListByAutomationAccount(ctx context.Context, resourceGroupName string, automationAccountName string, filter string, skip *int32, top *int32, inlinecount string) (result DscConfigurationListResultPage, err error) {
 	if tracing.IsEnabled() {

--- a/services/preview/automation/mgmt/2018-06-30-preview/automation/dscnode.go
+++ b/services/preview/automation/mgmt/2018-06-30-preview/automation/dscnode.go
@@ -221,7 +221,7 @@ func (client DscNodeClient) GetResponder(resp *http.Response) (result DscNode, e
 // automationAccountName - the name of the automation account.
 // filter - the filter to apply on the operation.
 // skip - the number of rows to skip.
-// top - the the number of rows to take.
+// top - the number of rows to take.
 // inlinecount - return total rows.
 func (client DscNodeClient) ListByAutomationAccount(ctx context.Context, resourceGroupName string, automationAccountName string, filter string, skip *int32, top *int32, inlinecount string) (result DscNodeListResultPage, err error) {
 	if tracing.IsEnabled() {

--- a/services/preview/automation/mgmt/2018-06-30-preview/automation/dscnodeconfiguration.go
+++ b/services/preview/automation/mgmt/2018-06-30-preview/automation/dscnodeconfiguration.go
@@ -320,7 +320,7 @@ func (client DscNodeConfigurationClient) GetResponder(resp *http.Response) (resu
 // automationAccountName - the name of the automation account.
 // filter - the filter to apply on the operation.
 // skip - the number of rows to skip.
-// top - the the number of rows to take.
+// top - the number of rows to take.
 // inlinecount - return total rows.
 func (client DscNodeConfigurationClient) ListByAutomationAccount(ctx context.Context, resourceGroupName string, automationAccountName string, filter string, skip *int32, top *int32, inlinecount string) (result DscNodeConfigurationListResultPage, err error) {
 	if tracing.IsEnabled() {


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7180