### PR TITLE
Update autorest.go and autorest.core version to unblock the generation on some new swaggers

### DIFF
--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -8,14 +8,14 @@
       "gofmt -w ./services/"
     ],
     "autorest_options": {
-      "use": "@microsoft.azure/autorest.go@~2.1.152",
+      "use": "@microsoft.azure/autorest.go@~2.1.153",
       "go": "",
       "verbose": "",
       "sdkrel:go-sdk-folder": ".",
       "multiapi": "",
       "use-onever": "",
       "preview-chk": "",
-      "version": "previous"
+      "version": "V2"
     },
     "repotag": "azure-sdk-for-go",
     "envs": {


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- Update `autorest.go` to `v2.1.153` to avoid some unexpect NPE when `namespace` is not set or not detected.
- Update `autorest.core` to `v2` instead of `previous` to catch the latest swagger definitions