### PR TITLE
azidentity: Remove DefaultXxxOptions() funcs 

### DIFF
--- a/sdk/azidentity/aad_identity_client_test.go
+++ b/sdk/azidentity/aad_identity_client_test.go
@@ -47,8 +47,6 @@ func TestTelemetryDefaultUserAgent(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	options := pipelineOptions{
 		HTTPClient: srv,
-		Telemetry:  azcore.DefaultTelemetryOptions(),
-		Retry:      azcore.DefaultRetryOptions(),
 	}
 	client, err := newAADIdentityClient(srv.URL(), options)
 	if err != nil {
@@ -77,8 +75,6 @@ func TestTelemetryCustom(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	options := pipelineOptions{
 		HTTPClient: srv,
-		Telemetry:  azcore.DefaultTelemetryOptions(),
-		Retry:      azcore.DefaultRetryOptions(),
 	}
 	options.Telemetry.Value = customTelemetry
 	client, err := newAADIdentityClient(srv.URL(), options)

--- a/sdk/azidentity/authorization_code_credential.go
+++ b/sdk/azidentity/authorization_code_credential.go
@@ -28,15 +28,6 @@ type AuthorizationCodeCredentialOptions struct {
 	Logging azcore.LogOptions
 }
 
-// DefaultAuthorizationCodeCredentialOptions returns an instance of AuthorizationCodeCredentialOptions initialized with default values.
-func DefaultAuthorizationCodeCredentialOptions() AuthorizationCodeCredentialOptions {
-	return AuthorizationCodeCredentialOptions{
-		Retry:     azcore.DefaultRetryOptions(),
-		Telemetry: azcore.DefaultTelemetryOptions(),
-		Logging:   azcore.DefaultLogOptions(),
-	}
-}
-
 // AuthorizationCodeCredential enables authentication to Azure Active Directory using an authorization code
 // that was obtained through the authorization code flow, described in more detail in the Azure Active Directory
 // documentation: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow.
@@ -60,8 +51,7 @@ func NewAuthorizationCodeCredential(tenantID string, clientID string, authCode s
 		return nil, &CredentialUnavailableError{credentialType: "Authorization Code Credential", message: tenantIDValidationErr}
 	}
 	if options == nil {
-		temp := DefaultAuthorizationCodeCredentialOptions()
-		options = &temp
+		options = &AuthorizationCodeCredentialOptions{}
 	}
 	authorityHost, err := setAuthorityHost(options.AuthorityHost)
 	if err != nil {

--- a/sdk/azidentity/authorization_code_credential_test.go
+++ b/sdk/azidentity/authorization_code_credential_test.go
@@ -79,7 +79,7 @@ func TestAuthorizationCodeCredential_GetTokenSuccess(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultAuthorizationCodeCredentialOptions()
+	options := AuthorizationCodeCredentialOptions{}
 	options.ClientSecret = secret
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
@@ -97,7 +97,7 @@ func TestAuthorizationCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte(accessTokenRespError)), mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultAuthorizationCodeCredentialOptions()
+	options := AuthorizationCodeCredentialOptions{}
 	options.ClientSecret = secret
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
@@ -146,7 +146,7 @@ func TestAuthorizationCodeCredential_GetTokenUnexpectedJSON(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespMalformed)))
-	options := DefaultAuthorizationCodeCredentialOptions()
+	options := AuthorizationCodeCredentialOptions{}
 	options.ClientSecret = secret
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -27,10 +27,7 @@ const (
 	defaultSuffix = "/.default"
 )
 
-const (
-	tenantIDValidationErr = "Invalid tenantID provided. You can locate your tenantID by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names."
-	defaultMaxRetries     = 3
-)
+const tenantIDValidationErr = "Invalid tenantID provided. You can locate your tenantID by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names."
 
 var (
 	successStatusCodes = [2]int{

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -27,7 +27,10 @@ const (
 	defaultSuffix = "/.default"
 )
 
-const tenantIDValidationErr = "Invalid tenantID provided. You can locate your tenantID by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names."
+const (
+	tenantIDValidationErr = "Invalid tenantID provided. You can locate your tenantID by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names."
+	defaultMaxRetries     = 3
+)
 
 var (
 	successStatusCodes = [2]int{

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -42,12 +42,13 @@ type AzureCLICredential struct {
 // NewAzureCLICredential constructs a new AzureCLICredential with the details needed to authenticate against Azure Active Directory
 // options: configure the management of the requests sent to Azure Active Directory.
 func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredential, error) {
-	if options == nil {
-		options = &AzureCLICredentialOptions{}
+	cp := AzureCLICredentialOptions{}
+	if options != nil {
+		cp = *options
 	}
-	options.init()
+	cp.init()
 	return &AzureCLICredential{
-		tokenProvider: options.TokenProvider,
+		tokenProvider: cp.TokenProvider,
 	}, nil
 }
 

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -27,9 +27,11 @@ type AzureCLICredentialOptions struct {
 	TokenProvider AzureCLITokenProvider
 }
 
-// DefaultAzureCLICredentialOptions returns an instance of AzureCLICredentialOptions initialized with default values.
-func DefaultAzureCLICredentialOptions() AzureCLICredentialOptions {
-	return AzureCLICredentialOptions{TokenProvider: defaultTokenProvider()}
+// init returns an instance of AzureCLICredentialOptions initialized with default values.
+func (o *AzureCLICredentialOptions) init() {
+	if o.TokenProvider == nil {
+		o.TokenProvider = defaultTokenProvider()
+	}
 }
 
 // AzureCLICredential enables authentication to Azure Active Directory using the Azure CLI command "az account get-access-token".
@@ -41,9 +43,9 @@ type AzureCLICredential struct {
 // options: configure the management of the requests sent to Azure Active Directory.
 func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredential, error) {
 	if options == nil {
-		def := DefaultAzureCLICredentialOptions()
-		options = &def
+		options = &AzureCLICredentialOptions{}
 	}
+	options.init()
 	return &AzureCLICredential{
 		tokenProvider: options.TokenProvider,
 	}, nil

--- a/sdk/azidentity/azure_cli_credential_test.go
+++ b/sdk/azidentity/azure_cli_credential_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestAzureCLICredential_GetTokenSuccess(t *testing.T) {
-	options := DefaultAzureCLICredentialOptions()
+	options := AzureCLICredentialOptions{}
 	options.TokenProvider = mockCLITokenProviderSuccess
 	cred, err := NewAzureCLICredential(&options)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestAzureCLICredential_GetTokenSuccess(t *testing.T) {
 }
 
 func TestAzureCLICredential_GetTokenInvalidToken(t *testing.T) {
-	options := DefaultAzureCLICredentialOptions()
+	options := AzureCLICredentialOptions{}
 	options.TokenProvider = mockCLITokenProviderFailure
 	cred, err := NewAzureCLICredential(&options)
 	if err != nil {
@@ -62,7 +62,7 @@ func TestBearerPolicy_AzureCLICredential(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultAzureCLICredentialOptions()
+	options := AzureCLICredentialOptions{}
 	options.TokenProvider = mockCLITokenProviderSuccess
 	cred, err := NewAzureCLICredential(&options)
 	if err != nil {

--- a/sdk/azidentity/bearer_token_policy_test.go
+++ b/sdk/azidentity/bearer_token_policy_test.go
@@ -22,9 +22,10 @@ const (
 )
 
 func defaultTestPipeline(srv azcore.Transport, cred azcore.Credential, scope string) azcore.Pipeline {
-	retryOpts := azcore.DefaultRetryOptions()
-	retryOpts.MaxRetryDelay = 500 * time.Millisecond
-	retryOpts.RetryDelay = 50 * time.Millisecond
+	retryOpts := azcore.RetryOptions{
+		TryTimeout: 1 * time.Minute,
+		MaxRetries: 1,
+	}
 	return azcore.NewPipeline(
 		srv,
 		azcore.NewRetryPolicy(&retryOpts),
@@ -37,7 +38,7 @@ func TestBearerPolicy_SuccessGetToken(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &options)
@@ -64,7 +65,7 @@ func TestBearerPolicy_CredentialFailGetToken(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &options)
@@ -95,7 +96,7 @@ func TestBearerTokenPolicy_TokenExpired(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespShortLived)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &options)
@@ -123,7 +124,7 @@ func TestRetryPolicy_NonRetriable(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &options)
@@ -146,7 +147,7 @@ func TestRetryPolicy_HTTPRequest(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &options)
@@ -174,10 +175,9 @@ func TestBearerPolicy_GetTokenFailsNoDeadlock(t *testing.T) {
 		HTTPClient:    srv,
 		AuthorityHost: srv.URL(),
 		Retry: azcore.RetryOptions{
-			// leaving TryTimeout at zero will trigger a deadline exceeded error causing GetToken() to fail
-			RetryDelay:    50 * time.Millisecond,
-			MaxRetryDelay: 500 * time.Millisecond,
-			MaxRetries:    3,
+			// leaving TryTimeout at -1 will assign a zero try timeout and will trigger a deadline exceeded error causing GetToken() to fail
+			TryTimeout: 1 * time.Nanosecond,
+			MaxRetries: 0,
 		}})
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)

--- a/sdk/azidentity/bearer_token_policy_test.go
+++ b/sdk/azidentity/bearer_token_policy_test.go
@@ -175,22 +175,16 @@ func TestBearerPolicy_GetTokenFailsNoDeadlock(t *testing.T) {
 		HTTPClient:    srv,
 		AuthorityHost: srv.URL(),
 		Retry: azcore.RetryOptions{
-			// leaving TryTimeout at as a very small value will trigger a deadline exceeded error causing GetToken() to fail
-			TryTimeout: 1 * time.Nanosecond,
-			MaxRetries: -1,
+			// use a negative try timeout to trigger a deadline exceeded error causing GetToken() to fail
+			TryTimeout:    -1 * time.Nanosecond,
+			MaxRetryDelay: 500 * time.Millisecond,
+			RetryDelay:    50 * time.Millisecond,
+			MaxRetries:    3,
 		}})
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	pipeline := azcore.NewPipeline(
-		srv,
-		azcore.NewRetryPolicy(&azcore.RetryOptions{
-			MaxRetryDelay: 500 * time.Millisecond,
-			RetryDelay:    50 * time.Millisecond,
-			MaxRetries:    -1,
-		}),
-		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewLogPolicy(nil))
+	pipeline := defaultTestPipeline(srv, cred, scope)
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/bearer_token_policy_test.go
+++ b/sdk/azidentity/bearer_token_policy_test.go
@@ -23,7 +23,9 @@ const (
 
 func defaultTestPipeline(srv azcore.Transport, cred azcore.Credential, scope string) azcore.Pipeline {
 	retryOpts := azcore.RetryOptions{
-		TryTimeout: 1 * time.Minute,
+		MaxRetryDelay: 500 * time.Millisecond,
+		RetryDelay:    50 * time.Millisecond,
+		TryTimeout:    1 * time.Minute,
 	}
 	return azcore.NewPipeline(
 		srv,
@@ -176,7 +178,7 @@ func TestBearerPolicy_GetTokenFailsNoDeadlock(t *testing.T) {
 		Retry: azcore.RetryOptions{
 			// leaving TryTimeout at as a very small value will trigger a deadline exceeded error causing GetToken() to fail
 			TryTimeout: 1 * time.Nanosecond,
-			MaxRetries: 0,
+			MaxRetries: -1,
 		}})
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
@@ -184,12 +186,12 @@ func TestBearerPolicy_GetTokenFailsNoDeadlock(t *testing.T) {
 	pipeline := azcore.NewPipeline(
 		srv,
 		azcore.NewRetryPolicy(&azcore.RetryOptions{
-			TryTimeout: 1 * time.Minute,
-			MaxRetries: 0,
+			MaxRetryDelay: 500 * time.Millisecond,
+			RetryDelay:    50 * time.Millisecond,
+			MaxRetries:    -1,
 		}),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewLogPolicy(nil))
-	// pipeline := defaultTestPipeline(srv, cred, scope)
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/bearer_token_policy_test.go
+++ b/sdk/azidentity/bearer_token_policy_test.go
@@ -25,7 +25,6 @@ func defaultTestPipeline(srv azcore.Transport, cred azcore.Credential, scope str
 	retryOpts := azcore.RetryOptions{
 		MaxRetryDelay: 500 * time.Millisecond,
 		RetryDelay:    50 * time.Millisecond,
-		TryTimeout:    1 * time.Minute,
 	}
 	return azcore.NewPipeline(
 		srv,

--- a/sdk/azidentity/bearer_token_policy_test.go
+++ b/sdk/azidentity/bearer_token_policy_test.go
@@ -166,7 +166,6 @@ func TestRetryPolicy_HTTPRequest(t *testing.T) {
 }
 
 func TestBearerPolicy_GetTokenFailsNoDeadlock(t *testing.T) {
-	t.Skip()
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -67,7 +67,7 @@ func TestChainedTokenCredential_GetTokenSuccess(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	secCred, err := NewClientSecretCredential(tenantID, clientID, secret, &options)
@@ -98,7 +98,7 @@ func TestChainedTokenCredential_GetTokenFail(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	secCred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &options)
@@ -127,7 +127,7 @@ func TestChainedTokenCredential_GetTokenWithUnavailableCredentialInChain(t *test
 	defer close()
 	srv.AppendError(&CredentialUnavailableError{credentialType: "MockCredential", message: "Mocking a credential unavailable error"})
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	secCred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &options)
@@ -164,7 +164,7 @@ func TestBearerPolicy_ChainedTokenCredential(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &options)

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -40,15 +40,6 @@ type ClientCertificateCredentialOptions struct {
 	Logging azcore.LogOptions
 }
 
-// DefaultClientCertificateCredentialOptions returns an instance of ClientCertificateCredentialOptions initialized with default values.
-func DefaultClientCertificateCredentialOptions() ClientCertificateCredentialOptions {
-	return ClientCertificateCredentialOptions{
-		Retry:     azcore.DefaultRetryOptions(),
-		Telemetry: azcore.DefaultTelemetryOptions(),
-		Logging:   azcore.DefaultLogOptions(),
-	}
-}
-
 // ClientCertificateCredential enables authentication of a service principal to Azure Active Directory using a certificate that is assigned to its App Registration. More information
 // on how to configure certificate authentication can be found here:
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-certificate-credentials#register-your-certificate-with-azure-ad
@@ -82,8 +73,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, certificat
 		return nil, credErr
 	}
 	if options == nil {
-		temp := DefaultClientCertificateCredentialOptions()
-		options = &temp
+		options = &ClientCertificateCredentialOptions{}
 	}
 	var cert *certContents
 	certificatePath = strings.ToUpper(certificatePath)

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -80,7 +80,7 @@ func TestClientCertificateCredential_CreateAuthRequestSuccess(t *testing.T) {
 }
 
 func TestClientCertificateCredential_CreateAuthRequestSuccess_withCertificateChain(t *testing.T) {
-	opts := DefaultClientCertificateCredentialOptions()
+	opts := ClientCertificateCredentialOptions{}
 	opts.SendCertificateChain = true
 	cred, err := NewClientCertificateCredential(tenantID, clientID, certificatePath, &opts)
 	if err != nil {
@@ -155,7 +155,7 @@ func TestClientCertificateCredential_GetTokenSuccess(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultClientCertificateCredentialOptions()
+	options := ClientCertificateCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientCertificateCredential(tenantID, clientID, certificatePath, &options)
@@ -172,7 +172,7 @@ func TestClientCertificateCredential_GetTokenSuccess_withCertificateChain(t *tes
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultClientCertificateCredentialOptions()
+	options := ClientCertificateCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.SendCertificateChain = true
 	options.HTTPClient = srv
@@ -190,7 +190,7 @@ func TestClientCertificateCredential_GetTokenInvalidCredentials(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultClientCertificateCredentialOptions()
+	options := ClientCertificateCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientCertificateCredential(tenantID, clientID, certificatePath, &options)
@@ -211,7 +211,7 @@ func TestClientCertificateCredential_WrongCertificatePath(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultClientCertificateCredentialOptions()
+	options := ClientCertificateCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	_, err := NewClientCertificateCredential(tenantID, clientID, wrongCertificatePath, &options)
@@ -224,7 +224,7 @@ func TestClientCertificateCredential_GetTokenCheckPrivateKeyBlocks(t *testing.T)
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultClientCertificateCredentialOptions()
+	options := ClientCertificateCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientCertificateCredential(tenantID, clientID, "testdata/certificate_formatB.pem", &options)
@@ -241,7 +241,7 @@ func TestClientCertificateCredential_GetTokenCheckCertificateBlocks(t *testing.T
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultClientCertificateCredentialOptions()
+	options := ClientCertificateCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientCertificateCredential(tenantID, clientID, "testdata/certificate_formatA.pem", &options)
@@ -258,7 +258,7 @@ func TestClientCertificateCredential_GetTokenEmptyCertificate(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultClientCertificateCredentialOptions()
+	options := ClientCertificateCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	_, err := NewClientCertificateCredential(tenantID, clientID, "testdata/certificate_empty.pem", &options)
@@ -271,7 +271,7 @@ func TestClientCertificateCredential_GetTokenNoPrivateKey(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultClientCertificateCredentialOptions()
+	options := ClientCertificateCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	_, err := NewClientCertificateCredential(tenantID, clientID, "testdata/certificate_nokey.pem", &options)
@@ -285,7 +285,7 @@ func TestBearerPolicy_ClientCertificateCredential(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultClientCertificateCredentialOptions()
+	options := ClientCertificateCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientCertificateCredential(tenantID, clientID, certificatePath, &options)

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -26,15 +26,6 @@ type ClientSecretCredentialOptions struct {
 	Logging azcore.LogOptions
 }
 
-// DefaultClientSecretCredentialOptions returns an instance of ClientSecretCredentialOptions initialized with default values.
-func DefaultClientSecretCredentialOptions() ClientSecretCredentialOptions {
-	return ClientSecretCredentialOptions{
-		Retry:     azcore.DefaultRetryOptions(),
-		Telemetry: azcore.DefaultTelemetryOptions(),
-		Logging:   azcore.DefaultLogOptions(),
-	}
-}
-
 // ClientSecretCredential enables authentication to Azure Active Directory using a client secret that was generated for an App Registration.  More information on how
 // to configure a client secret can be found here:
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis#add-credentials-to-your-web-application
@@ -55,8 +46,7 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 		return nil, &CredentialUnavailableError{credentialType: "Client Secret Credential", message: tenantIDValidationErr}
 	}
 	if options == nil {
-		temp := DefaultClientSecretCredentialOptions()
-		options = &temp
+		options = &ClientSecretCredentialOptions{}
 	}
 	authorityHost, err := setAuthorityHost(options.AuthorityHost)
 	if err != nil {

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -82,7 +82,7 @@ func TestClientSecretCredential_GetTokenSuccess(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &options)
@@ -99,7 +99,7 @@ func TestClientSecretCredential_GetTokenInvalidCredentials(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithBody([]byte(accessTokenRespError)), mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientSecretCredential(tenantID, clientID, wrongSecret, &options)
@@ -147,7 +147,7 @@ func TestClientSecretCredential_GetTokenUnexpectedJSON(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespMalformed)))
-	options := DefaultClientSecretCredentialOptions()
+	options := ClientSecretCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewClientSecretCredential(tenantID, clientID, secret, &options)

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -87,8 +87,7 @@ func TestDefaultAzureCredential_NilOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect to receive an error in creating the credential")
 	}
-	options := DefaultManagedIdentityCredentialOptions()
-	c := newManagedIdentityClient(&options)
+	c := newManagedIdentityClient(&ManagedIdentityCredentialOptions{})
 	// if the test is running in a MSI environment then the length of sources would be two since it will include environment credential and managed identity credential
 	if msiType, err := c.getMSIType(); !(msiType == msiTypeUnavailable || msiType == msiTypeUnknown) {
 		if len(cred.sources) != lengthOfChainFull {

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -39,21 +39,22 @@ type DeviceCodeCredentialOptions struct {
 	Logging azcore.LogOptions
 }
 
-// DefaultDeviceCodeCredentialOptions provides the default settings for DeviceCodeCredential.
+// init provides the default settings for DeviceCodeCredential.
 // It will set the following default values:
 // TenantID set to "organizations".
 // ClientID set to the default developer sign on client ID "04b07795-8ddb-461a-bbee-02f9e1bf7b46".
 // UserPrompt set to output login information for the user to stdout.
-func DefaultDeviceCodeCredentialOptions() DeviceCodeCredentialOptions {
-	return DeviceCodeCredentialOptions{
-		TenantID: organizationsTenantID,
-		ClientID: developerSignOnClientID,
-		UserPrompt: func(dc DeviceCodeMessage) {
+func (o *DeviceCodeCredentialOptions) init() {
+	if o.TenantID == "" {
+		o.TenantID = organizationsTenantID
+	}
+	if o.ClientID == "" {
+		o.ClientID = developerSignOnClientID
+	}
+	if o.UserPrompt == nil {
+		o.UserPrompt = func(dc DeviceCodeMessage) {
 			fmt.Println(dc.Message)
-		},
-		Retry:     azcore.DefaultRetryOptions(),
-		Telemetry: azcore.DefaultTelemetryOptions(),
-		Logging:   azcore.DefaultLogOptions(),
+		}
 	}
 }
 
@@ -82,9 +83,9 @@ type DeviceCodeCredential struct {
 // options: Options used to configure the management of the requests sent to Azure Active Directory, please see DeviceCodeCredentialOptions for a description of each field.
 func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeCredential, error) {
 	if options == nil {
-		temp := DefaultDeviceCodeCredentialOptions()
-		options = &temp
+		options = &DeviceCodeCredentialOptions{}
 	}
+	options.init()
 	if !validTenantID(options.TenantID) {
 		return nil, &CredentialUnavailableError{credentialType: "Device Code Credential", message: tenantIDValidationErr}
 	}

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -82,22 +82,23 @@ type DeviceCodeCredential struct {
 // NewDeviceCodeCredential constructs a new DeviceCodeCredential used to authenticate against Azure Active Directory with a device code.
 // options: Options used to configure the management of the requests sent to Azure Active Directory, please see DeviceCodeCredentialOptions for a description of each field.
 func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeCredential, error) {
-	if options == nil {
-		options = &DeviceCodeCredentialOptions{}
+	cp := DeviceCodeCredentialOptions{}
+	if options != nil {
+		cp = *options
 	}
-	options.init()
-	if !validTenantID(options.TenantID) {
+	cp.init()
+	if !validTenantID(cp.TenantID) {
 		return nil, &CredentialUnavailableError{credentialType: "Device Code Credential", message: tenantIDValidationErr}
 	}
-	authorityHost, err := setAuthorityHost(options.AuthorityHost)
+	authorityHost, err := setAuthorityHost(cp.AuthorityHost)
 	if err != nil {
 		return nil, err
 	}
-	c, err := newAADIdentityClient(authorityHost, pipelineOptions{HTTPClient: options.HTTPClient, Retry: options.Retry, Telemetry: options.Telemetry, Logging: options.Logging})
+	c, err := newAADIdentityClient(authorityHost, pipelineOptions{HTTPClient: cp.HTTPClient, Retry: cp.Retry, Telemetry: cp.Telemetry, Logging: cp.Logging})
 	if err != nil {
 		return nil, err
 	}
-	return &DeviceCodeCredential{tenantID: options.TenantID, clientID: options.ClientID, userPrompt: options.UserPrompt, client: c}, nil
+	return &DeviceCodeCredential{tenantID: cp.TenantID, clientID: cp.ClientID, userPrompt: cp.UserPrompt, client: c}, nil
 }
 
 // GetToken obtains a token from Azure Active Directory, following the device code authentication

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -24,7 +24,7 @@ const (
 )
 
 func TestDeviceCodeCredential_InvalidTenantID(t *testing.T) {
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.TenantID = badTenantID
 	cred, err := NewDeviceCodeCredential(&options)
 	if err == nil {
@@ -81,7 +81,7 @@ func TestDeviceCodeCredential_CreateAuthRequestSuccess(t *testing.T) {
 }
 
 func TestDeviceCodeCredential_CreateAuthRequestCustomClientID(t *testing.T) {
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.ClientID = clientID
 	cred, err := NewDeviceCodeCredential(&options)
 	if err != nil {
@@ -127,7 +127,7 @@ func TestDeviceCodeCredential_CreateAuthRequestCustomClientID(t *testing.T) {
 }
 
 func TestDeviceCodeCredential_RequestNewDeviceCodeCustomTenantIDClientID(t *testing.T) {
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.ClientID = clientID
 	options.TenantID = tenantID
 	cred, err := NewDeviceCodeCredential(&options)
@@ -173,7 +173,7 @@ func TestDeviceCodeCredential_GetTokenSuccess(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewDeviceCodeCredential(&options)
@@ -193,7 +193,7 @@ func TestDeviceCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.ClientID = clientID
 	options.TenantID = tenantID
 	options.HTTPClient = srv
@@ -215,7 +215,7 @@ func TestDeviceCodeCredential_GetTokenAuthorizationPending(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(authorizationPendingResponse)), mock.WithStatusCode(http.StatusUnauthorized))
 	srv.AppendResponse(mock.WithBody([]byte(authorizationPendingResponse)), mock.WithStatusCode(http.StatusUnauthorized))
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.ClientID = clientID
 	options.TenantID = tenantID
 	options.HTTPClient = srv
@@ -237,7 +237,7 @@ func TestDeviceCodeCredential_GetTokenExpiredToken(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
 	srv.AppendResponse(mock.WithBody([]byte(authorizationPendingResponse)), mock.WithStatusCode(http.StatusUnauthorized))
 	srv.AppendResponse(mock.WithBody([]byte(expiredTokenResponse)), mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.ClientID = clientID
 	options.TenantID = tenantID
 	options.HTTPClient = srv
@@ -257,7 +257,7 @@ func TestDeviceCodeCredential_GetTokenWithRefreshTokenFailure(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespError)), mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.ClientID = clientID
 	options.TenantID = tenantID
 	options.HTTPClient = srv
@@ -281,7 +281,7 @@ func TestDeviceCodeCredential_GetTokenWithRefreshTokenSuccess(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.ClientID = clientID
 	options.TenantID = tenantID
 	options.HTTPClient = srv
@@ -307,7 +307,7 @@ func TestBearerPolicy_DeviceCodeCredential(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(deviceCodeResponse)))
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultDeviceCodeCredentialOptions()
+	options := DeviceCodeCredentialOptions{}
 	options.ClientID = clientID
 	options.TenantID = tenantID
 	options.HTTPClient = srv

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -27,15 +27,6 @@ type EnvironmentCredentialOptions struct {
 	Logging azcore.LogOptions
 }
 
-// DefaultEnvironmentCredentialOptions returns an instance of EnvironmentCredentialOptions initialized with default values.
-func DefaultEnvironmentCredentialOptions() EnvironmentCredentialOptions {
-	return EnvironmentCredentialOptions{
-		Retry:     azcore.DefaultRetryOptions(),
-		Telemetry: azcore.DefaultTelemetryOptions(),
-		Logging:   azcore.DefaultLogOptions(),
-	}
-}
-
 // EnvironmentCredential enables authentication to Azure Active Directory using either ClientSecretCredential, ClientCertificateCredential or UsernamePasswordCredential.
 // This credential type will check for the following environment variables in the same order as listed:
 // - AZURE_TENANT_ID
@@ -55,8 +46,7 @@ type EnvironmentCredential struct {
 // options: The options used to configure the management of the requests sent to Azure Active Directory.
 func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*EnvironmentCredential, error) {
 	if options == nil {
-		temp := DefaultEnvironmentCredentialOptions()
-		options = &temp
+		options = &EnvironmentCredentialOptions{}
 	}
 	tenantID := os.Getenv("AZURE_TENANT_ID")
 	if tenantID == "" {

--- a/sdk/azidentity/go.mod
+++ b/sdk/azidentity/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-sdk-for-go/sdk/azidentity
 go 1.14
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.13.4
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.13.4 h1:7MfvHEWKfjZSKQNWERlXpHwCRoceEuQef/fB8CWmnQA=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.13.4/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0 h1:4HBTI/9UDZN7tsXyB5TYP3xCv5xVHIUTbvHHH2HFxQY=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -64,22 +64,23 @@ type InteractiveBrowserCredential struct {
 // NewInteractiveBrowserCredential constructs a new InteractiveBrowserCredential with the details needed to authenticate against Azure Active Directory through an interactive browser window.
 // options: allow to configure the management of the requests sent to Azure Active Directory, pass in nil for default behavior.
 func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOptions) (*InteractiveBrowserCredential, error) {
-	if options == nil {
-		options = &InteractiveBrowserCredentialOptions{}
+	cp := InteractiveBrowserCredentialOptions{}
+	if options != nil {
+		cp = *options
 	}
-	options.init()
-	if !validTenantID(options.TenantID) {
+	cp.init()
+	if !validTenantID(cp.TenantID) {
 		return nil, &CredentialUnavailableError{credentialType: "Interactive Browser Credential", message: tenantIDValidationErr}
 	}
-	authorityHost, err := setAuthorityHost(options.AuthorityHost)
+	authorityHost, err := setAuthorityHost(cp.AuthorityHost)
 	if err != nil {
 		return nil, err
 	}
-	c, err := newAADIdentityClient(authorityHost, pipelineOptions{HTTPClient: options.HTTPClient, Retry: options.Retry, Telemetry: options.Telemetry, Logging: options.Logging})
+	c, err := newAADIdentityClient(authorityHost, pipelineOptions{HTTPClient: cp.HTTPClient, Retry: cp.Retry, Telemetry: cp.Telemetry, Logging: cp.Logging})
 	if err != nil {
 		return nil, err
 	}
-	return &InteractiveBrowserCredential{options: *options, client: c}, nil
+	return &InteractiveBrowserCredential{options: cp, client: c}, nil
 }
 
 // GetToken obtains a token from Azure Active Directory using an interactive browser to authenticate.

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -44,14 +44,13 @@ type InteractiveBrowserCredentialOptions struct {
 	Logging azcore.LogOptions
 }
 
-// DefaultInteractiveBrowserCredentialOptions returns an instance of InteractiveBrowserCredentialOptions initialized with default values.
-func DefaultInteractiveBrowserCredentialOptions() InteractiveBrowserCredentialOptions {
-	return InteractiveBrowserCredentialOptions{
-		TenantID:  organizationsTenantID,
-		ClientID:  developerSignOnClientID,
-		Retry:     azcore.DefaultRetryOptions(),
-		Telemetry: azcore.DefaultTelemetryOptions(),
-		Logging:   azcore.DefaultLogOptions(),
+// init returns an instance of InteractiveBrowserCredentialOptions initialized with default values.
+func (o *InteractiveBrowserCredentialOptions) init() {
+	if o.TenantID == "" {
+		o.TenantID = organizationsTenantID
+	}
+	if o.ClientID == "" {
+		o.ClientID = developerSignOnClientID
 	}
 }
 
@@ -66,9 +65,9 @@ type InteractiveBrowserCredential struct {
 // options: allow to configure the management of the requests sent to Azure Active Directory, pass in nil for default behavior.
 func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOptions) (*InteractiveBrowserCredential, error) {
 	if options == nil {
-		temp := DefaultInteractiveBrowserCredentialOptions()
-		options = &temp
+		options = &InteractiveBrowserCredentialOptions{}
 	}
+	options.init()
 	if !validTenantID(options.TenantID) {
 		return nil, &CredentialUnavailableError{credentialType: "Interactive Browser Credential", message: tenantIDValidationErr}
 	}

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestInteractiveBrowserCredential_InvalidTenantID(t *testing.T) {
-	options := DefaultInteractiveBrowserCredentialOptions()
+	options := InteractiveBrowserCredentialOptions{}
 	options.TenantID = badTenantID
 	cred, err := NewInteractiveBrowserCredential(&options)
 	if err == nil {
@@ -56,7 +56,7 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 	tr.TLSClientConfig.InsecureSkipVerify = true
 	client := &http.Client{Transport: tr}
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultInteractiveBrowserCredentialOptions()
+	options := InteractiveBrowserCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = client
 	cred, err := NewInteractiveBrowserCredential(&options)
@@ -88,7 +88,7 @@ func TestInteractiveBrowserCredential_SetPort(t *testing.T) {
 	tr.TLSClientConfig.InsecureSkipVerify = true
 	client := &http.Client{Transport: tr}
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultInteractiveBrowserCredentialOptions()
+	options := InteractiveBrowserCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = client
 	options.Port = 8080
@@ -124,7 +124,7 @@ func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
 	tr.TLSClientConfig.InsecureSkipVerify = true
 	client := &http.Client{Transport: tr}
 	srv.SetResponse(mock.WithBody([]byte(accessTokenRespError)), mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultInteractiveBrowserCredentialOptions()
+	options := InteractiveBrowserCredentialOptions{}
 	options.ClientSecret = wrongSecret
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = client

--- a/sdk/azidentity/managed_identity_client_test.go
+++ b/sdk/azidentity/managed_identity_client_test.go
@@ -27,7 +27,6 @@ func TestMSITelemetryDefaultUserAgent(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	options := ManagedIdentityCredentialOptions{
 		HTTPClient: srv,
-		Telemetry:  azcore.DefaultTelemetryOptions(),
 	}
 	pipeline := newDefaultMSIPipeline(options)
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
@@ -53,7 +52,6 @@ func TestMSITelemetryCustom(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	options := ManagedIdentityCredentialOptions{
 		HTTPClient: srv,
-		Telemetry:  azcore.DefaultTelemetryOptions(),
 	}
 	options.Telemetry.Value = customTelemetry
 	pipeline := newDefaultMSIPipeline(options)

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -25,14 +25,6 @@ type ManagedIdentityCredentialOptions struct {
 	Logging azcore.LogOptions
 }
 
-// DefaultManagedIdentityCredentialOptions returns an instance of ManagedIdentityCredentialOptions initialized with default values.
-func DefaultManagedIdentityCredentialOptions() ManagedIdentityCredentialOptions {
-	return ManagedIdentityCredentialOptions{
-		Telemetry: azcore.DefaultTelemetryOptions(),
-		Logging:   azcore.DefaultLogOptions(),
-	}
-}
-
 // ManagedIdentityCredential attempts authentication using a managed identity that has been assigned to the deployment environment. This authentication type works in several
 // managed identity environments such as Azure VMs, App Service, Azure Functions, Azure CloudShell, among others. More information about configuring managed identities can be found here:
 // https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
@@ -49,8 +41,7 @@ type ManagedIdentityCredential struct {
 func NewManagedIdentityCredential(clientID string, options *ManagedIdentityCredentialOptions) (*ManagedIdentityCredential, error) {
 	// Create a new Managed Identity Client with default options
 	if options == nil {
-		def := DefaultManagedIdentityCredentialOptions()
-		options = &def
+		options = &ManagedIdentityCredentialOptions{}
 	}
 	client := newManagedIdentityClient(options)
 	msiType, err := client.getMSIType()

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -62,7 +62,7 @@ func TestManagedIdentityCredential_GetTokenInCloudShellMock(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	defer clearEnvVars("MSI_ENDPOINT")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential(clientID, &options)
 	if err != nil {
@@ -81,7 +81,7 @@ func TestManagedIdentityCredential_GetTokenInCloudShellMockFail(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	defer clearEnvVars("MSI_ENDPOINT")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential("", &options)
 	if err != nil {
@@ -101,7 +101,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_windows(t *
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	_ = os.Setenv("MSI_SECRET", "secret")
 	defer clearEnvVars("MSI_ENDPOINT", "MSI_SECRET")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential(clientID, &options)
 	if err != nil {
@@ -127,7 +127,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_linux(t *te
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	_ = os.Setenv("MSI_SECRET", "secret")
 	defer clearEnvVars("MSI_ENDPOINT", "MSI_SECRET")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential(clientID, &options)
 	if err != nil {
@@ -153,7 +153,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_windows(t *
 	_ = os.Setenv("IDENTITY_ENDPOINT", srv.URL())
 	_ = os.Setenv("IDENTITY_HEADER", "header")
 	defer clearEnvVars("IDENTITY_ENDPOINT", "IDENTITY_HEADER")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential("", &options)
 	if err != nil {
@@ -179,7 +179,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_linux(t *te
 	_ = os.Setenv("IDENTITY_ENDPOINT", srv.URL())
 	_ = os.Setenv("IDENTITY_HEADER", "header")
 	defer clearEnvVars("IDENTITY_ENDPOINT", "IDENTITY_HEADER")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential("", &options)
 	if err != nil {
@@ -302,7 +302,7 @@ func TestManagedIdentityCredential_CreateAccessTokenExpiresOnInt(t *testing.T) {
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	_ = os.Setenv("MSI_SECRET", "secret")
 	defer clearEnvVars("MSI_ENDPOINT", "MSI_SECRET")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential(clientID, &options)
 	if err != nil {
@@ -322,7 +322,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceMockFail(t *testing.T) {
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	_ = os.Setenv("MSI_SECRET", "secret")
 	defer clearEnvVars("MSI_ENDPOINT", "MSI_SECRET")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential("", &options)
 	if err != nil {
@@ -370,7 +370,7 @@ func TestManagedIdentityCredential_NewManagedIdentityCredentialFail(t *testing.T
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
 	_ = os.Setenv("MSI_ENDPOINT", "https://t .com")
 	defer clearEnvVars("MSI_ENDPOINT")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	cred, err := NewManagedIdentityCredential("", &options)
 	if err != nil {
@@ -389,7 +389,7 @@ func TestBearerPolicy_ManagedIdentityCredential(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	defer clearEnvVars("MSI_ENDPOINT")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	cred, err := NewManagedIdentityCredential(clientID, &options)
 	if err != nil {
@@ -413,7 +413,7 @@ func TestManagedIdentityCredential_GetTokenUnexpectedJSON(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespMalformed)))
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	defer clearEnvVars("MSI_ENDPOINT")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential(clientID, &options)
 	if err != nil {
@@ -471,7 +471,7 @@ func TestManagedIdentityCredential_GetTokenEnvVar(t *testing.T) {
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	_ = os.Setenv("MSI_ENDPOINT", srv.URL())
 	defer clearEnvVars("MSI_ENDPOINT")
-	options := DefaultManagedIdentityCredentialOptions()
+	options := ManagedIdentityCredentialOptions{}
 	options.HTTPClient = srv
 	msiCred, err := NewManagedIdentityCredential("", &options)
 	if err != nil {

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -210,9 +210,9 @@ func TestManagedIdentityCredential_GetTokenInAzureFunctions_linux(t *testing.T) 
 	_ = os.Setenv("IDENTITY_ENDPOINT", srv.URL())
 	_ = os.Setenv("IDENTITY_HEADER", "header")
 	defer clearEnvVars("IDENTITY_ENDPOINT", "IDENTITY_HEADER")
-	options := DefaultManagedIdentityCredentialOptions()
-	options.HTTPClient = srv
-	msiCred, err := NewManagedIdentityCredential(clientID, &options)
+	msiCred, err := NewManagedIdentityCredential(clientID, &ManagedIdentityCredentialOptions{
+		HTTPClient: srv,
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -27,15 +27,6 @@ type UsernamePasswordCredentialOptions struct {
 	Logging azcore.LogOptions
 }
 
-// DefaultUsernamePasswordCredentialOptions returns an instance of UsernamePasswordCredentialOptions initialized with default values.
-func DefaultUsernamePasswordCredentialOptions() UsernamePasswordCredentialOptions {
-	return UsernamePasswordCredentialOptions{
-		Retry:     azcore.DefaultRetryOptions(),
-		Telemetry: azcore.DefaultTelemetryOptions(),
-		Logging:   azcore.DefaultLogOptions(),
-	}
-}
-
 // UsernamePasswordCredential enables authentication to Azure Active Directory using a user's  username and password. If the user has MFA enabled this
 // credential will fail to get a token returning an AuthenticationFailureError. Also, this credential requires a high degree of trust and is not
 // recommended outside of prototyping when more secure credentials can be used.
@@ -59,8 +50,7 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 		return nil, &CredentialUnavailableError{credentialType: "Username Password Credential", message: tenantIDValidationErr}
 	}
 	if options == nil {
-		temp := DefaultUsernamePasswordCredentialOptions()
-		options = &temp
+		options = &UsernamePasswordCredentialOptions{}
 	}
 	authorityHost, err := setAuthorityHost(options.AuthorityHost)
 	if err != nil {

--- a/sdk/azidentity/username_password_credential_test.go
+++ b/sdk/azidentity/username_password_credential_test.go
@@ -80,7 +80,7 @@ func TestUsernamePasswordCredential_GetTokenSuccess(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	options := DefaultUsernamePasswordCredentialOptions()
+	options := UsernamePasswordCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", &options)
@@ -97,7 +97,7 @@ func TestUsernamePasswordCredential_GetTokenInvalidCredentials(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusUnauthorized))
-	options := DefaultUsernamePasswordCredentialOptions()
+	options := UsernamePasswordCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "wrong_password", &options)
@@ -115,7 +115,7 @@ func TestBearerPolicy_UsernamePasswordCredential(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	options := DefaultUsernamePasswordCredentialOptions()
+	options := UsernamePasswordCredentialOptions{}
 	options.AuthorityHost = srv.URL()
 	options.HTTPClient = srv
 	cred, err := NewUsernamePasswordCredential(tenantID, clientID, "username", "password", &options)


### PR DESCRIPTION
This PR removes the DefaultXxxOptions() funcs from every azidentity credential type. 