### PR TITLE
Adding sample for azcompute

### DIFF
--- a/sdk/compute/mgmt/2019-12-01/azcompute/example_test.go
+++ b/sdk/compute/mgmt/2019-12-01/azcompute/example_test.go
@@ -1,0 +1,164 @@
+package azcompute
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/network/mgmt/2020-03-01/aznetwork"
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
+)
+
+const (
+	vmName   = "sampleVM"
+	username = "sampleuser"
+	password = "SamplePassword0"
+)
+
+var (
+	// Azure location where the resource will be created
+	location = os.Getenv("AZURE_LOCATION")
+	// Name of the Network Interface to retrieve
+	nicName = os.Getenv("AZURE_NIC")
+	// Azure resource group to retrieve and create resources
+	resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP")
+	// The subscription ID where the resource group exists
+	subscriptionID = os.Getenv("AZURE_SUBSCRIPTION_ID")
+)
+
+// returns a credential that can be used to authenticate with blob storage
+func getCredential() azcore.Credential {
+	// NewEnvironmentCredential() will read various environment vars
+	// to obtain a credential.  see the documentation for more info.
+	cred, err := azidentity.NewEnvironmentCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+	return cred
+}
+
+func getVMClient() VirtualMachinesOperations {
+	vmClient, err := NewClient("https://management.azure.com", getCredential(), nil)
+	if err != nil {
+		return nil
+	}
+	return vmClient.VirtualMachinesOperations(subscriptionID)
+}
+
+func ExampleVirtualMachinesOperations_BeginCreateOrUpdate() {
+	nic, err := getNIC()
+	if err != nil {
+		panic(err)
+	}
+	client := getVMClient()
+	vm, err := client.BeginCreateOrUpdate(
+		context.Background(),
+		resourceGroupName,
+		vmName,
+		VirtualMachine{
+			Resource: Resource{
+				Location: to.StringPtr(location),
+			},
+			Properties: &VirtualMachineProperties{
+				HardwareProfile: &HardwareProfile{
+					VMSize: VirtualMachineSizeTypesStandardA0.ToPtr(),
+				},
+				StorageProfile: &StorageProfile{
+					ImageReference: &ImageReference{
+						Publisher: to.StringPtr("MicrosoftWindowsServer"),
+						Offer:     to.StringPtr("WindowsServer"),
+						Sku:       to.StringPtr("2012-R2-Datacenter"),
+						Version:   to.StringPtr("latest"),
+					},
+				},
+				OSProfile: &OSProfile{
+					ComputerName:  to.StringPtr(vmName),
+					AdminUsername: to.StringPtr(username),
+					AdminPassword: to.StringPtr(password),
+				},
+				NetworkProfile: &NetworkProfile{
+					NetworkInterfaces: &[]NetworkInterfaceReference{
+						{
+							SubResource: SubResource{
+								ID: nic.NetworkInterface.ID,
+							},
+							Properties: &NetworkInterfaceReferenceProperties{
+								Primary: to.BoolPtr(true),
+							},
+						},
+					},
+				},
+			},
+		})
+	if err != nil {
+		panic(err)
+	}
+	result, err := vm.PollUntilDone(context.Background(), 5*time.Second)
+	if err != nil {
+		panic(err)
+	}
+	if result != nil {
+		fmt.Println(*vm.VirtualMachine.Name)
+	}
+	// Output:
+	// sampleVM
+}
+
+func ExampleVirtualMachinesOperations_Get() {
+	client := getVMClient()
+	vm, err := client.Get(context.Background(), resourceGroupName, vmName)
+	if err != nil {
+		panic(err)
+	}
+	if vm.VirtualMachine != nil {
+		fmt.Println(*vm.VirtualMachine.Name)
+	}
+	// Output:
+	// sampleVM
+}
+
+func ExampleVirtualMachinesOperations_List() {
+	client := getVMClient()
+	vmList, err := client.List(resourceGroupName)
+	if err != nil {
+		panic(err)
+	}
+	var vmListResult []VirtualMachine
+	count := 0
+	for vmList.NextPage(context.Background()) {
+		resp := vmList.PageResponse()
+		if len(*resp.VirtualMachineListResult.Value) == 0 {
+			panic("missing payload")
+		}
+		for _, vm := range *resp.VirtualMachineListResult.Value {
+			vmListResult = append(vmListResult, vm)
+		}
+		count++
+	}
+	if err = vmList.Err(); err != nil {
+		panic(err)
+	}
+	for _, vm := range vmListResult {
+		fmt.Println(*vm.Name)
+	}
+	// Output:
+	// sampleVM
+}
+
+// client for using the operations on the NetworkInterfacesOperations
+func getNetworkInterfacesClient() aznetwork.NetworkInterfacesOperations {
+	nicClient, err := aznetwork.NewClient("https://management.azure.com", getCredential(), nil)
+	if err != nil {
+		panic(err)
+	}
+	return nicClient.NetworkInterfacesOperations(subscriptionID)
+}
+
+// returns the specified network interface from Azure
+func getNIC() (*aznetwork.NetworkInterfaceResponse, error) {
+	client := getNetworkInterfacesClient()
+	return client.Get(context.Background(), resourceGroupName, nicName, nil)
+}

--- a/sdk/compute/mgmt/2019-12-01/azcompute/go.mod
+++ b/sdk/compute/mgmt/2019-12-01/azcompute/go.mod
@@ -2,4 +2,13 @@ module github.com/Azure/azure-sdk-for-go/sdk/compute/mgmt/2019-12-01/azcompute
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.8.0
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.8.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.0.0-00010101000000-000000000000
+	github.com/Azure/azure-sdk-for-go/sdk/network/mgmt/2020-03-01/aznetwork v0.0.0-00010101000000-000000000000
+	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0
+)
+
+replace github.com/Azure/azure-sdk-for-go/sdk/azidentity => ../../../../azidentity
+
+replace github.com/Azure/azure-sdk-for-go/sdk/network/mgmt/2020-03-01/aznetwork => ../../../../network/mgmt/2020-03-01/aznetwork

--- a/sdk/compute/mgmt/2019-12-01/azcompute/go.sum
+++ b/sdk/compute/mgmt/2019-12-01/azcompute/go.sum
@@ -1,4 +1,7 @@
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.5.0/go.mod h1:UKq2za3CMGx75vfPM9tPSuTBNODR4hX1qAeb+GRoDkc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.8.0 h1:ogZVkNX3wS6ekWS3hD9sQCghWIGfw8CQ9JKv0rQQlVw=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.8.0/go.mod h1:UKq2za3CMGx75vfPM9tPSuTBNODR4hX1qAeb+GRoDkc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.0 h1:sgOdyT1ZAW3nErwCuvlGrkeP03pTtbRBW5MGCXWGZws=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
+github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0 h1:5PmE4x8xzfL3onRdC5adQPrJSMDhYT2h5DwPB1uR9tA=
+github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0/go.mod h1:UL/d4lvWAzSJUuX+19uKdN0ktyjoOyQhgY+HWNgtIYI=


### PR DESCRIPTION
Adding compute sample that creates/updates a VM, gets a VM and lists VMs in a resource group. Also demonstrates the use of pollers and pagers. 