### PR TITLE
Handle cosmosdb table API requests

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -141,15 +141,16 @@ type Client struct {
 	// automatic retry strategy built in. The Sender can be customized.
 	Sender Sender
 
-	accountName      string
-	accountKey       []byte
-	useHTTPS         bool
-	UseSharedKeyLite bool
-	baseURL          string
-	apiVersion       string
-	userAgent        string
-	sasClient        bool
-	accountSASToken  url.Values
+	accountName       string
+	accountKey        []byte
+	useHTTPS          bool
+	UseSharedKeyLite  bool
+	baseURL           string
+	apiVersion        string
+	userAgent         string
+	sasClient         bool
+	accountSASToken   url.Values
+	additionalHeaders map[string]string
 }
 
 type odataResponse struct {
@@ -432,6 +433,17 @@ func (c *Client) AddToUserAgent(extension string) error {
 	return fmt.Errorf("Extension was empty, User Agent stayed as %s", c.userAgent)
 }
 
+// AddAdditionalHeaders adds additional standard headers
+func (c *Client) AddAdditionalHeaders(headers map[string]string) error {
+	if headers != nil {
+		c.additionalHeaders = map[string]string{}
+		for k, v := range headers {
+			c.additionalHeaders[k] = v
+		}
+	}
+	return nil
+}
+
 // protectUserAgent is used in funcs that include extraheaders as a parameter.
 // It prevents the User-Agent header to be overwritten, instead if it happens to
 // be present, it gets added to the current User-Agent. Use it before getStandardHeaders
@@ -696,11 +708,16 @@ func (c Client) GetFileService() FileServiceClient {
 }
 
 func (c Client) getStandardHeaders() map[string]string {
-	return map[string]string{
-		userAgentHeader: c.userAgent,
-		"x-ms-version":  c.apiVersion,
-		"x-ms-date":     currentTimeRfc1123Formatted(),
+	headers := map[string]string{}
+	for k, v := range c.additionalHeaders {
+		headers[k] = v
 	}
+
+	headers[userAgentHeader] = c.userAgent
+	headers["x-ms-version"] = c.apiVersion
+	headers["x-ms-date"] = currentTimeRfc1123Formatted()
+
+	return headers
 }
 
 func (c Client) exec(verb, url string, headers map[string]string, body io.Reader, auth authentication) (*http.Response, error) {

--- a/storage/client.go
+++ b/storage/client.go
@@ -434,14 +434,13 @@ func (c *Client) AddToUserAgent(extension string) error {
 }
 
 // AddAdditionalHeaders adds additional standard headers
-func (c *Client) AddAdditionalHeaders(headers map[string]string) error {
+func (c *Client) AddAdditionalHeaders(headers map[string]string) {
 	if headers != nil {
 		c.additionalHeaders = map[string]string{}
 		for k, v := range headers {
 			c.additionalHeaders[k] = v
 		}
 	}
-	return nil
 }
 
 // protectUserAgent is used in funcs that include extraheaders as a parameter.

--- a/storage/entity.go
+++ b/storage/entity.go
@@ -234,7 +234,7 @@ func (e *Entity) InsertOrMerge(options *EntityOptions) error {
 }
 
 func (e *Entity) buildPath() string {
-	return fmt.Sprintf("%s(PartitionKey='%s', RowKey='%s')", e.Table.buildPath(), e.PartitionKey, e.RowKey)
+	return fmt.Sprintf("%s(PartitionKey='%s',RowKey='%s')", e.Table.buildPath(), e.PartitionKey, e.RowKey)
 }
 
 // MarshalJSON is a custom marshaller for entity

--- a/storage/recordings/StorageEntitySuite/TestDelete.yaml
+++ b/storage/recordings/StorageEntitySuite/TestDelete.yaml
@@ -123,7 +123,7 @@ interactions:
       - Tue, 28 May 2019 22:36:03 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel%28PartitionKey=%27pkey1%27,%20RowKey=%27rowkey1%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel%28PartitionKey=%27pkey1%27,RowKey=%27rowkey1%27%29
     method: DELETE
   response:
     body: ""
@@ -217,7 +217,7 @@ interactions:
       - Tue, 28 May 2019 22:36:03 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel%28PartitionKey=%27pkey2%27,%20RowKey=%27rowkey2%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel%28PartitionKey=%27pkey2%27,RowKey=%27rowkey2%27%29
     method: DELETE
   response:
     body: '{"odata.error":{"code":"InvalidInput","message":{"lang":"en-US","value":"The
@@ -258,7 +258,7 @@ interactions:
       - Tue, 28 May 2019 22:36:03 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel%28PartitionKey=%27pkey2%27,%20RowKey=%27rowkey2%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestdel%28PartitionKey=%27pkey2%27,RowKey=%27rowkey2%27%29
     method: DELETE
   response:
     body: ""

--- a/storage/recordings/StorageEntitySuite/TestGet.yaml
+++ b/storage/recordings/StorageEntitySuite/TestGet.yaml
@@ -121,7 +121,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29?%24select=IsActive&timeout=30
+    url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29?%24select=IsActive&timeout=30
     method: GET
   response:
     body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table26storageentitysuitetestget/@Element&$select=IsActive","odata.type":"golangrocksonazure.table26storageentitysuitetestget","odata.id":"https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-28T22%3A36%3A03.9362639Z''\"","odata.editLink":"table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","IsActive":true}'
@@ -160,7 +160,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29?%24select=AmountDue%2CCustomerCode%2CCustomerSince%2CIsActive%2CNumberOfOrders&timeout=30
+    url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29?%24select=AmountDue%2CCustomerCode%2CCustomerSince%2CIsActive%2CNumberOfOrders&timeout=30
     method: GET
   response:
     body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table26storageentitysuitetestget/@Element&$select=AmountDue,CustomerCode,CustomerSince,IsActive,NumberOfOrders","odata.type":"golangrocksonazure.table26storageentitysuitetestget","odata.id":"https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-28T22%3A36%3A03.9362639Z''\"","odata.editLink":"table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'
@@ -199,7 +199,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29?timeout=30
+    url: https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29?timeout=30
     method: GET
   response:
     body: '{"odata.metadata":"https://golangrocksonazure.table.core.windows.net/$metadata#table26storageentitysuitetestget/@Element","odata.type":"golangrocksonazure.table26storageentitysuitetestget","odata.id":"https://golangrocksonazure.table.core.windows.net/table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","odata.etag":"W/\"datetime''2019-05-28T22%3A36%3A03.9362639Z''\"","odata.editLink":"table26storageentitysuitetestget(PartitionKey=''mypartitionkey'',RowKey=''myrowkey'')","PartitionKey":"mypartitionkey","RowKey":"myrowkey","Timestamp@odata.type":"Edm.DateTime","Timestamp":"2019-05-28T22:36:03.9362639Z","AmountDue":200.23,"CustomerCode@odata.type":"Edm.Guid","CustomerCode":"c9da6455-213d-42c9-9a79-3e9149a57833","CustomerSince@odata.type":"Edm.DateTime","CustomerSince":"1992-12-20T21:55:00Z","IsActive":true,"NumberOfOrders@odata.type":"Edm.Int64","NumberOfOrders":"255"}'

--- a/storage/recordings/StorageEntitySuite/TestInsertOrMerge.yaml
+++ b/storage/recordings/StorageEntitySuite/TestInsertOrMerge.yaml
@@ -76,7 +76,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table36storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table36storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: MERGE
   response:
     body: ""
@@ -125,7 +125,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table36storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table36storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: MERGE
   response:
     body: ""

--- a/storage/recordings/StorageEntitySuite/TestInsertOrReplace.yaml
+++ b/storage/recordings/StorageEntitySuite/TestInsertOrReplace.yaml
@@ -76,7 +76,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table38storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table38storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: PUT
   response:
     body: ""
@@ -125,7 +125,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table38storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table38storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: PUT
   response:
     body: ""

--- a/storage/recordings/StorageEntitySuite/TestMerge.yaml
+++ b/storage/recordings/StorageEntitySuite/TestMerge.yaml
@@ -129,7 +129,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: MERGE
   response:
     body: ""
@@ -180,7 +180,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: MERGE
   response:
     body: '{"odata.error":{"code":"ConditionNotMet","message":{"lang":"en-US","value":"The
@@ -226,7 +226,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table28storageentitysuitetestmer%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: MERGE
   response:
     body: ""

--- a/storage/recordings/StorageEntitySuite/TestUpdate.yaml
+++ b/storage/recordings/StorageEntitySuite/TestUpdate.yaml
@@ -129,7 +129,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: PUT
   response:
     body: ""
@@ -180,7 +180,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: PUT
   response:
     body: '{"odata.error":{"code":"ConditionNotMet","message":{"lang":"en-US","value":"The
@@ -226,7 +226,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table29storageentitysuitetestupd%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
     method: PUT
   response:
     body: ""

--- a/storage/recordings/StorageEntitySuite/Test_InsertAndDeleteEntities.yaml
+++ b/storage/recordings/StorageEntitySuite/Test_InsertAndDeleteEntities.yaml
@@ -213,7 +213,7 @@ interactions:
       - Tue, 28 May 2019 22:36:04 GMT
       x-ms-version:
       - "2018-03-28"
-    url: https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27200%27%29
+    url: https://golangrocksonazure.table.core.windows.net/table47storageentitysuitetestins%28PartitionKey=%27mypartitionkey%27,RowKey=%27200%27%29
     method: DELETE
   response:
     body: ""

--- a/storage/recordings/TableBatchSuite/Test_BatchInsertMultipleEntities.yaml
+++ b/storage/recordings/TableBatchSuite/Test_BatchInsertMultipleEntities.yaml
@@ -56,10 +56,10 @@ interactions:
 - request:
     body: "--batch_882751a7-e115-4b8c-a9f2-8f9e603a54fb\r\nContent-Type: multipart/mixed;
       boundary=changeset_2187ca22-66ec-4b68-bafc-632bc3427155\r\n\r\n\r\n--changeset_2187ca22-66ec-4b68-bafc-632bc3427155\r\nContent-Transfer-Encoding:
-      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
       application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_2187ca22-66ec-4b68-bafc-632bc3427155\r\nContent-Transfer-Encoding:
-      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey2%27%29
+      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/tableme48tablebatchsuitetestbatc%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey2%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
       application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"111.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey2\"}\r\n--changeset_2187ca22-66ec-4b68-bafc-632bc3427155--\r\n\r\n--batch_882751a7-e115-4b8c-a9f2-8f9e603a54fb--\r\n"
     form: {}

--- a/storage/recordings/TableBatchSuite/Test_BatchInsertThenDeleteDifferentBatches.yaml
+++ b/storage/recordings/TableBatchSuite/Test_BatchInsertThenDeleteDifferentBatches.yaml
@@ -56,7 +56,7 @@ interactions:
 - request:
     body: "--batch_820deae5-06b6-4813-b620-1cff78664488\r\nContent-Type: multipart/mixed;
       boundary=changeset_06a8eb33-dab8-44b0-a383-02375144a315\r\n\r\n\r\n--changeset_06a8eb33-dab8-44b0-a383-02375144a315\r\nContent-Transfer-Encoding:
-      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
       application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_06a8eb33-dab8-44b0-a383-02375144a315--\r\n\r\n--batch_820deae5-06b6-4813-b620-1cff78664488--\r\n"
     form: {}
@@ -138,7 +138,7 @@ interactions:
 - request:
     body: "--batch_eda3440a-dffc-4bd7-910c-d7e5af3bfc74\r\nContent-Type: multipart/mixed;
       boundary=changeset_293dbedb-1040-4ae5-aaca-a1ab6ecd0b00\r\n\r\n\r\n--changeset_293dbedb-1040-4ae5-aaca-a1ab6ecd0b00\r\nContent-Transfer-Encoding:
-      binary\r\nContent-Type: application/http\r\n\r\nDELETE https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+      binary\r\nContent-Type: application/http\r\n\r\nDELETE https://golangrocksonazure.table.core.windows.net/table58tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
       application/json\r\nIf-Match: *\r\nPrefer: return-no-content\r\n\r\n\r\n--changeset_293dbedb-1040-4ae5-aaca-a1ab6ecd0b00--\r\n\r\n--batch_eda3440a-dffc-4bd7-910c-d7e5af3bfc74--\r\n"
     form: {}

--- a/storage/recordings/TableBatchSuite/Test_BatchInsertThenMergeDifferentBatches.yaml
+++ b/storage/recordings/TableBatchSuite/Test_BatchInsertThenMergeDifferentBatches.yaml
@@ -56,7 +56,7 @@ interactions:
 - request:
     body: "--batch_b8457413-5546-4582-be6a-23ca5f95ef9e\r\nContent-Type: multipart/mixed;
       boundary=changeset_73be3eec-8962-496e-a3ca-d5fd1d6cd971\r\n\r\n\r\n--changeset_73be3eec-8962-496e-a3ca-d5fd1d6cd971\r\nContent-Transfer-Encoding:
-      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table57tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table57tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
       application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"IsActive\":true,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_73be3eec-8962-496e-a3ca-d5fd1d6cd971--\r\n\r\n--batch_b8457413-5546-4582-be6a-23ca5f95ef9e--\r\n"
     form: {}
@@ -101,7 +101,7 @@ interactions:
 - request:
     body: "--batch_1358b69e-0bc1-49e2-a22d-d91161d812cb\r\nContent-Type: multipart/mixed;
       boundary=changeset_d5ad89eb-06a7-4d68-8a6b-7bbd1cc8e870\r\n\r\n\r\n--changeset_d5ad89eb-06a7-4d68-8a6b-7bbd1cc8e870\r\nContent-Transfer-Encoding:
-      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table57tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,%20RowKey=%27myrowkey%27%29
+      binary\r\nContent-Type: application/http\r\n\r\nPUT https://golangrocksonazure.table.core.windows.net/table57tablebatchsuitetestbatchi%28PartitionKey=%27mypartitionkey%27,RowKey=%27myrowkey%27%29
       HTTP/1.1\r\nAccept: application/json;odata=minimalmetadata\r\nContent-Type:
       application/json\r\nPrefer: return-no-content\r\n\r\n{\"AmountDue\":\"200.23\",\"AmountDue@odata.type\":\"Edm.Double\",\"CustomerCode\":\"c9da6455-213d-42c9-9a79-3e9149a57833\",\"CustomerCode@odata.type\":\"Edm.Guid\",\"CustomerSince\":\"1992-12-20T21:55:00Z\",\"CustomerSince@odata.type\":\"Edm.DateTime\",\"DifferentField\":123,\"NumberOfOrders\":\"255\",\"NumberOfOrders@odata.type\":\"Edm.Int64\",\"PartitionKey\":\"mypartitionkey\",\"RowKey\":\"myrowkey\"}\r\n--changeset_d5ad89eb-06a7-4d68-8a6b-7bbd1cc8e870--\r\n\r\n--batch_1358b69e-0bc1-49e2-a22d-d91161d812cb--\r\n"
     form: {}


### PR DESCRIPTION
This change allows azure-sdk-for-go to send the requests to
cosmosdb table API. It exposes a new method as AddAdditionalHeaders
which allows users to specify cosmosdb specific headers.
This change allows users to use azure-sdk-for-go to connect to and use
cosmosdb table storage. 
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
