### PR TITLE
add support for authfilecredential

### DIFF
--- a/sdk/azidentity/auth_file_credential.go
+++ b/sdk/azidentity/auth_file_credential.go
@@ -26,30 +26,26 @@ type authFileAccesstoken struct {
 	ManagementEndpointUrl          string `json:"managementEndpointUrl"`
 }
 
-// Enables authentication to Azure Active Directory using configuration information stored Azure SDK Auth File.
+// AuthFileCredential enables authentication to Azure Active Directory using configuration information stored Azure SDK Auth File.
 type AuthFileCredential struct {
 	filePath        string
 	credential      azcore.TokenCredential
 	authfileoptions *TokenCredentialOptions
 }
 
-// Creates an instance of the SdkAuthFileCredential class based on information in given SDK Auth file.
+// NewAuthFileCredential creates an instance of the AuthFileCredential class based on information in given SDK Auth file.
 func NewAuthFileCredential(filePath string, options *TokenCredentialOptions) (*AuthFileCredential, error) {
-	if filePath == "" {
-		return nil, fmt.Errorf("The parameter 'filePath' must set a value")
-	}
-
 	return &AuthFileCredential{filePath: filePath, authfileoptions: options}, nil
 }
 
-// Obtains a token from the Azure Active Directory service, using the specified client detailed specified in the SDK Auth file.
+// GetToken Obtains a token from the Azure Active Directory service, using the specified client detailed specified in the SDK Auth file.
 func (c *AuthFileCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	_, err := c.ensureCredential()
+	cred, err := c.ensureCredential()
 	if err != nil {
 		return nil, &AuthenticationFailedError{msg: "Error parsing SDK Auth File", inner: err}
 	}
 
-	return c.credential.GetToken(ctx, opts)
+	return cred.GetToken(ctx, opts)
 }
 
 // AuthenticationPolicy implements the azcore.Credential interface on AuthFileCredential.
@@ -57,16 +53,17 @@ func (c *AuthFileCredential) AuthenticationPolicy(options azcore.AuthenticationP
 	return newBearerTokenPolicy(c, options)
 }
 
-// Ensures that credential information is loaded from the SDK Auth file. This method should be called to initialize.
+// ensureCredential ensures that credential information is loaded from the SDK Auth file.
 func (c *AuthFileCredential) ensureCredential() (azcore.TokenCredential, error) {
 	if c.credential != nil {
 		return c.credential, nil
 	}
 
-	authData, err := c.parseCredentialsFile(c.filePath)
+	authData, err := ioutil.ReadFile(c.filePath)
 	if err != nil {
 		return nil, err
 	}
+
 
 	c.credential, err = c.buildCredentialForCredentialsFile(authData)
 	if err != nil {
@@ -76,17 +73,7 @@ func (c *AuthFileCredential) ensureCredential() (azcore.TokenCredential, error) 
 	return c.credential, nil
 }
 
-// Parse credential file from local file path to byte.
-func (c *AuthFileCredential) parseCredentialsFile(filePath string) ([]byte, error) {
-	authData, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return authData, nil
-}
-
-// Use the SDK auth file info to build a ClientSecretCredential
+// buildCredentialForCredentialsFile use the SDK auth file info to build a ClientSecretCredential
 func (c *AuthFileCredential) buildCredentialForCredentialsFile(authData []byte) (*ClientSecretCredential, error) {
 	token := &authFileAccesstoken{}
 
@@ -99,10 +86,6 @@ func (c *AuthFileCredential) buildCredentialForCredentialsFile(authData []byte) 
 	clientSecret := token.ClientSecret
 	tenantId := token.TenantId
 	activeDirectoryEndpointUrl := token.ActiveDirectoryEndpointUrl
-
-	if clientId == "" || clientSecret == "" || tenantId == "" || activeDirectoryEndpointUrl == "" {
-		return nil, fmt.Errorf("Malformed Azure SDK Auth file. The file should contain 'clientId', 'clientSecret', 'tenantId' and 'activeDirectoryEndpointUrl' values.")
-	}
 
 	// Parse string activeDirectoryEndpointUrl to a Url.
 	AuthorityHost, err := url.Parse(activeDirectoryEndpointUrl)

--- a/sdk/azidentity/auth_file_credential.go
+++ b/sdk/azidentity/auth_file_credential.go
@@ -13,19 +13,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-type authFileAccesstoken struct {
-	ClientId                       string `json:"clientId"`
-	ClientSecret                   string `json:"clientSecret"`
-	SubscriptionId                 string `json:"subscriptionId"`
-	TenantId                       string `json:"tenantId"`
-	ActiveDirectoryEndpointUrl     string `json:"activeDirectoryEndpointUrl"`
-	ResourceManagerEndpointUrl     string `json:"resourceManagerEndpointUrl"`
-	ActiveDirectoryGraphResourceId string `json:"activeDirectoryGraphResourceId"`
-	SqlManagementEndpointUrl       string `json:"sqlManagementEndpointUrl"`
-	GalleryEndpointUrl             string `json:"galleryEndpointUrl"`
-	ManagementEndpointUrl          string `json:"managementEndpointUrl"`
-}
-
 // AuthFileCredential enables authentication to Azure Active Directory using configuration information stored Azure SDK Auth File.
 type AuthFileCredential struct {
 	filePath        string
@@ -33,69 +20,60 @@ type AuthFileCredential struct {
 	authfileoptions TokenCredentialOptions
 }
 
-// NewAuthFileCredential creates an instance of the AuthFileCredential class based on information in given SDK Auth file.
+// NewAuthFileCredential creates an instance of the AuthFileCredential class based on information specified in the SDK Authentication file.
 func NewAuthFileCredential(filePath string, options *TokenCredentialOptions) (*AuthFileCredential, error) {
 	options, err := options.setDefaultValues()
 	if err != nil {
 		return nil, err
 	}
-	return &AuthFileCredential{filePath: filePath, authfileoptions: *options}, nil
-}
-
-// GetToken Obtains a token from the Azure Active Directory service, using the specified client detailed specified in the SDK Auth file.
-func (c *AuthFileCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	err := c.ensureCredential()
+	cred, err := NewClientSecretCredentialFromAuthenticationFile(filePath, options)
 	if err != nil {
 		return nil, &AuthenticationFailedError{msg: "Error parsing SDK Auth File", inner: err}
 	}
+	return &AuthFileCredential{filePath: filePath, credential: cred, authfileoptions: *options}, nil
+}
 
+// GetToken obtains a token from Azure Active Directory using the client specified in the SDK Authentication file.
+func (c *AuthFileCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
 	return c.credential.GetToken(ctx, opts)
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on AuthFileCredential.
+// AuthenticationPolicy implements the azcore.Credential interface and returns the policy associated with the AuthFileCredential type.
 func (c *AuthFileCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }
 
-// ensureCredential ensures that credential information is loaded from the SDK Auth file.
-func (c *AuthFileCredential) ensureCredential() error {
-	if c.credential != nil {
-		return nil
-	}
-
-	authData, err := ioutil.ReadFile(c.filePath)
-	if err != nil {
-		return err
-	}
-
-	c.credential, err = c.buildCredentialForCredentialsFile(authData)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// buildCredentialForCredentialsFile use the SDK auth file info to build a ClientSecretCredential
-func (c *AuthFileCredential) buildCredentialForCredentialsFile(authData []byte) (*ClientSecretCredential, error) {
-	token := &authFileAccesstoken{}
-
-	err := json.Unmarshal(authData, token)
+// NewClientSecretCredentialFromAuthenticationFile creates a ClientSecrentCredential initialized from the specified Authentication file.
+func NewClientSecretCredentialFromAuthenticationFile(filePath string, options *TokenCredentialOptions) (*ClientSecretCredential, error) {
+	// Read the SDK Authentication file into memory
+	authData, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	clientId := token.ClientId
-	clientSecret := token.ClientSecret
-	tenantId := token.TenantId
-	activeDirectoryEndpointUrl := token.ActiveDirectoryEndpointUrl
+	// Build the ClientSecretCredential from the Authentication File data
+	token := struct {
+		clientID                       string `json:"clientId"`
+		clientSecret                   string `json:"clientSecret"`
+		subscriptionID                 string `json:"subscriptionId"`
+		tenantID                       string `json:"tenantId"`
+		activeDirectoryEndpointURL     string `json:"activeDirectoryEndpointUrl"`
+		resourceManagerEndpointURL     string `json:"resourceManagerEndpointUrl"`
+		activeDirectoryGraphResourceID string `json:"activeDirectoryGraphResourceId"`
+		sqlManagementEndpointURL       string `json:"sqlManagementEndpointUrl"`
+		galleryEndpointURL             string `json:"galleryEndpointUrl"`
+		managementEndpointURL          string `json:"managementEndpointUrl"`
+	}{}
+
+	if err = json.Unmarshal(authData, &token); err != nil {
+		return nil, err
+	}
 
 	// Parse string activeDirectoryEndpointUrl to a Url.
-	AuthorityHost, err := url.Parse(activeDirectoryEndpointUrl)
+	var tco = *options // Make a copy of the passed-inoption to not change the customer's options
+	tco.AuthorityHost, err = url.Parse(token.activeDirectoryEndpointURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse activeDirectoryEndpointUrl in auth file: %w", err)
+		return nil, fmt.Errorf("failed to parse ActiveDirectoryEndpointUrl in auth file: %w", err)
 	}
-	c.authfileoptions.AuthorityHost = AuthorityHost
-
-	return NewClientSecretCredential(tenantId, clientId, clientSecret, &c.authfileoptions)
+	return NewClientSecretCredential(token.tenantID, token.clientID, token.clientSecret, &tco)
 }

--- a/sdk/azidentity/auth_file_credential.go
+++ b/sdk/azidentity/auth_file_credential.go
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/url"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+type authFileAccesstoken struct {
+	ClientId                       string `json:"clientId"`
+	ClientSecret                   string `json:"clientSecret"`
+	SubscriptionId                 string `json:"subscriptionId"`
+	TenantId                       string `json:"tenantId"`
+	ActiveDirectoryEndpointUrl     string `json:"activeDirectoryEndpointUrl"`
+	ResourceManagerEndpointUrl     string `json:"resourceManagerEndpointUrl"`
+	ActiveDirectoryGraphResourceId string `json:"activeDirectoryGraphResourceId"`
+	SqlManagementEndpointUrl       string `json:"sqlManagementEndpointUrl"`
+	GalleryEndpointUrl             string `json:"galleryEndpointUrl"`
+	ManagementEndpointUrl          string `json:"managementEndpointUrl"`
+}
+
+// Enables authentication to Azure Active Directory using configuration information stored Azure SDK Auth File.
+type AuthFileCredential struct {
+	filePath   string
+	credential azcore.TokenCredential
+}
+
+// Creates an instance of the SdkAuthFileCredential class based on information in given SDK Auth file.
+func NewAuthFileCredential(filePath string) (*AuthFileCredential, error) {
+	if filePath == "" {
+		return nil, fmt.Errorf("The parameter 'filePath' must set a value")
+	}
+
+	return &AuthFileCredential{filePath: filePath}, nil
+}
+
+// Obtains a token from the Azure Active Directory service, using the specified client detailed specified in the SDK Auth file.
+func (c *AuthFileCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
+	_, err := c.ensureCredential()
+	if err != nil {
+		return nil, &AuthenticationFailedError{msg: "Error parsing SDK Auth File: " + err.Error()}
+	}
+
+	return c.credential.GetToken(ctx, opts)
+}
+
+// AuthenticationPolicy implements the azcore.Credential interface on AuthFileCredential.
+func (c *AuthFileCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+	return newBearerTokenPolicy(c, options)
+}
+
+// Ensures that credential information is loaded from the SDK Auth file. This method should be called to initialize.
+func (c *AuthFileCredential) ensureCredential() (azcore.TokenCredential, error) {
+	if c.credential != nil {
+		return c.credential, nil
+	}
+
+	authData, err := c.parseCredentialsFile(c.filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	c.credential, err = c.buildCredentialForCredentialsFile(authData)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.credential, nil
+}
+
+// Parse credential file from local file path to byte.
+func (c *AuthFileCredential) parseCredentialsFile(filePath string) ([]byte, error) {
+	authData, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return authData, nil
+}
+
+// Use the SDK auth file info to build a ClientSecretCredential
+func (c *AuthFileCredential) buildCredentialForCredentialsFile(authData []byte) (*ClientSecretCredential, error) {
+	token := &authFileAccesstoken{}
+
+	err := json.Unmarshal(authData, token)
+	if err != nil {
+		return nil, err
+	}
+
+	clientId := token.ClientId
+	clientSecret := token.ClientSecret
+	tenantId := token.TenantId
+	activeDirectoryEndpointUrl := token.ActiveDirectoryEndpointUrl
+
+	if clientId == "" || clientSecret == "" || tenantId == "" || activeDirectoryEndpointUrl == "" {
+		return nil, fmt.Errorf("Malformed Azure SDK Auth file. The file should contain 'clientId', 'clientSecret', 'tenantId' and 'activeDirectoryEndpointUrl' values.")
+	}
+
+	// Parse string activeDirectoryEndpointUrl to a Url.
+	AuthorityHost, err := url.Parse(activeDirectoryEndpointUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClientSecretCredential(tenantId, clientId, clientSecret, &TokenCredentialOptions{AuthorityHost: AuthorityHost})
+}

--- a/sdk/azidentity/auth_file_credential_test.go
+++ b/sdk/azidentity/auth_file_credential_test.go
@@ -16,7 +16,7 @@ const (
 )
 
 func TestAuthFileCredential_BadSdkAuthFilePathThrowsDuringGetToken(t *testing.T) {
-	cred, err := NewAuthFileCredential("Bougs*File*Path")
+	cred, err := NewAuthFileCredential("Bougs*File*Path", nil)
 	if err != nil {
 		t.Fatalf("Expected an empty error but received: %s", err.Error())
 	}

--- a/sdk/azidentity/auth_file_credential_test.go
+++ b/sdk/azidentity/auth_file_credential_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+const (
+	scopeToResource = "https://storage.azure.com/.default"
+)
+
+func TestAuthFileCredential_BadSdkAuthFilePathThrowsDuringGetToken(t *testing.T) {
+	cred, err := NewAuthFileCredential("Bougs*File*Path")
+	if err != nil {
+		t.Fatalf("Expected an empty error but received: %s", err.Error())
+	}
+
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scopeToResource}})
+	if err == nil {
+		t.Fatalf("Expected an empty error but received: %v", err)
+	}
+
+	var authFailed *AuthenticationFailedError
+	if !errors.As(err, &authFailed) {
+		t.Fatalf("Expected: AuthenticationFailedError, Received: %T", err)
+	}
+}

--- a/sdk/azidentity/auth_file_credential_test.go
+++ b/sdk/azidentity/auth_file_credential_test.go
@@ -4,11 +4,8 @@
 package azidentity
 
 import (
-	"context"
 	"errors"
 	"testing"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 const (
@@ -16,16 +13,7 @@ const (
 )
 
 func TestAuthFileCredential_BadSdkAuthFilePathThrowsDuringGetToken(t *testing.T) {
-	cred, err := NewAuthFileCredential("Bougs*File*Path", nil)
-	if err != nil {
-		t.Fatalf("Expected an empty error but received: %s", err.Error())
-	}
-
-	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scopeToResource}})
-	if err == nil {
-		t.Fatalf("Expected an empty error but received: %v", err)
-	}
-
+	_, err := NewAuthFileCredential("Bougs*File*Path", nil)
 	var authFailed *AuthenticationFailedError
 	if !errors.As(err, &authFailed) {
 		t.Fatalf("Expected: AuthenticationFailedError, Received: %T", err)

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -5,26 +5,24 @@ package azidentity
 
 import (
 	"os"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 // NewEnvironmentCredential creates an instance of the EnvironmentCredential type and reads client secret details from environment variables.
 // If the expected environment variables are not found at this time, the GetToken method will return the default AccessToken when invoked.
 // options: The options used to configure the management of the requests sent to the Azure Active Directory service.
-func NewEnvironmentCredential(options *TokenCredentialOptions) (*ClientSecretCredential, error) {
+func NewEnvironmentCredential(options *TokenCredentialOptions) (azcore.TokenCredential, error) {
 	tenantID := os.Getenv("AZURE_TENANT_ID")
-	if tenantID == "" {
-		return nil, &CredentialUnavailableError{CredentialType: "Environment Credential", Message: "Missing environment variable AZURE_TENANT_ID"}
-	}
-
 	clientID := os.Getenv("AZURE_CLIENT_ID")
-	if clientID == "" {
-		return nil, &CredentialUnavailableError{CredentialType: "Environment Credential", Message: "Missing environment variable AZURE_CLIENT_ID"}
-	}
-
 	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
-	if clientSecret == "" {
-		return nil, &CredentialUnavailableError{CredentialType: "Environment Credential", Message: "Missing environment variable AZURE_CLIENT_SECRET"}
+	sdkAuthLocation := os.Getenv("AZURE_AUTH_LOCATION")
+	if clientID != "" && tenantID != "" && clientSecret != "" {
+		return NewClientSecretCredential(tenantID, clientID, clientSecret, options)
 	}
+	if sdkAuthLocation != "" {
+		return NewAuthFileCredential(sdkAuthLocation, options)
+	}
+	return nil, &CredentialUnavailableError{CredentialType: "Environment Credential", Message: "Missing environment variable"}
 
-	return NewClientSecretCredential(tenantID, clientID, clientSecret, options)
 }

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 )
 
+const (
+	sdkAuthLocation = "sdkAuthLocation"
+)
+
 func initEnvironmentVarsForTest() error {
 	err := os.Setenv("AZURE_TENANT_ID", tenantID)
 	if err != nil {
@@ -19,6 +23,10 @@ func initEnvironmentVarsForTest() error {
 		return err
 	}
 	err = os.Setenv("AZURE_CLIENT_SECRET", secret)
+	if err != nil {
+		return err
+	}
+	err = os.Setenv("AZURE_AUTH_LOCATION", sdkAuthLocation)
 	if err != nil {
 		return err
 	}
@@ -35,6 +43,10 @@ func resetEnvironmentVarsForTest() error {
 		return err
 	}
 	err = os.Setenv("AZURE_CLIENT_SECRET", "")
+	if err != nil {
+		return err
+	}
+	err = os.Setenv("AZURE_AUTH_LOCATION", "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-net/pull/9312

 The purpose of this PR is explained in this or a referenced issue.
Add Azure AuthFile credential into azidentity.
 
 The PR does not update generated files. 
These files are managed by the codegen framework at [Azure/autorest.go][].
Don't include any generated files.
 
 The PR targets the latest branch.
This PR would target track2 branch.
 
 Tests are included and/or updated for code changes.
unit tests are included.
 
 Updates to [CHANGELOG.md][] are included.
No any packages changed, so it don't include the CHANGELOG.md
 
 Apache v2 license headers are included in each file.
Included
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
