### PR TITLE
Storage Sync Service returns a string type instead of int

### DIFF
--- a/services/storagesync/mgmt/2019-06-01/storagesync/models.go
+++ b/services/storagesync/mgmt/2019-06-01/storagesync/models.go
@@ -1969,7 +1969,7 @@ func (scp ServiceCreateParameters) MarshalJSON() ([]byte, error) {
 // ServiceProperties storage Sync Service Properties object.
 type ServiceProperties struct {
 	// StorageSyncServiceStatus - READ-ONLY; Storage Sync service status.
-	StorageSyncServiceStatus *int32 `json:"storageSyncServiceStatus,omitempty"`
+	StorageSyncServiceStatus *string `json:"storageSyncServiceStatus,omitempty"`
 	// StorageSyncServiceUID - READ-ONLY; Storage Sync service Uid
 	StorageSyncServiceUID *string `json:"storageSyncServiceUid,omitempty"`
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->
The Storage Sync Service return a response with field "StorageSyncServiceStatus" string type instead of int type, declared in swagger. This causes error while call the get storage sync service in SDK.

- [X] The purpose of this PR is explained in this or a referenced issue.
- [X] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [X] The PR targets the `latest` branch.
- [X] Tests are included and/or updated for code changes.
- [X] Updates to [CHANGELOG.md][] are included.
- [X] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
