### PR TITLE
Include telemetry string in User-Agent

### DIFF
--- a/sdk/azcore/policy_telemetry.go
+++ b/sdk/azcore/policy_telemetry.go
@@ -64,6 +64,8 @@ func NewTelemetryPolicy(o *TelemetryOptions) Policy {
 		b.WriteString(o.Value)
 		b.WriteRune(' ')
 	}
+	b.WriteString(UserAgent)
+	b.WriteRune(' ')
 	b.WriteString(platformInfo)
 	tp.telemetryValue = b.String()
 	return &tp

--- a/sdk/azcore/policy_telemetry_test.go
+++ b/sdk/azcore/policy_telemetry_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
 
+var defaultTelemetry = UserAgent + " " + platformInfo
+
 func TestPolicyTelemetryDefault(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
@@ -27,7 +29,7 @@ func TestPolicyTelemetryDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(HeaderUserAgent); v != platformInfo {
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != defaultTelemetry {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -48,7 +50,7 @@ func TestPolicyTelemetryWithCustomInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", testValue, platformInfo) {
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", testValue, defaultTelemetry) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -68,7 +70,7 @@ func TestPolicyTelemetryPreserveExisting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", platformInfo, otherValue) {
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", defaultTelemetry, otherValue) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -89,7 +91,7 @@ func TestPolicyTelemetryWithAppID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", appID, platformInfo) {
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", appID, defaultTelemetry) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -111,7 +113,7 @@ func TestPolicyTelemetryWithAppIDAndReqTelemetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s %s", "TestPolicyTelemetryWithAppIDAndReqTelemetry", appID, platformInfo) {
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s %s", "TestPolicyTelemetryWithAppIDAndReqTelemetry", appID, defaultTelemetry) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -133,7 +135,7 @@ func TestPolicyTelemetryWithAppIDSanitized(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	const newAppID = "This/will/get/the/spaces"
-	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", newAppID, platformInfo) {
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s", newAppID, defaultTelemetry) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -156,7 +158,7 @@ func TestPolicyTelemetryPreserveExistingWithAppID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s %s", appID, platformInfo, otherValue) {
+	if v := resp.Request.Header.Get(HeaderUserAgent); v != fmt.Sprintf("%s %s %s", appID, defaultTelemetry, otherValue) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }

--- a/sdk/azcore/version.go
+++ b/sdk/azcore/version.go
@@ -9,6 +9,6 @@ const (
 	// UserAgent is the string to be used in the user agent string when making requests.
 	UserAgent = "azcore/" + Version
 
-	// Version is the semantic version (see http://semver.org) of the pipeline package.
-	Version = "0.13.0"
+	// Version is the semantic version (see http://semver.org) of this module.
+	Version = "v0.13.4"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
