### PR TITLE
Improvements to telemetry policy

### DIFF
--- a/sdk/azcore/policy_telemetry_test.go
+++ b/sdk/azcore/policy_telemetry_test.go
@@ -42,3 +42,69 @@ func TestPolicyTelemetryWithCustomInfo(t *testing.T) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
+
+func TestPolicyTelemetryPreserveExisting(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse()
+	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
+	req := NewRequest(http.MethodGet, srv.URL())
+	const otherValue = "this should stay"
+	req.Header.Set(HeaderUserAgent, otherValue)
+	resp, err := pl.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", platformInfo, otherValue) {
+		t.Fatalf("unexpected user agent value: %s", v)
+	}
+}
+
+func TestPolicyTelemetryWithAppID(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse()
+	const appID = "my_application"
+	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{ApplicationID: appID}))
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", appID, platformInfo) {
+		t.Fatalf("unexpected user agent value: %s", v)
+	}
+}
+
+func TestPolicyTelemetryWithAppIDSanitized(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse()
+	const appID = "This will get the spaces removed an truncated."
+	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{ApplicationID: appID}))
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	const newAppID = "This/will/get/the/spaces"
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", newAppID, platformInfo) {
+		t.Fatalf("unexpected user agent value: %s", v)
+	}
+}
+
+func TestPolicyTelemetryPreserveExistingWithAappID(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse()
+	const appID = "my_application"
+	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{ApplicationID: appID}))
+	req := NewRequest(http.MethodGet, srv.URL())
+	const otherValue = "this should stay"
+	req.Header.Set(HeaderUserAgent, otherValue)
+	resp, err := pl.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s %s", appID, platformInfo, otherValue) {
+		t.Fatalf("unexpected user agent value: %s", v)
+	}
+}

--- a/sdk/azcore/policy_telemetry_test.go
+++ b/sdk/azcore/policy_telemetry_test.go
@@ -79,7 +79,7 @@ func TestPolicyTelemetryWithAppIDSanitized(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse()
-	const appID = "This will get the spaces removed an truncated."
+	const appID = "This will get the spaces removed and truncated."
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{ApplicationID: appID}))
 	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
 	if err != nil {
@@ -91,7 +91,7 @@ func TestPolicyTelemetryWithAppIDSanitized(t *testing.T) {
 	}
 }
 
-func TestPolicyTelemetryPreserveExistingWithAappID(t *testing.T) {
+func TestPolicyTelemetryPreserveExistingWithAppID(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse()
@@ -105,6 +105,21 @@ func TestPolicyTelemetryPreserveExistingWithAappID(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s %s", appID, platformInfo, otherValue) {
+		t.Fatalf("unexpected user agent value: %s", v)
+	}
+}
+
+func TestPolicyTelemetryDisabled(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse()
+	const appID = "my_application"
+	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{ApplicationID: appID, Disabled: true}))
+	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != "" {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }


### PR DESCRIPTION
Add support for application ID string.
Preserve any existing user-agent string data.
Add flag to disable telemetry info.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
