### PR TITLE
Change the image version back to 16.04 to avoid the annoying path error in azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,11 +3,11 @@ jobs:
     strategy:
       matrix:
         Linux_Go112:
-          vm.image: 'ubuntu-18.04'
+          vm.image: 'ubuntu-16.04'
           go.version: '1.12'
           GOROOT: '/usr/local/go$(go.version)'
         Linux_Go113:
-          vm.image: 'ubuntu-18.04'
+          vm.image: 'ubuntu-16.04'
           go.version: '1.13'
           GOROOT: '/usr/local/go$(go.version)'
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
