### PR TITLE
Omit read-only content from request payloads

### DIFF
--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -266,7 +266,13 @@ func recursiveCloneWithoutReadOnlyFields(val reflect.Value) interface{} {
 		} else if reflect.Indirect(val.Field(i)).Kind() == reflect.Struct {
 			// recursive case
 			v := recursiveCloneWithoutReadOnlyFields(reflect.Indirect(val.Field(i)))
-			reflect.Indirect(clone).Field(i).Set(reflect.ValueOf(v))
+			if t.Field(i).Anonymous {
+				// NOTE: this does not handle the case of embedded fields of unexported struct types.
+				// this should be ok as we don't generate any code like this at present
+				reflect.Indirect(clone).Field(i).Set(reflect.Indirect(reflect.ValueOf(v)))
+			} else {
+				reflect.Indirect(clone).Field(i).Set(reflect.ValueOf(v))
+			}
 		} else {
 			// no azure RO tag, non-recursive case, include in payload
 			reflect.Indirect(clone).Field(i).Set(val.Field(i))

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -116,6 +116,7 @@ func (req *Request) MarshalAsByteArray(v []byte, format Base64Encoding) error {
 // MarshalAsJSON calls json.Marshal() to get the JSON encoding of v then calls SetBody.
 // If json.Marshal fails a MarshalError is returned.  Any error from SetBody is returned.
 func (req *Request) MarshalAsJSON(v interface{}) error {
+	v = cloneWithoutReadOnlyFields(v)
 	b, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Errorf("error marshalling type %s: %w", reflect.TypeOf(v).Name(), err)
@@ -218,4 +219,72 @@ func (req *Request) copy() *Request {
 			GetBody:       req.GetBody,
 		},
 	}
+}
+
+// returns a clone of the object graph pointed to by v, omitting values of all read-only
+// fields. if there are no read-only fields in the object graph, no clone is created.
+func cloneWithoutReadOnlyFields(v interface{}) interface{} {
+	val := reflect.Indirect(reflect.ValueOf(v))
+	if val.Kind() != reflect.Struct {
+		// not a struct, skip
+		return v
+	}
+	// first walk the graph to find any R/O fields.
+	// if there aren't any, skip cloning the graph.
+	if !recursiveFindReadOnlyField(val) {
+		return v
+	}
+	return recursiveCloneWithoutReadOnlyFields(val)
+}
+
+// returns true if any field in the object graph of val contains the `azure:"ro"` tag value
+func recursiveFindReadOnlyField(val reflect.Value) bool {
+	t := val.Type()
+	// iterate over the fields, looking for the "azure" tag.
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		aztag := field.Tag.Get("azure")
+		if azureTagIsReadOnly(aztag) {
+			return true
+		} else if reflect.Indirect(val.Field(i)).Kind() == reflect.Struct && recursiveFindReadOnlyField(reflect.Indirect(val.Field(i))) {
+			return true
+		}
+	}
+	return false
+}
+
+// clones the object graph of val.  all non-R/O properties are copied to the clone
+func recursiveCloneWithoutReadOnlyFields(val reflect.Value) interface{} {
+	clone := reflect.New(val.Type())
+	t := val.Type()
+	// iterate over the fields, looking for the "azure" tag.
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		aztag := field.Tag.Get("azure")
+		if azureTagIsReadOnly(aztag) {
+			// omit from payload
+		} else if reflect.Indirect(val.Field(i)).Kind() == reflect.Struct {
+			// recursive case
+			v := recursiveCloneWithoutReadOnlyFields(reflect.Indirect(val.Field(i)))
+			reflect.Indirect(clone).Field(i).Set(reflect.ValueOf(v))
+		} else {
+			// no azure RO tag, non-recursive case, include in payload
+			reflect.Indirect(clone).Field(i).Set(val.Field(i))
+		}
+	}
+	return clone.Interface()
+}
+
+// returns true if the "azure" tag contains the option "ro"
+func azureTagIsReadOnly(tag string) bool {
+	if tag == "" {
+		return false
+	}
+	parts := strings.Split(tag, ",")
+	for _, part := range parts {
+		if part == "ro" {
+			return true
+		}
+	}
+	return false
 }

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -420,6 +420,35 @@ func TestCloneWithoutReadOnlyFieldsCloneEmbedded(t *testing.T) {
 	}
 }
 
+func TestCloneWithoutReadOnlyFieldsCloneByVal(t *testing.T) {
+	id := int32(123)
+	name := "widget"
+	type withReadOnly struct {
+		ID   *int32  `json:"id" azure:"ro"`
+		Name *string `json:"name"`
+	}
+	nro := withReadOnly{
+		ID:   &id,
+		Name: &name,
+	}
+	v := cloneWithoutReadOnlyFields(nro)
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	um := withReadOnly{}
+	err = json.Unmarshal(b, &um)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if um.ID != nil {
+		t.Fatalf("expected nil ID, got %d", *um.ID)
+	}
+	if um.Name == nil {
+		t.Fatal("unexpected nil Name")
+	}
+}
+
 func TestAzureTagIsReadOnly(t *testing.T) {
 	if azureTagIsReadOnly("") {
 		t.Fatal()

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -451,18 +451,18 @@ func TestCloneWithoutReadOnlyFieldsCloneByVal(t *testing.T) {
 
 func TestAzureTagIsReadOnly(t *testing.T) {
 	if azureTagIsReadOnly("") {
-		t.Fatal()
+		t.Fatal("unexpected RO for empty string")
 	}
 	if azureTagIsReadOnly("rw") {
-		t.Fatal()
+		t.Fatal("unexpected RO for rw")
 	}
 	if azureTagIsReadOnly("this,that,the,other") {
-		t.Fatal()
+		t.Fatal("unexpected RO for this,that,the,other")
 	}
 	if !azureTagIsReadOnly("ro") {
-		t.Fatal()
+		t.Fatal("expected RO")
 	}
 	if !azureTagIsReadOnly("copy,ro,something") {
-		t.Fatal()
+		t.Fatal("expected RO")
 	}
 }

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -189,6 +189,9 @@ func TestCloneWithoutReadOnlyFieldsClone(t *testing.T) {
 	if um.ID != nil {
 		t.Fatalf("expected nil ID, got %d", *um.ID)
 	}
+	if um.Name == nil {
+		t.Fatal("unexpected nil Name")
+	}
 }
 
 func TestCloneWithoutReadOnlyFieldsCloneRecursive(t *testing.T) {
@@ -238,11 +241,20 @@ func TestCloneWithoutReadOnlyFieldsCloneRecursive(t *testing.T) {
 	if um.ID != nil {
 		t.Fatalf("expected nil ID, got %d", *um.ID)
 	}
+	if um.Name == nil {
+		t.Fatal("unexpected nil Name")
+	}
 	if um.Inner1.Thing != nil {
 		t.Fatalf("expected nil Thing, got %s", *um.Inner1.Thing)
 	}
+	if um.Inner1.Color == nil {
+		t.Fatal("unexpected nil Color")
+	}
 	if um.Inner1.Inner2.Unique != nil {
 		t.Fatalf("expected nil Unique, got %f", *um.Inner1.Inner2.Unique)
+	}
+	if um.Inner1.Inner2.Type == nil {
+		t.Fatal("unexpected nil Type")
 	}
 }
 
@@ -290,8 +302,23 @@ func TestCloneWithoutReadOnlyFieldsCloneNested(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if um.ID == nil {
+		t.Fatal("unexpected nil ID")
+	}
+	if um.Name == nil {
+		t.Fatal("unexpected nil Name")
+	}
+	if um.Inner1.Thing == nil {
+		t.Fatal("unexpected nil Thing")
+	}
+	if um.Inner1.Color == nil {
+		t.Fatal("unexpected nil Color")
+	}
 	if um.Inner1.Inner2.Unique != nil {
 		t.Fatalf("expected nil Unique, got %f", *um.Inner1.Inner2.Unique)
+	}
+	if um.Inner1.Inner2.Type == nil {
+		t.Fatal("unexpected nil Type")
 	}
 }
 


### PR DESCRIPTION
If any field in a payload's object graph contains `azure:"ro"`, make a
clone of the object graph, omitting all fields with this annotation.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
