### PR TITLE
Switching changelogs to track2 format

### DIFF
--- a/sdk/arm/compute/2020-09-30/armcompute/CHANGELOG.md
+++ b/sdk/arm/compute/2020-09-30/armcompute/CHANGELOG.md
@@ -1,3 +1,5 @@
-Generated from https://github.com/Azure/azure-rest-api-specs/tree/c72af9b8dca625d3f1429a0bd913bad7b3879645
+# Release History
 
-Code generator @autorest/go@4.0.0-preview.9
+## v0.1.0 (released)
+
+

--- a/sdk/arm/keyvault/2019-09-01/armkeyvault/CHANGELOG.md
+++ b/sdk/arm/keyvault/2019-09-01/armkeyvault/CHANGELOG.md
@@ -1,3 +1,4 @@
-Generated from https://github.com/Azure/azure-rest-api-specs/tree/c72af9b8dca625d3f1429a0bd913bad7b3879645
+# Release History
 
-Code generator @autorest/go@4.0.0-preview.9
+## v0.1.0 (released)
+

--- a/sdk/arm/network/2020-07-01/armnetwork/CHANGELOG.md
+++ b/sdk/arm/network/2020-07-01/armnetwork/CHANGELOG.md
@@ -1,3 +1,4 @@
-Generated from https://github.com/Azure/azure-rest-api-specs/tree/c72af9b8dca625d3f1429a0bd913bad7b3879645
+# Release History
 
-Code generator @autorest/go@4.0.0-preview.9
+## v0.1.0 (released)
+

--- a/sdk/arm/resources/2020-06-01/armresources/CHANGELOG.md
+++ b/sdk/arm/resources/2020-06-01/armresources/CHANGELOG.md
@@ -1,3 +1,4 @@
-Generated from https://github.com/Azure/azure-rest-api-specs/tree/c72af9b8dca625d3f1429a0bd913bad7b3879645
+# Release History
 
-Code generator @autorest/go@4.0.0-preview.9
+## v0.1.0 (released)
+

--- a/sdk/arm/storage/2019-06-01/armstorage/CHANGELOG.md
+++ b/sdk/arm/storage/2019-06-01/armstorage/CHANGELOG.md
@@ -1,3 +1,4 @@
-Generated from https://github.com/Azure/azure-rest-api-specs/tree/c72af9b8dca625d3f1429a0bd913bad7b3879645
+# Release History
 
-Code generator @autorest/go@4.0.0-preview.9
+## v0.1.0 (released)
+


### PR DESCRIPTION
This PR switches the content of the changelogs for the ARM modules to use the output from the apidiff tool. 