### PR TITLE
Fix analyze step to use Ubuntu

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
@@ -50,7 +50,7 @@ stages:
       variables:
         - template: ../variables/globals.yml
       pool:
-        name: azsdk-pool-mms-win-2019-general
+        name: azsdk-pool-mms-ubuntu-1804-general
 
       steps:
       - task: GoTool@0

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -24,18 +24,18 @@ steps:
       exit 0
     displayName: 'Lint'
     failOnStderr: false
-    workingDirectory: '${{parameters.GoWorkspace}}'
+    workingDirectory: '${{parameters.Directory}}'
 
   - script: |
       grep -L -r --include \*.go -P "Copyright (\d{4}|\(c\)) Microsoft" ./sdk | tee >&2
     displayName: 'Copyright Header Check'
     condition: succeededOrFailed()
     failOnStderr: true
-    workingDirectory: '${{parameters.GoWorkspace}}'
+    workingDirectory: '${{parameters.Directory}}'
 
   - script: |
       gofmt -s -l -w $(find ./sdk -name '*.go' -print) >&2
     displayName: 'Format Check'
     condition: succeededOrFailed()
     failOnStderr: true
-    workingDirectory: '${{parameters.GoWorkspace}}'
+    workingDirectory: '${{parameters.Directory}}'


### PR DESCRIPTION
Limit analyze to the service directory (it was scanning all of track 2)

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
