### PR TITLE
[SDK automation] Now use commit hash instead of the spec root in changelog

### DIFF
--- a/tools/generator/cmd/metadata.go
+++ b/tools/generator/cmd/metadata.go
@@ -34,7 +34,7 @@ func (ctx changelogContext) SpecRoot() string {
 }
 
 func (ctx changelogContext) SpecCommitHash() string {
-	return ctx.specRoot
+	return ctx.commitHash
 }
 
 func (ctx changelogContext) CodeGenVersion() string {


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
