### PR TITLE
Add Connection type

### DIFF
--- a/sdk/armcore/README.md
+++ b/sdk/armcore/README.md
@@ -4,14 +4,19 @@
 [![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/go/go%20-%20armcore%20-%20ci?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=1844&branchName=master)
 [![Code Coverage](https://img.shields.io/azure-devops/coverage/azure-sdk/public/1844/master)](https://img.shields.io/azure-devops/coverage/azure-sdk/public/1844/master)
 
-The `armcore` module provides utility functions and types for Go SDK ARM client modules.
+The `armcore` module provides functions and types for Go SDK ARM client modules.
 These modules follow the [Azure SDK Design Guidelines for Go](https://azure.github.io/azure-sdk/golang_introduction.html).
 
 ## Getting started
 
 This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for versioning and dependency management.
 
-The contents of this module are used by generated code.  It is not intended for external use.
+Typically, you will not need to explicitly install `armcore` as it will be installed as an ARM client module dependency.
+To add the latest version to your `go.mod` file, execute the following command.
+
+```bash
+go get -u github.com/Azure/azure-sdk-for-go/sdk/armcore
+```
 
 General documentation and examples can be found on [pkg.go.dev](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/armcore).
 

--- a/sdk/armcore/connection.go
+++ b/sdk/armcore/connection.go
@@ -54,15 +54,12 @@ func NewConnection(endpoint string, cred azcore.TokenCredential, options *Connec
 		o := DefaultConnectionOptions()
 		options = &o
 	}
-	policies := []azcore.Policy{
+	p := azcore.NewPipeline(options.HTTPClient,
 		azcore.NewTelemetryPolicy(&options.Telemetry),
-	}
-	policies = append(policies, NewRPRegistrationPolicy(cred, &options.RegisterRPOptions))
-	policies = append(policies,
+		NewRPRegistrationPolicy(cred, &options.RegisterRPOptions),
 		azcore.NewRetryPolicy(&options.Retry),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewLogPolicy(nil))
-	p := azcore.NewPipeline(options.HTTPClient, policies...)
 	return NewConnectionWithPipeline(endpoint, p)
 }
 

--- a/sdk/armcore/connection.go
+++ b/sdk/armcore/connection.go
@@ -1,0 +1,83 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package armcore
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+const scope = "https://management.azure.com//.default"
+
+// ConnectionOptions contains configuration settings for the connection's pipeline.
+type ConnectionOptions struct {
+	// HTTPClient sets the transport for making HTTP requests.
+	HTTPClient azcore.Transport
+	// Retry configures the built-in retry policy behavior.
+	Retry azcore.RetryOptions
+	// Telemetry configures the built-in telemetry policy behavior.
+	Telemetry azcore.TelemetryOptions
+	// RegisterRPOptions configures the built-in RP registration policy behavior.
+	RegisterRPOptions RegistrationOptions
+}
+
+// DefaultConnectionOptions creates a ConnectionOptions type initialized with default values.
+func DefaultConnectionOptions() ConnectionOptions {
+	return ConnectionOptions{
+		Retry:             azcore.DefaultRetryOptions(),
+		RegisterRPOptions: DefaultRegistrationOptions(),
+		Telemetry:         azcore.DefaultTelemetryOptions(),
+	}
+}
+
+// Connection is a connection to an Azure Resource Manager endpoint.
+// It contains the base ARM endpoint and a pipeline for making requests.
+type Connection struct {
+	u string
+	p azcore.Pipeline
+}
+
+// DefaultEndpoint is the Azure Resourece Manager public cloud endpoint.
+const DefaultEndpoint = "https://management.azure.com"
+
+// NewDefaultConnection creates an instance of the Connection type using the DefaultEndpoint.
+func NewDefaultConnection(cred azcore.TokenCredential, options *ConnectionOptions) *Connection {
+	return NewConnection(DefaultEndpoint, cred, options)
+}
+
+// NewConnection creates an instance of the Connection type with the specified endpoint.
+// Use this when connecting to clouds other than the Azure public cloud (stack/sovereign clouds).
+func NewConnection(endpoint string, cred azcore.TokenCredential, options *ConnectionOptions) *Connection {
+	if options == nil {
+		o := DefaultConnectionOptions()
+		options = &o
+	}
+	policies := []azcore.Policy{
+		azcore.NewTelemetryPolicy(&options.Telemetry),
+	}
+	policies = append(policies, NewRPRegistrationPolicy(cred, &options.RegisterRPOptions))
+	policies = append(policies,
+		azcore.NewRetryPolicy(&options.Retry),
+		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
+		azcore.NewLogPolicy(nil))
+	p := azcore.NewPipeline(options.HTTPClient, policies...)
+	return NewConnectionWithPipeline(endpoint, p)
+}
+
+// NewConnectionWithPipeline creates an instance of the Connection type with the specified endpoint and pipeline.
+// Use this when a custom pipeline is required.
+func NewConnectionWithPipeline(endpoint string, p azcore.Pipeline) *Connection {
+	return &Connection{u: endpoint, p: p}
+}
+
+// Do invokes the Do() method on the connection's pipeline.
+func (c *Connection) Do(req *azcore.Request) (*azcore.Response, error) {
+	return c.p.Do(req)
+}
+
+// Endpoint returns the connection's ARM endpoint.
+func (c *Connection) Endpoint() string {
+	return c.u
+}

--- a/sdk/armcore/connection_test.go
+++ b/sdk/armcore/connection_test.go
@@ -1,0 +1,68 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package armcore
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	//"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	//"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+)
+
+type mockTokenCred struct{}
+
+func (mockTokenCred) AuthenticationPolicy(azcore.AuthenticationPolicyOptions) azcore.Policy {
+	return azcore.PolicyFunc(func(req *azcore.Request) (*azcore.Response, error) {
+		return req.Next()
+	})
+}
+
+func (mockTokenCred) GetToken(context.Context, azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
+	return &azcore.AccessToken{
+		Token:     "abc123",
+		ExpiresOn: time.Now().Add(1 * time.Hour),
+	}, nil
+}
+
+func TestNewDefaultConnection(t *testing.T) {
+	opt := DefaultConnectionOptions()
+	con := NewDefaultConnection(mockTokenCred{}, &opt)
+	if ep := con.Endpoint(); ep != DefaultEndpoint {
+		t.Fatalf("unexpected endpoint %s", ep)
+	}
+}
+
+func TestNewConnection(t *testing.T) {
+	const customEndpoint = "https://contoso.com/fake/endpoint"
+	con := NewConnection(customEndpoint, mockTokenCred{}, nil)
+	if ep := con.Endpoint(); ep != customEndpoint {
+		t.Fatalf("unexpected endpoint %s", ep)
+	}
+}
+
+func TestNewConnectionWithPipeline(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse()
+	p := getPipeline(srv)
+	con := NewConnectionWithPipeline(srv.URL(), p)
+	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	resp, err := con.Do(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", resp.StatusCode)
+	}
+}

--- a/sdk/armcore/connection_test.go
+++ b/sdk/armcore/connection_test.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
-	//"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	//"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
 
 type mockTokenCred struct{}

--- a/sdk/armcore/doc.go
+++ b/sdk/armcore/doc.go
@@ -4,9 +4,27 @@
 // Use of this source code is governed by an MIT
 // license that can be found in the LICENSE file.
 
-// Package armcore implements various helpers for Azure Resource Manager APIs.
+// Package armcore provides connections and utilities for Go SDK ARM client modules.
 //
-// You do not need to explicitly import this module.  It will automatically be included as a dependency for all ARM modules.
+// All Azure Resource Manager clients require a Connection, which is simply a
+// combination of the desired ARM endpoint and a pipeline for handling HTTP requests
+// and responses.
 //
-// The contents of this module are used by generated code.  It is not intended for external use.
+// To access the Azure public cloud, use the NewDefaultConnection() constructor with
+// the required token credential.  Module azidentity provides several methods for
+// obtaining token credentials.
+//
+//		cred, _ := azidentity.NewDefaultAzureCredential(nil)
+//		con := armcore.NewDefaultConnection(cred, nil)
+//
+// When accessing clouds other than the Azure public cloud, use the NewConnection()
+// constructor with the required ARM endpoint and token credential.  The most common
+// case is connecting to an Azure sovereign cloud or Azure Stack instance.
+//
+// NewDefaultConnection() and NewConnection() are configured with the same pipeline
+// thus have the same pipeline configuration options.  Use the NewConnectionWithPipeline()
+// constructor to create a connection that uses a custom azcore.Pipeline.  Note that
+// any custom pipeline will require at minimum an authentication policy obtained from
+// a token credential in order to authenticate with ARM.  See the implementation of
+// NewConnection() for how to obtain a credential's authentication policy.
 package armcore

--- a/sdk/armcore/go.mod
+++ b/sdk/armcore/go.mod
@@ -3,6 +3,6 @@ module github.com/Azure/azure-sdk-for-go/sdk/armcore
 go 1.14
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.13.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0
 )

--- a/sdk/armcore/go.sum
+++ b/sdk/armcore/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.13.0 h1:JN0lbs2OdikXprbmj4c2xq6/yyQER/xCNQGast73hTM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.13.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.13.1 h1:YLBIWApuKB/RS0dK/mk/2g6x2+kjI9djMKqViZDTD88=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.13.1/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/sdk/armcore/policy_register_rp.go
+++ b/sdk/armcore/policy_register_rp.go
@@ -19,8 +19,6 @@ import (
 	sdkruntime "github.com/Azure/azure-sdk-for-go/sdk/internal/runtime"
 )
 
-const scope = "https://management.azure.com//.default"
-
 const (
 	// LogRPRegistration entries contain information specific to the automatic registration of an RP.
 	// Entries of this classification are written IFF the policy needs to take any action.


### PR DESCRIPTION
The Connection type will be used for managing connections to ARM.
Updated documentation with examples.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
