### PR TITLE
Add a new method to get cosmosdb client

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -356,6 +356,26 @@ func (s *StorageClientSuite) TestIsValidStorageAccount(c *chk.C) {
 	}
 }
 
+func (s *StorageClientSuite) TestIsValidCosmosAccount(c *chk.C) {
+	type test struct {
+		account  string
+		expected bool
+	}
+	testCases := []test{
+		{"name1", true},
+		{"Name2", false},
+		{"really-long-valid-name-less-than-44-chars", true},
+		{"really-long-invalid-name-greater-than-44-chars", false},
+		{"", false},
+		{"concated&name", false},
+		{"formatted name", false},
+	}
+
+	for _, tc := range testCases {
+		c.Assert(IsValidCosmosAccount(tc.account), chk.Equals, tc.expected)
+	}
+}
+
 func (s *StorageClientSuite) TestMalformedKeyError(c *chk.C) {
 	_, err := NewBasicClient(dummyStorageAccount, "malformed")
 	c.Assert(err, chk.ErrorMatches, "azure: malformed storage account key: .*")


### PR DESCRIPTION
The account name restrictions for cosmosdb are different than the ones enforced by
azure storage. This change adds a new method to return a cosmos client that allows
cosmosdb account name as enforced by azure cosmos db.
The cosmos account name can only contain lowercase letters, numbers, and the hyphen (-)
character. It must be between 3-44 characters in length.
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
