### PR TITLE
Add support for PKCE in interactive auth flow

### DIFF
--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -18,6 +18,7 @@ import (
 const (
 	clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 	tokenEndpoint       = "/oauth2/v2.0/token"
+	authEndpoint        = "/oauth2/v2.0/authorize"
 )
 
 const (

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -38,8 +38,9 @@ const (
 
 // interactiveConfig stores the authorization code obtained from the interactive browser and redirect URI used in the initial request
 type interactiveConfig struct {
-	authCode    string
-	redirectURI string
+	authCode     string
+	codeVerifier string
+	redirectURI  string
 }
 
 // aadIdentityClient provides the base for authenticating with Client Secret Credentials, Client Certificate Credentials
@@ -379,18 +380,12 @@ func (c *aadIdentityClient) createDeviceCodeNumberRequest(ctx context.Context, t
 
 // authenticateInteractiveBrowser opens an interactive browser window, gets the authorization code and requests an Access Token with the
 // authorization code and returns the token or an error in case of authentication failure.
-// ctx: The current request context.
-// tenantID: The Azure Active Directory tenant (directory) ID of the service principal.
-// clientID: The client (application) ID of the service principal.
-// clientSecret: Gets the client secret that was generated for the App Registration used to authenticate the client.
-// redirectURI: The redirect URI that was used to request the authorization code. Must be the same URI that is configured for the App Registration.
-// scopes: The scopes required for the token
-func (c *aadIdentityClient) authenticateInteractiveBrowser(ctx context.Context, tenantID string, clientID string, clientSecret string, redirectURI string, port int, scopes []string) (*azcore.AccessToken, error) {
-	cfg, err := authCodeReceiver(c.authorityHost, tenantID, clientID, redirectURI, port, scopes)
+func (c *aadIdentityClient) authenticateInteractiveBrowser(ctx context.Context, opts *InteractiveBrowserCredentialOptions, scopes []string) (*azcore.AccessToken, error) {
+	cfg, err := authCodeReceiver(c.authorityHost, opts, scopes)
 	if err != nil {
 		return nil, err
 	}
-	return c.authenticateAuthCode(ctx, tenantID, clientID, cfg.authCode, clientSecret, cfg.redirectURI, scopes)
+	return c.authenticateAuthCode(ctx, opts.TenantID, opts.ClientID, cfg.authCode, opts.ClientSecret, cfg.codeVerifier, cfg.redirectURI, scopes)
 }
 
 // authenticateAuthCode requests an Access Token with the authorization code and returns the token or an error in case of authentication failure.
@@ -401,8 +396,8 @@ func (c *aadIdentityClient) authenticateInteractiveBrowser(ctx context.Context, 
 // clientSecret: Gets the client secret that was generated for the App Registration used to authenticate the client.
 // redirectURI: The redirect URI that was used to request the authorization code. Must be the same URI that is configured for the App Registration.
 // scopes: The scopes required for the token
-func (c *aadIdentityClient) authenticateAuthCode(ctx context.Context, tenantID string, clientID string, authCode string, clientSecret string, redirectURI string, scopes []string) (*azcore.AccessToken, error) {
-	req, err := c.createAuthorizationCodeAuthRequest(ctx, tenantID, clientID, authCode, clientSecret, redirectURI, scopes)
+func (c *aadIdentityClient) authenticateAuthCode(ctx context.Context, tenantID, clientID, authCode, clientSecret, codeVerifier, redirectURI string, scopes []string) (*azcore.AccessToken, error) {
+	req, err := c.createAuthorizationCodeAuthRequest(ctx, tenantID, clientID, authCode, clientSecret, codeVerifier, redirectURI, scopes)
 	if err != nil {
 		return nil, err
 	}
@@ -420,12 +415,16 @@ func (c *aadIdentityClient) authenticateAuthCode(ctx context.Context, tenantID s
 }
 
 // createAuthorizationCodeAuthRequest creates a request for an Access Token for authorization_code grant types.
-func (c *aadIdentityClient) createAuthorizationCodeAuthRequest(ctx context.Context, tenantID string, clientID string, authCode string, clientSecret string, redirectURI string, scopes []string) (*azcore.Request, error) {
+func (c *aadIdentityClient) createAuthorizationCodeAuthRequest(ctx context.Context, tenantID, clientID, authCode, clientSecret, codeVerifier, redirectURI string, scopes []string) (*azcore.Request, error) {
 	data := url.Values{}
 	data.Set(qpGrantType, "authorization_code")
 	data.Set(qpClientID, clientID)
 	if clientSecret != "" {
 		data.Set(qpClientSecret, clientSecret) // only for web apps
+	}
+	if codeVerifier != "" {
+		// used during interactive browser auth
+		data.Set("code_verifier", codeVerifier)
 	}
 	data.Set(qpRedirectURI, redirectURI)
 	data.Set(qpScope, strings.Join(scopes, " "))

--- a/sdk/azidentity/authorization_code_credential.go
+++ b/sdk/azidentity/authorization_code_credential.go
@@ -69,7 +69,7 @@ func NewAuthorizationCodeCredential(tenantID string, clientID string, authCode s
 // opts: TokenRequestOptions contains the list of scopes for which the token will have access.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	tk, err := c.client.authenticateAuthCode(ctx, c.tenantID, c.clientID, c.authCode, c.clientSecret, c.redirectURI, opts.Scopes)
+	tk, err := c.client.authenticateAuthCode(ctx, c.tenantID, c.clientID, c.authCode, c.clientSecret, "", c.redirectURI, opts.Scopes)
 	if err != nil {
 		addGetTokenFailureLogs("Authorization Code Credential", err, true)
 		return nil, err

--- a/sdk/azidentity/authorization_code_credential_test.go
+++ b/sdk/azidentity/authorization_code_credential_test.go
@@ -39,7 +39,7 @@ func TestAuthorizationCodeCredential_CreateAuthRequestSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	req, err := cred.client.createAuthorizationCodeAuthRequest(context.Background(), cred.tenantID, cred.clientID, cred.authCode, cred.clientSecret, cred.redirectURI, []string{scope})
+	req, err := cred.client.createAuthorizationCodeAuthRequest(context.Background(), cred.tenantID, cred.clientID, cred.authCode, cred.clientSecret, "", cred.redirectURI, []string{scope})
 	if err != nil {
 		t.Fatalf("Unexpectedly received an error: %v", err)
 	}

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -150,7 +150,7 @@ func interactiveBrowserLogin(authorityHost string, opts *InteractiveBrowserCrede
 		values.Add("code_challenge", base64.RawURLEncoding.EncodeToString(cvh[:]))
 		values.Add("code_challenge_method", "S256")
 	}
-	u.Path = azcore.JoinPaths(u.Path, opts.TenantID, "oauth2/v2.0/authorize")
+	u.Path = azcore.JoinPaths(u.Path, opts.TenantID, authEndpoint)
 	u.RawQuery = values.Encode()
 	// open browser window so user can select credentials
 	err = browser.OpenURL(u.String())

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -5,13 +5,14 @@ package azidentity
 
 import (
 	"context"
-	"fmt"
+	"crypto/sha256"
+	"encoding/base64"
 	"math/rand"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"
 	"github.com/pkg/browser"
 )
 
@@ -30,6 +31,8 @@ type InteractiveBrowserCredentialOptions struct {
 	// The localhost port for the local server that will be used to redirect back. If left with a zero value, a random port
 	// will be selected.
 	Port int
+	// Disables use of PKCE during authorization.  The default is false.
+	DisablePKCE bool
 	// The host of the Azure Active Directory authority. The default is AzurePublicCloud.
 	// Leave empty to allow overriding the value from the AZURE_AUTHORITY_HOST environment variable.
 	AuthorityHost string
@@ -88,7 +91,7 @@ func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOption
 // opts: TokenRequestOptions contains the list of scopes for which the token will have access.
 // Returns an AccessToken which can be used to authenticate service client calls.
 func (c *InteractiveBrowserCredential) GetToken(ctx context.Context, opts azcore.TokenRequestOptions) (*azcore.AccessToken, error) {
-	tk, err := c.client.authenticateInteractiveBrowser(ctx, c.options.TenantID, c.options.ClientID, c.options.ClientSecret, c.options.RedirectURL, c.options.Port, opts.Scopes)
+	tk, err := c.client.authenticateInteractiveBrowser(ctx, &c.options, opts.Scopes)
 	if err != nil {
 		addGetTokenFailureLogs("Interactive Browser Credential", err, true)
 		return nil, err
@@ -106,36 +109,49 @@ func (c *InteractiveBrowserCredential) AuthenticationPolicy(options azcore.Authe
 var _ azcore.TokenCredential = (*InteractiveBrowserCredential)(nil)
 
 // authCodeReceiver is used to allow for testing without opening an interactive browser window. Allows mocking a response authorization code and redirect URI.
-var authCodeReceiver = func(authorityHost string, tenantID string, clientID string, redirectURI string, port int, scopes []string) (*interactiveConfig, error) {
-	return interactiveBrowserLogin(authorityHost, tenantID, clientID, redirectURI, port, scopes)
+var authCodeReceiver = func(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
+	return interactiveBrowserLogin(authorityHost, opts, scopes)
 }
 
 // interactiveBrowserLogin opens an interactive browser with the specified tenant and client IDs provided then returns the authorization code
 // received or an error.
-func interactiveBrowserLogin(authorityHost string, tenantID string, clientID string, redirectURL string, port int, scopes []string) (*interactiveConfig, error) {
-	const authPathFormat = "%s/oauth2/v2.0/authorize?response_type=code&response_mode=query&client_id=%s&redirect_uri=%s&state=%s&scope=%s&prompt=select_account"
-	state := func() string {
-		rand.Seed(time.Now().Unix())
-		// generate a 20-char random alpha-numeric string
-		const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-		buff := make([]byte, 20)
-		for i := range buff {
-			buff[i] = charset[rand.Intn(len(charset))]
-		}
-		return string(buff)
-	}()
+func interactiveBrowserLogin(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
 	// start local redirect server so login can call us back
 	rs := newServer()
+	state := uuid.New().String()
+	redirectURL := opts.RedirectURL
 	if redirectURL == "" {
-		redirectURL = rs.Start(state, port)
+		redirectURL = rs.Start(state, opts.Port)
 	}
 	defer rs.Stop()
 	u, err := url.Parse(authorityHost)
 	if err != nil {
 		return nil, err
 	}
-	authPath := fmt.Sprintf(authPathFormat, tenantID, clientID, redirectURL, state, strings.Join(scopes, " "))
-	u.Path = azcore.JoinPaths(u.Path, authPath)
+	values := url.Values{}
+	values.Add("response_type", "code")
+	values.Add("response_mode", "query")
+	values.Add("client_id", opts.ClientID)
+	values.Add("redirect_uri", redirectURL)
+	values.Add("state", state)
+	values.Add("scope", strings.Join(scopes, " "))
+	values.Add("prompt", "select_account")
+	cv := ""
+	if opts.DisablePKCE == false {
+		// the code verifier is a random 32-byte sequence that's been base-64 encoded without padding.
+		// it's used to prevent MitM attacks during auth code flow, see https://tools.ietf.org/html/rfc7636
+		b := make([]byte, 32, 32)
+		if _, err := rand.Read(b); err != nil {
+			return nil, err
+		}
+		cv = base64.RawURLEncoding.EncodeToString(b)
+		// for PKCE, create a hash of the code verifier
+		cvh := sha256.Sum256([]byte(cv))
+		values.Add("code_challenge", base64.RawURLEncoding.EncodeToString(cvh[:]))
+		values.Add("code_challenge_method", "S256")
+	}
+	u.Path = azcore.JoinPaths(u.Path, opts.TenantID, "oauth2/v2.0/authorize")
+	u.RawQuery = values.Encode()
 	// open browser window so user can select credentials
 	err = browser.OpenURL(u.String())
 	if err != nil {
@@ -149,7 +165,8 @@ func interactiveBrowserLogin(authorityHost string, tenantID string, clientID str
 		return nil, err
 	}
 	return &interactiveConfig{
-		authCode:    authCode,
-		redirectURI: redirectURL,
+		authCode:     authCode,
+		codeVerifier: cv,
+		redirectURI:  redirectURL,
 	}, nil
 }

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -63,7 +63,7 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	authCodeReceiver = func(authorityHost string, tenantID string, clientID string, redirectURI string, port int, scopes []string) (*interactiveConfig, error) {
+	authCodeReceiver = func(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
 		return &interactiveConfig{
 			authCode:    "12345",
 			redirectURI: srv.URL(),
@@ -96,9 +96,9 @@ func TestInteractiveBrowserCredential_SetPort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	authCodeReceiver = func(authorityHost string, tenantID string, clientID string, redirectURI string, port int, scopes []string) (*interactiveConfig, error) {
-		if port != 8080 {
-			t.Fatalf("Did not receive the correct port. Expected: %v, Received: %v", 8080, port)
+	authCodeReceiver = func(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
+		if opts.Port != 8080 {
+			t.Fatalf("Did not receive the correct port. Expected: %v, Received: %v", 8080, opts.Port)
 		}
 		return &interactiveConfig{
 			authCode:    "12345",
@@ -132,7 +132,7 @@ func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	authCodeReceiver = func(authorityHost string, tenantID string, clientID string, redirectURI string, port int, scopes []string) (*interactiveConfig, error) {
+	authCodeReceiver = func(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
 		return &interactiveConfig{
 			authCode:    "12345",
 			redirectURI: srv.URL(),


### PR DESCRIPTION
Implement as specified in RFC7636 to prevent auth code interception
attacks.  Enabled by default, can be disabled.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
