### PR TITLE
Enable 1ES hosted pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       matrix:
         Linux_Go113:
-          vm.image: 'ubuntu-18.04'
+          pool.name: azsdk-pool-mms-ubuntu-1804-general
           go.version: '1.14'
         Linux_Go114:
-          vm.image: 'ubuntu-18.04'
+          pool.name: azsdk-pool-mms-ubuntu-1804-general
           go.version: '1.15'
 
     pool:
-      vmImage: $(vm.image)
+      name: $(pool.name)
 
     variables:
       GOPATH: '$(system.defaultWorkingDirectory)/work'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
@@ -11,19 +11,19 @@ stages:
       strategy:
         matrix:
           Linux_Go115:
-            vm.image: 'ubuntu-18.04'
+            pool.name: azsdk-pool-mms-ubuntu-1804-general
             go.version: '1.15'
           Windows_Go115:
-            vm.image: 'windows-2019'
+            pool.name: azsdk-pool-mms-win-2019-general
             go.version: '1.15'
           Linux_Go114:
-            vm.image: 'ubuntu-18.04'
+            pool.name: azsdk-pool-mms-ubuntu-1804-general
             go.version: '1.14'
           Windows_Go114:
-            vm.image: 'windows-2019'
+            pool.name: azsdk-pool-mms-win-2019-general
             go.version: '1.14'
       pool:
-        vmImage: $(vm.image)
+        name: $(pool.name)
       steps:
       - task: GoTool@0
         inputs:
@@ -50,7 +50,7 @@ stages:
       variables:
         - template: ../variables/globals.yml
       pool:
-        vmImage: 'ubuntu-18.04'
+        name: azsdk-pool-mms-win-2019-general
 
       steps:
       - task: GoTool@0

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -11,19 +11,19 @@ stages:
       strategy:
         matrix:
           Linux_Go115:
-            vm.image: 'ubuntu-18.04'
+            pool.name: azsdk-pool-mms-ubuntu-1804-general
             go.version: '1.15'
           Windows_Go115:
-            vm.image: 'windows-2019'
+            pool.name: azsdk-pool-mms-win-2019-general
             go.version: '1.15'
           Linux_Go114:
-            vm.image: 'ubuntu-18.04'
+            pool.name: azsdk-pool-mms-ubuntu-1804-general
             go.version: '1.14'
           Windows_Go114:
-            vm.image: 'windows-2019'
+            pool.name: azsdk-pool-mms-win-2019-general
             go.version: '1.14'
       pool:
-        vmImage: $(vm.image)
+        name: $(pool.name)
       steps:
       - task: GoTool@0
         inputs:
@@ -50,7 +50,7 @@ stages:
       variables:
         - template: ../variables/globals.yml
       pool:
-        vmImage: 'ubuntu-18.04'
+        name: azsdk-pool-mms-ubuntu-1804-general
 
       steps:
       - task: GoTool@0

--- a/sdk/armcore/ci.yml
+++ b/sdk/armcore/ci.yml
@@ -13,3 +13,4 @@ stages:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: 'armcore'
+


### PR DESCRIPTION
This change switches the unified pipelines to use the 1ES hosted pools. This is just a straight up switch from the Azure Pipelines pool (specifying a VM image) to using the 1ES pool (no image specified).