### PR TITLE
Differentiate between standard and URL encoding

### DIFF
--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -81,14 +81,14 @@ func TestRequestMarshalJSON(t *testing.T) {
 	}
 }
 
-func TestRequestMarshalAsByteArray(t *testing.T) {
+func TestRequestMarshalAsByteArrayURLFormat(t *testing.T) {
 	u, err := url.Parse("https://contoso.com")
 	if err != nil {
 		panic(err)
 	}
 	req := NewRequest(http.MethodPost, *u)
 	const payload = "a string that gets encoded with base64url"
-	err = req.MarshalAsByteArray([]byte(payload))
+	err = req.MarshalAsByteArray([]byte(payload), Base64URLFormat)
 	if err != nil {
 		t.Fatalf("marshal failure: %v", err)
 	}
@@ -106,6 +106,35 @@ func TestRequestMarshalAsByteArray(t *testing.T) {
 		t.Fatal(err)
 	}
 	if string(b) != `"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw"` {
+		t.Fatalf("bad body, got %s", string(b))
+	}
+}
+
+func TestRequestMarshalAsByteArrayStdFormat(t *testing.T) {
+	u, err := url.Parse("https://contoso.com")
+	if err != nil {
+		panic(err)
+	}
+	req := NewRequest(http.MethodPost, *u)
+	const payload = "a string that gets encoded with base64url"
+	err = req.MarshalAsByteArray([]byte(payload), Base64StdFormat)
+	if err != nil {
+		t.Fatalf("marshal failure: %v", err)
+	}
+	if ct := req.Header.Get(HeaderContentType); ct != contentTypeAppJSON {
+		t.Fatalf("unexpected content type, got %s wanted %s", ct, contentTypeAppJSON)
+	}
+	if req.Body == nil {
+		t.Fatal("unexpected nil request body")
+	}
+	if req.ContentLength == 0 {
+		t.Fatal("unexpected zero content length")
+	}
+	b, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != `"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw="` {
 		t.Fatalf("bad body, got %s", string(b))
 	}
 }


### PR DESCRIPTION
Swagger specifies 'byte' format for standard base-64 encoding and
'base64url' for base-64 URL encoding.  Update the byte array encoder
and decoder to specify which type to use.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] The PR targets the `latest` branch.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
