### PR TITLE
Fix profileBuilder

### DIFF
--- a/tools/profileBuilder/model/aliasPackage.go
+++ b/tools/profileBuilder/model/aliasPackage.go
@@ -332,26 +332,19 @@ func (alias *AliasPackage) AddFunc(decl *ast.FuncDecl, originalFile *ast.File) e
 	alias.functions = append(alias.functions, decl)
 
 	for _, im := range imports {
-		if err := alias.addImport(im); err != nil {
-			return err
-		}
+		alias.addImport(im)
 	}
 	return nil
 }
 
-func (alias *AliasPackage) addImport(im *ast.ImportSpec) error {
-	if im == nil {
-		return errUnexpectedNil
-	}
-
+func (alias *AliasPackage) addImport(im *ast.ImportSpec) {
 	for _, i := range alias.imports {
 		if i.Path.Value == im.Path.Value {
-			return nil
+			return
 		}
 	}
 
 	alias.imports = append(alias.imports, im)
-	return nil
 }
 
 // Build add all pending functions and imports into the package

--- a/tools/profileBuilder/model/aliasPackage.go
+++ b/tools/profileBuilder/model/aliasPackage.go
@@ -33,7 +33,7 @@ import (
 // AliasPackage is an abstraction around ast.Package to provide convenience methods for manipulating it.
 type AliasPackage struct {
 	ast.Package
-	general []*ast.GenDecl
+	general   []*ast.GenDecl
 	functions []*ast.FuncDecl
 	imports   []*ast.ImportSpec
 }

--- a/tools/profileBuilder/model/transforms.go
+++ b/tools/profileBuilder/model/transforms.go
@@ -39,7 +39,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/tools/internal/modinfo"
-
 	"golang.org/x/tools/imports"
 )
 
@@ -255,6 +254,7 @@ func writeAliasPackage(ap *AliasPackage, outputPath string, outputLog, errLog *l
 
 	var b bytes.Buffer
 	printer.Fprint(&b, files, file)
+	// this import command only add imports for built-in packages
 	res, err := imports.Process(aliasFile, b.Bytes(), nil)
 	if err != nil {
 		errLog.Fatalf("failed to process imports: %v", err)


### PR DESCRIPTION
it turns out after applying https://github.com/Azure/autorest.go/pull/520, the profileBuilder might not work (check the results [here](https://github.com/Azure/azure-sdk-for-go/pull/13413)).
The tool will not automatically import the new uuid package, and therefore compile errors occur.

This PR fix the profileBuilder to let it scan the import statement and add them to the generated file when necessary. 