### PR TITLE
Add ability to log request/response bodies

### DIFF
--- a/sdk/azcore/policy_logging_test.go
+++ b/sdk/azcore/policy_logging_test.go
@@ -6,6 +6,7 @@
 package azcore
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -115,5 +116,30 @@ func TestPolicyLoggingError(t *testing.T) {
 		}
 	} else {
 		t.Fatal("missing LogResponse")
+	}
+}
+
+func TestShouldLogBody(t *testing.T) {
+	b := bytes.NewBuffer(make([]byte, 64))
+	if shouldLogBody(b, "application/octet-stream") {
+		t.Fatal("shouldn't log for application/octet-stream")
+	} else if b.Len() == 0 {
+		t.Fatal("skip logging should write skip message to buffer")
+	}
+	b.Reset()
+	if !shouldLogBody(b, "application/json") {
+		t.Fatal("should log for application/json")
+	} else if b.Len() != 0 {
+		t.Fatal("logging shouldn't write message")
+	}
+	if !shouldLogBody(b, "application/xml") {
+		t.Fatal("should log for application/xml")
+	} else if b.Len() != 0 {
+		t.Fatal("logging shouldn't write message")
+	}
+	if !shouldLogBody(b, "text/plain") {
+		t.Fatal("should log for text/plain")
+	} else if b.Len() != 0 {
+		t.Fatal("logging shouldn't write message")
 	}
 }

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -261,9 +261,7 @@ func (req *Request) writeBody(b *bytes.Buffer) error {
 	if err := req.RewindBody(); err != nil {
 		return err
 	}
-	fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
-	fmt.Fprintln(b, string(body))
-	fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
+	logBody(b, body)
 	return nil
 }
 
@@ -339,4 +337,10 @@ func azureTagIsReadOnly(tag string) bool {
 		}
 	}
 	return false
+}
+
+func logBody(b *bytes.Buffer, body []byte) {
+	fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
+	fmt.Fprintln(b, string(body))
+	fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
 }

--- a/sdk/azcore/response.go
+++ b/sdk/azcore/response.go
@@ -162,6 +162,26 @@ func (r *Response) retryAfter() time.Duration {
 	return RetryAfter(r.Response)
 }
 
+// writes to a buffer, used for logging purposes
+func (r *Response) writeBody(b *bytes.Buffer) error {
+	if ct := r.Header.Get(HeaderContentType); !shouldLogBody(b, ct) {
+		return nil
+	}
+	body, err := r.payload()
+	if err != nil {
+		fmt.Fprintf(b, "   Failed to read response body: %s\n", err.Error())
+		return err
+	}
+	if len(body) > 0 {
+		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
+		fmt.Fprintln(b, string(body))
+		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
+	} else {
+		fmt.Fprint(b, "   Response contained no body\n")
+	}
+	return nil
+}
+
 // RetryAfter returns non-zero if the response contains a Retry-After header value.
 func RetryAfter(resp *http.Response) time.Duration {
 	if resp == nil {

--- a/sdk/azcore/response.go
+++ b/sdk/azcore/response.go
@@ -173,9 +173,7 @@ func (r *Response) writeBody(b *bytes.Buffer) error {
 		return err
 	}
 	if len(body) > 0 {
-		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
-		fmt.Fprintln(b, string(body))
-		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
+		logBody(b, body)
 	} else {
 		fmt.Fprint(b, "   Response contained no body\n")
 	}


### PR DESCRIPTION
Added IncludeBody to LogOptions to enable logging of HTTP request and
response bodies.  The default is false and cannot be enabled by way of
environment variable.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
