### PR TITLE
refactor azblob

### DIFF
--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -5,6 +5,7 @@ package azcore
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -132,3 +133,6 @@ func (n nopCloser) Close() error {
 func NopCloser(rs io.ReadSeeker) ReadSeekCloser {
 	return nopCloser{rs}
 }
+
+// IterationDone is returned by an iterator's Next method when iteration is complete.
+var IterationDone = errors.New("no more items in iterator")

--- a/sdk/storage/azblob/examples_test.go
+++ b/sdk/storage/azblob/examples_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -37,7 +36,7 @@ func ExampleAnonymousCredential() {
 	iter := client.ListContainers(nil)
 	for {
 		p, err := iter.NextPage(context.Background())
-		if errors.Is(err, io.EOF) {
+		if errors.Is(err, azcore.IterationDone) {
 			break
 		} else if err != nil {
 			panic(err)

--- a/sdk/storage/azblob/examples_test.go
+++ b/sdk/storage/azblob/examples_test.go
@@ -22,7 +22,7 @@ const (
 	clientSecret = "<secret>"
 )
 
-func ExampleAnonymousCredential() {
+func ExampleServiceClientListContainers() {
 	cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
 	if err != nil {
 		panic(err)
@@ -41,7 +41,7 @@ func ExampleAnonymousCredential() {
 		} else if err != nil {
 			panic(err)
 		}
-		for _, i := range p.Value.ContainerItems {
+		for _, i := range p.ContainerItems {
 			fmt.Println(i.Name)
 		}
 	}

--- a/sdk/storage/azblob/examples_test.go
+++ b/sdk/storage/azblob/examples_test.go
@@ -22,7 +22,7 @@ const (
 	clientSecret = "<secret>"
 )
 
-func ExampleServiceClientListContainers() {
+func ExampleServiceClient_ListContainers() {
 	cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
 	if err != nil {
 		panic(err)

--- a/sdk/storage/azblob/go.mod
+++ b/sdk/storage/azblob/go.mod
@@ -3,13 +3,11 @@ module github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.0.0-00010101000000-000000000000
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azstorage v0.0.0-00010101000000-000000000000
 )
 
 replace (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore => ../../azcore
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity => ../../azidentity
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azstorage => ../azstorage
 )
 
 go 1.13

--- a/sdk/storage/azblob/internal/azblob/models.go
+++ b/sdk/storage/azblob/internal/azblob/models.go
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azblob
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// ETag is an entity tag.
+// TODO: does this belong in azcore?
+type ETag string
+
+const (
+	// ETagNone represents an empty entity tag.
+	ETagNone ETag = ""
+
+	// ETagAny matches any entity tag.
+	ETagAny ETag = "*"
+)
+
+// Metadata contains metadata key/value pairs.
+// TODO: does this belong in azcore?
+type Metadata map[string]string
+
+const mdPrefix = "x-ms-meta-"
+
+const mdPrefixLen = len(mdPrefix)
+
+// UnmarshalXML implements the xml.Unmarshaler interface for Metadata.
+func (md *Metadata) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	tokName := ""
+	for t, err := d.Token(); err == nil; t, err = d.Token() {
+		switch tt := t.(type) {
+		case xml.StartElement:
+			tokName = strings.ToLower(tt.Name.Local)
+			break
+		case xml.CharData:
+			if *md == nil {
+				*md = Metadata{}
+			}
+			(*md)[tokName] = string(tt)
+			break
+		}
+	}
+	return nil
+}
+
+// LeaseDurationType enumerates the values for lease duration type.
+type LeaseDurationType string
+
+const (
+	// LeaseDurationFixed ...
+	LeaseDurationFixed LeaseDurationType = "fixed"
+	// LeaseDurationInfinite ...
+	LeaseDurationInfinite LeaseDurationType = "infinite"
+	// LeaseDurationNone represents an empty LeaseDurationType.
+	LeaseDurationNone LeaseDurationType = ""
+)
+
+// PossibleLeaseDurationTypeValues returns an array of possible values for the LeaseDurationType const type.
+func PossibleLeaseDurationTypeValues() []LeaseDurationType {
+	return []LeaseDurationType{LeaseDurationFixed, LeaseDurationInfinite, LeaseDurationNone}
+}
+
+// LeaseStateType enumerates the values for lease state type.
+type LeaseStateType string
+
+const (
+	// LeaseStateAvailable ...
+	LeaseStateAvailable LeaseStateType = "available"
+	// LeaseStateBreaking ...
+	LeaseStateBreaking LeaseStateType = "breaking"
+	// LeaseStateBroken ...
+	LeaseStateBroken LeaseStateType = "broken"
+	// LeaseStateExpired ...
+	LeaseStateExpired LeaseStateType = "expired"
+	// LeaseStateLeased ...
+	LeaseStateLeased LeaseStateType = "leased"
+	// LeaseStateNone represents an empty LeaseStateType.
+	LeaseStateNone LeaseStateType = ""
+)
+
+// PossibleLeaseStateTypeValues returns an array of possible values for the LeaseStateType const type.
+func PossibleLeaseStateTypeValues() []LeaseStateType {
+	return []LeaseStateType{LeaseStateAvailable, LeaseStateBreaking, LeaseStateBroken, LeaseStateExpired, LeaseStateLeased, LeaseStateNone}
+}
+
+// LeaseStatusType enumerates the values for lease status type.
+type LeaseStatusType string
+
+const (
+	// LeaseStatusLocked ...
+	LeaseStatusLocked LeaseStatusType = "locked"
+	// LeaseStatusNone represents an empty LeaseStatusType.
+	LeaseStatusNone LeaseStatusType = ""
+	// LeaseStatusUnlocked ...
+	LeaseStatusUnlocked LeaseStatusType = "unlocked"
+)
+
+// ListContainersIncludeType enumerates the values for list containers include type.
+type ListContainersIncludeType string
+
+const (
+	// ListContainersIncludeMetadata ...
+	ListContainersIncludeMetadata ListContainersIncludeType = "metadata"
+	// ListContainersIncludeNone represents an empty ListContainersIncludeType.
+	ListContainersIncludeNone ListContainersIncludeType = ""
+)
+
+// PublicAccessType enumerates the values for public access type.
+type PublicAccessType string
+
+const (
+	// PublicAccessBlob ...
+	PublicAccessBlob PublicAccessType = "blob"
+	// PublicAccessContainer ...
+	PublicAccessContainer PublicAccessType = "container"
+	// PublicAccessNone represents an empty PublicAccessType.
+	PublicAccessNone PublicAccessType = ""
+)
+
+// PossiblePublicAccessTypeValues returns an array of possible values for the PublicAccessType const type.
+func PossiblePublicAccessTypeValues() []PublicAccessType {
+	return []PublicAccessType{PublicAccessBlob, PublicAccessContainer, PublicAccessNone}
+}
+
+type BlobContainersSegment struct {
+	ServiceEndpoint string          `xml:"ServiceEndpoint,attr"`
+	Prefix          *string         `xml:"Prefix"`
+	Marker          *string         `xml:"Marker"`
+	MaxResults      *int32          `xml:"MaxResults"`
+	ContainerItems  []ContainerItem `xml:"Containers>Container"`
+	NextMarker      *string         `xml:"NextMarker"`
+}
+
+// ContainerItem - An Azure Storage container
+type ContainerItem struct {
+	// XMLName is used for marshalling and is subject to removal in a future release.
+	XMLName    xml.Name            `xml:"Container"`
+	Name       string              `xml:"Name"`
+	Properties ContainerProperties `xml:"Properties"`
+	Metadata   Metadata            `xml:"Metadata"`
+}
+
+// ContainerProperties - Properties of a container
+type ContainerProperties struct {
+	// TODO: LastModified time.Time `xml:"Last-Modified"`
+	Etag ETag `xml:"Etag"`
+	// LeaseStatus - Possible values include: 'LeaseStatusLocked', 'LeaseStatusUnlocked', 'LeaseStatusNone'
+	LeaseStatus LeaseStatusType `xml:"LeaseStatus"`
+	// LeaseState - Possible values include: 'LeaseStateAvailable', 'LeaseStateLeased', 'LeaseStateExpired', 'LeaseStateBreaking', 'LeaseStateBroken', 'LeaseStateNone'
+	LeaseState LeaseStateType `xml:"LeaseState"`
+	// LeaseDuration - Possible values include: 'LeaseDurationInfinite', 'LeaseDurationFixed', 'LeaseDurationNone'
+	LeaseDuration LeaseDurationType `xml:"LeaseDuration"`
+	// PublicAccess - Possible values include: 'PublicAccessContainer', 'PublicAccessBlob', 'PublicAccessNone'
+	PublicAccess          PublicAccessType `xml:"PublicAccess"`
+	HasImmutabilityPolicy *bool            `xml:"HasImmutabilityPolicy"`
+	HasLegalHold          *bool            `xml:"HasLegalHold"`
+}
+
+type ListContainersOptions struct {
+	Prefix     *string
+	Marker     *string
+	Maxresults *int32
+	Include    ListContainersIncludeType
+	Timeout    *int32
+	RequestID  *string
+}
+
+// ListContainersPage - An enumeration of containers
+type ListContainersPage struct {
+	RawResponse *azcore.Response
+	Value       *BlobContainersSegment `xml:"EnumerationResults"`
+}

--- a/sdk/storage/azblob/internal/azblob/models.go
+++ b/sdk/storage/azblob/internal/azblob/models.go
@@ -6,8 +6,6 @@ package azblob
 import (
 	"encoding/xml"
 	"strings"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 // ETag is an entity tag.
@@ -128,15 +126,6 @@ func PossiblePublicAccessTypeValues() []PublicAccessType {
 	return []PublicAccessType{PublicAccessBlob, PublicAccessContainer, PublicAccessNone}
 }
 
-type BlobContainersSegment struct {
-	ServiceEndpoint string          `xml:"ServiceEndpoint,attr"`
-	Prefix          *string         `xml:"Prefix"`
-	Marker          *string         `xml:"Marker"`
-	MaxResults      *int32          `xml:"MaxResults"`
-	ContainerItems  []ContainerItem `xml:"Containers>Container"`
-	NextMarker      *string         `xml:"NextMarker"`
-}
-
 // ContainerItem - An Azure Storage container
 type ContainerItem struct {
 	// XMLName is used for marshalling and is subject to removal in a future release.
@@ -173,6 +162,12 @@ type ListContainersOptions struct {
 
 // ListContainersPage - An enumeration of containers
 type ListContainersPage struct {
-	RawResponse *azcore.Response
-	Value       *BlobContainersSegment `xml:"EnumerationResults"`
+	// XMLName is used for marshalling and is subject to removal in a future release.
+	XMLName         xml.Name        `xml:"EnumerationResults"`
+	ServiceEndpoint string          `xml:"ServiceEndpoint,attr"`
+	Prefix          *string         `xml:"Prefix"`
+	Marker          *string         `xml:"Marker"`
+	MaxResults      *int32          `xml:"MaxResults"`
+	ContainerItems  []ContainerItem `xml:"Containers>Container"`
+	NextMarker      *string         `xml:"NextMarker"`
 }

--- a/sdk/storage/azblob/internal/azblob/service.go
+++ b/sdk/storage/azblob/internal/azblob/service.go
@@ -42,8 +42,8 @@ func (Service) ListContainersCreateRequest(u *url.URL, p azcore.Pipeline, option
 	return req
 }
 
-// ListContainersCreateResponse handles the response to the ListContainersSegment request.
-func (Service) ListContainersCreateResponse(resp *azcore.Response) (*ListContainersPage, error) {
+// ListContainersHandleResponse handles the response to the ListContainersSegment request.
+func (Service) ListContainersHandleResponse(resp *azcore.Response) (*ListContainersPage, error) {
 	if err := resp.CheckStatusCode(http.StatusOK); err != nil {
 		return nil, err
 	}

--- a/sdk/storage/azblob/internal/azblob/service.go
+++ b/sdk/storage/azblob/internal/azblob/service.go
@@ -47,6 +47,6 @@ func (Service) ListContainersCreateResponse(resp *azcore.Response) (*ListContain
 	if err := resp.CheckStatusCode(http.StatusOK); err != nil {
 		return nil, err
 	}
-	result := &ListContainersPage{RawResponse: resp, Value: &BlobContainersSegment{}}
-	return result, resp.UnmarshalAsXML(result.Value)
+	result := &ListContainersPage{}
+	return result, resp.UnmarshalAsXML(result)
 }

--- a/sdk/storage/azblob/internal/azblob/service.go
+++ b/sdk/storage/azblob/internal/azblob/service.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azblob
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// Service contains all methods for operations on the service.
+type Service struct{}
+
+// ListContainersCreateRequest prepares the ListContainersSegment request.
+func (Service) ListContainersCreateRequest(u *url.URL, p azcore.Pipeline, options *ListContainersOptions) *azcore.Request {
+	req := p.NewRequest(http.MethodGet, *u)
+	if options != nil {
+		if options.Prefix != nil && len(*options.Prefix) > 0 {
+			req.SetQueryParam("prefix", *options.Prefix)
+		}
+		if options.Marker != nil && len(*options.Marker) > 0 {
+			req.SetQueryParam("marker", *options.Marker)
+		}
+		if options.Maxresults != nil {
+			req.SetQueryParam("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
+		}
+		if options.Include != ListContainersIncludeNone {
+			req.SetQueryParam("include", string(options.Include))
+		}
+		if options.Timeout != nil {
+			req.SetQueryParam("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
+		}
+		if options.RequestID != nil {
+			req.Header.Set("x-ms-client-request-id", *options.RequestID)
+		}
+	}
+	req.SetQueryParam("comp", "list")
+	req.Header.Set("x-ms-version", "2018-11-09")
+	return req
+}
+
+// ListContainersCreateResponse handles the response to the ListContainersSegment request.
+func (Service) ListContainersCreateResponse(resp *azcore.Response) (*ListContainersPage, error) {
+	if err := resp.CheckStatusCode(http.StatusOK); err != nil {
+		return nil, err
+	}
+	result := &ListContainersPage{RawResponse: resp, Value: &BlobContainersSegment{}}
+	return result, resp.UnmarshalAsXML(result.Value)
+}

--- a/sdk/storage/azblob/models.go
+++ b/sdk/storage/azblob/models.go
@@ -27,7 +27,7 @@ func (iter *ListContainersIterator) NextPage(ctx context.Context) (*ListContaine
 	if err != nil {
 		return nil, err
 	}
-	page, err := iter.client.s.ListContainersCreateResponse(resp)
+	page, err := iter.client.s.ListContainersHandleResponse(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/storage/azblob/models.go
+++ b/sdk/storage/azblob/models.go
@@ -31,7 +31,7 @@ func (iter *ListContainersIterator) NextPage(ctx context.Context) (*ListContaine
 	if err != nil {
 		return nil, err
 	}
-	iter.op.Marker = page.Value.NextMarker
+	iter.op.Marker = page.NextMarker
 	return page, nil
 }
 

--- a/sdk/storage/azblob/models.go
+++ b/sdk/storage/azblob/models.go
@@ -5,243 +5,38 @@ package azblob
 
 import (
 	"context"
-	"encoding/xml"
-	"strings"
+	"io"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azinternal "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/azblob"
 )
 
-// ETag is an entity tag.
-// TODO: does this belong in azcore?
-type ETag string
-
-const (
-	// ETagNone represents an empty entity tag.
-	ETagNone ETag = ""
-
-	// ETagAny matches any entity tag.
-	ETagAny ETag = "*"
-)
-
-// Metadata contains metadata key/value pairs.
-// TODO: does this belong in azcore?
-type Metadata map[string]string
-
-const mdPrefix = "x-ms-meta-"
-
-const mdPrefixLen = len(mdPrefix)
-
-// UnmarshalXML implements the xml.Unmarshaler interface for Metadata.
-func (md *Metadata) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	tokName := ""
-	for t, err := d.Token(); err == nil; t, err = d.Token() {
-		switch tt := t.(type) {
-		case xml.StartElement:
-			tokName = strings.ToLower(tt.Name.Local)
-			break
-		case xml.CharData:
-			if *md == nil {
-				*md = Metadata{}
-			}
-			(*md)[tokName] = string(tt)
-			break
-		}
-	}
-	return nil
-}
-
-// LeaseDurationType enumerates the values for lease duration type.
-type LeaseDurationType string
-
-const (
-	// LeaseDurationFixed ...
-	LeaseDurationFixed LeaseDurationType = "fixed"
-	// LeaseDurationInfinite ...
-	LeaseDurationInfinite LeaseDurationType = "infinite"
-	// LeaseDurationNone represents an empty LeaseDurationType.
-	LeaseDurationNone LeaseDurationType = ""
-)
-
-// PossibleLeaseDurationTypeValues returns an array of possible values for the LeaseDurationType const type.
-func PossibleLeaseDurationTypeValues() []LeaseDurationType {
-	return []LeaseDurationType{LeaseDurationFixed, LeaseDurationInfinite, LeaseDurationNone}
-}
-
-// LeaseStateType enumerates the values for lease state type.
-type LeaseStateType string
-
-const (
-	// LeaseStateAvailable ...
-	LeaseStateAvailable LeaseStateType = "available"
-	// LeaseStateBreaking ...
-	LeaseStateBreaking LeaseStateType = "breaking"
-	// LeaseStateBroken ...
-	LeaseStateBroken LeaseStateType = "broken"
-	// LeaseStateExpired ...
-	LeaseStateExpired LeaseStateType = "expired"
-	// LeaseStateLeased ...
-	LeaseStateLeased LeaseStateType = "leased"
-	// LeaseStateNone represents an empty LeaseStateType.
-	LeaseStateNone LeaseStateType = ""
-)
-
-// PossibleLeaseStateTypeValues returns an array of possible values for the LeaseStateType const type.
-func PossibleLeaseStateTypeValues() []LeaseStateType {
-	return []LeaseStateType{LeaseStateAvailable, LeaseStateBreaking, LeaseStateBroken, LeaseStateExpired, LeaseStateLeased, LeaseStateNone}
-}
-
-// LeaseStatusType enumerates the values for lease status type.
-type LeaseStatusType string
-
-const (
-	// LeaseStatusLocked ...
-	LeaseStatusLocked LeaseStatusType = "locked"
-	// LeaseStatusNone represents an empty LeaseStatusType.
-	LeaseStatusNone LeaseStatusType = ""
-	// LeaseStatusUnlocked ...
-	LeaseStatusUnlocked LeaseStatusType = "unlocked"
-)
-
-// ListContainersIncludeType enumerates the values for list containers include type.
-type ListContainersIncludeType string
-
-const (
-	// ListContainersIncludeMetadata ...
-	ListContainersIncludeMetadata ListContainersIncludeType = "metadata"
-	// ListContainersIncludeNone represents an empty ListContainersIncludeType.
-	ListContainersIncludeNone ListContainersIncludeType = ""
-)
-
-// PublicAccessType enumerates the values for public access type.
-type PublicAccessType string
-
-const (
-	// PublicAccessBlob ...
-	PublicAccessBlob PublicAccessType = "blob"
-	// PublicAccessContainer ...
-	PublicAccessContainer PublicAccessType = "container"
-	// PublicAccessNone represents an empty PublicAccessType.
-	PublicAccessNone PublicAccessType = ""
-)
-
-// PossiblePublicAccessTypeValues returns an array of possible values for the PublicAccessType const type.
-func PossiblePublicAccessTypeValues() []PublicAccessType {
-	return []PublicAccessType{PublicAccessBlob, PublicAccessContainer, PublicAccessNone}
-}
-
-// ContainerItem - An Azure Storage container
-type ContainerItem struct {
-	// XMLName is used for marshalling and is subject to removal in a future release.
-	XMLName    xml.Name            `xml:"Container"`
-	Name       string              `xml:"Name"`
-	Properties ContainerProperties `xml:"Properties"`
-	Metadata   Metadata            `xml:"Metadata"`
-}
-
-// ContainerProperties - Properties of a container
-type ContainerProperties struct {
-	// TODO: LastModified time.Time `xml:"Last-Modified"`
-	Etag ETag `xml:"Etag"`
-	// LeaseStatus - Possible values include: 'LeaseStatusLocked', 'LeaseStatusUnlocked', 'LeaseStatusNone'
-	LeaseStatus LeaseStatusType `xml:"LeaseStatus"`
-	// LeaseState - Possible values include: 'LeaseStateAvailable', 'LeaseStateLeased', 'LeaseStateExpired', 'LeaseStateBreaking', 'LeaseStateBroken', 'LeaseStateNone'
-	LeaseState LeaseStateType `xml:"LeaseState"`
-	// LeaseDuration - Possible values include: 'LeaseDurationInfinite', 'LeaseDurationFixed', 'LeaseDurationNone'
-	LeaseDuration LeaseDurationType `xml:"LeaseDuration"`
-	// PublicAccess - Possible values include: 'PublicAccessContainer', 'PublicAccessBlob', 'PublicAccessNone'
-	PublicAccess          PublicAccessType `xml:"PublicAccess"`
-	HasImmutabilityPolicy *bool            `xml:"HasImmutabilityPolicy"`
-	HasLegalHold          *bool            `xml:"HasLegalHold"`
-}
-
+// ListContainersIterator provides an abstraction for iterating over a collection of containers.
 type ListContainersIterator struct {
 	client *ServiceClient
 	op     *ListContainersOptions
-	page   *ListContainersPage
-	i      int
-	err    error
 }
 
-func (iter *ListContainersIterator) Err() error {
-	return iter.err
-}
-
-// Index returns the position of the iterator within the current page.
-func (iter *ListContainersIterator) Index() int {
-	return iter.i
-}
-
-// Item returns the current ContainerItem based on the iterator's index.
-func (iter *ListContainersIterator) Item() *ContainerItem {
-	if iter.page == nil {
-		return nil
+// NextPage fetches the next page.  It returns the page and nil or nil and
+// an error.  If there are no more pages the error returned is io.EOF.
+func (iter *ListContainersIterator) NextPage(ctx context.Context) (*ListContainersPage, error) {
+	if iter.op.Marker != nil && *iter.op.Marker == "" {
+		return nil, io.EOF
 	}
-	return &iter.page.ContainerItems[iter.i]
-}
-
-// NextItem returns true if the iterator advanced to the next item.
-// Returns false if there are no more items or an error occurred.
-func (iter *ListContainersIterator) NextItem(ctx context.Context) bool {
-	if iter.page != nil && iter.i+1 < len(iter.page.ContainerItems) {
-		iter.i++
-		return true
-	}
-	if ok := iter.NextPage(ctx); !ok {
-		return false
-	}
-	return len(iter.page.ContainerItems) > 0
-}
-
-// NextPage returns true if the iterator advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (iter *ListContainersIterator) NextPage(ctx context.Context) bool {
-	if iter.page.done() {
-		return false
-	}
-	msg := iter.client.listContainersPreparer(iter.op)
-	resp, err := msg.Do(ctx)
+	req := iter.client.s.ListContainersCreateRequest(iter.client.u, iter.client.p, iter.op)
+	resp, err := req.Do(ctx)
 	if err != nil {
-		iter.err = err
-		return false
+		return nil, err
 	}
-	next, err := iter.client.listContainersResponder(resp)
+	page, err := iter.client.s.ListContainersCreateResponse(resp)
 	if err != nil {
-		iter.err = err
-		return false
+		return nil, err
 	}
-	iter.page = next
-	iter.op.Marker = iter.page.NextMarker
-	iter.i = 0
-	return true
+	iter.op.Marker = page.Value.NextMarker
+	return page, nil
 }
 
-// Page returns the current ListContainersPage.
-func (iter *ListContainersIterator) Page() *ListContainersPage {
-	return iter.page
-}
-
-type ListContainersOptions struct {
-	Prefix     *string
-	Marker     *string
-	Maxresults *int32
-	Include    ListContainersIncludeType
-	Timeout    *int32
-	RequestID  *string
-}
+// ListContainersOptions - Options for listing containers.
+type ListContainersOptions = azinternal.ListContainersOptions
 
 // ListContainersPage - An enumeration of containers
-type ListContainersPage struct {
-	response *azcore.Response
-	// XMLName is used for marshalling and is subject to removal in a future release.
-	XMLName         xml.Name        `xml:"EnumerationResults"`
-	ServiceEndpoint string          `xml:"ServiceEndpoint,attr"`
-	Prefix          *string         `xml:"Prefix"`
-	Marker          *string         `xml:"Marker"`
-	MaxResults      *int32          `xml:"MaxResults"`
-	ContainerItems  []ContainerItem `xml:"Containers>Container"`
-	NextMarker      *string         `xml:"NextMarker"`
-}
-
-func (l *ListContainersPage) done() bool {
-	return l != nil && len(*l.NextMarker) == 0
-}
+type ListContainersPage = azinternal.ListContainersPage

--- a/sdk/storage/azblob/models.go
+++ b/sdk/storage/azblob/models.go
@@ -5,8 +5,8 @@ package azblob
 
 import (
 	"context"
-	"io"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azinternal "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/azblob"
 )
 
@@ -16,11 +16,11 @@ type ListContainersIterator struct {
 	op     *ListContainersOptions
 }
 
-// NextPage fetches the next page.  It returns the page and nil or nil and
-// an error.  If there are no more pages the error returned is io.EOF.
+// NextPage fetches the next page.  It returns the page and nil or nil and an
+// error.  If there are no more pages the error returned is azcore.IterationDone.
 func (iter *ListContainersIterator) NextPage(ctx context.Context) (*ListContainersPage, error) {
 	if iter.op.Marker != nil && *iter.op.Marker == "" {
-		return nil, io.EOF
+		return nil, azcore.IterationDone
 	}
 	req := iter.client.s.ListContainersCreateRequest(iter.client.u, iter.client.p, iter.op)
 	resp, err := req.Do(ctx)


### PR DESCRIPTION
move generated code to internal package
simplified codegen to contain only request creation/response handling
internal types are exposed via type aliasing in the public package
updated page iterator per latest discussion
