### PR TITLE
Fix a concurrency issue in profileBuilder

### DIFF
--- a/tools/profileBuilder/cmd/latest.go
+++ b/tools/profileBuilder/cmd/latest.go
@@ -86,7 +86,7 @@ By default, this command ignores API versions that are in preview.`,
 		}
 		listDef, err := model.GetLatestPackages(rootDir, includePreview, outputLog)
 		// don't recursively build profiles as we already built the list of packages recursively
-		model.BuildProfile(listDef, profileName, outputRootDir, outputLog, errLog, false, modulesFlag)
+		model.BuildProfile(listDef, profileName, outputRootDir, outputLog, errLog, false, modulesFlag, semLimit)
 	},
 }
 

--- a/tools/profileBuilder/cmd/list.go
+++ b/tools/profileBuilder/cmd/list.go
@@ -127,7 +127,7 @@ $> ../model/testdata/smallProfile.txt > profileBuilder list --name small_profile
 			}
 		}
 		// use recursive build to include the *api packages
-		model.BuildProfile(listDef, profileName, outputRootDir, outputLog, errLog, true, modulesFlag)
+		model.BuildProfile(listDef, profileName, outputRootDir, outputLog, errLog, true, modulesFlag, semLimit)
 	},
 }
 

--- a/tools/profileBuilder/cmd/root.go
+++ b/tools/profileBuilder/cmd/root.go
@@ -30,6 +30,7 @@ var (
 	modulesFlag     bool
 	profileName     string
 	outputRootDir   string
+	semLimit        int
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -62,6 +63,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&modulesFlag, "modules", "m", false, "Executes commands in modules-aware mode.")
 	rootCmd.PersistentFlags().StringVarP(&profileName, "name", "n", "", "The name that should be used to identify the profile.")
 	rootCmd.PersistentFlags().StringVarP(&outputRootDir, "output-location", "o", "", "The folder in which to output the generated profile.")
+	rootCmd.PersistentFlags().IntVar(&semLimit, "sem-limit", 8, "The limit of the maximum goroutines")
 	rootCmd.MarkPersistentFlagRequired("name")
 	rootCmd.MarkPersistentFlagRequired("output-location")
 }

--- a/tools/profileBuilder/cmd/root.go
+++ b/tools/profileBuilder/cmd/root.go
@@ -63,7 +63,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&modulesFlag, "modules", "m", false, "Executes commands in modules-aware mode.")
 	rootCmd.PersistentFlags().StringVarP(&profileName, "name", "n", "", "The name that should be used to identify the profile.")
 	rootCmd.PersistentFlags().StringVarP(&outputRootDir, "output-location", "o", "", "The folder in which to output the generated profile.")
-	rootCmd.PersistentFlags().IntVar(&semLimit, "sem-limit", 8, "The limit of the maximum goroutines")
+	rootCmd.PersistentFlags().IntVar(&semLimit, "sem-limit", 8, "The maximum number of packages to concurrently build.")
 	rootCmd.MarkPersistentFlagRequired("name")
 	rootCmd.MarkPersistentFlagRequired("output-location")
 }

--- a/tools/profileBuilder/model/transforms.go
+++ b/tools/profileBuilder/model/transforms.go
@@ -33,7 +33,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -56,13 +55,7 @@ const (
 )
 
 // BuildProfile takes a list of packages and creates a profile
-func BuildProfile(packageList ListDefinition, name, outputLocation string, outputLog, errLog *log.Logger, recursive, modules bool) {
-	// limit the number of concurrent calls to parser.ParseDir()
-	semLimit := 32
-	if runtime.GOOS == "darwin" {
-		// set a lower limit for darwin as it runs out of file handles
-		semLimit = 16
-	}
+func BuildProfile(packageList ListDefinition, name, outputLocation string, outputLog, errLog *log.Logger, recursive, modules bool, semLimit int) {
 	sem := make(chan struct{}, semLimit)
 	wg := &sync.WaitGroup{}
 	wg.Add(len(packageList.Include))


### PR DESCRIPTION
limit the maximum concurrency to 8 by default, add a flag to manually set this

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
