### PR TITLE
ProfileBuilder: turn the concurrency off by default

### DIFF
--- a/tools/profileBuilder/cmd/root.go
+++ b/tools/profileBuilder/cmd/root.go
@@ -63,7 +63,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&modulesFlag, "modules", "m", false, "Executes commands in modules-aware mode.")
 	rootCmd.PersistentFlags().StringVarP(&profileName, "name", "n", "", "The name that should be used to identify the profile.")
 	rootCmd.PersistentFlags().StringVarP(&outputRootDir, "output-location", "o", "", "The folder in which to output the generated profile.")
-	rootCmd.PersistentFlags().IntVar(&semLimit, "sem-limit", 8, "The maximum number of packages to concurrently build.")
+	rootCmd.PersistentFlags().IntVar(&semLimit, "sem-limit", 1, "The maximum number of packages to concurrently build. The concurrency is off by default to avoid causing issues on some operation systems.")
 	rootCmd.MarkPersistentFlagRequired("name")
 	rootCmd.MarkPersistentFlagRequired("output-location")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
