### PR TITLE
Adding track2 API diff tools

### DIFF
--- a/sdk/tools/apidiff/cmd/changelog.go
+++ b/sdk/tools/apidiff/cmd/changelog.go
@@ -20,8 +20,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/markdown"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/markdown"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/report"
 	"github.com/spf13/cobra"
 )
 

--- a/sdk/tools/apidiff/cmd/changelog.go
+++ b/sdk/tools/apidiff/cmd/changelog.go
@@ -1,0 +1,217 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/markdown"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
+	"github.com/spf13/cobra"
+)
+
+var changelogCmd = &cobra.Command{
+	Use:   "changelog <package search dir> <base commit> <target commit>",
+	Short: "Generates a CHANGELOG report in markdown format for the packages under the specified directory.",
+	Long: `The changelog command generates a CHANGELOG for all of the packages under the directory specified in <package dir>.
+A table for added, removed, updated, and breaking changes will be created as required.`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		// there should be exactly three args, a directory and two commit hashes
+		if err := cobra.ExactArgs(3)(cmd, args); err != nil {
+			return err
+		}
+		if strings.Index(args[2], ",") > -1 {
+			return errors.New("sequence of target commits is not supported")
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return theChangelogCmd(args)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(changelogCmd)
+}
+
+func theChangelogCmd(args []string) error {
+	// TODO: refactor so that we don't depend on the packages command
+	rpt, err := thePackagesCmd(args)
+	if err != nil {
+		return err
+	}
+	if rpt.IsEmpty() {
+		return nil
+	}
+
+	// there should only be one report, the delta between the base and target commits
+	if len(rpt.CommitsReports) > 1 {
+		panic("expected only one report")
+	}
+	for _, cr := range rpt.CommitsReports {
+		changelog, err := writePackageChangelog(cr)
+		if err != nil {
+			return err
+		}
+		fmt.Println(changelog)
+	}
+	return nil
+}
+
+func writePackageChangelog(pr report.PkgsReport) (string, error) {
+	md := &markdown.Writer{}
+	if err := reportAddedPkgs(pr, md); err != nil {
+		return "", fmt.Errorf("failed to write table for added packages: %+v", err)
+	}
+	if err := reportUpdatedPkgs(pr, md); err != nil {
+		return "", fmt.Errorf("failed to write table for updated packages: %+v", err)
+	}
+	if err := reportBreakingPkgs(pr, md); err != nil {
+		return "", fmt.Errorf("failed to write table for breaking change packages: %+v", err)
+	}
+	if err := reportRemovedPkgs(pr, md); err != nil {
+		return "", fmt.Errorf("failed to write table for removed packages: %+v", err)
+	}
+	return md.String(), nil
+}
+
+func reportAddedPkgs(pr report.PkgsReport, md *markdown.Writer) error {
+	if len(pr.AddedPackages) == 0 {
+		return nil
+	}
+	t, err := createPackageTable(pr.AddedPackages)
+	if err != nil {
+		return err
+	}
+	if t.Rows() > 0 {
+		md.WriteSubheader("New Packages")
+		md.WriteTable(*t)
+	}
+	return nil
+}
+
+func reportUpdatedPkgs(pr report.PkgsReport, md *markdown.Writer) error {
+	if pr.ModifiedPackages == nil || !pr.ModifiedPackages.HasAdditiveChanges() {
+		return nil
+	}
+	var updated []string
+	for pkgName, pkgRpt := range pr.ModifiedPackages {
+		if pkgRpt.HasAdditiveChanges() && !pkgRpt.HasBreakingChanges() {
+			updated = append(updated, pkgName)
+		}
+	}
+	t, err := createPackageTable(updated)
+	if err != nil {
+		return err
+	}
+	if t.Rows() > 0 {
+		md.WriteSubheader("Updated Packages")
+		md.WriteTable(*t)
+	}
+	return nil
+}
+
+func reportBreakingPkgs(pr report.PkgsReport, md *markdown.Writer) error {
+	if pr.ModifiedPackages == nil || !pr.ModifiedPackages.HasBreakingChanges() {
+		return nil
+	}
+	var breaking []string
+	for pkgName, pkgRpt := range pr.ModifiedPackages {
+		if pkgRpt.HasBreakingChanges() {
+			breaking = append(breaking, pkgName)
+		}
+	}
+	t, err := createPackageTable(breaking)
+	if err != nil {
+		return err
+	}
+	if t.Rows() > 0 {
+		md.WriteSubheader("Breaking Changes")
+		md.WriteTable(*t)
+	}
+	return nil
+}
+
+func reportRemovedPkgs(pr report.PkgsReport, md *markdown.Writer) error {
+	if len(pr.RemovedPackages) == 0 {
+		return nil
+	}
+	t, err := createPackageTable(pr.RemovedPackages)
+	if err != nil {
+		return err
+	}
+	if t.Rows() > 0 {
+		md.WriteSubheader("Removed Packages")
+		md.WriteTable(*t)
+	}
+	return nil
+}
+
+type tableRow struct {
+	pkgName     string
+	apiVersions []string
+}
+
+func convertFullPackagePathToPackageNameAndAPIVersion(packageName string) (string, string, error) {
+	// packageName is a string like "github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2018-08-31/consumption"
+	segments := strings.Split(packageName, "/")
+	if len(segments) < 2 {
+		return "", "", fmt.Errorf("expecting package name '%s' to have at least two segments", packageName)
+	}
+	return segments[len(segments)-1], segments[len(segments)-2], nil
+}
+
+func createPackageTable(pkgs []string) (*markdown.Table, error) {
+	t := markdown.NewTable("rc", "Package Name", "API Version")
+	rows, err := categorizePackageAPIVersions(pkgs)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		t.AddRow(row.pkgName, strings.Join(row.apiVersions, "<br/>"))
+	}
+	return t, nil
+}
+
+func categorizePackageAPIVersions(pkgs []string) ([]tableRow, error) {
+	entries := make(map[string][]string)
+	for _, pkg := range pkgs {
+		pkgName, apiVer, err := convertFullPackagePathToPackageNameAndAPIVersion(pkg)
+		if err != nil {
+			return nil, err
+		}
+		if apis, ok := entries[pkgName]; ok {
+			entries[pkgName] = append(apis, apiVer)
+		} else {
+			entries[pkgName] = []string{apiVer}
+		}
+	}
+	// convert the map to a slice of tableRows
+	var rows []tableRow
+	for pkgName, apiVers := range entries {
+		sort.Strings(apiVers)
+		rows = append(rows, tableRow{
+			pkgName:     pkgName,
+			apiVersions: apiVers,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].pkgName < rows[j].pkgName
+	})
+	return rows, nil
+}

--- a/sdk/tools/apidiff/cmd/common.go
+++ b/sdk/tools/apidiff/cmd/common.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
-	"github.com/Azure/azure-sdk-for-go/tools/internal/ioext"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/repo"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/report"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/internal/ioext"
 )
 
 func printf(format string, a ...interface{}) {

--- a/sdk/tools/apidiff/cmd/common.go
+++ b/sdk/tools/apidiff/cmd/common.go
@@ -1,0 +1,197 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
+	"github.com/Azure/azure-sdk-for-go/tools/internal/ioext"
+)
+
+func printf(format string, a ...interface{}) {
+	if !quietFlag {
+		fmt.Printf(format, a...)
+	}
+}
+
+func println(a ...interface{}) {
+	if !quietFlag {
+		fmt.Println(a...)
+	}
+}
+
+func dprintf(format string, a ...interface{}) {
+	if debugFlag {
+		printf(format, a...)
+	}
+}
+
+func dprintln(a ...interface{}) {
+	if debugFlag {
+		println(a...)
+	}
+}
+
+func vprintf(format string, a ...interface{}) {
+	if verboseFlag {
+		printf(format, a...)
+	}
+}
+
+func vprintln(a ...interface{}) {
+	if verboseFlag {
+		println(a...)
+	}
+}
+
+func processArgsAndClone(args []string) (cln repo.WorkingTree, err error) {
+	if onlyAdditiveChangesFlag && onlyBreakingChangesFlag {
+		err = errors.New("flags 'additions' and 'breakingchanges' are mutually exclusive")
+		return
+	}
+
+	// there should be at minimum two args, a directory and a
+	// sequence of commits, i.e. "d:\foo 1,2,3".  else a directory
+	// and two commits, i.e. "d:\foo 1 2" or "d:\foo 1 2,3"
+	if len(args) < 2 {
+		err = errors.New("not enough args were supplied")
+		return
+	}
+
+	// here args[1] should be a comma-delimited list of commits
+	if len(args) == 2 && strings.Index(args[1], ",") < 0 {
+		err = errors.New("expected a comma-delimited list of commits")
+		return
+	}
+
+	dir := args[0]
+	dir, err = filepath.Abs(dir)
+	if err != nil {
+		err = fmt.Errorf("failed to convert path '%s' to absolute path: %v", dir, err)
+		return
+	}
+
+	src, err := repo.Get(dir)
+	if err != nil {
+		err = fmt.Errorf("failed to get repository: %v", err)
+		return
+	}
+
+	tempRepoDir := filepath.Join(os.TempDir(), fmt.Sprintf("apidiff-%v", time.Now().Unix()))
+	if copyRepoFlag {
+		vprintf("copying '%s' into '%s'...\n", src.Root(), tempRepoDir)
+		err = ioext.CopyDir(src.Root(), tempRepoDir)
+		if err != nil {
+			err = fmt.Errorf("failed to copy repo: %v", err)
+			return
+		}
+		cln, err = repo.Get(tempRepoDir)
+		if err != nil {
+			err = fmt.Errorf("failed to get copied repo: %v", err)
+			return
+		}
+	} else {
+		vprintf("cloning '%s' into '%s'...\n", src.Root(), tempRepoDir)
+		cln, err = src.Clone(tempRepoDir)
+		if err != nil {
+			err = fmt.Errorf("failed to clone repository: %v", err)
+			return
+		}
+	}
+
+	// fix up pkgDir to the clone
+	args[0] = strings.Replace(dir, src.Root(), cln.Root(), 1)
+
+	return
+}
+
+type reportGenFunc func(dir string, cln repo.WorkingTree, baseCommit, targetCommit string) error
+
+func generateReports(args []string, cln repo.WorkingTree, fn reportGenFunc) error {
+	defer func() {
+		// delete clone
+		vprintln("cleaning up clone")
+		err := os.RemoveAll(cln.Root())
+		if err != nil {
+			vprintf("failed to delete temp repo: %v\n", err)
+		}
+	}()
+
+	var commits []string
+
+	// if the commits are specified as 1 2,3,4 then it means that commit 1 is
+	// always the base commit and to compare it against each target commit in
+	// the sequence.  however if it's specifed as 1,2,3,4 then the base commit
+	// is relative to the iteration, i.e. compare 1-2, 2-3, 3-4.
+	fixedBase := true
+	if len(args) == 3 {
+		commits = make([]string, 2, 2)
+		commits[0] = args[1]
+		commits[1] = args[2]
+	} else {
+		commits = strings.Split(args[1], ",")
+		fixedBase = false
+	}
+
+	for i := 0; i+1 < len(commits); i++ {
+		baseCommit := commits[i]
+		if fixedBase {
+			baseCommit = commits[0]
+		}
+		targetCommit := commits[i+1]
+
+		err := fn(args[0], cln, baseCommit, targetCommit)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// compares report status with the desired report options (breaking/additions)
+// to determine if the program should terminate with a non-zero exit code.
+func evalReportStatus(r report.Status) {
+	if onlyBreakingChangesFlag && r.HasBreakingChanges() {
+		os.Exit(1)
+	}
+	if onlyAdditiveChangesFlag && !r.HasAdditiveChanges() {
+		os.Exit(1)
+	}
+}
+
+// PrintReport prints the report to stdout
+func PrintReport(r report.Status) error {
+	if r.IsEmpty() {
+		println("no changes were found")
+		return nil
+	}
+
+	if !suppressReport {
+		b, err := json.MarshalIndent(r, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal report: %v", err)
+		}
+		println(string(b))
+	}
+	return nil
+}

--- a/sdk/tools/apidiff/cmd/diff.go
+++ b/sdk/tools/apidiff/cmd/diff.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+)
+
+var diffCmd = &cobra.Command{
+	Use:   "diff <base export filepath> <target export filepath>",
+	Short: "Generate a diff report between the two export report files",
+	Long:  `The diff command consumes two JSON files with the export reports, and generates a diff report between them.`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return diffCommand(args[0], args[1])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(diffCmd)
+	diffCmd.PersistentFlags().BoolVarP(&asMarkdown, "markdown", "m", false, "emits the report in markdown format")
+}
+
+func diffCommand(basePath, targetPath string) error {
+	base, err := ioutil.ReadFile(basePath)
+	if err != nil {
+		return fmt.Errorf("failed to read base export file %s: %+v", basePath, err)
+	}
+	target, err := ioutil.ReadFile(targetPath)
+	if err != nil {
+		return fmt.Errorf("failed to read target export file %s: %+v", targetPath, err)
+	}
+	var baseExport, targetExport RepoContent
+	if err := json.Unmarshal(base, &baseExport); err != nil {
+		return fmt.Errorf("failed to unmarshal base export: %+v", err)
+	}
+	if err := json.Unmarshal(target, &targetExport); err != nil {
+		return fmt.Errorf("failed to unmarshal target export: %+v", err)
+	}
+
+	r := getPkgsReport(baseExport, targetExport)
+
+	if asMarkdown {
+		fmt.Println(r.ToMarkdown())
+	} else {
+		b, _ := json.Marshal(r)
+		fmt.Println(string(b))
+	}
+	return nil
+}

--- a/sdk/tools/apidiff/cmd/diff.go
+++ b/sdk/tools/apidiff/cmd/diff.go
@@ -23,12 +23,12 @@ import (
 )
 
 var diffCmd = &cobra.Command{
-	Use:   "diff <base export filepath> <target export filepath>",
+	Use:   "diff <base export filepath> <target export filepath> <release tag version> <release marker>",
 	Short: "Generate a diff report between the two export report files",
 	Long:  `The diff command consumes two JSON files with the export reports, and generates a diff report between them.`,
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.ExactArgs(4),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return diffCommand(args[0], args[1])
+		return diffCommand(args[0], args[1], args[2], args[3])
 	},
 }
 
@@ -37,7 +37,7 @@ func init() {
 	diffCmd.PersistentFlags().BoolVarP(&asMarkdown, "markdown", "m", false, "emits the report in markdown format")
 }
 
-func diffCommand(basePath, targetPath string) error {
+func diffCommand(basePath, targetPath, version, marker string) error {
 	base, err := ioutil.ReadFile(basePath)
 	if err != nil {
 		return fmt.Errorf("failed to read base export file %s: %+v", basePath, err)
@@ -57,7 +57,7 @@ func diffCommand(basePath, targetPath string) error {
 	r := getPkgsReport(baseExport, targetExport)
 
 	if asMarkdown {
-		fmt.Println(r.ToMarkdown())
+		fmt.Println(r.ToMarkdown(true, version, marker))
 	} else {
 		b, _ := json.Marshal(r)
 		fmt.Println(string(b))

--- a/sdk/tools/apidiff/cmd/export.go
+++ b/sdk/tools/apidiff/cmd/export.go
@@ -1,0 +1,52 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/spf13/cobra"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export <package searching dir>",
+	Short: "Generates a report of all the export content for every package under the specified directory.",
+	Long: `The export command generates a report of all the export content for all of the packages under the directory 
+specified in <package searching dir>.
+
+The export content will be categorized by consts, funcs, interfaces, structs`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return exportCommand(args[0])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(exportCmd)
+}
+
+func exportCommand(searchingDir string) error {
+	wt, err := repo.Get(searchingDir)
+	if err != nil {
+		return fmt.Errorf("failed to get repo: %+v", err)
+	}
+	r, err := getRepoContent(&wt, searchingDir)
+	if err != nil {
+		return err
+	}
+	return r.Print(os.Stdout)
+}

--- a/sdk/tools/apidiff/cmd/export.go
+++ b/sdk/tools/apidiff/cmd/export.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/repo"
 	"github.com/spf13/cobra"
 )
 

--- a/sdk/tools/apidiff/cmd/package.go
+++ b/sdk/tools/apidiff/cmd/package.go
@@ -18,9 +18,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/repo"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/report"
 	"github.com/spf13/cobra"
 )
 

--- a/sdk/tools/apidiff/cmd/package.go
+++ b/sdk/tools/apidiff/cmd/package.go
@@ -1,0 +1,144 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
+	"github.com/spf13/cobra"
+)
+
+var (
+	dirMode    bool
+	asMarkdown bool
+)
+
+var packageCmd = &cobra.Command{
+	Use:   "package <package dir> (<base commit> <target commit(s)>) | (<commit sequence>)",
+	Short: "Generates a report for the package in the specified directory containing the delta between commits.",
+	Long: `The package command generates a report for the package in the directory specified in <package dir>.
+Commits can be specified as either a base and one or more target commits or a sequence of commits.
+For a base/target pair each target commit is compared against the base commit.
+For a commit sequence each commit N in the sequence is compared against commit N+1.
+Commit sequences must be comma-delimited.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rpt, err := thePackageCmd(args)
+		if err != nil {
+			return err
+		}
+		evalReportStatus(rpt)
+		return nil
+	},
+}
+
+// split into its own func as we can't call os.Exit from it (the defer won't get executed)
+func thePackageCmd(args []string) (rs report.Status, err error) {
+	if dirMode {
+		return packageCmdDirMode(args)
+	}
+	return packageCmdCommitMode(args)
+}
+
+func init() {
+	packageCmd.PersistentFlags().BoolVarP(&dirMode, "directories", "i", false, "compares packages in two different directories")
+	packageCmd.PersistentFlags().BoolVarP(&asMarkdown, "markdown", "m", false, "emits the report in markdown format")
+	rootCmd.AddCommand(packageCmd)
+}
+
+func getContentForCommit(wt repo.WorkingTree, dir, commit string) (cnt exports.Content, err error) {
+	err = wt.Checkout(commit)
+	if err != nil {
+		err = fmt.Errorf("failed to check out commit '%s': %s", commit, err)
+		return
+	}
+
+	cnt, err = exports.Get(dir)
+	if err != nil {
+		err = fmt.Errorf("failed to get exports for commit '%s': %s", commit, err)
+	}
+	return
+}
+
+func packageCmdCommitMode(args []string) (rs report.Status, err error) {
+	cloneRepo, err := processArgsAndClone(args)
+	if err != nil {
+		return
+	}
+
+	var rpt report.CommitPkgReport
+	rpt.CommitsReports = map[string]report.Package{}
+	worker := func(pkgDir string, cloneRepo repo.WorkingTree, baseCommit, targetCommit string) error {
+		// lhs
+		vprintf("checking out base commit %s and gathering exports\n", baseCommit)
+		var lhs exports.Content
+		lhs, err = getContentForCommit(cloneRepo, pkgDir, baseCommit)
+		if err != nil {
+			return err
+		}
+
+		// rhs
+		vprintf("checking out target commit %s and gathering exports\n", targetCommit)
+		var rhs exports.Content
+		rhs, err = getContentForCommit(cloneRepo, pkgDir, targetCommit)
+		if err != nil {
+			return err
+		}
+		r := report.Generate(lhs, rhs, &report.GenerationOption{
+			OnlyBreakingChanges: onlyBreakingChangesFlag,
+			OnlyAdditiveChanges: onlyAdditiveChangesFlag,
+		})
+		if r.HasBreakingChanges() {
+			rpt.BreakingChanges = append(rpt.BreakingChanges, targetCommit)
+		}
+		rpt.CommitsReports[fmt.Sprintf("%s:%s", baseCommit, targetCommit)] = r
+		return nil
+	}
+
+	err = generateReports(args, cloneRepo, worker)
+	if err != nil {
+		return
+	}
+
+	err = PrintReport(rpt)
+	return
+}
+
+func packageCmdDirMode(args []string) (rs report.Status, err error) {
+	if len(args) != 2 {
+		return nil, errors.New("directories mode requires two arguments")
+	}
+	lhs, err := exports.Get(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to get exports for package '%s': %s", args[0], err)
+	}
+	rhs, err := exports.Get(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to get exports for package '%s': %s", args[1], err)
+	}
+	r := report.Generate(lhs, rhs, &report.GenerationOption{
+		OnlyBreakingChanges: onlyBreakingChangesFlag,
+		OnlyAdditiveChanges: onlyAdditiveChangesFlag,
+	})
+	if asMarkdown && !suppressReport {
+		println(r.ToMarkdown())
+	} else {
+		err = PrintReport(r)
+	}
+	return r, err
+}

--- a/sdk/tools/apidiff/cmd/packages.go
+++ b/sdk/tools/apidiff/cmd/packages.go
@@ -1,0 +1,207 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
+	"github.com/spf13/cobra"
+)
+
+var packagesCmd = &cobra.Command{
+	Use:   "packages <package search dir> (<base commit> <target commit(s)>) | (<commit sequence>)",
+	Short: "Generates a report for all packages under the specified directory containing the delta between commits.",
+	Long: `The packages command generates a report for all of the packages under the directory specified in <package dir>.
+Commits can be specified as either a base and one or more target commits or a sequence of commits.
+For a base/target pair each target commit is compared against the base commit.
+For a commit sequence each commit N in the sequence is compared against commit N+1.
+Commit sequences must be comma-delimited.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rpt, err := thePackagesCmd(args)
+		if err != nil {
+			return err
+		}
+		err = PrintReport(rpt)
+		if err != nil {
+			return err
+		}
+		evalReportStatus(rpt)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(packagesCmd)
+}
+
+// ExecPackagesCmd is the programmatic interface for the packages command.
+func ExecPackagesCmd(pkgDir string, commitSeq string, flags CommandFlags) (report.CommitPkgsReport, error) {
+	flags.apply()
+	return thePackagesCmd([]string{pkgDir, commitSeq})
+}
+
+// split into its own func as we can't call os.Exit from it (the defer won't get executed)
+func thePackagesCmd(args []string) (rpt report.CommitPkgsReport, err error) {
+	cloneRepo, err := processArgsAndClone(args)
+	if err != nil {
+		return
+	}
+
+	rpt.CommitsReports = map[string]report.PkgsReport{}
+	worker := func(rootDir string, cloneRepo repo.WorkingTree, baseCommit, targetCommit string) error {
+		vprintf("generating diff between %s and %s\n", baseCommit, targetCommit)
+		// get for lhs
+		dprintf("checking out base commit %s and gathering exports\n", baseCommit)
+		lhs, err := getRepoContentForCommit(&cloneRepo, rootDir, baseCommit)
+		if err != nil {
+			return err
+		}
+
+		// get for rhs
+		dprintf("checking out target commit %s and gathering exports\n", targetCommit)
+		rhs, err := getRepoContentForCommit(&cloneRepo, rootDir, targetCommit)
+		if err != nil {
+			return err
+		}
+		r := getPkgsReport(lhs, rhs)
+		rpt.UpdateAffectedPackages(targetCommit, r)
+		if r.HasBreakingChanges() {
+			rpt.BreakingChanges = append(rpt.BreakingChanges, targetCommit)
+		}
+		rpt.CommitsReports[fmt.Sprintf("%s:%s", baseCommit, targetCommit)] = r
+		return nil
+	}
+
+	err = generateReports(args, cloneRepo, worker)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func getRepoContentForCommit(wt *repo.WorkingTree, dir, commit string) (r RepoContent, err error) {
+	err = wt.Checkout(commit)
+	if err != nil {
+		err = fmt.Errorf("failed to check out commit '%s': %s", commit, err)
+		return
+	}
+
+	return getRepoContent(wt, dir)
+}
+
+func getRepoContent(wt *repo.WorkingTree, dir string) (RepoContent, error) {
+	pkgDirs, err := report.GetPackages(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	if debugFlag {
+		fmt.Println("found the following package directories")
+		for _, d := range pkgDirs {
+			fmt.Printf("\t%s\n", d)
+		}
+	}
+
+	r, err := getExportsForPackages(wt.Root(), pkgDirs)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// RepoContent contains repo content, it's structured as "package path":content
+type RepoContent map[string]exports.Content
+
+// returns RepoContent based on the provided slice of package directories
+func getExportsForPackages(root string, pkgDirs []string) (RepoContent, error) {
+	exps := RepoContent{}
+	for _, pkgDir := range pkgDirs {
+		dprintf("getting exports for %s\n", pkgDir)
+		// pkgDir = "C:\Users\somebody\AppData\Local\Temp\apidiff-1529437978\services\addons\mgmt\2017-05-15\addons"
+		// convert to package path "github.com/Azure/azure-sdk-for-go/services/analysisservices/mgmt/2016-05-16/analysisservices"
+		pkgPath := strings.Replace(pkgDir, root, "github.com/Azure/azure-sdk-for-go", -1)
+		pkgPath = strings.Replace(pkgPath, string(os.PathSeparator), "/", -1)
+		if _, ok := exps[pkgPath]; ok {
+			return nil, fmt.Errorf("duplicate package: %s", pkgPath)
+		}
+		exp, err := exports.Get(pkgDir)
+		if err != nil {
+			return nil, err
+		}
+		exps[pkgPath] = exp
+	}
+	return exps, nil
+}
+
+// Print prints the RepoContent to a Writer as JSON string
+func (r *RepoContent) Print(o io.Writer) error {
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal report: %v", err)
+	}
+	_, err = o.Write(b)
+	return err
+}
+
+// generates a PkgsReport based on the delta between lhs and rhs
+func getPkgsReport(lhs, rhs RepoContent) report.PkgsReport {
+	rpt := report.PkgsReport{}
+
+	if !onlyBreakingChangesFlag {
+		rpt.AddedPackages = getDiffPkgs(lhs, rhs)
+	}
+	if !onlyAdditiveChangesFlag {
+		rpt.RemovedPackages = getDiffPkgs(rhs, lhs)
+	}
+
+	// diff packages
+	for rhsPkg, rhsCnt := range rhs {
+		if _, ok := lhs[rhsPkg]; !ok {
+			continue
+		}
+		if r := report.Generate(lhs[rhsPkg], rhsCnt, &report.GenerationOption{
+			OnlyBreakingChanges: onlyBreakingChangesFlag,
+			OnlyAdditiveChanges: onlyAdditiveChangesFlag,
+		}); !r.IsEmpty() {
+			// only add an entry if the report contains data
+			if rpt.ModifiedPackages == nil {
+				rpt.ModifiedPackages = report.ModifiedPackages{}
+			}
+			rpt.ModifiedPackages[rhsPkg] = r
+		}
+	}
+
+	return rpt
+}
+
+// returns a list of packages in rhs that aren't in lhs
+func getDiffPkgs(lhs, rhs RepoContent) report.PkgsList {
+	list := report.PkgsList{}
+	for rhsPkg := range rhs {
+		if _, ok := lhs[rhsPkg]; !ok {
+			list = append(list, rhsPkg)
+		}
+	}
+	return list
+}

--- a/sdk/tools/apidiff/cmd/packages.go
+++ b/sdk/tools/apidiff/cmd/packages.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/repo"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/report"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/repo"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/report"
 	"github.com/spf13/cobra"
 )
 

--- a/sdk/tools/apidiff/cmd/root.go
+++ b/sdk/tools/apidiff/cmd/root.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var copyRepoFlag bool
+var debugFlag bool
+var onlyAdditiveChangesFlag bool
+var onlyBreakingChangesFlag bool
+var quietFlag bool
+var suppressReport bool
+var verboseFlag bool
+
+var rootCmd = &cobra.Command{
+	Use:   "apidiff",
+	Short: "Generates a diff of exported package content between two commits.",
+	Long: `This tool will generate a report in JSON format describing changes to
+public surface area between two specified commits.  It can work on
+individual packages or a set of packages under a specified directory.`,
+}
+
+func init() {
+	rootCmd.PersistentFlags().BoolVarP(&copyRepoFlag, "copyrepo", "c", false, "copy the repo instead of cloning it")
+	rootCmd.PersistentFlags().BoolVarP(&debugFlag, "debug", "d", false, "debug output")
+	rootCmd.PersistentFlags().BoolVarP(&onlyAdditiveChangesFlag, "additions", "a", false, "only include additive changes in the report")
+	rootCmd.PersistentFlags().BoolVarP(&onlyBreakingChangesFlag, "breakingchanges", "b", false, "only include breaking changes in the report")
+	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "suppress console output")
+	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "verbose output")
+}
+
+// Execute executes the specified command.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(-1)
+	}
+}
+
+// CommandFlags is used to specify flags when invoking commands programatically.
+type CommandFlags struct {
+	CopyRepo            bool
+	Debug               bool
+	OnlyAdditions       bool
+	OnlyBreakingChanges bool
+	Quiet               bool
+	SuppressReport      bool
+	Verbose             bool
+}
+
+// applies the specified flags to their global equivalents
+func (cf CommandFlags) apply() {
+	copyRepoFlag = cf.CopyRepo
+	debugFlag = cf.Debug
+	onlyAdditiveChangesFlag = cf.OnlyAdditions
+	onlyBreakingChangesFlag = cf.OnlyBreakingChanges
+	quietFlag = cf.Quiet
+	suppressReport = cf.SuppressReport
+	verboseFlag = cf.Verbose
+}

--- a/sdk/tools/apidiff/delta/delta.go
+++ b/sdk/tools/apidiff/delta/delta.go
@@ -17,7 +17,7 @@ package delta
 import (
 	"sort"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/exports"
 )
 
 // Content defines the set of exported constants, funcs, and structs.

--- a/sdk/tools/apidiff/delta/delta.go
+++ b/sdk/tools/apidiff/delta/delta.go
@@ -1,0 +1,356 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delta
+
+import (
+	"sort"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+)
+
+// Content defines the set of exported constants, funcs, and structs.
+type Content struct {
+	exports.Content
+
+	// contains the names of structs that are modified in whole (i.e. new/removed)
+	CompleteStructs []string `json:"newStructs,omitempty"`
+}
+
+// Count returns the count of items
+func (c Content) Count() int {
+	return c.Content.Count() + len(c.CompleteStructs)
+}
+
+// NewContent returns an initialized Content object.
+func NewContent() Content {
+	return Content{
+		Content: exports.NewContent(),
+	}
+}
+
+// GetModifiedStructs returns the subset, if any, of structs that are modified.
+func (c Content) GetModifiedStructs() map[string]exports.Struct {
+	if len(c.CompleteStructs) == 0 {
+		return c.Structs
+	}
+	ms := map[string]exports.Struct{}
+	for k, v := range c.Structs {
+		if contains(c.CompleteStructs, k) {
+			continue
+		}
+		ms[k] = v
+	}
+	return ms
+}
+
+// returns true if sl contains x
+func contains(sl []string, x string) bool {
+	for _, s := range sl {
+		if s == x {
+			return true
+		}
+	}
+	return false
+}
+
+// GetExports returns a exports.Content struct containing all exports in rhs that aren't in lhs.
+// This includes any new fields added to structs or methods added to interfaces.
+func GetExports(lhs, rhs exports.Content) Content {
+	nc := NewContent()
+
+	for n, v := range rhs.Consts {
+		if _, ok := lhs.Consts[n]; !ok {
+			nc.Consts[n] = v
+		}
+	}
+
+	for n, v := range rhs.Funcs {
+		if _, ok := lhs.Funcs[n]; !ok {
+			nc.Funcs[n] = v
+		}
+	}
+
+	for n, v := range rhs.Interfaces {
+		if _, ok := lhs.Interfaces[n]; !ok {
+			nc.Interfaces[n] = v
+		}
+	}
+
+	for n, v := range rhs.Structs {
+		if _, ok := lhs.Structs[n]; !ok {
+			nc.Structs[n] = v
+			nc.CompleteStructs = append(nc.CompleteStructs, n)
+		}
+	}
+
+	structFields := GetStructFields(lhs, rhs)
+	if len(structFields) > 0 {
+		for k, v := range structFields {
+			nc.Structs[k] = v
+		}
+	}
+
+	intMethods := GetInterfaceMethods(lhs, rhs)
+	if len(intMethods) > 0 {
+		for k, v := range intMethods {
+			nc.Interfaces[k] = v
+		}
+	}
+
+	sort.Strings(nc.CompleteStructs)
+	return nc
+}
+
+// GetStructFields returns structs common to lhs and rhs where structs in rhs contain
+// fields not in lhs.  Key is the struct type name, value contains the added content.
+func GetStructFields(lhs, rhs exports.Content) map[string]exports.Struct {
+	nf := map[string]exports.Struct{}
+
+	for rhsKey, rhsVal := range rhs.Structs {
+		if lhsStruct, ok := lhs.Structs[rhsKey]; ok {
+			nc := exports.Struct{}
+			for _, rhsAnon := range rhsVal.AnonymousFields {
+				found := false
+				for _, lhsAnon := range lhsStruct.AnonymousFields {
+					if lhsAnon == rhsAnon {
+						found = true
+						break
+					}
+				}
+				if !found {
+					nc.AnonymousFields = append(nc.AnonymousFields, rhsAnon)
+				}
+			}
+			for fn, fv := range rhsVal.Fields {
+				if _, ok := lhsStruct.Fields[fn]; !ok {
+					if nc.Fields == nil {
+						nc.Fields = map[string]string{}
+					}
+					nc.Fields[fn] = fv
+				}
+			}
+			// only add it if there's new content
+			if len(nc.AnonymousFields) > 0 || len(nc.Fields) > 0 {
+				nf[rhsKey] = nc
+			}
+		}
+	}
+	return nf
+}
+
+// GetInterfaceMethods returns interfaces common to lhs and rhs where interfaces in rhs contain
+// methods not in lhs.  Key is the interface type name, value contains the added content.
+func GetInterfaceMethods(lhs, rhs exports.Content) map[string]exports.Interface {
+	ni := map[string]exports.Interface{}
+
+	for rhsKey, rhsValue := range rhs.Interfaces {
+		if lhsInterface, ok := lhs.Interfaces[rhsKey]; ok {
+			nc := exports.Interface{}
+			for in, iv := range rhsValue.Methods {
+				if _, ok := lhsInterface.Methods[in]; !ok {
+					if nc.Methods == nil {
+						nc.Methods = map[string]exports.Func{}
+					}
+					nc.Methods[in] = iv
+				}
+			}
+			// only add it if there's new content
+			if len(nc.Methods) > 0 {
+				ni[rhsKey] = nc
+			}
+		}
+	}
+	return ni
+}
+
+// Signature contains the details of how a type signature changed (e.g. From:"int" To:"string").
+type Signature struct {
+	// From contains the original signature.
+	From string `json:"from"`
+
+	// To contains the new signature.
+	To string `json:"to"`
+}
+
+// GetConstTypeChanges returns a collection of const where the type has changed.
+// Key is the const name, value contains the type change information.
+func GetConstTypeChanges(lhs, rhs exports.Content) map[string]Signature {
+	cc := map[string]Signature{}
+
+	for rhsKey, rhsValue := range rhs.Consts {
+		if _, ok := lhs.Consts[rhsKey]; !ok {
+			continue
+		}
+		if lhs.Consts[rhsKey].Type != rhsValue.Type {
+			cc[rhsKey] = Signature{
+				From: lhs.Consts[rhsKey].Type,
+				To:   rhsValue.Type,
+			}
+		}
+	}
+	return cc
+}
+
+// None is the value used for functions with no parameters and/or no return values.
+const None = "<none>"
+
+// FuncSig contains the details of how a function's signature changed.
+type FuncSig struct {
+	// Params contains the parameter signature changes, may be nil.
+	Params *Signature `json:"params,omitempty"`
+
+	// Returns contains the return signature changes, may be nil.
+	Returns *Signature `json:"returns,omitempty"`
+}
+
+func (fs FuncSig) isEmpty() bool {
+	return fs.Params == nil && fs.Returns == nil
+}
+
+// GetFuncSigChanges returns a collection of functions that contain signature changes (params and/or returns).
+// Key is the function name, value contains the signature change information.
+func GetFuncSigChanges(lhs, rhs exports.Content) map[string]FuncSig {
+	fsc := map[string]FuncSig{}
+
+	for rhsKey, rhsValue := range rhs.Funcs {
+		if _, ok := lhs.Funcs[rhsKey]; !ok {
+			continue
+		}
+		sig := FuncSig{}
+		if !safeStrCmp(lhs.Funcs[rhsKey].Params, rhsValue.Params) {
+			sig.Params = &Signature{
+				From: safeFuncSig(lhs.Funcs[rhsKey].Params),
+				To:   safeFuncSig(rhsValue.Params),
+			}
+		}
+		if !safeStrCmp(lhs.Funcs[rhsKey].Returns, rhsValue.Returns) {
+			sig.Returns = &Signature{
+				From: safeFuncSig(lhs.Funcs[rhsKey].Returns),
+				To:   safeFuncSig(rhsValue.Returns),
+			}
+		}
+
+		if !sig.isEmpty() {
+			fsc[rhsKey] = sig
+		}
+	}
+	return fsc
+}
+
+// InterfaceDef contains a collection of interface methods with signature changes.
+// Key is the method name, value contains the signature change information.
+type InterfaceDef struct {
+	MethodSigs map[string]FuncSig `json:"funcSig"`
+}
+
+// GetInterfaceMethodSigChanges returns a collection of interfaces with method signature changes.
+// Key is the interface name, value contains the method signature change information.
+func GetInterfaceMethodSigChanges(lhs, rhs exports.Content) map[string]InterfaceDef {
+	isc := map[string]InterfaceDef{}
+
+	for rhsKey, rhsValue := range rhs.Interfaces {
+		if _, ok := lhs.Interfaces[rhsKey]; !ok {
+			continue
+		}
+		id := InterfaceDef{}
+
+		for rhsMethod, rhsSig := range rhsValue.Methods {
+			if _, ok := lhs.Interfaces[rhsKey].Methods[rhsMethod]; !ok {
+				continue
+			}
+			sig := FuncSig{}
+			if !safeStrCmp(lhs.Interfaces[rhsKey].Methods[rhsMethod].Params, rhsSig.Params) {
+				sig.Params = &Signature{
+					From: safeFuncSig(lhs.Interfaces[rhsKey].Methods[rhsMethod].Params),
+					To:   safeFuncSig(rhsSig.Params),
+				}
+			}
+			if !safeStrCmp(lhs.Interfaces[rhsKey].Methods[rhsMethod].Returns, rhsSig.Returns) {
+				sig.Returns = &Signature{
+					From: safeFuncSig(lhs.Interfaces[rhsKey].Methods[rhsMethod].Returns),
+					To:   safeFuncSig(rhsSig.Returns),
+				}
+			}
+
+			if !sig.isEmpty() {
+				if id.MethodSigs == nil {
+					id.MethodSigs = map[string]FuncSig{}
+				}
+				id.MethodSigs[rhsMethod] = sig
+			}
+		}
+
+		if len(id.MethodSigs) > 0 {
+			isc[rhsKey] = id
+		}
+	}
+	return isc
+}
+
+// StructDef contains a collection of fields within a struct where the field's type has changed.
+// Key is the field name, value contains the signature change information.
+type StructDef struct {
+	Fields map[string]Signature `json:"fields"`
+}
+
+// GetStructFieldChanges returns a collection of structs with fields that changed their type.
+// Key is the struct name, value contains fields with signature changes.
+func GetStructFieldChanges(lhs, rhs exports.Content) map[string]StructDef {
+	sfc := map[string]StructDef{}
+
+	for rhsKey, rhsValue := range rhs.Structs {
+		if _, ok := lhs.Structs[rhsKey]; !ok {
+			continue
+		}
+		sd := StructDef{}
+
+		for rhsField, rhsSig := range rhsValue.Fields {
+			if _, ok := lhs.Structs[rhsKey].Fields[rhsField]; !ok {
+				continue
+			}
+			if lhs.Structs[rhsKey].Fields[rhsField] != rhsSig {
+				if sd.Fields == nil {
+					sd.Fields = map[string]Signature{}
+				}
+				sd.Fields[rhsField] = Signature{
+					From: lhs.Structs[rhsKey].Fields[rhsField],
+					To:   rhsSig,
+				}
+			}
+		}
+
+		if len(sd.Fields) > 0 {
+			sfc[rhsKey] = sd
+		}
+	}
+	return sfc
+}
+
+func safeFuncSig(s *string) string {
+	if s == nil {
+		return None
+	}
+	return *s
+}
+
+func safeStrCmp(lhs, rhs *string) bool {
+	if lhs == nil && rhs == nil {
+		return true
+	}
+	if lhs == nil || rhs == nil {
+		return false
+	}
+	return *lhs == *rhs
+}

--- a/sdk/tools/apidiff/delta/delta_test.go
+++ b/sdk/tools/apidiff/delta/delta_test.go
@@ -19,8 +19,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/delta"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/delta"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/exports"
 )
 
 var oContent exports.Content

--- a/sdk/tools/apidiff/delta/delta_test.go
+++ b/sdk/tools/apidiff/delta/delta_test.go
@@ -1,0 +1,378 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delta_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/delta"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+)
+
+var oContent exports.Content
+var nContent exports.Content
+var oBreaking exports.Content
+var nBreaking exports.Content
+
+func init() {
+	oContent, _ = exports.Get("./testdata/nonbreaking/old")
+	nContent, _ = exports.Get("./testdata/nonbreaking/new")
+	oBreaking, _ = exports.Get("./testdata/breaking/old")
+	nBreaking, _ = exports.Get("./testdata/breaking/new")
+}
+
+func Test_GetAddedExports(t *testing.T) {
+	aContent := delta.GetExports(oContent, nContent)
+
+	// const
+
+	if l := len(aContent.Consts); l != 4 {
+		t.Logf("wrong number of consts added, have %v, want %v", l, 4)
+		t.Fail()
+	}
+
+	cAdded := map[string]exports.Const{
+		"Blue":    {Type: "Color", Value: "Blue"},
+		"Green":   {Type: "Color", Value: "Green"},
+		"Red":     {Type: "Color", Value: "Red"},
+		"Holiday": {Type: "DayOfWeek", Value: "Holiday"},
+	}
+
+	for k, v := range cAdded {
+		t.Run(fmt.Sprintf("const %s", k), func(t *testing.T) {
+			if c, ok := aContent.Consts[k]; !ok {
+				t.Log("missing")
+				t.Fail()
+			} else if c.Type != v.Type {
+				t.Logf("mismatched const type, have %s, want %s", aContent.Consts[k].Type, v.Type)
+				t.Fail()
+			}
+		})
+	}
+
+	// func
+
+	if l := len(aContent.Funcs); l != 6 {
+		t.Logf("wrong number of funcs added, have %v, want %v", l, 6)
+		t.Fail()
+	}
+
+	fAdded := map[string]exports.Func{
+		"DoNothing2":                 {},
+		"Client.ExportData":          {Params: strPtr("context.Context, string, string, ExportRDBParameters"), Returns: strPtr("ExportDataFuture, error")},
+		"Client.ExportDataPreparer":  {Params: strPtr("context.Context, string, string, ExportRDBParameters"), Returns: strPtr("*http.Request, error")},
+		"Client.ExportDataSender":    {Params: strPtr("*http.Request"), Returns: strPtr("ExportDataFuture, error")},
+		"Client.ExportDataResponder": {Params: strPtr("*http.Response"), Returns: strPtr("autorest.Response, error")},
+		"ExportDataFuture.Result":    {Params: strPtr("Client"), Returns: strPtr("autorest.Response, error")},
+	}
+
+	for k, v := range fAdded {
+		t.Run(fmt.Sprintf("func %s", k), func(t *testing.T) {
+			if f, ok := aContent.Funcs[k]; !ok {
+				t.Log("missing")
+				t.Fail()
+			} else if !reflect.DeepEqual(f, v) {
+				t.Logf("mismatched func type, have %+v, want %+v", v, f)
+				t.Fail()
+			}
+		})
+	}
+
+	// interface
+
+	if l := len(aContent.Interfaces); l != 2 {
+		t.Logf("wrong number of interfaces added, have %v, want %v", l, 2)
+		t.Fail()
+	}
+
+	iAdded := map[string]exports.Interface{
+		"NewInterface": {Methods: map[string]exports.Func{
+			"One": {Params: strPtr("int")},
+			"Two": {Returns: strPtr("error")},
+		}},
+		"SomeInterface": {Methods: map[string]exports.Func{
+			"NewMethod": {Params: strPtr("string"), Returns: strPtr("bool, error")},
+		}},
+	}
+
+	for k, v := range iAdded {
+		t.Run(fmt.Sprintf("interface %s", k), func(t *testing.T) {
+			if i, ok := aContent.Interfaces[k]; !ok {
+				t.Log("missing")
+				t.Fail()
+			} else if !reflect.DeepEqual(i, v) {
+				t.Logf("mismatched interface type, have %+v, want %+v", i, v)
+				t.Fail()
+			}
+		})
+	}
+
+	// struct
+
+	if l := len(aContent.Structs); l != 4 {
+		t.Logf("wrong number of structs added, have %v, want %v", l, 4)
+		t.Fail()
+	}
+
+	sAdded := map[string]exports.Struct{
+		"ExportDataFuture": {
+			AnonymousFields: []string{"azure.Future"},
+			Fields:          map[string]string{"NewField": "string"},
+		},
+		"ExportRDBParameters": {
+			Fields: map[string]string{
+				"Format":    "*string",
+				"Prefix":    "*string",
+				"Container": "*string",
+			},
+		},
+		"CreateProperties": {
+			Fields: map[string]string{
+				"NewField": "*float64",
+			},
+		},
+		"DeleteFuture": {
+			Fields: map[string]string{
+				"NewField": "string",
+			},
+		},
+	}
+
+	for k, v := range sAdded {
+		t.Run(fmt.Sprintf("struct %s", k), func(t *testing.T) {
+			if s, ok := aContent.Structs[k]; !ok {
+				t.Log("missing")
+				t.Fail()
+			} else if !reflect.DeepEqual(s, v) {
+				t.Logf("mismatched struct type, have %+v, want %+v", v, s)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func Test_GetAddedStructFields(t *testing.T) {
+	nf := delta.GetStructFields(oContent, nContent)
+
+	if l := len(nf); l != 2 {
+		t.Logf("wrong number of structs with new fields, have %v, want %v", l, 2)
+		t.Fail()
+	}
+
+	added := map[string]exports.Struct{
+		"CreateProperties": {
+			Fields: map[string]string{"NewField": "*float64"},
+		},
+		"DeleteFuture": {
+			Fields: map[string]string{"NewField": "string"},
+		},
+	}
+
+	if !reflect.DeepEqual(added, nf) {
+		t.Logf("mismatched fields added, have %+v, want %+v", nf, added)
+		t.Fail()
+	}
+}
+
+func Test_GetAddedInterfaceMethods(t *testing.T) {
+	ni := delta.GetInterfaceMethods(oContent, nContent)
+
+	if l := len(ni); l != 1 {
+		t.Logf("wrong number of interfaces with new methods, have %v, want %v", l, 1)
+		t.Fail()
+	}
+
+	added := map[string]exports.Interface{
+		"SomeInterface": {
+			Methods: map[string]exports.Func{
+				"NewMethod": {Params: strPtr("string"), Returns: strPtr("bool, error")},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(added, ni) {
+		t.Logf("mismatched methods added, have %+v, want %+v", ni, added)
+		t.Fail()
+	}
+}
+
+func Test_GetNoChanges(t *testing.T) {
+	nc := delta.GetExports(nContent, nContent)
+	if !reflect.DeepEqual(nc, delta.NewContent()) {
+		t.Log("expected empty exports")
+		t.Fail()
+	}
+
+	ni := delta.GetInterfaceMethods(nContent, nContent)
+	if !reflect.DeepEqual(ni, map[string]exports.Interface{}) {
+		t.Log("expected no new interfaces")
+		t.Fail()
+	}
+
+	nf := delta.GetStructFields(oContent, oContent)
+	if !reflect.DeepEqual(nf, map[string]exports.Struct{}) {
+		t.Log("expected no new struct fields")
+		t.Fail()
+	}
+}
+
+func Test_GetConstTypeChanges(t *testing.T) {
+	cc := delta.GetConstTypeChanges(oBreaking, nBreaking)
+
+	if l := len(cc); l != 8 {
+		t.Logf("wrong number of const changed, have %v, want %v", l, 8)
+		t.Fail()
+	}
+
+	change := delta.Signature{
+		From: "DayOfWeek",
+		To:   "Day",
+	}
+	changed := map[string]delta.Signature{
+		"Friday":    change,
+		"Monday":    change,
+		"Saturday":  change,
+		"Sunday":    change,
+		"Thursday":  change,
+		"Tuesday":   change,
+		"Wednesday": change,
+		"Weekend":   change,
+	}
+
+	if !reflect.DeepEqual(cc, changed) {
+		t.Logf("mismatched changes, have %+v, want %+v", cc, changed)
+		t.Fail()
+	}
+}
+
+func Test_GetFuncSigChanges(t *testing.T) {
+	fsc := delta.GetFuncSigChanges(oBreaking, nBreaking)
+
+	if l := len(fsc); l != 6 {
+		t.Logf("wrong number of func sigs changed, have %v want %v", l, 6)
+		t.Fail()
+	}
+
+	changed := map[string]delta.FuncSig{
+		"DoNothing": {
+			Params: &delta.Signature{From: delta.None, To: "string"},
+		},
+		"DoNothingWithParam": {
+			Params: &delta.Signature{From: "int", To: delta.None},
+		},
+		"Client.List": {
+			Params:  &delta.Signature{From: "context.Context", To: "context.Context, string"},
+			Returns: &delta.Signature{From: "ListResultPage, error", To: "ListResult, error"},
+		},
+		"Client.ListPreparer": {
+			Params: &delta.Signature{From: "context.Context", To: "context.Context, string"},
+		},
+		"Client.Delete": {
+			Params: &delta.Signature{From: "context.Context, string, string", To: "context.Context, string"},
+		},
+		"Client.DeletePreparer": {
+			Params: &delta.Signature{From: "context.Context, string, string", To: "context.Context, string"},
+		},
+	}
+
+	for k, v := range changed {
+		t.Run(fmt.Sprintf("func %s", k), func(t *testing.T) {
+			if f, ok := fsc[k]; !ok {
+				t.Log("missing")
+				t.Fail()
+			} else {
+				if !reflect.DeepEqual(v, f) {
+					t.Logf("mismatched changes, have %+v, want %+v", f, v)
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func Test_GetInterfaceMethodSigChanges(t *testing.T) {
+	isc := delta.GetInterfaceMethodSigChanges(oBreaking, nBreaking)
+
+	if l := len(isc); l != 1 {
+		t.Logf("wrong number of interfaces with method sig changes, have %v, want %v", l, 1)
+		t.Fail()
+	}
+
+	changed := map[string]delta.InterfaceDef{
+		"SomeInterface": {
+			MethodSigs: map[string]delta.FuncSig{
+				"One": {Params: &delta.Signature{From: delta.None, To: "string"}},
+				"Two": {Params: &delta.Signature{From: "bool", To: "bool, int"}},
+			},
+		},
+	}
+
+	for k, v := range changed {
+		t.Run(fmt.Sprintf("interface %s", k), func(t *testing.T) {
+			if i, ok := isc[k]; !ok {
+				t.Log("missing")
+				t.Fail()
+			} else {
+				if !reflect.DeepEqual(v, i) {
+					t.Logf("mismatched changes, have %+v, want %+v", i, v)
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func Test_GetStructFieldChanges(t *testing.T) {
+	sfc := delta.GetStructFieldChanges(oBreaking, nBreaking)
+
+	if l := len(sfc); l != 2 {
+		t.Logf("wrong number of structs with field changes, have %v, want %v", l, 2)
+		t.Fail()
+	}
+
+	changed := map[string]delta.StructDef{
+		"CreateProperties": {
+			Fields: map[string]delta.Signature{
+				"SubnetID":           {From: "*string", To: "*int"},
+				"RedisConfiguration": {From: "map[string]*string", To: "interface{}"},
+			},
+		},
+		"ListResult": {
+			Fields: map[string]delta.Signature{
+				"NextLink": {From: "*string", To: "string"},
+			},
+		},
+	}
+
+	for k, v := range changed {
+		t.Run(fmt.Sprintf("struct %s", k), func(t *testing.T) {
+			if s, ok := sfc[k]; !ok {
+				t.Log("missing")
+				t.Fail()
+			} else {
+				if !reflect.DeepEqual(v, s) {
+					t.Logf("mismatched changes, have %+v, want %+v", s, v)
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/sdk/tools/apidiff/delta/testdata/breaking/new/new.go
+++ b/sdk/tools/apidiff/delta/testdata/breaking/new/new.go
@@ -1,0 +1,225 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/version"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// content lifted from redis
+
+// summary of changes
+//
+// const
+// changed type DayOfWeek to Day
+// removed Everyday
+//
+// func
+// added param to DoNothing
+// removed param from DoNothingWithParam
+// changed return type on List
+// added param to List and ListPreparer
+// removed name param on Delete and DeletePreparer
+//
+// interface
+// added params to methods on SomeInterface
+//
+// struct
+// removed Tags field from CreateParameters
+// changed field types SubnetID and RedisConfiguration in CreateProperties
+// made BaseClient field in Client type explicit
+// made NextLink in ListResult byval
+//
+
+const (
+	DefaultBaseURI = "https://management.azure.com"
+)
+
+type Day string
+
+const (
+	Friday    Day = "Friday"
+	Monday    Day = "Monday"
+	Saturday  Day = "Saturday"
+	Sunday    Day = "Sunday"
+	Thursday  Day = "Thursday"
+	Tuesday   Day = "Tuesday"
+	Wednesday Day = "Wednesday"
+	Weekend   Day = "Weekend"
+)
+
+type KeyType string
+
+const (
+	Primary   KeyType = "Primary"
+	Secondary KeyType = "Secondary"
+)
+
+type BaseClient struct {
+	autorest.Client
+	BaseURI        string
+	SubscriptionID string
+}
+
+type Client struct {
+	BC BaseClient
+}
+
+func DoNothing(s string) {
+}
+
+func DoNothingWithParam() {
+}
+
+func New(subscriptionID string) BaseClient {
+	return NewWithBaseURI(DefaultBaseURI, subscriptionID)
+}
+
+func NewWithBaseURI(baseURI string, subscriptionID string) BaseClient {
+	return BaseClient{
+		Client:         autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI:        baseURI,
+		SubscriptionID: subscriptionID,
+	}
+}
+
+func UserAgent() string {
+	return "Azure-SDK-For-Go/" + version.Number + " redis/2017-10-01"
+}
+
+type CreateParameters struct {
+	*CreateProperties `json:"properties,omitempty"`
+	Zones             *[]string `json:"zones,omitempty"`
+	Location          *string   `json:"location,omitempty"`
+}
+
+func (cp CreateParameters) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
+func (cp *CreateParameters) UnmarshalJSON(body []byte) error {
+	return nil
+}
+
+type CreateProperties struct {
+	SubnetID           *int               `json:"subnetId,omitempty"`
+	StaticIP           *string            `json:"staticIP,omitempty"`
+	RedisConfiguration interface{}        `json:"redisConfiguration"`
+	EnableNonSslPort   *bool              `json:"enableNonSslPort,omitempty"`
+	TenantSettings     map[string]*string `json:"tenantSettings"`
+	ShardCount         *int32             `json:"shardCount,omitempty"`
+}
+
+type DeleteFuture struct {
+	azure.Future
+	req *http.Request
+}
+
+func (future DeleteFuture) Result(client Client) (ar autorest.Response, err error) {
+	return
+}
+
+type ListResult struct {
+	autorest.Response `json:"-"`
+	Value             *[]ResourceType `json:"value,omitempty"`
+	NextLink          string          `json:"nextLink,omitempty"`
+}
+
+func (lr ListResult) IsEmpty() bool {
+	return lr.Value == nil || len(*lr.Value) == 0
+}
+
+type ListResultPage struct {
+	fn func(ListResult) (ListResult, error)
+	lr ListResult
+}
+
+func (page *ListResultPage) Next() error {
+	return nil
+}
+
+func (page ListResultPage) NotDone() bool {
+	return !page.lr.IsEmpty()
+}
+
+func (page ListResultPage) Response() ListResult {
+	return page.lr
+}
+
+func (page ListResultPage) Values() []ResourceType {
+	return *page.lr.Value
+}
+
+type ResourceType struct {
+	autorest.Response `json:"-"`
+	Zones             *[]string          `json:"zones,omitempty"`
+	Tags              map[string]*string `json:"tags"`
+	Location          *string            `json:"location,omitempty"`
+	ID                *string            `json:"id,omitempty"`
+	Name              *string            `json:"name,omitempty"`
+	Type              *string            `json:"type,omitempty"`
+}
+
+func (client Client) Delete(ctx context.Context, resourceGroupName string) (result DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeletePreparer(ctx context.Context, resourceGroupName string) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) DeleteSender(req *http.Request) (future DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeleteResponder(resp *http.Response) (result autorest.Response, err error) {
+	return
+}
+
+func (client Client) List(ctx context.Context, s string) (result ListResult, err error) {
+	return
+}
+
+func (client Client) ListPreparer(ctx context.Context, s string) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) ListSender(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (client Client) ListResponder(resp *http.Response) (result ListResult, err error) {
+	return
+}
+
+func (client Client) listNextResults(lastResults ListResult) (result ListResult, err error) {
+	return
+}
+
+type SomeInterface interface {
+	One(string)
+	Two(bool, int)
+}
+
+type AnotherInterface interface {
+	One()
+}

--- a/sdk/tools/apidiff/delta/testdata/breaking/old/old.go
+++ b/sdk/tools/apidiff/delta/testdata/breaking/old/old.go
@@ -1,0 +1,204 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/version"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// content lifted from redis
+
+const (
+	DefaultBaseURI = "https://management.azure.com"
+)
+
+type DayOfWeek string
+
+const (
+	Everyday  DayOfWeek = "Everyday"
+	Friday    DayOfWeek = "Friday"
+	Monday    DayOfWeek = "Monday"
+	Saturday  DayOfWeek = "Saturday"
+	Sunday    DayOfWeek = "Sunday"
+	Thursday  DayOfWeek = "Thursday"
+	Tuesday   DayOfWeek = "Tuesday"
+	Wednesday DayOfWeek = "Wednesday"
+	Weekend   DayOfWeek = "Weekend"
+)
+
+type KeyType string
+
+const (
+	Primary   KeyType = "Primary"
+	Secondary KeyType = "Secondary"
+)
+
+type BaseClient struct {
+	autorest.Client
+	BaseURI        string
+	SubscriptionID string
+}
+
+type Client struct {
+	BaseClient
+}
+
+func DoNothing() {
+}
+
+func DoNothingWithParam(foo int) {
+}
+
+func New(subscriptionID string) BaseClient {
+	return NewWithBaseURI(DefaultBaseURI, subscriptionID)
+}
+
+func NewWithBaseURI(baseURI string, subscriptionID string) BaseClient {
+	return BaseClient{
+		Client:         autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI:        baseURI,
+		SubscriptionID: subscriptionID,
+	}
+}
+
+func UserAgent() string {
+	return "Azure-SDK-For-Go/" + version.Number + " redis/2017-10-01"
+}
+
+type CreateParameters struct {
+	*CreateProperties `json:"properties,omitempty"`
+	Zones             *[]string          `json:"zones,omitempty"`
+	Location          *string            `json:"location,omitempty"`
+	Tags              map[string]*string `json:"tags"`
+}
+
+func (cp CreateParameters) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
+func (cp *CreateParameters) UnmarshalJSON(body []byte) error {
+	return nil
+}
+
+type CreateProperties struct {
+	SubnetID           *string            `json:"subnetId,omitempty"`
+	StaticIP           *string            `json:"staticIP,omitempty"`
+	RedisConfiguration map[string]*string `json:"redisConfiguration"`
+	EnableNonSslPort   *bool              `json:"enableNonSslPort,omitempty"`
+	TenantSettings     map[string]*string `json:"tenantSettings"`
+	ShardCount         *int32             `json:"shardCount,omitempty"`
+}
+
+type DeleteFuture struct {
+	azure.Future
+	req *http.Request
+}
+
+func (future DeleteFuture) Result(client Client) (ar autorest.Response, err error) {
+	return
+}
+
+type ListResult struct {
+	autorest.Response `json:"-"`
+	Value             *[]ResourceType `json:"value,omitempty"`
+	NextLink          *string         `json:"nextLink,omitempty"`
+}
+
+func (lr ListResult) IsEmpty() bool {
+	return lr.Value == nil || len(*lr.Value) == 0
+}
+
+type ListResultPage struct {
+	fn func(ListResult) (ListResult, error)
+	lr ListResult
+}
+
+func (page *ListResultPage) Next() error {
+	return nil
+}
+
+func (page ListResultPage) NotDone() bool {
+	return !page.lr.IsEmpty()
+}
+
+func (page ListResultPage) Response() ListResult {
+	return page.lr
+}
+
+func (page ListResultPage) Values() []ResourceType {
+	return *page.lr.Value
+}
+
+type ResourceType struct {
+	autorest.Response `json:"-"`
+	Zones             *[]string          `json:"zones,omitempty"`
+	Tags              map[string]*string `json:"tags"`
+	Location          *string            `json:"location,omitempty"`
+	ID                *string            `json:"id,omitempty"`
+	Name              *string            `json:"name,omitempty"`
+	Type              *string            `json:"type,omitempty"`
+}
+
+func (client Client) Delete(ctx context.Context, resourceGroupName string, name string) (result DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeletePreparer(ctx context.Context, resourceGroupName string, name string) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) DeleteSender(req *http.Request) (future DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeleteResponder(resp *http.Response) (result autorest.Response, err error) {
+	return
+}
+
+func (client Client) List(ctx context.Context) (result ListResultPage, err error) {
+	return
+}
+
+func (client Client) ListPreparer(ctx context.Context) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) ListSender(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (client Client) ListResponder(resp *http.Response) (result ListResult, err error) {
+	return
+}
+
+func (client Client) listNextResults(lastResults ListResult) (result ListResult, err error) {
+	return
+}
+
+type SomeInterface interface {
+	One()
+	Two(bool)
+}
+
+type AnotherInterface interface {
+	One()
+}

--- a/sdk/tools/apidiff/delta/testdata/nonbreaking/new/new.go
+++ b/sdk/tools/apidiff/delta/testdata/nonbreaking/new/new.go
@@ -1,0 +1,277 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/version"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// content lifted from redis
+
+// summary of changes
+//
+// const:
+// added new const type Color with some values
+// added Holiday to DayOfWeek
+//
+// func:
+// added DoNothing2 func
+// added Client.Export* methods
+// added ExportDataFuture.Result method
+//
+// interface:
+// added NewInterface interface
+// added NewMethod to SomeInterface
+//
+// struct:
+// added ExportDataFuture and ExportRDBParameters types
+// added field NewField to CreateProperties and DeleteFuture types
+//
+
+const (
+	DefaultBaseURI = "https://management.azure.com"
+)
+
+type DayOfWeek string
+
+const (
+	Everyday  DayOfWeek = "Everyday"
+	Friday    DayOfWeek = "Friday"
+	Monday    DayOfWeek = "Monday"
+	Saturday  DayOfWeek = "Saturday"
+	Sunday    DayOfWeek = "Sunday"
+	Thursday  DayOfWeek = "Thursday"
+	Tuesday   DayOfWeek = "Tuesday"
+	Wednesday DayOfWeek = "Wednesday"
+	Weekend   DayOfWeek = "Weekend"
+	Holiday   DayOfWeek = "Holiday"
+)
+
+type KeyType string
+
+const (
+	Primary   KeyType = "Primary"
+	Secondary KeyType = "Secondary"
+)
+
+type Color string
+
+const (
+	Blue  Color = "Blue"
+	Green Color = "Green"
+	Red   Color = "Red"
+)
+
+type BaseClient struct {
+	autorest.Client
+	BaseURI        string
+	SubscriptionID string
+}
+
+type Client struct {
+	BaseClient
+}
+
+func DoNothing() {
+}
+
+func DoNothing2() {
+}
+
+func DoNothingWithParam(foo int) {
+}
+
+func New(subscriptionID string) BaseClient {
+	return NewWithBaseURI(DefaultBaseURI, subscriptionID)
+}
+
+func NewWithBaseURI(baseURI string, subscriptionID string) BaseClient {
+	return BaseClient{
+		Client:         autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI:        baseURI,
+		SubscriptionID: subscriptionID,
+	}
+}
+
+func UserAgent() string {
+	return "Azure-SDK-For-Go/" + version.Number + " redis/2017-10-01"
+}
+
+type CreateParameters struct {
+	*CreateProperties `json:"properties,omitempty"`
+	Zones             *[]string          `json:"zones,omitempty"`
+	Location          *string            `json:"location,omitempty"`
+	Tags              map[string]*string `json:"tags"`
+}
+
+func (cp CreateParameters) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
+func (cp *CreateParameters) UnmarshalJSON(body []byte) error {
+	return nil
+}
+
+type CreateProperties struct {
+	SubnetID           *string            `json:"subnetId,omitempty"`
+	StaticIP           *string            `json:"staticIP,omitempty"`
+	RedisConfiguration map[string]*string `json:"redisConfiguration"`
+	EnableNonSslPort   *bool              `json:"enableNonSslPort,omitempty"`
+	TenantSettings     map[string]*string `json:"tenantSettings"`
+	ShardCount         *int32             `json:"shardCount,omitempty"`
+	NewField           *float64
+}
+
+type DeleteFuture struct {
+	azure.Future
+	req      *http.Request
+	NewField string
+}
+
+func (future DeleteFuture) Result(client Client) (ar autorest.Response, err error) {
+	return
+}
+
+type ExportDataFuture struct {
+	azure.Future
+	req      *http.Request
+	NewField string
+}
+
+func (future ExportDataFuture) Result(client Client) (ar autorest.Response, err error) {
+	return
+}
+
+type ExportRDBParameters struct {
+	Format    *string `json:"format,omitempty"`
+	Prefix    *string `json:"prefix,omitempty"`
+	Container *string `json:"container,omitempty"`
+}
+
+type ListResult struct {
+	autorest.Response `json:"-"`
+	Value             *[]ResourceType `json:"value,omitempty"`
+	NextLink          *string         `json:"nextLink,omitempty"`
+}
+
+func (lr ListResult) IsEmpty() bool {
+	return lr.Value == nil || len(*lr.Value) == 0
+}
+
+type ListResultPage struct {
+	fn func(ListResult) (ListResult, error)
+	lr ListResult
+}
+
+func (page *ListResultPage) Next() error {
+	return nil
+}
+
+func (page ListResultPage) NotDone() bool {
+	return !page.lr.IsEmpty()
+}
+
+func (page ListResultPage) Response() ListResult {
+	return page.lr
+}
+
+func (page ListResultPage) Values() []ResourceType {
+	return *page.lr.Value
+}
+
+type ResourceType struct {
+	autorest.Response `json:"-"`
+	Zones             *[]string          `json:"zones,omitempty"`
+	Tags              map[string]*string `json:"tags"`
+	Location          *string            `json:"location,omitempty"`
+	ID                *string            `json:"id,omitempty"`
+	Name              *string            `json:"name,omitempty"`
+	Type              *string            `json:"type,omitempty"`
+}
+
+func (client Client) Delete(ctx context.Context, resourceGroupName string, name string) (result DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeletePreparer(ctx context.Context, resourceGroupName string, name string) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) DeleteSender(req *http.Request) (future DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeleteResponder(resp *http.Response) (result autorest.Response, err error) {
+	return
+}
+
+func (client Client) ExportData(ctx context.Context, resourceGroupName string, name string, parameters ExportRDBParameters) (result ExportDataFuture, err error) {
+	return
+}
+
+func (client Client) ExportDataPreparer(ctx context.Context, resourceGroupName string, name string, parameters ExportRDBParameters) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) ExportDataSender(req *http.Request) (future ExportDataFuture, err error) {
+	return
+}
+
+func (client Client) ExportDataResponder(resp *http.Response) (result autorest.Response, err error) {
+	return
+}
+
+func (client Client) List(ctx context.Context) (result ListResultPage, err error) {
+	return
+}
+
+func (client Client) ListPreparer(ctx context.Context) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) ListSender(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (client Client) ListResponder(resp *http.Response) (result ListResult, err error) {
+	return
+}
+
+func (client Client) listNextResults(lastResults ListResult) (result ListResult, err error) {
+	return
+}
+
+type SomeInterface interface {
+	One()
+	Two(bool)
+	NewMethod(string) (bool, error)
+}
+
+type AnotherInterface interface {
+	One()
+}
+
+type NewInterface interface {
+	One(int)
+	Two() error
+}

--- a/sdk/tools/apidiff/delta/testdata/nonbreaking/old/old.go
+++ b/sdk/tools/apidiff/delta/testdata/nonbreaking/old/old.go
@@ -1,0 +1,204 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/version"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// content lifted from redis
+
+const (
+	DefaultBaseURI = "https://management.azure.com"
+)
+
+type DayOfWeek string
+
+const (
+	Everyday  DayOfWeek = "Everyday"
+	Friday    DayOfWeek = "Friday"
+	Monday    DayOfWeek = "Monday"
+	Saturday  DayOfWeek = "Saturday"
+	Sunday    DayOfWeek = "Sunday"
+	Thursday  DayOfWeek = "Thursday"
+	Tuesday   DayOfWeek = "Tuesday"
+	Wednesday DayOfWeek = "Wednesday"
+	Weekend   DayOfWeek = "Weekend"
+)
+
+type KeyType string
+
+const (
+	Primary   KeyType = "Primary"
+	Secondary KeyType = "Secondary"
+)
+
+type BaseClient struct {
+	autorest.Client
+	BaseURI        string
+	SubscriptionID string
+}
+
+type Client struct {
+	BaseClient
+}
+
+func DoNothing() {
+}
+
+func DoNothingWithParam(foo int) {
+}
+
+func New(subscriptionID string) BaseClient {
+	return NewWithBaseURI(DefaultBaseURI, subscriptionID)
+}
+
+func NewWithBaseURI(baseURI string, subscriptionID string) BaseClient {
+	return BaseClient{
+		Client:         autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI:        baseURI,
+		SubscriptionID: subscriptionID,
+	}
+}
+
+func UserAgent() string {
+	return "Azure-SDK-For-Go/" + version.Number + " redis/2017-10-01"
+}
+
+type CreateParameters struct {
+	*CreateProperties `json:"properties,omitempty"`
+	Zones             *[]string          `json:"zones,omitempty"`
+	Location          *string            `json:"location,omitempty"`
+	Tags              map[string]*string `json:"tags"`
+}
+
+func (cp CreateParameters) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
+func (cp *CreateParameters) UnmarshalJSON(body []byte) error {
+	return nil
+}
+
+type CreateProperties struct {
+	SubnetID           *string            `json:"subnetId,omitempty"`
+	StaticIP           *string            `json:"staticIP,omitempty"`
+	RedisConfiguration map[string]*string `json:"redisConfiguration"`
+	EnableNonSslPort   *bool              `json:"enableNonSslPort,omitempty"`
+	TenantSettings     map[string]*string `json:"tenantSettings"`
+	ShardCount         *int32             `json:"shardCount,omitempty"`
+}
+
+type DeleteFuture struct {
+	azure.Future
+	req *http.Request
+}
+
+func (future DeleteFuture) Result(client Client) (ar autorest.Response, err error) {
+	return
+}
+
+type ListResult struct {
+	autorest.Response `json:"-"`
+	Value             *[]ResourceType `json:"value,omitempty"`
+	NextLink          *string         `json:"nextLink,omitempty"`
+}
+
+func (lr ListResult) IsEmpty() bool {
+	return lr.Value == nil || len(*lr.Value) == 0
+}
+
+type ListResultPage struct {
+	fn func(ListResult) (ListResult, error)
+	lr ListResult
+}
+
+func (page *ListResultPage) Next() error {
+	return nil
+}
+
+func (page ListResultPage) NotDone() bool {
+	return !page.lr.IsEmpty()
+}
+
+func (page ListResultPage) Response() ListResult {
+	return page.lr
+}
+
+func (page ListResultPage) Values() []ResourceType {
+	return *page.lr.Value
+}
+
+type ResourceType struct {
+	autorest.Response `json:"-"`
+	Zones             *[]string          `json:"zones,omitempty"`
+	Tags              map[string]*string `json:"tags"`
+	Location          *string            `json:"location,omitempty"`
+	ID                *string            `json:"id,omitempty"`
+	Name              *string            `json:"name,omitempty"`
+	Type              *string            `json:"type,omitempty"`
+}
+
+func (client Client) Delete(ctx context.Context, resourceGroupName string, name string) (result DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeletePreparer(ctx context.Context, resourceGroupName string, name string) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) DeleteSender(req *http.Request) (future DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeleteResponder(resp *http.Response) (result autorest.Response, err error) {
+	return
+}
+
+func (client Client) List(ctx context.Context) (result ListResultPage, err error) {
+	return
+}
+
+func (client Client) ListPreparer(ctx context.Context) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) ListSender(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (client Client) ListResponder(resp *http.Response) (result ListResult, err error) {
+	return
+}
+
+func (client Client) listNextResults(lastResults ListResult) (result ListResult, err error) {
+	return
+}
+
+type SomeInterface interface {
+	One()
+	Two(bool)
+}
+
+type AnotherInterface interface {
+	One()
+}

--- a/sdk/tools/apidiff/exports/exports.go
+++ b/sdk/tools/apidiff/exports/exports.go
@@ -1,0 +1,190 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exports
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+)
+
+// Content defines the set of exported constants, funcs, and structs.
+type Content struct {
+	// the list of exported constants.
+	// key is the exported name, value is its type and value.
+	Consts map[string]Const `json:"consts,omitempty"`
+
+	// the list of exported functions and methods.
+	// key is the exported name, for methods it's prefixed with the receiver type (e.g. "Type.Method").
+	// value contains the list of params and return types.
+	Funcs map[string]Func `json:"funcs,omitempty"`
+
+	// the list of exported interfaces.
+	// key is the exported name, value contains the interface definition.
+	Interfaces map[string]Interface `json:"interfaces,omitempty"`
+
+	// the list of exported struct types.
+	// key is the exported name, value contains field information.
+	Structs map[string]Struct `json:"structs,omitempty"`
+}
+
+// Count returns the count of items
+func (c Content) Count() int {
+	return len(c.Consts) + len(c.Funcs) + len(c.Interfaces) + len(c.Structs)
+}
+
+// Const is a const definition.
+type Const struct {
+	// the type of the constant
+	Type string `json:"type"`
+
+	// the value of the constant
+	Value string `json:"value"`
+}
+
+// Func contains parameter and return types of a function/method.
+type Func struct {
+	// a comma-delimited list of the param types
+	Params *string `json:"params,omitempty"`
+
+	// a comma-delimited list of the return types
+	Returns *string `json:"returns,omitempty"`
+}
+
+// Interface contains the list of methods for an interface.
+type Interface struct {
+	// a list of embedded interfaces
+	AnonymousFields []string `json:"anon,omitempty"`
+
+	// key/value pairs of the methd names and their definitions
+	Methods map[string]Func
+}
+
+// Struct contains field info about a struct.
+type Struct struct {
+	// a list of anonymous fields
+	AnonymousFields []string `json:"anon,omitempty"`
+
+	// key/value pairs of the field names and types respectively.
+	Fields map[string]string `json:"fields,omitempty"`
+}
+
+// NewContent returns an initialized Content object.
+func NewContent() Content {
+	return Content{
+		Consts:     make(map[string]Const),
+		Funcs:      make(map[string]Func),
+		Interfaces: make(map[string]Interface),
+		Structs:    make(map[string]Struct),
+	}
+}
+
+// IsEmpty returns true if there is no content in any of the fields.
+func (c Content) IsEmpty() bool {
+	return len(c.Consts) == 0 && len(c.Funcs) == 0 && len(c.Interfaces) == 0 && len(c.Structs) == 0
+}
+
+// adds the specified const declaration to the exports list
+func (c *Content) addConst(pkg Package, g *ast.GenDecl) {
+	for _, s := range g.Specs {
+		co := Const{}
+		vs := s.(*ast.ValueSpec)
+		v := ""
+		// Type is nil for untyped consts
+		if vs.Type != nil {
+			switch x := vs.Type.(type) {
+			case *ast.Ident:
+				co.Type = x.Name
+				v = vs.Values[0].(*ast.BasicLit).Value
+			case *ast.SelectorExpr:
+				co.Type = x.Sel.Name
+				v = vs.Values[0].(*ast.BasicLit).Value
+			default:
+				panic(fmt.Sprintf("wrong type %T", vs.Type))
+			}
+		} else {
+			// get the type from the token type
+			if bl, ok := vs.Values[0].(*ast.BasicLit); ok {
+				co.Type = strings.ToLower(bl.Kind.String())
+				v = bl.Value
+			} else if ce, ok := vs.Values[0].(*ast.CallExpr); ok {
+				// const FooConst = FooType("value")
+				co.Type = pkg.getText(ce.Fun.Pos(), ce.Fun.End())
+				v = pkg.getText(ce.Args[0].Pos(), ce.Args[0].End())
+			} else if ce, ok := vs.Values[0].(*ast.BinaryExpr); ok {
+				// const FooConst = "value" + Bar
+				co.Type = "*ast.BinaryExpr"
+				v = pkg.getText(ce.X.Pos(), ce.Y.End())
+			} else {
+				panic(fmt.Sprintf("unhandled case for adding constant: %s", pkg.getText(vs.Pos(), vs.End())))
+			}
+		}
+		// TODO should this also be removed?
+		// remove any surrounding quotes
+		if v[0] == '"' {
+			v = v[1 : len(v)-1]
+		}
+		co.Value = v
+		c.Consts[vs.Names[0].Name] = co
+	}
+}
+
+// adds the specified function declaration to the exports list
+func (c *Content) addFunc(pkg Package, f *ast.FuncDecl) {
+	// create a method sig, for methods it's a combination of the receiver type
+	// with the function name e.g. "FooReceiver.Method", else just the function name.
+	sig := ""
+	if f.Recv != nil {
+		sig = pkg.getText(f.Recv.List[0].Type.Pos(), f.Recv.List[0].Type.End())
+		sig += "."
+	}
+	sig += f.Name.Name
+	c.Funcs[sig] = pkg.buildFunc(f.Type)
+}
+
+// adds the specified interface type to the exports list.
+func (c *Content) addInterface(pkg Package, name string, i *ast.InterfaceType) {
+	in := Interface{Methods: map[string]Func{}}
+	if i.Methods != nil {
+		pkg.translateFieldList(i.Methods.List, func(n *string, t string, f *ast.Field) {
+			if n == nil {
+				in.AnonymousFields = append(in.AnonymousFields, t)
+			} else {
+				if in.Methods == nil {
+					in.Methods = map[string]Func{}
+				}
+				in.Methods[*n] = pkg.buildFunc(f.Type.(*ast.FuncType))
+			}
+		})
+	}
+	c.Interfaces[name] = in
+}
+
+// adds the specified struct type to the exports list.
+func (c *Content) addStruct(pkg Package, name string, s *ast.StructType) {
+	sd := Struct{}
+	// assumes all struct types have fields
+	pkg.translateFieldList(s.Fields.List, func(n *string, t string, f *ast.Field) {
+		if n == nil {
+			sd.AnonymousFields = append(sd.AnonymousFields, t)
+		} else {
+			if sd.Fields == nil {
+				sd.Fields = map[string]string{}
+			}
+			sd.Fields[*n] = t
+		}
+	})
+	c.Structs[name] = sd
+}

--- a/sdk/tools/apidiff/exports/package.go
+++ b/sdk/tools/apidiff/exports/package.go
@@ -1,0 +1,199 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exports
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// Package represents a Go package.
+type Package struct {
+	f     *token.FileSet
+	p     *ast.Package
+	files map[string][]byte
+}
+
+// LoadPackageErrorInfo provides extended information about certain LoadPackage() failures.
+type LoadPackageErrorInfo interface {
+	Packages() []string
+}
+
+type errorInfo struct {
+	m string
+	p []string
+}
+
+func (ei errorInfo) Error() string {
+	return ei.m
+}
+
+func (ei errorInfo) Packages() []string {
+	return ei.p
+}
+
+var _ LoadPackageErrorInfo = (*errorInfo)(nil)
+
+// LoadPackage loads the package in the specified directory.
+// It's required there is only one package in the directory.
+func LoadPackage(dir string) (pkg Package, err error) {
+	pkg.files = map[string][]byte{}
+	pkg.f = token.NewFileSet()
+	packages, err := parser.ParseDir(pkg.f, dir, func(f os.FileInfo) bool {
+		// exclude test files
+		return !strings.HasSuffix(f.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		return
+	}
+	if len(packages) < 1 {
+		err = errorInfo{
+			m: fmt.Sprintf("didn't find any packages in '%s'", dir),
+		}
+		return
+	}
+	if len(packages) > 1 {
+		pkgs := []string{}
+		for p := range packages {
+			pkgs = append(pkgs, p)
+		}
+		err = errorInfo{
+			m: fmt.Sprintf("found multiple packages in '%s': %s", dir, strings.Join(pkgs, ", ")),
+			p: pkgs,
+		}
+		return
+	}
+	for pn := range packages {
+		p := packages[pn]
+		// trim any non-exported nodes
+		if exp := ast.PackageExports(p); !exp {
+			err = fmt.Errorf("package '%s' doesn't contain any exports", pn)
+			return
+		}
+		pkg.p = p
+		return
+	}
+	// shouldn't ever get here...
+	panic("failed to return package")
+}
+
+// GetExports returns the exported content of the package.
+func (pkg Package) GetExports() (c Content) {
+	c = NewContent()
+	ast.Inspect(pkg.p, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.TypeSpec:
+			if t, ok := x.Type.(*ast.StructType); ok {
+				c.addStruct(pkg, x.Name.Name, t)
+			} else if t, ok := x.Type.(*ast.InterfaceType); ok {
+				c.addInterface(pkg, x.Name.Name, t)
+			}
+		case *ast.FuncDecl:
+			c.addFunc(pkg, x)
+			// return false as we don't care about the function body.
+			// this is super important as it filters out the majority of
+			// the package's AST making it WAY easier to find the bits
+			// of interest (not doing this will break a lot of code).
+			return false
+		case *ast.GenDecl:
+			if x.Tok == token.CONST {
+				c.addConst(pkg, x)
+			}
+		}
+		return true
+	})
+	return
+}
+
+// Name returns the package name.
+func (pkg Package) Name() string {
+	return pkg.p.Name
+}
+
+// Get loads the package in the specified directory and returns the exported
+// content.  It's a convenience wrapper around LoadPackage() and GetExports().
+func Get(pkgDir string) (Content, error) {
+	pkg, err := LoadPackage(pkgDir)
+	if err != nil {
+		return Content{}, err
+	}
+	return pkg.GetExports(), nil
+}
+
+// returns the text between [start, end]
+func (pkg Package) getText(start token.Pos, end token.Pos) string {
+	// convert to absolute position within the containing file
+	p := pkg.f.Position(start)
+	// check if the file has been loaded, if not then load it
+	if _, ok := pkg.files[p.Filename]; !ok {
+		b, err := ioutil.ReadFile(p.Filename)
+		if err != nil {
+			panic(err)
+		}
+		pkg.files[p.Filename] = b
+	}
+	return string(pkg.files[p.Filename][p.Offset : p.Offset+int(end-start)])
+}
+
+// iterates over the specified field list, for each field the specified
+// callback is invoked with the name of the field and the type name.  the field
+// name can be nil, e.g. anonymous fields in structs, unnamed return types etc.
+func (pkg Package) translateFieldList(fl []*ast.Field, cb func(*string, string, *ast.Field)) {
+	for _, f := range fl {
+		var name *string
+		if f.Names != nil {
+			n := pkg.getText(f.Names[0].Pos(), f.Names[0].End())
+			name = &n
+		}
+		t := pkg.getText(f.Type.Pos(), f.Type.End())
+		cb(name, t, f)
+	}
+}
+
+// creates a Func object from the specified ast.FuncType
+func (pkg Package) buildFunc(ft *ast.FuncType) (f Func) {
+	// appends a to s, comma-delimited style, and returns s
+	appendString := func(s, a string) string {
+		if s != "" {
+			s += ", "
+		}
+		s += a
+		return s
+	}
+
+	// build the params type list
+	if ft.Params.List != nil {
+		p := ""
+		pkg.translateFieldList(ft.Params.List, func(n *string, t string, f *ast.Field) {
+			p = appendString(p, t)
+		})
+		f.Params = &p
+	}
+
+	// build the return types list
+	if ft.Results != nil {
+		r := ""
+		pkg.translateFieldList(ft.Results.List, func(n *string, t string, f *ast.Field) {
+			r = appendString(r, t)
+		})
+		f.Returns = &r
+	}
+	return
+}

--- a/sdk/tools/apidiff/exports/package_test.go
+++ b/sdk/tools/apidiff/exports/package_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/exports"
 )
 
 var pkg exports.Package

--- a/sdk/tools/apidiff/exports/package_test.go
+++ b/sdk/tools/apidiff/exports/package_test.go
@@ -1,0 +1,211 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exports_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+)
+
+var pkg exports.Package
+var exp exports.Content
+
+func init() {
+	pkg, _ = exports.LoadPackage("./testdata")
+	exp = pkg.GetExports()
+}
+
+func Test_Constants(t *testing.T) {
+	if l := len(exp.Consts); l != 13 {
+		t.Logf("wrong number of constants, got %v", l)
+		t.Fail()
+	}
+
+	tests := []struct {
+		cn string
+		exports.Const
+	}{
+		{"DefaultBaseURI", exports.Const{Type: "string", Value: "https://management.azure.com"}},
+		{"Tuesday", exports.Const{Type: "DayOfWeek", Value: "Tuesday"}},
+		{"Primary", exports.Const{Type: "KeyType", Value: "Primary"}},
+		{"Backup", exports.Const{Type: "KeyType", Value: "Backup"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.cn, func(t *testing.T) {
+			c := exp.Consts[test.cn]
+			if !reflect.DeepEqual(c.Type, test.Type) {
+				t.Logf("mismatched types, %s != %s", c.Type, test.Type)
+				t.Fail()
+			}
+			if c.Value != test.Value {
+				t.Logf("mismatched values, %s != %s", c.Value, test.Value)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func Test_Funcs(t *testing.T) {
+	if l := len(exp.Funcs); l != 21 {
+		t.Logf("wrong number of funcs, got %v", l)
+		t.Fail()
+	}
+
+	tests := []struct {
+		fn string
+		exports.Func
+	}{
+		{"DoNothing", exports.Func{}},
+		{"DoNothingWithParam", exports.Func{Params: strPtr("int"), Returns: nil}},
+		{"UserAgent", exports.Func{Params: nil, Returns: strPtr("string")}},
+		{"Client.Delete", exports.Func{Params: strPtr("context.Context, string, string"), Returns: strPtr("DeleteFuture, error")}},
+		{"Client.ListSender", exports.Func{Params: strPtr("*http.Request"), Returns: strPtr("*http.Response, error")}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.fn, func(t *testing.T) {
+			f := exp.Funcs[test.fn]
+			if !reflect.DeepEqual(f.Params, test.Params) {
+				t.Logf("mismatched params, %s != %s", safeStr(f.Params), safeStr(test.Params))
+				t.Fail()
+			}
+			if !reflect.DeepEqual(f.Returns, test.Returns) {
+				t.Logf("mismatched returns, %s != %s", safeStr(f.Returns), safeStr(test.Returns))
+				t.Fail()
+			}
+		})
+	}
+}
+
+func Test_Interfaces(t *testing.T) {
+	if l := len(exp.Interfaces); l != 1 {
+		t.Logf("wrong number of interfaces, got %v", l)
+		t.Fail()
+	}
+
+	tests := []struct {
+		in string
+		exports.Interface
+	}{
+		{"SomeInterface", exports.Interface{
+			Methods: map[string]exports.Func{
+				"One": {
+					Params:  nil,
+					Returns: nil,
+				},
+				"Two": {
+					Params:  strPtr("bool"),
+					Returns: nil,
+				},
+				"Three": {
+					Params:  nil,
+					Returns: strPtr("string"),
+				},
+				"Four": {
+					Params:  strPtr("int"),
+					Returns: strPtr("error"),
+				},
+				"Five": {
+					Params:  strPtr("int, bool"),
+					Returns: strPtr("int, error"),
+				},
+			},
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			i := exp.Interfaces[test.in]
+			if !reflect.DeepEqual(i.Methods, test.Methods) {
+				t.Logf("mismatched methods, have %+v, want %+v", i.Methods, test.Methods)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func Test_Structs(t *testing.T) {
+	if l := len(exp.Structs); l != 8 {
+		t.Logf("wrong number of structs, got %v", l)
+		t.Fail()
+	}
+
+	tests := []struct {
+		sn string
+		exports.Struct
+	}{
+		{"BaseClient", exports.Struct{
+			AnonymousFields: []string{"autorest.Client"},
+			Fields: map[string]string{
+				"BaseURI":        "string",
+				"SubscriptionID": "string",
+			}}},
+		{"DeleteFuture", exports.Struct{
+			AnonymousFields: []string{"azure.Future"},
+		}},
+		{"ListResultPage", exports.Struct{}},
+		{"CreateParameters", exports.Struct{
+			AnonymousFields: []string{"*CreateProperties"},
+			Fields: map[string]string{
+				"Zones":    "*[]string",
+				"Location": "*string",
+				"Tags":     "map[string]*string",
+			}}},
+		{"CreateProperties", exports.Struct{
+			Fields: map[string]string{
+				"SubnetID":           "*string",
+				"StaticIP":           "*string",
+				"RedisConfiguration": "map[string]*string",
+				"EnableNonSslPort":   "*bool",
+				"TenantSettings":     "map[string]*string",
+				"ShardCount":         "*int32",
+			}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.sn, func(t *testing.T) {
+			s := exp.Structs[test.sn]
+			if !reflect.DeepEqual(s.AnonymousFields, test.AnonymousFields) {
+				t.Logf("mismatched anonymous fields, have %+v, want %v", s.AnonymousFields, test.AnonymousFields)
+				t.Fail()
+			}
+			if !reflect.DeepEqual(s.Fields, test.Fields) {
+				t.Logf("mismatched fields, have %+v want %+v", s.Fields, test.Fields)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func Test_Name(t *testing.T) {
+	if n := pkg.Name(); n != "testdata" {
+		t.Logf("incorrect package name, have '%s', want 'testdata'", n)
+		t.Fail()
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func safeStr(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
+}

--- a/sdk/tools/apidiff/exports/testdata/td.go
+++ b/sdk/tools/apidiff/exports/testdata/td.go
@@ -1,0 +1,204 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/version"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// content lifted from redis
+
+const (
+	DefaultBaseURI = "https://management.azure.com"
+)
+
+type DayOfWeek string
+
+const (
+	Everyday  DayOfWeek = "Everyday"
+	Friday    DayOfWeek = "Friday"
+	Monday    DayOfWeek = "Monday"
+	Saturday  DayOfWeek = "Saturday"
+	Sunday    DayOfWeek = "Sunday"
+	Thursday  DayOfWeek = "Thursday"
+	Tuesday   DayOfWeek = "Tuesday"
+	Wednesday DayOfWeek = "Wednesday"
+	Weekend   DayOfWeek = "Weekend"
+)
+
+type KeyType string
+
+const (
+	Primary   KeyType = "Primary"
+	Secondary KeyType = "Secondary"
+	Backup            = KeyType("Backup")
+)
+
+type BaseClient struct {
+	autorest.Client
+	BaseURI        string
+	SubscriptionID string
+}
+
+type Client struct {
+	BaseClient
+}
+
+func DoNothing() {
+}
+
+func DoNothingWithParam(foo int) {
+}
+
+func New(subscriptionID string) BaseClient {
+	return NewWithBaseURI(DefaultBaseURI, subscriptionID)
+}
+
+func NewWithBaseURI(baseURI string, subscriptionID string) BaseClient {
+	return BaseClient{
+		Client:         autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI:        baseURI,
+		SubscriptionID: subscriptionID,
+	}
+}
+
+func UserAgent() string {
+	return "Azure-SDK-For-Go/" + version.Number + " redis/2017-10-01"
+}
+
+type CreateParameters struct {
+	*CreateProperties `json:"properties,omitempty"`
+	Zones             *[]string          `json:"zones,omitempty"`
+	Location          *string            `json:"location,omitempty"`
+	Tags              map[string]*string `json:"tags"`
+}
+
+func (cp CreateParameters) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
+func (cp *CreateParameters) UnmarshalJSON(body []byte) error {
+	return nil
+}
+
+type CreateProperties struct {
+	SubnetID           *string            `json:"subnetId,omitempty"`
+	StaticIP           *string            `json:"staticIP,omitempty"`
+	RedisConfiguration map[string]*string `json:"redisConfiguration"`
+	EnableNonSslPort   *bool              `json:"enableNonSslPort,omitempty"`
+	TenantSettings     map[string]*string `json:"tenantSettings"`
+	ShardCount         *int32             `json:"shardCount,omitempty"`
+}
+
+type DeleteFuture struct {
+	azure.Future
+	req *http.Request
+}
+
+func (future DeleteFuture) Result(client Client) (ar autorest.Response, err error) {
+	return
+}
+
+type ListResult struct {
+	autorest.Response `json:"-"`
+	Value             *[]ResourceType `json:"value,omitempty"`
+	NextLink          *string         `json:"nextLink,omitempty"`
+}
+
+func (lr ListResult) IsEmpty() bool {
+	return lr.Value == nil || len(*lr.Value) == 0
+}
+
+type ListResultPage struct {
+	fn func(ListResult) (ListResult, error)
+	lr ListResult
+}
+
+func (page *ListResultPage) Next() error {
+	return nil
+}
+
+func (page ListResultPage) NotDone() bool {
+	return !page.lr.IsEmpty()
+}
+
+func (page ListResultPage) Response() ListResult {
+	return page.lr
+}
+
+func (page ListResultPage) Values() []ResourceType {
+	return *page.lr.Value
+}
+
+type ResourceType struct {
+	autorest.Response `json:"-"`
+	Zones             *[]string          `json:"zones,omitempty"`
+	Tags              map[string]*string `json:"tags"`
+	Location          *string            `json:"location,omitempty"`
+	ID                *string            `json:"id,omitempty"`
+	Name              *string            `json:"name,omitempty"`
+	Type              *string            `json:"type,omitempty"`
+}
+
+func (client Client) Delete(ctx context.Context, resourceGroupName string, name string) (result DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeletePreparer(ctx context.Context, resourceGroupName string, name string) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) DeleteSender(req *http.Request) (future DeleteFuture, err error) {
+	return
+}
+
+func (client Client) DeleteResponder(resp *http.Response) (result autorest.Response, err error) {
+	return
+}
+
+func (client Client) List(ctx context.Context) (result ListResultPage, err error) {
+	return
+}
+
+func (client Client) ListPreparer(ctx context.Context) (*http.Request, error) {
+	const APIVersion = "2017-10-01"
+	return nil, nil
+}
+
+func (client Client) ListSender(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (client Client) ListResponder(resp *http.Response) (result ListResult, err error) {
+	return
+}
+
+func (client Client) listNextResults(lastResults ListResult) (result ListResult, err error) {
+	return
+}
+
+type SomeInterface interface {
+	One()
+	Two(bool)
+	Three() string
+	Four(int) error
+	Five(int, bool) (int, error)
+}

--- a/sdk/tools/apidiff/main.go
+++ b/sdk/tools/apidiff/main.go
@@ -1,0 +1,44 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/cmd"
+)
+
+// breaking changes definitions
+//
+// const
+//
+// 1. removal/renaming of a const
+// 2. changing the type of a const
+//
+// func/method
+//
+// 1. removal/renaming of a func
+// 2. addition/removal of params and/or return values
+// 3. changing param/retval types
+// 4. changing receiver/param/retval byval/byref
+//
+// struct
+// 1. removal/renaming of a field
+// 2. chaning a field's type
+// 3. changing a field from anonymous to explicit or explicit to anonymous
+// 4. changing byval/byref
+//
+
+func main() {
+	cmd.Execute()
+}

--- a/sdk/tools/apidiff/main.go
+++ b/sdk/tools/apidiff/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/cmd"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/cmd"
 )
 
 // breaking changes definitions

--- a/sdk/tools/apidiff/markdown/markdown.go
+++ b/sdk/tools/apidiff/markdown/markdown.go
@@ -37,10 +37,26 @@ func (md *Writer) checkNL() {
 	}
 }
 
+// WriteTitle writes a title to the markdown document
+func (md *Writer) WriteTitle(h string) {
+	md.checkNL()
+	md.sb.WriteString("# ")
+	md.sb.WriteString(h)
+	md.sb.WriteString("\n\n")
+}
+
+// WriteTopLevelHeader writes a header to the markdown document
+func (md *Writer) WriteTopLevelHeader(h string) {
+	md.checkNL()
+	md.sb.WriteString("## ")
+	md.sb.WriteString(h)
+	md.sb.WriteString("\n\n")
+}
+
 // WriteHeader writes a header to the markdown document
 func (md *Writer) WriteHeader(h string) {
 	md.checkNL()
-	md.sb.WriteString("## ")
+	md.sb.WriteString("### ")
 	md.sb.WriteString(h)
 	md.sb.WriteString("\n\n")
 }
@@ -48,7 +64,7 @@ func (md *Writer) WriteHeader(h string) {
 // WriteSubheader writes a sub-header to the markdown document
 func (md *Writer) WriteSubheader(sh string) {
 	md.checkNL()
-	md.sb.WriteString("### ")
+	md.sb.WriteString("#### ")
 	md.sb.WriteString(sh)
 	md.sb.WriteString("\n\n")
 }

--- a/sdk/tools/apidiff/markdown/markdown.go
+++ b/sdk/tools/apidiff/markdown/markdown.go
@@ -1,0 +1,197 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package markdown
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderLink returns a rendered markdown link
+func RenderLink(name, link string) string {
+	return fmt.Sprintf("[%s](%s)", name, link)
+}
+
+// Writer is a writer to write contents in markdown format
+type Writer struct {
+	sb strings.Builder
+	nl bool
+}
+
+func (md *Writer) checkNL() {
+	if md.nl {
+		md.sb.WriteString("\n")
+		md.nl = false
+	}
+}
+
+// WriteHeader writes a header to the markdown document
+func (md *Writer) WriteHeader(h string) {
+	md.checkNL()
+	md.sb.WriteString("## ")
+	md.sb.WriteString(h)
+	md.sb.WriteString("\n\n")
+}
+
+// WriteSubheader writes a sub-header to the markdown document
+func (md *Writer) WriteSubheader(sh string) {
+	md.checkNL()
+	md.sb.WriteString("### ")
+	md.sb.WriteString(sh)
+	md.sb.WriteString("\n\n")
+}
+
+// WriteLine writes a line to the markdown document
+func (md *Writer) WriteLine(s string) {
+	md.nl = true
+	md.sb.WriteString(s)
+	md.sb.WriteString("\n")
+}
+
+// WriteTable writes a table to the markdown document
+func (md *Writer) WriteTable(table Table) {
+	md.WriteLine(table.String())
+}
+
+// EmptyLine inserts an empty line to the markdown document
+func (md *Writer) EmptyLine() {
+	md.WriteLine("")
+}
+
+// String outputs the markdown document as a string
+func (md *Writer) String() string {
+	return md.sb.String()
+}
+
+// Table describes a table in a markdown document
+type Table struct {
+	sb        *strings.Builder
+	headers   []string
+	alignment string
+	rows      []markdownTableRow
+}
+
+const (
+	leftAlignment   = ":---"
+	centerAlignment = ":---:"
+	rightAlignment  = "---:"
+)
+
+// NewTable creates a new table with given alignments and headers
+func NewTable(alignment string, headers ...string) *Table {
+	alignment, headers = checkAlignmentAndHeaders(alignment, headers)
+	t := Table{
+		sb:        &strings.Builder{},
+		headers:   headers,
+		alignment: alignment,
+	}
+	return &t
+}
+
+// Columns returns the number of columns in this table
+func (t *Table) Columns() int {
+	return len(t.headers)
+}
+
+// Rows returns the number of rows in this table
+func (t *Table) Rows() int {
+	return len(t.rows)
+}
+
+// AddRow adds a new row to the table
+func (t *Table) AddRow(items ...string) {
+	t.rows = append(t.rows, markdownTableRow{
+		items: items,
+	})
+}
+
+func checkAlignmentAndHeaders(alignment string, headers []string) (string, []string) {
+	if len(alignment) == len(headers) {
+		return alignment, headers
+	}
+	if len(alignment) > len(headers) {
+		return alignment[:len(headers)], headers
+	}
+	// default alignment is l
+	return alignment + strings.Repeat("l", len(headers)-len(alignment)), headers
+}
+
+type markdownTableRow struct {
+	items []string
+}
+
+func (r *markdownTableRow) ensureItems(count int) []string {
+	if len(r.items) < count {
+		var items []string
+		for i := 0; i < count-len(r.items); i++ {
+			items = append(r.items, "")
+		}
+		return items
+	}
+	if len(r.items) > count {
+		return r.items[:count]
+	}
+	return r.items
+}
+
+func (t *Table) writeHeader() {
+	if len(t.headers) == 0 {
+		return
+	}
+	t.sb.WriteString("| ")
+	t.sb.WriteString(strings.Join(t.headers, " | "))
+	t.sb.WriteString(" |")
+}
+
+func (t *Table) writeAlignment() {
+	if len(t.alignment) == 0 {
+		return
+	}
+	var alignments []string
+	for _, a := range t.alignment {
+		switch a {
+		case 'c':
+			alignments = append(alignments, centerAlignment)
+		case 'r':
+			alignments = append(alignments, rightAlignment)
+		default:
+			alignments = append(alignments, leftAlignment)
+		}
+	}
+	t.sb.WriteString("\n| ")
+	t.sb.WriteString(strings.Join(alignments, " | "))
+	t.sb.WriteString(" |")
+}
+
+func (t *Table) writeRows() {
+	for _, r := range t.rows {
+		t.writeRow(r)
+	}
+}
+
+func (t *Table) writeRow(row markdownTableRow) {
+	items := row.ensureItems(t.Columns())
+	t.sb.WriteString("\n| ")
+	t.sb.WriteString(strings.Join(items, " | "))
+	t.sb.WriteString(" |")
+}
+
+// String outputs the markdown table to a string
+func (t *Table) String() string {
+	t.writeHeader()
+	t.writeAlignment()
+	t.writeRows()
+	return t.sb.String()
+}

--- a/sdk/tools/apidiff/markdown/markdown_test.go
+++ b/sdk/tools/apidiff/markdown/markdown_test.go
@@ -1,0 +1,51 @@
+package markdown
+
+import "testing"
+
+func TestMarkdownWriter_String(t *testing.T) {
+	md := Writer{}
+	md.WriteHeader("Header1")
+	md.WriteSubheader("Sub-header1")
+	md.WriteLine("Foo")
+	md.WriteSubheader("Sub-header2")
+	md.WriteLine(getTable().String())
+	result := md.String()
+	expected := `## Header1
+
+### Sub-header1
+
+Foo
+
+### Sub-header2
+
+| packages | api-versions |
+| :--- | :--- |
+| compute | 2020-06-01 |
+| network | 2020-06-01 |
+| resources | 2020-09-01 |
+`
+	if result != expected {
+		t.Fatalf("expected %s, but got %s", expected, result)
+	}
+}
+
+func getTable() *Table {
+	table := NewTable("ll", "packages", "api-versions")
+	table.AddRow("compute", "2020-06-01")
+	table.AddRow("network", "2020-06-01")
+	table.AddRow("resources", "2020-09-01")
+	return table
+}
+
+func TestMarkdownTable_String(t *testing.T) {
+	table := getTable()
+	result := table.String()
+	expected := `| packages | api-versions |
+| :--- | :--- |
+| compute | 2020-06-01 |
+| network | 2020-06-01 |
+| resources | 2020-09-01 |`
+	if result != expected {
+		t.Fatalf("expected %s, but got %s", expected, result)
+	}
+}

--- a/sdk/tools/apidiff/repo/repo.go
+++ b/sdk/tools/apidiff/repo/repo.go
@@ -1,0 +1,210 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repo
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// WorkingTree encapsulates a git repository.
+type WorkingTree struct {
+	dir string
+}
+
+// Get returns a WorkingTree for the specified directory.  If the directory is not the
+// root of a git repository the directory hierarchy is walked to find the root (i.e. the
+// directory where the .git dir resides).
+func Get(dir string) (wt WorkingTree, err error) {
+	orig := dir
+	for found := false; !found; {
+		var fi []os.FileInfo
+		fi, err = ioutil.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		// look for the .git directory
+		for _, f := range fi {
+			if f.Name() == ".git" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// not the root of the repo, move to parent directory
+			i := strings.LastIndexByte(dir, os.PathSeparator)
+			if i < 0 {
+				err = fmt.Errorf("failed to find repo root under '%s'", orig)
+				return
+			}
+			dir = dir[:i]
+		}
+	}
+	wt.dir = dir
+	return
+}
+
+// Branch calls "git branch" to determine the current branch.
+func (wt WorkingTree) Branch() (string, error) {
+	cmd := exec.Command("git", "branch")
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.New(string(output))
+	}
+	branches := strings.Split(string(output), "\n")
+	for _, branch := range branches {
+		if branch[0] == '*' {
+			return branch[2:], nil
+		}
+	}
+	return "", fmt.Errorf("failed to determine active branch: %s", strings.Join(branches, ","))
+}
+
+// DeleteBranch call "git branch -d branchname" to delete a local branch.
+func (wt WorkingTree) DeleteBranch(branchName string) error {
+	cmd := exec.Command("git", "branch", "-d", branchName)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+	return nil
+}
+
+// Clone calls "git clone", cloning the working tree into the specified directory.
+// The returned WorkingTree points to the clone of the repository.
+func (wt WorkingTree) Clone(dest string) (result WorkingTree, err error) {
+	cmd := exec.Command("git", "clone", fmt.Sprintf("file://%s", wt.dir), dest)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		err = errors.New(string(output))
+		return
+	}
+	result.dir = dest
+	return
+}
+
+// Checkout calls "git checkout" with the specified tree.
+func (wt WorkingTree) Checkout(tree string) error {
+	cmd := exec.Command("git", "checkout", tree)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+	return nil
+}
+
+// Root returns the root directory of the working tree.
+func (wt WorkingTree) Root() string {
+	return wt.dir
+}
+
+// CherryCommit contains an entry returned by the "git cherry" command.
+type CherryCommit struct {
+	// Hash is the SHA1 of the commit.
+	Hash string
+
+	// Found indicates if the commit was found in the upstream branch.
+	Found bool
+}
+
+// Cherry calls "git cherry" with the specified value for upstream.
+// Returns a slice of commits yet to be applied to the specified upstream branch.
+func (wt WorkingTree) Cherry(upstream string) ([]CherryCommit, error) {
+	cmd := exec.Command("git", "cherry", upstream)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.New(string(output))
+	}
+
+	items := strings.Split(string(output), "\n")
+	// skip the last entry as it's just an empty string
+	commits := make([]CherryCommit, len(items)-1, len(items)-1)
+	for i := 0; i < len(items)-1; i++ {
+		commits[i].Found = items[i][0] == '-'
+		commits[i].Hash = items[i][2:]
+	}
+	return commits, nil
+}
+
+// CherryPick calls "git cherry-pick" with the specified commit.
+func (wt WorkingTree) CherryPick(commit string) error {
+	cmd := exec.Command("git", "cherry-pick", commit)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+	return nil
+}
+
+// CreateTag calls "git tag <name>" to create the specified tag.
+func (wt WorkingTree) CreateTag(name string) error {
+	cmd := exec.Command("git", "tag", name)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+	return nil
+}
+
+// ListTags calls "git tag -l <pattern>" to obtain the list of tags.
+// If there are no tags the returned slice will have zero length.
+// Tags are sorted in lexographic ascending order.
+func (wt WorkingTree) ListTags(pattern string) ([]string, error) {
+	cmd := exec.Command("git", "tag", "-l", pattern)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.New(string(output))
+	}
+	if len(output) == 0 {
+		return []string{}, nil
+	}
+	tags := strings.Split(strings.TrimSpace(string(output)), "\n")
+	sort.Strings(tags)
+	return tags, nil
+}
+
+// Pull calls "git pull upstream branch" to update local working tree.
+func (wt WorkingTree) Pull(upstream, branch string) error {
+	cmd := exec.Command("git", "pull", upstream, branch)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+	return nil
+}
+
+// CreateAndCheckout create and checkout to a new branch
+func (wt WorkingTree) CreateAndCheckout(branch string) error {
+	cmd := exec.Command("git", "checkout", "-b", branch)
+	cmd.Dir = wt.dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+	return nil
+}

--- a/sdk/tools/apidiff/report/package.go
+++ b/sdk/tools/apidiff/report/package.go
@@ -1,0 +1,46 @@
+package report
+
+// Status ...
+type Status interface {
+	IsEmpty() bool
+	HasBreakingChanges() bool
+	HasAdditiveChanges() bool
+}
+
+// CommitPkgReport represents a collection of per-package reports, one for each commit hash
+type CommitPkgReport struct {
+	// BreakingChanges includes the commit hashes that contains breaking changes
+	BreakingChanges []string `json:"breakingChanges,omitempty"`
+	// CommitsReports stores the package report with the key of commit hashes
+	CommitsReports map[string]Package `json:"deltas"`
+}
+
+// IsEmpty returns true if the report contains no data
+func (c CommitPkgReport) IsEmpty() bool {
+	for _, rpt := range c.CommitsReports {
+		if !rpt.IsEmpty() {
+			return false
+		}
+	}
+	return true
+}
+
+// HasBreakingChanges returns true if the report contains breaking changes
+func (c CommitPkgReport) HasBreakingChanges() bool {
+	for _, r := range c.CommitsReports {
+		if r.HasBreakingChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAdditiveChanges returns true if the report contains additive changes
+func (c CommitPkgReport) HasAdditiveChanges() bool {
+	for _, r := range c.CommitsReports {
+		if r.HasAdditiveChanges() {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/tools/apidiff/report/package.go
+++ b/sdk/tools/apidiff/report/package.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package report
 
 // Status ...

--- a/sdk/tools/apidiff/report/packages.go
+++ b/sdk/tools/apidiff/report/packages.go
@@ -1,0 +1,210 @@
+package report
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/markdown"
+)
+
+const apiDirSuffix = "api"
+
+// GetPackages returns all the go sdk packages under the given root directory
+func GetPackages(dir string) ([]string, error) {
+	var pkgDirs []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// check if leaf dir
+			fi, err := ioutil.ReadDir(path)
+			if err != nil {
+				return err
+			}
+			hasSubDirs := false
+			for _, f := range fi {
+				// check if this is the interfaces subdir, if it is don't count it as a subdir
+				if f.IsDir() && f.Name() != filepath.Base(path)+apiDirSuffix {
+					hasSubDirs = true
+					break
+				}
+			}
+			if !hasSubDirs {
+				pkgDirs = append(pkgDirs, path)
+				// skip any dirs under us (i.e. interfaces subdir)
+				return filepath.SkipDir
+			}
+		}
+		return nil
+	})
+	return pkgDirs, err
+}
+
+// PkgsList contains a collection of packages
+type PkgsList []string
+
+// ModifiedPackages contains a collection of package reports, it's structured as "package path":pkgReport
+type ModifiedPackages map[string]Package
+
+// IsEmpty ...
+func (m ModifiedPackages) IsEmpty() bool {
+	return len(m) == 0
+}
+
+// HasBreakingChanges returns true if any package contained in has a breaking change
+func (m ModifiedPackages) HasBreakingChanges() bool {
+	for _, p := range m {
+		if p.HasBreakingChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAdditiveChanges returns true if any package contained in has an additive change
+func (m ModifiedPackages) HasAdditiveChanges() bool {
+	for _, p := range m {
+		if p.HasAdditiveChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+// CommitPkgsReport represents a collection of reports, one for each commit hash.
+type CommitPkgsReport struct {
+	// AffectedPackages stores the package list with key of commit hashes
+	AffectedPackages map[string]PkgsList `json:"affectedPackages"`
+	// BreakingChanges stores the commit hashes that contain breaking changes
+	BreakingChanges []string `json:"breakingChanges,omitempty"`
+	// CommitsReports stores the detailed reports with the key of commit hashes
+	CommitsReports map[string]PkgsReport `json:"deltas"`
+}
+
+// IsEmpty returns true if the report contains no data.
+func (c CommitPkgsReport) IsEmpty() bool {
+	for _, r := range c.CommitsReports {
+		if !r.IsEmpty() {
+			return false
+		}
+	}
+	return true
+}
+
+// HasBreakingChanges returns true if the report contains breaking changes.
+func (c CommitPkgsReport) HasBreakingChanges() bool {
+	for _, r := range c.CommitsReports {
+		if r.HasBreakingChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAdditiveChanges returns true if the package contains additive changes.
+func (c CommitPkgsReport) HasAdditiveChanges() bool {
+	for _, r := range c.CommitsReports {
+		if r.HasAdditiveChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+// UpdateAffectedPackages updates the collection of affected packages with the packages that were touched in the specified commit
+func (c *CommitPkgsReport) UpdateAffectedPackages(commit string, r PkgsReport) {
+	if c.AffectedPackages == nil {
+		c.AffectedPackages = map[string]PkgsList{}
+	}
+
+	for _, pkg := range r.AddedPackages {
+		c.AffectedPackages[commit] = append(c.AffectedPackages[commit], pkg)
+	}
+
+	for pkgName := range r.ModifiedPackages {
+		c.AffectedPackages[commit] = append(c.AffectedPackages[commit], pkgName)
+	}
+
+	for _, pkg := range r.RemovedPackages {
+		c.AffectedPackages[commit] = append(c.AffectedPackages[commit], pkg)
+	}
+}
+
+// PkgsReport represents a complete report of added, removed, and modified packages
+type PkgsReport struct {
+	// AddedPackages stores the added packages in the report
+	AddedPackages PkgsList `json:"added,omitempty"`
+	// ModifiedPackages stores the details of all modified packages
+	ModifiedPackages ModifiedPackages `json:"modified,omitempty"`
+	// RemovedPackages stores the removed packages in the report
+	RemovedPackages PkgsList `json:"removed,omitempty"`
+}
+
+// HasBreakingChanges returns true if the package report contains breaking changes
+func (r PkgsReport) HasBreakingChanges() bool {
+	return len(r.RemovedPackages) > 0 || (r.ModifiedPackages != nil && r.ModifiedPackages.HasBreakingChanges())
+}
+
+// HasAdditiveChanges returns true if the package report contains additive changes
+func (r PkgsReport) HasAdditiveChanges() bool {
+	return len(r.AddedPackages) > 0 || (r.ModifiedPackages != nil && r.ModifiedPackages.HasAdditiveChanges())
+}
+
+// IsEmpty returns true if the report contains no data
+func (r PkgsReport) IsEmpty() bool {
+	return len(r.AddedPackages) == 0 && len(r.ModifiedPackages) == 0 && len(r.RemovedPackages) == 0
+}
+
+// ToMarkdown writes the report to string in the markdown form
+func (r *PkgsReport) ToMarkdown() string {
+	if r.IsEmpty() {
+		return ""
+	}
+	md := markdown.Writer{}
+	r.writeAddedPackages(&md)
+	r.writeRemovedPackages(&md)
+	r.writeModifiedPackages(&md)
+	return md.String()
+}
+
+func (r *PkgsReport) writeAddedPackages(md *markdown.Writer) {
+	if len(r.AddedPackages) == 0 {
+		return
+	}
+	md.WriteHeader("New Packages")
+	// write list
+	for _, p := range r.AddedPackages {
+		md.WriteLine("- " + p)
+	}
+}
+
+func (r *PkgsReport) writeModifiedPackages(md *markdown.Writer) {
+	if len(r.ModifiedPackages) == 0 {
+		return
+	}
+	md.WriteHeader("Modified Packages")
+	// write list
+	for n := range r.ModifiedPackages {
+		md.WriteLine(fmt.Sprintf("- `%s`", n))
+	}
+	// write details
+	for n, p := range r.ModifiedPackages {
+		md.WriteHeader(fmt.Sprintf("Modified `%s`", n))
+		md.WriteLine(p.ToMarkdown())
+	}
+}
+
+func (r *PkgsReport) writeRemovedPackages(md *markdown.Writer) {
+	if len(r.RemovedPackages) == 0 {
+		return
+	}
+	md.WriteHeader("Removed Packages")
+	// write list
+	for _, p := range r.RemovedPackages {
+		md.WriteLine("- " + p)
+	}
+	md.EmptyLine()
+}

--- a/sdk/tools/apidiff/report/packages.go
+++ b/sdk/tools/apidiff/report/packages.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package report
 
 import (

--- a/sdk/tools/apidiff/report/packages.go
+++ b/sdk/tools/apidiff/report/packages.go
@@ -159,15 +159,23 @@ func (r PkgsReport) IsEmpty() bool {
 }
 
 // ToMarkdown writes the report to string in the markdown form
-func (r *PkgsReport) ToMarkdown() string {
+func (r *PkgsReport) ToMarkdown(withHeader bool, version, marker string) string {
 	if r.IsEmpty() {
 		return ""
 	}
 	md := markdown.Writer{}
+	if withHeader {
+		r.writeHeader(&md, version, marker)
+	}
 	r.writeAddedPackages(&md)
 	r.writeRemovedPackages(&md)
 	r.writeModifiedPackages(&md)
 	return md.String()
+}
+
+func (r *PkgsReport) writeHeader(md *markdown.Writer, version, marker string) {
+	md.WriteTitle("Release History")
+	md.WriteTopLevelHeader(fmt.Sprintf("%s (%s)", version, marker))
 }
 
 func (r *PkgsReport) writeAddedPackages(md *markdown.Writer) {

--- a/sdk/tools/apidiff/report/packages.go
+++ b/sdk/tools/apidiff/report/packages.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/markdown"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/markdown"
 )
 
 const apiDirSuffix = "api"

--- a/sdk/tools/apidiff/report/report.go
+++ b/sdk/tools/apidiff/report/report.go
@@ -1,0 +1,283 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/delta"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/tools/apidiff/markdown"
+)
+
+// Package represents a per-package report that contains additive and breaking changes.
+type Package struct {
+	AdditiveChanges *delta.Content   `json:"additiveChanges,omitempty"`
+	BreakingChanges *BreakingChanges `json:"breakingChanges,omitempty"`
+}
+
+// HasBreakingChanges returns true if the package report contains breaking changes.
+func (p Package) HasBreakingChanges() bool {
+	return p.BreakingChanges != nil && !p.BreakingChanges.IsEmpty()
+}
+
+// HasAdditiveChanges returns true if the package report contains additive changes.
+func (p Package) HasAdditiveChanges() bool {
+	return p.AdditiveChanges != nil && !p.AdditiveChanges.IsEmpty()
+}
+
+// IsEmpty returns true if the report contains no data (e.g. no changes in exported types).
+func (p Package) IsEmpty() bool {
+	return (p.AdditiveChanges == nil || p.AdditiveChanges.IsEmpty()) &&
+		(p.BreakingChanges == nil || p.BreakingChanges.IsEmpty())
+}
+
+// BreakingChanges represents a set of breaking changes.
+type BreakingChanges struct {
+	Consts     map[string]delta.Signature    `json:"consts,omitempty"`
+	Funcs      map[string]delta.FuncSig      `json:"funcs,omitempty"`
+	Interfaces map[string]delta.InterfaceDef `json:"interfaces,omitempty"`
+	Structs    map[string]delta.StructDef    `json:"structs,omitempty"`
+	Removed    *delta.Content                `json:"removed,omitempty"`
+}
+
+// Count returns the count of breaking changes
+func (bc BreakingChanges) Count() int {
+	removed := 0
+	if bc.Removed != nil {
+		removed = bc.Removed.Count()
+	}
+	return len(bc.Consts) + len(bc.Funcs) + len(bc.Interfaces) + len(bc.Structs) + removed
+}
+
+// IsEmpty returns true if there are no breaking changes.
+func (bc BreakingChanges) IsEmpty() bool {
+	return len(bc.Consts) == 0 && len(bc.Funcs) == 0 && len(bc.Interfaces) == 0 && len(bc.Structs) == 0 &&
+		(bc.Removed == nil || bc.Removed.IsEmpty())
+}
+
+// GenerationOption ...
+type GenerationOption struct {
+	// OnlyBreakingChanges ...
+	OnlyBreakingChanges bool
+	// OnlyAdditiveChanges ...
+	OnlyAdditiveChanges bool
+}
+
+// Generate generates a package report based on the delta between lhs and rhs.
+// onlyBreakingChanges - pass true to include only breaking changes in the report.
+// onlyAdditions - pass true to include only addition changes in the report.
+func Generate(lhs, rhs exports.Content, option *GenerationOption) Package {
+	onlyBreakingChanges := option != nil && option.OnlyAdditiveChanges
+	onlyAdditiveChanges := option != nil && option.OnlyAdditiveChanges
+	r := Package{}
+	if !onlyBreakingChanges {
+		if adds := delta.GetExports(lhs, rhs); !adds.IsEmpty() {
+			r.AdditiveChanges = &adds
+		}
+	}
+
+	if !onlyAdditiveChanges {
+		breaks := BreakingChanges{}
+		breaks.Consts = delta.GetConstTypeChanges(lhs, rhs)
+		breaks.Funcs = delta.GetFuncSigChanges(lhs, rhs)
+		breaks.Interfaces = delta.GetInterfaceMethodSigChanges(lhs, rhs)
+		breaks.Structs = delta.GetStructFieldChanges(lhs, rhs)
+		if removed := delta.GetExports(rhs, lhs); !removed.IsEmpty() {
+			breaks.Removed = &removed
+		}
+		if !breaks.IsEmpty() {
+			r.BreakingChanges = &breaks
+		}
+	}
+	return r
+}
+
+// ToMarkdown creates a report of the package changes in markdown format.
+func (p Package) ToMarkdown() string {
+	if p.IsEmpty() {
+		return ""
+	}
+	md := markdown.Writer{}
+	p.writeBreakingChanges(&md)
+	p.writeNewContent(&md)
+	return md.String()
+}
+
+func (p Package) writeBreakingChanges(md *markdown.Writer) {
+	if !p.HasBreakingChanges() {
+		return
+	}
+	md.WriteHeader("Breaking Changes")
+	writeRemovedContent(p.BreakingChanges.Removed, md)
+	writeSigChanges(p.BreakingChanges, md)
+}
+
+func (p Package) writeNewContent(md *markdown.Writer) {
+	if !p.HasAdditiveChanges() {
+		return
+	}
+	writeConsts(p.AdditiveChanges.Consts, "New Constants", md)
+	writeFuncs(p.AdditiveChanges.Funcs, "New Funcs", md)
+	writeStructs(p.AdditiveChanges, "New Structs", "New Struct Fields", md)
+}
+
+// writes the subset of breaking changes pertaining to removed content
+func writeRemovedContent(removed *delta.Content, md *markdown.Writer) {
+	if removed == nil {
+		return
+	}
+	writeConsts(removed.Consts, "Removed Constants", md)
+	writeFuncs(removed.Funcs, "Removed Funcs", md)
+	writeStructs(removed, "Removed Structs", "Removed Struct Fields", md)
+}
+
+// writes the subset of breaking changes pertaining to signature changes
+func writeSigChanges(bc *BreakingChanges, md *markdown.Writer) {
+	if len(bc.Consts) == 0 && len(bc.Funcs) == 0 && len(bc.Structs) == 0 {
+		return
+	}
+	md.WriteHeader("Signature Changes")
+	if len(bc.Consts) > 0 {
+		items := make([]string, len(bc.Consts))
+		i := 0
+		for k, v := range bc.Consts {
+			items[i] = fmt.Sprintf("1. %s changed type from %s to %s", k, v.From, v.To)
+			i++
+		}
+		sort.Strings(items)
+		md.WriteSubheader("Const Types")
+		for _, item := range items {
+			md.WriteLine(item)
+		}
+	}
+	if len(bc.Funcs) > 0 {
+		// first get all the funcs so we can sort them
+		items := make([]string, len(bc.Funcs))
+		i := 0
+		for k := range bc.Funcs {
+			items[i] = k
+			i++
+		}
+		sort.Strings(items)
+		md.WriteSubheader("Funcs")
+		for _, item := range items {
+			// now add params/returns info
+			changes := bc.Funcs[item]
+			if changes.Params != nil {
+				item = fmt.Sprintf("%s\n\t- Params\n\t\t- From: %s\n\t\t- To: %s", item, changes.Params.From, changes.Params.To)
+			}
+			if changes.Returns != nil {
+				item = fmt.Sprintf("%s\n\t- Returns\n\t\t- From: %s\n\t\t- To: %s", item, changes.Returns.From, changes.Returns.To)
+			}
+			md.WriteLine(fmt.Sprintf("1. %s", item))
+		}
+	}
+	if len(bc.Structs) > 0 {
+		items := make([]string, 0, len(bc.Structs))
+		for k, v := range bc.Structs {
+			for f, d := range v.Fields {
+				items = append(items, fmt.Sprintf("1. %s.%s changed type from %s to %s", k, f, d.From, d.To))
+			}
+		}
+		sort.Strings(items)
+		md.WriteSubheader("Struct Fields")
+		for _, item := range items {
+			md.WriteLine(item)
+		}
+	}
+}
+
+// writes out const information formatted as TypeName.ConstName
+func writeConsts(co map[string]exports.Const, subheader string, md *markdown.Writer) {
+	if len(co) == 0 {
+		return
+	}
+	items := make([]string, len(co))
+	i := 0
+	for c, t := range co {
+		items[i] = fmt.Sprintf("1. %s.%s", t.Type, c)
+		i++
+	}
+	sort.Strings(items)
+	md.WriteSubheader(subheader)
+	for _, item := range items {
+		md.WriteLine(item)
+	}
+}
+
+// writes out func information formatted as [receiver].FuncName([params]) [returns]
+func writeFuncs(funcs map[string]exports.Func, subheader string, md *markdown.Writer) {
+	if len(funcs) == 0 {
+		return
+	}
+	items := make([]string, len(funcs))
+	i := 0
+	for k, v := range funcs {
+		params := ""
+		if v.Params != nil {
+			params = *v.Params
+		}
+		returns := ""
+		if v.Returns != nil {
+			returns = *v.Returns
+			if strings.Index(returns, ",") > -1 {
+				returns = fmt.Sprintf("(%s)", returns)
+			}
+		}
+		items[i] = fmt.Sprintf("1. %s(%s) %s", k, params, returns)
+		i++
+	}
+	sort.Strings(items)
+	md.WriteSubheader(subheader)
+	for _, item := range items {
+		md.WriteLine(item)
+	}
+}
+
+// writes out struct information
+// sheader1 is for added/removed struct types formatted as TypeName
+// sheader2 is for added/removed struct fields formatted as TypeName.FieldName
+func writeStructs(content *delta.Content, sheader1, sheader2 string, md *markdown.Writer) {
+	if len(content.Structs) == 0 {
+		return
+	}
+	md.WriteHeader("Struct Changes")
+	if len(content.CompleteStructs) > 0 {
+		md.WriteSubheader(sheader1)
+		for _, s := range content.CompleteStructs {
+			md.WriteLine(fmt.Sprintf("1. %s", s))
+		}
+	}
+	modified := content.GetModifiedStructs()
+	if len(modified) > 0 {
+		md.WriteSubheader(sheader2)
+		items := make([]string, 0, len(content.Structs)-len(content.CompleteStructs))
+		for s, f := range modified {
+			for _, af := range f.AnonymousFields {
+				items = append(items, fmt.Sprintf("1. %s.%s", s, af))
+			}
+			for f := range f.Fields {
+				items = append(items, fmt.Sprintf("1. %s.%s", s, f))
+			}
+		}
+		sort.Strings(items)
+		for _, item := range items {
+			md.WriteLine(item)
+		}
+	}
+}

--- a/sdk/tools/apidiff/report/report.go
+++ b/sdk/tools/apidiff/report/report.go
@@ -19,9 +19,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/delta"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/exports"
-	"github.com/Azure/azure-sdk-for-go/tools/apidiff/markdown"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/delta"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/markdown"
 )
 
 // Package represents a per-package report that contains additive and breaking changes.

--- a/sdk/tools/internal/dirs/dirs.go
+++ b/sdk/tools/internal/dirs/dirs.go
@@ -1,0 +1,53 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dirs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// GetSubdirs returns all of the subdirectories under current.
+// Returns an empty slice if current contains no subdirectories.
+func GetSubdirs(current string) ([]string, error) {
+	children, err := ioutil.ReadDir(current)
+	if err != nil {
+		return nil, err
+	}
+	dirs := []string{}
+	for _, info := range children {
+		if info.IsDir() {
+			dirs = append(dirs, info.Name())
+		}
+	}
+	return dirs, nil
+}
+
+// DeleteChildDirs deletes all child directories in the specified directory.
+func DeleteChildDirs(dir string) error {
+	children, err := GetSubdirs(dir)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, child := range children {
+		childPath := filepath.Join(dir, child)
+		err = os.RemoveAll(childPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sdk/tools/internal/dirs/dirs_test.go
+++ b/sdk/tools/internal/dirs/dirs_test.go
@@ -1,0 +1,47 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dirs
+
+import "testing"
+
+func TestGetSubdirs(t *testing.T) {
+	sd, err := GetSubdirs("../..")
+	if err != nil {
+		t.Fatalf("failed to get subdirs: %v", err)
+	}
+	if len(sd) == 0 {
+		t.Fatal("unexpected zero length subdirs")
+	}
+}
+
+func TestGetSubdirsEmpty(t *testing.T) {
+	sd, err := GetSubdirs(".")
+	if err != nil {
+		t.Fatalf("failed to get subdirs: %v", err)
+	}
+	if len(sd) != 0 {
+		t.Fatal("expected zero length subdirs")
+	}
+}
+
+func TestGetSubdirsNoExist(t *testing.T) {
+	sd, err := GetSubdirs("../thisdoesntexist")
+	if err == nil {
+		t.Fatal("expected nil error")
+	}
+	if sd != nil {
+		t.Fatal("expected nil subdirs")
+	}
+}

--- a/sdk/tools/internal/ioext/ioext.go
+++ b/sdk/tools/internal/ioext/ioext.go
@@ -1,0 +1,134 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ioext
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// CopyDir recursively copies the specified source directory tree to the
+// specified destination.  The destination directory must not exist.  Any
+// symlinks under src are ignored.
+func CopyDir(src, dst string) error {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	// verify that src is a directory
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !srcInfo.IsDir() {
+		return fmt.Errorf("source is not a directory")
+	}
+
+	// now verify that dst doesn't exist
+	_, err = os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil {
+		return fmt.Errorf("destination directory already exists")
+	}
+
+	err = os.MkdirAll(dst, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	// get the collection of directory entries under src.
+	// for each entry build its corresponding path under dst.
+	entries, err := ioutil.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		// skip symlinks
+		if entry.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			err = CopyDir(srcPath, dstPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = CopyFile(srcPath, dstPath, true)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// CopyFile copies the specified source file to the specified destination file.
+// Specify true for overwrite to overwrite the destination file if it already exits.
+func CopyFile(src, dst string, overwrite bool) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	if !overwrite {
+		// check if the file exists, if it does then return an error
+		_, err := os.Stat(dst)
+		if err != nil && !os.IsNotExist(err) {
+			return errors.New("won't overwrite destination file")
+		}
+	}
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	// flush the buffer
+	err = dstFile.Sync()
+	if err != nil {
+		return err
+	}
+
+	// copy file permissions
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	err = os.Chmod(dst, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sdk/tools/internal/modinfo/modinfo.go
+++ b/sdk/tools/internal/modinfo/modinfo.go
@@ -1,0 +1,214 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modinfo
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/delta"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/exports"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/apidiff/report"
+	"github.com/Azure/azure-sdk-for-go/sdk/tools/internal/dirs"
+	"github.com/Masterminds/semver"
+)
+
+var (
+	verSuffixRegex = regexp.MustCompile(`v\d+$`)
+)
+
+// HasVersionSuffix returns true if the specified path has a version suffix in the form vN.
+func HasVersionSuffix(path string) bool {
+	return verSuffixRegex.MatchString(path)
+}
+
+// FindVersionSuffix returns the version suffix or the empty string.
+func FindVersionSuffix(path string) string {
+	return verSuffixRegex.FindString(path)
+}
+
+// GetModuleSubdirs returns all subdirectories under path that correspond to module major versions.
+// The subdirectories are sorted according to semantic version.
+func GetModuleSubdirs(path string) ([]string, error) {
+	subdirs, err := dirs.GetSubdirs(path)
+	if err != nil {
+		return nil, err
+	}
+	modDirs := []string{}
+	for _, subdir := range subdirs {
+		matched := HasVersionSuffix(subdir)
+		if matched {
+			modDirs = append(modDirs, subdir)
+		}
+	}
+	sortModuleTagsBySemver(modDirs)
+	return modDirs, nil
+}
+
+// IncrementModuleVersion increments the passed in module major version by one.
+// E.g. a provided value of "v2" will return "v3".  If ver is "" the return value is "v2".
+func IncrementModuleVersion(ver string) string {
+	if ver == "" {
+		return "v2"
+	}
+	v, err := strconv.ParseInt(ver[1:], 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("v%d", v+1)
+}
+
+// sorts module tags based on their semantic versions.
+// this is necessary because lexically sorted is not sufficient
+// due to v10.0.0 appearing before v2.0.0
+func sortModuleTagsBySemver(modDirs []string) {
+	sort.SliceStable(modDirs, func(i, j int) bool {
+		lv, err := semver.NewVersion(modDirs[i])
+		if err != nil {
+			panic(err)
+		}
+		rv, err := semver.NewVersion(modDirs[j])
+		if err != nil {
+			panic(err)
+		}
+		return lv.LessThan(rv)
+	})
+}
+
+// CreateModuleNameFromPath creates a module name from the provided path.
+func CreateModuleNameFromPath(pkgDir string) (string, error) {
+	// e.g. /work/src/github.com/Azure/azure-sdk-for-go/services/foo/2019-01-01/foo
+	// returns github.com/Azure/azure-sdk-for-go/services/foo/2019-01-01/foo
+	repoRoot := filepath.Join("github.com", "Azure", "azure-sdk-for-go")
+	i := strings.Index(pkgDir, repoRoot)
+	if i < 0 {
+		return "", fmt.Errorf("didn't find '%s' in '%s'", repoRoot, pkgDir)
+	}
+	return strings.Replace(pkgDir[i:], "\\", "/", -1), nil
+}
+
+// Provider provides information about a module staged for release.
+type Provider interface {
+	DestDir() string
+	NewExports() bool
+	BreakingChanges() bool
+	VersionSuffix() bool
+	NewModule() bool
+	GenerateReport() report.Package
+}
+
+type module struct {
+	lhs  exports.Content
+	rhs  exports.Content
+	dest string
+}
+
+// GetModuleInfo collects information about a module staged for release.
+// baseline is the directory for the current module
+// staged is the directory for the module staged for release
+func GetModuleInfo(baseline, staged string) (Provider, error) {
+	// TODO: verify staged is a child of baseline
+	lhs, err := exports.Get(baseline)
+	if err != nil {
+		// if baseline has no content then this is a v1 package
+		if ei, ok := err.(exports.LoadPackageErrorInfo); !ok || len(ei.Packages()) != 0 {
+			return nil, fmt.Errorf("failed to get exports for package '%s': %s", baseline, err)
+		}
+	}
+	rhs, err := exports.Get(staged)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get exports for package '%s': %s", staged, err)
+	}
+	mod := module{
+		lhs:  lhs,
+		rhs:  rhs,
+		dest: baseline,
+	}
+	// calculate the destination directory
+	// if there are breaking changes calculate the new directory
+	if mod.BreakingChanges() {
+		dest := filepath.Dir(staged)
+		v := 2
+		if verSuffixRegex.MatchString(baseline) {
+			// baseline has a version, get the number and increment it
+			s := string(baseline[len(baseline)-1])
+			v, err = strconv.Atoi(s)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert '%s' to int: %v", s, err)
+			}
+			v++
+		}
+		mod.dest = filepath.Join(dest, fmt.Sprintf("v%d", v))
+	}
+	return mod, nil
+}
+
+// DestDir returns the fully qualified module destination directory.
+func (m module) DestDir() string {
+	return m.dest
+}
+
+// NewExports returns true if the module contains any additive changes.
+func (m module) NewExports() bool {
+	if m.lhs.IsEmpty() {
+		return true
+	}
+	adds := delta.GetExports(m.lhs, m.rhs)
+	return !adds.IsEmpty()
+}
+
+// BreakingChanges returns true if the module contains breaking changes.
+func (m module) BreakingChanges() bool {
+	if m.lhs.IsEmpty() {
+		return false
+	}
+	// check for changed content
+	if len(delta.GetConstTypeChanges(m.lhs, m.rhs)) > 0 ||
+		len(delta.GetFuncSigChanges(m.lhs, m.rhs)) > 0 ||
+		len(delta.GetInterfaceMethodSigChanges(m.lhs, m.rhs)) > 0 ||
+		len(delta.GetStructFieldChanges(m.lhs, m.rhs)) > 0 {
+		return true
+	}
+	// check for removed content
+	if removed := delta.GetExports(m.rhs, m.lhs); !removed.IsEmpty() {
+		return true
+	}
+	return false
+}
+
+// VersionSuffix returns true if the module path contains a version suffix.
+func (m module) VersionSuffix() bool {
+	return verSuffixRegex.MatchString(m.dest)
+}
+
+// NewModule returns true if the module is new, i.e. v1.0.0.
+func (m module) NewModule() bool {
+	return m.lhs.IsEmpty()
+}
+
+// GenerateReport generates a package report for the module.
+func (m module) GenerateReport() report.Package {
+	return report.Generate(m.lhs, m.rhs, nil)
+}
+
+// IsValidModuleVersion returns true if the provided string is a valid module version (e.g. v1.2.3).
+func IsValidModuleVersion(v string) bool {
+	r := regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+	return r.MatchString(v)
+}

--- a/sdk/tools/internal/modinfo/modinfo_test.go
+++ b/sdk/tools/internal/modinfo/modinfo_test.go
@@ -1,0 +1,226 @@
+// Copyright 2018 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modinfo
+
+import (
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func Test_ScenarioA(t *testing.T) {
+	// scenario A has no breaking changes, additive only
+	mod, err := GetModuleInfo("../../testdata/scenarioa/foo", "../../testdata/scenarioa/foo/stage")
+	if err != nil {
+		t.Fatalf("failed to get module info: %v", err)
+	}
+	if mod.BreakingChanges() {
+		t.Fatal("no breaking changes in scenario A")
+	}
+	if !mod.NewExports() {
+		t.Fatal("expected new exports in scenario A")
+	}
+	if mod.VersionSuffix() {
+		t.Fatalf("unexpected version suffix in scenario A")
+	}
+	regex := regexp.MustCompile(`testdata/scenarioa/foo$`)
+	if !regex.MatchString(mod.DestDir()) {
+		t.Fatalf("bad destination dir: %s", mod.DestDir())
+	}
+}
+
+func Test_ScenarioB(t *testing.T) {
+	// scenario B has a breaking change
+	mod, err := GetModuleInfo("../../testdata/scenariob/foo", "../../testdata/scenariob/foo/stage")
+	if err != nil {
+		t.Fatalf("failed to get module info: %v", err)
+	}
+	if !mod.BreakingChanges() {
+		t.Fatal("expected breaking changes in scenario B")
+	}
+	if !mod.NewExports() {
+		t.Fatal("expected new exports in scenario B")
+	}
+	if !mod.VersionSuffix() {
+		t.Fatalf("expected version suffix in scenario B")
+	}
+	regex := regexp.MustCompile(`testdata[/\\]scenariob[/\\]foo[/\\]v2$`)
+	if !regex.MatchString(mod.DestDir()) {
+		t.Fatalf("bad destination dir: %s", mod.DestDir())
+	}
+}
+
+func Test_ScenarioC(t *testing.T) {
+	// scenario C has no new exports or breaking changes (function body/doc changes only)
+	mod, err := GetModuleInfo("../../testdata/scenarioc/foo", "../../testdata/scenarioc/foo/stage")
+	if err != nil {
+		t.Fatalf("failed to get module info: %v", err)
+	}
+	if mod.BreakingChanges() {
+		t.Fatal("unexpected breaking changes in scenario C")
+	}
+	if mod.NewExports() {
+		t.Fatal("unexpected new exports in scenario C")
+	}
+	if mod.VersionSuffix() {
+		t.Fatalf("unexpected version suffix in scenario C")
+	}
+	regex := regexp.MustCompile(`testdata/scenarioc/foo$`)
+	if !regex.MatchString(mod.DestDir()) {
+		t.Fatalf("bad destination dir: %s", mod.DestDir())
+	}
+}
+
+func Test_ScenarioD(t *testing.T) {
+	// scenario D has a breaking change on top of a v2 release
+	mod, err := GetModuleInfo("../../testdata/scenariod/foo/v2", "../../testdata/scenariod/foo/stage")
+	if err != nil {
+		t.Fatalf("failed to get module info: %v", err)
+	}
+	if !mod.BreakingChanges() {
+		t.Fatal("expected breaking changes in scenario D")
+	}
+	if mod.NewExports() {
+		t.Fatal("unexpected new exports in scenario D")
+	}
+	if !mod.VersionSuffix() {
+		t.Fatalf("expected version suffix in scenario D")
+	}
+	regex := regexp.MustCompile(`testdata[/\\]scenariod[/\\]foo[/\\]v3$`)
+	if !regex.MatchString(mod.DestDir()) {
+		t.Fatalf("bad destination dir: %s", mod.DestDir())
+	}
+}
+
+func Test_ScenarioE(t *testing.T) {
+	// scenario E has a new export on top of a v2 release
+	mod, err := GetModuleInfo("../../testdata/scenarioe/foo/v2", "../../testdata/scenarioe/foo/stage")
+	if err != nil {
+		t.Fatalf("failed to get module info: %v", err)
+	}
+	if mod.BreakingChanges() {
+		t.Fatal("unexpected breaking changes in scenario E")
+	}
+	if !mod.NewExports() {
+		t.Fatal("expected new exports in scenario E")
+	}
+	if !mod.VersionSuffix() {
+		t.Fatalf("expected version suffix in scenario E")
+	}
+	regex := regexp.MustCompile(`testdata/scenarioe/foo/v2$`)
+	if !regex.MatchString(mod.DestDir()) {
+		t.Fatalf("bad destination dir: %s", mod.DestDir())
+	}
+}
+
+func Test_ScenarioF(t *testing.T) {
+	// scenario F is a new module
+	mod, err := GetModuleInfo("../../testdata/scenariof/foo", "../../testdata/scenariof/foo/stage")
+	if err != nil {
+		t.Fatalf("failed to get module info: %v", err)
+	}
+	if mod.BreakingChanges() {
+		t.Fatal("unexpected breaking changes in scenario F")
+	}
+	if !mod.NewExports() {
+		t.Fatal("expected new exports in scenario F")
+	}
+	if mod.VersionSuffix() {
+		t.Fatalf("unexpected version suffix in scenario F")
+	}
+	if !mod.NewModule() {
+		t.Fatal("expected new module in scenario F")
+	}
+	regex := regexp.MustCompile(`testdata/scenariof/foo$`)
+	if !regex.MatchString(mod.DestDir()) {
+		t.Fatalf("bad destination dir: %s", mod.DestDir())
+	}
+}
+
+func Test_sortModuleTagsBySemver(t *testing.T) {
+	before := []string{
+		"v1.0.0",
+		"v1.0.1",
+		"v1.1.0",
+		"v10.0.0",
+		"v11.1.1",
+		"v2.0.0",
+		"v20.2.3",
+		"v3.1.0",
+	}
+	sortModuleTagsBySemver(before)
+	after := []string{
+		"v1.0.0",
+		"v1.0.1",
+		"v1.1.0",
+		"v2.0.0",
+		"v3.1.0",
+		"v10.0.0",
+		"v11.1.1",
+		"v20.2.3",
+	}
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("sort order doesn't match, expected '%v' got '%v'", after, before)
+	}
+}
+
+func TestIncrementModuleVersion(t *testing.T) {
+	v := IncrementModuleVersion("")
+	if v != "v2" {
+		t.Fatalf("expected v2 got %s", v)
+	}
+	v = IncrementModuleVersion("v2")
+	if v != "v3" {
+		t.Fatalf("expected v3 got %s", v)
+	}
+	v = IncrementModuleVersion("v10")
+	if v != "v11" {
+		t.Fatalf("expected v11 got %s", v)
+	}
+}
+
+func TestCreateModuleNameFromPath(t *testing.T) {
+	n, err := CreateModuleNameFromPath(filepath.Join("work", "src", "github.com", "Azure", "azure-sdk-for-go", "services", "foo", "apiver", "foo"))
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	const expected = "github.com/Azure/azure-sdk-for-go/services/foo/apiver/foo"
+	if n != expected {
+		t.Fatalf("expected '%s' got '%s'", expected, n)
+	}
+}
+
+func TestCreateModuleNameFromPathFail(t *testing.T) {
+	n, err := CreateModuleNameFromPath(filepath.Join("work", "src", "github.com", "other", "project", "foo", "bar"))
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if n != "" {
+		t.Fatalf("expected empty module name, got %s", n)
+	}
+}
+
+func TestIsValidModuleVersion(t *testing.T) {
+	if !IsValidModuleVersion("v10.21.23") {
+		t.Fatal("unexpected invalid module version")
+	}
+	if IsValidModuleVersion("1.2.3") {
+		t.Fatal("unexpected valid module version, missing v")
+	}
+	if IsValidModuleVersion("v11.563") {
+		t.Fatal("unexpected valid module version, missing patch")
+	}
+}


### PR DESCRIPTION
This PR adds the API diff tool with some slight modifications so that the `diff` command outputs content that complied with track2 changelog release guidelines. 