### PR TITLE
decouple request creation from pipeline

### DIFF
--- a/sdk/azcore/error.go
+++ b/sdk/azcore/error.go
@@ -4,7 +4,13 @@
 package azcore
 
 import (
+	"errors"
 	"fmt"
+)
+
+var (
+	// ErrNoMorePolicies is returned from Request.Next() if there are no more policies in the pipeline.
+	ErrNoMorePolicies = errors.New("no more policies")
 )
 
 // TODO: capture frame info for marshal, unmarshal, and parsing errors

--- a/sdk/azcore/policy_anonymous_credential.go
+++ b/sdk/azcore/policy_anonymous_credential.go
@@ -10,7 +10,7 @@ import "context"
 func AnonymousCredential() Credential {
 	return credentialFunc(func(AuthenticationPolicyOptions) Policy {
 		return PolicyFunc(func(ctx context.Context, req *Request) (*Response, error) {
-			return req.Do(ctx)
+			return req.Next(ctx)
 		})
 	})
 }

--- a/sdk/azcore/policy_anonymous_credential_test.go
+++ b/sdk/azcore/policy_anonymous_credential_test.go
@@ -17,8 +17,8 @@ func TestAnonymousCredential(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 	pl := NewPipeline(srv, AnonymousCredential().AuthenticationPolicy(AuthenticationPolicyOptions{}))
-	req := pl.NewRequest(http.MethodGet, srv.URL())
-	resp, err := req.Do(context.Background())
+	req := NewRequest(http.MethodGet, srv.URL())
+	resp, err := pl.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/policy_body_download.go
+++ b/sdk/azcore/policy_body_download.go
@@ -12,7 +12,7 @@ import (
 // newBodyDownloadPolicy creates a policy object that downloads the response's body to a []byte.
 func newBodyDownloadPolicy() Policy {
 	return PolicyFunc(func(ctx context.Context, req *Request) (*Response, error) {
-		resp, err := req.Do(ctx)
+		resp, err := req.Next(ctx)
 		if err != nil {
 			return resp, err
 		}

--- a/sdk/azcore/policy_body_download_test.go
+++ b/sdk/azcore/policy_body_download_test.go
@@ -18,8 +18,7 @@ func TestDownloadBody(t *testing.T) {
 	srv.SetResponse(mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
-	req := pl.NewRequest(http.MethodGet, srv.URL())
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -38,9 +37,9 @@ func TestSkipBodyDownload(t *testing.T) {
 	srv.SetResponse(mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
-	req := pl.NewRequest(http.MethodGet, srv.URL())
+	req := NewRequest(http.MethodGet, srv.URL())
 	req.SkipBodyDownload()
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/policy_logging.go
+++ b/sdk/azcore/policy_logging.go
@@ -65,7 +65,7 @@ func (p *requestLogPolicy) Do(ctx context.Context, req *Request) (*Response, err
 
 	// Set the time for this particular retry operation and then Do the operation.
 	tryStart := time.Now()
-	response, err := req.Do(ctx) // Make the request
+	response, err := req.Next(ctx) // Make the request
 	tryEnd := time.Now()
 	tryDuration := tryEnd.Sub(tryStart)
 	opDuration := tryEnd.Sub(opValues.start)

--- a/sdk/azcore/policy_logging_test.go
+++ b/sdk/azcore/policy_logging_test.go
@@ -22,10 +22,10 @@ func TestPolicyLoggingSuccess(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewRequestLogPolicy(RequestLogOptions{}))
-	req := pl.NewRequest(http.MethodGet, srv.URL())
+	req := NewRequest(http.MethodGet, srv.URL())
 	req.SetQueryParam("one", "fish")
 	req.SetQueryParam("sig", "redact")
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -70,10 +70,10 @@ func TestPolicyLoggingError(t *testing.T) {
 	defer close()
 	srv.SetError(errors.New("bogus error"))
 	pl := NewPipeline(srv, NewRequestLogPolicy(RequestLogOptions{}))
-	req := pl.NewRequest(http.MethodGet, srv.URL())
+	req := NewRequest(http.MethodGet, srv.URL())
 	req.Header.Add("header", "one")
 	req.Header.Add("Authorization", "redact")
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), req)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}

--- a/sdk/azcore/policy_retry.go
+++ b/sdk/azcore/policy_retry.go
@@ -145,7 +145,7 @@ func (p *retryPolicy) Do(ctx context.Context, req *Request) (resp *Response, err
 
 		// Set the time for this particular retry operation and then Do the operation.
 		tryCtx, tryCancel := context.WithTimeout(ctx, p.options.TryTimeout)
-		resp, err = req.Do(tryCtx) // Make the request
+		resp, err = req.Next(tryCtx) // Make the request
 		tryCancel()
 		if shouldLog {
 			Log().Write(LogRetryPolicy, fmt.Sprintf("Err=%v, response=%v\n", err, resp))

--- a/sdk/azcore/policy_telemetry.go
+++ b/sdk/azcore/policy_telemetry.go
@@ -35,7 +35,7 @@ func NewTelemetryPolicy(o TelemetryOptions) Policy {
 
 func (p telemetryPolicy) Do(ctx context.Context, req *Request) (*Response, error) {
 	req.Request.Header.Set(HeaderUserAgent, p.telemetryValue)
-	return req.Do(ctx)
+	return req.Next(ctx)
 }
 
 // NOTE: the ONLY function that should write to this variable is this func

--- a/sdk/azcore/policy_telemetry_test.go
+++ b/sdk/azcore/policy_telemetry_test.go
@@ -17,8 +17,7 @@ func TestPolicyTelemetryDefault(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	req := pl.NewRequest(http.MethodGet, srv.URL())
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -33,8 +32,7 @@ func TestPolicyTelemetryWithCustomInfo(t *testing.T) {
 	srv.SetResponse()
 	const testValue = "azcore_test"
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{Value: testValue}))
-	req := pl.NewRequest(http.MethodGet, srv.URL())
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/policy_unique_request_id.go
+++ b/sdk/azcore/policy_unique_request_id.go
@@ -19,6 +19,6 @@ func NewUniqueRequestIDPolicy() Policy {
 			// Add a unique request ID if the caller didn't specify one already
 			req.Request.Header.Set(xMsClientRequestID, uuid.New().String())
 		}
-		return req.Do(ctx)
+		return req.Next(ctx)
 	})
 }

--- a/sdk/azcore/policy_unique_request_id_test.go
+++ b/sdk/azcore/policy_unique_request_id_test.go
@@ -16,8 +16,7 @@ func TestUniqueRequestIDPolicy(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewUniqueRequestIDPolicy())
-	req := pl.NewRequest(http.MethodGet, srv.URL())
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -31,10 +30,10 @@ func TestUniqueRequestIDPolicyUserDefined(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewUniqueRequestIDPolicy())
-	req := pl.NewRequest(http.MethodGet, srv.URL())
+	req := NewRequest(http.MethodGet, srv.URL())
 	const customID = "my-custom-id"
 	req.Header.Set(xMsClientRequestID, customID)
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/progress_test.go
+++ b/sdk/azcore/progress_test.go
@@ -25,14 +25,14 @@ func TestProgressReporting(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithBody(content))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	req := pl.NewRequest(http.MethodGet, srv.URL())
+	req := NewRequest(http.MethodGet, srv.URL())
 	req.SkipBodyDownload()
 	var bytesSent int64
 	reqRpt := NewRequestBodyProgress(NopCloser(body), func(bytesTransferred int64) {
 		bytesSent = bytesTransferred
 	})
 	req.SetBody(reqRpt)
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -4,6 +4,8 @@
 package azcore
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"testing"
@@ -19,8 +21,7 @@ func TestRequestMarshalXML(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	pl := NewPipeline(nil)
-	req := pl.NewRequest(http.MethodPost, *u)
+	req := NewRequest(http.MethodPost, *u)
 	err = req.MarshalAsXML(testXML{SomeInt: 1, SomeString: "s"})
 	if err != nil {
 		t.Fatalf("marshal failure: %v", err)
@@ -33,5 +34,20 @@ func TestRequestMarshalXML(t *testing.T) {
 	}
 	if req.ContentLength == 0 {
 		t.Fatal("unexpected zero content length")
+	}
+}
+
+func TestRequestEmptyPipeline(t *testing.T) {
+	u, err := url.Parse("https://contoso.com")
+	if err != nil {
+		panic(err)
+	}
+	req := NewRequest(http.MethodPost, *u)
+	resp, err := req.Next(context.Background())
+	if resp != nil {
+		t.Fatal("expected nil response")
+	}
+	if !errors.Is(err, ErrNoMorePolicies) {
+		t.Fatalf("expected ErrNoMorePolicies, got %v", err)
 	}
 }

--- a/sdk/azcore/response.go
+++ b/sdk/azcore/response.go
@@ -37,7 +37,7 @@ func (r *Response) CheckStatusCode(statusCodes ...int) error {
 	return nil
 }
 
-// hasStatusCode returns true if the Response's status code is one of the specified values.
+// HasStatusCode returns true if the Response's status code is one of the specified values.
 func (r *Response) HasStatusCode(statusCodes ...int) bool {
 	if r == nil {
 		return false

--- a/sdk/azcore/response_test.go
+++ b/sdk/azcore/response_test.go
@@ -16,8 +16,7 @@ func TestResponseUnmarshalXML(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte("<testXML><SomeInt>1</SomeInt><SomeString>s</SomeString></testXML>")))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	req := pl.NewRequest(http.MethodGet, srv.URL())
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -38,8 +37,7 @@ func TestResponseFailureStatusCode(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusForbidden))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	req := pl.NewRequest(http.MethodGet, srv.URL())
-	resp, err := req.Do(context.Background())
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -67,7 +67,7 @@ func (c *aadIdentityClient) authenticate(ctx context.Context, tenantID string, c
 		return nil, err
 	}
 
-	resp, err := msg.Do(ctx)
+	resp, err := c.pipeline.Do(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (c *aadIdentityClient) authenticateCertificate(ctx context.Context, tenantI
 		return nil, err
 	}
 
-	resp, err := msg.Do(ctx)
+	resp, err := c.pipeline.Do(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (c *aadIdentityClient) createClientSecretAuthRequest(tenantID string, clien
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := c.pipeline.NewRequest(http.MethodPost, *urlFormat)
+	msg := azcore.NewRequest(http.MethodPost, *urlFormat)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
 	err = msg.SetBody(body)
 	if err != nil {
@@ -171,7 +171,7 @@ func (c *aadIdentityClient) createClientCertificateAuthRequest(tenantID string, 
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := c.pipeline.NewRequest(http.MethodPost, *urlFormat)
+	msg := azcore.NewRequest(http.MethodPost, *urlFormat)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
 
 	err = msg.SetBody(body)
@@ -195,7 +195,7 @@ func (c *aadIdentityClient) authenticateUsernamePassword(ctx context.Context, te
 		return nil, err
 	}
 
-	resp, err := msg.Do(ctx)
+	resp, err := c.pipeline.Do(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (c *aadIdentityClient) createUsernamePasswordAuthRequest(tenantID string, c
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := c.pipeline.NewRequest(http.MethodPost, *urlFormat)
+	msg := azcore.NewRequest(http.MethodPost, *urlFormat)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
 	err = msg.SetBody(body)
 	if err != nil {

--- a/sdk/azidentity/bearer_token_policy.go
+++ b/sdk/azidentity/bearer_token_policy.go
@@ -79,5 +79,5 @@ func (b *bearerTokenPolicy) Do(ctx context.Context, req *azcore.Request) (*azcor
 		} // else { another go routine is refreshing the token, use previous token }
 	}
 	req.Request.Header.Set(azcore.HeaderAuthorization, b.header.Load())
-	return req.Do(ctx)
+	return req.Next(ctx)
 }

--- a/sdk/azidentity/bearer_token_policy_test.go
+++ b/sdk/azidentity/bearer_token_policy_test.go
@@ -33,8 +33,7 @@ func TestBearerPolicy_SuccessGetToken(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	req := pipeline.NewRequest(http.MethodGet, srv.URL())
-	_, err := req.Do(context.Background())
+	_, err := pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("Expected nil error but received one")
 	}
@@ -54,8 +53,7 @@ func TestBearerPolicy_CredentialFailGetToken(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	req := pipeline.NewRequest(http.MethodGet, srv.URL())
-	_, err := req.Do(context.Background())
+	_, err := pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -80,12 +78,12 @@ func TestBearerTokenPolicy_TokenExpired(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	req := pipeline.NewRequest(http.MethodGet, srv.URL())
-	_, err := req.Do(context.Background())
+	req := azcore.NewRequest(http.MethodGet, srv.URL())
+	_, err := pipeline.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Expected nil error but received one")
 	}
-	_, err = req.Do(context.Background())
+	_, err = pipeline.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Expected nil error but received one")
 	}
@@ -106,8 +104,7 @@ func TestRetryPolicy_IsNotRetriable(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	req := pipeline.NewRequest(http.MethodGet, srv.URL())
-	_, err := req.Do(context.Background())
+	_, err := pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -126,8 +123,7 @@ func TestRetryPolicy_HTTPRequest(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	req := pipeline.NewRequest(http.MethodGet, srv.URL())
-	_, err := req.Do(context.Background())
+	_, err := pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -135,8 +135,7 @@ func TestBearerPolicy_ChainedTokenCredential(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		chainedCred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	req := pipeline.NewRequest(http.MethodGet, srv.URL())
-	_, err = req.Do(context.Background())
+	_, err = pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("Expected an empty error but receive: %v", err)
 	}

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -202,8 +202,7 @@ func TestBearerPolicy_ClientCertificateCredential(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	req := pipeline.NewRequest(http.MethodGet, srv.URL())
-	_, err = req.Do(context.Background())
+	_, err = pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("Expected nil error but received one")
 	}

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -115,7 +115,7 @@ func (c *managedIdentityClient) sendAuthRequest(ctx context.Context, msiType msi
 		return nil, err
 	}
 
-	resp, err := msg.Do(ctx)
+	resp, err := c.pipeline.Do(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (c *managedIdentityClient) createAuthRequest(msiType msiType, clientID stri
 }
 
 func (c *managedIdentityClient) createIMDSAuthRequest(clientID string, scopes []string) (*azcore.Request, error) {
-	request := c.pipeline.NewRequest(http.MethodGet, *c.endpoint)
+	request := azcore.NewRequest(http.MethodGet, *c.endpoint)
 	request.Header.Set(azcore.HeaderMetadata, "true")
 	q := request.URL.Query()
 	q.Add("api-version", c.imdsAPIVersion)
@@ -186,7 +186,7 @@ func (c *managedIdentityClient) createIMDSAuthRequest(clientID string, scopes []
 }
 
 func (c *managedIdentityClient) createAppServiceAuthRequest(clientID string, scopes []string) (*azcore.Request, error) {
-	request := c.pipeline.NewRequest(http.MethodGet, *c.endpoint)
+	request := azcore.NewRequest(http.MethodGet, *c.endpoint)
 	request.Header.Set("secret", os.Getenv(msiSecretEnvironemntVariable))
 	q := request.URL.Query()
 	q.Add("api-version", appServiceMsiAPIVersion)
@@ -200,7 +200,7 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(clientID string, sco
 }
 
 func (c *managedIdentityClient) createCloudShellAuthRequest(clientID string, scopes []string) (*azcore.Request, error) {
-	request := c.pipeline.NewRequest(http.MethodPost, *c.endpoint)
+	request := azcore.NewRequest(http.MethodPost, *c.endpoint)
 	request.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
 	request.Header.Set(azcore.HeaderMetadata, "true")
 	data := url.Values{}
@@ -244,10 +244,10 @@ func (c *managedIdentityClient) getMSIType(ctx context.Context) (msiType, error)
 func (c *managedIdentityClient) imdsAvailable(ctx context.Context) bool {
 	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	request := c.pipeline.NewRequest(http.MethodGet, *imdsURL)
+	request := azcore.NewRequest(http.MethodGet, *imdsURL)
 	q := request.URL.Query()
 	q.Add("api-version", c.imdsAPIVersion)
 	request.URL.RawQuery = q.Encode()
-	_, err := request.Do(tempCtx)
+	_, err := c.pipeline.Do(tempCtx, request)
 	return err == nil
 }

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -153,8 +153,7 @@ func TestBearerPolicy_ManagedIdentityCredential(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	req := pipeline.NewRequest(http.MethodGet, srv.URL())
-	_, err := req.Do(context.Background())
+	_, err := pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("Expected an empty error but receive: %v", err)
 	}

--- a/sdk/azidentity/username_password_credential_test.go
+++ b/sdk/azidentity/username_password_credential_test.go
@@ -109,8 +109,7 @@ func TestBearerPolicy_UsernamePasswordCredential(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	req := pipeline.NewRequest(http.MethodGet, srv.URL())
-	_, err := req.Do(context.Background())
+	_, err := pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("Expected an empty error but receive: %v", err)
 	}

--- a/sdk/storage/blob/2018-11-09/azblob/internal/azblob/service.go
+++ b/sdk/storage/blob/2018-11-09/azblob/internal/azblob/service.go
@@ -16,7 +16,7 @@ type Service struct{}
 
 // ListContainersCreateRequest prepares the ListContainersSegment request.
 func (Service) ListContainersCreateRequest(u *url.URL, p azcore.Pipeline, options *ListContainersOptions) *azcore.Request {
-	req := p.NewRequest(http.MethodGet, *u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	if options != nil {
 		if options.Prefix != nil && len(*options.Prefix) > 0 {
 			req.SetQueryParam("prefix", *options.Prefix)

--- a/sdk/storage/blob/2018-11-09/azblob/models.go
+++ b/sdk/storage/blob/2018-11-09/azblob/models.go
@@ -23,7 +23,7 @@ func (iter *ListContainersIterator) NextPage(ctx context.Context) (*ListContaine
 		return nil, azcore.IterationDone
 	}
 	req := iter.client.s.ListContainersCreateRequest(iter.client.u, iter.client.p, iter.op)
-	resp, err := req.Do(ctx)
+	resp, err := iter.client.p.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/storage/blob/2018-11-09/azblob/policy_shared_key_credential.go
+++ b/sdk/storage/blob/2018-11-09/azblob/policy_shared_key_credential.go
@@ -176,7 +176,7 @@ func (c *SharedKeyCredential) AuthenticationPolicy(azcore.AuthenticationPolicyOp
 		authHeader := strings.Join([]string{"SharedKey ", c.AccountName(), ":", signature}, "")
 		req.Request.Header[azcore.HeaderAuthorization] = []string{authHeader}
 
-		response, err := req.Do(ctx)
+		response, err := req.Next(ctx)
 		if err != nil && response != nil && response.StatusCode == http.StatusForbidden {
 			// Service failed to authenticate request, log it
 			azcore.Log().Write(azcore.LogError, "===== HTTP Forbidden status, String-to-Sign:\n"+stringToSign+"\n===============================\n")

--- a/sdk/storage/fileshare/2019-02-02/azfileshare/policy_shared_key_credential.go
+++ b/sdk/storage/fileshare/2019-02-02/azfileshare/policy_shared_key_credential.go
@@ -176,7 +176,7 @@ func (c *SharedKeyCredential) AuthenticationPolicy(azcore.AuthenticationPolicyOp
 		authHeader := strings.Join([]string{"SharedKey ", c.AccountName(), ":", signature}, "")
 		req.Request.Header[azcore.HeaderAuthorization] = []string{authHeader}
 
-		response, err := req.Do(ctx)
+		response, err := req.Next(ctx)
 		if err != nil && response != nil && response.StatusCode == http.StatusForbidden {
 			// Service failed to authenticate request, log it
 			azcore.Log().Write(azcore.LogError, "===== HTTP Forbidden status, String-to-Sign:\n"+stringToSign+"\n===============================\n")


### PR DESCRIPTION
added Pipeline.Do() for sending requests through a pipeline
renamed Request.Do() to Request.Next() for advancing to the next policy
added ErrNoMorePolicies if Request.Next() is called on an empty pipeline
