### PR TITLE
Set the Content-Length header in Request.SetBody

### DIFF
--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -169,6 +170,7 @@ func (req *Request) SetBody(body ReadSeekCloser) error {
 	}
 	req.Request.Body = body
 	req.Request.ContentLength = size
+	req.Header.Set(HeaderContentLength, strconv.FormatInt(size, 10))
 	return nil
 }
 

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -6,6 +6,7 @@
 package azcore
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	"testing"
 	"unsafe"
 )
@@ -464,5 +466,22 @@ func TestAzureTagIsReadOnly(t *testing.T) {
 	}
 	if !azureTagIsReadOnly("copy,ro,something") {
 		t.Fatal("expected RO")
+	}
+}
+
+func TestRequestSetBodyContentLengthHeader(t *testing.T) {
+	endpoint, err := url.Parse("http://test.contoso.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := NewRequest(http.MethodPut, *endpoint)
+	buff := make([]byte, 768, 768)
+	const buffLen = 768
+	for i := 0; i < buffLen; i++ {
+		buff[i] = 1
+	}
+	req.SetBody(NopCloser(bytes.NewReader(buff)))
+	if req.Header.Get(HeaderContentLength) != strconv.FormatInt(buffLen, 10) {
+		t.Fatalf("expected content-length %d, got %s", buffLen, req.Header.Get(HeaderContentLength))
 	}
 }


### PR DESCRIPTION
Even though the underlying transport will set this header, some
operations depend on this being available earlier (string-to-sign).

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
