### PR TITLE
Adding DeviceCodeCredential, MSI Access Token creation, fixed error handling in ChainedTokenCredential

### DIFF
--- a/sdk/azcore/credential.go
+++ b/sdk/azcore/credential.go
@@ -34,7 +34,7 @@ func (cf credentialFunc) AuthenticationPolicy(options AuthenticationPolicyOption
 // TokenCredential represents a credential capable of providing an OAuth token.
 type TokenCredential interface {
 	Credential
-	// GetToken requests an access token for the specified set of scopes.
+	// GetToken requests an access token for the specified set of scopes from the identity service.
 	GetToken(ctx context.Context, options TokenRequestOptions) (*AccessToken, error)
 }
 

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -283,8 +283,8 @@ func (c *aadIdentityClient) createUsernamePasswordAuthRequest(tenantID string, c
 	return msg, nil
 }
 
-func createDeviceCodeResult(res *azcore.Response) (*DeviceCodeResult, error) {
-	value := &DeviceCodeResult{}
+func createDeviceCodeResult(res *azcore.Response) (*deviceCodeResult, error) {
+	value := &deviceCodeResult{}
 	if err := json.Unmarshal(res.Payload, &value); err != nil {
 		return nil, fmt.Errorf("DeviceCodeResult: %w", err)
 	}
@@ -342,7 +342,7 @@ func (c *aadIdentityClient) createDeviceCodeAuthRequest(tenantID string, clientI
 	return msg, nil
 }
 
-func (c *aadIdentityClient) requestNewDeviceCode(ctx context.Context, tenantID, clientID string, scopes []string) (*DeviceCodeResult, error) {
+func (c *aadIdentityClient) requestNewDeviceCode(ctx context.Context, tenantID, clientID string, scopes []string) (*deviceCodeResult, error) {
 	msg, err := c.createDeviceCodeNumberRequest(tenantID, clientID, scopes)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -152,7 +152,9 @@ func (c *aadIdentityClient) createAccessToken(res *azcore.Response) (*azcore.Acc
 }
 
 func (c *aadIdentityClient) createRefreshAccessToken(res *azcore.Response) (*tokenResponse, error) {
-	value := struct { // TODO add link to device code page
+	// To know more about refreshing access tokens please see: https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code#refreshing-the-access-tokens
+	// DeviceCodeCredential uses refresh token, please see the authentication flow here: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code
+	value := struct {
 		Token        string      `json:"access_token"`
 		RefreshToken string      `json:"refresh_token"`
 		ExpiresIn    json.Number `json:"expires_in"`
@@ -169,7 +171,6 @@ func (c *aadIdentityClient) createRefreshAccessToken(res *azcore.Response) (*tok
 		Token:     value.Token,
 		ExpiresOn: time.Now().Add(time.Second * time.Duration(t)).UTC(),
 	}
-	// NOTE: look at go-autorest
 	return &tokenResponse{token: accessToken, refreshToken: value.RefreshToken}, nil
 }
 
@@ -183,7 +184,10 @@ func (c *aadIdentityClient) createRefreshTokenRequest(tenantID, clientID, client
 	data := url.Values{}
 	data.Set(qpGrantType, "refresh_token")
 	data.Set(qpClientID, clientID)
-	data.Set(qpClientSecret, clientSecret)
+	// clientSecret is only required for web apps. To know more about refreshing access tokens please see: https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code#refreshing-the-access-tokens
+	if len(clientSecret) != 0 {
+		data.Set(qpClientSecret, clientSecret)
+	}
 	data.Set(qpRefreshToken, refreshToken)
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -175,12 +175,7 @@ func (c *aadIdentityClient) createRefreshAccessToken(res *azcore.Response) (*tok
 }
 
 func (c *aadIdentityClient) createRefreshTokenRequest(tenantID, clientID, clientSecret, refreshToken string, scopes []string) (*azcore.Request, error) {
-	urlStr := c.options.AuthorityHost.String()
-	urlFormat, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	urlFormat.Path = path.Join(urlFormat.Path, tenantID+tokenEndpoint)
+	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	data := url.Values{}
 	data.Set(qpGrantType, "refresh_token")
 	data.Set(qpClientID, clientID)
@@ -192,9 +187,9 @@ func (c *aadIdentityClient) createRefreshTokenRequest(tenantID, clientID, client
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, *urlFormat)
+	msg := azcore.NewRequest(http.MethodPost, *c.options.AuthorityHost)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
-	err = msg.SetBody(body)
+	err := msg.SetBody(body)
 	if err != nil {
 		return nil, err
 	}
@@ -203,12 +198,7 @@ func (c *aadIdentityClient) createRefreshTokenRequest(tenantID, clientID, client
 }
 
 func (c *aadIdentityClient) createClientSecretAuthRequest(tenantID string, clientID string, clientSecret string, scopes []string) (*azcore.Request, error) {
-	urlStr := c.options.AuthorityHost.String()
-	urlFormat, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	urlFormat.Path = path.Join(urlFormat.Path, tenantID+tokenEndpoint)
+	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	data := url.Values{}
 	data.Set(qpGrantType, "client_credentials")
 	data.Set(qpClientID, clientID)
@@ -216,9 +206,9 @@ func (c *aadIdentityClient) createClientSecretAuthRequest(tenantID string, clien
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, *urlFormat)
+	msg := azcore.NewRequest(http.MethodPost, *c.options.AuthorityHost)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
-	err = msg.SetBody(body)
+	err := msg.SetBody(body)
 	if err != nil {
 		return nil, err
 	}
@@ -227,13 +217,8 @@ func (c *aadIdentityClient) createClientSecretAuthRequest(tenantID string, clien
 }
 
 func (c *aadIdentityClient) createClientCertificateAuthRequest(tenantID string, clientID string, clientCertificate string, scopes []string) (*azcore.Request, error) {
-	urlStr := c.options.AuthorityHost.String()
-	urlFormat, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	urlFormat.Path = path.Join(urlFormat.Path, tenantID+tokenEndpoint)
-	clientAssertion, err := createClientAssertionJWT(clientID, urlStr, clientCertificate)
+	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
+	clientAssertion, err := createClientAssertionJWT(clientID, c.options.AuthorityHost.String(), clientCertificate)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +231,7 @@ func (c *aadIdentityClient) createClientCertificateAuthRequest(tenantID string, 
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, *urlFormat)
+	msg := azcore.NewRequest(http.MethodPost, *c.options.AuthorityHost)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
 
 	err = msg.SetBody(body)
@@ -283,12 +268,7 @@ func (c *aadIdentityClient) authenticateUsernamePassword(ctx context.Context, te
 }
 
 func (c *aadIdentityClient) createUsernamePasswordAuthRequest(tenantID string, clientID string, username string, password string, scopes []string) (*azcore.Request, error) {
-	urlStr := c.options.AuthorityHost.String()
-	urlFormat, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	urlFormat.Path = path.Join(urlFormat.Path, tenantID+tokenEndpoint)
+	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	data := url.Values{}
 	data.Set(qpResponseType, "token")
 	data.Set(qpGrantType, "password")
@@ -298,9 +278,9 @@ func (c *aadIdentityClient) createUsernamePasswordAuthRequest(tenantID string, c
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, *urlFormat)
+	msg := azcore.NewRequest(http.MethodPost, *c.options.AuthorityHost)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
-	err = msg.SetBody(body)
+	err := msg.SetBody(body)
 	if err != nil {
 		return nil, err
 	}
@@ -344,12 +324,7 @@ func (c *aadIdentityClient) createDeviceCodeAuthRequest(tenantID string, clientI
 	if len(tenantID) == 0 { // if the user did not pass in a tenantID then the default value is set
 		tenantID = "organizations"
 	}
-	urlStr := c.options.AuthorityHost.String()
-	urlFormat, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	urlFormat.Path = path.Join(urlFormat.Path, tenantID+tokenEndpoint)
+	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	data := url.Values{}
 	data.Set(qpGrantType, deviceCodeGrantType)
 	data.Set(qpClientID, clientID)
@@ -357,9 +332,9 @@ func (c *aadIdentityClient) createDeviceCodeAuthRequest(tenantID string, clientI
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, *urlFormat)
+	msg := azcore.NewRequest(http.MethodPost, *c.options.AuthorityHost)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
-	err = msg.SetBody(body)
+	err := msg.SetBody(body)
 	if err != nil {
 		return nil, err
 	}
@@ -387,20 +362,15 @@ func (c *aadIdentityClient) createDeviceCodeNumberRequest(tenantID string, clien
 	if len(tenantID) == 0 { // if the user did not pass in a tenantID then the default value is set
 		tenantID = "organizations"
 	}
-	urlStr := c.options.AuthorityHost.String()
-	urlFormat, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	urlFormat.Path = path.Join(urlFormat.Path, tenantID+"/oauth2/v2.0/devicecode") // endpoint that will return a device code along with the other necessary authentication flow parameters in the DeviceCodeResult struct
+	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+"/oauth2/v2.0/devicecode") // endpoint that will return a device code along with the other necessary authentication flow parameters in the DeviceCodeResult struct
 	data := url.Values{}
 	data.Set(qpClientID, clientID)
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, *urlFormat)
+	msg := azcore.NewRequest(http.MethodPost, *c.options.AuthorityHost)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
-	err = msg.SetBody(body)
+	err := msg.SetBody(body)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -201,7 +201,6 @@ func (c *aadIdentityClient) createRefreshTokenRequest(tenantID, clientID, client
 }
 
 func (c *aadIdentityClient) createClientSecretAuthRequest(tenantID string, clientID string, clientSecret string, scopes []string) (*azcore.Request, error) {
-	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	data := url.Values{}
 	data.Set(qpGrantType, "client_credentials")
 	data.Set(qpClientID, clientID)
@@ -220,7 +219,6 @@ func (c *aadIdentityClient) createClientSecretAuthRequest(tenantID string, clien
 }
 
 func (c *aadIdentityClient) createClientCertificateAuthRequest(tenantID string, clientID string, clientCertificate string, scopes []string) (*azcore.Request, error) {
-	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	clientAssertion, err := createClientAssertionJWT(clientID, c.options.AuthorityHost.String(), clientCertificate)
 	if err != nil {
 		return nil, err
@@ -271,7 +269,6 @@ func (c *aadIdentityClient) authenticateUsernamePassword(ctx context.Context, te
 }
 
 func (c *aadIdentityClient) createUsernamePasswordAuthRequest(tenantID string, clientID string, username string, password string, scopes []string) (*azcore.Request, error) {
-	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	data := url.Values{}
 	data.Set(qpResponseType, "token")
 	data.Set(qpGrantType, "password")

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -52,9 +52,12 @@ type aadIdentityClient struct {
 // that are passed into it along with a default pipeline.
 // options: IdentityClientOptions that adds policies for the pipeline and the authority host that
 // will be used to retrieve tokens and authenticate
-func newAADIdentityClient(options *TokenCredentialOptions) *aadIdentityClient {
-	options = options.setDefaultValues()
-	return &aadIdentityClient{options: *options, pipeline: newDefaultPipeline(*options)}
+func newAADIdentityClient(options *TokenCredentialOptions) (*aadIdentityClient, error) {
+	options, err := options.setDefaultValues()
+	if err != nil {
+		return nil, err
+	}
+	return &aadIdentityClient{options: *options, pipeline: newDefaultPipeline(*options)}, nil
 }
 
 // Authenticate creates a client secret authentication request and returns the resulting Access Token or

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -74,11 +74,6 @@ func (c *aadIdentityClient) refreshAccessToken(ctx context.Context, tenantID str
 		return nil, err
 	}
 
-	// This should never happen under normal conditions
-	if resp == nil {
-		return nil, &AuthenticationFailedError{msg: "Something unexpected happened with the request and received a nil response"}
-	}
-
 	if resp.HasStatusCode(successStatusCodes[:]...) {
 		return c.createAccessToken(resp)
 	}
@@ -104,11 +99,6 @@ func (c *aadIdentityClient) authenticate(ctx context.Context, tenantID string, c
 		return nil, err
 	}
 
-	// This should never happen under normal conditions
-	if resp == nil {
-		return nil, &AuthenticationFailedError{msg: "Something unexpected happened with the request and received a nil response"}
-	}
-
 	if resp.HasStatusCode(successStatusCodes[:]...) {
 		return c.createAccessToken(resp)
 	}
@@ -132,11 +122,6 @@ func (c *aadIdentityClient) authenticateCertificate(ctx context.Context, tenantI
 	resp, err := c.pipeline.Do(ctx, msg)
 	if err != nil {
 		return nil, err
-	}
-
-	// This should never happen under normal conditions
-	if resp == nil {
-		return nil, &AuthenticationFailedError{msg: "Something unexpected happened with the request and received a nil response"}
 	}
 
 	if resp.HasStatusCode(successStatusCodes[:]...) {
@@ -264,11 +249,6 @@ func (c *aadIdentityClient) authenticateUsernamePassword(ctx context.Context, te
 		return nil, err
 	}
 
-	// This should never happen under normal conditions
-	if resp == nil {
-		return nil, &AuthenticationFailedError{msg: "Something unexpected happened with the request and received a nil response"}
-	}
-
 	if resp.HasStatusCode(successStatusCodes[:]...) {
 		return c.createAccessToken(resp)
 	}
@@ -326,11 +306,6 @@ func (c *aadIdentityClient) authenticateDeviceCode(ctx context.Context, tenantID
 		return nil, err
 	}
 
-	// This should never happen under normal conditions
-	if resp == nil {
-		return nil, &AuthenticationFailedError{msg: "Something unexpected happened with the request and received a nil response"}
-	}
-
 	if resp.HasStatusCode(successStatusCodes[:]...) {
 		return c.createAccessToken(resp)
 	}
@@ -377,10 +352,7 @@ func (c *aadIdentityClient) requestNewDeviceCode(ctx context.Context, tenantID, 
 	if err != nil {
 		return nil, err
 	}
-	// This should never happen under normal conditions
-	if resp == nil {
-		return nil, &AuthenticationFailedError{msg: "Something unexpected happened with the request and received a nil response"}
-	}
+
 	if resp.HasStatusCode(successStatusCodes[:]...) {
 		return createDeviceCodeResult(resp)
 	}

--- a/sdk/azidentity/aad_identity_client_test.go
+++ b/sdk/azidentity/aad_identity_client_test.go
@@ -24,8 +24,11 @@ func TestClientSecretCredential_GetTokenUnexpectedJSON(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespMalformed)))
 	srvURL := srv.URL()
-	cred := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Failed to create the credential")
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
 	if err == nil {
 		t.Fatalf("Expected a JSON marshal error but received nil")
 	}

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -41,7 +41,7 @@ type tokenResponse struct {
 }
 
 // AADAuthenticationFailedError is a struct used to marshal responses when authentication has failed
-type AADAuthenticationFailedError struct { // TODO rename
+type AADAuthenticationFailedError struct {
 	Message       string `json:"error"`
 	Description   string `json:"error_description"`
 	Timestamp     string `json:"timestamp"`
@@ -62,7 +62,7 @@ func (e *AADAuthenticationFailedError) Error() string {
 // AuthenticationFailedError is a struct used to marshal responses when authentication has failed
 type AuthenticationFailedError struct {
 	inner error
-	msg   string // TODO check if this is necessary
+	msg   string
 }
 
 // Unwrap method on AuthenticationFailedError provides access to the inner error

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -24,17 +24,6 @@ var (
 	}
 )
 
-var (
-	defaultAuthorityHostURL    *url.URL
-	defaultTokenCredentialOpts *TokenCredentialOptions
-)
-
-func init() {
-	// The error check is handled in azidentity_test.go
-	defaultAuthorityHostURL, _ = url.Parse(defaultAuthorityHost)
-	defaultTokenCredentialOpts = &TokenCredentialOptions{AuthorityHost: defaultAuthorityHostURL}
-}
-
 type tokenResponse struct {
 	token        *azcore.AccessToken
 	refreshToken string

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -192,18 +191,4 @@ func newDefaultMSIPipeline(o ManagedIdentityCredentialOptions) azcore.Pipeline {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(retryOpts),
 		azcore.NewRequestLogPolicy(o.LogOptions))
-}
-
-const defaultSuffix = "/.default"
-
-func scopesToResource(scope string) string {
-	if strings.HasSuffix(scope, defaultSuffix) {
-		return scope[:len(scope)-len(defaultSuffix)]
-	}
-	return scope
-}
-
-func resourceToScope(resource string) string {
-	resource += defaultSuffix
-	return resource
 }

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -128,19 +128,29 @@ type TokenCredentialOptions struct {
 }
 
 // NewIdentityClientOptions initializes an instance of IdentityClientOptions with default settings
-func (c *TokenCredentialOptions) setDefaultValues() *TokenCredentialOptions {
+// NewIdentityClientOptions initializes an instance of IdentityClientOptions with default settings
+func (c *TokenCredentialOptions) setDefaultValues() (*TokenCredentialOptions, error) {
 	if c == nil {
-		c = defaultTokenCredentialOpts
+		defaultAuthorityHostURL, err := url.Parse(defaultAuthorityHost)
+		if err != nil {
+			return nil, err
+		}
+		c = &TokenCredentialOptions{AuthorityHost: defaultAuthorityHostURL}
 	}
 
 	if c.AuthorityHost == nil {
-		c.AuthorityHost = defaultTokenCredentialOpts.AuthorityHost
+		defaultAuthorityHostURL, err := url.Parse(defaultAuthorityHost)
+		if err != nil {
+			return nil, err
+		}
+		c.AuthorityHost = defaultAuthorityHostURL
 	}
+
 	if len(c.AuthorityHost.Path) == 0 || c.AuthorityHost.Path[len(c.AuthorityHost.Path)-1:] != "/" {
 		c.AuthorityHost.Path = c.AuthorityHost.Path + "/"
 	}
 
-	return c
+	return c, nil
 }
 
 // NewDefaultPipeline creates a Pipeline using the specified pipeline options

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -76,6 +76,9 @@ func (e *AuthenticationFailedError) IsNotRetriable() bool {
 }
 
 func (e *AuthenticationFailedError) Error() string {
+	if len(e.msg) == 0 {
+		e.msg = e.inner.Error()
+	}
 	return e.msg
 }
 

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -19,8 +19,10 @@ func Test_AuthorityHost_Parse(t *testing.T) {
 
 func Test_NonNilTokenCredentialOptsNilAuthorityHost(t *testing.T) {
 	opts := &TokenCredentialOptions{Retry: azcore.RetryOptions{MaxTries: 6}}
-	opts = opts.setDefaultValues()
-
+	opts, err := opts.setDefaultValues()
+	if err != nil {
+		t.Fatalf("Received an error: %v", err)
+	}
 	if opts.AuthorityHost == nil {
 		t.Fatalf("Did not set default authority host")
 	}

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -25,3 +25,10 @@ func Test_NonNilTokenCredentialOptsNilAuthorityHost(t *testing.T) {
 		t.Fatalf("Did not set default authority host")
 	}
 }
+
+func TestSuffix(t *testing.T) {
+	str := scopesToResource("https://storage.azure.com/.default")
+	if str != "https://storage.azure.com" {
+		t.Fatalf("Could not convert scope string to a proper resource string")
+	}
+}

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -27,10 +27,3 @@ func Test_NonNilTokenCredentialOptsNilAuthorityHost(t *testing.T) {
 		t.Fatalf("Did not set default authority host")
 	}
 }
-
-func TestSuffix(t *testing.T) {
-	str := scopesToResource("https://storage.azure.com/.default")
-	if str != "https://storage.azure.com" {
-		t.Fatalf("Could not convert scope string to a proper resource string")
-	}
-}

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -6,6 +6,7 @@ package azidentity
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
@@ -22,7 +23,7 @@ func NewChainedTokenCredential(sources ...azcore.TokenCredential) (*ChainedToken
 		return nil, &CredentialUnavailableError{CredentialType: "Chained Token Credential", Message: "Length of sources cannot be 0"}
 	}
 	for _, source := range sources {
-		if source == nil {
+		if source == nil { // cannot have a nil credential in the chain or else the application will panic when GetToken() is called on nil
 			return nil, &CredentialUnavailableError{CredentialType: "Chained Token Credential", Message: "Sources cannot contain a nil TokenCredential"}
 		}
 	}
@@ -30,30 +31,41 @@ func NewChainedTokenCredential(sources ...azcore.TokenCredential) (*ChainedToken
 }
 
 // GetToken sequentially calls TokenCredential.GetToken on all the specified sources, returning the first non default AccessToken.
-func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	var token *azcore.AccessToken
-	var err error
+func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (token *azcore.AccessToken, err error) {
 	var errList []*CredentialUnavailableError
-	for i := 0; i < len(c.sources); i++ {
+	for _, cred := range c.sources { // loop through all of the credentials provided in sources
+		token, err = cred.GetToken(ctx, opts) // make a GetToken request for the current credential in the loop
 		var credErr *CredentialUnavailableError
-		token, err = c.sources[i].GetToken(ctx, opts)
-		if errors.As(err, &credErr) {
-			errList = append(errList, credErr)
-		} else if err != nil {
-			errList = append(errList, &CredentialUnavailableError{CredentialType: "Chained Token Credential", Message: err.Error()})
-			break
+		if errors.As(err, &credErr) { // check if we received a CredentialUnavailableError
+			errList = append(errList, credErr) // if we did receive a CredentialUnavailableError then we append it to our error slice and continue looping for a good credential
+		} else if err != nil { // if we receive some other type of error then we must stop looping and process the error accordingly
+			var authenticationFailed *AuthenticationFailedError
+			if errors.As(err, &authenticationFailed) { // if the error is an AuthenticationFailedError we return the error related to the invalid credential and append all of the other error messages received prior to this point
+				return nil, &AuthenticationFailedError{msg: "Received an AuthenticationFailedError, there is an invalid credential in the chain. " + createChainedErrorMessage(errList), inner: err}
+			}
+			return nil, fmt.Errorf("Received an unexpected error: %w", err) // if we receive some other error type this is unexpected and we simple return the unexpected error
 		} else {
-			return token, nil
+			return token, nil // if we did not receive an error then we return the token
 		}
 	}
-	// This condition should never be true
+	// this condition should never be true
 	if token == nil && len(errList) == 0 {
-		return nil, nil
+		return nil, &CredentialUnavailableError{CredentialType: "Chained Token Credential", Message: "Did not receive a token, make sure the credential is correctly configured and the length of sources is greater than 0"}
 	}
-	return nil, &AuthenticationFailedError{inner: &ChainedCredentialError{ErrorList: errList}, msg: "Could not find any available credentials in chain"}
+	return nil, &CredentialUnavailableError{CredentialType: "Chained Token Credential", Message: createChainedErrorMessage(errList)} // if we reach this point it means that all of the credentials in the chain returned CredentialUnavailableErrors
 }
 
 // AuthenticationPolicy implements the azcore.Credential interface on ChainedTokenCredential.
 func (c *ChainedTokenCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
+}
+
+// Helper function used to chain the error messages of the CredentialUnavailableError slice
+func createChainedErrorMessage(errList []*CredentialUnavailableError) string {
+	msg := ""
+	for _, err := range errList {
+		msg += err.Error()
+	}
+
+	return msg
 }

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -48,10 +48,6 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts azcore.Token
 			return token, nil // if we did not receive an error then we return the token
 		}
 	}
-	// this condition should never be true
-	if token == nil && len(errList) == 0 {
-		return nil, &CredentialUnavailableError{CredentialType: "Chained Token Credential", Message: "Did not receive a token, make sure the credential is correctly configured and the length of sources is greater than 0"}
-	}
 	return nil, &CredentialUnavailableError{CredentialType: "Chained Token Credential", Message: createChainedErrorMessage(errList)} // if we reach this point it means that all of the credentials in the chain returned CredentialUnavailableErrors
 }
 

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -19,7 +19,10 @@ func TestChainedTokenCredential_InstantiateSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not set environment variables for testing: %v", err)
 	}
-	secCred := NewClientSecretCredential(tenantID, clientID, secret, nil)
+	secCred, err := NewClientSecretCredential(tenantID, clientID, secret, nil)
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	envCred, err := NewEnvironmentCredential(nil)
 	if err != nil {
 		t.Fatalf("Could not find appropriate environment credentials")
@@ -45,7 +48,10 @@ func TestChainedTokenCredential_GetTokenSuccess(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srvURL := srv.URL()
-	secCred := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	secCred, err := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	envCred, err := NewEnvironmentCredential(&TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
 	if err != nil {
 		t.Fatalf("Failed to create environment credential: %v", err)
@@ -71,7 +77,10 @@ func TestChainedTokenCredential_GetTokenFail(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	testURL := srv.URL()
-	secCred := NewClientSecretCredential(tenantID, clientID, wrongSecret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &testURL})
+	secCred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &testURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	msiCred := NewManagedIdentityCredential("", nil)
 	cred, err := NewChainedTokenCredential(msiCred, secCred)
 	if err != nil {
@@ -130,7 +139,10 @@ func TestBearerPolicy_ChainedTokenCredential(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	srvURL := srv.URL()
-	cred := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	chainedCred, err := NewChainedTokenCredential(cred)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -38,11 +38,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, clientCert
 // ctx: controlling the request lifetime.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	tr, err := c.client.authenticateCertificate(ctx, c.tenantID, c.clientID, c.clientCertificate, opts.Scopes)
-	if err != nil {
-		return nil, err
-	}
-	return tr.token, err
+	return c.client.authenticateCertificate(ctx, c.tenantID, c.clientID, c.clientCertificate, opts.Scopes)
 }
 
 // AuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential.

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -30,7 +30,11 @@ func NewClientCertificateCredential(tenantID string, clientID string, clientCert
 	if err != nil {
 		return nil, &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: "Certificate file not found in path: " + clientCertificate}
 	}
-	return &ClientCertificateCredential{tenantID: tenantID, clientID: clientID, clientCertificate: clientCertificate, client: newAADIdentityClient(options)}, nil
+	c, err := newAADIdentityClient(options)
+	if err != nil {
+		return nil, err
+	}
+	return &ClientCertificateCredential{tenantID: tenantID, clientID: clientID, clientCertificate: clientCertificate, client: c}, nil
 }
 
 // GetToken obtains a token from the Azure Active Directory service, using the certificate in the file path to authenticate.

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -38,7 +38,11 @@ func NewClientCertificateCredential(tenantID string, clientID string, clientCert
 // ctx: controlling the request lifetime.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	return c.client.authenticateCertificate(ctx, c.tenantID, c.clientID, c.clientCertificate, opts.Scopes)
+	tr, err := c.client.authenticateCertificate(ctx, c.tenantID, c.clientID, c.clientCertificate, opts.Scopes)
+	if err != nil {
+		return nil, err
+	}
+	return tr.token, err
 }
 
 // AuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential.

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -6,6 +6,7 @@ package azidentity
 import (
 	"context"
 	"os"
+	"path"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
@@ -34,6 +35,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, clientCert
 	if err != nil {
 		return nil, err
 	}
+	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	return &ClientCertificateCredential{tenantID: tenantID, clientID: clientID, clientCertificate: clientCertificate, client: c}, nil
 }
 

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -33,7 +33,11 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 // scopes: The list of scopes for which the token will have access.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *ClientSecretCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	return c.client.authenticate(ctx, c.tenantID, c.clientID, c.clientSecret, opts.Scopes)
+	tr, err := c.client.authenticate(ctx, c.tenantID, c.clientID, c.clientSecret, opts.Scopes)
+	if err != nil {
+		return nil, err
+	}
+	return tr.token, nil
 }
 
 // AuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential.

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -33,11 +33,7 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 // scopes: The list of scopes for which the token will have access.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *ClientSecretCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	tr, err := c.client.authenticate(ctx, c.tenantID, c.clientID, c.clientSecret, opts.Scopes)
-	if err != nil {
-		return nil, err
-	}
-	return tr.token, nil
+	return c.client.authenticate(ctx, c.tenantID, c.clientID, c.clientSecret, opts.Scopes)
 }
 
 // AuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential.

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -5,6 +5,7 @@ package azidentity
 
 import (
 	"context"
+	"path"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
@@ -29,6 +30,7 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 	if err != nil {
 		return nil, err
 	}
+	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	return &ClientSecretCredential{tenantID: tenantID, clientID: clientID, clientSecret: clientSecret, client: c}, nil
 }
 

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -24,8 +24,12 @@ type ClientSecretCredential struct {
 // clientID: The client (application) ID of the service principal.
 // clientSecret: A client secret that was generated for the App Registration used to authenticate the client.
 // options: allow to configure the management of the requests sent to the Azure Active Directory service.
-func NewClientSecretCredential(tenantID string, clientID string, clientSecret string, options *TokenCredentialOptions) *ClientSecretCredential {
-	return &ClientSecretCredential{tenantID: tenantID, clientID: clientID, clientSecret: clientSecret, client: newAADIdentityClient(options)}
+func NewClientSecretCredential(tenantID string, clientID string, clientSecret string, options *TokenCredentialOptions) (*ClientSecretCredential, error) {
+	c, err := newAADIdentityClient(options)
+	if err != nil {
+		return nil, err
+	}
+	return &ClientSecretCredential{tenantID: tenantID, clientID: clientID, clientSecret: clientSecret, client: c}, nil
 }
 
 // GetToken obtains a token from the Azure Active Directory service, using the specified client secret to authenticate.

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -86,9 +86,9 @@ func TestClientSecretCredential_GetTokenInvalidCredentials(t *testing.T) {
 	if !errors.As(err, &authFailed) {
 		t.Fatalf("Expected: AuthenticationFailedError, Received: %T", err)
 	} else {
-		var respError *AuthenticationResponseError
+		var respError *AADAuthenticationFailedError
 		if !errors.As(authFailed.Unwrap(), &respError) {
-			t.Fatalf("Expected: AuthenticationResponseError, Received: %T", err)
+			t.Fatalf("Expected: AADAuthenticationFailedError, Received: %T", err)
 		} else {
 			if len(respError.Message) == 0 {
 				t.Fatalf("Did not receive an error message")

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -26,7 +26,10 @@ const (
 )
 
 func TestClientSecretCredential_CreateAuthRequestSuccess(t *testing.T) {
-	cred := NewClientSecretCredential(tenantID, clientID, secret, nil)
+	cred, err := NewClientSecretCredential(tenantID, clientID, secret, nil)
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	req, err := cred.client.createClientSecretAuthRequest(cred.tenantID, cred.clientID, cred.clientSecret, []string{scope})
 	if err != nil {
 		t.Fatalf("Unexpectedly received an error: %v", err)
@@ -65,8 +68,11 @@ func TestClientSecretCredential_GetTokenSuccess(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srvURL := srv.URL()
-	cred := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
 	if err != nil {
 		t.Fatalf("Expected an empty error but received: %v", err)
 	}
@@ -77,8 +83,11 @@ func TestClientSecretCredential_GetTokenInvalidCredentials(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte(accessTokenRespError)), mock.WithStatusCode(http.StatusUnauthorized))
 	srvURL := srv.URL()
-	cred := NewClientSecretCredential(tenantID, clientID, wrongSecret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	cred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one.")
 	}
@@ -121,8 +130,11 @@ func TestClientSecretCredential_CreateAuthRequestFail(t *testing.T) {
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	srvURL := srv.URL()
 	srvURL.Host = "ht @"
-	cred := NewClientSecretCredential(tenantID, clientID, wrongSecret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	cred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}

--- a/sdk/azidentity/default_token_credential.go
+++ b/sdk/azidentity/default_token_credential.go
@@ -3,22 +3,11 @@
 
 package azidentity
 
-import (
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-)
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 const (
 	developerSignOnClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 )
-
-// DefaultTokenCredential provides a default ChainedTokenCredential configuration for applications that will be deployed to Azure.  The following credential
-// types will be tried, in order:
-// - EnvironmentCredential
-// - ManagedIdentityCredential
-// Consult the documentation of these credential types for more information on how they attempt authentication.
-type DefaultTokenCredential struct {
-	sources []azcore.TokenCredential
-}
 
 // DefaultTokenCredentialOptions contain information that can configure Default Token Credentials
 type DefaultTokenCredentialOptions struct {
@@ -32,7 +21,8 @@ type DefaultTokenCredentialOptions struct {
 // - ManagedIdentityCredential
 // Consult the documentation of these credential types for more information on how they attempt authentication.
 func NewDefaultTokenCredential(options *DefaultTokenCredentialOptions) (*ChainedTokenCredential, error) {
-	cred := &DefaultTokenCredential{}
+	var creds []azcore.TokenCredential
+	errMsg := ""
 
 	if options == nil {
 		options = &DefaultTokenCredentialOptions{}
@@ -41,15 +31,18 @@ func NewDefaultTokenCredential(options *DefaultTokenCredentialOptions) (*Chained
 	if !options.ExcludeEnvironmentCredential {
 		envCred, err := NewEnvironmentCredential(nil)
 		if err == nil {
-			cred.sources = append(cred.sources, envCred)
-			return NewChainedTokenCredential(cred.sources...)
+			creds = append(creds, envCred)
+		} else {
+			errMsg += err.Error()
 		}
 	}
 
 	if !options.ExcludeMSICredential {
-		cred.sources = append(cred.sources, NewManagedIdentityCredential("", nil))
-		return NewChainedTokenCredential(cred.sources...)
+		creds = append(creds, NewManagedIdentityCredential("", nil))
 	}
 
-	return nil, &CredentialUnavailableError{CredentialType: "Default Token Credential", Message: "Failed to find any available credentials. Make sure you are running in a Managed Identity Environment or have set the appropriate environment variables"}
+	if len(creds) == 0 {
+		return nil, &CredentialUnavailableError{CredentialType: "Default Token Credential", Message: errMsg}
+	}
+	return NewChainedTokenCredential(creds...)
 }

--- a/sdk/azidentity/default_token_credential_test.go
+++ b/sdk/azidentity/default_token_credential_test.go
@@ -60,7 +60,7 @@ func TestDefaultTokenCredential_NilOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
-	if len(cred.sources) != 1 {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 1, Received: %d", len(cred.sources))
+	if len(cred.sources) != 2 {
+		t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 2, Received: %d", len(cred.sources))
 	}
 }

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -30,8 +30,12 @@ type DeviceCodeCredential struct {
 // clientID: The client (application) ID of the service principal.
 // callback: The callback function used to send the login message back to the user
 // options: allow to configure the management of the requests sent to the Azure Active Directory service.
-func NewDeviceCodeCredential(tenantID string, clientID string, callback func(string), options *TokenCredentialOptions) *DeviceCodeCredential {
-	return &DeviceCodeCredential{tenantID: tenantID, clientID: clientID, callback: callback, client: newAADIdentityClient(options)}
+func NewDeviceCodeCredential(tenantID string, clientID string, callback func(string), options *TokenCredentialOptions) (*DeviceCodeCredential, error) {
+	c, err := newAADIdentityClient(options)
+	if err != nil {
+		return nil, err
+	}
+	return &DeviceCodeCredential{tenantID: tenantID, clientID: clientID, callback: callback, client: c}, nil
 }
 
 // GetToken obtains a token from the Azure Active Directory service, following the device code authentication

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -23,7 +23,7 @@ type DeviceCodeCredential struct {
 	tenantID     string       // Gets the Azure Active Directory tenant (directory) Id of the service principal
 	clientID     string       // Gets the client (application) ID of the service principal
 	callback     func(string) // Sends the user a message with a verification URL and device code to sign in to the login server
-	refreshToken string       // Gets the refresh token sent from the service and will be used to retreive new access tokens after the initial request for a token
+	refreshToken string       // Gets the refresh token sent from the service and will be used to retreive new access tokens after the initial request for a token. Thread safety for updates is handled in the AuthenticationPolicy since only one goroutine will be updating at a time
 }
 
 // NewDeviceCodeCredential constructs a new DeviceCodeCredential with the details needed to authenticate against Azure Active Directory with a device code.

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+const (
+	deviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+)
+
+// DeviceCodeResult is used to store device code related information to help the user login and allow the device code flow to continue
+// to request a token to authenticate a user
+type DeviceCodeResult struct {
+	UserCode        string `json:"user_code"`        // User code returned by the service
+	DeviceCode      string `json:"device_code"`      // Device code returned by the service
+	VerificationURL string `json:"verification_uri"` // Verification URL where the user must navigate to authenticate using the device code and credentials.
+	Interval        int64  `json:"interval"`         // Polling interval time to check for completion of authentication flow.
+	Message         string `json:"message"`          // User friendly text response that can be used for display purpose.
+}
+
+// DeviceCodeCredential authenticates a user using the device code flow, and provides access tokens for that user account.
+// For more information on the device code authentication flow see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code
+type DeviceCodeCredential struct {
+	client       *aadIdentityClient
+	tenantID     string       // Gets the Azure Active Directory tenant (directory) Id of the service principal
+	clientID     string       // Gets the client (application) ID of the service principal
+	callback     func(string) // Sends the user a message with a verification URL and device code to sign in to the login server
+	refreshToken string       // Gets the refresh token sent from the service and will be used to retreive new access tokens after the initial request for a token
+}
+
+// NewDeviceCodeCredential constructs a new DeviceCodeCredential with the details needed to authenticate against Azure Active Directory with a device code.
+// tenantID: The Azure Active Directory tenant (directory) Id of the service principal.
+// clientID: The client (application) ID of the service principal.
+// callback: The callback function used to send the login message back to the user
+// options: allow to configure the management of the requests sent to the Azure Active Directory service.
+func NewDeviceCodeCredential(tenantID string, clientID string, callback func(string), options *TokenCredentialOptions) *DeviceCodeCredential {
+	return &DeviceCodeCredential{tenantID: tenantID, clientID: clientID, callback: callback, client: newAADIdentityClient(options)}
+}
+
+// GetToken obtains a token from the Azure Active Directory service, following the device code authentication
+// flow. This function first requests a device code and requests that the user login to continue authenticating.
+// This function will keep polling the service for a token meanwhile the user logs.
+// - scopes: The list of scopes for which the token will have access.
+// - ctx: controlling the request lifetime.
+// Returns an AccessToken which can be used to authenticate service client calls.
+func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
+	if len(c.refreshToken) != 0 {
+		tk, err := c.client.refreshAccessToken(ctx, c.tenantID, c.clientID, "", c.refreshToken, opts.Scopes)
+		if tk == nil { // this would only happen if there was an unmarshal error or a failure to parse ExpiresOn
+			return nil, err
+		}
+		// assign new refresh token to the credential for future use
+		c.refreshToken = tk.refreshToken
+		// passing the access token and/or error back up
+		return tk.token, err
+	}
+	// if there is no refreshToken, then begin the Device Code flow from the beginning
+	// make initial request to the device code endpoint for a device code and instructions for authentication
+	dc, err := c.client.requestNewDeviceCode(ctx, c.tenantID, c.clientID, opts.Scopes)
+	if err != nil {
+		return nil, err
+	}
+	// send authentication flow instructions back to the user to log in and authorize the device
+	c.callback(dc.Message)
+	// poll the token endpoint until a valid access token is received or until authentication fails
+	for {
+		tk, err := c.client.authenticateDeviceCode(ctx, c.tenantID, c.clientID, dc.DeviceCode, opts.Scopes)
+		// if there is no error, save the refresh token and return the token credential
+		if err == nil {
+			c.refreshToken = tk.refreshToken
+			return tk.token, err
+		}
+		// if there is an error, check for an AADAuthenticationFailedError in order to check the status for token retrieval
+		var authRespErr *AADAuthenticationFailedError
+		// if the error is not an AADAuthenticationFailedError, then fail here since something unexpected occurred
+		if !errors.As(err, &authRespErr) {
+			return nil, err
+		}
+		switch authRespErr.Message {
+		// wait for the interval specified from the initial device code endpoint and then poll for the token again
+		case "authorization_pending":
+			time.Sleep(time.Duration(dc.Interval) * time.Second)
+		default:
+			// any other error should be returned
+			return nil, err
+		}
+	}
+}
+
+// AuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential.
+func (c *DeviceCodeCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+	return newBearerTokenPolicy(c, options)
+}

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -16,16 +16,6 @@ const (
 	deviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
 )
 
-// DeviceCodeResult is used to store device code related information to help the user login and allow the device code flow to continue
-// to request a token to authenticate a user
-type DeviceCodeResult struct {
-	UserCode        string `json:"user_code"`        // User code returned by the service
-	DeviceCode      string `json:"device_code"`      // Device code returned by the service
-	VerificationURL string `json:"verification_uri"` // Verification URL where the user must navigate to authenticate using the device code and credentials.
-	Interval        int64  `json:"interval"`         // Polling interval time to check for completion of authentication flow.
-	Message         string `json:"message"`          // User friendly text response that can be used for display purpose.
-}
-
 // DeviceCodeCredential authenticates a user using the device code flow, and provides access tokens for that user account.
 // For more information on the device code authentication flow see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code
 type DeviceCodeCredential struct {
@@ -48,7 +38,7 @@ func NewDeviceCodeCredential(tenantID string, clientID string, callback func(str
 // GetToken obtains a token from the Azure Active Directory service, following the device code authentication
 // flow. This function first requests a device code and requests that the user login to continue authenticating.
 // This function will keep polling the service for a token meanwhile the user logs.
-// scopes: The list of scopes for which the token will have access.
+// scopes: The list of scopes for which the token will have access. The "offline_access" scope is checked for and automatically added in case it isn't present to allow for silent token refresh.
 // ctx: controlling the request lifetime.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
@@ -101,4 +91,14 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts azcore.TokenRe
 // AuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential.
 func (c *DeviceCodeCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
+}
+
+// deviceCodeResult is used to store device code related information to help the user login and allow the device code flow to continue
+// to request a token to authenticate a user
+type deviceCodeResult struct {
+	UserCode        string `json:"user_code"`        // User code returned by the service
+	DeviceCode      string `json:"device_code"`      // Device code returned by the service
+	VerificationURL string `json:"verification_uri"` // Verification URL where the user must navigate to authenticate using the device code and credentials.
+	Interval        int64  `json:"interval"`         // Polling interval time to check for completion of authentication flow.
+	Message         string `json:"message"`          // User friendly text response that can be used for display purpose.
 }

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -98,7 +98,7 @@ func TestDeviceCodeCredential_CreateAuthRequestEmptyTenant(t *testing.T) {
 	if req.Request.URL.Scheme != "https" {
 		t.Fatalf("Wrong request scheme")
 	}
-	if req.Request.URL.Path != "/organizations/oauth2/v2.0/token/" {
+	if req.Request.URL.Path != "/organizations/oauth2/v2.0/token" {
 		t.Fatalf("Did not set the right path when passing in an empty tenant ID")
 	}
 }

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+)
+
+const (
+	deviceCode                   = "device_code"
+	deviceCodeResponse           = `{"user_code":"test_code","device_code":"test_device_code","verification_uri":"https://microsoft.com/devicelogin","expires_in":900,"interval":5,"message":"To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code test_code to authenticate."}`
+	deviceCodeScopes             = "user.read offline_access openid profile email"
+	authorizationPendingResponse = `{"error": "authorization_pending","error_description": "Authorization pending.","error_codes": [],"timestamp": "2019-12-01 19:00:00Z","trace_id": "2d091b0","correlation_id": "a999","error_uri": "https://login.contoso.com/error?code=7000215"}`
+	expiredTokenResponse         = `{"error": "expired_token","error_description": "Token has expired.","error_codes": [],"timestamp": "2019-12-01 19:00:00Z","trace_id": "2d091b0","correlation_id": "a999","error_uri": "https://login.contoso.com/error?code=7000215"}`
+)
+
+func TestDeviceCodeCredential_CreateAuthRequestSuccess(t *testing.T) {
+	handler := func(s string) {}
+	cred := NewDeviceCodeCredential(tenantID, clientID, handler, nil)
+	req, err := cred.client.createDeviceCodeAuthRequest(cred.tenantID, cred.clientID, deviceCode, []string{deviceCodeScopes})
+	if err != nil {
+		t.Fatalf("Unexpectedly received an error: %v", err)
+	}
+	if req.Request.Header.Get(azcore.HeaderContentType) != azcore.HeaderURLEncoded {
+		t.Fatalf("Unexpected value for Content-Type header")
+	}
+	body, err := ioutil.ReadAll(req.Request.Body)
+	if err != nil {
+		t.Fatalf("Unable to read request body")
+	}
+	bodyStr := string(body)
+	reqQueryParams, err := url.ParseQuery(bodyStr)
+	if err != nil {
+		t.Fatalf("Unable to parse query params in request")
+	}
+	if reqQueryParams[qpGrantType][0] != deviceCodeGrantType {
+		t.Fatalf("Unexpected grant type")
+	}
+	if reqQueryParams[qpClientID][0] != clientID {
+		t.Fatalf("Unexpected client ID in the client_id header")
+	}
+	if reqQueryParams[qpDeviceCode][0] != deviceCode {
+		t.Fatalf("Unexpected username in the username header")
+	}
+	if reqQueryParams[qpScope][0] != deviceCodeScopes {
+		t.Fatalf("Unexpected scope in scope header")
+	}
+	if req.Request.URL.Host != defaultTestAuthorityHost {
+		t.Fatalf("Unexpected default authority host")
+	}
+	if req.Request.URL.Scheme != "https" {
+		t.Fatalf("Wrong request scheme")
+	}
+}
+
+func TestDeviceCodeCredential_CreateAuthRequestEmptyTenant(t *testing.T) {
+	handler := func(s string) {}
+	cred := NewDeviceCodeCredential("", clientID, handler, nil)
+	req, err := cred.client.createDeviceCodeAuthRequest(cred.tenantID, cred.clientID, deviceCode, []string{deviceCodeScopes})
+	if err != nil {
+		t.Fatalf("Unexpectedly received an error: %v", err)
+	}
+	if req.Request.Header.Get(azcore.HeaderContentType) != azcore.HeaderURLEncoded {
+		t.Fatalf("Unexpected value for Content-Type header")
+	}
+	body, err := ioutil.ReadAll(req.Request.Body)
+	if err != nil {
+		t.Fatalf("Unable to read request body")
+	}
+	bodyStr := string(body)
+	reqQueryParams, err := url.ParseQuery(bodyStr)
+	if err != nil {
+		t.Fatalf("Unable to parse query params in request")
+	}
+	if reqQueryParams[qpGrantType][0] != deviceCodeGrantType {
+		t.Fatalf("Unexpected grant type")
+	}
+	if reqQueryParams[qpClientID][0] != clientID {
+		t.Fatalf("Unexpected client ID in the client_id header")
+	}
+	if reqQueryParams[qpDeviceCode][0] != deviceCode {
+		t.Fatalf("Unexpected username in the username header")
+	}
+	if reqQueryParams[qpScope][0] != deviceCodeScopes {
+		t.Fatalf("Unexpected scope in scope header")
+	}
+	if req.Request.URL.Host != defaultTestAuthorityHost {
+		t.Fatalf("Unexpected default authority host")
+	}
+	if req.Request.URL.Scheme != "https" {
+		t.Fatalf("Wrong request scheme")
+	}
+	if req.Request.URL.Path != "/organizations/oauth2/v2.0/token/" {
+		t.Fatalf("Did not set the right path when passing in an empty tenant ID")
+	}
+}
+
+func TestDeviceCodeCredential_RequestNewDeviceCodeEmptyTenant(t *testing.T) {
+	handler := func(s string) {}
+	cred := NewDeviceCodeCredential("", clientID, handler, nil)
+	req, err := cred.client.createDeviceCodeNumberRequest(cred.tenantID, cred.clientID, []string{deviceCodeScopes})
+	if err != nil {
+		t.Fatalf("Unexpectedly received an error: %v", err)
+	}
+	if req.Request.Header.Get(azcore.HeaderContentType) != azcore.HeaderURLEncoded {
+		t.Fatalf("Unexpected value for Content-Type header")
+	}
+	body, err := ioutil.ReadAll(req.Request.Body)
+	if err != nil {
+		t.Fatalf("Unable to read request body")
+	}
+	bodyStr := string(body)
+	reqQueryParams, err := url.ParseQuery(bodyStr)
+	if err != nil {
+		t.Fatalf("Unable to parse query params in request")
+	}
+	if reqQueryParams[qpClientID][0] != clientID {
+		t.Fatalf("Unexpected client ID in the client_id header")
+	}
+	if reqQueryParams[qpScope][0] != deviceCodeScopes {
+		t.Fatalf("Unexpected scope in scope header")
+	}
+	if req.Request.URL.Host != defaultTestAuthorityHost {
+		t.Fatalf("Unexpected default authority host")
+	}
+	if req.Request.URL.Scheme != "https" {
+		t.Fatalf("Wrong request scheme")
+	}
+	if req.Request.URL.Path != "/organizations/oauth2/v2.0/devicecode" {
+		t.Fatalf("Did not set the right path when passing in an empty tenant ID")
+	}
+}
+
+func TestDeviceCodeCredential_GetTokenSuccess(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
+	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+	srvURL := srv.URL()
+	handler := func(string) {}
+	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	tk, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	if err != nil {
+		t.Fatalf("Expected an empty error but received: %s", err.Error())
+	}
+	if tk.Token != "new_token" {
+		t.Fatalf("Received an unexpected value in azcore.AccessToken.Token")
+	}
+}
+
+func TestDeviceCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
+	srvURL := srv.URL()
+	handler := func(string) {}
+	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	if err == nil {
+		t.Fatalf("Expected an error but did not receive one.")
+	}
+}
+
+func TestDeviceCodeCredential_GetTokenAuthorizationPending(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
+	srv.AppendResponse(mock.WithBody([]byte(authorizationPendingResponse)), mock.WithStatusCode(http.StatusUnauthorized))
+	srv.AppendResponse(mock.WithBody([]byte(authorizationPendingResponse)), mock.WithStatusCode(http.StatusUnauthorized))
+	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	srvURL := srv.URL()
+	handler := func(string) {}
+	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	if err != nil {
+		t.Fatalf("Expected an empty error but received %v", err)
+	}
+}
+
+func TestDeviceCodeCredential_GetTokenExpiredToken(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
+	srv.AppendResponse(mock.WithBody([]byte(authorizationPendingResponse)), mock.WithStatusCode(http.StatusUnauthorized))
+	srv.AppendResponse(mock.WithBody([]byte(expiredTokenResponse)), mock.WithStatusCode(http.StatusUnauthorized))
+	srvURL := srv.URL()
+	handler := func(string) {}
+	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	if err == nil {
+		t.Fatalf("Expected an error but received none")
+	}
+}
+
+func TestDeviceCodeCredential_CreateAuthRequestFail(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
+	srvURL := srv.URL()
+	srvURL.Host = "ht @"
+	handler := func(string) {}
+	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	if err == nil {
+		t.Fatalf("Expected an error but did not receive one")
+	}
+}
+
+func TestBearerPolicy_DeviceCodeCredential(t *testing.T) {
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
+	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+	srvURL := srv.URL()
+	handler := func(string) {}
+	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	pipeline := azcore.NewPipeline(
+		srv,
+		azcore.NewTelemetryPolicy(azcore.TelemetryOptions{}),
+		azcore.NewUniqueRequestIDPolicy(),
+		azcore.NewRetryPolicy(azcore.RetryOptions{}),
+		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}}}),
+		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+	req := azcore.NewRequest(http.MethodGet, srv.URL())
+	_, err := pipeline.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Expected an empty error but receive: %v", err)
+	}
+}

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -24,7 +24,10 @@ const (
 
 func TestDeviceCodeCredential_CreateAuthRequestSuccess(t *testing.T) {
 	handler := func(s string) {}
-	cred := NewDeviceCodeCredential(tenantID, clientID, handler, nil)
+	cred, err := NewDeviceCodeCredential(tenantID, clientID, handler, nil)
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	req, err := cred.client.createDeviceCodeAuthRequest(cred.tenantID, cred.clientID, deviceCode, []string{deviceCodeScopes})
 	if err != nil {
 		t.Fatalf("Unexpectedly received an error: %v", err)
@@ -63,7 +66,10 @@ func TestDeviceCodeCredential_CreateAuthRequestSuccess(t *testing.T) {
 
 func TestDeviceCodeCredential_CreateAuthRequestEmptyTenant(t *testing.T) {
 	handler := func(s string) {}
-	cred := NewDeviceCodeCredential("", clientID, handler, nil)
+	cred, err := NewDeviceCodeCredential("", clientID, handler, nil)
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	req, err := cred.client.createDeviceCodeAuthRequest(cred.tenantID, cred.clientID, deviceCode, []string{deviceCodeScopes})
 	if err != nil {
 		t.Fatalf("Unexpectedly received an error: %v", err)
@@ -105,7 +111,10 @@ func TestDeviceCodeCredential_CreateAuthRequestEmptyTenant(t *testing.T) {
 
 func TestDeviceCodeCredential_RequestNewDeviceCodeEmptyTenant(t *testing.T) {
 	handler := func(s string) {}
-	cred := NewDeviceCodeCredential("", clientID, handler, nil)
+	cred, err := NewDeviceCodeCredential("", clientID, handler, nil)
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	req, err := cred.client.createDeviceCodeNumberRequest(cred.tenantID, cred.clientID, []string{deviceCodeScopes})
 	if err != nil {
 		t.Fatalf("Unexpectedly received an error: %v", err)
@@ -147,7 +156,10 @@ func TestDeviceCodeCredential_GetTokenSuccess(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	srvURL := srv.URL()
 	handler := func(string) {}
-	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	cred, err := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	tk, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
 	if err != nil {
 		t.Fatalf("Expected an empty error but received: %s", err.Error())
@@ -163,8 +175,11 @@ func TestDeviceCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	srvURL := srv.URL()
 	handler := func(string) {}
-	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	cred, err := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one.")
 	}
@@ -179,8 +194,11 @@ func TestDeviceCodeCredential_GetTokenAuthorizationPending(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srvURL := srv.URL()
 	handler := func(string) {}
-	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	cred, err := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
 	if err != nil {
 		t.Fatalf("Expected an empty error but received %v", err)
 	}
@@ -194,8 +212,11 @@ func TestDeviceCodeCredential_GetTokenExpiredToken(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(expiredTokenResponse)), mock.WithStatusCode(http.StatusUnauthorized))
 	srvURL := srv.URL()
 	handler := func(string) {}
-	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	cred, err := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
 	if err == nil {
 		t.Fatalf("Expected an error but received none")
 	}
@@ -208,8 +229,11 @@ func TestDeviceCodeCredential_CreateAuthRequestFail(t *testing.T) {
 	srvURL := srv.URL()
 	srvURL.Host = "ht @"
 	handler := func(string) {}
-	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	cred, err := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -223,7 +247,10 @@ func TestBearerPolicy_DeviceCodeCredential(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	srvURL := srv.URL()
 	handler := func(string) {}
-	cred := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	cred, err := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	pipeline := azcore.NewPipeline(
 		srv,
 		azcore.NewTelemetryPolicy(azcore.TelemetryOptions{}),
@@ -232,7 +259,7 @@ func TestBearerPolicy_DeviceCodeCredential(t *testing.T) {
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
 	req := azcore.NewRequest(http.MethodGet, srv.URL())
-	_, err := pipeline.Do(context.Background(), req)
+	_, err = pipeline.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Expected an empty error but receive: %v", err)
 	}

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -26,5 +26,5 @@ func NewEnvironmentCredential(options *TokenCredentialOptions) (*ClientSecretCre
 		return nil, &CredentialUnavailableError{CredentialType: "Environment Credential", Message: "Missing environment variable AZURE_CLIENT_SECRET"}
 	}
 
-	return NewClientSecretCredential(tenantID, clientID, clientSecret, options), nil
+	return NewClientSecretCredential(tenantID, clientID, clientSecret, options)
 }

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,11 +36,11 @@ const (
 type msiType int
 
 const (
-	unknown     msiType = 0
-	imds        msiType = 1
-	appService  msiType = 2
-	cloudShell  msiType = 3
-	unavailable msiType = 4
+	msiTypeUnknown     msiType = 0
+	msiTypeIMDS        msiType = 1
+	msiTypeAppService  msiType = 2
+	msiTypeCloudShell  msiType = 3
+	msiTypeUnavailable msiType = 4
 )
 
 // ManagedIdentityClient provides the base for authenticating with Managed Identities on Azure VMs and Cloud Shell
@@ -48,20 +49,19 @@ type managedIdentityClient struct {
 	options                TokenCredentialOptions
 	pipeline               azcore.Pipeline
 	imdsAPIVersion         string
-	imdsAvailableTimeoutMS int
+	imdsAvailableTimeoutMS time.Duration
 	msiType                msiType
 	endpoint               *url.URL
 }
 
 var (
-	imdsURL        *url.URL
-	defaultMSIOpts *ManagedIdentityCredentialOptions
+	imdsURL        *url.URL // these are initialized in the init func and are R/O afterwards
+	defaultMSIOpts = newDefaultManagedIdentityOptions()
 )
 
 func init() {
-	// The error check is handled in managed_identity_client_test.go
+	// The error is checked for in managed_identity_client_test.go and should not be ignored if the test fails
 	imdsURL, _ = url.Parse(imdsEndpoint)
-	defaultMSIOpts = newDefaultManagedIdentityOptions()
 }
 
 func newDefaultManagedIdentityOptions() *ManagedIdentityCredentialOptions {
@@ -76,12 +76,11 @@ func newDefaultManagedIdentityOptions() *ManagedIdentityCredentialOptions {
 // will be used to retrieve tokens and authenticate
 func newManagedIdentityClient(options *ManagedIdentityCredentialOptions) *managedIdentityClient {
 	options = options.setDefaultValues()
-	// TODO document the use of these variables
 	return &managedIdentityClient{
-		pipeline:               newDefaultMSIPipeline(*options),
-		imdsAPIVersion:         imdsAPIVersion,
-		imdsAvailableTimeoutMS: 500,
-		msiType:                unknown,
+		pipeline:               newDefaultMSIPipeline(*options), // a pipeline that includes the specific requirements for MSI authentication, such as custom retry policy options
+		imdsAPIVersion:         imdsAPIVersion,                  // this field will be set to whatever value exists in the constant and is used when creating requests to IMDS
+		imdsAvailableTimeoutMS: 500,                             // we allow a timeout of 500 ms since the endpoint might be slow to respond
+		msiType:                msiTypeUnknown,                  // when creating a new managedIdentityClient, the current MSI type is unknown and will be tested for and replaced once authenticate() is called from GetToken on the credential side
 	}
 }
 
@@ -97,7 +96,7 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, clientID strin
 	}
 	// This condition should never be true since getMSIType returns an error in these cases
 	// if msi is unavailable or we were unable to determine the type return a nil access token
-	if currentMSI == unavailable || currentMSI == unknown {
+	if currentMSI == msiTypeUnavailable || currentMSI == msiTypeUnknown {
 		return nil, &CredentialUnavailableError{CredentialType: "Managed Identity Credential", Message: "Please make sure you are running in a managed identity environment, such as a VM, Azure Functions, Cloud Shell, etc..."}
 	}
 
@@ -128,49 +127,52 @@ func (c *managedIdentityClient) sendAuthRequest(ctx context.Context, msiType msi
 		return c.createAccessToken(resp)
 	}
 
-	return nil, &AuthenticationFailedError{inner: newAuthenticationResponseError(resp)}
+	return nil, &AuthenticationFailedError{inner: newAADAuthenticationFailedError(resp)}
 }
 
 func (c *managedIdentityClient) createAccessToken(res *azcore.Response) (*azcore.AccessToken, error) {
-	value := internalAccessToken{}
-	accessToken := &azcore.AccessToken{}
+	value := struct {
+		// these are the only fields that we use
+		Token        string      `json:"access_token"`
+		RefreshToken string      `json:"refresh_token"`
+		ExpiresIn    json.Number `json:"expires_in"` // this field should always return the number of seconds for which a token is valid
+		ExpiresOn    string      `json:"expires_on"` // the value returned in this field varies between a number and a date string
+	}{}
 	if err := json.Unmarshal(res.Payload, &value); err != nil {
-		return nil, fmt.Errorf("internalAccessToken: %w", err)
+		return nil, fmt.Errorf("internal AccessToken: %w", err)
 	}
-
-	if value.ExpiresIn == "" {
-		if value.ExpiresOn == "" {
-			return nil, &AuthenticationFailedError{msg: "did not receive a valid token expiration time"}
+	if value.ExpiresIn != "" {
+		expiresIn, err := value.ExpiresIn.Int64()
+		if err != nil {
+			return nil, err
 		}
-		accessToken.Token = value.Token
-		// TODO: missing here is parsing expires on to a time.Time value
-		return accessToken, nil
+		return &azcore.AccessToken{Token: value.Token, ExpiresOn: time.Now().Add(time.Second * time.Duration(expiresIn)).UTC()}, nil
 	}
-	// CP: This will change based on the MSI type
-	t, err := value.ExpiresIn.Int64()
-	if err != nil {
+	if expiresOn, err := strconv.Atoi(value.ExpiresOn); err == nil {
+		return &azcore.AccessToken{Token: value.Token, ExpiresOn: time.Now().Add(time.Second * time.Duration(expiresOn)).UTC()}, nil
+	}
+	// this is the case when expires_on is a time string
+	// this is the format of the string coming from the service
+	if expiresOn, err := time.Parse("01/02/2006 15:04:05 PM +00:00", value.ExpiresOn); err == nil { // the date string specified in the layout param of time.Parse cannot be changed, Golang expects whatever layout to always signify January 2, 2006 at 3:04 PM
+		eo := expiresOn.UTC()
+		return &azcore.AccessToken{Token: value.Token, ExpiresOn: eo}, nil
+	} else {
 		return nil, err
 	}
-	// NOTE: look at go-autorest
-	accessToken.Token = value.Token
-	accessToken.ExpiresOn = time.Now().Add(time.Second * time.Duration(t)).UTC()
-	return accessToken, nil
 }
 
 func (c *managedIdentityClient) createAuthRequest(msiType msiType, clientID string, scopes []string) (*azcore.Request, error) {
-	var req *azcore.Request
-	var err error
 	switch msiType {
-	case imds:
-		req = c.createIMDSAuthRequest(clientID, scopes)
-	case appService:
-		req = c.createAppServiceAuthRequest(clientID, scopes)
-	case cloudShell:
-		req, err = c.createCloudShellAuthRequest(clientID, scopes)
+	case msiTypeIMDS:
+		return c.createIMDSAuthRequest(scopes), nil
+	case msiTypeAppService:
+		return c.createAppServiceAuthRequest(clientID, scopes), nil
+	case msiTypeCloudShell:
+		return c.createCloudShellAuthRequest(clientID, scopes)
 	default:
 		errorMsg := ""
 		switch msiType {
-		case unavailable:
+		case msiTypeUnavailable:
 			errorMsg = "unavailable"
 		default:
 			errorMsg = "unknown"
@@ -178,11 +180,9 @@ func (c *managedIdentityClient) createAuthRequest(msiType msiType, clientID stri
 
 		return nil, &CredentialUnavailableError{CredentialType: "Managed Identity Credential", Message: "Make sure you are running in a valid Managed Identity Environment. Status: " + errorMsg}
 	}
-
-	return req, err
 }
 
-func (c *managedIdentityClient) createIMDSAuthRequest(clientID string, scopes []string) *azcore.Request {
+func (c *managedIdentityClient) createIMDSAuthRequest(scopes []string) *azcore.Request {
 	request := azcore.NewRequest(http.MethodGet, *c.endpoint)
 	request.Header.Set(azcore.HeaderMetadata, "true")
 	q := request.URL.Query()
@@ -200,7 +200,7 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(clientID string, sco
 	q.Add("api-version", appServiceMsiAPIVersion)
 	q.Add("resource", strings.Join(scopes, " "))
 	if clientID != "" {
-		q.Add("client_id", clientID)
+		q.Add(qpClientID, clientID)
 	}
 	request.URL.RawQuery = q.Encode()
 
@@ -226,23 +226,23 @@ func (c *managedIdentityClient) createCloudShellAuthRequest(clientID string, sco
 }
 
 func (c *managedIdentityClient) getMSIType(ctx context.Context) (msiType, error) {
-	if c.msiType == unknown { // if we haven't already determined the msi type
+	if c.msiType == msiTypeUnknown { // if we haven't already determined the msi type
 		if endpointEnvVar := os.Getenv(msiEndpointEnvironemntVariable); endpointEnvVar != "" { // if the env var MSI_ENDPOINT is set
 			endpoint, err := url.Parse(endpointEnvVar)
 			if err != nil {
-				return unknown, err
+				return msiTypeUnknown, err
 			}
 			c.endpoint = endpoint
 			if secretEnvVar := os.Getenv(msiSecretEnvironemntVariable); secretEnvVar != "" { // if BOTH the env vars MSI_ENDPOINT and MSI_SECRET are set the MsiType is AppService
-				c.msiType = appService
+				c.msiType = msiTypeAppService
 			} else { // if ONLY the env var MSI_ENDPOINT is set the MsiType is CloudShell
-				c.msiType = cloudShell
+				c.msiType = msiTypeCloudShell
 			}
-		} else if c.imdsAvailable(ctx) { // if MSI_ENDPOINT is NOT set AND the IMDS endpoint is available the MsiType is Imds
+		} else if c.imdsAvailable(ctx) { // if MSI_ENDPOINT is NOT set AND the IMDS endpoint is available the MsiType is Imds. This will timeout after 500 milliseconds
 			c.endpoint = imdsURL
-			c.msiType = imds
+			c.msiType = msiTypeIMDS
 		} else { // if MSI_ENDPOINT is NOT set and IMDS enpoint is not available ManagedIdentity is not available
-			c.msiType = unavailable
+			c.msiType = msiTypeUnavailable
 			return c.msiType, &CredentialUnavailableError{CredentialType: "Managed Identity Credential", Message: "Make sure you are running in a valid Managed Identity Environment"}
 		}
 	}
@@ -250,7 +250,7 @@ func (c *managedIdentityClient) getMSIType(ctx context.Context) (msiType, error)
 }
 
 func (c *managedIdentityClient) imdsAvailable(ctx context.Context) bool {
-	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	tempCtx, cancel := context.WithTimeout(ctx, c.imdsAvailableTimeoutMS*time.Millisecond)
 	defer cancel()
 	request := azcore.NewRequest(http.MethodGet, *imdsURL)
 	q := request.URL.Query()

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -118,11 +118,6 @@ func (c *managedIdentityClient) sendAuthRequest(ctx context.Context, msiType msi
 		return nil, err
 	}
 
-	// This should never happen under normal conditions
-	if resp == nil {
-		return nil, &AuthenticationFailedError{msg: "Something unexpected happened with the request and received a nil response"}
-	}
-
 	if resp.HasStatusCode(successStatusCodes[:]...) {
 		return c.createAccessToken(resp)
 	}

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -54,5 +54,6 @@ func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts azcore.To
 
 // AuthenticationPolicy implements the azcore.Credential interface on ManagedIdentityCredential.
 func (c *ManagedIdentityCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+	options.Options.Scopes = []string{scopesToResource(options.Options.Scopes[0])}
 	return newBearerTokenPolicy(c, options)
 }

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -56,6 +56,7 @@ func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts azcore.To
 }
 
 // AuthenticationPolicy implements the azcore.Credential interface on ManagedIdentityCredential.
+// Please note: the TokenRequestOptions included in AuthenticationPolicyOptions must be a slice of resources in this case and not scopes
 func (c *ManagedIdentityCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
 	// The following code will remove the /.default suffix from any scopes passed into the method since ManagedIdentityCredentials expect a resource string instead of a scope string
 	for i, s := range options.Options.Scopes {

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -6,6 +6,7 @@ package azidentity
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"os"
 	"testing"
 
@@ -13,13 +14,19 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
 
+const (
+	msiScope                   = "https://storage.azure.com"
+	appServiceTokenSuccessResp = `{"access_token": "new_token", "expires_on": "09/14/2017 00:00:00 PM +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
+	expiresOnIntResp           = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": "1560974028", "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
+)
+
 func TestManagedIdentityCredential_GetTokenInCloudShellLive(t *testing.T) {
 	msiEndpoint := os.Getenv("MSI_ENDPOINT")
 	if len(msiEndpoint) == 0 {
 		t.Skip()
 	}
-	msiCred := NewManagedIdentityCredential(clientID, newDefaultManagedIdentityOptions())
-	_, err := msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	msiCred := NewManagedIdentityCredential(clientID, nil)
+	_, err := msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -36,7 +43,7 @@ func TestManagedIdentityCredential_GetTokenInCloudShellMock(t *testing.T) {
 	testURL := srv.URL()
 	_ = os.Setenv("MSI_ENDPOINT", testURL.String())
 	msiCred := NewManagedIdentityCredential(clientID, &ManagedIdentityCredentialOptions{HTTPClient: srv})
-	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -53,7 +60,7 @@ func TestManagedIdentityCredential_GetTokenInCloudShellMockFail(t *testing.T) {
 	testURL := srv.URL()
 	_ = os.Setenv("MSI_ENDPOINT", testURL.String())
 	msiCred := NewManagedIdentityCredential("", &ManagedIdentityCredentialOptions{HTTPClient: srv})
-	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -66,12 +73,30 @@ func TestManagedIdentityCredential_GetTokenInAppServiceMock(t *testing.T) {
 	}
 	srv, close := mock.NewServer()
 	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(accessTokenAppServSuccess)))
+	srv.AppendResponse(mock.WithBody([]byte(appServiceTokenSuccessResp)))
 	testURL := srv.URL()
 	_ = os.Setenv("MSI_ENDPOINT", testURL.String())
 	_ = os.Setenv("MSI_SECRET", "secret")
 	msiCred := NewManagedIdentityCredential(clientID, &ManagedIdentityCredentialOptions{HTTPClient: srv})
-	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
+	if err != nil {
+		t.Fatalf("Received an error when attempting to retrieve a token")
+	}
+}
+
+func TestManagedIdentityCredential_CreateAccessTokenExpiresOnInt(t *testing.T) {
+	err := resetEnvironmentVarsForTest()
+	if err != nil {
+		t.Fatalf("Unable to set environment variables")
+	}
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithBody([]byte(expiresOnIntResp)))
+	testURL := srv.URL()
+	_ = os.Setenv("MSI_ENDPOINT", testURL.String())
+	_ = os.Setenv("MSI_SECRET", "secret")
+	msiCred := NewManagedIdentityCredential(clientID, &ManagedIdentityCredentialOptions{HTTPClient: srv})
+	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -89,7 +114,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceMockFail(t *testing.T) {
 	_ = os.Setenv("MSI_ENDPOINT", testURL.String())
 	_ = os.Setenv("MSI_SECRET", "secret")
 	msiCred := NewManagedIdentityCredential("", &ManagedIdentityCredentialOptions{HTTPClient: srv})
-	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -107,7 +132,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceMockFail(t *testing.T) {
 // 		defer close()
 // 		srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 // 		msiCred := NewManagedIdentityCredential("", &ManagedIdentityCredentialOptions{HTTPClient: srv})
-// 		_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+// 		_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
 // 		if err == nil {
 // 			t.Fatalf("Cannot run IMDS test in this environment")
 // 		}
@@ -132,7 +157,7 @@ func TestManagedIdentityCredential_GetTokenUnknownFail(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	_ = os.Setenv("MSI_ENDPOINT", "https://t .com")
 	msiCred := NewManagedIdentityCredential("", &ManagedIdentityCredentialOptions{HTTPClient: srv})
-	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -151,7 +176,7 @@ func TestBearerPolicy_ManagedIdentityCredential(t *testing.T) {
 		azcore.NewTelemetryPolicy(azcore.TelemetryOptions{}),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
-		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
+		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{msiScope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
 	_, err := pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
@@ -170,8 +195,33 @@ func TestManagedIdentityCredential_GetTokenUnexpectedJSON(t *testing.T) {
 	testURL := srv.URL()
 	_ = os.Setenv("MSI_ENDPOINT", testURL.String())
 	msiCred := NewManagedIdentityCredential(clientID, &ManagedIdentityCredentialOptions{HTTPClient: srv})
-	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	_, err = msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
 	if err == nil {
 		t.Fatalf("Expected a JSON marshal error but received nil")
+	}
+}
+
+func TestManagedIdentityCredential_CreateIMDSAuthRequest(t *testing.T) {
+	cred := NewManagedIdentityCredential(clientID, nil)
+	cred.client.endpoint = imdsURL
+	req := cred.client.createIMDSAuthRequest([]string{msiScope})
+	if req.Request.Header.Get(azcore.HeaderMetadata) != "true" {
+		t.Fatalf("Unexpected value for Content-Type header")
+	}
+	reqQueryParams, err := url.ParseQuery(req.URL.RawQuery)
+	if err != nil {
+		t.Fatalf("Unable to parse IMDS query params: %v", err)
+	}
+	if reqQueryParams["api-version"][0] != imdsAPIVersion {
+		t.Fatalf("Unexpected IMDS API version")
+	}
+	if reqQueryParams["resource"][0] != msiScope {
+		t.Fatalf("Unexpected resource in resource query param")
+	}
+	if req.Request.URL.Host != imdsURL.Host {
+		t.Fatalf("Unexpected default authority host")
+	}
+	if req.Request.URL.Scheme != "http" {
+		t.Fatalf("Wrong request scheme")
 	}
 }

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -8,6 +8,7 @@ package azidentity
 
 import (
 	"context"
+	"path"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
@@ -36,6 +37,7 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 	if err != nil {
 		return nil, err
 	}
+	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
 	return &UsernamePasswordCredential{tenantID: tenantID, clientID: clientID, username: username, password: password, client: c}, nil
 }
 

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -31,8 +31,12 @@ type UsernamePasswordCredential struct {
 // - username: A user's account username
 // - password: A user's account password
 // - options: The options configure the management of the requests sent to the Azure Active Directory service.
-func NewUsernamePasswordCredential(tenantID string, clientID string, username string, password string, options *TokenCredentialOptions) *UsernamePasswordCredential {
-	return &UsernamePasswordCredential{tenantID: tenantID, clientID: clientID, username: username, password: password, client: newAADIdentityClient(options)}
+func NewUsernamePasswordCredential(tenantID string, clientID string, username string, password string, options *TokenCredentialOptions) (*UsernamePasswordCredential, error) {
+	c, err := newAADIdentityClient(options)
+	if err != nil {
+		return nil, err
+	}
+	return &UsernamePasswordCredential{tenantID: tenantID, clientID: clientID, username: username, password: password, client: c}, nil
 }
 
 // GetToken obtains a token from the Azure Active Directory service, using the specified username and password.

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -40,11 +40,7 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 // - ctx: controlling the request lifetime.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	tr, err := c.client.authenticateUsernamePassword(ctx, c.tenantID, c.clientID, c.username, c.password, opts.Scopes)
-	if err != nil {
-		return nil, err
-	}
-	return tr.token, err
+	return c.client.authenticateUsernamePassword(ctx, c.tenantID, c.clientID, c.username, c.password, opts.Scopes)
 }
 
 // AuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential.

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -40,7 +40,11 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 // - ctx: controlling the request lifetime.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	return c.client.authenticateUsernamePassword(ctx, c.tenantID, c.clientID, c.username, c.password, opts.Scopes)
+	tr, err := c.client.authenticateUsernamePassword(ctx, c.tenantID, c.clientID, c.username, c.password, opts.Scopes)
+	if err != nil {
+		return nil, err
+	}
+	return tr.token, err
 }
 
 // AuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential.

--- a/sdk/azidentity/username_password_credential_test.go
+++ b/sdk/azidentity/username_password_credential_test.go
@@ -15,7 +15,10 @@ import (
 )
 
 func TestUsernamePasswordCredential_CreateAuthRequestSuccess(t *testing.T) {
-	cred := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", nil)
+	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", nil)
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	req, err := cred.client.createUsernamePasswordAuthRequest(cred.tenantID, cred.clientID, cred.username, cred.password, []string{scope})
 	if err != nil {
 		t.Fatalf("Unexpectedly received an error: %v", err)
@@ -63,8 +66,11 @@ func TestUsernamePasswordCredential_GetTokenSuccess(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srvURL := srv.URL()
-	cred := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
 	if err != nil {
 		t.Fatalf("Expected an empty error but received: %s", err.Error())
 	}
@@ -75,8 +81,11 @@ func TestUsernamePasswordCredential_GetTokenInvalidCredentials(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	srvURL := srv.URL()
-	cred := NewUsernamePasswordCredential(tenantID, clientID, "username", "wrong_password", &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "wrong_password", &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one.")
 	}
@@ -88,8 +97,11 @@ func TestUsernamePasswordCredential_CreateAuthRequestFail(t *testing.T) {
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	srvURL := srv.URL()
 	srvURL.Host = "ht @"
-	cred := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
-	_, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -101,7 +113,10 @@ func TestBearerPolicy_UsernamePasswordCredential(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	srvURL := srv.URL()
-	cred := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
 	pipeline := azcore.NewPipeline(
 		srv,
 		azcore.NewTelemetryPolicy(azcore.TelemetryOptions{}),
@@ -109,7 +124,7 @@ func TestBearerPolicy_UsernamePasswordCredential(t *testing.T) {
 		azcore.NewRetryPolicy(azcore.RetryOptions{}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
-	_, err := pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
+	_, err = pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
 		t.Fatalf("Expected an empty error but receive: %v", err)
 	}

--- a/sdk/storage/blob/2018-11-09/azblob/examples_test.go
+++ b/sdk/storage/blob/2018-11-09/azblob/examples_test.go
@@ -23,7 +23,10 @@ const (
 )
 
 func ExampleServiceClient_ListContainers() {
-	cred := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
+	cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
+	if err != nil {
+		panic(err)
+	}
 	client, err := NewServiceClient(endpoint, cred, nil)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR includes: 
- Adding DeviceCodeCredential and corresponding unit/mock tests  #6433
- Adding MSI Access Token parsing to include ExpiresOn cases #6350
- Updating error handling for ChainedTokenCredential
- Fixed MSI tests to use MSI specific scopes
- Added IMDS request creation test
- Updated DefaultTokenCredential chain creation
- Updated MSI type const names
- Removed ChainedCredentialError #6549
