### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Combined, these techniques will ensure that breaking changes should not occur. I
 Starting with `go-autorest v10.15.0` you can enable basic logging of requests and responses through setting environment variables.
 Setting `AZURE_GO_SDK_LOG_LEVEL` to `INFO` will log request/response without their bodies. To include the bodies set the log level to `DEBUG`.
 
-By default the logger writes to strerr, however it can also write to stdout or a file
+By default the logger writes to stderr, however it can also write to stdout or a file
 if specified in `AZURE_GO_SDK_LOG_FILE`. Note that if the specified file already exists it will be truncated.
 
 **IMPORTANT:** by default the logger will redact the Authorization and Ocp-Apim-Subscription-Key


### PR DESCRIPTION
I fixed typo from "strerr"(string error?) to "stderr"(standard error!) in README.md. Please check it.

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
