### PR TITLE
Azure Identity add more test coverage

### DIFF
--- a/sdk/azidentity/aad_identity_client_test.go
+++ b/sdk/azidentity/aad_identity_client_test.go
@@ -4,32 +4,34 @@
 package azidentity
 
 import (
-	"context"
 	"net/url"
 	"testing"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
 
-func TestCreateClientAssertionJWT(t *testing.T) {
+func TestAzurePublicCloudParse(t *testing.T) {
 	_, err := url.Parse(AzurePublicCloud)
 	if err != nil {
 		t.Fatalf("Failed to parse default authority host: %v", err)
 	}
 }
 
-func TestClientSecretCredential_GetTokenUnexpectedJSON(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespMalformed)))
-	srvURL := srv.URL()
-	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+func TestAzureChinaParse(t *testing.T) {
+	_, err := url.Parse(AzureChina)
 	if err != nil {
-		t.Fatalf("Failed to create the credential")
+		t.Fatalf("Failed to parse AzureChina authority host: %v", err)
 	}
-	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
-	if err == nil {
-		t.Fatalf("Expected a JSON marshal error but received nil")
+}
+
+func TestAzureGermanyParse(t *testing.T) {
+	_, err := url.Parse(AzureGermany)
+	if err != nil {
+		t.Fatalf("Failed to parse AzureGermany authority host: %v", err)
+	}
+}
+
+func TestAzureGovernmentParse(t *testing.T) {
+	_, err := url.Parse(AzureGovernment)
+	if err != nil {
+		t.Fatalf("Failed to parse AzureGovernment authority host: %v", err)
 	}
 }

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -80,13 +80,12 @@ func (e *AuthenticationFailedError) Error() string {
 }
 
 func newAADAuthenticationFailedError(resp *azcore.Response) error {
-	authFailed := &AADAuthenticationFailedError{}
+	authFailed := &AADAuthenticationFailedError{Response: resp}
 	err := resp.UnmarshalAsJSON(authFailed)
 	if err != nil {
 		authFailed.Message = resp.Status
 		authFailed.Description = "Failed to unmarshal response: " + err.Error()
 	}
-	authFailed.Response = resp
 	return authFailed
 }
 

--- a/sdk/azidentity/azure_cli_credential_test.go
+++ b/sdk/azidentity/azure_cli_credential_test.go
@@ -73,6 +73,6 @@ func TestBearerPolicy_AzureCLICredential(t *testing.T) {
 		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
 	_, err = pipeline.Do(context.Background(), azcore.NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
-		t.Fatalf("Expected nil error but received one")
+		t.Fatal("Expected nil error but received one")
 	}
 }

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -50,7 +50,10 @@ func TestChainedTokenCredential_InstantiateFailure(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected an error for not sending any credential sources")
 	}
-
+	var credErr *CredentialUnavailableError
+	if !errors.As(err, &credErr) {
+		t.Fatalf("Expected a CredentialUnavailableError, but received: %T", credErr)
+	}
 }
 
 func TestChainedTokenCredential_GetTokenSuccess(t *testing.T) {

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -35,6 +35,21 @@ func TestChainedTokenCredential_InstantiateSuccess(t *testing.T) {
 			t.Fatalf("Expected 2 sources in the chained token credential, instead found %d", len(cred.sources))
 		}
 	}
+}
+
+func TestChainedTokenCredential_InstantiateFailure(t *testing.T) {
+	secCred, err := NewClientSecretCredential(tenantID, clientID, secret, nil)
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	_, err = NewChainedTokenCredential(secCred, nil)
+	if err == nil {
+		t.Fatalf("Expected an error for sending a nil credential in the chain")
+	}
+	_, err = NewChainedTokenCredential()
+	if err == nil {
+		t.Fatalf("Expected an error for not sending any credential sources")
+	}
 
 }
 

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -46,11 +46,14 @@ func TestChainedTokenCredential_InstantiateFailure(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected an error for sending a nil credential in the chain")
 	}
+	var credErr *CredentialUnavailableError
+	if !errors.As(err, &credErr) {
+		t.Fatalf("Expected a CredentialUnavailableError, but received: %T", credErr)
+	}
 	_, err = NewChainedTokenCredential()
 	if err == nil {
 		t.Fatalf("Expected an error for not sending any credential sources")
 	}
-	var credErr *CredentialUnavailableError
 	if !errors.As(err, &credErr) {
 		t.Fatalf("Expected a CredentialUnavailableError, but received: %T", credErr)
 	}

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -123,3 +123,18 @@ func TestClientSecretCredential_GetTokenInvalidCredentials(t *testing.T) {
 		}
 	}
 }
+
+func TestClientSecretCredential_GetTokenUnexpectedJSON(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespMalformed)))
+	srvURL := srv.URL()
+	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: &srvURL})
+	if err != nil {
+		t.Fatalf("Failed to create the credential")
+	}
+	_, err = cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{scope}})
+	if err == nil {
+		t.Fatalf("Expected a JSON marshal error but received nil")
+	}
+}


### PR DESCRIPTION
This PR increases test coverage for untested paths in Azure Identity. Increases package test coverage to 81.3%.