### PR TITLE
Adding firewall policies sample with more complex examples

### DIFF
--- a/sdk/arm/network/2020-03-01/armnetwork/example_firewallpolicies_test.go
+++ b/sdk/arm/network/2020-03-01/armnetwork/example_firewallpolicies_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
+// This sample requires the following environment variables to be set correctly in order to run:
+// AZURE_LOCATION: Azure location where the resource will be created
+// AZURE_RESOURCE_GROUP: Azure resource group to retrieve and create resources
+// AZURE_SUBSCRIPTION_ID: The subscription ID where the resource group exists
+// AZURE_TENANT_ID: The Azure Active Directory tenant (directory) ID of the service principal.
+// AZURE_CLIENT_ID: The client (application) ID of the service principal.
+// AZURE_CLIENT_SECRET: A client secret that was generated for the App Registration used to authenticate the client.
+
 const (
 	policyName    = "samplepolicy"
 	ruleGroupName = "sampleRuleGroup"

--- a/sdk/arm/network/2020-03-01/armnetwork/example_firewallpolicies_test.go
+++ b/sdk/arm/network/2020-03-01/armnetwork/example_firewallpolicies_test.go
@@ -32,6 +32,9 @@ func getFirewallPoliciesOperations() FirewallPoliciesOperations {
 	return client.FirewallPoliciesOperations(subscriptionID)
 }
 
+// Environment variables that are required to run this example:
+// AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET,
+// AZURE_RESOURCE_GROUP, AZURE_LOCATION
 func ExampleFirewallPolicyRuleGroupsOperations_BeginCreateOrUpdate() {
 	// get FirewallPoliciesOperations and create a new FirewallPolicy to use in the FirewallPolicyRuleGroup
 	fwPolicy := createFirewallPolicy(resourceGroupName, location, policyName)
@@ -72,6 +75,9 @@ func ExampleFirewallPolicyRuleGroupsOperations_BeginCreateOrUpdate() {
 	// 200
 }
 
+// Environment variables that are required to run this example:
+// AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET,
+// AZURE_RESOURCE_GROUP
 func ExampleFirewallPolicyRuleGroupsOperations_BeginDelete() {
 	fwClient := getFirewallPolicyRuleGroupsOperations()
 	fwResp, err := fwClient.BeginDelete(context.Background(), resourceGroupName, policyName, ruleGroupName)

--- a/sdk/arm/network/2020-03-01/armnetwork/example_firewallpolicies_test.go
+++ b/sdk/arm/network/2020-03-01/armnetwork/example_firewallpolicies_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package armnetwork
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/arm/resources/2019-05-01/armresources"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
+)
+
+const (
+	policyName    = "samplepolicy"
+	ruleGroupName = "sampleRuleGroup"
+)
+
+func getResourceGroupsOperations() armresources.ResourceGroupsOperations {
+	client, err := armresources.NewDefaultClient(getCredential(), nil)
+	if err != nil {
+		panic(err)
+	}
+	return client.ResourceGroupsOperations(subscriptionID)
+}
+
+func getFirewallPolicyRuleGroupsOperations() FirewallPolicyRuleGroupsOperations {
+	client, err := NewDefaultClient(getCredential(), nil)
+	if err != nil {
+		panic(err)
+	}
+	return client.FirewallPolicyRuleGroupsOperations(subscriptionID)
+}
+
+func getFirewallPoliciesOperations() FirewallPoliciesOperations {
+	client, err := NewDefaultClient(getCredential(), nil)
+	if err != nil {
+		panic(err)
+	}
+	return client.FirewallPoliciesOperations(subscriptionID)
+}
+
+func ExampleFirewallPolicyRuleGroupsOperations_BeginCreateOrUpdate() {
+	// create a new resource group to create resource in
+	rg := createResourceGroup(resourceGroupName, location)
+	rgName := *rg.Name
+	// get FirewallPoliciesOperations and create a new FirewallPolicy to use in the FirewallPolicyRuleGroup
+	fwPolicy := createFirewallPolicy(rgName, location, policyName)
+	fwPolicyName := *fwPolicy.Name
+	// get FirewallPolicyRuleGroupsOperations and create a new FirewallPolicyRuleGroup using the FirewallPolicy that was previously created
+	fwClient := getFirewallPolicyRuleGroupsOperations()
+	fwResp, err := fwClient.BeginCreateOrUpdate(
+		context.Background(),
+		rgName,
+		fwPolicyName,
+		ruleGroupName,
+		FirewallPolicyRuleGroup{
+			Name: to.StringPtr(ruleGroupName),
+			Properties: &FirewallPolicyRuleGroupProperties{
+				Priority: to.Int32Ptr(110),
+				Rules: &[]FirewallPolicyRuleClassification{
+					&FirewallPolicyFilterRule{
+						FirewallPolicyRule: FirewallPolicyRule{
+							Priority: to.Int32Ptr(110),
+							Name:     to.StringPtr("rule1"),
+							RuleType: FirewallPolicyRuleTypeFirewallPolicyFilterRule.ToPtr(),
+						},
+						Action: &FirewallPolicyFilterRuleAction{
+							Type: FirewallPolicyFilterRuleActionTypeDeny.ToPtr(),
+						},
+					},
+				},
+			},
+		})
+	if err != nil {
+		panic(err)
+	}
+	res, err := fwResp.PollUntilDone(context.Background(), 5*time.Second)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(*res)
+}
+
+func ExampleFirewallPolicyRuleGroupsOperations_BeginDelete() {
+	fwClient := getFirewallPolicyRuleGroupsOperations()
+	fwResp, err := fwClient.BeginDelete(context.Background(), resourceGroupName, policyName, ruleGroupName)
+	if err != nil {
+		panic(err)
+	}
+	res, err := fwResp.PollUntilDone(context.Background(), 5*time.Second)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res.StatusCode)
+}
+
+func ExampleResourceGroupsOperations_BeginDelete() {
+	rgClient := getResourceGroupsOperations()
+	rgResp, err := rgClient.BeginDelete(context.Background(), resourceGroupName)
+	if err != nil {
+		panic(err)
+	}
+	// the following demonstrates the recommended way to manually handle polling
+	poller := rgResp.Poller
+	for {
+		resp, err := poller.Poll(context.Background())
+		if err != nil {
+			panic(err)
+		}
+		if poller.Done() {
+			break
+		}
+		if delay := azcore.RetryAfter(resp); delay > 0 {
+			time.Sleep(delay)
+		} else {
+			time.Sleep(5 * time.Second)
+		}
+	}
+	res := poller.FinalResponse()
+	fmt.Println(res.StatusCode)
+}
+
+func createResourceGroup(rgName, loc string) *armresources.ResourceGroup {
+	rgClient := getResourceGroupsOperations()
+	rgResp, err := rgClient.CreateOrUpdate(
+		context.Background(),
+		rgName,
+		armresources.ResourceGroup{
+			Name:     to.StringPtr(rgName),
+			Location: to.StringPtr(loc),
+		})
+	if err != nil {
+		panic(err)
+	}
+	return rgResp.ResourceGroup
+}
+
+func createFirewallPolicy(rgName, loc, policyName string) *FirewallPolicy {
+	fpClient := getFirewallPoliciesOperations()
+	fpResp, err := fpClient.BeginCreateOrUpdate(
+		context.Background(),
+		rgName,
+		policyName,
+		FirewallPolicy{
+			Resource: Resource{
+				Name:     to.StringPtr(policyName),
+				Location: to.StringPtr(loc),
+			},
+		})
+	if err != nil {
+		panic(err)
+	}
+	return fpResp.FirewallPolicy
+}

--- a/sdk/arm/network/2020-03-01/armnetwork/example_firewallpolicies_test.go
+++ b/sdk/arm/network/2020-03-01/armnetwork/example_firewallpolicies_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 // This sample requires the following environment variables to be set correctly in order to run:
-// AZURE_LOCATION: Azure location where the resource will be created
-// AZURE_RESOURCE_GROUP: Azure resource group to retrieve and create resources
-// AZURE_SUBSCRIPTION_ID: The subscription ID where the resource group exists
+// AZURE_LOCATION: Azure location where the resource will be created.
+// AZURE_RESOURCE_GROUP: Azure resource group to retrieve and create resources.
+// AZURE_SUBSCRIPTION_ID: The subscription ID where the resource group exists.
 // AZURE_TENANT_ID: The Azure Active Directory tenant (directory) ID of the service principal.
 // AZURE_CLIENT_ID: The client (application) ID of the service principal.
 // AZURE_CLIENT_SECRET: A client secret that was generated for the App Registration used to authenticate the client.

--- a/sdk/arm/network/2020-03-01/armnetwork/go.mod
+++ b/sdk/arm/network/2020-03-01/armnetwork/go.mod
@@ -5,7 +5,10 @@ go 1.13
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.0.0-00010101000000-000000000000
+	github.com/Azure/azure-sdk-for-go/sdk/arm/resources/2019-05-01/armresources v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0
 )
 
 replace github.com/Azure/azure-sdk-for-go/sdk/azidentity => ../../../../azidentity
+
+replace github.com/Azure/azure-sdk-for-go/sdk/arm/resources/2019-05-01/armresources => ../../../resources/2019-05-01/armresources

--- a/sdk/arm/network/2020-03-01/armnetwork/go.mod
+++ b/sdk/arm/network/2020-03-01/armnetwork/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.0.0-00010101000000-000000000000
-	github.com/Azure/azure-sdk-for-go/sdk/arm/resources/2019-05-01/armresources v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0
 )
 


### PR DESCRIPTION
This PR includes:
- Example for creating a FirewallPolicy
- Example for create a FirewallPolicyRuleGroup that first creates a resource group that will then have the firewall resources added to it. This example also uses FirewallPolicyRuleClassifications which are discriminated types and also uses the previously created FirewallPolicy for the FirewallPolicyRuleGroup.
- Example for deleting FirewallPolicyRuleGroup
- Example for deleting a ResourceGroup with a manual example for polling
