### PR TITLE
Add new error types to sdk/internal/runtime package

### DIFF
--- a/sdk/internal/runtime/frame_error.go
+++ b/sdk/internal/runtime/frame_error.go
@@ -12,12 +12,13 @@ import (
 
 // NewFrameError wraps the specified error with an error that provides stack frame information.
 // Call this at the inner error's origin to provide file name and line number info with the error.
+// You MUST supply an inner error.
 // DO NOT ARBITRARILY CALL THIS TO WRAP ERRORS!  There MUST be only ONE error of this type in the chain.
 func NewFrameError(inner error, stackTrace bool, skipFrames, totalFrames int) error {
 	fe := frameError{inner: inner, info: "stack trace unavailable"}
 	if stackTrace {
-		// the skipFrames+2 is to skip StackTrace and ourselves
-		fe.info = StackTrace(skipFrames+2, totalFrames)
+		// the skipFrames+3 is to skip runtime.Callers(), StackTrace and ourselves
+		fe.info = StackTrace(skipFrames+3, totalFrames)
 	} else if pc, file, line, ok := runtime.Caller(skipFrames + 1); ok {
 		// the skipFrames + 1 is to skip ourselves
 		frame := runtime.FuncForPC(pc)

--- a/sdk/internal/runtime/frame_error.go
+++ b/sdk/internal/runtime/frame_error.go
@@ -1,0 +1,43 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// NewFrameError wraps the specified error with an error that provides stack frame information.
+// Call this at the inner error's origin to provide file name and line number info with the error.
+// DO NOT ARBITRARILY CALL THIS TO WRAP ERRORS!  There MUST be only ONE error of this type in the chain.
+func NewFrameError(inner error, stackTrace bool, skipFrames, totalFrames int) error {
+	fe := frameError{inner: inner, info: "stack trace unavailable"}
+	if stackTrace {
+		// the skipFrames+2 is to skip StackTrace and ourselves
+		fe.info = StackTrace(skipFrames+2, totalFrames)
+	} else if pc, file, line, ok := runtime.Caller(skipFrames + 1); ok {
+		// the skipFrames + 1 is to skip ourselves
+		frame := runtime.FuncForPC(pc)
+		fe.info = fmt.Sprintf("%s()\n\t%s:%d\n", frame.Name(), file, line)
+	}
+	return &fe
+}
+
+// contains stack frame info
+type frameError struct {
+	inner error
+	info  string
+}
+
+// Error implements the error interface for type frameError.
+func (f *frameError) Error() string {
+	return fmt.Sprintf("%s: \n%s\n", f.inner.Error(), f.info)
+}
+
+// Unwrap returns the inner error.
+func (f *frameError) Unwrap() error {
+	return f.inner
+}

--- a/sdk/internal/runtime/frame_error.go
+++ b/sdk/internal/runtime/frame_error.go
@@ -34,7 +34,7 @@ type frameError struct {
 
 // Error implements the error interface for type frameError.
 func (f *frameError) Error() string {
-	return fmt.Sprintf("%s: \n%s\n", f.inner.Error(), f.info)
+	return fmt.Sprintf("%s:\n%s\n", f.inner.Error(), f.info)
 }
 
 // Unwrap returns the inner error.

--- a/sdk/internal/runtime/frame_error_test.go
+++ b/sdk/internal/runtime/frame_error_test.go
@@ -1,0 +1,42 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFrameError(t *testing.T) {
+	err := NewFrameError(errors.New("failed"), false, 0, 0)
+	trace := strings.TrimSpace(err.Error())
+	parts := strings.Split(trace, "\n")
+	// parts will be three:
+	// failed:
+	//   path/to/TestFrameError()
+	//     <source code and line number>
+	const length = 3
+	if l := len(parts); l != length {
+		t.Fatalf("expected %d frames, got %d", length, l)
+	}
+	if strings.LastIndex(parts[1], "TestFrameError()") == -1 {
+		t.Fatalf("didn't find TestFrameError() in %s", parts[1])
+	}
+}
+
+func TestFrameErrorWithStack(t *testing.T) {
+	err := NewFrameError(errors.New("failed"), true, 0, 5)
+	trace := strings.TrimSpace(err.Error())
+	parts := strings.Split(trace, "\n")
+	if l := len(parts); l < 3 {
+		t.Fatalf("not enough frames, got %d", l)
+	}
+	// parts will be more than three but with the same top-most values as previous test
+	if strings.LastIndex(parts[1], "TestFrameErrorWithStack()") == -1 {
+		t.Fatalf("didn't find TestFrameErrorWithStack() in %s", parts[1])
+	}
+}

--- a/sdk/internal/runtime/response_error.go
+++ b/sdk/internal/runtime/response_error.go
@@ -8,8 +8,9 @@ package runtime
 import "net/http"
 
 // NewResponseError wraps the specified error with an error that provides access to an HTTP response.
-// If an HTTP request fails, wrap the response and any associated error in this error type so that
+// If an HTTP request fails, wrap the response and the associated error in this error type so that
 // callers can access the underlying *http.Response as required.
+// You MUST supply an inner error.
 func NewResponseError(inner error, resp *http.Response) error {
 	return &ResponseError{inner: inner, resp: resp}
 }

--- a/sdk/internal/runtime/response_error.go
+++ b/sdk/internal/runtime/response_error.go
@@ -1,0 +1,37 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import "net/http"
+
+// NewResponseError wraps the specified error with an error that provides access to an HTTP response.
+// If an HTTP request fails, wrap the response and any associated error in this error type so that
+// callers can access the underlying *http.Response as required.
+func NewResponseError(inner error, resp *http.Response) error {
+	return &ResponseError{inner: inner, resp: resp}
+}
+
+// ResponseError associates an error with an HTTP response.
+// Exported for type assertion purposes in azcore, use NewResponseError().
+type ResponseError struct {
+	inner error
+	resp  *http.Response
+}
+
+// Error implements the error interface for type ResponseError.
+func (e *ResponseError) Error() string {
+	return e.inner.Error()
+}
+
+// Unwrap returns the inner error.
+func (e *ResponseError) Unwrap() error {
+	return e.inner
+}
+
+// Response returns the HTTP response associated with this error.
+func (e *ResponseError) Response() *http.Response {
+	return e.resp
+}

--- a/sdk/internal/runtime/runtime.go
+++ b/sdk/internal/runtime/runtime.go
@@ -1,0 +1,34 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// StackTrace returns a formatted stack trace string.
+// skipFrames - the number of stack frames to skip before composing the trace string.
+// totalFrames - the maximum number of stack frames to include in the trace string.
+func StackTrace(skipFrames, totalFrames int) string {
+	sb := strings.Builder{}
+	pcCallers := make([]uintptr, totalFrames)
+	runtime.Callers(skipFrames, pcCallers)
+	frames := runtime.CallersFrames(pcCallers)
+	for {
+		frame, more := frames.Next()
+		sb.WriteString(frame.Function)
+		sb.WriteString("()\n\t")
+		sb.WriteString(frame.File)
+		sb.WriteRune(':')
+		sb.WriteString(fmt.Sprintf("%d\n", frame.Line))
+		if !more {
+			break
+		}
+	}
+	return sb.String()
+}

--- a/sdk/internal/runtime/runtime_test.go
+++ b/sdk/internal/runtime/runtime_test.go
@@ -1,0 +1,42 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStackTraceBasic(t *testing.T) {
+	trace := StackTrace(0, 1)
+	trace = strings.TrimSpace(trace)
+	parts := strings.Split(trace, "\n")
+	const topFrame = "runtime.Callers()"
+	if parts[0] != topFrame {
+		t.Fatalf("got %s, expected %s", parts[0], topFrame)
+	}
+}
+
+func TestStackTraceSkipFrame(t *testing.T) {
+	trace := StackTrace(1, 1)
+	trace = strings.TrimSpace(trace)
+	parts := strings.Split(trace, "\n")
+	const topFrame = "runtime.StackTrace()"
+	if strings.LastIndex(parts[0], topFrame) == -1 {
+		t.Fatalf("%s didn't end with %s", parts[0], topFrame)
+	}
+}
+
+func TestStackTraceFrameCount(t *testing.T) {
+	trace := StackTrace(0, 5)
+	trace = strings.TrimSpace(trace)
+	parts := strings.Split(trace, "\n")
+	// five stack frames, each is two lines, total 10 parts
+	const length = 10
+	if l := len(parts); l != length {
+		t.Fatalf("expected %d frames, got %d", length, l)
+	}
+}


### PR DESCRIPTION
Added NewFrameError() for wrapping errors with stack frame information.
Added NewResponseError() for wrapping errors and/or failed HTTP requests
with the underlying HTTP response.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
