### PR TITLE
Add support for base-64 encoding and decoding of payloads

### DIFF
--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -8,6 +8,7 @@ package azcore
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -79,6 +80,13 @@ func (req *Request) Next(ctx context.Context) (*Response, error) {
 	nextReq := *req
 	nextReq.policies = nextReq.policies[1:]
 	return nextPolicy.Do(ctx, &nextReq)
+}
+
+// MarshalAsByteArray will base-64 encode the byte slice v then calls MarshalAsJSON.
+// It uses the raw standard encoder to encode the JSON string.
+func (req *Request) MarshalAsByteArray(v []byte) error {
+	encode := base64.RawStdEncoding.EncodeToString(v)
+	return req.MarshalAsJSON(encode)
 }
 
 // MarshalAsJSON calls json.Marshal() to get the JSON encoding of v then calls SetBody.


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
