### PR TITLE
Refine the format of anonymous field in selector expression

### DIFF
--- a/tools/apidiff/delta/delta_test.go
+++ b/tools/apidiff/delta/delta_test.go
@@ -130,8 +130,13 @@ func Test_GetAddedExports(t *testing.T) {
 
 	sAdded := map[string]exports.Struct{
 		"ExportDataFuture": {
-			AnonymousFields: []string{"azure.Future"},
-			Fields:          map[string]string{"NewField": "string"},
+			AnonymousFields: []exports.AnonymousField{
+				{
+					FullIdentifier: "azure.Future",
+					Identifier:     "Future",
+				},
+			},
+			Fields: map[string]string{"NewField": "string"},
 		},
 		"ExportRDBParameters": {
 			Fields: map[string]string{

--- a/tools/apidiff/exports/exports.go
+++ b/tools/apidiff/exports/exports.go
@@ -82,6 +82,7 @@ type Struct struct {
 	Fields map[string]string `json:"fields,omitempty"`
 }
 
+// AnonymousField describes an anonymous field of a struct type
 type AnonymousField struct {
 	FullIdentifier string `json:"full,omitempty"`
 	Identifier     string `json:"identifier,omitempty"`
@@ -199,7 +200,7 @@ func (c *Content) addStruct(pkg Package, name string, s *ast.StructType) {
 		if n == nil {
 			sd.AnonymousFields = append(sd.AnonymousFields, AnonymousField{
 				FullIdentifier: t,
-				Identifier: getIdentifier(f.Type),
+				Identifier:     getIdentifier(f.Type),
 			})
 		} else {
 			if sd.Fields == nil {

--- a/tools/apidiff/exports/package_test.go
+++ b/tools/apidiff/exports/package_test.go
@@ -140,7 +140,7 @@ func Test_Interfaces(t *testing.T) {
 }
 
 func Test_Structs(t *testing.T) {
-	if l := len(exp.Structs); l != 8 {
+	if l := len(exp.Structs); l != 11 {
 		t.Logf("wrong number of structs, got %v", l)
 		t.Fail()
 	}
@@ -150,22 +150,61 @@ func Test_Structs(t *testing.T) {
 		exports.Struct
 	}{
 		{"BaseClient", exports.Struct{
-			AnonymousFields: []string{"autorest.Client"},
+			AnonymousFields: []exports.AnonymousField{
+				{
+					FullIdentifier: "autorest.Client",
+					Identifier:     "Client",
+				},
+			},
 			Fields: map[string]string{
 				"BaseURI":        "string",
 				"SubscriptionID": "string",
-			}}},
+			},
+		}},
 		{"DeleteFuture", exports.Struct{
-			AnonymousFields: []string{"azure.Future"},
+			AnonymousFields: []exports.AnonymousField{
+				{
+					FullIdentifier: "azure.Future",
+					Identifier:     "Future",
+				},
+			},
+		}},
+		{"NewDeleteFuture", exports.Struct{
+			AnonymousFields: []exports.AnonymousField{
+				{
+					FullIdentifier: "azure.FutureAPI",
+					Identifier:     "FutureAPI",
+				},
+			},
+			Fields: map[string]string{
+				"Result": "func(Client) (autorest.Response, error)",
+			},
+		}},
+		{"StructWithStarAnonymousField", exports.Struct{
+			AnonymousFields: []exports.AnonymousField{
+				{
+					FullIdentifier: "*azure.Future",
+					Identifier:     "*Future",
+				},
+			},
+			Fields: map[string]string{
+				"Test": "string",
+			},
 		}},
 		{"ListResultPage", exports.Struct{}},
 		{"CreateParameters", exports.Struct{
-			AnonymousFields: []string{"*CreateProperties"},
+			AnonymousFields: []exports.AnonymousField{
+				{
+					FullIdentifier: "*CreateProperties",
+					Identifier:     "*CreateProperties",
+				},
+			},
 			Fields: map[string]string{
 				"Zones":    "*[]string",
 				"Location": "*string",
 				"Tags":     "map[string]*string",
-			}}},
+			},
+		}},
 		{"CreateProperties", exports.Struct{
 			Fields: map[string]string{
 				"SubnetID":           "*string",
@@ -174,7 +213,19 @@ func Test_Structs(t *testing.T) {
 				"EnableNonSslPort":   "*bool",
 				"TenantSettings":     "map[string]*string",
 				"ShardCount":         "*int32",
-			}}},
+			},
+		}},
+		{"StructWithAnonymousInterface", exports.Struct{
+			AnonymousFields: []exports.AnonymousField{
+				{
+					FullIdentifier: "SomeInterface",
+					Identifier:     "SomeInterface",
+				},
+			},
+			Fields: map[string]string{
+				"Test": "string",
+			},
+		}},
 	}
 
 	for _, test := range tests {

--- a/tools/apidiff/exports/testdata/td.go
+++ b/tools/apidiff/exports/testdata/td.go
@@ -116,6 +116,16 @@ func (future DeleteFuture) Result(client Client) (ar autorest.Response, err erro
 	return
 }
 
+type NewDeleteFuture struct {
+	azure.FutureAPI
+	Result func(Client) (autorest.Response, error)
+}
+
+type StructWithStarAnonymousField struct {
+	*azure.Future
+	Test string
+}
+
 type ListResult struct {
 	autorest.Response `json:"-"`
 	Value             *[]ResourceType `json:"value,omitempty"`
@@ -201,4 +211,9 @@ type SomeInterface interface {
 	Three() string
 	Four(int) error
 	Five(int, bool) (int, error)
+}
+
+type StructWithAnonymousInterface struct {
+	SomeInterface
+	Test string
 }

--- a/tools/apidiff/report/report.go
+++ b/tools/apidiff/report/report.go
@@ -269,7 +269,7 @@ func writeStructs(content *delta.Content, sheader1, sheader2 string, md *markdow
 		items := make([]string, 0, len(content.Structs)-len(content.CompleteStructs))
 		for s, f := range modified {
 			for _, af := range f.AnonymousFields {
-				items = append(items, fmt.Sprintf("1. %s.%s", s, af))
+				items = append(items, fmt.Sprintf("1. %s.%s", s, af.Identifier))
 			}
 			for f := range f.Fields {
 				items = append(items, fmt.Sprintf("1. %s.%s", s, f))

--- a/tools/generator/autorest/model/changelog.go
+++ b/tools/generator/autorest/model/changelog.go
@@ -118,7 +118,7 @@ func writeNewContent(c *delta.Content, md *markdown.Writer) {
 		modified := c.GetModifiedStructs()
 		for s, f := range modified {
 			for _, af := range f.AnonymousFields {
-				line := fmt.Sprintf("- New anonymous field `%s` in struct `%s`", af, s)
+				line := fmt.Sprintf("- New anonymous field `%s` in struct `%s`", af.FullIdentifier, s)
 				md.WriteLine(line)
 			}
 			for f := range f.Fields {
@@ -205,7 +205,7 @@ func writeRemovedContent(removed *delta.Content, md *markdown.Writer) {
 	if len(modified) > 0 {
 		for s, f := range modified {
 			for _, af := range f.AnonymousFields {
-				line := fmt.Sprintf("- Field `%s` of struct `%s` has been removed", af, s)
+				line := fmt.Sprintf("- Field `%s` of struct `%s` has been removed", af.FullIdentifier, s)
 				md.WriteLine(line)
 			}
 			for f := range f.Fields {


### PR DESCRIPTION
The changelog tool now produce the anonymous field using its full name, which is not quite intuitive in the changelog. For example, the `Future` type will be encode into changelog like this:
```
DeleteFuture.azure.Future
```
we could either change this to 
```
DeleteFuture.Future (this is the style we are now using in changelogs)
```
or
```
DeleteFuture.(azure.Future)
```

With this change, I also introduced 3 more test cases that try to cover more cases that might happen in generated code.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
