### PR TITLE
Update MSI App Service 2017 api-version 

### DIFF
--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -124,10 +124,10 @@ func (c *managedIdentityClient) createAccessToken(res *azcore.Response) (*azcore
 	}
 	// this is the case when expires_on is a time string
 	// this is the format of the string coming from the service
-	if expiresOn, err := time.Parse("01/02/2006 15:04:05 PM +00:00", value.ExpiresOn); err == nil { // the date string specified is for Windows OS
+	if expiresOn, err := time.Parse("1/2/2006 15:04:05 PM +00:00", value.ExpiresOn); err == nil { // the date string specified is for Windows OS
 		eo := expiresOn.UTC()
 		return &azcore.AccessToken{Token: value.Token, ExpiresOn: eo}, nil
-	} else if expiresOn, err := time.Parse("01/02/2006 15:04:05 +00:00", value.ExpiresOn); err == nil { // the date string specified is for Linux OS
+	} else if expiresOn, err := time.Parse("1/2/2006 15:04:05 +00:00", value.ExpiresOn); err == nil { // the date string specified is for Linux OS
 		eo := expiresOn.UTC()
 		return &azcore.AccessToken{Token: value.Token, ExpiresOn: eo}, nil
 	} else {
@@ -186,6 +186,7 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context,
 		q.Add("api-version", "2017-09-01")
 		q.Add("resource", strings.Join(scopes, " "))
 		if clientID != "" {
+			// the legacy 2017 API version specifically specifies "clientid" and not "client_id" as a query param
 			q.Add("clientid", clientID)
 		}
 	} else if c.msiType == msiTypeAppServiceV20190801 {

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -124,7 +124,10 @@ func (c *managedIdentityClient) createAccessToken(res *azcore.Response) (*azcore
 	}
 	// this is the case when expires_on is a time string
 	// this is the format of the string coming from the service
-	if expiresOn, err := time.Parse("01/02/2006 15:04:05 PM +00:00", value.ExpiresOn); err == nil { // the date string specified in the layout param of time.Parse cannot be changed, Golang expects whatever layout to always signify January 2, 2006 at 3:04 PM
+	if expiresOn, err := time.Parse("01/02/2006 15:04:05 PM +00:00", value.ExpiresOn); err == nil { // the date string specified is for Windows OS
+		eo := expiresOn.UTC()
+		return &azcore.AccessToken{Token: value.Token, ExpiresOn: eo}, nil
+	} else if expiresOn, err := time.Parse("01/02/2006 15:04:05 +00:00", value.ExpiresOn); err == nil { // the date string specified is for Linux OS
 		eo := expiresOn.UTC()
 		return &azcore.AccessToken{Token: value.Token, ExpiresOn: eo}, nil
 	} else {
@@ -182,14 +185,18 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context,
 		request.Header.Set("secret", os.Getenv(msiSecret))
 		q.Add("api-version", "2017-09-01")
 		q.Add("resource", strings.Join(scopes, " "))
+		if clientID != "" {
+			q.Add("clientid", clientID)
+		}
 	} else if c.msiType == msiTypeAppServiceV20190801 {
 		request.Header.Set("X-IDENTITY-HEADER", os.Getenv(identityHeader))
 		q.Add("api-version", "2019-08-01")
 		q.Add("resource", scopes[0])
+		if clientID != "" {
+			q.Add(qpClientID, clientID)
+		}
 	}
-	if clientID != "" {
-		q.Add(qpClientID, clientID)
-	}
+
 	request.URL.RawQuery = q.Encode()
 	return request, nil
 }

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	msiScope                     = "https://storage.azure.com"
-	appServiceWindowsSuccessResp = `{"access_token": "new_token", "expires_on": "09/14/2017 00:00:00 PM +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
+	appServiceWindowsSuccessResp = `{"access_token": "new_token", "expires_on": "9/14/2017 00:00:00 PM +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 	appServiceLinuxSuccessResp   = `{"access_token": "new_token", "expires_on": "09/14/2017 00:00:00 +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 	expiresOnIntResp             = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": "1560974028", "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 )

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	msiScope                   = "https://storage.azure.com"
-	appServiceTokenSuccessResp = `{"access_token": "new_token", "expires_on": "09/14/2017 00:00:00 PM +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
-	expiresOnIntResp           = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": "1560974028", "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
+	msiScope                     = "https://storage.azure.com"
+	appServiceWindowsSuccessResp = `{"access_token": "new_token", "expires_on": "09/14/2017 00:00:00 PM +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
+	appServiceLinuxSuccessResp   = `{"access_token": "new_token", "expires_on": "09/14/2017 00:00:00 +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
+	expiresOnIntResp             = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": "1560974028", "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 )
 
 func clearEnvVars(envVars ...string) {
@@ -92,11 +93,11 @@ func TestManagedIdentityCredential_GetTokenInCloudShellMockFail(t *testing.T) {
 	}
 }
 
-func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock(t *testing.T) {
+func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_windows(t *testing.T) {
 	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(appServiceTokenSuccessResp)))
+	srv.AppendResponse(mock.WithBody([]byte(appServiceWindowsSuccessResp)))
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	_ = os.Setenv("MSI_SECRET", "secret")
 	defer clearEnvVars("MSI_ENDPOINT", "MSI_SECRET")
@@ -118,11 +119,37 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock(t *testing.
 	}
 }
 
-func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock(t *testing.T) {
+func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_linux(t *testing.T) {
 	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()
 	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(appServiceTokenSuccessResp)))
+	srv.AppendResponse(mock.WithBody([]byte(appServiceLinuxSuccessResp)))
+	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
+	_ = os.Setenv("MSI_SECRET", "secret")
+	defer clearEnvVars("MSI_ENDPOINT", "MSI_SECRET")
+	options := DefaultManagedIdentityCredentialOptions()
+	options.HTTPClient = srv
+	msiCred, err := NewManagedIdentityCredential(clientID, &options)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tk, err := msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
+	if err != nil {
+		t.Fatalf("Received an error when attempting to retrieve a token")
+	}
+	if tk.Token != "new_token" {
+		t.Fatalf("Did not receive the correct token. Expected \"new_token\", Received: %s", tk.Token)
+	}
+	if msiCred.client.msiType != msiTypeAppServiceV20170901 {
+		t.Fatalf("Failed to detect the correct MSI Environment. Expected: %d, Received: %d", msiTypeAppServiceV20170901, msiCred.client.msiType)
+	}
+}
+
+func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_windows(t *testing.T) {
+	resetEnvironmentVarsForTest()
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithBody([]byte(appServiceWindowsSuccessResp)))
 	_ = os.Setenv("IDENTITY_ENDPOINT", srv.URL())
 	_ = os.Setenv("IDENTITY_HEADER", "header")
 	defer clearEnvVars("IDENTITY_ENDPOINT", "IDENTITY_HEADER")
@@ -144,7 +171,33 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock(t *testing.
 	}
 }
 
-func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20170901(t *testing.T) {
+func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_linux(t *testing.T) {
+	resetEnvironmentVarsForTest()
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithBody([]byte(appServiceLinuxSuccessResp)))
+	_ = os.Setenv("IDENTITY_ENDPOINT", srv.URL())
+	_ = os.Setenv("IDENTITY_HEADER", "header")
+	defer clearEnvVars("IDENTITY_ENDPOINT", "IDENTITY_HEADER")
+	options := DefaultManagedIdentityCredentialOptions()
+	options.HTTPClient = srv
+	msiCred, err := NewManagedIdentityCredential("", &options)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tk, err := msiCred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{msiScope}})
+	if err != nil {
+		t.Fatalf("Received an error when attempting to retrieve a token")
+	}
+	if tk.Token != "new_token" {
+		t.Fatalf("Did not receive the correct token. Expected \"new_token\", Received: %s", tk.Token)
+	}
+	if msiCred.client.msiType != msiTypeAppServiceV20190801 {
+		t.Fatalf("Failed to detect the correct MSI Environment. Expected: %d, Received: %d", msiTypeAppServiceV20190801, msiCred.client.msiType)
+	}
+}
+
+func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20190801(t *testing.T) {
 	// setting a dummy value for MSI_ENDPOINT in order to be able to get a ManagedIdentityCredential type in order
 	// to test App Service authentication request creation.
 	_ = os.Setenv("IDENTITY_ENDPOINT", "somevalue")
@@ -155,7 +208,7 @@ func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20170901(t *testi
 		t.Fatalf("unexpected error: %v", err)
 	}
 	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createAuthRequest(context.Background(), "", []string{msiScope})
+	req, err := cred.client.createAuthRequest(context.Background(), clientID, []string{msiScope})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,9 +225,12 @@ func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20170901(t *testi
 	if reqQueryParams["resource"][0] != msiScope {
 		t.Fatalf("Unexpected resource in resource query param")
 	}
+	if reqQueryParams[qpClientID][0] != clientID {
+		t.Fatalf("Unexpected client ID in resource query param")
+	}
 }
 
-func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20190801(t *testing.T) {
+func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20170901(t *testing.T) {
 	// setting a dummy value for MSI_ENDPOINT in order to be able to get a ManagedIdentityCredential type in order
 	// to test App Service authentication request creation.
 	_ = os.Setenv("MSI_ENDPOINT", "somevalue")
@@ -185,7 +241,7 @@ func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20190801(t *testi
 		t.Fatalf("unexpected error: %v", err)
 	}
 	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createAuthRequest(context.Background(), "", []string{msiScope})
+	req, err := cred.client.createAuthRequest(context.Background(), clientID, []string{msiScope})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,6 +257,9 @@ func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20190801(t *testi
 	}
 	if reqQueryParams["resource"][0] != msiScope {
 		t.Fatalf("Unexpected resource in resource query param")
+	}
+	if reqQueryParams["clientid"][0] != clientID {
+		t.Fatalf("Unexpected client ID in resource query param")
 	}
 }
 


### PR DESCRIPTION
This PR updates managed identity credential to parse both Windows and Linux datetime strings for tokens expires on values and also updates the client ID param for app service api-version 2017-09-01.