### PR TITLE
Ensure interactive auth flow can be cancelled

### DIFF
--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -382,7 +382,7 @@ func (c *aadIdentityClient) createDeviceCodeNumberRequest(ctx context.Context, t
 // authenticateInteractiveBrowser opens an interactive browser window, gets the authorization code and requests an Access Token with the
 // authorization code and returns the token or an error in case of authentication failure.
 func (c *aadIdentityClient) authenticateInteractiveBrowser(ctx context.Context, opts *InteractiveBrowserCredentialOptions, scopes []string) (*azcore.AccessToken, error) {
-	cfg, err := authCodeReceiver(c.authorityHost, opts, scopes)
+	cfg, err := authCodeReceiver(ctx, c.authorityHost, opts, scopes)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -34,10 +34,6 @@ type InteractiveBrowserCredentialOptions struct {
 	// The localhost port for the local server that will be used to redirect back.
 	// By default, a random port number will be selected.
 	Port int
-	// Deprecated: Disables use of PKCE during authorization.
-	// The default is false.
-	// TODO: remove
-	DisablePKCE bool
 	// The host of the Azure Active Directory authority. The default is AzurePublicCloud.
 	// Leave empty to allow overriding the value from the AZURE_AUTHORITY_HOST environment variable.
 	AuthorityHost string

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -34,8 +34,9 @@ type InteractiveBrowserCredentialOptions struct {
 	// The localhost port for the local server that will be used to redirect back.
 	// By default, a random port number will be selected.
 	Port int
-	// Disables use of PKCE during authorization.
+	// Deprecated: Disables use of PKCE during authorization.
 	// The default is false.
+	// TODO: remove
 	DisablePKCE bool
 	// The host of the Azure Active Directory authority. The default is AzurePublicCloud.
 	// Leave empty to allow overriding the value from the AZURE_AUTHORITY_HOST environment variable.
@@ -112,13 +113,13 @@ func (c *InteractiveBrowserCredential) AuthenticationPolicy(options azcore.Authe
 var _ azcore.TokenCredential = (*InteractiveBrowserCredential)(nil)
 
 // authCodeReceiver is used to allow for testing without opening an interactive browser window. Allows mocking a response authorization code and redirect URI.
-var authCodeReceiver = func(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
-	return interactiveBrowserLogin(authorityHost, opts, scopes)
+var authCodeReceiver = func(ctx context.Context, authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
+	return interactiveBrowserLogin(ctx, authorityHost, opts, scopes)
 }
 
 // interactiveBrowserLogin opens an interactive browser with the specified tenant and client IDs provided then returns the authorization code
 // received or an error.
-func interactiveBrowserLogin(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
+func interactiveBrowserLogin(ctx context.Context, authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
 	// start local redirect server so login can call us back
 	rs := newServer()
 	state := uuid.New().String()
@@ -140,28 +141,27 @@ func interactiveBrowserLogin(authorityHost string, opts *InteractiveBrowserCrede
 	values.Add("scope", strings.Join(scopes, " "))
 	values.Add("prompt", "select_account")
 	cv := ""
-	if opts.DisablePKCE == false {
-		// the code verifier is a random 32-byte sequence that's been base-64 encoded without padding.
-		// it's used to prevent MitM attacks during auth code flow, see https://tools.ietf.org/html/rfc7636
-		b := make([]byte, 32, 32)
-		if _, err := rand.Read(b); err != nil {
-			return nil, err
-		}
-		cv = base64.RawURLEncoding.EncodeToString(b)
-		// for PKCE, create a hash of the code verifier
-		cvh := sha256.Sum256([]byte(cv))
-		values.Add("code_challenge", base64.RawURLEncoding.EncodeToString(cvh[:]))
-		values.Add("code_challenge_method", "S256")
+	// the code verifier is a random 32-byte sequence that's been base-64 encoded without padding.
+	// it's used to prevent MitM attacks during auth code flow, see https://tools.ietf.org/html/rfc7636
+	b := make([]byte, 32, 32)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
 	}
+	cv = base64.RawURLEncoding.EncodeToString(b)
+	// for PKCE, create a hash of the code verifier
+	cvh := sha256.Sum256([]byte(cv))
+	values.Add("code_challenge", base64.RawURLEncoding.EncodeToString(cvh[:]))
+	values.Add("code_challenge_method", "S256")
 	u.Path = azcore.JoinPaths(u.Path, opts.TenantID, authEndpoint)
 	u.RawQuery = values.Encode()
 	// open browser window so user can select credentials
-	err = browser.OpenURL(u.String())
-	if err != nil {
+	if err = browser.OpenURL(u.String()); err != nil {
 		return nil, err
 	}
 	// now wait until the logic calls us back
-	rs.WaitForCallback()
+	if err := rs.WaitForCallback(ctx); err != nil {
+		return nil, err
+	}
 
 	authCode, err := rs.AuthorizationCode()
 	if err != nil {

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -63,7 +63,7 @@ func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	authCodeReceiver = func(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
+	authCodeReceiver = func(ctx context.Context, authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
 		return &interactiveConfig{
 			authCode:    "12345",
 			redirectURI: srv.URL(),
@@ -96,7 +96,7 @@ func TestInteractiveBrowserCredential_SetPort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	authCodeReceiver = func(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
+	authCodeReceiver = func(ctx context.Context, authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
 		if opts.Port != 8080 {
 			t.Fatalf("Did not receive the correct port. Expected: %v, Received: %v", 8080, opts.Port)
 		}
@@ -132,7 +132,7 @@ func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	authCodeReceiver = func(authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
+	authCodeReceiver = func(ctx context.Context, authorityHost string, opts *InteractiveBrowserCredentialOptions, scopes []string) (*interactiveConfig, error) {
 		return &interactiveConfig{
 			authCode:    "12345",
 			redirectURI: srv.URL(),


### PR DESCRIPTION
Replaced WaitGroup with channel.
Flow context to WaitForCallback() and select on both channels.
Disabling PKCE should not be allowed.  The functionality was disabled
and the config option can be removed in the next breaking change.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
