### PR TITLE
Fix generator

### DIFF
--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -4,6 +4,7 @@
     "generateScript": {
       "path": "go run ./tools/generator/main.go",
       "stderr": {
+        "showInComment": "^\\[AUTOREST\\]",
         "scriptError": "^\\[ERROR\\]",
         "scriptWarning": "^\\[WARNING\\]"
       }

--- a/tools/generator/autorest/autorest.go
+++ b/tools/generator/autorest/autorest.go
@@ -1,6 +1,7 @@
 package autorest
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -35,9 +36,36 @@ func (t *Task) executeAutorest(options []string) error {
 	arguments := append(options, t.AbsReadmeMd)
 	c := exec.Command("autorest", arguments...)
 	log.Printf("Executing autorest with parameters: %+v", arguments)
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	c.Start()
+
+	stdout, _ := c.StdoutPipe()
+	stderr, _ := c.StderrPipe()
+	errScanner := bufio.NewScanner(stderr)
+	errScanner.Split(bufio.ScanLines)
+	outScanner := bufio.NewScanner(stdout)
+	outScanner.Split(bufio.ScanLines)
+
+	if err := c.Start(); err != nil {
+		return &TaskError{
+			AbsReadmeMd: t.AbsReadmeMd,
+			Script:      "autorest",
+			Message:     err.Error(),
+		}
+	}
+
+	go func() {
+		for errScanner.Scan() {
+			line := errScanner.Text()
+			fmt.Fprintln(os.Stderr, "[AUTOREST] " + line)
+		}
+	}()
+
+	go func() {
+		for outScanner.Scan() {
+			line := outScanner.Text()
+			fmt.Fprintln(os.Stdout, "[AUTOREST] " + line)
+		}
+	}()
+
 	if err := c.Wait(); err != nil {
 		return &TaskError{
 			AbsReadmeMd: t.AbsReadmeMd,

--- a/tools/generator/autorest/autorest.go
+++ b/tools/generator/autorest/autorest.go
@@ -55,14 +55,14 @@ func (t *Task) executeAutorest(options []string) error {
 	go func() {
 		for errScanner.Scan() {
 			line := errScanner.Text()
-			fmt.Fprintln(os.Stderr, "[AUTOREST] " + line)
+			fmt.Fprintln(os.Stderr, "[AUTOREST] "+line)
 		}
 	}()
 
 	go func() {
 		for outScanner.Scan() {
 			line := outScanner.Text()
-			fmt.Fprintln(os.Stdout, "[AUTOREST] " + line)
+			fmt.Fprintln(os.Stdout, "[AUTOREST] "+line)
 		}
 	}()
 

--- a/tools/generator/changelog/export.go
+++ b/tools/generator/changelog/export.go
@@ -2,7 +2,6 @@ package changelog
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
@@ -22,7 +21,6 @@ func NewChangelogForPackage(pkgDir string) (c *Changelog, err error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Exports of package '%s': %+v", pkgDir, rhs)
 	// stash everything and get the previous status of the package
 	if err := stashEverything(); err != nil {
 		return nil, err
@@ -36,7 +34,6 @@ func NewChangelogForPackage(pkgDir string) (c *Changelog, err error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Exports of original package '%s': %+v", pkgDir, lhs)
 	return getChangelogForPackage(pkgDir, lhs, rhs)
 }
 

--- a/tools/generator/cmd/root.go
+++ b/tools/generator/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/tools/generator/changelog"
 	"log"
 	"os"
 	"os/exec"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/tools/generator/autorest"
+	"github.com/Azure/azure-sdk-for-go/tools/generator/changelog"
 	"github.com/Azure/azure-sdk-for-go/tools/generator/model"
 	"github.com/spf13/cobra"
 )
@@ -109,7 +109,7 @@ func generate(input *model.GenerateInput, optionPath string) (*model.GenerateOut
 	log.Printf("Autorest options: \n%s", options.String())
 
 	// iterate over all the readme
-	var results []model.PackageResult
+	results := make([]model.PackageResult, 0)
 	for _, readme := range input.RelatedReadmeMdFiles {
 		log.Printf("Processing readme '%s'...", readme)
 		task := autorest.Task{

--- a/tools/generator/model/model.go
+++ b/tools/generator/model/model.go
@@ -50,7 +50,7 @@ type InstallInstructionScriptInput struct {
 
 // GenerateOutput ...
 type GenerateOutput struct {
-	Packages []PackageResult `json:"packages,omitempty"`
+	Packages []PackageResult `json:"packages"`
 }
 
 // String ...


### PR DESCRIPTION
Because in the definition of GenerateOutput, `packages` is required in the schema. Therefore we should never produce null packages, instead we should produce an empty array of packages when there is not any

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
