### PR TITLE
Replace Connection's Do() with Pipeline()

### DIFF
--- a/sdk/armcore/connection.go
+++ b/sdk/armcore/connection.go
@@ -69,12 +69,12 @@ func NewConnectionWithPipeline(endpoint string, p azcore.Pipeline) *Connection {
 	return &Connection{u: endpoint, p: p}
 }
 
-// Do invokes the Do() method on the connection's pipeline.
-func (c *Connection) Do(req *azcore.Request) (*azcore.Response, error) {
-	return c.p.Do(req)
-}
-
 // Endpoint returns the connection's ARM endpoint.
 func (c *Connection) Endpoint() string {
 	return c.u
+}
+
+// Pipeline returns the connection's pipeline.
+func (c *Connection) Pipeline() azcore.Pipeline {
+	return c.p
 }

--- a/sdk/armcore/connection_test.go
+++ b/sdk/armcore/connection_test.go
@@ -56,7 +56,7 @@ func TestNewConnectionWithPipeline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	resp, err := con.Do(req)
+	resp, err := con.Pipeline().Do(req)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
LROs and pagers require access to the Connection's pipeline.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
