### PR TITLE
[AutoPR appplatform/resource-manager] Change the order of parameters in `appplatform` to comply the convention in SDK

### DIFF
--- a/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/appplatformapi/interfaces.go
+++ b/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/appplatformapi/interfaces.go
@@ -26,7 +26,7 @@ import (
 // ServicesClientAPI contains the set of methods on the ServicesClient type.
 type ServicesClientAPI interface {
 	CheckNameAvailability(ctx context.Context, location string, availabilityParameters appplatform.NameAvailabilityParameters) (result appplatform.NameAvailability, err error)
-	CreateOrUpdate(ctx context.Context, resource appplatform.ServiceResource, resourceGroupName string, serviceName string) (result appplatform.ServicesCreateOrUpdateFuture, err error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, resource appplatform.ServiceResource) (result appplatform.ServicesCreateOrUpdateFuture, err error)
 	Delete(ctx context.Context, resourceGroupName string, serviceName string) (result appplatform.ServicesDeleteFuture, err error)
 	DisableTestEndpoint(ctx context.Context, resourceGroupName string, serviceName string) (result autorest.Response, err error)
 	EnableTestEndpoint(ctx context.Context, resourceGroupName string, serviceName string) (result appplatform.TestKeys, err error)
@@ -42,7 +42,7 @@ var _ ServicesClientAPI = (*appplatform.ServicesClient)(nil)
 
 // AppsClientAPI contains the set of methods on the AppsClient type.
 type AppsClientAPI interface {
-	CreateOrUpdate(ctx context.Context, appResource appplatform.AppResource, resourceGroupName string, serviceName string, appName string) (result appplatform.AppsCreateOrUpdateFuture, err error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, appName string, appResource appplatform.AppResource) (result appplatform.AppsCreateOrUpdateFuture, err error)
 	Delete(ctx context.Context, resourceGroupName string, serviceName string, appName string) (result autorest.Response, err error)
 	Get(ctx context.Context, resourceGroupName string, serviceName string, appName string, syncStatus string) (result appplatform.AppResource, err error)
 	GetResourceUploadURL(ctx context.Context, resourceGroupName string, serviceName string, appName string) (result appplatform.ResourceUploadDefinition, err error)
@@ -54,7 +54,7 @@ var _ AppsClientAPI = (*appplatform.AppsClient)(nil)
 
 // BindingsClientAPI contains the set of methods on the BindingsClient type.
 type BindingsClientAPI interface {
-	CreateOrUpdate(ctx context.Context, bindingResource appplatform.BindingResource, resourceGroupName string, serviceName string, appName string, bindingName string) (result appplatform.BindingResource, err error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, appName string, bindingName string, bindingResource appplatform.BindingResource) (result appplatform.BindingResource, err error)
 	Delete(ctx context.Context, resourceGroupName string, serviceName string, appName string, bindingName string) (result autorest.Response, err error)
 	Get(ctx context.Context, resourceGroupName string, serviceName string, appName string, bindingName string) (result appplatform.BindingResource, err error)
 	List(ctx context.Context, resourceGroupName string, serviceName string, appName string) (result appplatform.BindingResourceCollectionPage, err error)
@@ -65,7 +65,7 @@ var _ BindingsClientAPI = (*appplatform.BindingsClient)(nil)
 
 // DeploymentsClientAPI contains the set of methods on the DeploymentsClient type.
 type DeploymentsClientAPI interface {
-	CreateOrUpdate(ctx context.Context, deploymentResource appplatform.DeploymentResource, resourceGroupName string, serviceName string, appName string, deploymentName string) (result appplatform.DeploymentsCreateOrUpdateFuture, err error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, appName string, deploymentName string, deploymentResource appplatform.DeploymentResource) (result appplatform.DeploymentsCreateOrUpdateFuture, err error)
 	Delete(ctx context.Context, resourceGroupName string, serviceName string, appName string, deploymentName string) (result autorest.Response, err error)
 	Get(ctx context.Context, resourceGroupName string, serviceName string, appName string, deploymentName string) (result appplatform.DeploymentResource, err error)
 	GetLogFileURL(ctx context.Context, resourceGroupName string, serviceName string, appName string, deploymentName string) (result appplatform.LogFileURLResponse, err error)

--- a/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/apps.go
+++ b/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/apps.go
@@ -43,12 +43,12 @@ func NewAppsClientWithBaseURI(baseURI string, subscriptionID string) AppsClient 
 
 // CreateOrUpdate create a new App or update an exiting App.
 // Parameters:
-// appResource - parameters for the create or update operation
 // resourceGroupName - the name of the resource group that contains the resource. You can obtain this value
 // from the Azure Resource Manager API or the portal.
 // serviceName - the name of the Service resource.
 // appName - the name of the App resource.
-func (client AppsClient) CreateOrUpdate(ctx context.Context, appResource AppResource, resourceGroupName string, serviceName string, appName string) (result AppsCreateOrUpdateFuture, err error) {
+// appResource - parameters for the create or update operation
+func (client AppsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, appName string, appResource AppResource) (result AppsCreateOrUpdateFuture, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/AppsClient.CreateOrUpdate")
 		defer func() {
@@ -82,7 +82,7 @@ func (client AppsClient) CreateOrUpdate(ctx context.Context, appResource AppReso
 		return result, validation.NewError("appplatform.AppsClient", "CreateOrUpdate", err.Error())
 	}
 
-	req, err := client.CreateOrUpdatePreparer(ctx, appResource, resourceGroupName, serviceName, appName)
+	req, err := client.CreateOrUpdatePreparer(ctx, resourceGroupName, serviceName, appName, appResource)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "appplatform.AppsClient", "CreateOrUpdate", nil, "Failure preparing request")
 		return
@@ -98,7 +98,7 @@ func (client AppsClient) CreateOrUpdate(ctx context.Context, appResource AppReso
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client AppsClient) CreateOrUpdatePreparer(ctx context.Context, appResource AppResource, resourceGroupName string, serviceName string, appName string) (*http.Request, error) {
+func (client AppsClient) CreateOrUpdatePreparer(ctx context.Context, resourceGroupName string, serviceName string, appName string, appResource AppResource) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"appName":           autorest.Encode("path", appName),
 		"resourceGroupName": autorest.Encode("path", resourceGroupName),

--- a/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/bindings.go
+++ b/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/bindings.go
@@ -42,13 +42,13 @@ func NewBindingsClientWithBaseURI(baseURI string, subscriptionID string) Binding
 
 // CreateOrUpdate create a new Binding or update an exiting Binding.
 // Parameters:
-// bindingResource - parameters for the create or update operation
 // resourceGroupName - the name of the resource group that contains the resource. You can obtain this value
 // from the Azure Resource Manager API or the portal.
 // serviceName - the name of the Service resource.
 // appName - the name of the App resource.
 // bindingName - the name of the Binding resource.
-func (client BindingsClient) CreateOrUpdate(ctx context.Context, bindingResource BindingResource, resourceGroupName string, serviceName string, appName string, bindingName string) (result BindingResource, err error) {
+// bindingResource - parameters for the create or update operation
+func (client BindingsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, appName string, bindingName string, bindingResource BindingResource) (result BindingResource, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/BindingsClient.CreateOrUpdate")
 		defer func() {
@@ -59,7 +59,7 @@ func (client BindingsClient) CreateOrUpdate(ctx context.Context, bindingResource
 			tracing.EndSpan(ctx, sc, err)
 		}()
 	}
-	req, err := client.CreateOrUpdatePreparer(ctx, bindingResource, resourceGroupName, serviceName, appName, bindingName)
+	req, err := client.CreateOrUpdatePreparer(ctx, resourceGroupName, serviceName, appName, bindingName, bindingResource)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "appplatform.BindingsClient", "CreateOrUpdate", nil, "Failure preparing request")
 		return
@@ -81,7 +81,7 @@ func (client BindingsClient) CreateOrUpdate(ctx context.Context, bindingResource
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client BindingsClient) CreateOrUpdatePreparer(ctx context.Context, bindingResource BindingResource, resourceGroupName string, serviceName string, appName string, bindingName string) (*http.Request, error) {
+func (client BindingsClient) CreateOrUpdatePreparer(ctx context.Context, resourceGroupName string, serviceName string, appName string, bindingName string, bindingResource BindingResource) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"appName":           autorest.Encode("path", appName),
 		"bindingName":       autorest.Encode("path", bindingName),

--- a/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/deployments.go
+++ b/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/deployments.go
@@ -43,13 +43,13 @@ func NewDeploymentsClientWithBaseURI(baseURI string, subscriptionID string) Depl
 
 // CreateOrUpdate create a new Deployment or update an exiting Deployment.
 // Parameters:
-// deploymentResource - parameters for the create or update operation
 // resourceGroupName - the name of the resource group that contains the resource. You can obtain this value
 // from the Azure Resource Manager API or the portal.
 // serviceName - the name of the Service resource.
 // appName - the name of the App resource.
 // deploymentName - the name of the Deployment resource.
-func (client DeploymentsClient) CreateOrUpdate(ctx context.Context, deploymentResource DeploymentResource, resourceGroupName string, serviceName string, appName string, deploymentName string) (result DeploymentsCreateOrUpdateFuture, err error) {
+// deploymentResource - parameters for the create or update operation
+func (client DeploymentsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, appName string, deploymentName string, deploymentResource DeploymentResource) (result DeploymentsCreateOrUpdateFuture, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/DeploymentsClient.CreateOrUpdate")
 		defer func() {
@@ -81,7 +81,7 @@ func (client DeploymentsClient) CreateOrUpdate(ctx context.Context, deploymentRe
 		return result, validation.NewError("appplatform.DeploymentsClient", "CreateOrUpdate", err.Error())
 	}
 
-	req, err := client.CreateOrUpdatePreparer(ctx, deploymentResource, resourceGroupName, serviceName, appName, deploymentName)
+	req, err := client.CreateOrUpdatePreparer(ctx, resourceGroupName, serviceName, appName, deploymentName, deploymentResource)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "appplatform.DeploymentsClient", "CreateOrUpdate", nil, "Failure preparing request")
 		return
@@ -97,7 +97,7 @@ func (client DeploymentsClient) CreateOrUpdate(ctx context.Context, deploymentRe
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client DeploymentsClient) CreateOrUpdatePreparer(ctx context.Context, deploymentResource DeploymentResource, resourceGroupName string, serviceName string, appName string, deploymentName string) (*http.Request, error) {
+func (client DeploymentsClient) CreateOrUpdatePreparer(ctx context.Context, resourceGroupName string, serviceName string, appName string, deploymentName string, deploymentResource DeploymentResource) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"appName":           autorest.Encode("path", appName),
 		"deploymentName":    autorest.Encode("path", deploymentName),

--- a/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/services.go
+++ b/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform/services.go
@@ -128,11 +128,11 @@ func (client ServicesClient) CheckNameAvailabilityResponder(resp *http.Response)
 
 // CreateOrUpdate create a new Service or update an exiting Service.
 // Parameters:
-// resource - parameters for the create or update operation
 // resourceGroupName - the name of the resource group that contains the resource. You can obtain this value
 // from the Azure Resource Manager API or the portal.
 // serviceName - the name of the Service resource.
-func (client ServicesClient) CreateOrUpdate(ctx context.Context, resource ServiceResource, resourceGroupName string, serviceName string) (result ServicesCreateOrUpdateFuture, err error) {
+// resource - parameters for the create or update operation
+func (client ServicesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, resource ServiceResource) (result ServicesCreateOrUpdateFuture, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/ServicesClient.CreateOrUpdate")
 		defer func() {
@@ -156,7 +156,7 @@ func (client ServicesClient) CreateOrUpdate(ctx context.Context, resource Servic
 		return result, validation.NewError("appplatform.ServicesClient", "CreateOrUpdate", err.Error())
 	}
 
-	req, err := client.CreateOrUpdatePreparer(ctx, resource, resourceGroupName, serviceName)
+	req, err := client.CreateOrUpdatePreparer(ctx, resourceGroupName, serviceName, resource)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "appplatform.ServicesClient", "CreateOrUpdate", nil, "Failure preparing request")
 		return
@@ -172,7 +172,7 @@ func (client ServicesClient) CreateOrUpdate(ctx context.Context, resource Servic
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client ServicesClient) CreateOrUpdatePreparer(ctx context.Context, resource ServiceResource, resourceGroupName string, serviceName string) (*http.Request, error) {
+func (client ServicesClient) CreateOrUpdatePreparer(ctx context.Context, resourceGroupName string, serviceName string, resource ServiceResource) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": autorest.Encode("path", resourceGroupName),
 		"serviceName":       autorest.Encode("path", serviceName),


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7874