### PR TITLE
Fixed badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
 # Azure SDK for Go
 
 [![godoc](https://godoc.org/github.com/Azure/azure-sdk-for-go?status.svg)](https://godoc.org/github.com/Azure/azure-sdk-for-go)
-
-[![Build Status](https://travis-ci.org/Azure/azure-sdk-for-go.svg?branch=master)](https://travis-ci.org/Azure/azure-sdk-for-go)
-
-[![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/go/Azure.azure-sdk-for-go?branchName=latest)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=640&branchName=latest)
-
-[![Go Report Card](https://goreportcard.com/badge/github.com/Azure/azure-sdk-for-go)](https://goreportcard.com/report/github.com/Azure/azure-sdk-for-go)
+[![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/go/Azure.azure-sdk-for-go?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=640&branchName=master)
 
 azure-sdk-for-go provides Go packages for managing and using Azure services.
 It officially supports the last two major releases of Go.  Older versions of

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         Linux_Go113:
           vm.image: 'ubuntu-18.04'
-          go.version: '1.13'
+          go.version: '1.14'
         Linux_Go114:
           vm.image: 'ubuntu-18.04'
-          go.version: '1.14'
+          go.version: '1.15'
 
     pool:
       vmImage: $(vm.image)


### PR DESCRIPTION
Fixed build status badge to point to correct branch.
Removed travis CI badge as we no longer use travis.
Removed report card badge as the service chokes on the size of the repo.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
