### PR TITLE
Add new App Service version and improve Managed Identity Credential

### DIFF
--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -170,9 +170,10 @@ func newDefaultMSIPipeline(o ManagedIdentityCredentialOptions) azcore.Pipeline {
 	var statusCodes []int
 	// retry policy for MSI is not end-user configurable
 	retryOpts := azcore.RetryOptions{
-		MaxRetries: 4,
-		RetryDelay: 2 * time.Second,
-		TryTimeout: 1 * time.Minute,
+		MaxRetries:    5,
+		MaxRetryDelay: 1 * time.Minute,
+		RetryDelay:    2 * time.Second,
+		TryTimeout:    1 * time.Minute,
 		StatusCodes: append(statusCodes,
 			// The following status codes are a subset of those found in azcore.StatusCodesForRetry, these are the only ones specifically needed for MSI scenarios
 			http.StatusRequestTimeout,      // 408
@@ -180,16 +181,16 @@ func newDefaultMSIPipeline(o ManagedIdentityCredentialOptions) azcore.Pipeline {
 			http.StatusInternalServerError, // 500
 			http.StatusBadGateway,          // 502
 			http.StatusGatewayTimeout,      // 504
-			http.StatusNotFound,
-			http.StatusGone,
+			http.StatusNotFound,            //404
+			http.StatusGone,                //410
 			// all remaining 5xx
-			http.StatusNotImplemented,
-			http.StatusHTTPVersionNotSupported,
-			http.StatusVariantAlsoNegotiates,
-			http.StatusInsufficientStorage,
-			http.StatusLoopDetected,
-			http.StatusNotExtended,
-			http.StatusNetworkAuthenticationRequired),
+			http.StatusNotImplemented,                 // 501
+			http.StatusHTTPVersionNotSupported,        // 505
+			http.StatusVariantAlsoNegotiates,          // 506
+			http.StatusInsufficientStorage,            // 507
+			http.StatusLoopDetected,                   // 508
+			http.StatusNotExtended,                    // 510
+			http.StatusNetworkAuthenticationRequired), // 511
 	}
 
 	return azcore.NewPipeline(

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -4,7 +4,6 @@
 package azidentity
 
 import (
-	"context"
 	"errors"
 	"os"
 	"testing"
@@ -90,7 +89,7 @@ func TestDefaultAzureCredential_NilOptions(t *testing.T) {
 	}
 	c := newManagedIdentityClient(nil)
 	// if the test is running in a MSI environment then the length of sources would be two since it will include environment credential and managed identity credential
-	if msiType, err := c.getMSIType(context.Background()); !(msiType == msiTypeUnavailable || msiType == msiTypeUnknown) {
+	if msiType, err := c.getMSIType(); !(msiType == msiTypeUnavailable || msiType == msiTypeUnknown) {
 		if len(cred.sources) != lengthOfChainFull {
 			t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainFull, len(cred.sources))
 		}

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -98,8 +98,8 @@ func TestDefaultAzureCredential_NilOptions(t *testing.T) {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
 	c := newManagedIdentityClient(nil)
-	// if the test is running in a MSI environment then the length of sources would be two since it will include environmnet credential and managed identity credential
-	if msiType, err := c.getMSIType(context.Background()); msiType == msiTypeIMDS || msiType == msiTypeCloudShell || msiType == msiTypeAppService {
+	// if the test is running in a MSI environment then the length of sources would be two since it will include environment credential and managed identity credential
+	if msiType, err := c.getMSIType(context.Background()); !(msiType == msiTypeUnavailable || msiType == msiTypeUnknown) {
 		if len(cred.sources) != lengthOfChainFull {
 			t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainFull, len(cred.sources))
 		}

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -16,10 +16,7 @@ const (
 )
 
 func TestDefaultAzureCredential_ExcludeEnvCredential(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
+	resetEnvironmentVarsForTest()
 	_ = os.Setenv("MSI_ENDPOINT", "http://localhost:3000")
 	cred, err := NewDefaultAzureCredential(&DefaultAzureCredentialOptions{ExcludeEnvironmentCredential: true})
 	if err != nil {
@@ -60,17 +57,14 @@ func TestDefaultAzureCredential_ExcludeAzureCLICredential(t *testing.T) {
 	if len(cred.sources) != lengthOfChainOneExcluded {
 		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainOneExcluded, len(cred.sources))
 	}
-	_ = os.Setenv("MSI_ENDPOINT", "")
-	_ = resetEnvironmentVarsForTest()
+	clearEnvVars("MSI_ENDPOINT")
+	resetEnvironmentVarsForTest()
 }
 
 func TestDefaultAzureCredential_ExcludeAllCredentials(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
-	}
+	resetEnvironmentVarsForTest()
 	var credUnavailable *CredentialUnavailableError
-	_, err = NewDefaultAzureCredential(&DefaultAzureCredentialOptions{
+	_, err := NewDefaultAzureCredential(&DefaultAzureCredentialOptions{
 		ExcludeEnvironmentCredential: true,
 		ExcludeMSICredential:         true,
 		ExcludeAzureCLICredential:    true,
@@ -85,11 +79,8 @@ func TestDefaultAzureCredential_ExcludeAllCredentials(t *testing.T) {
 }
 
 func TestDefaultAzureCredential_NilOptions(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
-	err = initEnvironmentVarsForTest()
+	resetEnvironmentVarsForTest()
+	err := initEnvironmentVarsForTest()
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -26,18 +26,7 @@ func initEnvironmentVarsForTest() error {
 }
 
 func resetEnvironmentVarsForTest() error {
-	err := os.Setenv("AZURE_TENANT_ID", "")
-	if err != nil {
-		return err
-	}
-	err = os.Setenv("AZURE_CLIENT_ID", "")
-	if err != nil {
-		return err
-	}
-	err = os.Setenv("AZURE_CLIENT_SECRET", "")
-	if err != nil {
-		return err
-	}
+	clearEnvVars("AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET")
 	return nil
 }
 

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -25,17 +25,13 @@ func initEnvironmentVarsForTest() error {
 	return nil
 }
 
-func resetEnvironmentVarsForTest() error {
+func resetEnvironmentVarsForTest() {
 	clearEnvVars("AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET")
-	return nil
 }
 
 func TestEnvironmentCredential_TenantIDNotSet(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
-	}
-	err = os.Setenv("AZURE_CLIENT_ID", clientID)
+	resetEnvironmentVarsForTest()
+	err := os.Setenv("AZURE_CLIENT_ID", clientID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -54,11 +50,8 @@ func TestEnvironmentCredential_TenantIDNotSet(t *testing.T) {
 }
 
 func TestEnvironmentCredential_ClientIDNotSet(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
-	}
-	err = os.Setenv("AZURE_TENANT_ID", tenantID)
+	resetEnvironmentVarsForTest()
+	err := os.Setenv("AZURE_TENANT_ID", tenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -77,11 +70,8 @@ func TestEnvironmentCredential_ClientIDNotSet(t *testing.T) {
 }
 
 func TestEnvironmentCredential_ClientSecretNotSet(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
-	}
-	err = os.Setenv("AZURE_TENANT_ID", tenantID)
+	resetEnvironmentVarsForTest()
+	err := os.Setenv("AZURE_TENANT_ID", tenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -104,7 +104,7 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, clientID strin
 }
 
 func (c *managedIdentityClient) sendAuthRequest(ctx context.Context, clientID string, scopes []string) (*azcore.AccessToken, error) {
-	msg, err := c.createAuthRequest(ctx, c.msiType, clientID, scopes)
+	msg, err := c.createAuthRequest(ctx, clientID, scopes)
 	if err != nil {
 		return nil, err
 	}
@@ -152,8 +152,8 @@ func (c *managedIdentityClient) createAccessToken(res *azcore.Response) (*azcore
 	}
 }
 
-func (c *managedIdentityClient) createAuthRequest(ctx context.Context, msiType msiType, clientID string, scopes []string) (*azcore.Request, error) {
-	switch msiType {
+func (c *managedIdentityClient) createAuthRequest(ctx context.Context, clientID string, scopes []string) (*azcore.Request, error) {
+	switch c.msiType {
 	case msiTypeIMDS:
 		return c.createIMDSAuthRequest(ctx, scopes)
 	case msiTypeAppServiceV20170901:
@@ -164,7 +164,7 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, msiType m
 		return c.createCloudShellAuthRequest(ctx, clientID, scopes)
 	default:
 		errorMsg := ""
-		switch msiType {
+		switch c.msiType {
 		case msiTypeUnavailable:
 			errorMsg = "unavailable"
 		default:

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -142,9 +142,7 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, clientID 
 	switch c.msiType {
 	case msiTypeIMDS:
 		return c.createIMDSAuthRequest(ctx, scopes)
-	case msiTypeAppServiceV20170901:
-		return c.createAppServiceAuthRequest(ctx, clientID, scopes)
-	case msiTypeAppServiceV20190801:
+	case msiTypeAppServiceV20170901, msiTypeAppServiceV20190801:
 		return c.createAppServiceAuthRequest(ctx, clientID, scopes)
 	case msiTypeCloudShell:
 		return c.createCloudShellAuthRequest(ctx, clientID, scopes)

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
@@ -48,10 +47,9 @@ type ManagedIdentityCredential struct {
 func NewManagedIdentityCredential(clientID string, options *ManagedIdentityCredentialOptions) (*ManagedIdentityCredential, error) {
 	// Create a new Managed Identity Client with default options
 	client := newManagedIdentityClient(options)
-	// Create a context that will timeout after 500 milliseconds (that is the amount of time designated to find out if the IMDS endpoint is available)
-	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(client.imdsAvailableTimeoutMS)*time.Millisecond)
-	defer cancelFunc()
-	msiType, err := client.getMSIType(ctx)
+	// The context passed in here will only be used to check for the IMDS endpoint and will be set to timeout after
+	// 500 milliseconds in imdsAvailable()
+	msiType, err := client.getMSIType(context.Background())
 	// If there is an error that means that the code is not running in a Managed Identity environment
 	if err != nil {
 		credErr := &CredentialUnavailableError{CredentialType: "Managed Identity Credential", Message: "Please make sure you are running in a managed identity environment, such as a VM, Azure Functions, Cloud Shell, etc..."}

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -47,9 +47,7 @@ type ManagedIdentityCredential struct {
 func NewManagedIdentityCredential(clientID string, options *ManagedIdentityCredentialOptions) (*ManagedIdentityCredential, error) {
 	// Create a new Managed Identity Client with default options
 	client := newManagedIdentityClient(options)
-	// The context passed in here will only be used to check for the IMDS endpoint and will be set to timeout after
-	// 500 milliseconds in imdsAvailable()
-	msiType, err := client.getMSIType(context.Background())
+	msiType, err := client.getMSIType()
 	// If there is an error that means that the code is not running in a Managed Identity environment
 	if err != nil {
 		credErr := &CredentialUnavailableError{CredentialType: "Managed Identity Credential", Message: "Please make sure you are running in a managed identity environment, such as a VM, Azure Functions, Cloud Shell, etc..."}

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -41,10 +41,7 @@ func TestManagedIdentityCredential_GetTokenInCloudShellLive(t *testing.T) {
 }
 
 func TestManagedIdentityCredential_GetTokenInCloudShellMock(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
+	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
@@ -61,10 +58,7 @@ func TestManagedIdentityCredential_GetTokenInCloudShellMock(t *testing.T) {
 }
 
 func TestManagedIdentityCredential_GetTokenInCloudShellMockFail(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
+	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
@@ -81,10 +75,7 @@ func TestManagedIdentityCredential_GetTokenInCloudShellMockFail(t *testing.T) {
 }
 
 func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
+	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(appServiceTokenSuccessResp)))
@@ -108,10 +99,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock(t *testing.
 }
 
 func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
+	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(appServiceTokenSuccessResp)))
@@ -195,10 +183,7 @@ func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20190801(t *testi
 }
 
 func TestManagedIdentityCredential_CreateAccessTokenExpiresOnInt(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
+	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(expiresOnIntResp)))
@@ -216,10 +201,7 @@ func TestManagedIdentityCredential_CreateAccessTokenExpiresOnInt(t *testing.T) {
 }
 
 func TestManagedIdentityCredential_GetTokenInAppServiceMockFail(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
+	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
@@ -264,10 +246,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceMockFail(t *testing.T) {
 // }
 
 func TestManagedIdentityCredential_NewManagedIdentityCredentialFail(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
+	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
@@ -312,10 +291,7 @@ func TestBearerPolicy_ManagedIdentityCredential(t *testing.T) {
 }
 
 func TestManagedIdentityCredential_GetTokenUnexpectedJSON(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
+	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespMalformed)))
@@ -367,11 +343,8 @@ func TestManagedIdentityCredential_CreateIMDSAuthRequest(t *testing.T) {
 }
 
 func TestManagedIdentityCredential_GetTokenEnvVar(t *testing.T) {
-	err := resetEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unable to set environment variables")
-	}
-	err = os.Setenv("AZURE_CLIENT_ID", "test_client_id")
+	resetEnvironmentVarsForTest()
+	err := os.Setenv("AZURE_CLIENT_ID", "test_client_id")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds support for App Service api-version 2019-08-01 in ManagedIdentityCredential, as well as cleans up redundant code in the same credential type. 
Add missing MaxRetryDelay to MSI credential pipelines. 
