### PR TITLE
Enable custom RetryOptions to be specified per API call

### DIFF
--- a/sdk/azcore/headers.go
+++ b/sdk/azcore/headers.go
@@ -22,6 +22,7 @@ const (
 	HeaderIfUnmodifiedSince  = "If-Unmodified-Since"
 	HeaderMetadata           = "Metadata"
 	HeaderRange              = "Range"
+	HeaderRetryAfter         = "Retry-After"
 	HeaderURLEncoded         = "application/x-www-form-urlencoded"
 	HeaderUserAgent          = "User-Agent"
 	HeaderXmsDate            = "x-ms-date"

--- a/sdk/azcore/policy_logging_test.go
+++ b/sdk/azcore/policy_logging_test.go
@@ -25,8 +25,10 @@ func TestPolicyLoggingSuccess(t *testing.T) {
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewRequestLogPolicy(RequestLogOptions{}))
 	req := NewRequest(http.MethodGet, srv.URL())
-	req.SetQueryParam("one", "fish")
-	req.SetQueryParam("sig", "redact")
+	qp := req.URL.Query()
+	qp.Set("one", "fish")
+	qp.Set("sig", "redact")
+	req.URL.RawQuery = qp.Encode()
 	resp, err := pl.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/sdk/azcore/policy_retry.go
+++ b/sdk/azcore/policy_retry.go
@@ -70,6 +70,7 @@ func DefaultRetryOptions() RetryOptions {
 	}
 }
 
+// used as a context key for adding/retrieving RetryOptions
 type ctxWithRetryOptionsKey struct{}
 
 // WithRetryOptions adds the specified RetryOptions to the parent context.

--- a/sdk/azcore/policy_retry.go
+++ b/sdk/azcore/policy_retry.go
@@ -70,9 +70,9 @@ func DefaultRetryOptions() RetryOptions {
 // used as a context key for adding/retrieving RetryOptions
 type ctxWithRetryOptionsKey struct{}
 
-// WithRetryOptions adds the specified RetryOptions to the parent context.
+// ContextWithRetryOptions adds the specified RetryOptions to the parent context.
 // Use this to specify custom RetryOptions at the API-call level.
-func WithRetryOptions(parent context.Context, options RetryOptions) context.Context {
+func ContextWithRetryOptions(parent context.Context, options RetryOptions) context.Context {
 	return context.WithValue(parent, ctxWithRetryOptionsKey{}, options)
 }
 

--- a/sdk/azcore/policy_retry.go
+++ b/sdk/azcore/policy_retry.go
@@ -21,14 +21,11 @@ const (
 // RetryOptions configures the retry policy's behavior.
 type RetryOptions struct {
 	// MaxTries specifies the maximum number of attempts an operation will be tried before producing an error (0=default).
-	// A value of zero means that you accept our default policy. A value of 1 means 1 try and no retries.
+	// A value of zero means that you accept the default value. A value of 1 means 1 try and no retries.
 	MaxTries int32
 
 	// TryTimeout indicates the maximum time allowed for any single try of an HTTP request.
-	// A value of zero means that you accept our default timeout. NOTE: When transferring large amounts
-	// of data, the default TryTimeout will probably not be sufficient. You should override this value
-	// based on the bandwidth available to the host machine and proximity to the service. A good
-	// starting point may be something like (60 seconds per MB of anticipated-payload-size).
+	// A value of zero means that you accept the default timeout.
 	TryTimeout time.Duration
 
 	// RetryDelay specifies the amount of delay to use before retrying an operation (0=default).

--- a/sdk/azcore/policy_retry.go
+++ b/sdk/azcore/policy_retry.go
@@ -69,9 +69,9 @@ func DefaultRetryOptions() RetryOptions {
 // used as a context key for adding/retrieving RetryOptions
 type ctxWithRetryOptionsKey struct{}
 
-// ContextWithRetryOptions adds the specified RetryOptions to the parent context.
+// WithRetryOptions adds the specified RetryOptions to the parent context.
 // Use this to specify custom RetryOptions at the API-call level.
-func ContextWithRetryOptions(parent context.Context, options RetryOptions) context.Context {
+func WithRetryOptions(parent context.Context, options RetryOptions) context.Context {
 	return context.WithValue(parent, ctxWithRetryOptionsKey{}, options)
 }
 

--- a/sdk/azcore/policy_retry_test.go
+++ b/sdk/azcore/policy_retry_test.go
@@ -212,7 +212,7 @@ func TestRetryPolicyIsNotRetriable(t *testing.T) {
 	}
 }
 
-func TestWithRetryOptions(t *testing.T) {
+func TestContextWithRetryOptions(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.RepeatResponse(9, mock.WithStatusCode(http.StatusRequestTimeout))
@@ -222,7 +222,7 @@ func TestWithRetryOptions(t *testing.T) {
 	customOptions := *defaultOptions
 	customOptions.MaxTries = 10
 	customOptions.MaxRetryDelay = 200 * time.Millisecond
-	retryCtx := WithRetryOptions(context.Background(), customOptions)
+	retryCtx := ContextWithRetryOptions(context.Background(), customOptions)
 	req := NewRequest(http.MethodGet, srv.URL())
 	body := newRewindTrackingBody("stuff")
 	req.SetBody(body)

--- a/sdk/azcore/policy_retry_test.go
+++ b/sdk/azcore/policy_retry_test.go
@@ -212,7 +212,7 @@ func TestRetryPolicyIsNotRetriable(t *testing.T) {
 	}
 }
 
-func TestContextWithRetryOptions(t *testing.T) {
+func TestWithRetryOptions(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.RepeatResponse(9, mock.WithStatusCode(http.StatusRequestTimeout))
@@ -222,7 +222,7 @@ func TestContextWithRetryOptions(t *testing.T) {
 	customOptions := *defaultOptions
 	customOptions.MaxRetries = 10
 	customOptions.MaxRetryDelay = 200 * time.Millisecond
-	retryCtx := ContextWithRetryOptions(context.Background(), customOptions)
+	retryCtx := WithRetryOptions(context.Background(), customOptions)
 	req := NewRequest(http.MethodGet, srv.URL())
 	body := newRewindTrackingBody("stuff")
 	req.SetBody(body)

--- a/sdk/azcore/policy_retry_test.go
+++ b/sdk/azcore/policy_retry_test.go
@@ -233,7 +233,7 @@ func TestWithRetryOptions(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	if body.rcount != 9 {
+	if body.rcount != int(customOptions.MaxTries-1) {
 		t.Fatalf("unexpected rewind count: %d", body.rcount)
 	}
 	if !body.closed {

--- a/sdk/azcore/policy_retry_test.go
+++ b/sdk/azcore/policy_retry_test.go
@@ -61,10 +61,10 @@ func TestRetryPolicyFailOnStatusCode(t *testing.T) {
 	if resp.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	if r := srv.Requests(); r != defaultMaxTries {
-		t.Fatalf("wrong retry count, got %d expected %d", r, defaultMaxTries)
+	if r := srv.Requests(); r != defaultMaxRetries+1 {
+		t.Fatalf("wrong request count, got %d expected %d", r, defaultMaxRetries+1)
 	}
-	if body.rcount != defaultMaxTries-1 {
+	if body.rcount != defaultMaxRetries {
 		t.Fatalf("unexpected rewind count: %d", body.rcount)
 	}
 	if !body.closed {
@@ -116,10 +116,10 @@ func TestRetryPolicyFailOnError(t *testing.T) {
 	if resp != nil {
 		t.Fatal("unexpected response")
 	}
-	if r := srv.Requests(); r != defaultMaxTries {
-		t.Fatalf("wrong retry count, got %d expected %d", r, defaultMaxTries)
+	if r := srv.Requests(); r != defaultMaxRetries+1 {
+		t.Fatalf("wrong request count, got %d expected %d", r, defaultMaxRetries+1)
 	}
-	if body.rcount != defaultMaxTries-1 {
+	if body.rcount != defaultMaxRetries {
 		t.Fatalf("unexpected rewind count: %d", body.rcount)
 	}
 	if !body.closed {
@@ -145,10 +145,10 @@ func TestRetryPolicySuccessWithRetryComplex(t *testing.T) {
 	if resp.StatusCode != http.StatusAccepted {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	if r := srv.Requests(); r != defaultMaxTries {
-		t.Fatalf("wrong retry count, got %d expected %d", r, 3)
+	if r := srv.Requests(); r != defaultMaxRetries+1 {
+		t.Fatalf("wrong request count, got %d expected %d", r, defaultMaxRetries+1)
 	}
-	if body.rcount != defaultMaxTries-1 {
+	if body.rcount != defaultMaxRetries {
 		t.Fatalf("unexpected rewind count: %d", body.rcount)
 	}
 	if !body.closed {
@@ -220,7 +220,7 @@ func TestContextWithRetryOptions(t *testing.T) {
 	defaultOptions := testRetryOptions()
 	pl := NewPipeline(srv, NewRetryPolicy(defaultOptions))
 	customOptions := *defaultOptions
-	customOptions.MaxTries = 10
+	customOptions.MaxRetries = 10
 	customOptions.MaxRetryDelay = 200 * time.Millisecond
 	retryCtx := ContextWithRetryOptions(context.Background(), customOptions)
 	req := NewRequest(http.MethodGet, srv.URL())
@@ -233,7 +233,7 @@ func TestContextWithRetryOptions(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	if body.rcount != int(customOptions.MaxTries-1) {
+	if body.rcount != int(customOptions.MaxRetries-1) {
 		t.Fatalf("unexpected rewind count: %d", body.rcount)
 	}
 	if !body.closed {

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -27,7 +27,6 @@ const (
 type Request struct {
 	*http.Request
 	policies []Policy
-	qp       url.Values
 	values   opValues
 }
 
@@ -79,11 +78,6 @@ func (req *Request) Next(ctx context.Context) (*Response, error) {
 	nextPolicy := req.policies[0]
 	nextReq := *req
 	nextReq.policies = nextReq.policies[1:]
-	// encode any pending query params
-	if nextReq.qp != nil {
-		nextReq.Request.URL.RawQuery = nextReq.qp.Encode()
-		nextReq.qp = nil
-	}
 	return nextPolicy.Do(ctx, &nextReq)
 }
 
@@ -123,14 +117,6 @@ func (req *Request) OperationValue(value interface{}) bool {
 		return false
 	}
 	return req.values.get(value)
-}
-
-// SetQueryParam sets the key to value.
-func (req *Request) SetQueryParam(key, value string) {
-	if req.qp == nil {
-		req.qp = req.Request.URL.Query()
-	}
-	req.qp.Set(key, value)
 }
 
 // SetBody sets the specified ReadSeekCloser as the HTTP request body.


### PR DESCRIPTION
Added WithRetryOptions() that adds a custom RetryOptions to the provided
context, allowing custom settings per API call.
Remove 429 from the list of default HTTP status codes for retry.
Change StatusCodesForRetry to a slice so consumers can append to it.
