### PR TITLE
Fix nil pointer dereference for mock TLS server

### DIFF
--- a/sdk/internal/mock/mock.go
+++ b/sdk/internal/mock/mock.go
@@ -40,20 +40,24 @@ type Server struct {
 	count int
 }
 
+func newServer() *Server {
+	return &Server{respLock: &sync.RWMutex{}}
+}
+
 // NewServer creates a new Server object.
 // The returned close func must be called when the server is no longer needed.
 func NewServer() (*Server, func()) {
-	s := Server{respLock: &sync.RWMutex{}}
+	s := newServer()
 	s.srv = httptest.NewServer(http.HandlerFunc(s.serveHTTP))
-	return &s, func() { s.srv.Close() }
+	return s, func() { s.srv.Close() }
 }
 
 // NewTLSServer creates a new Server object.
 // The returned close func must be called when the server is no longer needed.
 func NewTLSServer() (*Server, func()) {
-	s := Server{}
+	s := newServer()
 	s.srv = httptest.NewTLSServer(http.HandlerFunc(s.serveHTTP))
-	return &s, func() { s.srv.Close() }
+	return s, func() { s.srv.Close() }
 }
 
 // returns true if the next response is an error response


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
