### PR TITLE
Don't implement stateless polices as first-class funcs

### DIFF
--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -69,7 +69,7 @@ func NewPipeline(transport Transport, policies ...Policy) Pipeline {
 		transport = defaultHTTPClient
 	}
 	// transport policy must always be the last in the slice
-	policies = append(policies, newHTTPHeaderPolicy(), newBodyDownloadPolicy(), transportPolicy{trans: transport})
+	policies = append(policies, PolicyFunc(httpHeaderPolicy), PolicyFunc(bodyDownloadPolicy), transportPolicy{trans: transport})
 	return Pipeline{
 		policies: policies,
 	}

--- a/sdk/azcore/policy_anonymous_credential.go
+++ b/sdk/azcore/policy_anonymous_credential.go
@@ -5,12 +5,16 @@
 
 package azcore
 
+func anonCredAuthPolicyFunc(AuthenticationPolicyOptions) Policy {
+	return PolicyFunc(anonCredPolicyFunc)
+}
+
+func anonCredPolicyFunc(req *Request) (*Response, error) {
+	return req.Next()
+}
+
 // AnonymousCredential is for use with HTTP(S) requests that read public resource
 // or for use with Shared Access Signatures (SAS).
 func AnonymousCredential() Credential {
-	return credentialFunc(func(AuthenticationPolicyOptions) Policy {
-		return PolicyFunc(func(req *Request) (*Response, error) {
-			return req.Next()
-		})
-	})
+	return credentialFunc(anonCredAuthPolicyFunc)
 }

--- a/sdk/azcore/policy_body_download.go
+++ b/sdk/azcore/policy_body_download.go
@@ -13,28 +13,26 @@ import (
 	"strings"
 )
 
-// newBodyDownloadPolicy creates a policy object that downloads the response's body to a []byte.
-func newBodyDownloadPolicy() Policy {
-	return PolicyFunc(func(req *Request) (*Response, error) {
-		resp, err := req.Next()
-		if err != nil {
-			return resp, err
-		}
-		var opValues bodyDownloadPolicyOpValues
-		// don't skip downloading error response bodies
-		if req.OperationValue(&opValues); opValues.skip && resp.StatusCode < 400 {
-			return resp, err
-		}
-		// Either bodyDownloadPolicyOpValues was not specified (so skip is false)
-		// or it was specified and skip is false: don't skip downloading the body
-		b, err := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return resp, newBodyDownloadError(err, req)
-		}
-		resp.Body = &nopClosingBytesReader{s: b}
+// bodyDownloadPolicy creates a policy object that downloads the response's body to a []byte.
+func bodyDownloadPolicy(req *Request) (*Response, error) {
+	resp, err := req.Next()
+	if err != nil {
 		return resp, err
-	})
+	}
+	var opValues bodyDownloadPolicyOpValues
+	// don't skip downloading error response bodies
+	if req.OperationValue(&opValues); opValues.skip && resp.StatusCode < 400 {
+		return resp, err
+	}
+	// Either bodyDownloadPolicyOpValues was not specified (so skip is false)
+	// or it was specified and skip is false: don't skip downloading the body
+	b, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return resp, newBodyDownloadError(err, req)
+	}
+	resp.Body = &nopClosingBytesReader{s: b}
+	return resp, err
 }
 
 type bodyDownloadError struct {

--- a/sdk/azcore/policy_http_header.go
+++ b/sdk/azcore/policy_http_header.go
@@ -14,22 +14,20 @@ import (
 type ctxWithHTTPHeader struct{}
 
 // newHTTPHeaderPolicy creates a policy object that adds custom HTTP headers to a request
-func newHTTPHeaderPolicy() Policy {
-	return PolicyFunc(func(req *Request) (*Response, error) {
-		// check if any custom HTTP headers have been specified
-		if header := req.Context().Value(ctxWithHTTPHeader{}); header != nil {
-			for k, v := range header.(http.Header) {
-				// use Set to replace any existing value
-				// it also canonicalizes the header key
-				req.Header.Set(k, v[0])
-				// add any remaining values
-				for i := 1; i < len(v); i++ {
-					req.Header.Add(k, v[i])
-				}
+func httpHeaderPolicy(req *Request) (*Response, error) {
+	// check if any custom HTTP headers have been specified
+	if header := req.Context().Value(ctxWithHTTPHeader{}); header != nil {
+		for k, v := range header.(http.Header) {
+			// use Set to replace any existing value
+			// it also canonicalizes the header key
+			req.Header.Set(k, v[0])
+			// add any remaining values
+			for i := 1; i < len(v); i++ {
+				req.Header.Add(k, v[i])
 			}
 		}
-		return req.Next()
-	})
+	}
+	return req.Next()
 }
 
 // WithHTTPHeader adds the specified http.Header to the parent context.


### PR DESCRIPTION
They are needlessly allocated on the heap.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
