### PR TITLE
Switching the environment variable check for ManagedIdentityCredential

### DIFF
--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -287,7 +287,7 @@ func (c *managedIdentityClient) getMSIType() (msiType, error) {
 				c.msiType = msiTypeAppServiceV20190801
 			} else if arcIMDS := os.Getenv(arcIMDSEndpoint); arcIMDS != "" {
 				c.msiType = msiTypeAzureArc
-			} else { // if ONLY the env var IDENTITY_ENDPOINT is set the msiType is Azure Functions
+			} else {
 				c.msiType = msiTypeUnavailable
 				return c.msiType, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: "This Managed Identity Environment is not supported yet"}
 			}


### PR DESCRIPTION
This PR gives priority to checking the MSI_ENDPOINT and MSI_SECRET environment variables over the IDENTITY_ENDPOINT and IDENTITY_HEADER variables. This is because in Azure Functions on Linux consumptions hosts, the latest api-version is not yet supported and causes an error. 

Fixes #12981