### PR TITLE
[AutoPR network/resource-manager] Fix the typo for actionsRequired in PrivateLinkServiceConnectionState.

### DIFF
--- a/services/network/mgmt/2019-04-01/network/models.go
+++ b/services/network/mgmt/2019-04-01/network/models.go
@@ -21409,8 +21409,8 @@ type PrivateLinkServiceConnectionState struct {
 	Status *string `json:"status,omitempty"`
 	// Description - The reason for approval/rejection of the connection.
 	Description *string `json:"description,omitempty"`
-	// ActionRequired - A message indicating if changes on the service provider require any updates on the consumer.
-	ActionRequired *string `json:"actionRequired,omitempty"`
+	// ActionsRequired - A message indicating if changes on the service provider require any updates on the consumer.
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
 }
 
 // PrivateLinkServiceIPConfiguration the private link service ip configuration.

--- a/services/network/mgmt/2019-06-01/network/models.go
+++ b/services/network/mgmt/2019-06-01/network/models.go
@@ -23123,8 +23123,8 @@ type PrivateLinkServiceConnectionState struct {
 	Status *string `json:"status,omitempty"`
 	// Description - The reason for approval/rejection of the connection.
 	Description *string `json:"description,omitempty"`
-	// ActionRequired - A message indicating if changes on the service provider require any updates on the consumer.
-	ActionRequired *string `json:"actionRequired,omitempty"`
+	// ActionsRequired - A message indicating if changes on the service provider require any updates on the consumer.
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
 }
 
 // PrivateLinkServiceIPConfiguration the private link service ip configuration.

--- a/services/network/mgmt/2019-07-01/network/models.go
+++ b/services/network/mgmt/2019-07-01/network/models.go
@@ -23185,8 +23185,8 @@ type PrivateLinkServiceConnectionState struct {
 	Status *string `json:"status,omitempty"`
 	// Description - The reason for approval/rejection of the connection.
 	Description *string `json:"description,omitempty"`
-	// ActionRequired - A message indicating if changes on the service provider require any updates on the consumer.
-	ActionRequired *string `json:"actionRequired,omitempty"`
+	// ActionsRequired - A message indicating if changes on the service provider require any updates on the consumer.
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
 }
 
 // PrivateLinkServiceIPConfiguration the private link service ip configuration.

--- a/services/network/mgmt/2019-08-01/network/models.go
+++ b/services/network/mgmt/2019-08-01/network/models.go
@@ -23143,8 +23143,8 @@ type PrivateLinkServiceConnectionState struct {
 	Status *string `json:"status,omitempty"`
 	// Description - The reason for approval/rejection of the connection.
 	Description *string `json:"description,omitempty"`
-	// ActionRequired - A message indicating if changes on the service provider require any updates on the consumer.
-	ActionRequired *string `json:"actionRequired,omitempty"`
+	// ActionsRequired - A message indicating if changes on the service provider require any updates on the consumer.
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
 }
 
 // PrivateLinkServiceIPConfiguration the private link service ip configuration.

--- a/services/network/mgmt/2019-09-01/network/models.go
+++ b/services/network/mgmt/2019-09-01/network/models.go
@@ -23348,8 +23348,8 @@ type PrivateLinkServiceConnectionState struct {
 	Status *string `json:"status,omitempty"`
 	// Description - The reason for approval/rejection of the connection.
 	Description *string `json:"description,omitempty"`
-	// ActionRequired - A message indicating if changes on the service provider require any updates on the consumer.
-	ActionRequired *string `json:"actionRequired,omitempty"`
+	// ActionsRequired - A message indicating if changes on the service provider require any updates on the consumer.
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
 }
 
 // PrivateLinkServiceIPConfiguration the private link service ip configuration.


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7672