### PR TITLE
add `ignoredPaths` to profileBuilder

### DIFF
--- a/tools/profileBuilder/cmd/latest.go
+++ b/tools/profileBuilder/cmd/latest.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Azure/azure-sdk-for-go/tools/internal/dirs"
 	"github.com/Azure/azure-sdk-for-go/tools/profileBuilder/model"
 	"github.com/spf13/cobra"
 )
@@ -77,7 +76,7 @@ By default, this command ignores API versions that are in preview.`,
 		}
 
 		if clearOutputFlag {
-			if err := dirs.DeleteChildDirs(outputRootDir); err != nil {
+			if err := clearOutputFolder(outputRootDir, nil); err != nil {
 				errLog.Fatalf("Unable to clear output-folder: %v", err)
 			}
 		}

--- a/tools/profileBuilder/cmd/list.go
+++ b/tools/profileBuilder/cmd/list.go
@@ -122,7 +122,7 @@ $> ../model/testdata/smallProfile.txt > profileBuilder list --name small_profile
 		fmt.Printf("Executes profileBuilder in %s\n", outputRootDir)
 		outputLog.Printf("Output-Location set to: %s", outputRootDir)
 		if clearOutputFlag {
-			if err := dirs.DeleteChildDirs(outputRootDir); err != nil {
+			if err := clearOutputFolder(outputRootDir, listDef.IgnoredPaths); err != nil {
 				errLog.Fatalf("Unable to clear output-folder: %v", err)
 			}
 		}
@@ -200,4 +200,31 @@ func generateGoMod(modDir string) error {
 	}
 	_, err = fmt.Fprintf(gomod, gomodFormat, mod)
 	return err
+}
+
+func clearOutputFolder(root string, excepts []string) error {
+	children, err := dirs.GetSubdirs(root)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, child := range children {
+		if contains(excepts, child) {
+			continue
+		}
+		childPath := filepath.Join(root, child)
+		err = os.RemoveAll(childPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func contains(array []string, item string) bool {
+	for _, e := range array {
+		if e == item {
+			return true
+		}
+	}
+	return false
 }

--- a/tools/profileBuilder/model/transforms.go
+++ b/tools/profileBuilder/model/transforms.go
@@ -47,6 +47,7 @@ import (
 type ListDefinition struct {
 	Include      []string          `json:"include"`
 	PathOverride map[string]string `json:"pathOverride"`
+	IgnoredPaths []string          `json:"ignoredPaths"`
 }
 
 const (


### PR DESCRIPTION
Makes the `profileBuilder` could ignore some certain directories when it is clearing output folder. The new requirement of profiles contains some combination of swaggers that is not present in the go SDK repo now (also its package version is occupied), therefore we should directly generate this profile using autorest, and let profileBuilder to ignore it when it is clearing output folder.
