### PR TITLE
Improvements to body download policy

### DIFF
--- a/sdk/azcore/policy_body_download.go
+++ b/sdk/azcore/policy_body_download.go
@@ -22,17 +22,19 @@ func newBodyDownloadPolicy() Policy {
 			return resp, err
 		}
 		var opValues bodyDownloadPolicyOpValues
-		if req.OperationValue(&opValues); !opValues.skip && resp.Body != nil {
-			// Either bodyDownloadPolicyOpValues was not specified (so skip is false)
-			// or it was specified and skip is false: don't skip downloading the body
-			var b []byte
-			b, err = ioutil.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				return resp, newBodyDownloadError(err, req)
-			}
-			resp.Body = &nopClosingBytesReader{s: b}
+		// don't skip downloading error response bodies
+		if req.OperationValue(&opValues); opValues.skip && resp.StatusCode < 400 {
+			return resp, err
 		}
+		// Either bodyDownloadPolicyOpValues was not specified (so skip is false)
+		// or it was specified and skip is false: don't skip downloading the body
+		var b []byte
+		b, err = ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return resp, newBodyDownloadError(err, req)
+		}
+		resp.Body = &nopClosingBytesReader{s: b}
 		return resp, err
 	})
 }

--- a/sdk/azcore/policy_body_download.go
+++ b/sdk/azcore/policy_body_download.go
@@ -28,8 +28,7 @@ func newBodyDownloadPolicy() Policy {
 		}
 		// Either bodyDownloadPolicyOpValues was not specified (so skip is false)
 		// or it was specified and skip is false: don't skip downloading the body
-		var b []byte
-		b, err = ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			return resp, newBodyDownloadError(err, req)


### PR DESCRIPTION
Always download the response body for error responses, i.e. HTTP status
codes >= 400.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
