### PR TITLE
Add default console logger

### DIFF
--- a/sdk/azcore/log.go
+++ b/sdk/azcore/log.go
@@ -107,15 +107,13 @@ func Log() *Logger {
 	return &log
 }
 
-// simple console logger, it writes to stderr in the following format:
-// [time-stamp] Classification: message
-func consoleLogger(cls LogClassification, msg string) {
-	fmt.Fprintf(os.Stderr, "[%s] %s: %s\n", time.Now().Format(time.StampMicro), cls, msg)
-}
-
 func init() {
 	if cls := os.Getenv("AZURE_SDK_GO_LOGGING"); cls == "all" {
 		// cls could be enhanced to support a comma-delimited list of log classifications
-		log.lst = consoleLogger
+		log.lst = func(cls LogClassification, msg string) {
+			// simple console logger, it writes to stderr in the following format:
+			// [time-stamp] Classification: message
+			fmt.Fprintf(os.Stderr, "[%s] %s: %s\n", time.Now().Format(time.StampMicro), cls, msg)
+		}
 	}
 }

--- a/sdk/azcore/log.go
+++ b/sdk/azcore/log.go
@@ -32,6 +32,10 @@ const (
 
 	// LogSlowResponse entries contain information for responses that take longer than the specified threshold.
 	LogSlowResponse LogClassification = "SlowResponse"
+
+	// LogLongRunningOperation entries contain information specific to long-running operations.
+	// This includes information like polling location, operation state and sleep intervals.
+	LogLongRunningOperation LogClassification = "LongRunningOperation"
 )
 
 // Listener is the function signature invoked when writing log entries.

--- a/sdk/azcore/log_test.go
+++ b/sdk/azcore/log_test.go
@@ -5,7 +5,11 @@
 
 package azcore
 
-import "testing"
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
 
 func TestLoggingDefault(t *testing.T) {
 	// ensure logging with nil listener doesn't fail
@@ -18,15 +22,15 @@ func TestLoggingDefault(t *testing.T) {
 	})
 	const req = "this is a request"
 	Log().Write(LogRequest, req)
-	const resp = "this is a response"
-	Log().Write(LogResponse, resp)
+	const resp = "this is a response: %d"
+	Log().Writef(LogResponse, resp, http.StatusOK)
 	if l := len(log); l != 2 {
 		t.Fatalf("unexpected log entry count: %d", l)
 	}
 	if log[LogRequest] != req {
 		t.Fatalf("unexpected log request: %s", log[LogRequest])
 	}
-	if log[LogResponse] != resp {
+	if log[LogResponse] != fmt.Sprintf(resp, http.StatusOK) {
 		t.Fatalf("unexpected log response: %s", log[LogResponse])
 	}
 }

--- a/sdk/azcore/version.go
+++ b/sdk/azcore/version.go
@@ -10,5 +10,5 @@ const (
 	UserAgent = "azcore/" + Version
 
 	// Version is the semantic version (see http://semver.org) of the pipeline package.
-	Version = "0.10.0"
+	Version = "0.10.1"
 )


### PR DESCRIPTION
Default console logger writes to stderr.  To enable it, set env var
AZURE_SDK_GO_LOGGING to the value 'all'.
Added Logger.Writef() to reduce the need for ShouldLog() checks.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
