### PR TITLE
Logging clean-up

### DIFF
--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -119,9 +119,6 @@ type TokenCredentialOptions struct {
 	// Leave this as nil to use the default HTTP transport
 	HTTPClient azcore.Transport
 
-	// LogOptions configures the built-in request logging policy behavior
-	LogOptions azcore.RequestLogOptions
-
 	// Retry configures the built-in retry policy behavior
 	Retry *azcore.RetryOptions
 
@@ -158,7 +155,7 @@ func newDefaultPipeline(o TokenCredentialOptions) azcore.Pipeline {
 		azcore.NewTelemetryPolicy(o.Telemetry),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(o.Retry),
-		azcore.NewRequestLogPolicy(o.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 }
 
 // newDefaultMSIPipeline creates a pipeline using the specified pipeline options needed
@@ -198,5 +195,5 @@ func newDefaultMSIPipeline(o ManagedIdentityCredentialOptions) azcore.Pipeline {
 		azcore.NewTelemetryPolicy(o.Telemetry),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&retryOpts),
-		azcore.NewRequestLogPolicy(o.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 }

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -51,10 +51,10 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts azcore.TokenRequ
 	opts.Scopes[0] = strings.TrimSuffix(opts.Scopes[0], defaultSuffix)
 	at, err := c.authenticate(ctx, opts.Scopes[0])
 	if err != nil {
-		addGetTokenFailureLogs("Azure CLI Credential", err)
+		addGetTokenFailureLogs("Azure CLI Credential", err, true)
 		return nil, err
 	}
-	azcore.Log().Write(LogCredential, logGetTokenSuccess(c, opts))
+	logGetTokenSuccess(c, opts)
 	return at, nil
 }
 

--- a/sdk/azidentity/azure_cli_credential_test.go
+++ b/sdk/azidentity/azure_cli_credential_test.go
@@ -68,7 +68,7 @@ func TestBearerPolicy_AzureCLICredential(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/bearer_token_policy_test.go
+++ b/sdk/azidentity/bearer_token_policy_test.go
@@ -35,7 +35,7 @@ func TestBearerPolicy_SuccessGetToken(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +65,7 @@ func TestBearerPolicy_CredentialFailGetToken(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func TestBearerTokenPolicy_TokenExpired(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +131,7 @@ func TestRetryPolicy_NonRetriable(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)
@@ -157,7 +157,7 @@ func TestRetryPolicy_HTTPRequest(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -169,7 +169,7 @@ func TestBearerPolicy_ChainedTokenCredential(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		chainedCred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -37,13 +37,13 @@ func NewClientCertificateCredential(tenantID string, clientID string, clientCert
 	_, err := os.Stat(clientCertificate)
 	if err != nil {
 		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: "Certificate file not found in path: " + clientCertificate}
-		azcore.Log().Write(azcore.LogError, logCredentialError(credErr.CredentialType, credErr))
+		logCredentialError(credErr.CredentialType, credErr)
 		return nil, credErr
 	}
 	certData, err := ioutil.ReadFile(clientCertificate)
 	if err != nil {
 		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: err.Error()}
-		azcore.Log().Write(azcore.LogError, logCredentialError(credErr.CredentialType, credErr))
+		logCredentialError(credErr.CredentialType, credErr)
 		return nil, credErr
 	}
 	var cert *certContents
@@ -57,7 +57,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, clientCert
 	}
 	if err != nil {
 		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: err.Error()}
-		azcore.Log().Write(azcore.LogError, logCredentialError(credErr.CredentialType, credErr))
+		logCredentialError(credErr.CredentialType, credErr)
 		return nil, credErr
 	}
 	c, err := newAADIdentityClient(options)
@@ -171,10 +171,10 @@ func extractFromPFXFile(certData []byte, password *string) (*certContents, error
 func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
 	tk, err := c.client.authenticateCertificate(ctx, c.tenantID, c.clientID, c.cert, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Client Certificate Credential", err)
+		addGetTokenFailureLogs("Client Certificate Credential", err, true)
 		return nil, err
 	}
-	azcore.Log().Write(LogCredential, logGetTokenSuccess(c, opts))
+	logGetTokenSuccess(c, opts)
 	return tk, nil
 }
 

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -169,7 +169,7 @@ func TestBearerPolicy_ClientCertificateCredential(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -39,10 +39,10 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 func (c *ClientSecretCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
 	tk, err := c.client.authenticate(ctx, c.tenantID, c.clientID, c.clientSecret, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Client Secret Credential", err)
+		addGetTokenFailureLogs("Client Secret Credential", err, true)
 		return nil, err
 	}
-	azcore.Log().Write(LogCredential, logGetTokenSuccess(c, opts))
+	logGetTokenSuccess(c, opts)
 	return tk, nil
 }
 

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -68,7 +68,7 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Chained
 	// if no credentials are added to the slice of TokenCredentials then return a CredentialUnavailableError
 	if len(creds) == 0 {
 		err := &CredentialUnavailableError{CredentialType: "Default Azure Credential", Message: errMsg}
-		azcore.Log().Write(azcore.LogError, logCredentialError(err.CredentialType, err))
+		logCredentialError(err.CredentialType, err)
 		return nil, err
 	}
 	azcore.Log().Write(LogCredential, "Azure Identity => NewDefaultAzureCredential() invoking NewChainedTokenCredential()")

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -275,7 +275,7 @@ func TestBearerPolicy_DeviceCodeCredential(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{deviceCodeScopes}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -16,21 +16,21 @@ func NewEnvironmentCredential(options *TokenCredentialOptions) (*ClientSecretCre
 	tenantID := os.Getenv("AZURE_TENANT_ID")
 	if tenantID == "" {
 		err := &CredentialUnavailableError{CredentialType: "Environment Credential", Message: "Missing environment variable AZURE_TENANT_ID"}
-		azcore.Log().Write(azcore.LogError, logCredentialError(err.CredentialType, err))
+		logCredentialError(err.CredentialType, err)
 		return nil, err
 	}
 
 	clientID := os.Getenv("AZURE_CLIENT_ID")
 	if clientID == "" {
 		err := &CredentialUnavailableError{CredentialType: "Environment Credential", Message: "Missing environment variable AZURE_CLIENT_ID"}
-		azcore.Log().Write(azcore.LogError, logCredentialError(err.CredentialType, err))
+		logCredentialError(err.CredentialType, err)
 		return nil, err
 	}
 
 	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
 	if clientSecret == "" {
 		err := &CredentialUnavailableError{CredentialType: "Environment Credential", Message: "Missing environment variable AZURE_CLIENT_SECRET"}
-		azcore.Log().Write(azcore.LogError, logCredentialError(err.CredentialType, err))
+		logCredentialError(err.CredentialType, err)
 		return nil, err
 	}
 	azcore.Log().Write(LogCredential, "Azure Identity => NewEnvironmentCredential() invoking ClientSecretCredential")

--- a/sdk/azidentity/go.mod
+++ b/sdk/azidentity/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-sdk-for-go/sdk/azidentity
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 )

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0 h1:bicoLZMjsxg6LqSFRpLaAmVGqZtOS9hrCVi0KdqcCco=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0 h1:OhkQQEj0+3Kq3ufXVRggYeJ7dPECSjK1JR+wCsdLBfw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0 h1:l7b+GcynB+tNmqq4yrQG2mMzp34gNu65CC5iGTKVlOA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -17,9 +17,6 @@ type ManagedIdentityCredentialOptions struct {
 	// Leave this as nil to use the default HTTP transport.
 	HTTPClient azcore.Transport
 
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
-
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
 }
@@ -51,7 +48,7 @@ func NewManagedIdentityCredential(clientID string, options *ManagedIdentityCrede
 	// If there is an error that means that the code is not running in a Managed Identity environment
 	if err != nil {
 		credErr := &CredentialUnavailableError{CredentialType: "Managed Identity Credential", Message: "Please make sure you are running in a managed identity environment, such as a VM, Azure Functions, Cloud Shell, etc..."}
-		azcore.Log().Write(azcore.LogError, logCredentialError(credErr.CredentialType, credErr))
+		logCredentialError(credErr.CredentialType, credErr)
 		return nil, credErr
 	}
 	// Assign the msiType discovered onto the client
@@ -69,11 +66,11 @@ func NewManagedIdentityCredential(clientID string, options *ManagedIdentityCrede
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
 	tk, err := c.client.authenticate(ctx, c.clientID, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Managed Identity Credential", err)
+		addGetTokenFailureLogs("Managed Identity Credential", err, true)
 		return nil, err
 	}
-	azcore.Log().Write(LogCredential, logGetTokenSuccess(c, opts))
-	azcore.Log().Write(LogCredential, logMSIEnv(c.client.msiType))
+	logGetTokenSuccess(c, opts)
+	logMSIEnv(c.client.msiType)
 	return tk, err
 }
 

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -279,7 +279,7 @@ func TestBearerPolicy_ManagedIdentityCredential(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{msiScope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -42,10 +42,10 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
 	tk, err := c.client.authenticateUsernamePassword(ctx, c.tenantID, c.clientID, c.username, c.password, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Username Password Credential", err)
+		addGetTokenFailureLogs("Username Password Credential", err, true)
 		return nil, err
 	}
-	azcore.Log().Write(LogCredential, logGetTokenSuccess(c, opts))
+	logGetTokenSuccess(c, opts)
 	return tk, err
 }
 

--- a/sdk/azidentity/username_password_credential_test.go
+++ b/sdk/azidentity/username_password_credential_test.go
@@ -104,7 +104,7 @@ func TestBearerPolicy_UsernamePasswordCredential(t *testing.T) {
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(nil),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(azcore.RequestLogOptions{}))
+		azcore.NewRequestLogPolicy(nil))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Updated calls to azcore.NewRequestLogPolicy() to pass nil options.
Ensure logging calls are no-op when logging is disabled.
Removed some duplicate stack trace logging.
Updated logMSIEnv() with new value.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
