### PR TITLE
Add HTTPResponse interface

### DIFF
--- a/sdk/azcore/error.go
+++ b/sdk/azcore/error.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"net/http"
 
-	azruntime "github.com/Azure/azure-sdk-for-go/sdk/internal/runtime"
+	sdkruntime "github.com/Azure/azure-sdk-for-go/sdk/internal/runtime"
 )
 
 var (
@@ -32,4 +32,4 @@ type HTTPResponse interface {
 }
 
 // ensure our internal ResponseError type implements HTTPResponse
-var _ HTTPResponse = (*azruntime.ResponseError)(nil)
+var _ HTTPResponse = (*sdkruntime.ResponseError)(nil)

--- a/sdk/azcore/error.go
+++ b/sdk/azcore/error.go
@@ -7,7 +7,9 @@ package azcore
 
 import (
 	"errors"
-	"fmt"
+	"net/http"
+
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/internal/runtime"
 )
 
 var (
@@ -15,39 +17,19 @@ var (
 	ErrNoMorePolicies = errors.New("no more policies")
 )
 
-// TODO: capture frame info for marshal, unmarshal, and parsing errors
-// built in frame in xerror?  %w
-type frameInfo struct {
-	file string
-	line int
+var (
+	// StackFrameCount contains the number of stack frames to include when a trace is being collected.
+	StackFrameCount = 32
+)
+
+// HTTPResponse provides access to an HTTP response when available.
+// Errors returned from failed API calls will implement this interface.
+// Use errors.As() to access this interface in the error chain.
+// If there was no HTTP response then this interface will be omitted
+// from any error in the chain.
+type HTTPResponse interface {
+	RawResponse() *http.Response
 }
 
-func (f frameInfo) String() string {
-	if f.zero() {
-		return ""
-	}
-	return fmt.Sprintf("file: %s, line: %d", f.file, f.line)
-}
-
-func (f frameInfo) zero() bool {
-	return f.file == "" && f.line == 0
-}
-
-// RequestError is returned when the service returns an unsuccessful resopnse code (4xx, 5xx).
-type RequestError struct {
-	msg  string
-	resp *Response
-}
-
-func newRequestError(message string, response *Response) error {
-	return RequestError{msg: message, resp: response}
-}
-
-func (re RequestError) Error() string {
-	return re.msg
-}
-
-// Response returns the underlying response.
-func (re RequestError) Response() *Response {
-	return re.resp
-}
+// ensure our internal ResponseError type implements HTTPResponse
+var _ HTTPResponse = (*azruntime.ResponseError)(nil)

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -1,5 +1,5 @@
 module github.com/Azure/azure-sdk-for-go/sdk/azcore
 
-require github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.1
+require github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.0
 
 go 1.13

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -1,2 +1,2 @@
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.1 h1:S87cbjhPwbSqbygGH69JpB6txa/y1ce2ewaWBQa8Cws=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.1/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.0 h1:cLpVMIkXC/umSP9DMz9I6FttDWJAsmvhpaB6MlkagGY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=


### PR DESCRIPTION
To be used by callers to access the raw HTTP response from an error in
the event of an API call failure.
Updated sdk/internal dependency to latest version.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
