### PR TITLE
Bug fix for conflicting request paths in DeviceCodeCredential

### DIFF
--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -179,7 +179,8 @@ func (c *aadIdentityClient) createRefreshAccessToken(res *azcore.Response) (*tok
 }
 
 func (c *aadIdentityClient) createRefreshTokenRequest(tenantID, clientID, clientSecret, refreshToken string, scopes []string) (*azcore.Request, error) {
-	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
+	u := *c.options.AuthorityHost
+	u.Path = path.Join(u.Path, tenantID, tokenEndpoint)
 	data := url.Values{}
 	data.Set(qpGrantType, "refresh_token")
 	data.Set(qpClientID, clientID)
@@ -191,14 +192,13 @@ func (c *aadIdentityClient) createRefreshTokenRequest(tenantID, clientID, client
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, *c.options.AuthorityHost)
-	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
-	err := msg.SetBody(body)
+	req := azcore.NewRequest(http.MethodPost, u)
+	req.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
+	err := req.SetBody(body)
 	if err != nil {
 		return nil, err
 	}
-
-	return msg, nil
+	return req, nil
 }
 
 func (c *aadIdentityClient) createClientSecretAuthRequest(tenantID string, clientID string, clientSecret string, scopes []string) (*azcore.Request, error) {
@@ -325,7 +325,8 @@ func (c *aadIdentityClient) createDeviceCodeAuthRequest(tenantID string, clientI
 	if len(tenantID) == 0 { // if the user did not pass in a tenantID then the default value is set
 		tenantID = "organizations"
 	}
-	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+tokenEndpoint)
+	u := *c.options.AuthorityHost
+	u.Path = path.Join(u.Path, tenantID, tokenEndpoint)
 	data := url.Values{}
 	data.Set(qpGrantType, deviceCodeGrantType)
 	data.Set(qpClientID, clientID)
@@ -333,13 +334,13 @@ func (c *aadIdentityClient) createDeviceCodeAuthRequest(tenantID string, clientI
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, *c.options.AuthorityHost)
-	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
-	err := msg.SetBody(body)
+	req := azcore.NewRequest(http.MethodPost, u)
+	req.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
+	err := req.SetBody(body)
 	if err != nil {
 		return nil, err
 	}
-	return msg, nil
+	return req, nil
 }
 
 func (c *aadIdentityClient) requestNewDeviceCode(ctx context.Context, tenantID, clientID string, scopes []string) (*deviceCodeResult, error) {
@@ -363,13 +364,14 @@ func (c *aadIdentityClient) createDeviceCodeNumberRequest(tenantID string, clien
 	if len(tenantID) == 0 { // if the user did not pass in a tenantID then the default value is set
 		tenantID = "organizations"
 	}
-	c.options.AuthorityHost.Path = path.Join(c.options.AuthorityHost.Path, tenantID+"/oauth2/v2.0/devicecode") // endpoint that will return a device code along with the other necessary authentication flow parameters in the DeviceCodeResult struct
+	u := *c.options.AuthorityHost
+	u.Path = path.Join(u.Path, tenantID, "/oauth2/v2.0/devicecode") // endpoint that will return a device code along with the other necessary authentication flow parameters in the DeviceCodeResult struct
 	data := url.Values{}
 	data.Set(qpClientID, clientID)
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, *c.options.AuthorityHost)
+	msg := azcore.NewRequest(http.MethodPost, u)
 	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
 	err := msg.SetBody(body)
 	if err != nil {

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -371,13 +371,13 @@ func (c *aadIdentityClient) createDeviceCodeNumberRequest(tenantID string, clien
 	data.Set(qpScope, strings.Join(scopes, " "))
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	msg := azcore.NewRequest(http.MethodPost, u)
-	msg.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
-	err := msg.SetBody(body)
+	req := azcore.NewRequest(http.MethodPost, u)
+	req.Header.Set(azcore.HeaderContentType, azcore.HeaderURLEncoded)
+	err := req.SetBody(body)
 	if err != nil {
 		return nil, err
 	}
-	return msg, nil
+	return req, nil
 }
 
 func getPrivateKey(cert string) (*rsa.PrivateKey, error) {

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -222,6 +222,26 @@ func TestDeviceCodeCredential_GetTokenExpiredToken(t *testing.T) {
 	}
 }
 
+func TestDeviceCodeCredential_GetTokenWithRefreshToken(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	srvURL := srv.URL()
+	handler := func(string) {}
+	cred, err := NewDeviceCodeCredential(tenantID, clientID, handler, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	cred.refreshToken = "refresh_token"
+	tk, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}})
+	if err != nil {
+		t.Fatalf("Expected an empty error but received: %s", err.Error())
+	}
+	if tk.Token != "new_token" {
+		t.Fatalf("Received an unexpected value in azcore.AccessToken.Token")
+	}
+}
+
 func TestBearerPolicy_DeviceCodeCredential(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()


### PR DESCRIPTION
This PR fixes a problem where the request path for a refresh token was in conflict with the previous request path set in the DeviceCodeCredential flow. Changes request creation to make a copy of the authority host in all of the requests related to DeviceCodeCredential, instead of changing the value on the credential. 