### PR TITLE
Add LRO state machine logging

### DIFF
--- a/sdk/armcore/go.mod
+++ b/sdk/armcore/go.mod
@@ -3,6 +3,6 @@ module github.com/Azure/azure-sdk-for-go/sdk/armcore
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.1
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0
 )

--- a/sdk/armcore/go.sum
+++ b/sdk/armcore/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0 h1:bicoLZMjsxg6LqSFRpLaAmVGqZtOS9hrCVi0KdqcCco=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.1 h1:6Do3Te6Dgs+XrNKe6ubHgjSHo5Ws9dG/2NKVBKhSpa0=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.1/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0 h1:l7b+GcynB+tNmqq4yrQG2mMzp34gNu65CC5iGTKVlOA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/sdk/armcore/policy_register_rp_test.go
+++ b/sdk/armcore/policy_register_rp_test.go
@@ -93,12 +93,13 @@ func TestRPRegistrationPolicySuccess(t *testing.T) {
 	if resp.Request.URL.Path != requestEndpoint {
 		t.Fatalf("unexpected path in response %s", resp.Request.URL.Path)
 	}
-	// should be three entries
+	// should be four entries
 	// 1st is for start
 	// 2nd is for first response to get state
 	// 3rd is when state transitions to success
-	if logEntries != 3 {
-		t.Fatalf("expected 3 log entries, got %d", logEntries)
+	// 4th is for end
+	if logEntries != 4 {
+		t.Fatalf("expected 4 log entries, got %d", logEntries)
 	}
 }
 
@@ -196,11 +197,12 @@ func TestRPRegistrationPolicyTimesOut(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected DeadlineExceeded, got %v", err)
 	}
-	// should be two entries
+	// should be three entries
 	// 1st is for start
 	// 2nd is for first response to get state
-	if logEntries != 2 {
-		t.Fatalf("expected 2 log entries, got %d", logEntries)
+	// 3rd is the deadline exceeded error
+	if logEntries != 3 {
+		t.Fatalf("expected 3 log entries, got %d", logEntries)
 	}
 	// we should get the response from the original request
 	if resp.StatusCode != http.StatusConflict {
@@ -248,12 +250,13 @@ func TestRPRegistrationPolicyExceedsAttempts(t *testing.T) {
 	if resp.Request.URL.Path != requestEndpoint {
 		t.Fatalf("unexpected path in response %s", resp.Request.URL.Path)
 	}
-	// should be 3 entries for each attempt, total 9 entries
+	// should be 4 entries for each attempt, total 12 entries
 	// 1st is for start
 	// 2nd is for first response to get state
 	// 3rd is when state transitions to success
-	if logEntries != 9 {
-		t.Fatalf("expected 9 log entries, got %d", logEntries)
+	// 4th is for end
+	if logEntries != 12 {
+		t.Fatalf("expected 12 log entries, got %d", logEntries)
 	}
 }
 


### PR DESCRIPTION
Added back some methods to the polling tracker for logging purposes.
Added failure case logging for auto-RP registration policy.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
