### PR TITLE
[AutoPR advisor/resource-manager] [Advisor] Add OperationalExcellence category to enum list.

### DIFF
--- a/profiles/latest/advisor/mgmt/advisor/models.go
+++ b/profiles/latest/advisor/mgmt/advisor/models.go
@@ -32,10 +32,11 @@ const (
 type Category = original.Category
 
 const (
-	Cost             Category = original.Cost
-	HighAvailability Category = original.HighAvailability
-	Performance      Category = original.Performance
-	Security         Category = original.Security
+	Cost                  Category = original.Cost
+	HighAvailability      Category = original.HighAvailability
+	OperationalExcellence Category = original.OperationalExcellence
+	Performance           Category = original.Performance
+	Security              Category = original.Security
 )
 
 type Impact = original.Impact

--- a/profiles/preview/advisor/mgmt/advisor/models.go
+++ b/profiles/preview/advisor/mgmt/advisor/models.go
@@ -32,10 +32,11 @@ const (
 type Category = original.Category
 
 const (
-	Cost             Category = original.Cost
-	HighAvailability Category = original.HighAvailability
-	Performance      Category = original.Performance
-	Security         Category = original.Security
+	Cost                  Category = original.Cost
+	HighAvailability      Category = original.HighAvailability
+	OperationalExcellence Category = original.OperationalExcellence
+	Performance           Category = original.Performance
+	Security              Category = original.Security
 )
 
 type Impact = original.Impact

--- a/services/advisor/mgmt/2017-03-31/advisor/models.go
+++ b/services/advisor/mgmt/2017-03-31/advisor/models.go
@@ -39,6 +39,8 @@ const (
 	Cost Category = "Cost"
 	// HighAvailability ...
 	HighAvailability Category = "HighAvailability"
+	// OperationalExcellence ...
+	OperationalExcellence Category = "OperationalExcellence"
 	// Performance ...
 	Performance Category = "Performance"
 	// Security ...
@@ -47,7 +49,7 @@ const (
 
 // PossibleCategoryValues returns an array of possible values for the Category const type.
 func PossibleCategoryValues() []Category {
-	return []Category{Cost, HighAvailability, Performance, Security}
+	return []Category{Cost, HighAvailability, OperationalExcellence, Performance, Security}
 }
 
 // Impact enumerates the values for impact.
@@ -258,7 +260,7 @@ func NewOperationEntityListResultPage(getNextPage func(context.Context, Operatio
 
 // RecommendationProperties the properties of the recommendation.
 type RecommendationProperties struct {
-	// Category - The category of the recommendation. Possible values include: 'HighAvailability', 'Security', 'Performance', 'Cost'
+	// Category - The category of the recommendation. Possible values include: 'HighAvailability', 'Security', 'Performance', 'Cost', 'OperationalExcellence'
 	Category Category `json:"category,omitempty"`
 	// Impact - The business impact of the recommendation. Possible values include: 'High', 'Medium', 'Low'
 	Impact Impact `json:"impact,omitempty"`

--- a/services/advisor/mgmt/2017-04-19/advisor/models.go
+++ b/services/advisor/mgmt/2017-04-19/advisor/models.go
@@ -39,6 +39,8 @@ const (
 	Cost Category = "Cost"
 	// HighAvailability ...
 	HighAvailability Category = "HighAvailability"
+	// OperationalExcellence ...
+	OperationalExcellence Category = "OperationalExcellence"
 	// Performance ...
 	Performance Category = "Performance"
 	// Security ...
@@ -47,7 +49,7 @@ const (
 
 // PossibleCategoryValues returns an array of possible values for the Category const type.
 func PossibleCategoryValues() []Category {
-	return []Category{Cost, HighAvailability, Performance, Security}
+	return []Category{Cost, HighAvailability, OperationalExcellence, Performance, Security}
 }
 
 // Impact enumerates the values for impact.
@@ -749,7 +751,7 @@ func NewOperationEntityListResultPage(getNextPage func(context.Context, Operatio
 
 // RecommendationProperties the properties of the recommendation.
 type RecommendationProperties struct {
-	// Category - The category of the recommendation. Possible values include: 'HighAvailability', 'Security', 'Performance', 'Cost'
+	// Category - The category of the recommendation. Possible values include: 'HighAvailability', 'Security', 'Performance', 'Cost', 'OperationalExcellence'
 	Category Category `json:"category,omitempty"`
 	// Impact - The business impact of the recommendation. Possible values include: 'High', 'Medium', 'Low'
 	Impact Impact `json:"impact,omitempty"`


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7495