### PR TITLE
Adding AzureCLICredential to the DefaultAzureCredential chain

### DIFF
--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -10,6 +10,11 @@ import (
 	"testing"
 )
 
+const (
+	lengthOfChainOneExcluded = 2
+	lengthOfChainFull        = 3
+)
+
 func TestDefaultAzureCredential_ExcludeEnvCredential(t *testing.T) {
 	err := resetEnvironmentVarsForTest()
 	if err != nil {
@@ -21,8 +26,8 @@ func TestDefaultAzureCredential_ExcludeEnvCredential(t *testing.T) {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
 
-	if len(cred.sources) != 2 {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: 2, Received: %d", len(cred.sources))
+	if len(cred.sources) != lengthOfChainOneExcluded {
+		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainOneExcluded, len(cred.sources))
 	}
 	_ = os.Setenv("MSI_ENDPOINT", "")
 }
@@ -36,8 +41,8 @@ func TestDefaultAzureCredential_ExcludeMSICredential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
-	if len(cred.sources) != 2 {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: 2, Received: %d", len(cred.sources))
+	if len(cred.sources) != lengthOfChainOneExcluded {
+		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainOneExcluded, len(cred.sources))
 	}
 }
 
@@ -52,8 +57,8 @@ func TestDefaultAzureCredential_ExcludeAzureCLICredential(t *testing.T) {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
 
-	if len(cred.sources) != 2 {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: 2, Received: %d", len(cred.sources))
+	if len(cred.sources) != lengthOfChainOneExcluded {
+		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainOneExcluded, len(cred.sources))
 	}
 	_ = os.Setenv("MSI_ENDPOINT", "")
 	_ = resetEnvironmentVarsForTest()
@@ -95,13 +100,13 @@ func TestDefaultAzureCredential_NilOptions(t *testing.T) {
 	c := newManagedIdentityClient(nil)
 	// if the test is running in a MSI environment then the length of sources would be two since it will include environmnet credential and managed identity credential
 	if msiType, err := c.getMSIType(context.Background()); msiType == msiTypeIMDS || msiType == msiTypeCloudShell || msiType == msiTypeAppService {
-		if len(cred.sources) != 3 {
-			t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: 3, Received: %d", len(cred.sources))
+		if len(cred.sources) != lengthOfChainFull {
+			t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainFull, len(cred.sources))
 		}
 		//if a credential unavailable error is received or msiType is unknown then only the environment credential will be added
 	} else if unavailableErr := (*CredentialUnavailableError)(nil); errors.As(err, &unavailableErr) || msiType == msiTypeUnknown {
-		if len(cred.sources) != 2 {
-			t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: 2, Received: %d", len(cred.sources))
+		if len(cred.sources) != lengthOfChainOneExcluded {
+			t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainOneExcluded, len(cred.sources))
 		}
 		// if there is some other unexpected error then we fail here
 	} else if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
