### PR TITLE
Refactor azcore public surface area

### DIFF
--- a/sdk/azcore/error.go
+++ b/sdk/azcore/error.go
@@ -33,3 +33,12 @@ type HTTPResponse interface {
 
 // ensure our internal ResponseError type implements HTTPResponse
 var _ HTTPResponse = (*sdkruntime.ResponseError)(nil)
+
+// NonRetriableError represents a non-transient error.  This works in
+// conjunction with the retry policy, indicating that the error condition
+// is idempotent, so no retries will be attempted.
+// Use errors.As() to access this interface in the error chain.
+type NonRetriableError interface {
+	error
+	NonRetriable()
+}

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -1,10 +1,8 @@
 module github.com/Azure/azure-sdk-for-go/sdk/azcore
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
 )
 
 go 1.13
-
-replace github.com/Azure/azure-sdk-for-go/sdk/internal => ../internal

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -1,5 +1,10 @@
 module github.com/Azure/azure-sdk-for-go/sdk/azcore
 
-require github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3
+	golang.org/x/net v0.0.0-20200904194848-62affa334b73
+)
 
 go 1.13
+
+replace github.com/Azure/azure-sdk-for-go/sdk/internal => ../internal

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -1,2 +1,12 @@
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3 h1:LqwNXxJyW493jG65Ki37BSgGtWN/YJHS8U8Pa7RGwrU=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
+golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3 h1:LqwNXxJyW493jG65Ki37BSgGtWN/YJHS8U8Pa7RGwrU=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0 h1:l7b+GcynB+tNmqq4yrQG2mMzp34gNu65CC5iGTKVlOA=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/sdk/azcore/policy_anonymous_credential.go
+++ b/sdk/azcore/policy_anonymous_credential.go
@@ -5,14 +5,12 @@
 
 package azcore
 
-import "context"
-
 // AnonymousCredential is for use with HTTP(S) requests that read public resource
 // or for use with Shared Access Signatures (SAS).
 func AnonymousCredential() Credential {
 	return credentialFunc(func(AuthenticationPolicyOptions) Policy {
-		return PolicyFunc(func(ctx context.Context, req *Request) (*Response, error) {
-			return req.Next(ctx)
+		return PolicyFunc(func(req *Request) (*Response, error) {
+			return req.Next()
 		})
 	})
 }

--- a/sdk/azcore/policy_anonymous_credential_test.go
+++ b/sdk/azcore/policy_anonymous_credential_test.go
@@ -19,8 +19,11 @@ func TestAnonymousCredential(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 	pl := NewPipeline(srv, AnonymousCredential().AuthenticationPolicy(AuthenticationPolicyOptions{}))
-	req := NewRequest(http.MethodGet, srv.URL())
-	resp, err := pl.Do(context.Background(), req)
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/policy_body_download_test.go
+++ b/sdk/azcore/policy_body_download_test.go
@@ -20,7 +20,11 @@ func TestDownloadBody(t *testing.T) {
 	srv.SetResponse(mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -39,9 +43,12 @@ func TestSkipBodyDownload(t *testing.T) {
 	srv.SetResponse(mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
-	req := NewRequest(http.MethodGet, srv.URL())
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	req.SkipBodyDownload()
-	resp, err := pl.Do(context.Background(), req)
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -56,7 +63,11 @@ func TestDownloadBodyFail(t *testing.T) {
 	srv.SetResponse(mock.WithBodyReadError())
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -74,7 +85,11 @@ func TestDownloadBodyWithRetryGet(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,7 +113,11 @@ func TestDownloadBodyWithRetryDelete(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodDelete, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodDelete, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -122,7 +141,11 @@ func TestDownloadBodyWithRetryPut(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodPut, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodPut, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -146,7 +169,11 @@ func TestDownloadBodyWithRetryPatch(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodPatch, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodPatch, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -171,7 +198,11 @@ func TestDownloadBodyWithRetryPost(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodPost, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodPost, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -194,9 +225,12 @@ func TestSkipBodyDownloadWith400(t *testing.T) {
 	srv.SetResponse(mock.WithStatusCode(http.StatusBadRequest), mock.WithBody([]byte(message)))
 	// download policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
-	req := NewRequest(http.MethodGet, srv.URL())
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	req.SkipBodyDownload()
-	resp, err := pl.Do(context.Background(), req)
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/policy_http_header.go
+++ b/sdk/azcore/policy_http_header.go
@@ -15,9 +15,9 @@ type ctxWithHTTPHeader struct{}
 
 // newHTTPHeaderPolicy creates a policy object that adds custom HTTP headers to a request
 func newHTTPHeaderPolicy() Policy {
-	return PolicyFunc(func(ctx context.Context, req *Request) (*Response, error) {
+	return PolicyFunc(func(req *Request) (*Response, error) {
 		// check if any custom HTTP headers have been specified
-		if header := ctx.Value(ctxWithHTTPHeader{}); header != nil {
+		if header := req.Context().Value(ctxWithHTTPHeader{}); header != nil {
 			for k, v := range header.(http.Header) {
 				// use Set to replace any existing value
 				// it also canonicalizes the header key
@@ -28,7 +28,7 @@ func newHTTPHeaderPolicy() Policy {
 				}
 			}
 		}
-		return req.Next(ctx)
+		return req.Next()
 	})
 }
 

--- a/sdk/azcore/policy_http_header_test.go
+++ b/sdk/azcore/policy_http_header_test.go
@@ -28,11 +28,14 @@ func TestAddCustomHTTPHeaderSuccess(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
 	// HTTP header policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
-	req := NewRequest(http.MethodGet, srv.URL())
-	req.Header.Set(preexistingHeader, preexistingValue)
-	resp, err := pl.Do(WithHTTPHeader(context.Background(), http.Header{
+	req, err := NewRequest(WithHTTPHeader(context.Background(), http.Header{
 		customHeader: []string{customValue},
-	}), req)
+	}), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req.Header.Set(preexistingHeader, preexistingValue)
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -51,7 +54,11 @@ func TestAddCustomHTTPHeaderFail(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
 	// HTTP header policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,9 +78,13 @@ func TestAddCustomHTTPHeaderOverwrite(t *testing.T) {
 	// HTTP header policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
 	// overwrite the request ID with our own value
-	resp, err := pl.Do(WithHTTPHeader(context.Background(), http.Header{
+	req, err := NewRequest(WithHTTPHeader(context.Background(), http.Header{
 		xMsClientRequestID: []string{customValue},
-	}), NewRequest(http.MethodGet, srv.URL()))
+	}), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,9 +109,13 @@ func TestAddCustomHTTPHeaderMultipleValues(t *testing.T) {
 	// HTTP header policy is automatically added during pipeline construction
 	pl := NewPipeline(srv)
 	// overwrite the request ID with our own value
-	resp, err := pl.Do(WithHTTPHeader(context.Background(), http.Header{
+	req, err := NewRequest(WithHTTPHeader(context.Background(), http.Header{
 		customHeader: []string{customValue1, customValue2},
-	}), NewRequest(http.MethodGet, srv.URL()))
+	}), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/policy_logging.go
+++ b/sdk/azcore/policy_logging.go
@@ -7,7 +7,6 @@ package azcore
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -48,7 +47,7 @@ type logPolicyOpValues struct {
 	start time.Time
 }
 
-func (p *requestLogPolicy) Do(ctx context.Context, req *Request) (*Response, error) {
+func (p *requestLogPolicy) Do(req *Request) (*Response, error) {
 	// Get the per-operation values. These are saved in the Message's map so that they persist across each retry calling into this policy object.
 	var opValues logPolicyOpValues
 	if req.OperationValue(&opValues); opValues.start.IsZero() {
@@ -67,7 +66,7 @@ func (p *requestLogPolicy) Do(ctx context.Context, req *Request) (*Response, err
 
 	// Set the time for this particular retry operation and then Do the operation.
 	tryStart := time.Now()
-	response, err := req.Next(ctx) // Make the request
+	response, err := req.Next() // Make the request
 	tryEnd := time.Now()
 	tryDuration := tryEnd.Sub(tryStart)
 	opDuration := tryEnd.Sub(opValues.start)

--- a/sdk/azcore/policy_logging_test.go
+++ b/sdk/azcore/policy_logging_test.go
@@ -24,12 +24,15 @@ func TestPolicyLoggingSuccess(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewRequestLogPolicy(RequestLogOptions{}))
-	req := NewRequest(http.MethodGet, srv.URL())
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	qp := req.URL.Query()
 	qp.Set("one", "fish")
 	qp.Set("sig", "redact")
 	req.URL.RawQuery = qp.Encode()
-	resp, err := pl.Do(context.Background(), req)
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -74,10 +77,13 @@ func TestPolicyLoggingError(t *testing.T) {
 	defer close()
 	srv.SetError(errors.New("bogus error"))
 	pl := NewPipeline(srv, NewRequestLogPolicy(RequestLogOptions{}))
-	req := NewRequest(http.MethodGet, srv.URL())
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	req.Header.Add("header", "one")
 	req.Header.Add("Authorization", "redact")
-	resp, err := pl.Do(context.Background(), req)
+	resp, err := pl.Do(req)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}

--- a/sdk/azcore/policy_telemetry.go
+++ b/sdk/azcore/policy_telemetry.go
@@ -7,7 +7,6 @@ package azcore
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -59,16 +58,16 @@ func NewTelemetryPolicy(o TelemetryOptions) Policy {
 	return &tp
 }
 
-func (p telemetryPolicy) Do(ctx context.Context, req *Request) (*Response, error) {
+func (p telemetryPolicy) Do(req *Request) (*Response, error) {
 	if p.telemetryValue == "" {
-		return req.Next(ctx)
+		return req.Next()
 	}
 	// preserve the existing User-Agent string
 	if ua := req.Request.Header.Get(HeaderUserAgent); ua != "" {
 		p.telemetryValue = fmt.Sprintf("%s %s", p.telemetryValue, ua)
 	}
 	req.Request.Header.Set(HeaderUserAgent, p.telemetryValue)
-	return req.Next(ctx)
+	return req.Next()
 }
 
 // NOTE: the ONLY function that should write to this variable is this func

--- a/sdk/azcore/policy_telemetry_test.go
+++ b/sdk/azcore/policy_telemetry_test.go
@@ -19,7 +19,11 @@ func TestPolicyTelemetryDefault(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -34,7 +38,11 @@ func TestPolicyTelemetryWithCustomInfo(t *testing.T) {
 	srv.SetResponse()
 	const testValue = "azcore_test"
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{Value: testValue}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -48,10 +56,13 @@ func TestPolicyTelemetryPreserveExisting(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	req := NewRequest(http.MethodGet, srv.URL())
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	const otherValue = "this should stay"
 	req.Header.Set(HeaderUserAgent, otherValue)
-	resp, err := pl.Do(context.Background(), req)
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -66,7 +77,11 @@ func TestPolicyTelemetryWithAppID(t *testing.T) {
 	srv.SetResponse()
 	const appID = "my_application"
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{ApplicationID: appID}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -81,7 +96,11 @@ func TestPolicyTelemetryWithAppIDSanitized(t *testing.T) {
 	srv.SetResponse()
 	const appID = "This will get the spaces removed and truncated."
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{ApplicationID: appID}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -97,10 +116,13 @@ func TestPolicyTelemetryPreserveExistingWithAppID(t *testing.T) {
 	srv.SetResponse()
 	const appID = "my_application"
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{ApplicationID: appID}))
-	req := NewRequest(http.MethodGet, srv.URL())
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	const otherValue = "this should stay"
 	req.Header.Set(HeaderUserAgent, otherValue)
-	resp, err := pl.Do(context.Background(), req)
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -115,7 +137,11 @@ func TestPolicyTelemetryDisabled(t *testing.T) {
 	srv.SetResponse()
 	const appID = "my_application"
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{ApplicationID: appID, Disabled: true}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/policy_unique_request_id.go
+++ b/sdk/azcore/policy_unique_request_id.go
@@ -6,8 +6,6 @@
 package azcore
 
 import (
-	"context"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"
 )
 
@@ -15,12 +13,12 @@ const xMsClientRequestID = "x-ms-client-request-id"
 
 // NewUniqueRequestIDPolicy creates a policy object that sets the request's x-ms-client-request-id header if it doesn't already exist.
 func NewUniqueRequestIDPolicy() Policy {
-	return PolicyFunc(func(ctx context.Context, req *Request) (*Response, error) {
+	return PolicyFunc(func(req *Request) (*Response, error) {
 		id := req.Request.Header.Get(xMsClientRequestID)
 		if id == "" {
 			// Add a unique request ID if the caller didn't specify one already
 			req.Request.Header.Set(xMsClientRequestID, uuid.New().String())
 		}
-		return req.Next(ctx)
+		return req.Next()
 	})
 }

--- a/sdk/azcore/policy_unique_request_id_test.go
+++ b/sdk/azcore/policy_unique_request_id_test.go
@@ -18,7 +18,11 @@ func TestUniqueRequestIDPolicy(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewUniqueRequestIDPolicy())
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -32,10 +36,13 @@ func TestUniqueRequestIDPolicyUserDefined(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	pl := NewPipeline(srv, NewUniqueRequestIDPolicy())
-	req := NewRequest(http.MethodGet, srv.URL())
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	const customID = "my-custom-id"
 	req.Header.Set(xMsClientRequestID, customID)
-	resp, err := pl.Do(context.Background(), req)
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/progress_test.go
+++ b/sdk/azcore/progress_test.go
@@ -27,16 +27,19 @@ func TestProgressReporting(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithBody(content))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	req := NewRequest(http.MethodGet, srv.URL())
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	req.SkipBodyDownload()
 	var bytesSent int64
 	reqRpt := NewRequestBodyProgress(NopCloser(body), func(bytesTransferred int64) {
 		bytesSent = bytesTransferred
 	})
-	if err := req.SetBody(reqRpt); err != nil {
+	if err := req.SetBody(reqRpt, "application/octet-stream"); err != nil {
 		t.Fatal(err)
 	}
-	resp, err := pl.Do(context.Background(), req)
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -62,20 +62,30 @@ func (ov opValues) get(value interface{}) bool {
 	return ok
 }
 
+// JoinPaths concatenates multiple URL path segments into one path,
+// inserting path separation characters as required.
+func JoinPaths(paths ...string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	path := paths[0]
+	for i := 1; i < len(paths); i++ {
+		if path[len(path)-1] == '/' && paths[i][0] == '/' {
+			// strip off trailing '/' to avoid doubling up
+			path = path[:len(path)-1]
+		} else if path[len(path)-1] != '/' && paths[i][0] != '/' {
+			// add a trailing '/'
+			path = path + "/"
+		}
+		path += paths[i]
+	}
+	return path
+}
+
 // NewRequest creates a new Request with the specified input.
 // Endpoint contains the host URL along with any base path.
 // Path contains optional URL path segments to be concatenated to the endpoint.
-func NewRequest(ctx context.Context, httpMethod string, endpoint string, path ...string) (*Request, error) {
-	for i := 0; i < len(path); i++ {
-		if endpoint[len(endpoint)-1] == '/' && path[i][0] == '/' {
-			// strip off trailing '/' to avoid doubling up
-			endpoint = endpoint[:len(endpoint)-1]
-		} else if endpoint[len(endpoint)-1] != '/' && path[i][0] != '/' {
-			// add a trailing '/'
-			endpoint = endpoint + "/"
-		}
-		endpoint += path[i]
-	}
+func NewRequest(ctx context.Context, httpMethod string, endpoint string) (*Request, error) {
 	req, err := http.NewRequestWithContext(ctx, httpMethod, endpoint, nil)
 	if err != nil {
 		return nil, err

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -83,8 +83,6 @@ func JoinPaths(paths ...string) string {
 }
 
 // NewRequest creates a new Request with the specified input.
-// Endpoint contains the host URL along with any base path.
-// Path contains optional URL path segments to be concatenated to the endpoint.
 func NewRequest(ctx context.Context, httpMethod string, endpoint string) (*Request, error) {
 	req, err := http.NewRequestWithContext(ctx, httpMethod, endpoint, nil)
 	if err != nil {

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -503,10 +503,12 @@ func TestNewRequestFail(t *testing.T) {
 }
 
 func TestJoinPaths(t *testing.T) {
-	path := JoinPaths("http://test.contoso.com/", "/path/one", "path/two", "/path/three/", "path/four/")
+	if path := JoinPaths(); path != "" {
+		t.Fatalf("unexpected path %s", path)
+	}
 	const expected = "http://test.contoso.com/path/one/path/two/path/three/path/four/"
-	if got := path; got != expected {
-		t.Fatalf("got %s, expected %s", got, expected)
+	if path := JoinPaths("http://test.contoso.com/", "/path/one", "path/two", "/path/three/", "path/four/"); path != expected {
+		t.Fatalf("got %s, expected %s", path, expected)
 	}
 }
 

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"reflect"
 	"strconv"
 	"testing"
@@ -30,11 +29,10 @@ type testXML struct {
 }
 
 func TestRequestMarshalXML(t *testing.T) {
-	u, err := url.Parse("https://contoso.com")
+	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	req := NewRequest(http.MethodPost, *u)
 	err = req.MarshalAsXML(testXML{SomeInt: 1, SomeString: "s"})
 	if err != nil {
 		t.Fatalf("marshal failure: %v", err)
@@ -51,12 +49,11 @@ func TestRequestMarshalXML(t *testing.T) {
 }
 
 func TestRequestEmptyPipeline(t *testing.T) {
-	u, err := url.Parse("https://contoso.com")
+	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	req := NewRequest(http.MethodPost, *u)
-	resp, err := req.Next(context.Background())
+	resp, err := req.Next()
 	if resp != nil {
 		t.Fatal("expected nil response")
 	}
@@ -66,11 +63,10 @@ func TestRequestEmptyPipeline(t *testing.T) {
 }
 
 func TestRequestMarshalJSON(t *testing.T) {
-	u, err := url.Parse("https://contoso.com")
+	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	req := NewRequest(http.MethodPost, *u)
 	err = req.MarshalAsJSON(testJSON{SomeInt: 1, SomeString: "s"})
 	if err != nil {
 		t.Fatalf("marshal failure: %v", err)
@@ -87,11 +83,10 @@ func TestRequestMarshalJSON(t *testing.T) {
 }
 
 func TestRequestMarshalAsByteArrayURLFormat(t *testing.T) {
-	u, err := url.Parse("https://contoso.com")
+	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	req := NewRequest(http.MethodPost, *u)
 	const payload = "a string that gets encoded with base64url"
 	err = req.MarshalAsByteArray([]byte(payload), Base64URLFormat)
 	if err != nil {
@@ -116,11 +111,10 @@ func TestRequestMarshalAsByteArrayURLFormat(t *testing.T) {
 }
 
 func TestRequestMarshalAsByteArrayStdFormat(t *testing.T) {
-	u, err := url.Parse("https://contoso.com")
+	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	req := NewRequest(http.MethodPost, *u)
 	const payload = "a string that gets encoded with base64url"
 	err = req.MarshalAsByteArray([]byte(payload), Base64StdFormat)
 	if err != nil {
@@ -325,11 +319,10 @@ func TestCloneWithoutReadOnlyFieldsCloneNested(t *testing.T) {
 }
 
 func TestCloneWithoutReadOnlyFieldsEndToEnd(t *testing.T) {
-	u, err := url.Parse("https://contoso.com")
+	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	req := NewRequest(http.MethodPost, *u)
 	id := int32(123)
 	name := "widget"
 	type withReadOnly struct {
@@ -470,18 +463,78 @@ func TestAzureTagIsReadOnly(t *testing.T) {
 }
 
 func TestRequestSetBodyContentLengthHeader(t *testing.T) {
-	endpoint, err := url.Parse("http://test.contoso.com")
+	req, err := NewRequest(context.Background(), http.MethodPut, "http://test.contoso.com")
 	if err != nil {
 		t.Fatal(err)
 	}
-	req := NewRequest(http.MethodPut, *endpoint)
 	buff := make([]byte, 768, 768)
 	const buffLen = 768
 	for i := 0; i < buffLen; i++ {
 		buff[i] = 1
 	}
-	req.SetBody(NopCloser(bytes.NewReader(buff)))
+	req.SetBody(NopCloser(bytes.NewReader(buff)), "application/octet-stream")
 	if req.Header.Get(HeaderContentLength) != strconv.FormatInt(buffLen, 10) {
 		t.Fatalf("expected content-length %d, got %s", buffLen, req.Header.Get(HeaderContentLength))
+	}
+}
+
+func TestNewRequestFail(t *testing.T) {
+	req, err := NewRequest(context.Background(), http.MethodOptions, "://test.contoso.com/")
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if req != nil {
+		t.Fatal("unexpected request")
+	}
+	req, err = NewRequest(context.Background(), http.MethodPatch, "/missing/the/host")
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if req != nil {
+		t.Fatal("unexpected request")
+	}
+	req, err = NewRequest(context.Background(), http.MethodPatch, "mailto://nobody.contoso.com")
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if req != nil {
+		t.Fatal("unexpected request")
+	}
+}
+
+func TestRequestPathSegments(t *testing.T) {
+	req, err := NewRequest(context.Background(), http.MethodGet, "http://test.contoso.com/", "/path/one", "path/two", "path/three")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const expected = "http://test.contoso.com/path/one/path/two/path/three"
+	if got := req.URL.String(); got != expected {
+		t.Fatalf("got %s, expected %s", got, expected)
+	}
+}
+
+func TestRequestValidFail(t *testing.T) {
+	req, err := NewRequest(context.Background(), http.MethodGet, "http://test.contoso.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("inval d", "header")
+	p := NewPipeline(nil)
+	resp, err := p.Do(req)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if resp != nil {
+		t.Fatal("unexpected response")
+	}
+	req.Header = http.Header{}
+	// the string "null\0"
+	req.Header.Add("invalid", string([]byte{0x6e, 0x75, 0x6c, 0x6c, 0x0}))
+	resp, err = p.Do(req)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if resp != nil {
+		t.Fatal("unexpected response")
 	}
 }

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -502,13 +502,10 @@ func TestNewRequestFail(t *testing.T) {
 	}
 }
 
-func TestRequestPathSegments(t *testing.T) {
-	req, err := NewRequest(context.Background(), http.MethodGet, "http://test.contoso.com/", "/path/one", "path/two", "path/three")
-	if err != nil {
-		t.Fatal(err)
-	}
-	const expected = "http://test.contoso.com/path/one/path/two/path/three"
-	if got := req.URL.String(); got != expected {
+func TestJoinPaths(t *testing.T) {
+	path := JoinPaths("http://test.contoso.com/", "/path/one", "path/two", "/path/three/", "path/four/")
+	const expected = "http://test.contoso.com/path/one/path/two/path/three/path/four/"
+	if got := path; got != expected {
 		t.Fatalf("got %s, expected %s", got, expected)
 	}
 }

--- a/sdk/azcore/response_test.go
+++ b/sdk/azcore/response_test.go
@@ -20,7 +20,11 @@ func TestResponseUnmarshalXML(t *testing.T) {
 	// include UTF8 BOM
 	srv.SetResponse(mock.WithBody([]byte("\xef\xbb\xbf<testXML><SomeInt>1</SomeInt><SomeString>s</SomeString></testXML>")))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,7 +45,11 @@ func TestResponseFailureStatusCode(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusForbidden))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,7 +63,11 @@ func TestResponseUnmarshalJSON(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte(`{ "someInt": 1, "someString": "s" }`)))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -76,7 +88,11 @@ func TestResponseUnmarshalJSONNoBody(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte{}))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -93,7 +109,11 @@ func TestResponseUnmarshalXMLNoBody(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte{}))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -138,7 +158,11 @@ func TestResponseUnmarshalAsByteArrayURLFormat(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte(`"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw"`)))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -159,7 +183,11 @@ func TestResponseUnmarshalAsByteArrayStdFormat(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte(`"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw="`)))
 	pl := NewPipeline(srv, NewTelemetryPolicy(TelemetryOptions{}))
-	resp, err := pl.Do(context.Background(), NewRequest(http.MethodGet, srv.URL()))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/transport_default_http_client.go
+++ b/sdk/azcore/transport_default_http_client.go
@@ -6,7 +6,6 @@
 package azcore
 
 import (
-	"context"
 	"crypto/tls"
 	"net/http"
 )
@@ -34,7 +33,7 @@ func init() {
 
 // DefaultHTTPClientTransport ...
 func DefaultHTTPClientTransport() Transport {
-	return TransportFunc(func(ctx context.Context, req *http.Request) (*http.Response, error) {
-		return defaultHTTPClient.Do(req.WithContext(ctx))
+	return TransportFunc(func(req *http.Request) (*http.Response, error) {
+		return defaultHTTPClient.Do(req)
 	})
 }

--- a/sdk/azcore/version.go
+++ b/sdk/azcore/version.go
@@ -10,5 +10,5 @@ const (
 	UserAgent = "azcore/" + Version
 
 	// Version is the semantic version (see http://semver.org) of the pipeline package.
-	Version = "0.1.0"
+	Version = "0.10.0"
 )


### PR DESCRIPTION
The request and transport interfaces have been refactored to align with
the patterns in the standard library.
NewRequest() now uses http.NewRequestWithContext() and performs
additional validation.  It requires a context parameter.
The Policy and Transport interfaces have had their ctx parameter removed
as the context is associated with the underlying http.Request.
Pipeline.Do() will validate the HTTP request before sending it through
the pipeline, avoiding retrying on an malformed request.
The Retrier interface has been replaced with the NonRetriableError
interface, and the retry policy updated to test for this.
Request.SetBody() now requires a content type parameter for setting the
request's MIME type.