### PR TITLE
only retrieve bearer token when expired

### DIFF
--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -57,7 +57,5 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, scopes []string) 
 
 // Policy implements the azcore.Policy interface on ChainedTokenCredential.
 func (c *ChainedTokenCredential) Policy(options azcore.CredentialPolicyOptions) azcore.Policy {
-	return azcore.PolicyFunc(func(ctx context.Context, req *azcore.Request) (*azcore.Response, error) {
-		return applyToken(ctx, c, req, options)
-	})
+	return newBearerTokenPolicy(c, options.Scopes)
 }


### PR DESCRIPTION
uses double-checked lock when updating bearer token
