### PR TITLE
Ensure CLI CredentialUnavailableError has a message

### DIFF
--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -129,7 +129,12 @@ func defaultTokenProvider() func(ctx context.Context, resource string) ([]byte, 
 
 		output, err := cliCmd.Output()
 		if err != nil {
-			return nil, &CredentialUnavailableError{credentialType: "Azure CLI Credential", message: stderr.String()}
+			msg := stderr.String()
+			if msg == "" {
+				// if there's no output in stderr report the error message instead
+				msg = err.Error()
+			}
+			return nil, &CredentialUnavailableError{credentialType: "Azure CLI Credential", message: msg}
 		}
 
 		return output, nil


### PR DESCRIPTION
If there was no output written to stderr, fall back to the message from
the error.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
