### PR TITLE
Adding port option for interactive browser

### DIFF
--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -385,8 +385,8 @@ func (c *aadIdentityClient) createDeviceCodeNumberRequest(ctx context.Context, t
 // clientSecret: Gets the client secret that was generated for the App Registration used to authenticate the client.
 // redirectURI: The redirect URI that was used to request the authorization code. Must be the same URI that is configured for the App Registration.
 // scopes: The scopes required for the token
-func (c *aadIdentityClient) authenticateInteractiveBrowser(ctx context.Context, tenantID string, clientID string, clientSecret string, redirectURI string, scopes []string) (*azcore.AccessToken, error) {
-	cfg, err := authCodeReceiver(c.authorityHost, tenantID, clientID, redirectURI, scopes)
+func (c *aadIdentityClient) authenticateInteractiveBrowser(ctx context.Context, tenantID string, clientID string, clientSecret string, redirectURI string, port int, scopes []string) (*azcore.AccessToken, error) {
+	cfg, err := authCodeReceiver(c.authorityHost, tenantID, clientID, redirectURI, port, scopes)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -147,8 +147,8 @@ func interactiveBrowserLogin(authorityHost string, tenantID string, clientID str
 	}, nil
 }
 
+// if the authority host ends with a "/"" remove it and return
 func checkAuthHostFormat(s string) string {
-	// if the authority host ends with a / remove it and return
 	if string(s[len(s)-1]) == "/" {
 		return s[:len(s)-1]
 	}

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -153,11 +153,3 @@ func interactiveBrowserLogin(authorityHost string, tenantID string, clientID str
 		redirectURI: redirectURL,
 	}, nil
 }
-
-// if the authority host ends with a "/"" remove it and return
-func checkAuthHostFormat(s string) string {
-	if string(s[len(s)-1]) == "/" {
-		return s[:len(s)-1]
-	}
-	return s
-}

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -63,7 +63,7 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	authCodeReceiver = func(authorityHost string, tenantID string, clientID string, redirectURI string, scopes []string) (*interactiveConfig, error) {
+	authCodeReceiver = func(authorityHost string, tenantID string, clientID string, redirectURI string, port int, scopes []string) (*interactiveConfig, error) {
 		return &interactiveConfig{
 			authCode:    "12345",
 			redirectURI: srv.URL(),
@@ -96,7 +96,7 @@ func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	authCodeReceiver = func(authorityHost string, tenantID string, clientID string, redirectURI string, scopes []string) (*interactiveConfig, error) {
+	authCodeReceiver = func(authorityHost string, tenantID string, clientID string, redirectURI string, port int, scopes []string) (*interactiveConfig, error) {
 		return &interactiveConfig{
 			authCode:    "12345",
 			redirectURI: srv.URL(),

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -78,6 +78,42 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 	}
 }
 
+func TestInteractiveBrowserCredential_SetPort(t *testing.T) {
+	srv, close := mock.NewTLSServer(mock.WithHTTP2Enabled(true))
+	defer close()
+	tr := &http.Transport{}
+	if err := http2.ConfigureTransport(tr); err != nil {
+		t.Fatalf("Failed to configure http2 transport: %v", err)
+	}
+	tr.TLSClientConfig.InsecureSkipVerify = true
+	client := &http.Client{Transport: tr}
+	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	options := DefaultInteractiveBrowserCredentialOptions()
+	options.AuthorityHost = srv.URL()
+	options.HTTPClient = client
+	options.Port = 8080
+	cred, err := NewInteractiveBrowserCredential(&options)
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	authCodeReceiver = func(authorityHost string, tenantID string, clientID string, redirectURI string, port int, scopes []string) (*interactiveConfig, error) {
+		if port != 8080 {
+			t.Fatalf("Did not receive the correct port. Expected: %v, Received: %v", 8080, port)
+		}
+		return &interactiveConfig{
+			authCode:    "12345",
+			redirectURI: srv.URL(),
+		}, nil
+	}
+	tk, err := cred.GetToken(context.Background(), azcore.TokenRequestOptions{Scopes: []string{"https://storage.azure.com/.default"}})
+	if err != nil {
+		t.Fatalf("Expected an empty error but received: %v", err)
+	}
+	if tk.Token != "new_token" {
+		t.Fatal("Received unexpected token")
+	}
+}
+
 func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
 	srv, close := mock.NewTLSServer(mock.WithHTTP2Enabled(true))
 	defer close()

--- a/sdk/azidentity/interactive_browser_server.go
+++ b/sdk/azidentity/interactive_browser_server.go
@@ -58,8 +58,10 @@ func newServer() *server {
 
 // Start starts the local HTTP server on a separate go routine.
 // The return value is the full URL plus port number.
-func (s *server) Start(reqState string) string {
-	port := rand.Intn(600) + 8400
+func (s *server) Start(reqState string, port int) string {
+	if port == 0 {
+		port = rand.Intn(600) + 8400
+	}
 	s.s.Addr = fmt.Sprintf(":%d", port)
 	s.s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer s.wg.Done()


### PR DESCRIPTION
Users may need to set a specific port for their localhost server. Enable that option and also check that the authority host for interactive browser is in the right format for the string format it is going to be added into.

Fixes #14052.