### PR TITLE
Ensure per-try timeout is properly cancelled

### DIFF
--- a/sdk/azcore/log.go
+++ b/sdk/azcore/log.go
@@ -51,8 +51,15 @@ func (l *Logger) SetListener(lst Listener) {
 }
 
 // Should returns true if the specified log classification should be written to the log.
-// TODO: explain why you would want to call this
+// By default all log classifications will be logged.  Call SetClassification() to limit
+// the log classifications for logging.
+// If no listener has been set this will return false.
+// Calling this method is useful when the message to log is computationally expensive
+// and you want to avoid the overhead if its log classification is not enabled.
 func (l *Logger) Should(cls LogClassification) bool {
+	if l.lst == nil {
+		return false
+	}
 	if l.cls == nil || len(l.cls) == 0 {
 		return true
 	}

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -144,6 +144,13 @@ func (req *Request) SkipBodyDownload() {
 	req.SetOperationValue(bodyDownloadPolicyOpValues{skip: true})
 }
 
+// returns true if auto-body download policy is enabled
+func (req *Request) bodyDownloadEnabled() bool {
+	var opValues bodyDownloadPolicyOpValues
+	req.OperationValue(&opValues)
+	return !opValues.skip
+}
+
 // RewindBody seeks the request's Body stream back to the beginning so it can be resent when retrying an operation.
 func (req *Request) RewindBody() error {
 	if req.Body != nil {


### PR DESCRIPTION
Explicitly call cancel the per-try timeout when the response body has
been read/closed by the body download policy.
When the response body is returned to the caller for reading/closing,
wrap it in a responseBodyReader that will cancel the timeout when the
body is closed.
Logger.Should() will return false if no listener is set.
