### PR TITLE
The output-folder for a profile now no longer reports errors

### DIFF
--- a/tools/generator/validate/validation.go
+++ b/tools/generator/validate/validation.go
@@ -77,7 +77,7 @@ func MgmtCheck(ctx *MetadataValidateContext, tag string, metadata model.Metadata
 			return err
 		}
 		if !mgmtOutputRegex.MatchString(rel) {
-			return fmt.Errorf("the output-folder of a management plane package '%s' must be in this pattern: '^services(/preview)?/[^/]+/mgmt/[^/]+/[^/]+$'", tag)
+			return fmt.Errorf("the output-folder of a management plane package '%s' is expected to have this pattern: 'services/(preview)?/{RPname}/mgmt/{packageVersion}/{namespace}'", tag)
 		}
 	}
 	return nil

--- a/tools/generator/validate/validation.go
+++ b/tools/generator/validate/validation.go
@@ -104,5 +104,5 @@ var (
 	previewSwaggerRegex = regexp.MustCompile(`^preview|.+[/\\]preview[/\\]`)
 	previewOutputRegex  = regexp.MustCompile(`^services/preview/`)
 	mgmtReadmeRegex     = regexp.MustCompile(`[/\\]resource-manager[/\\]`)
-	mgmtOutputRegex     = regexp.MustCompile(`^services(/preview)?/[^/]+/mgmt/[^/]+/[^/]+$`)
+	mgmtOutputRegex     = regexp.MustCompile(`^services(/preview)?/[^/]+/mgmt/[^/]+/[^/]+$|^profiles/[^/]+/[^/]+/mgmt/[^/]+$`)
 )


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
