### PR TITLE
Fix deadlock in bearer token refresh

### DIFF
--- a/sdk/azidentity/bearer_token_policy.go
+++ b/sdk/azidentity/bearer_token_policy.go
@@ -89,24 +89,24 @@ func (b *bearerTokenPolicy) Do(req *azcore.Request) (*azcore.Response, error) {
 		tk, err := b.creds.GetToken(req.Context(), b.options)
 		// update shared state
 		b.cond.L.Lock()
-		// didn't use defer here in order to explicitly control when unlocking happens
-		unlock := func() {
-			// signal any waiters that the token has been refreshed
-			b.cond.Broadcast()
-			b.cond.L.Unlock()
-		}
 		// to avoid a deadlock if GetToken() fails we MUST reset b.renewing to false before returning
 		b.renewing = false
 		if err != nil {
-			unlock()
+			b.unlock()
 			return nil, err
 		}
 		header = bearerTokenPrefix + tk.Token
 		b.header = header
 		b.expiresOn = tk.ExpiresOn
-		unlock()
+		b.unlock()
 	}
 	req.Request.Header.Set(azcore.HeaderXmsDate, time.Now().UTC().Format(http.TimeFormat))
 	req.Request.Header.Set(azcore.HeaderAuthorization, header)
 	return req.Next()
+}
+
+// signal any waiters that the token has been refreshed
+func (b *bearerTokenPolicy) unlock() {
+	b.cond.Broadcast()
+	b.cond.L.Unlock()
 }


### PR DESCRIPTION
If GetToken() fails the renewing flag wasn't reset, leading to a
deadlock.  Ensure the flag is reset before exiting.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
