### PR TITLE
Add initial work for CLI Credential

### DIFF
--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -85,7 +85,7 @@ func (c *aadIdentityClient) refreshAccessToken(ctx context.Context, tenantID str
 	return nil, &AuthenticationFailedError{inner: newAADAuthenticationFailedError(resp)}
 }
 
-// Authenticate creates a client secret authentication request and returns the resulting Access Token or
+// authenticate creates a client secret authentication request and returns the resulting Access Token or
 // an error in case of authentication failure.
 // ctx: The current request context
 // tenantID: The Azure Active Directory tenant (directory) ID of the service principal
@@ -110,7 +110,7 @@ func (c *aadIdentityClient) authenticate(ctx context.Context, tenantID string, c
 	return nil, &AuthenticationFailedError{inner: newAADAuthenticationFailedError(resp)}
 }
 
-// AuthenticateCertificate creates a client certificate authentication request and returns an Access Token or
+// authenticateCertificate creates a client certificate authentication request and returns an Access Token or
 // an error.
 // ctx: The current request context
 // tenantID: The Azure Active Directory tenant (directory) ID of the service principal

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -21,6 +21,8 @@ const (
 	AzureGovernment = "https://login.microsoftonline.us/"
 	// AzurePublicCloud is a global constant to use in order to access the Azure public cloud.
 	AzurePublicCloud = "https://login.microsoftonline.com/"
+	// defaultSuffix is a suffix the signals that a string is in scope format
+	defaultSuffix = "/.default"
 )
 
 var (

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -60,8 +60,7 @@ func (c *AzureCLICredential) AuthenticationPolicy(options azcore.AuthenticationP
 	return newBearerTokenPolicy(c, options)
 }
 
-// TODO: should the CLI request have a timeout? This is currently not being used
-const timeoutCLIRequest = 10000
+const timeoutCLIRequest = 10000 * time.Millisecond
 
 // authenticate creates a client secret authentication request and returns the resulting Access Token or
 // an error in case of authentication failure.
@@ -97,7 +96,7 @@ func defaultTokenProvider() func(ctx context.Context, resource string) ([]byte, 
 			return nil, fmt.Errorf(invalidResourceErrorTemplate, resource)
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, timeoutCLIRequest*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, timeoutCLIRequest)
 		defer cancel()
 
 		// Execute Azure CLI to get token

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -35,9 +35,7 @@ type AzureCLICredential struct {
 // options: configure the management of the requests sent to Azure Active Directory.
 func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredential, error) {
 	if options == nil {
-		var o AzureCLICredentialOptions
-		o.TokenProvider = defaultTokenProvider()
-		options = &o
+		options = &AzureCLICredentialOptions{TokenProvider: defaultTokenProvider()}
 	}
 	return &AzureCLICredential{
 		tokenProvider: options.TokenProvider,

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// AzureCLICredentialOptions contains options used to configure the AzureCLICredential
+type AzureCLICredentialOptions struct{}
+
+// AzureCLICredential enables authentication to Azure Active Directory using the Azure CLI command "az account get-access-token".
+type AzureCLICredential struct{}
+
+// TODO: do we want an options bag for this credential that includes a developer specified Azure CLI path or only specify with env var?
+// NewAzureCLICredential constructs a new AzureCLICredential with the details needed to authenticate against Azure Active Directory
+// options: configure the management of the requests sent to Azure Active Directory.
+func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredential, error) {
+	return &AzureCLICredential{}, nil
+}
+
+// GetToken obtains a token from Azure Active Directory, using the Azure CLI command to authenticate.
+// ctx: Context used to control the request lifetime.
+// opts: TokenRequestOptions contains the list of scopes for which the token will have access.
+// Returns an AccessToken which can be used to authenticate service client calls.
+func (c *AzureCLICredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
+	// The following code will remove the /.default suffix from the scope passed into the method since AzureCLI expect a resource string instead of a scope string
+	if strings.HasSuffix(opts.Scopes[0], defaultSuffix) {
+		opts.Scopes[0] = opts.Scopes[0][:len(opts.Scopes[0])-len(defaultSuffix)]
+	}
+	return c.authenticate(ctx, opts.Scopes[0])
+}
+
+// AuthenticationPolicy implements the azcore.Credential interface on AzureCLICredential and calls the Bearer Token policy
+// to get the bearer token.
+func (c *AzureCLICredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+	return newBearerTokenPolicy(c, options)
+}
+
+// TODO: should the CLI request have a timeout? This is currently not being used
+const timeoutCLIRequest = 10000
+
+// cliToken represents an AccessToken from the Azure CLI
+type cliToken struct {
+	AccessToken      string `json:"accessToken"`
+	Authority        string `json:"_authority"`
+	ClientID         string `json:"_clientId"`
+	ExpiresOn        string `json:"expiresOn"`
+	IdentityProvider string `json:"identityProvider"`
+	IsMRRT           bool   `json:"isMRRT"`
+	RefreshToken     string `json:"refreshToken"`
+	Resource         string `json:"resource"`
+	TokenType        string `json:"tokenType"`
+	UserID           string `json:"userId"`
+}
+
+// authenticate creates a client secret authentication request and returns the resulting Access Token or
+// an error in case of authentication failure.
+// ctx: The current request context
+// scopes: The scopes for which the token has access
+func (c *AzureCLICredential) authenticate(ctx context.Context, resource string) (*azcore.AccessToken, error) {
+	output, err := c.executeCLICommand(ctx, resource)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.createAccessToken(output)
+}
+
+func (c *AzureCLICredential) executeCLICommand(ctx context.Context, resource string) (*cliToken, error) {
+	// This is the path that a developer can set to tell this class what the install path for Azure CLI is.
+	const azureCLIPath = "AZURE_CLI_PATH"
+
+	// The default install paths are used to find Azure CLI. This is for security, so that any path in the calling program's Path environment is not used to execute Azure CLI.
+	azureCLIDefaultPathWindows := fmt.Sprintf("%s\\Microsoft SDKs\\Azure\\CLI2\\wbin; %s\\Microsoft SDKs\\Azure\\CLI2\\wbin", os.Getenv("ProgramFiles(x86)"), os.Getenv("ProgramFiles"))
+
+	// Default path for non-Windows.
+	const azureCLIDefaultPath = "/bin:/sbin:/usr/bin:/usr/local/bin"
+
+	// Validate resource, since it gets sent as a command line argument to Azure CLI
+	const invalidResourceErrorTemplate = "Resource %s is not in expected format. Only alphanumeric characters, [dot], [colon], [hyphen], and [forward slash] are allowed."
+	match, err := regexp.MatchString("^[0-9a-zA-Z-.:/]+$", resource)
+	if err != nil {
+		return nil, err
+	}
+	if !match {
+		return nil, fmt.Errorf(invalidResourceErrorTemplate, resource)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeoutCLIRequest*time.Second)
+	defer cancel()
+
+	// Execute Azure CLI to get token
+	var cliCmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cliCmd = exec.Command(fmt.Sprintf("%s\\system32\\cmd.exe", os.Getenv("windir")))
+		cliCmd.Env = os.Environ()
+		cliCmd.Env = append(cliCmd.Env, fmt.Sprintf("PATH=%s;%s", os.Getenv(azureCLIPath), azureCLIDefaultPathWindows))
+		cliCmd.Args = append(cliCmd.Args, "/c", "az")
+	} else {
+		cliCmd = exec.Command("az")
+		cliCmd.Env = os.Environ()
+		cliCmd.Env = append(cliCmd.Env, fmt.Sprintf("PATH=%s:%s", os.Getenv(azureCLIPath), azureCLIDefaultPath))
+	}
+	cliCmd.Args = append(cliCmd.Args, "account", "get-access-token", "-o", "json", "--resource", resource)
+
+	var stderr bytes.Buffer
+	cliCmd.Stderr = &stderr
+
+	output, err := cliCmd.Output()
+	if err != nil {
+		return nil, &CredentialUnavailableError{CredentialType: "Azure CLI Credential", Message: stderr.String()}
+	}
+
+	tokenResponse := cliToken{}
+	err = json.Unmarshal(output, &tokenResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tokenResponse, err
+}
+
+func (c *AzureCLICredential) createAccessToken(t *cliToken) (*azcore.AccessToken, error) {
+	tokenExpirationDate, err := parseExpirationDate(t.ExpiresOn)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing Token Expiration Date %q: %+v", t.ExpiresOn, err)
+	}
+
+	converted := &azcore.AccessToken{
+		Token:     t.AccessToken,
+		ExpiresOn: *tokenExpirationDate,
+	}
+	return converted, nil
+}
+
+// parseExpirationDate parses either a Azure CLI or CloudShell date into a time object
+func parseExpirationDate(input string) (*time.Time, error) {
+	// CloudShell (and potentially the Azure CLI in future)
+	expirationDate, cloudShellErr := time.Parse(time.RFC3339, input)
+	if cloudShellErr != nil {
+		// Azure CLI (Python) e.g. 2017-08-31 19:48:57.998857 (plus the local timezone)
+		const cliFormat = "2006-01-02 15:04:05.999999"
+		expirationDate, cliErr := time.ParseInLocation(cliFormat, input, time.Local)
+		if cliErr != nil {
+			return nil, fmt.Errorf("Error parsing expiration date %q.\n\nCloudShell Error: \n%+v\n\nCLI Error:\n%+v", input, cloudShellErr, cliErr)
+		}
+		return &expirationDate, nil
+	}
+	return &expirationDate, nil
+}

--- a/sdk/azidentity/azure_cli_credential_test.go
+++ b/sdk/azidentity/azure_cli_credential_test.go
@@ -12,25 +12,21 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-type mockCLITokenProviderSuccess struct{}
-
-func (p *mockCLITokenProviderSuccess) GetCLIToken(ctx context.Context, resource string) ([]byte, error) {
-	return []byte(" {\"accessToken\":\"mocktoken\" , " +
-		"\"expiresOn\": \"2007-01-01 01:01:01.079627\"," +
-		"\"subscription\": \"mocksub\"," +
-		"\"tenant\": \"mocktenant\"," +
-		"\"tokenType\": \"mocktype\"}"), nil
-}
-
-type mockCLITokenProviderFailure struct{}
-
-func (p *mockCLITokenProviderFailure) GetCLIToken(ctx context.Context, resource string) ([]byte, error) {
-	return nil, errors.New("provider failure message")
-}
+var (
+	mockCLITokenProviderSuccess = func(ctx context.Context, resource string) ([]byte, error) {
+		return []byte(" {\"accessToken\":\"mocktoken\" , " +
+			"\"expiresOn\": \"2007-01-01 01:01:01.079627\"," +
+			"\"subscription\": \"mocksub\"," +
+			"\"tenant\": \"mocktenant\"," +
+			"\"tokenType\": \"mocktype\"}"), nil
+	}
+	mockCLITokenProviderFailure = func(ctx context.Context, resource string) ([]byte, error) {
+		return nil, errors.New("provider failure message")
+	}
+)
 
 func TestAzureCLICredential_GetTokenSuccess(t *testing.T) {
-	mockTkProvider := &mockCLITokenProviderSuccess{}
-	cred, err := NewAzureCLICredential(&AzureCLICredentialOptions{TokenProvider: mockTkProvider})
+	cred, err := NewAzureCLICredential(&AzureCLICredentialOptions{TokenProvider: mockCLITokenProviderSuccess})
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
@@ -48,8 +44,7 @@ func TestAzureCLICredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestAzureCLICredential_GetTokenInvalidToken(t *testing.T) {
-	mockTkProvider := &mockCLITokenProviderFailure{}
-	cred, err := NewAzureCLICredential(&AzureCLICredentialOptions{TokenProvider: mockTkProvider})
+	cred, err := NewAzureCLICredential(&AzureCLICredentialOptions{TokenProvider: mockCLITokenProviderFailure})
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}

--- a/sdk/azidentity/azure_cli_credential_test.go
+++ b/sdk/azidentity/azure_cli_credential_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+type mockCLITokenProviderSuccess struct{}
+
+func (p *mockCLITokenProviderSuccess) GetCLIToken(ctx context.Context, resource string) ([]byte, error) {
+	return []byte(" {\"accessToken\":\"mocktoken\" , " +
+		"\"expiresOn\": \"2007-01-01 01:01:01.079627\"," +
+		"\"subscription\": \"mocksub\"," +
+		"\"tenant\": \"mocktenant\"," +
+		"\"tokenType\": \"mocktype\"}"), nil
+}
+
+type mockCLITokenProviderFailure struct{}
+
+func (p *mockCLITokenProviderFailure) GetCLIToken(ctx context.Context, resource string) ([]byte, error) {
+	return nil, errors.New("provider failure message")
+}
+
+func TestAzureCLICredential_GetTokenSuccess(t *testing.T) {
+	mockTkProvider := &mockCLITokenProviderSuccess{}
+	cred, err := NewAzureCLICredential(&AzureCLICredentialOptions{TokenProvider: mockTkProvider})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	at, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	if err != nil {
+		fmt.Println(err.Error())
+		t.Fatalf("Expected an empty error but received: %v", err)
+	}
+	if len(at.Token) == 0 {
+		t.Fatalf(("Did not receive a token"))
+	}
+	if at.Token != "mocktoken" {
+		t.Fatalf(("Did not receive the correct access token"))
+	}
+}
+
+func TestAzureCLICredential_GetTokenInvalidToken(t *testing.T) {
+	mockTkProvider := &mockCLITokenProviderFailure{}
+	cred, err := NewAzureCLICredential(&AzureCLICredentialOptions{TokenProvider: mockTkProvider})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	if err == nil {
+		t.Fatalf("Expected an error but did not receive one.")
+	}
+}

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -36,7 +36,7 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 
 // GetToken obtains a token from Azure Active Directory, using the specified client secret to authenticate.
 // ctx: Context used to control the request lifetime.
-// scopes: The list of scopes for which the token will have access.
+// opts: TokenRequestOptions contains the list of scopes for which the token will have access.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *ClientSecretCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
 	return c.client.authenticate(ctx, c.tenantID, c.clientID, c.clientSecret, opts.Scopes)

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -11,8 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-const defaultSuffix = "/.default"
-
 // ManagedIdentityCredentialOptions contains parameters that can be used to configure the pipeline used with Managed Identity Credential.
 type ManagedIdentityCredentialOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.


### PR DESCRIPTION
This PR ports the track1 CLI Credential implementation to track2 format, so that users can use the token provided when authenticating with the CLI.
