### PR TITLE
[AutoPR cognitiveservices/data-plane/QnAMaker] Updating the docs to include rankerType field in QueryDTO

### DIFF
--- a/services/cognitiveservices/v4.0/qnamakerruntime/models.go
+++ b/services/cognitiveservices/v4.0/qnamakerruntime/models.go
@@ -256,6 +256,8 @@ type QueryDTO struct {
 	ScoreThreshold *float64 `json:"scoreThreshold,omitempty"`
 	// Context - Context object with previous QnA's information.
 	Context *QueryDTOContext `json:"context,omitempty"`
+	// RankerType - Optional field. Set to 'QuestionOnly' for using a question only Ranker.
+	RankerType *string `json:"rankerType,omitempty"`
 	// StrictFilters - Find only answers that contain these metadata.
 	StrictFilters *[]MetadataDTO `json:"strictFilters,omitempty"`
 }


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7538