### PR TITLE
Change RetryAfter() to a function

### DIFF
--- a/sdk/azcore/policy_retry.go
+++ b/sdk/azcore/policy_retry.go
@@ -182,7 +182,7 @@ func (p *retryPolicy) Do(ctx context.Context, req *Request) (resp *Response, err
 		}
 
 		// use the delay from retry-after if available
-		delay := resp.RetryAfter()
+		delay := resp.retryAfter()
 		if delay <= 0 {
 			delay = options.calcDelay(try)
 		}

--- a/sdk/azcore/response.go
+++ b/sdk/azcore/response.go
@@ -96,12 +96,20 @@ func (r *Response) removeBOM() {
 	}
 }
 
-// RetryAfter returns non-zero if the response contains a Retry-After header value.
-func (r *Response) RetryAfter() time.Duration {
+// helper to reduce nil Response checks
+func (r *Response) retryAfter() time.Duration {
 	if r == nil {
 		return 0
 	}
-	ra := r.Header.Get(HeaderRetryAfter)
+	return RetryAfter(r.Response)
+}
+
+// RetryAfter returns non-zero if the response contains a Retry-After header value.
+func RetryAfter(resp *http.Response) time.Duration {
+	if resp == nil {
+		return 0
+	}
+	ra := resp.Header.Get(HeaderRetryAfter)
 	if ra == "" {
 		return 0
 	}

--- a/sdk/azcore/response_test.go
+++ b/sdk/azcore/response_test.go
@@ -110,11 +110,11 @@ func TestRetryAfter(t *testing.T) {
 		Header: http.Header{},
 	}
 	resp := Response{raw}
-	if d := resp.RetryAfter(); d > 0 {
+	if d := resp.retryAfter(); d > 0 {
 		t.Fatalf("unexpected retry-after value %d", d)
 	}
 	raw.Header.Set(HeaderRetryAfter, "300")
-	d := resp.RetryAfter()
+	d := resp.retryAfter()
 	if d <= 0 {
 		t.Fatal("expected retry-after value from seconds")
 	}
@@ -123,7 +123,7 @@ func TestRetryAfter(t *testing.T) {
 	}
 	atDate := time.Now().Add(600 * time.Second)
 	raw.Header.Set(HeaderRetryAfter, atDate.Format(time.RFC1123))
-	d = resp.RetryAfter()
+	d = resp.retryAfter()
 	if d <= 0 {
 		t.Fatal("expected retry-after value from date")
 	}


### PR DESCRIPTION
Since azcore.Response isn't directly exposed to callers they cannot use
this convenience method.  Changed it to a function.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
