### PR TITLE
Renaming DefaultTokenCredential to DefaultAzureCredential

### DIFF
--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -9,10 +9,14 @@ const (
 	developerSignOnClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 )
 
-// DefaultAzureCredentialOptions contain information that can configure Default Token Credentials
+// DefaultAzureCredentialOptions contains options for configuring how credentials are acquired.
 type DefaultAzureCredentialOptions struct {
+	// set this field to true in order to exclude the EnvironmentCredential from the set of
+	// credentials that will be used to authenticate with
 	ExcludeEnvironmentCredential bool
-	ExcludeMSICredential         bool
+	// set this field to true in order to exclude the ManagedIdentityCredential from the set of
+	// credentials that will be used to authenticate with
+	ExcludeMSICredential bool
 }
 
 // NewDefaultAzureCredential provides a default ChainedTokenCredential configuration for applications that will be deployed to Azure.  The following credential

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -9,23 +9,23 @@ const (
 	developerSignOnClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 )
 
-// DefaultTokenCredentialOptions contain information that can configure Default Token Credentials
-type DefaultTokenCredentialOptions struct {
+// DefaultAzureCredentialOptions contain information that can configure Default Token Credentials
+type DefaultAzureCredentialOptions struct {
 	ExcludeEnvironmentCredential bool
 	ExcludeMSICredential         bool
 }
 
-// NewDefaultTokenCredential provides a default ChainedTokenCredential configuration for applications that will be deployed to Azure.  The following credential
+// NewDefaultAzureCredential provides a default ChainedTokenCredential configuration for applications that will be deployed to Azure.  The following credential
 // types will be tried, in order:
 // - EnvironmentCredential
 // - ManagedIdentityCredential
 // Consult the documentation of these credential types for more information on how they attempt authentication.
-func NewDefaultTokenCredential(options *DefaultTokenCredentialOptions) (*ChainedTokenCredential, error) {
+func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*ChainedTokenCredential, error) {
 	var creds []azcore.TokenCredential
 	errMsg := ""
 
 	if options == nil {
-		options = &DefaultTokenCredentialOptions{}
+		options = &DefaultAzureCredentialOptions{}
 	}
 
 	if !options.ExcludeEnvironmentCredential {

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -10,46 +10,46 @@ import (
 	"testing"
 )
 
-func TestDefaultTokenCredential_ExcludeEnvCredential(t *testing.T) {
+func TestDefaultAzureCredential_ExcludeEnvCredential(t *testing.T) {
 	err := resetEnvironmentVarsForTest()
 	if err != nil {
 		t.Fatalf("Unable to set environment variables")
 	}
 	_ = os.Setenv("MSI_ENDPOINT", "http://localhost:3000")
-	cred, err := NewDefaultTokenCredential(&DefaultTokenCredentialOptions{ExcludeEnvironmentCredential: true})
+	cred, err := NewDefaultAzureCredential(&DefaultAzureCredentialOptions{ExcludeEnvironmentCredential: true})
 	if err != nil {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
 
 	if len(cred.sources) != 1 {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 1, Received: %d", len(cred.sources))
+		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: 1, Received: %d", len(cred.sources))
 	}
 	_ = os.Setenv("MSI_ENDPOINT", "")
 
 }
 
-func TestDefaultTokenCredential_ExcludeMSICredential(t *testing.T) {
+func TestDefaultAzureCredential_ExcludeMSICredential(t *testing.T) {
 	err := initEnvironmentVarsForTest()
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	cred, err := NewDefaultTokenCredential(&DefaultTokenCredentialOptions{ExcludeMSICredential: true})
+	cred, err := NewDefaultAzureCredential(&DefaultAzureCredentialOptions{ExcludeMSICredential: true})
 	if err != nil {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
 	if len(cred.sources) != 1 {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 1, Received: %d", len(cred.sources))
+		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: 1, Received: %d", len(cred.sources))
 	}
 
 }
 
-func TestDefaultTokenCredential_ExcludeAllCredentials(t *testing.T) {
+func TestDefaultAzureCredential_ExcludeAllCredentials(t *testing.T) {
 	err := resetEnvironmentVarsForTest()
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
 	var credUnavailable *CredentialUnavailableError
-	_, err = NewDefaultTokenCredential(&DefaultTokenCredentialOptions{ExcludeEnvironmentCredential: false, ExcludeMSICredential: true})
+	_, err = NewDefaultAzureCredential(&DefaultAzureCredentialOptions{ExcludeEnvironmentCredential: false, ExcludeMSICredential: true})
 	if err == nil {
 		t.Fatalf("Expected an error but received nil")
 	}
@@ -59,7 +59,7 @@ func TestDefaultTokenCredential_ExcludeAllCredentials(t *testing.T) {
 
 }
 
-func TestDefaultTokenCredential_NilOptions(t *testing.T) {
+func TestDefaultAzureCredential_NilOptions(t *testing.T) {
 	err := resetEnvironmentVarsForTest()
 	if err != nil {
 		t.Fatalf("Unable to set environment variables")
@@ -68,7 +68,7 @@ func TestDefaultTokenCredential_NilOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	cred, err := NewDefaultTokenCredential(nil)
+	cred, err := NewDefaultAzureCredential(nil)
 	if err != nil {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
@@ -76,12 +76,12 @@ func TestDefaultTokenCredential_NilOptions(t *testing.T) {
 	// if the test is running in a MSI environment then the length of sources would be two since it will include environmnet credential and managed identity credential
 	if msiType, err := c.getMSIType(context.Background()); msiType == msiTypeIMDS || msiType == msiTypeCloudShell || msiType == msiTypeAppService {
 		if len(cred.sources) != 2 {
-			t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 2, Received: %d", len(cred.sources))
+			t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: 2, Received: %d", len(cred.sources))
 		}
 		//if a credential unavailable error is received or msiType is unknown then only the environment credential will be added
 	} else if unavailableErr := (*CredentialUnavailableError)(nil); errors.As(err, &unavailableErr) || msiType == msiTypeUnknown {
 		if len(cred.sources) != 1 {
-			t.Fatalf("Length of ChainedTokenCredential sources for DefaultTokenCredential. Expected: 1, Received: %d", len(cred.sources))
+			t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: 1, Received: %d", len(cred.sources))
 		}
 		// if there is some other unexpected error then we fail here
 	} else if err != nil {


### PR DESCRIPTION
This PR renames DefaultTokenCredential to DefaultAzureCredential.