### PR TITLE
Add service-level builds for track 2 sdk-for-go

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,5 +1,5 @@
 parameters:
-  ServiceDirectory: 'sdk/...' #defaults to building all track 2 go packages
+  ServiceDirectory: ''
 
 stages:
   - stage: Build

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -20,8 +20,8 @@ steps:
       $modDirs = (./eng/scripts/get_module_dirs.ps1 -serviceDir $(SCOPE))
       foreach ($md in $modDirs) {
         pushd $md
-        Write-Host "##[command]Executing go build -v $md"
-        go build -v
+        Write-Host "##[command]Executing go build -v ./... in $md"
+        go build -v ./...
       }
     displayName: 'Build'
     workingDirectory: '${{parameters.GoWorkspace}}'
@@ -32,8 +32,8 @@ steps:
       $modDirs = (./eng/scripts/get_module_dirs.ps1 -serviceDir $(SCOPE))
       foreach ($md in $modDirs) {
         pushd $md
-        Write-Host "##[command]Executing go vet $md"
-        go vet
+        Write-Host "##[command]Executing go vet ./... in $md"
+        go vet ./...
       }
     displayName: 'Vet'
     workingDirectory: '${{parameters.GoWorkspace}}'

--- a/sdk/armcore/ci.yml
+++ b/sdk/armcore/ci.yml
@@ -1,0 +1,14 @@
+trigger:
+  paths:
+    include:
+    - sdk/armcore/
+
+pr:
+  paths:
+    include:
+    - sdk/armcore/
+    
+stages:
+- template: ../eng/pipelines/templates/jobs/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: 'armcore'

--- a/sdk/azcore/ci.yml
+++ b/sdk/azcore/ci.yml
@@ -1,0 +1,14 @@
+trigger:
+  paths:
+    include:
+    - sdk/azcore/
+
+pr:
+  paths:
+    include:
+    - sdk/azcore/
+    
+stages:
+- template: ../eng/pipelines/templates/jobs/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: 'azcore'

--- a/sdk/internal/ci.yml
+++ b/sdk/internal/ci.yml
@@ -1,0 +1,14 @@
+trigger:
+  paths:
+    include:
+    - sdk/internal/
+
+pr:
+  paths:
+    include:
+    - sdk/internal/
+    
+stages:
+- template: ../eng/pipelines/templates/jobs/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: 'internal'

--- a/sdk/to/ci.yml
+++ b/sdk/to/ci.yml
@@ -1,0 +1,14 @@
+trigger:
+  paths:
+    include:
+    - sdk/to/
+
+pr:
+  paths:
+    include:
+    - sdk/to/
+    
+stages:
+- template: ../eng/pipelines/templates/jobs/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: 'to'


### PR DESCRIPTION
This will enable us to shift from

`track 2 CI builds All sdk/...` TO `track 2 CI builds only the sdk/<service> where files have been affected`.

@jhendrixMSFT 