### PR TITLE
Add support for PFX files

### DIFF
--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -5,30 +5,60 @@ package azidentity
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"golang.org/x/crypto/pkcs12"
 )
 
 // ClientCertificateCredential enables authentication of a service principal to Azure Active Directory using a certificate that is assigned to its App Registration. More information
 // on how to configure certificate authentication can be found here:
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-certificate-credentials#register-your-certificate-with-azure-ad
 type ClientCertificateCredential struct {
-	client            *aadIdentityClient
-	tenantID          string // The Azure Active Directory tenant (directory) ID of the service principal
-	clientID          string // The client (application) ID of the service principal
-	clientCertificate string // Path to the client certificate generated for the App Registration used to authenticate the client
+	client   *aadIdentityClient
+	tenantID string        // The Azure Active Directory tenant (directory) ID of the service principal
+	clientID string        // The client (application) ID of the service principal
+	cert     *certContents // The contents of the certificate file
 }
 
 // NewClientCertificateCredential creates an instance of ClientCertificateCredential with the details needed to authenticate against Azure Active Directory with the specified certificate.
 // tenantID: The Azure Active Directory tenant (directory) ID of the service principal.
 // clientID: The client (application) ID of the service principal.
-// clientCertificate: The path to the client certificate that was generated for the App Registration used to authenticate the client.
+// clientCertificate: The path to the client certificate used to authenticate the client.  Supported formats are PEM and PFX.
+// password: The password required to decrypt the private key.  Pass nil if there is no password.
 // options: configure the management of the requests sent to Azure Active Directory.
-func NewClientCertificateCredential(tenantID string, clientID string, clientCertificate string, options *TokenCredentialOptions) (*ClientCertificateCredential, error) {
+func NewClientCertificateCredential(tenantID string, clientID string, clientCertificate string, password *string, options *TokenCredentialOptions) (*ClientCertificateCredential, error) {
 	_, err := os.Stat(clientCertificate)
 	if err != nil {
 		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: "Certificate file not found in path: " + clientCertificate}
+		azcore.Log().Write(azcore.LogError, logCredentialError(credErr.CredentialType, credErr))
+		return nil, credErr
+	}
+	certData, err := ioutil.ReadFile(clientCertificate)
+	if err != nil {
+		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: err.Error()}
+		azcore.Log().Write(azcore.LogError, logCredentialError(credErr.CredentialType, credErr))
+		return nil, credErr
+	}
+	var cert *certContents
+	clientCertificate = strings.ToUpper(clientCertificate)
+	if strings.HasSuffix(clientCertificate, ".PEM") {
+		cert, err = extractFromPEMFile(certData, password)
+	} else if strings.HasSuffix(clientCertificate, ".PFX") {
+		cert, err = extractFromPFXFile(certData, password)
+	} else {
+		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: "only PEM and PFX files are supported"}
+		azcore.Log().Write(azcore.LogError, logCredentialError(credErr.CredentialType, credErr))
+		return nil, credErr
+	}
+	if err != nil {
+		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: err.Error()}
 		azcore.Log().Write(azcore.LogError, logCredentialError(credErr.CredentialType, credErr))
 		return nil, credErr
 	}
@@ -36,7 +66,104 @@ func NewClientCertificateCredential(tenantID string, clientID string, clientCert
 	if err != nil {
 		return nil, err
 	}
-	return &ClientCertificateCredential{tenantID: tenantID, clientID: clientID, clientCertificate: clientCertificate, client: c}, nil
+	return &ClientCertificateCredential{tenantID: tenantID, clientID: clientID, cert: cert, client: c}, nil
+}
+
+// contains decoded cert contents we care about
+type certContents struct {
+	fp fingerprint
+	pk *rsa.PrivateKey
+}
+
+func newCertContents(blocks []*pem.Block, fromPEM bool) (*certContents, error) {
+	cc := certContents{}
+	// first extract the private key
+	for _, block := range blocks {
+		if block.Type == "PRIVATE KEY" {
+			var key interface{}
+			var err error
+			if fromPEM {
+				key, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+			} else {
+				key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+			}
+			if err != nil {
+				return nil, err
+			}
+			rsaKey, ok := key.(*rsa.PrivateKey)
+			if !ok {
+				return nil, errors.New("unexpected private key type")
+			}
+			cc.pk = rsaKey
+			break
+		}
+	}
+	if cc.pk == nil {
+		return nil, errors.New("missing private key")
+	}
+	// now find the certificate with the matching public key of our private key
+	for _, block := range blocks {
+		if block.Type == "CERTIFICATE" {
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			certKey, ok := cert.PublicKey.(*rsa.PublicKey)
+			if !ok {
+				// keep looking
+				continue
+			}
+			if cc.pk.E != certKey.E || cc.pk.N.Cmp(certKey.N) != 0 {
+				// keep looking
+				continue
+			}
+			// found a match
+			fp, err := newFingerprint(block)
+			if err != nil {
+				return nil, err
+			}
+			cc.fp = fp
+			break
+		}
+	}
+	if cc.fp == nil {
+		return nil, errors.New("missing certificate")
+	}
+	return &cc, nil
+}
+
+func extractFromPEMFile(certData []byte, password *string) (*certContents, error) {
+	// TODO: wire up support for password
+	blocks := []*pem.Block{}
+	// read all of the PEM blocks
+	for {
+		var block *pem.Block
+		block, certData = pem.Decode(certData)
+		if block == nil {
+			break
+		}
+		blocks = append(blocks, block)
+	}
+	if len(blocks) == 0 {
+		return nil, errors.New("didn't find any blocks in PEM file")
+	}
+	return newCertContents(blocks, true)
+}
+
+func extractFromPFXFile(certData []byte, password *string) (*certContents, error) {
+	if password == nil {
+		empty := ""
+		password = &empty
+	}
+	// convert PFX binary data to PEM blocks
+	blocks, err := pkcs12.ToPEM(certData, *password)
+	if err != nil {
+		return nil, err
+	}
+	if len(blocks) == 0 {
+		return nil, errors.New("didn't find any blocks in PFX file")
+	}
+	return newCertContents(blocks, false)
 }
 
 // GetToken obtains a token from Azure Active Directory, using the certificate in the file path.
@@ -44,7 +171,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, clientCert
 // ctx: controlling the request lifetime.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	tk, err := c.client.authenticateCertificate(ctx, c.tenantID, c.clientID, c.clientCertificate, opts.Scopes)
+	tk, err := c.client.authenticateCertificate(ctx, c.tenantID, c.clientID, c.cert, opts.Scopes)
 	if err != nil {
 		addGetTokenFailureLogs("Client Certificate Credential", err)
 		return nil, err

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -53,9 +53,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, clientCert
 	} else if strings.HasSuffix(clientCertificate, ".PFX") {
 		cert, err = extractFromPFXFile(certData, password)
 	} else {
-		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: "only PEM and PFX files are supported"}
-		azcore.Log().Write(azcore.LogError, logCredentialError(credErr.CredentialType, credErr))
-		return nil, credErr
+		err = errors.New("only PEM and PFX files are supported")
 	}
 	if err != nil {
 		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: err.Error()}

--- a/sdk/azidentity/fingerprint.go
+++ b/sdk/azidentity/fingerprint.go
@@ -4,13 +4,10 @@
 package azidentity
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/sha1"
 	"encoding/pem"
-	"errors"
 	"fmt"
-	"os"
 )
 
 // fingerprint type wraps a byte slice that contains the corresponding SHA-1 fingerprint for the client's certificate
@@ -29,51 +26,13 @@ func (f fingerprint) String() string {
 	return buf.String()
 }
 
-// spkiFingerprint calculates the fingerprint of the certificate based on it's Subject Public Key Info with the SHA-1
+// newFingerprint calculates the fingerprint of the certificate based on it's Subject Public Key Info with the SHA-1
 // signing algorithm.
-func spkiFingerprint(cert string) (fingerprint, error) {
-	privateKeyFile, err := os.Open(cert)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", cert, err)
-	}
-	defer privateKeyFile.Close()
-
-	pemFileInfo, err := privateKeyFile.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	var size int64 = pemFileInfo.Size()
-	pemBytes := make([]byte, size)
-	buffer := bufio.NewReader(privateKeyFile)
-	_, err = buffer.Read(pemBytes)
-	if err != nil {
-		return nil, err
-	}
-	// Get first block of PEM file
-	data, rest := pem.Decode([]byte(pemBytes))
-	const certificateBlock = "CERTIFICATE"
-	if data.Type != certificateBlock {
-		for len(rest) > 0 {
-			data, rest = pem.Decode(rest)
-			if data.Type == certificateBlock {
-				// Sign the CERTIFICATE block with SHA1
-				h := sha1.New()
-				_, err := h.Write(data.Bytes)
-				if err != nil {
-					return nil, err
-				}
-
-				return fingerprint(h.Sum(nil)), nil
-			}
-		}
-		return nil, errors.New("Cannot find CERTIFICATE in file")
-	}
+func newFingerprint(block *pem.Block) (fingerprint, error) {
 	h := sha1.New()
-	_, err = h.Write(data.Bytes)
+	_, err := h.Write(block.Bytes)
 	if err != nil {
 		return nil, err
 	}
-
 	return fingerprint(h.Sum(nil)), nil
 }

--- a/sdk/azidentity/go.mod
+++ b/sdk/azidentity/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.1
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.2
+	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 )

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -4,3 +4,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.1 h1:xY9/wUJ8PcxmTEJ6z+0qKuj
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.1/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.2 h1:d1hG+ChFZNyblEulXP3unkwzUmh83grtG3t4sMV+6Xg=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.2/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This is to keep parity with track 1 that only supported PFX.
Moved reading and parsing of certificate data into the
NewClientCertificateCredential constructor so it will fail earlier.
Fixed an issue with certificates containing intermediate authorities.
