### PR TITLE
Fixes to sdk/internal/runtime

### DIFF
--- a/sdk/internal/runtime/frame_error.go
+++ b/sdk/internal/runtime/frame_error.go
@@ -15,7 +15,7 @@ import (
 // You MUST supply an inner error.
 // DO NOT ARBITRARILY CALL THIS TO WRAP ERRORS!  There MUST be only ONE error of this type in the chain.
 func NewFrameError(inner error, stackTrace bool, skipFrames, totalFrames int) error {
-	fe := frameError{inner: inner, info: "stack trace unavailable"}
+	fe := FrameError{inner: inner, info: "stack trace unavailable"}
 	if stackTrace {
 		// the skipFrames+3 is to skip runtime.Callers(), StackTrace and ourselves
 		fe.info = StackTrace(skipFrames+3, totalFrames)
@@ -27,18 +27,19 @@ func NewFrameError(inner error, stackTrace bool, skipFrames, totalFrames int) er
 	return &fe
 }
 
-// contains stack frame info
-type frameError struct {
+// FrameError associates an error with stack frame information.
+// Exported for testing purposes, use NewFrameError().
+type FrameError struct {
 	inner error
 	info  string
 }
 
-// Error implements the error interface for type frameError.
-func (f *frameError) Error() string {
+// Error implements the error interface for type FrameError.
+func (f *FrameError) Error() string {
 	return fmt.Sprintf("%s:\n%s\n", f.inner.Error(), f.info)
 }
 
 // Unwrap returns the inner error.
-func (f *frameError) Unwrap() error {
+func (f *FrameError) Unwrap() error {
 	return f.inner
 }

--- a/sdk/internal/runtime/response_error.go
+++ b/sdk/internal/runtime/response_error.go
@@ -32,7 +32,7 @@ func (e *ResponseError) Unwrap() error {
 	return e.inner
 }
 
-// Response returns the HTTP response associated with this error.
-func (e *ResponseError) Response() *http.Response {
+// RawResponse returns the HTTP response associated with this error.
+func (e *ResponseError) RawResponse() *http.Response {
 	return e.resp
 }


### PR DESCRIPTION
Export FrameError so it can be used for type assertions in test cases
outside the internal module.
Renamed Response() method to RawResponse() per new guidelines.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
