### PR TITLE
Make sure authority hosts are https

### DIFF
--- a/sdk/azidentity/authorization_code_credential_test.go
+++ b/sdk/azidentity/authorization_code_credential_test.go
@@ -62,7 +62,7 @@ func TestAuthorizationCodeCredential_CreateAuthRequestSuccess(t *testing.T) {
 }
 
 func TestAuthorizationCodeCredential_GetTokenSuccess(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	options := DefaultAuthorizationCodeCredentialOptions()
@@ -80,7 +80,7 @@ func TestAuthorizationCodeCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestAuthorizationCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte(accessTokenRespError)), mock.WithStatusCode(http.StatusUnauthorized))
 	options := DefaultAuthorizationCodeCredentialOptions()
@@ -129,7 +129,7 @@ func TestAuthorizationCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
 }
 
 func TestAuthorizationCodeCredential_GetTokenUnexpectedJSON(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespMalformed)))
 	options := DefaultAuthorizationCodeCredentialOptions()

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -4,7 +4,9 @@
 package azidentity
 
 import (
+	"errors"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -140,7 +142,13 @@ func (c *TokenCredentialOptions) setDefaultValues() (*TokenCredentialOptions, er
 	if c.AuthorityHost == "" {
 		c.AuthorityHost = authorityHost
 	}
-
+	u, err := url.Parse(c.AuthorityHost)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "https" {
+		return nil, errors.New("cannot use an authority host without https")
+	}
 	return c, nil
 }
 

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -128,6 +128,17 @@ type TokenCredentialOptions struct {
 	Telemetry azcore.TelemetryOptions
 }
 
+var schemeCheck = func(u string) error {
+	s, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	if s.Scheme != "https" {
+		return errors.New("cannot use an authority host without https")
+	}
+	return nil
+}
+
 // setDefaultValues initializes an instance of TokenCredentialOptions with default settings.
 func (c *TokenCredentialOptions) setDefaultValues() (*TokenCredentialOptions, error) {
 	authorityHost := AzurePublicCloud
@@ -142,12 +153,9 @@ func (c *TokenCredentialOptions) setDefaultValues() (*TokenCredentialOptions, er
 	if c.AuthorityHost == "" {
 		c.AuthorityHost = authorityHost
 	}
-	u, err := url.Parse(c.AuthorityHost)
+	err := schemeCheck(c.AuthorityHost)
 	if err != nil {
 		return nil, err
-	}
-	if u.Scheme != "https" {
-		return nil, errors.New("cannot use an authority host without https")
 	}
 	return c, nil
 }

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -128,17 +128,6 @@ type TokenCredentialOptions struct {
 	Telemetry azcore.TelemetryOptions
 }
 
-var schemeCheck = func(u string) error {
-	s, err := url.Parse(u)
-	if err != nil {
-		return err
-	}
-	if s.Scheme != "https" {
-		return errors.New("cannot use an authority host without https")
-	}
-	return nil
-}
-
 // setDefaultValues initializes an instance of TokenCredentialOptions with default settings.
 func (c *TokenCredentialOptions) setDefaultValues() (*TokenCredentialOptions, error) {
 	authorityHost := AzurePublicCloud
@@ -153,9 +142,14 @@ func (c *TokenCredentialOptions) setDefaultValues() (*TokenCredentialOptions, er
 	if c.AuthorityHost == "" {
 		c.AuthorityHost = authorityHost
 	}
-	err := schemeCheck(c.AuthorityHost)
+
+	s, err := url.Parse(c.AuthorityHost)
 	if err != nil {
 		return nil, err
+	}
+
+	if s.Scheme != "https" {
+		return nil, errors.New("cannot use an authority host without https")
 	}
 	return c, nil
 }

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -115,3 +115,11 @@ func Test_AzureGovernmentAuthorityHost(t *testing.T) {
 		t.Fatalf("Did not retrieve expected authority host string")
 	}
 }
+
+func Test_NonHTTPSAuthorityHost(t *testing.T) {
+	opts := &TokenCredentialOptions{AuthorityHost: "http://foo.com"}
+	opts, err := opts.setDefaultValues()
+	if err == nil {
+		t.Fatal("Expected an error but did not receive one.")
+	}
+}

--- a/sdk/azidentity/bearer_token_policy_test.go
+++ b/sdk/azidentity/bearer_token_policy_test.go
@@ -128,7 +128,7 @@ func TestRetryPolicy_NonRetriable(t *testing.T) {
 }
 
 func TestRetryPolicy_HTTPRequest(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	cred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &ClientSecretCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -64,7 +64,7 @@ func TestChainedTokenCredential_GetTokenSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not set environment variables for testing: %v", err)
 	}
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	secCred, err := NewClientSecretCredential(tenantID, clientID, secret, &ClientSecretCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -92,7 +92,7 @@ func TestChainedTokenCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestChainedTokenCredential_GetTokenFail(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	secCred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &ClientSecretCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -117,7 +117,7 @@ func TestChainedTokenCredential_GetTokenFail(t *testing.T) {
 }
 
 func TestChainedTokenCredential_GetTokenWithUnavailableCredentialInChain(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendError(&CredentialUnavailableError{CredentialType: "MockCredential", Message: "Mocking a credential unavailable error"})
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -65,7 +65,7 @@ func TestClientCertificateCredential_CreateAuthRequestSuccess(t *testing.T) {
 }
 
 func TestClientCertificateCredential_GetTokenSuccess(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	cred, err := NewClientCertificateCredential(tenantID, clientID, certificatePath, &ClientCertificateCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -79,7 +79,7 @@ func TestClientCertificateCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestClientCertificateCredential_GetTokenInvalidCredentials(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	cred, err := NewClientCertificateCredential(tenantID, clientID, certificatePath, &ClientCertificateCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -97,7 +97,7 @@ func TestClientCertificateCredential_GetTokenInvalidCredentials(t *testing.T) {
 }
 
 func TestClientCertificateCredential_WrongCertificatePath(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	_, err := NewClientCertificateCredential(tenantID, clientID, wrongCertificatePath, &ClientCertificateCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -107,7 +107,7 @@ func TestClientCertificateCredential_WrongCertificatePath(t *testing.T) {
 }
 
 func TestClientCertificateCredential_GetTokenCheckPrivateKeyBlocks(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	cred, err := NewClientCertificateCredential(tenantID, clientID, "testdata/certificate_formatB.pem", &ClientCertificateCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -121,7 +121,7 @@ func TestClientCertificateCredential_GetTokenCheckPrivateKeyBlocks(t *testing.T)
 }
 
 func TestClientCertificateCredential_GetTokenCheckCertificateBlocks(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	cred, err := NewClientCertificateCredential(tenantID, clientID, "testdata/certificate_formatA.pem", &ClientCertificateCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -135,7 +135,7 @@ func TestClientCertificateCredential_GetTokenCheckCertificateBlocks(t *testing.T
 }
 
 func TestClientCertificateCredential_GetTokenEmptyCertificate(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	_, err := NewClientCertificateCredential(tenantID, clientID, "testdata/certificate_empty.pem", &ClientCertificateCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -145,7 +145,7 @@ func TestClientCertificateCredential_GetTokenEmptyCertificate(t *testing.T) {
 }
 
 func TestClientCertificateCredential_GetTokenNoPrivateKey(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	_, err := NewClientCertificateCredential(tenantID, clientID, "testdata/certificate_nokey.pem", &ClientCertificateCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -64,7 +64,7 @@ func TestClientSecretCredential_CreateAuthRequestSuccess(t *testing.T) {
 }
 
 func TestClientSecretCredential_GetTokenSuccess(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &ClientSecretCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -78,7 +78,7 @@ func TestClientSecretCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestClientSecretCredential_GetTokenInvalidCredentials(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte(accessTokenRespError)), mock.WithStatusCode(http.StatusUnauthorized))
 	cred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &ClientSecretCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -123,7 +123,7 @@ func TestClientSecretCredential_GetTokenInvalidCredentials(t *testing.T) {
 }
 
 func TestClientSecretCredential_GetTokenUnexpectedJSON(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespMalformed)))
 	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &ClientSecretCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -149,7 +149,7 @@ func TestDeviceCodeCredential_RequestNewDeviceCodeCustomTenantIDClientID(t *test
 }
 
 func TestDeviceCodeCredential_GetTokenSuccess(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
@@ -170,7 +170,7 @@ func TestDeviceCodeCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestDeviceCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	cred, err := NewDeviceCodeCredential(&DeviceCodeCredentialOptions{TenantID: tenantID, ClientID: clientID, Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -184,7 +184,7 @@ func TestDeviceCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
 }
 
 func TestDeviceCodeCredential_GetTokenAuthorizationPending(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
 	srv.AppendResponse(mock.WithBody([]byte(authorizationPendingResponse)), mock.WithStatusCode(http.StatusUnauthorized))
@@ -202,7 +202,7 @@ func TestDeviceCodeCredential_GetTokenAuthorizationPending(t *testing.T) {
 }
 
 func TestDeviceCodeCredential_GetTokenExpiredToken(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
 	srv.AppendResponse(mock.WithBody([]byte(authorizationPendingResponse)), mock.WithStatusCode(http.StatusUnauthorized))
@@ -219,7 +219,7 @@ func TestDeviceCodeCredential_GetTokenExpiredToken(t *testing.T) {
 }
 
 func TestDeviceCodeCredential_GetTokenWithRefreshTokenFailure(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespError)), mock.WithStatusCode(http.StatusUnauthorized))
 	cred, err := NewDeviceCodeCredential(&DeviceCodeCredentialOptions{TenantID: tenantID, ClientID: clientID, Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -238,7 +238,7 @@ func TestDeviceCodeCredential_GetTokenWithRefreshTokenFailure(t *testing.T) {
 }
 
 func TestDeviceCodeCredential_GetTokenWithRefreshTokenSuccess(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	handler := func(DeviceCodeMessage) {}

--- a/sdk/azidentity/go.mod
+++ b/sdk/azidentity/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.1
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
+	golang.org/x/net v0.0.0-20201010224723-4f7140c49acb
 )

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -11,10 +11,13 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
+golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb h1:mUVeFHoDKis5nxCAzoAi7E8Ghb86EXh/RK6wtvJIqRY=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -11,13 +11,10 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
-golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb h1:mUVeFHoDKis5nxCAzoAi7E8Ghb86EXh/RK6wtvJIqRY=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -1,5 +1,5 @@
-// // Copyright (c) Microsoft Corporation. All rights reserved.
-// // Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 package azidentity
 

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -32,11 +32,7 @@ func TestInteractiveBrowserCredential_CreateWithNilOptions(t *testing.T) {
 }
 
 func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
-	tempSrv := &http.Server{}
-	if err := http2.ConfigureServer(tempSrv, new(http2.Server)); err != nil {
-		panic(err)
-	}
-	srv, close := mock.NewTLSServer(mock.WithTLSConfig(tempSrv.TLSConfig))
+	srv, close := mock.NewTLSServer(mock.WithHTTP2Enabled(true))
 	defer close()
 	tr := &http.Transport{TLSClientConfig: srv.ServerConfig().TLSConfig}
 	if err := http2.ConfigureTransport(tr); err != nil {
@@ -67,11 +63,7 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
-	tempSrv := &http.Server{}
-	if err := http2.ConfigureServer(tempSrv, new(http2.Server)); err != nil {
-		panic(err)
-	}
-	srv, close := mock.NewTLSServer(mock.WithTLSConfig(tempSrv.TLSConfig))
+	srv, close := mock.NewTLSServer(mock.WithHTTP2Enabled(true))
 	defer close()
 	tr := &http.Transport{TLSClientConfig: srv.ServerConfig().TLSConfig}
 	if err := http2.ConfigureTransport(tr); err != nil {

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -32,7 +33,13 @@ func TestInteractiveBrowserCredential_CreateWithNilOptions(t *testing.T) {
 }
 
 func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
-	srv, close := mock.NewTLSHTTP2Server()
+	f := func(s *httptest.Server) {
+		if err := http2.ConfigureServer(s.Config, new(http2.Server)); err != nil {
+			panic(err)
+		}
+		s.TLS = s.Config.TLSConfig
+	}
+	srv, close := mock.NewTLSServer(f)
 	defer close()
 	tr := &http.Transport{TLSClientConfig: srv.ServerConfig().TLSConfig}
 	if err := http2.ConfigureTransport(tr); err != nil {
@@ -63,7 +70,13 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
-	srv, close := mock.NewTLSHTTP2Server()
+	f := func(s *httptest.Server) {
+		if err := http2.ConfigureServer(s.Config, new(http2.Server)); err != nil {
+			panic(err)
+		}
+		s.TLS = s.Config.TLSConfig
+	}
+	srv, close := mock.NewTLSServer(f)
 	defer close()
 	tr := &http.Transport{TLSClientConfig: srv.ServerConfig().TLSConfig}
 	if err := http2.ConfigureTransport(tr); err != nil {

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -33,13 +32,11 @@ func TestInteractiveBrowserCredential_CreateWithNilOptions(t *testing.T) {
 }
 
 func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
-	f := func(s *httptest.Server) {
-		if err := http2.ConfigureServer(s.Config, new(http2.Server)); err != nil {
-			panic(err)
-		}
-		s.TLS = s.Config.TLSConfig
+	tempSrv := &http.Server{}
+	if err := http2.ConfigureServer(tempSrv, new(http2.Server)); err != nil {
+		panic(err)
 	}
-	srv, close := mock.NewTLSServer(f)
+	srv, close := mock.NewTLSServer(mock.WithTLSConfig(tempSrv.TLSConfig))
 	defer close()
 	tr := &http.Transport{TLSClientConfig: srv.ServerConfig().TLSConfig}
 	if err := http2.ConfigureTransport(tr); err != nil {
@@ -70,13 +67,11 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
-	f := func(s *httptest.Server) {
-		if err := http2.ConfigureServer(s.Config, new(http2.Server)); err != nil {
-			panic(err)
-		}
-		s.TLS = s.Config.TLSConfig
+	tempSrv := &http.Server{}
+	if err := http2.ConfigureServer(tempSrv, new(http2.Server)); err != nil {
+		panic(err)
 	}
-	srv, close := mock.NewTLSServer(f)
+	srv, close := mock.NewTLSServer(mock.WithTLSConfig(tempSrv.TLSConfig))
 	defer close()
 	tr := &http.Transport{TLSClientConfig: srv.ServerConfig().TLSConfig}
 	if err := http2.ConfigureTransport(tr); err != nil {

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -31,7 +31,7 @@ func TestInteractiveBrowserCredential_CreateWithNilOptions(t *testing.T) {
 }
 
 func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	options := DefaultInteractiveBrowserCredentialOptions()
@@ -56,7 +56,7 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte(accessTokenRespError)), mock.WithStatusCode(http.StatusUnauthorized))
 	options := DefaultInteractiveBrowserCredentialOptions()

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -34,7 +34,7 @@ func TestInteractiveBrowserCredential_CreateWithNilOptions(t *testing.T) {
 func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 	srv, close := mock.NewTLSServer(mock.WithHTTP2Enabled(true))
 	defer close()
-	tr := &http.Transport{TLSClientConfig: srv.ServerConfig().TLSConfig}
+	tr := &http.Transport{}
 	if err := http2.ConfigureTransport(tr); err != nil {
 		t.Fatalf("Failed to configure http2 transport: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
 	srv, close := mock.NewTLSServer(mock.WithHTTP2Enabled(true))
 	defer close()
-	tr := &http.Transport{TLSClientConfig: srv.ServerConfig().TLSConfig}
+	tr := &http.Transport{}
 	if err := http2.ConfigureTransport(tr); err != nil {
 		t.Fatalf("Failed to configure http2 transport: %v", err)
 	}

--- a/sdk/azidentity/username_password_credential_test.go
+++ b/sdk/azidentity/username_password_credential_test.go
@@ -62,7 +62,7 @@ func TestUsernamePasswordCredential_CreateAuthRequestSuccess(t *testing.T) {
 }
 
 func TestUsernamePasswordCredential_GetTokenSuccess(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", &UsernamePasswordCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})
@@ -76,7 +76,7 @@ func TestUsernamePasswordCredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestUsernamePasswordCredential_GetTokenInvalidCredentials(t *testing.T) {
-	srv, close := mock.NewServer()
+	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "wrong_password", &UsernamePasswordCredentialOptions{Options: &TokenCredentialOptions{HTTPClient: srv, AuthorityHost: srv.URL()}})


### PR DESCRIPTION
This PR adds a check for Authority Hosts to ensure that all authority host urls provided are HTTPS, since non-https authority hosts are not permitted. 

Addresses #12686