### PR TITLE
Update ManagedIdentityCredential constructor

### DIFF
--- a/sdk/azidentity/default_token_credential.go
+++ b/sdk/azidentity/default_token_credential.go
@@ -38,7 +38,12 @@ func NewDefaultTokenCredential(options *DefaultTokenCredentialOptions) (*Chained
 	}
 
 	if !options.ExcludeMSICredential {
-		creds = append(creds, NewManagedIdentityCredential("", nil))
+		msiCred, err := NewManagedIdentityCredential("", nil)
+		if err == nil {
+			creds = append(creds, msiCred)
+		} else {
+			errMsg += err.Error()
+		}
 	}
 
 	if len(creds) == 0 {

--- a/sdk/azidentity/default_token_credential_test.go
+++ b/sdk/azidentity/default_token_credential_test.go
@@ -4,11 +4,18 @@
 package azidentity
 
 import (
+	"context"
 	"errors"
+	"os"
 	"testing"
 )
 
 func TestDefaultTokenCredential_ExcludeEnvCredential(t *testing.T) {
+	err := resetEnvironmentVarsForTest()
+	if err != nil {
+		t.Fatalf("Unable to set environment variables")
+	}
+	_ = os.Setenv("MSI_ENDPOINT", "http://localhost:3000")
 	cred, err := NewDefaultTokenCredential(&DefaultTokenCredentialOptions{ExcludeEnvironmentCredential: true})
 	if err != nil {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
@@ -17,6 +24,7 @@ func TestDefaultTokenCredential_ExcludeEnvCredential(t *testing.T) {
 	if len(cred.sources) != 1 {
 		t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 1, Received: %d", len(cred.sources))
 	}
+	_ = os.Setenv("MSI_ENDPOINT", "")
 
 }
 
@@ -52,7 +60,11 @@ func TestDefaultTokenCredential_ExcludeAllCredentials(t *testing.T) {
 }
 
 func TestDefaultTokenCredential_NilOptions(t *testing.T) {
-	err := initEnvironmentVarsForTest()
+	err := resetEnvironmentVarsForTest()
+	if err != nil {
+		t.Fatalf("Unable to set environment variables")
+	}
+	err = initEnvironmentVarsForTest()
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -60,7 +72,19 @@ func TestDefaultTokenCredential_NilOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
-	if len(cred.sources) != 2 {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 2, Received: %d", len(cred.sources))
+	c := newManagedIdentityClient(nil)
+	// if the test is running in a MSI environment then the length of sources would be two since it will include environmnet credential and managed identity credential
+	if msiType, err := c.getMSIType(context.Background()); msiType == msiTypeIMDS || msiType == msiTypeCloudShell || msiType == msiTypeAppService {
+		if len(cred.sources) != 2 {
+			t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 2, Received: %d", len(cred.sources))
+		}
+		//if a credential unavailable error is received or msiType is unknown then only the environment credential will be added
+	} else if unavailableErr := (*CredentialUnavailableError)(nil); errors.As(err, &unavailableErr) || msiType == msiTypeUnknown {
+		if len(cred.sources) != 1 {
+			t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 1, Received: %d", len(cred.sources))
+		}
+		// if there is some other unexpected error then we fail here
+	} else if err != nil {
+		t.Fatalf("Received an error when trying to determine MSI type: %v", err)
 	}
 }

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -6,6 +6,7 @@ package azidentity
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
@@ -44,8 +45,20 @@ type ManagedIdentityCredential struct {
 // clientID: The client id to authenticate for a user assigned managed identity.  More information on user assigned managed identities cam be found here:
 // https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm
 // options: Options that allow to configure the management of the requests sent to the Azure Active Directory service.
-func NewManagedIdentityCredential(clientID string, options *ManagedIdentityCredentialOptions) *ManagedIdentityCredential {
-	return &ManagedIdentityCredential{clientID: clientID, client: newManagedIdentityClient(options)}
+func NewManagedIdentityCredential(clientID string, options *ManagedIdentityCredentialOptions) (*ManagedIdentityCredential, error) {
+	// Create a new Managed Identity Client with default options
+	client := newManagedIdentityClient(options)
+	// Create a context that will timeout after 500 milliseconds (that is the amount of time designated to find out if the IMDS endpoint is available)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(client.imdsAvailableTimeoutMS)*time.Millisecond)
+	defer cancelFunc()
+	msiType, err := client.getMSIType(ctx)
+	// If there is an error that means that the code is not running in a Managed Identity environment
+	if err != nil {
+		return nil, &CredentialUnavailableError{CredentialType: "Managed Identity Credential", Message: "Please make sure you are running in a managed identity environment, such as a VM, Azure Functions, Cloud Shell, etc..."}
+	}
+	// Assign the msiType discovered onto the client
+	client.msiType = msiType
+	return &ManagedIdentityCredential{clientID: clientID, client: client}, nil
 }
 
 // GetToken obtains an AccessToken from the Managed Identity service if available.


### PR DESCRIPTION
Updated ManagedIdentityCredential constructor to check for MSI environment upon creation. Also updated tests and other references to Managed Identity Credential