### PR TITLE
Add support for custom HTTP request headers

### DIFF
--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -70,7 +70,7 @@ func NewPipeline(transport Transport, policies ...Policy) Pipeline {
 		transport = DefaultHTTPClientTransport()
 	}
 	// transport policy must always be the last in the slice
-	policies = append(policies, newBodyDownloadPolicy(), transportPolicy{trans: transport})
+	policies = append(policies, newHTTPHeaderPolicy(), newBodyDownloadPolicy(), transportPolicy{trans: transport})
 	return Pipeline{
 		policies: policies,
 	}

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -1,5 +1,5 @@
 module github.com/Azure/azure-sdk-for-go/sdk/azcore
 
-require github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.1
+require github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3
 
 go 1.13

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -1,2 +1,2 @@
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.1 h1:xY9/wUJ8PcxmTEJ6z+0qKuj9rb3Aw9nhiL+ik5evR/g=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.1/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3 h1:LqwNXxJyW493jG65Ki37BSgGtWN/YJHS8U8Pa7RGwrU=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=

--- a/sdk/azcore/policy_http_header.go
+++ b/sdk/azcore/policy_http_header.go
@@ -1,0 +1,40 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcore
+
+import (
+	"context"
+	"net/http"
+)
+
+// used as a context key for adding/retrieving http.Header
+type ctxWithHTTPHeader struct{}
+
+// newHTTPHeaderPolicy creates a policy object that adds custom HTTP headers to a request
+func newHTTPHeaderPolicy() Policy {
+	return PolicyFunc(func(ctx context.Context, req *Request) (*Response, error) {
+		// check if any custom HTTP headers have been specified
+		if header := ctx.Value(ctxWithHTTPHeader{}); header != nil {
+			for k, v := range header.(http.Header) {
+				// use Set to replace any existing value
+				// it also canonicalizes the header key
+				req.Header.Set(k, v[0])
+				// add any remaining values
+				for i := 1; i < len(v); i++ {
+					req.Header.Add(k, v[i])
+				}
+			}
+		}
+		return req.Next(ctx)
+	})
+}
+
+// WithHTTPHeader adds the specified http.Header to the parent context.
+// Use this to specify custom HTTP headers at the API-call level.
+// Any overlapping headers will have their values replaced with the values specified here.
+func WithHTTPHeader(parent context.Context, header http.Header) context.Context {
+	return context.WithValue(parent, ctxWithHTTPHeader{}, header)
+}

--- a/sdk/azcore/policy_http_header_test.go
+++ b/sdk/azcore/policy_http_header_test.go
@@ -1,0 +1,107 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcore
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+)
+
+func TestAddCustomHTTPHeaderSuccess(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	const customHeader = "custom-header"
+	const customValue = "custom-value"
+	const preexistingHeader = "preexisting-header"
+	const preexistingValue = "preexisting-value"
+	srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
+		// ensure preexisting header wasn't removed
+		return r.Header.Get(customHeader) == customValue && r.Header.Get(preexistingHeader) == preexistingValue
+	}), mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
+	// HTTP header policy is automatically added during pipeline construction
+	pl := NewPipeline(srv)
+	req := NewRequest(http.MethodGet, srv.URL())
+	req.Header.Set(preexistingHeader, preexistingValue)
+	resp, err := pl.Do(WithHTTPHeader(context.Background(), http.Header{
+		customHeader: []string{customValue},
+	}), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+}
+
+func TestAddCustomHTTPHeaderFail(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	const customValue = "custom-value"
+	srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
+		return r.Header.Get(xMsClientRequestID) == customValue
+	}), mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
+	// HTTP header policy is automatically added during pipeline construction
+	pl := NewPipeline(srv)
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+}
+
+func TestAddCustomHTTPHeaderOverwrite(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	const customValue = "custom-value"
+	srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
+		return r.Header.Get(xMsClientRequestID) == customValue
+	}), mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
+	// HTTP header policy is automatically added during pipeline construction
+	pl := NewPipeline(srv)
+	// overwrite the request ID with our own value
+	resp, err := pl.Do(WithHTTPHeader(context.Background(), http.Header{
+		xMsClientRequestID: []string{customValue},
+	}), NewRequest(http.MethodGet, srv.URL()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+}
+
+func TestAddCustomHTTPHeaderMultipleValues(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	const customHeader = "custom-header"
+	const customValue1 = "custom-value1"
+	const customValue2 = "custom-value2"
+	srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
+		vals := r.Header.Values(customHeader)
+		return vals[0] == customValue1 && vals[1] == customValue2
+	}), mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
+	// HTTP header policy is automatically added during pipeline construction
+	pl := NewPipeline(srv)
+	// overwrite the request ID with our own value
+	resp, err := pl.Do(WithHTTPHeader(context.Background(), http.Header{
+		customHeader: []string{customValue1, customValue2},
+	}), NewRequest(http.MethodGet, srv.URL()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+}

--- a/sdk/azcore/policy_http_header_test.go
+++ b/sdk/azcore/policy_http_header_test.go
@@ -8,6 +8,7 @@ package azcore
 import (
 	"context"
 	"net/http"
+	"net/textproto"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
@@ -88,7 +89,9 @@ func TestAddCustomHTTPHeaderMultipleValues(t *testing.T) {
 	const customValue1 = "custom-value1"
 	const customValue2 = "custom-value2"
 	srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
-		vals := r.Header.Values(customHeader)
+		// Values() method is Go 1.14+
+		//vals := r.Header.Values(customHeader)
+		vals := r.Header[textproto.CanonicalMIMEHeaderKey(customHeader)]
 		return vals[0] == customValue1 && vals[1] == customValue2
 	}), mock.WithStatusCode(http.StatusOK))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))


### PR DESCRIPTION
Inserts an internal policy into the pipeline that can extract HTTP
header values from the caller's context, adding them to the request.
Use azcore.WithHTTPHeader to add HTTP headers to a context.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
