### PR TITLE
Accept zero-value options for default values

### DIFF
--- a/sdk/azcore/policy_logging.go
+++ b/sdk/azcore/policy_logging.go
@@ -22,22 +22,15 @@ type LogOptions struct {
 	IncludeBody bool
 }
 
-// DefaultLogOptions returns an instance of LogOptions initialized with default values.
-func DefaultLogOptions() LogOptions {
-	return LogOptions{}
-}
-
 type logPolicy struct {
 	options LogOptions
 }
 
 // NewLogPolicy creates a RequestLogPolicy object configured using the specified options.
-// Pass nil to accept the default values; this is the same as passing the result
-// from a call to DefaultLogOptions().
+// Pass nil to accept the default values; this is the same as passing a zero-value options.
 func NewLogPolicy(o *LogOptions) Policy {
 	if o == nil {
-		def := DefaultLogOptions()
-		o = &def
+		o = &LogOptions{}
 	}
 	return &logPolicy{options: *o}
 }

--- a/sdk/azcore/policy_retry.go
+++ b/sdk/azcore/policy_retry.go
@@ -39,7 +39,7 @@ type RetryOptions struct {
 
 	// MaxRetryDelay specifies the maximum delay allowed before retrying an operation.
 	// Typically the value is greater than or equal to the value specified in RetryDelay.
-	// The default Value is 120 seconds.  A value less than zero means ther is no cap.
+	// The default Value is 120 seconds.  A value less than zero means there is no cap.
 	MaxRetryDelay time.Duration
 
 	// StatusCodes specifies the HTTP status codes that indicate the operation should be retried.

--- a/sdk/azcore/policy_retry.go
+++ b/sdk/azcore/policy_retry.go
@@ -83,8 +83,6 @@ func (o *RetryOptions) init() {
 	}
 	if o.TryTimeout == 0 {
 		o.TryTimeout = 1 * time.Minute
-	} else if o.TryTimeout < 0 {
-		o.TryTimeout = 0 // this doesn't seem very useful
 	}
 }
 

--- a/sdk/azcore/policy_retry_test.go
+++ b/sdk/azcore/policy_retry_test.go
@@ -156,6 +156,53 @@ func TestRetryPolicySuccessWithRetry(t *testing.T) {
 		t.Fatal("request body wasn't closed")
 	}
 }
+func TestRetryPolicyNoRetries(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
+	srv.AppendResponse()
+	pl := NewPipeline(srv, NewRetryPolicy(&RetryOptions{MaxRetries: -1}))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("unexpected status code: %d", resp.StatusCode)
+	}
+	if r := srv.Requests(); r != 1 {
+		t.Fatalf("wrong try count, got %d expected %d", r, 1)
+	}
+}
+
+func TestRetryPolicyUnlimitedRetryDelay(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
+	srv.AppendResponse()
+	opt := testRetryOptions()
+	opt.MaxRetryDelay = -1
+	pl := NewPipeline(srv, NewRetryPolicy(opt))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", resp.StatusCode)
+	}
+	if r := srv.Requests(); r != 3 {
+		t.Fatalf("wrong try count, got %d expected %d", r, 3)
+	}
+}
 
 func TestRetryPolicyFailOnError(t *testing.T) {
 	srv, close := mock.NewServer()

--- a/sdk/azcore/policy_retry_test.go
+++ b/sdk/azcore/policy_retry_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func testRetryOptions() *RetryOptions {
-	def := DefaultRetryOptions()
+	def := RetryOptions{}
 	def.RetryDelay = 20 * time.Millisecond
 	def.TryTimeout = 1 * time.Second
 	return &def

--- a/sdk/azcore/policy_telemetry.go
+++ b/sdk/azcore/policy_telemetry.go
@@ -27,23 +27,16 @@ type TelemetryOptions struct {
 	Disabled bool
 }
 
-// DefaultTelemetryOptions returns an instance of TelemetryOptions initialized with default values.
-func DefaultTelemetryOptions() TelemetryOptions {
-	return TelemetryOptions{}
-}
-
 type telemetryPolicy struct {
 	telemetryValue string
 }
 
 // NewTelemetryPolicy creates a telemetry policy object that adds telemetry information to outgoing HTTP requests.
 // The format is [<application_id> ]azsdk-<sdk_language>-<package_name>/<package_version> <platform_info> [<custom>].
-// Pass nil to accept the default values; this is the same as passing the result
-// from a call to DefaultTelemetryOptions().
+// Pass nil to accept the default values; this is the same as passing a zero-value options.
 func NewTelemetryPolicy(o *TelemetryOptions) Policy {
 	if o == nil {
-		def := DefaultTelemetryOptions()
-		o = &def
+		o = &TelemetryOptions{}
 	}
 	tp := telemetryPolicy{}
 	if o.Disabled {

--- a/sdk/azcore/policy_telemetry_test.go
+++ b/sdk/azcore/policy_telemetry_test.go
@@ -39,9 +39,7 @@ func TestPolicyTelemetryWithCustomInfo(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const testValue = "azcore_test"
-	o := DefaultTelemetryOptions()
-	o.Value = testValue
-	pl := NewPipeline(srv, NewTelemetryPolicy(&o))
+	pl := NewPipeline(srv, NewTelemetryPolicy(&TelemetryOptions{Value: testValue}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -80,9 +78,7 @@ func TestPolicyTelemetryWithAppID(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const appID = "my_application"
-	o := DefaultTelemetryOptions()
-	o.ApplicationID = appID
-	pl := NewPipeline(srv, NewTelemetryPolicy(&o))
+	pl := NewPipeline(srv, NewTelemetryPolicy(&TelemetryOptions{ApplicationID: appID}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -101,9 +97,7 @@ func TestPolicyTelemetryWithAppIDAndReqTelemetry(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const appID = "my_application"
-	o := DefaultTelemetryOptions()
-	o.ApplicationID = appID
-	pl := NewPipeline(srv, NewTelemetryPolicy(&o))
+	pl := NewPipeline(srv, NewTelemetryPolicy(&TelemetryOptions{ApplicationID: appID}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -123,9 +117,7 @@ func TestPolicyTelemetryWithAppIDSanitized(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const appID = "This will get the spaces removed and truncated."
-	o := DefaultTelemetryOptions()
-	o.ApplicationID = appID
-	pl := NewPipeline(srv, NewTelemetryPolicy(&o))
+	pl := NewPipeline(srv, NewTelemetryPolicy(&TelemetryOptions{ApplicationID: appID}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -145,9 +137,7 @@ func TestPolicyTelemetryPreserveExistingWithAppID(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const appID = "my_application"
-	o := DefaultTelemetryOptions()
-	o.ApplicationID = appID
-	pl := NewPipeline(srv, NewTelemetryPolicy(&o))
+	pl := NewPipeline(srv, NewTelemetryPolicy(&TelemetryOptions{ApplicationID: appID}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -168,10 +158,7 @@ func TestPolicyTelemetryDisabled(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const appID = "my_application"
-	o := DefaultTelemetryOptions()
-	o.ApplicationID = appID
-	o.Disabled = true
-	pl := NewPipeline(srv, NewTelemetryPolicy(&o))
+	pl := NewPipeline(srv, NewTelemetryPolicy(&TelemetryOptions{ApplicationID: appID, Disabled: true}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Specify zero-value options structs to accept default values.
Remove DefaultXxxOptions() methods.
Fixed up docs for RetryOptions.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
