### PR TITLE
refactoring and clean-up

### DIFF
--- a/sdk/azcore/doc.go
+++ b/sdk/azcore/doc.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 /*
-package azcore implements an HTTP request/response middleware pipeline whose
+Package azcore implements an HTTP request/response middleware pipeline whose
 policy objects mutate an HTTP request's URL, query parameters, and/or headers before
 the request is sent over the wire.
 
@@ -157,5 +157,6 @@ can see the Response but cannot see the additional struct with the deserialized 
 Policy objects have returned, the pipeline.Response interface is returned by Pipeline's Do method.
 The caller of this method can perform a type assertion attempting to get back to the struct type
 really returned by the Policy object. If the type assertion is successful, the caller now has
-access to both the http.Response and the deserialized struct object.*/
+access to both the http.Response and the deserialized struct object.
+*/
 package azcore

--- a/sdk/azcore/error.go
+++ b/sdk/azcore/error.go
@@ -14,11 +14,15 @@ type frameInfo struct {
 	line int
 }
 
-func (f *frameInfo) String() string {
-	if f == nil {
+func (f frameInfo) String() string {
+	if f.zero() {
 		return ""
 	}
 	return fmt.Sprintf("file: %s, line: %d", f.file, f.line)
+}
+
+func (f frameInfo) zero() bool {
+	return f.file == "" && f.line == 0
 }
 
 // RequestError is returned when the service returns an unsuccessful resopnse code (4xx, 5xx).

--- a/sdk/azcore/log.go
+++ b/sdk/azcore/log.go
@@ -38,7 +38,7 @@ func (l *Logger) SetListener(lst Listener) {
 
 // Should returns true if the specified log classification should be written to the log.
 // TODO: explain why you would want to call this
-func (l Logger) Should(cls LogClassification) bool {
+func (l *Logger) Should(cls LogClassification) bool {
 	if l.cls == nil || len(l.cls) == 0 {
 		return true
 	}
@@ -52,7 +52,7 @@ func (l Logger) Should(cls LogClassification) bool {
 
 // Write invokes the underlying Listener with the specified classification and message.
 // If the classification shouldn't be logged or there is no listener then Write does nothing.
-func (l Logger) Write(cls LogClassification, message string) {
+func (l *Logger) Write(cls LogClassification, message string) {
 	if l.lst == nil || !l.Should(cls) {
 		return
 	}

--- a/sdk/azcore/policy_body_download.go
+++ b/sdk/azcore/policy_body_download.go
@@ -5,33 +5,32 @@ package azcore
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 )
 
-// NewBodyDownloaderPolicy creates a policy object that downloads the response's body to a []byte.
+// NewBodyDownloadPolicy creates a policy object that downloads the response's body to a []byte.
 func NewBodyDownloadPolicy() Policy {
-	return &bodyDownloadPolicy{}
-}
-
-type bodyDownloadPolicy struct {
+	return PolicyFunc(func(ctx context.Context, req *Request) (*Response, error) {
+		response, err := req.Do(ctx)
+		if err != nil {
+			return response, err
+		}
+		var opValues bodyDownloadPolicyOpValues
+		if req.OperationValue(&opValues); !opValues.skip {
+			// Either bodyDownloadPolicyOpValues was not specified (so skip is false)
+			// or it was specified and skip is false: don't skip downloading the body
+			response.Payload, err = ioutil.ReadAll(response.Body)
+			response.Body.Close()
+			if err != nil {
+				err = fmt.Errorf("body download policy: %w", err)
+			}
+		}
+		return response, err
+	})
 }
 
 // bodyDownloadPolicyOpValues is the struct containing the per-operation values
 type bodyDownloadPolicyOpValues struct {
 	skip bool
-}
-
-func (p bodyDownloadPolicy) Do(ctx context.Context, req *Request) (*Response, error) {
-	response, err := req.Do(ctx)
-	if err != nil {
-		return response, err
-	}
-	var opValues bodyDownloadPolicyOpValues
-	if req.OperationValue(&opValues); !opValues.skip {
-		// Either bodyDownloadPolicyOpValues was not specified (so skip is false)
-		// or it was specified and skip is false: don't skip downloading the body
-		response.Payload, err = ioutil.ReadAll(response.Body)
-		response.Body.Close()
-	}
-	return response, err
 }

--- a/sdk/azcore/policy_default_http_client.go
+++ b/sdk/azcore/policy_default_http_client.go
@@ -9,13 +9,6 @@ import (
 	"net/http"
 )
 
-type httpClientPolicy struct {
-	// Intentionally left empty because all instance share the same defaultHTTPClient object
-}
-
-// DefaultHTTPClientPolicy ...
-func DefaultHTTPClientPolicy() Policy { return &httpClientPolicy{} }
-
 var defaultHTTPClient *http.Client
 
 func init() {
@@ -37,11 +30,13 @@ func init() {
 	}
 }
 
-// Do ...
-func (p httpClientPolicy) Do(ctx context.Context, req *Request) (*Response, error) {
-	response, err := defaultHTTPClient.Do(req.Request.WithContext(ctx))
-	if err != nil {
-		return nil, err
-	}
-	return &Response{Response: response}, nil
+// DefaultHTTPClientPolicy ...
+func DefaultHTTPClientPolicy() Policy {
+	return PolicyFunc(func(ctx context.Context, req *Request) (*Response, error) {
+		response, err := defaultHTTPClient.Do(req.Request.WithContext(ctx))
+		if err != nil {
+			return nil, err
+		}
+		return &Response{Response: response}, nil
+	})
 }

--- a/sdk/azcore/policy_telemetry.go
+++ b/sdk/azcore/policy_telemetry.go
@@ -33,7 +33,7 @@ func NewTelemetryPolicy(o TelemetryOptions) Policy {
 	return &telemetryPolicy{telemetryValue: b.String()}
 }
 
-func (p *telemetryPolicy) Do(ctx context.Context, req *Request) (*Response, error) {
+func (p telemetryPolicy) Do(ctx context.Context, req *Request) (*Response, error) {
 	req.Request.Header.Set("User-Agent", p.telemetryValue)
 	return req.Do(ctx)
 }

--- a/sdk/azcore/policy_token_credential.go
+++ b/sdk/azcore/policy_token_credential.go
@@ -80,7 +80,7 @@ type tokenCredentialWithRefresh struct {
 }
 
 // marker satisfies the Credential interface making Credential policies "special"
-func (p *tokenCredentialWithRefresh) marker() {}
+func (c *tokenCredentialWithRefresh) marker() {}
 
 // Token returns the current token value
 func (c *tokenCredentialWithRefresh) Token() string { return c.token.Token() }

--- a/sdk/azcore/policy_unique_request_id.go
+++ b/sdk/azcore/policy_unique_request_id.go
@@ -9,20 +9,13 @@ import (
 
 // NewUniqueRequestIDPolicy creates a policy object that sets the request's x-ms-client-request-id header if it doesn't already exist.
 func NewUniqueRequestIDPolicy() Policy {
-	return &singletonUniqueRequestIDPolicy
-}
-
-var singletonUniqueRequestIDPolicy = uniqueRequestIDPolicy{}
-
-type uniqueRequestIDPolicy struct {
-}
-
-func (p *uniqueRequestIDPolicy) Do(ctx context.Context, req *Request) (*Response, error) {
-	const xMsClientRequestID = "x-ms-client-request-id"
-	id := req.Request.Header.Get(xMsClientRequestID)
-	if id == "" {
-		// Add a unique request ID if the caller didn't specify one already
-		req.Request.Header.Set(xMsClientRequestID, "TODO" /*newUUID().String()*/)
-	}
-	return req.Do(ctx)
+	return PolicyFunc(func(ctx context.Context, req *Request) (*Response, error) {
+		const xMsClientRequestID = "x-ms-client-request-id"
+		id := req.Request.Header.Get(xMsClientRequestID)
+		if id == "" {
+			// Add a unique request ID if the caller didn't specify one already
+			req.Request.Header.Set(xMsClientRequestID, "TODO" /*newUUID().String()*/)
+		}
+		return req.Do(ctx)
+	})
 }

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -78,7 +78,7 @@ func (req *Request) Do(ctx context.Context) (*Response, error) {
 
 // MarshalAsXML calls xml.Marshal() to get the XML encoding of v then calls SetBody.
 // If xml.Marshal fails a MarshalError is returned.  Any error from SetBody is returned.
-func (req Request) MarshalAsXML(v interface{}) error {
+func (req *Request) MarshalAsXML(v interface{}) error {
 	b, err := xml.Marshal(v)
 	if err != nil {
 		return fmt.Errorf("error marshalling type %s: %w", reflect.TypeOf(v).Name(), err)
@@ -96,20 +96,22 @@ func (req *Request) SetOperationValue(value interface{}) {
 }
 
 // OperationValue looks for a value set by SetOperationValue().
-func (req Request) OperationValue(value interface{}) bool {
+func (req *Request) OperationValue(value interface{}) bool {
 	if req.values == nil {
 		return false
 	}
 	return req.values.get(&value)
 }
 
+// SetQueryParam sets the key to value.
 func (req *Request) SetQueryParam(key, value string) {
 	if req.qp == nil {
 		req.qp = req.Request.URL.Query()
 	}
-	req.qp.Add(key, value)
+	req.qp.Set(key, value)
 }
 
+// SetBody sets the specified ReadSeekCloser as the HTTP request body.
 func (req *Request) SetBody(body ReadSeekCloser) error {
 	// Set the body and content length.
 	size, err := body.Seek(0, io.SeekEnd) // Seek to the end to get the stream's size
@@ -149,7 +151,7 @@ func (req *Request) RewindBody() error {
 	return nil
 }
 
-func (req Request) copy() *Request {
+func (req *Request) copy() *Request {
 	clonedURL := *req.URL
 	// Copy the values and immutable references
 	return &Request{


### PR DESCRIPTION
added/fixed various export comments
fixed up receivers by-val and by-ref
implemented stateless policies as first-class funcs
rewrote the retry policy to be generic and always retry on errors

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
