### PR TITLE
Validate tenant ID passed to credentials

### DIFF
--- a/sdk/azidentity/authorization_code_credential.go
+++ b/sdk/azidentity/authorization_code_credential.go
@@ -41,6 +41,9 @@ func DefaultAuthorizationCodeCredentialOptions() AuthorizationCodeCredentialOpti
 // redirectURI: The redirect URI that was used to request the authorization code. Must be the same URI that is configured for the App Registration.
 // options: Manage the configuration of the requests sent to Azure Active Directory, they can also include a client secret for web app authentication.
 func NewAuthorizationCodeCredential(tenantID string, clientID string, authCode string, redirectURI string, options *AuthorizationCodeCredentialOptions) (*AuthorizationCodeCredential, error) {
+	if !validTenantID(tenantID) {
+		return nil, &CredentialUnavailableError{CredentialType: "Authorization Code Credential", Message: "invalid tenant ID passed to credential"}
+	}
 	if options == nil {
 		temp := DefaultAuthorizationCodeCredentialOptions()
 		options = &temp

--- a/sdk/azidentity/authorization_code_credential_test.go
+++ b/sdk/azidentity/authorization_code_credential_test.go
@@ -20,6 +20,20 @@ const (
 	testRedirectURI = "http://localhost"
 )
 
+func TestAuthorizationCodeCredential_InvalidTenantID(t *testing.T) {
+	cred, err := NewAuthorizationCodeCredential(badTenantID, clientID, testAuthCode, testRedirectURI, nil)
+	if err == nil {
+		t.Fatal("Expected an error but received none")
+	}
+	if cred != nil {
+		t.Fatalf("Expected a nil credential value. Received: %v", cred)
+	}
+	var errType *CredentialUnavailableError
+	if !errors.As(err, &errType) {
+		t.Fatalf("Did not receive a CredentialUnavailableError. Received: %t", err)
+	}
+}
+
 func TestAuthorizationCodeCredential_CreateAuthRequestSuccess(t *testing.T) {
 	cred, err := NewAuthorizationCodeCredential(tenantID, clientID, testAuthCode, testRedirectURI, nil)
 	if err != nil {

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -197,4 +198,13 @@ func newDefaultMSIPipeline(o ManagedIdentityCredentialOptions) azcore.Pipeline {
 		azcore.NewTelemetryPolicy(&o.Telemetry),
 		azcore.NewRetryPolicy(&retryOpts),
 		azcore.NewLogPolicy(nil))
+}
+
+// validTenantID return true is it receives a valid tenantID, returns false otherwise
+func validTenantID(tenantID string) bool {
+	match, err := regexp.MatchString("^[0-9a-zA-Z-.]+$", tenantID)
+	if err != nil {
+		return false
+	}
+	return match
 }

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -123,3 +123,33 @@ func Test_NonHTTPSAuthorityHost(t *testing.T) {
 		t.Fatal("Expected an error but did not receive one.")
 	}
 }
+
+func Test_ValidTenantIDFalse(t *testing.T) {
+	if validTenantID("bad@tenant") {
+		t.Fatal("Expected to receive false, but received true")
+	}
+	if validTenantID("bad/tenant") {
+		t.Fatal("Expected to receive false, but received true")
+	}
+	if validTenantID("bad(tenant") {
+		t.Fatal("Expected to receive false, but received true")
+	}
+	if validTenantID("bad)tenant") {
+		t.Fatal("Expected to receive false, but received true")
+	}
+	if validTenantID("bad:tenant") {
+		t.Fatal("Expected to receive false, but received true")
+	}
+}
+
+func Test_ValidTenantIDTrue(t *testing.T) {
+	if !validTenantID("goodtenant") {
+		t.Fatal("Expected to receive true, but received false")
+	}
+	if !validTenantID("good-tenant") {
+		t.Fatal("Expected to receive true, but received false")
+	}
+	if !validTenantID("good.tenant") {
+		t.Fatal("Expected to receive true, but received false")
+	}
+}

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -49,6 +49,9 @@ func DefaultClientCertificateCredentialOptions() ClientCertificateCredentialOpti
 // password: The password required to decrypt the private key.  Pass nil if there is no password.
 // options: ClientCertificateCredentialOptions that can be used to provide additional configurations for the credential.
 func NewClientCertificateCredential(tenantID string, clientID string, clientCertificate string, options *ClientCertificateCredentialOptions) (*ClientCertificateCredential, error) {
+	if !validTenantID(tenantID) {
+		return nil, &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: "invalid tenant ID passed to credential"}
+	}
 	_, err := os.Stat(clientCertificate)
 	if err != nil {
 		credErr := &CredentialUnavailableError{CredentialType: "Client Certificate Credential", Message: "Certificate file not found in path: " + clientCertificate}

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -20,6 +20,20 @@ const (
 	wrongCertificatePath = "wrong_certificate_path.pem"
 )
 
+func TestClientCertificateCredential_InvalidTenantID(t *testing.T) {
+	cred, err := NewClientCertificateCredential(badTenantID, clientID, certificatePath, nil)
+	if err == nil {
+		t.Fatal("Expected an error but received none")
+	}
+	if cred != nil {
+		t.Fatalf("Expected a nil credential value. Received: %v", cred)
+	}
+	var errType *CredentialUnavailableError
+	if !errors.As(err, &errType) {
+		t.Fatalf("Did not receive a CredentialUnavailableError. Received: %t", err)
+	}
+}
+
 func TestClientCertificateCredential_CreateAuthRequestSuccess(t *testing.T) {
 	cred, err := NewClientCertificateCredential(tenantID, clientID, certificatePath, nil)
 	if err != nil {

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -36,6 +36,9 @@ func DefaultClientSecretCredentialOptions() ClientSecretCredentialOptions {
 // clientSecret: A client secret that was generated for the App Registration used to authenticate the client.
 // options: allow to configure the management of the requests sent to Azure Active Directory.
 func NewClientSecretCredential(tenantID string, clientID string, clientSecret string, options *ClientSecretCredentialOptions) (*ClientSecretCredential, error) {
+	if !validTenantID(tenantID) {
+		return nil, &CredentialUnavailableError{CredentialType: "Client Secret Credential", Message: "invalid tenant ID passed to credential"}
+	}
 	if options == nil {
 		temp := DefaultClientSecretCredentialOptions()
 		options = &temp

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	tenantID                 = "expected_tenant"
+	tenantID                 = "expected-tenant"
+	badTenantID              = "bad_tenant"
 	clientID                 = "expected_client"
 	secret                   = "secret"
 	wrongSecret              = "wrong_secret"
@@ -24,6 +25,20 @@ const (
 	scope                    = "http://storage.azure.com/.default"
 	defaultTestAuthorityHost = "login.microsoftonline.com"
 )
+
+func TestClientSecretCredential_InvalidTenantID(t *testing.T) {
+	cred, err := NewClientSecretCredential(badTenantID, clientID, secret, nil)
+	if err == nil {
+		t.Fatal("Expected an error but received none")
+	}
+	if cred != nil {
+		t.Fatalf("Expected a nil credential value. Received: %v", cred)
+	}
+	var errType *CredentialUnavailableError
+	if !errors.As(err, &errType) {
+		t.Fatalf("Did not receive a CredentialUnavailableError. Received: %t", err)
+	}
+}
 
 func TestClientSecretCredential_CreateAuthRequestSuccess(t *testing.T) {
 	cred, err := NewClientSecretCredential(tenantID, clientID, secret, nil)

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -71,6 +71,9 @@ func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeC
 		temp := DefaultDeviceCodeCredentialOptions()
 		options = &temp
 	}
+	if !validTenantID(options.TenantID) {
+		return nil, &CredentialUnavailableError{CredentialType: "Device Code Credential", Message: "invalid tenant ID passed to credential"}
+	}
 	c, err := newAADIdentityClient(options.Options)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -23,6 +23,20 @@ const (
 	expiredTokenResponse         = `{"error": "expired_token","error_description": "Token has expired.","error_codes": [],"timestamp": "2019-12-01 19:00:00Z","trace_id": "2d091b0","correlation_id": "a999","error_uri": "https://login.contoso.com/error?code=0"}`
 )
 
+func TestDeviceCodeCredential_InvalidTenantID(t *testing.T) {
+	cred, err := NewDeviceCodeCredential(&DeviceCodeCredentialOptions{TenantID: badTenantID})
+	if err == nil {
+		t.Fatal("Expected an error but received none")
+	}
+	if cred != nil {
+		t.Fatalf("Expected a nil credential value. Received: %v", cred)
+	}
+	var errType *CredentialUnavailableError
+	if !errors.As(err, &errType) {
+		t.Fatalf("Did not receive a CredentialUnavailableError. Received: %t", err)
+	}
+}
+
 func TestDeviceCodeCredential_CreateAuthRequestSuccess(t *testing.T) {
 	cred, err := NewDeviceCodeCredential(nil)
 	if err != nil {
@@ -143,7 +157,7 @@ func TestDeviceCodeCredential_RequestNewDeviceCodeCustomTenantIDClientID(t *test
 	if req.Request.URL.Scheme != "https" {
 		t.Fatalf("Wrong request scheme")
 	}
-	if req.Request.URL.Path != "/expected_tenant/oauth2/v2.0/devicecode" {
+	if req.Request.URL.Path != "/expected-tenant/oauth2/v2.0/devicecode" {
 		t.Fatalf("Did not set the right path when passing in an empty tenant ID")
 	}
 }

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -53,6 +53,9 @@ func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOption
 		temp := DefaultInteractiveBrowserCredentialOptions()
 		options = &temp
 	}
+	if !validTenantID(options.TenantID) {
+		return nil, &CredentialUnavailableError{CredentialType: "Interactive Browser Credential", Message: "invalid tenant ID passed to credential"}
+	}
 	c, err := newAADIdentityClient(options.Options)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -15,6 +15,20 @@ import (
 	"golang.org/x/net/http2"
 )
 
+func TestInteractiveBrowserCredential_InvalidTenantID(t *testing.T) {
+	cred, err := NewInteractiveBrowserCredential(&InteractiveBrowserCredentialOptions{TenantID: badTenantID})
+	if err == nil {
+		t.Fatal("Expected an error but received none")
+	}
+	if cred != nil {
+		t.Fatalf("Expected a nil credential value. Received: %v", cred)
+	}
+	var errType *CredentialUnavailableError
+	if !errors.As(err, &errType) {
+		t.Fatalf("Did not receive a CredentialUnavailableError. Received: %t", err)
+	}
+}
+
 func TestInteractiveBrowserCredential_CreateWithNilOptions(t *testing.T) {
 	cred, err := NewInteractiveBrowserCredential(nil)
 	if err != nil {

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -39,6 +39,9 @@ func DefaultUsernamePasswordCredentialOptions() UsernamePasswordCredentialOption
 // password: A user's account password
 // options: UsernamePasswordCredentialOptions used to configure the pipeline for the requests sent to Azure Active Directory.
 func NewUsernamePasswordCredential(tenantID string, clientID string, username string, password string, options *UsernamePasswordCredentialOptions) (*UsernamePasswordCredential, error) {
+	if !validTenantID(tenantID) {
+		return nil, &CredentialUnavailableError{CredentialType: "Username Password Credential", Message: "invalid tenant ID passed to credential"}
+	}
 	if options == nil {
 		temp := DefaultUsernamePasswordCredentialOptions()
 		options = &temp

--- a/sdk/azidentity/username_password_credential_test.go
+++ b/sdk/azidentity/username_password_credential_test.go
@@ -5,6 +5,7 @@ package azidentity
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -13,6 +14,20 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
+
+func TestUsernamePasswordCredential_InvalidTenantID(t *testing.T) {
+	cred, err := NewUsernamePasswordCredential(badTenantID, clientID, "username", "password", nil)
+	if err == nil {
+		t.Fatal("Expected an error but received none")
+	}
+	if cred != nil {
+		t.Fatalf("Expected a nil credential value. Received: %v", cred)
+	}
+	var errType *CredentialUnavailableError
+	if !errors.As(err, &errType) {
+		t.Fatalf("Did not receive a CredentialUnavailableError. Received: %t", err)
+	}
+}
 
 func TestUsernamePasswordCredential_CreateAuthRequestSuccess(t *testing.T) {
 	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", nil)


### PR DESCRIPTION
Validate tenant IDs passed to credential types after Arch Board discussion with the Identity crew, adding corresponding tests. 