### PR TITLE
Fix block blob operations

### DIFF
--- a/sdk/storage/blob/2019-07-07/azblob/examples_test.go
+++ b/sdk/storage/blob/2019-07-07/azblob/examples_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -66,15 +67,11 @@ func generateBlobContent(size int) []byte {
 
 // concatenates all elements together with a '/' between each element
 func pathJoin(elem ...string) string {
-	// add a trailing '/' if it doesn't already end with one
-	if i := len(elem[0]); elem[0][i-1] != '/' {
-		elem[0] = elem[0] + "/"
+	// remove trailing '/' if needed
+	if i := len(elem[0]); elem[0][i-1] == '/' {
+		elem[0] = elem[0][0 : i-1]
 	}
-	// join all the parts together
-	for i := 1; i < len(elem); i++ {
-		elem[0] = elem[0] + elem[i] + "/"
-	}
-	return elem[0]
+	return strings.Join(elem, "/")
 }
 
 func ExampleContainerOperations_Create() {
@@ -119,15 +116,10 @@ func ExampleBlockBlobOperations_Upload() {
 	if err != nil {
 		panic(err)
 	}
-	blockSize := int32(80)
-	blockID := "myblockID"
+	const blockSize = 80
 	blobClient := client.BlockBlobOperations()
-	block := Block{
-		Name: &blockID,
-		Size: &blockSize,
-	}
-	body := azcore.NopCloser(bytes.NewReader(generateBlobContent(int(blockSize))))
-	b, err := blobClient.Upload(context.Background(), block, body, nil)
+	body := azcore.NopCloser(bytes.NewReader(generateBlobContent(blockSize)))
+	b, err := blobClient.Upload(context.Background(), blockSize, body, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -192,8 +184,8 @@ func ExampleContainerOperations_ListBlobFlatSegment() {
 		panic(err)
 	}
 	// Unordered output:
-	// azblobsampleblockblob/
-	// azblobsampleappendblob/
+	// azblobsampleblockblob
+	// azblobsampleappendblob
 }
 
 func ExampleBlobOperations_Delete() {


### PR DESCRIPTION
Updated block blobs with latest codegen, reverting hand edits.
Fixed block blob sample based on codegen.
Fixed pathJoin to omit trailing '/'

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
