### PR TITLE
Track2 chainedcredentialtest

### DIFF
--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -107,7 +107,7 @@ func TestChainedTokenCredential_GetTokenWithUnavailableCredentialInChain(t *test
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	// It doesn't matter what credential we add to the chain as long as it is not a nil credential.
+	// The chain has the same credential twice, since it doesn't matter what credential we add to the chain as long as it is not a nil credential.
 	// Most credentials will not be instantiated if the conditions do not exist to allow them to be used, thus returning a
 	// CredentialUnavailable error from the constructor. In order to test the CredentialUnavailable functionality for
 	// ChainedTokenCredential we have to mock with two valid credentials, but the first will fail since the first response queued

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -55,7 +55,7 @@ func TestChainedTokenCredential_GetTokenSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create environment credential: %v", err)
 	}
-	cred, err := NewChainedTokenCredential(envCred, secCred)
+	cred, err := NewChainedTokenCredential(secCred, envCred)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -6,7 +6,6 @@ package azidentity
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -121,7 +120,6 @@ func TestChainedTokenCredential_GetTokenWithUnavailableCredentialInChain(t *test
 	if err != nil {
 		t.Fatalf("Received an error when attempting to get a token but expected none")
 	}
-	fmt.Println("CRED:" + cred.GetAuthenticatedCredentialType().credential.String() + " ClientID:" + cred.GetAuthenticatedCredentialType().credentialClientID)
 	if tk.Token != tokenValue {
 		t.Fatalf("Received an incorrect access token")
 	}

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -116,16 +116,15 @@ func TestChainedTokenCredential_GetTokenWithUnavailableCredentialInChain(t *test
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	tk, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to get a token but expected none")
 	}
-	var authErr *AuthenticationFailedError
-	if !errors.As(err, &authErr) {
-		t.Fatalf("Expected Error Type: AuthenticationFailedError, ReceivedErrorType: %T", err)
+	if tk.Token != tokenValue {
+		t.Fatalf("Received an incorrect access token")
 	}
-	if len(err.Error()) == 0 {
-		t.Fatalf("Did not create an appropriate error message")
+	if tk.ExpiresOn.IsZero() {
+		t.Fatalf("Received an incorrect time in the response")
 	}
 }
 

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -6,6 +6,7 @@ package azidentity
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -100,7 +101,7 @@ func TestChainedTokenCredential_GetTokenFail(t *testing.T) {
 func TestChainedTokenCredential_GetTokenWithUnavailableCredentialInChain(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
-	srv.AppendResponse(mock.WithError(&CredentialUnavailableError{CredentialType: "MockCredential", Message: "Mocking a credential unavailable error"}))
+	srv.AppendError(&CredentialUnavailableError{CredentialType: "MockCredential", Message: "Mocking a credential unavailable error"})
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	testURL := srv.URL()
 	secCred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &testURL})
@@ -120,6 +121,7 @@ func TestChainedTokenCredential_GetTokenWithUnavailableCredentialInChain(t *test
 	if err != nil {
 		t.Fatalf("Received an error when attempting to get a token but expected none")
 	}
+	fmt.Println("CRED:" + cred.GetAuthenticatedCredentialType().credential.String() + " ClientID:" + cred.GetAuthenticatedCredentialType().credentialClientID)
 	if tk.Token != tokenValue {
 		t.Fatalf("Received an incorrect access token")
 	}

--- a/sdk/internal/mock/mock.go
+++ b/sdk/internal/mock/mock.go
@@ -196,17 +196,3 @@ func WithBody(b []byte) ResponseOption {
 		mr.body = b
 	})
 }
-
-// WithHeader adds the specified header and value to the HTTP response.
-func WithHeader(k, v string) ResponseOption {
-	return fnRespOpt(func(mr *mockResponse) {
-		mr.headers.Add(k, v)
-	})
-}
-
-// WithError sets the HTTP response's error to the specified value.
-func WithError(e error) ResponseOption {
-	return fnRespOpt(func(mr *mockResponse) {
-		mr.err = e
-	})
-}

--- a/sdk/internal/mock/mock.go
+++ b/sdk/internal/mock/mock.go
@@ -203,3 +203,10 @@ func WithHeader(k, v string) ResponseOption {
 		mr.headers.Add(k, v)
 	})
 }
+
+// WithError sets the HTTP response's error to the specified value.
+func WithError(e error) ResponseOption {
+	return fnRespOpt(func(mr *mockResponse) {
+		mr.err = e
+	})
+}

--- a/sdk/internal/mock/mock.go
+++ b/sdk/internal/mock/mock.go
@@ -196,3 +196,10 @@ func WithBody(b []byte) ResponseOption {
 		mr.body = b
 	})
 }
+
+// WithHeader adds the specified header and value to the HTTP response.
+func WithHeader(k, v string) ResponseOption {
+	return fnRespOpt(func(mr *mockResponse) {
+		mr.headers.Add(k, v)
+	})
+}


### PR DESCRIPTION
Adding a test to check for CredentialUnavailable errors in the ChainedTokenCredential test suite. 
Also adding a function to append errors as responses for the test server. 