### PR TITLE
Simple grammar fix

### DIFF
--- a/storage/blob.go
+++ b/storage/blob.go
@@ -566,7 +566,7 @@ type DeleteBlobOptions struct {
 }
 
 // Delete deletes the given blob from the specified container.
-// If the blob does not exists at the time of the Delete Blob operation, it
+// If the blob does not exist at the time of the Delete Blob operation, it
 // returns error.
 // See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/Delete-Blob
 func (b *Blob) Delete(options *DeleteBlobOptions) error {

--- a/storage/directory.go
+++ b/storage/directory.go
@@ -94,7 +94,7 @@ func (d *Directory) Create(options *FileRequestOptions) error {
 }
 
 // CreateIfNotExists creates this directory under the associated share if the
-// directory does not exists. Returns true if the directory is newly created or
+// directory does not exist. Returns true if the directory is newly created or
 // false if the directory already exists.
 //
 // See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/Create-Directory


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] The PR targets the `latest` branch.
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md

Not sure this warrants a Change Log entry to be honest. I've just created a series of PRs across the board for products involved with Hashicorp Vault.

Will update Change Log if requested of course.