### PR TITLE
Add support for encoding JSON null values

### DIFF
--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"reflect"
 )
 
 // Policy represents an extensibility point for the Pipeline that can mutate the specified
@@ -144,4 +145,42 @@ type Pager interface {
 
 	// Err returns the last error encountered while paging.
 	Err() error
+}
+
+// holds sentinel values used to send nulls
+var nullables map[reflect.Type]interface{} = map[reflect.Type]interface{}{}
+
+// NullValue is used to send an explicit 'null' within a request.
+// This is typically used in JSON-PATCH operations to delete a value.
+func NullValue(v interface{}) interface{} {
+	t := reflect.TypeOf(v)
+	if t.Kind() != reflect.Ptr {
+		// t is not of pointer type, make it be of pointer type
+		t = reflect.PtrTo(t)
+	}
+	v, found := nullables[t]
+	if !found {
+		o := reflect.New(t.Elem())
+		v = o.Interface()
+		nullables[t] = v
+	}
+	// return the sentinel object
+	return v
+}
+
+// IsNullValue returns true if the field contains a null sentinel value.
+// This is used by custom marshallers to properly encode a null value.
+func IsNullValue(v interface{}) bool {
+	// see if our map has a sentinel object for this *T
+	t := reflect.TypeOf(v)
+	if t.Kind() != reflect.Ptr {
+		// v isn't a pointer type so it can never be a null
+		return false
+	}
+	if o, found := nullables[t]; found {
+		// we found it; return true if v points to the sentinel object
+		return o == v
+	}
+	// no sentinel object for this *t
+	return false
 }

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -151,7 +151,7 @@ type Pager interface {
 var nullables map[reflect.Type]interface{} = map[reflect.Type]interface{}{}
 
 // NullValue is used to send an explicit 'null' within a request.
-// This is typically used in JSON-PATCH operations to delete a value.
+// This is typically used in JSON-MERGE-PATCH operations to delete a value.
 func NullValue(v interface{}) interface{} {
 	t := reflect.TypeOf(v)
 	if t.Kind() != reflect.Ptr {

--- a/sdk/azcore/core_test.go
+++ b/sdk/azcore/core_test.go
@@ -1,0 +1,52 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcore
+
+import "testing"
+
+func TestNullValue(t *testing.T) {
+	v := NullValue("")
+	if _, ok := v.(*string); !ok {
+		t.Fatalf("unexpected type %T", v)
+	}
+	vv := NullValue((*string)(nil))
+	if _, ok := vv.(*string); !ok {
+		t.Fatalf("unexpected type %T", vv)
+	}
+	if v != vv {
+		t.Fatal("null values should match for the same types")
+	}
+	i := NullValue(1)
+	if _, ok := i.(*int); !ok {
+		t.Fatalf("unexpected type %T", v)
+	}
+	if v == i {
+		t.Fatal("null values for string and int should not match")
+	}
+}
+
+func TestIsNullValue(t *testing.T) {
+	if IsNullValue("") {
+		t.Fatal("string literal can't be a null value")
+	}
+	s := ""
+	if IsNullValue(&s) {
+		t.Fatal("&s isn't a null value")
+	}
+	var i *int
+	if IsNullValue(i) {
+		t.Fatal("i isn't a null value")
+	}
+	i = NullValue(0).(*int)
+	if !IsNullValue(i) {
+		t.Fatal("expected null value for i")
+	}
+	i2 := 0
+	i = &i2
+	if IsNullValue(i) {
+		t.Fatal("i should no longer be null value")
+	}
+}

--- a/sdk/azcore/doc.go
+++ b/sdk/azcore/doc.go
@@ -125,6 +125,36 @@ If the Request should contain a body, call the SetBody method.
 A seekable stream is required so that upon retry, the retry Policy instance can seek the stream
 back to the beginning before retrying the network request and re-uploading the body.
 
+Sending an Explicit Null
+
+Operations like JSON-PATCH send a JSON null to indicate a value should be deleted.
+
+   {
+      "delete-me": null
+   }
+
+This requirement conflicts with the SDK's default marshalling that specifies "omitempty" as
+a means to resolve the ambiguity between a field to be excluded and its zero-value.
+
+   type Widget struct {
+      Name  *string `json:",omitempty"`
+      Count *int    `json:",omitempty"`
+   }
+
+In the above example, Name and Count are defined as pointer-to-type to disambiguate between
+a missing value (nil) and a zero-value (0) which might have semantic differences.
+
+In a PATCH operation, any fields left as `nil` are to have their values preserved.  When updating
+a Widget's count, one simply specifies the new value for Count, leaving Name nil.
+
+To fulfill the requirement for sending a JSON null, the NullValue() function can be used.
+
+   w := Widget{
+      Count: azcore.NullValue(0).(*int),
+   }
+
+This sends an explict "null" for Count, indicating that any current value for Count should be deleted.
+
 Processing the Response
 
 When the HTTP response is received, the underlying *http.Response is wrapped in a Response type.

--- a/sdk/azcore/doc.go
+++ b/sdk/azcore/doc.go
@@ -127,7 +127,7 @@ back to the beginning before retrying the network request and re-uploading the b
 
 Sending an Explicit Null
 
-Operations like JSON-PATCH send a JSON null to indicate a value should be deleted.
+Operations like JSON-MERGE-PATCH send a JSON null to indicate a value should be deleted.
 
    {
       "delete-me": null

--- a/sdk/azcore/example_test.go
+++ b/sdk/azcore/example_test.go
@@ -8,6 +8,7 @@ package azcore_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -66,4 +67,34 @@ func ExampleLogger_SetListener() {
 	azcore.Log().SetListener(func(cls azcore.LogClassification, msg string) {
 		fmt.Printf("%s: %s\n", cls, msg)
 	})
+}
+
+type Widget struct {
+	Name  *string `json:",omitempty"`
+	Count *int    `json:",omitempty"`
+}
+
+func (w Widget) MarshalJSON() ([]byte, error) {
+	msg := map[string]interface{}{}
+	if azcore.IsNullValue(w.Name) {
+		msg["name"] = nil
+	} else if w.Name != nil {
+		msg["name"] = w.Name
+	}
+	if azcore.IsNullValue(w.Count) {
+		msg["count"] = nil
+	} else if w.Count != nil {
+		msg["count"] = w.Count
+	}
+	return json.Marshal(msg)
+}
+
+func ExampleNullValue() {
+	w := Widget{
+		Count: azcore.NullValue(0).(*int),
+	}
+	b, _ := json.Marshal(w)
+	fmt.Println(string(b))
+	// Output:
+	// {"count":null}
 }

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -131,22 +131,20 @@ func (req *Request) MarshalAsByteArray(v []byte, format Base64Encoding) error {
 }
 
 // MarshalAsJSON calls json.Marshal() to get the JSON encoding of v then calls SetBody.
-// If json.Marshal fails a MarshalError is returned.  Any error from SetBody is returned.
 func (req *Request) MarshalAsJSON(v interface{}) error {
 	v = cloneWithoutReadOnlyFields(v)
 	b, err := json.Marshal(v)
 	if err != nil {
-		return fmt.Errorf("error marshalling type %s: %w", reflect.TypeOf(v).Name(), err)
+		return fmt.Errorf("error marshalling type %T: %s", v, err)
 	}
 	return req.SetBody(NopCloser(bytes.NewReader(b)), contentTypeAppJSON)
 }
 
 // MarshalAsXML calls xml.Marshal() to get the XML encoding of v then calls SetBody.
-// If xml.Marshal fails a MarshalError is returned.  Any error from SetBody is returned.
 func (req *Request) MarshalAsXML(v interface{}) error {
 	b, err := xml.Marshal(v)
 	if err != nil {
-		return fmt.Errorf("error marshalling type %s: %w", reflect.TypeOf(v).Name(), err)
+		return fmt.Errorf("error marshalling type %T: %s", v, err)
 	}
 	return req.SetBody(NopCloser(bytes.NewReader(b)), contentTypeAppXML)
 }

--- a/sdk/azcore/response.go
+++ b/sdk/azcore/response.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -89,7 +88,6 @@ func (r *Response) UnmarshalAsByteArray(v **[]byte, format Base64Encoding) error
 }
 
 // UnmarshalAsJSON calls json.Unmarshal() to unmarshal the received payload into the value pointed to by v.
-// If no payload was received a RequestError is returned.  If json.Unmarshal fails a UnmarshalError is returned.
 func (r *Response) UnmarshalAsJSON(v interface{}) error {
 	payload, err := r.payload()
 	if err != nil {
@@ -105,13 +103,12 @@ func (r *Response) UnmarshalAsJSON(v interface{}) error {
 	}
 	err = json.Unmarshal(payload, v)
 	if err != nil {
-		err = fmt.Errorf("unmarshalling type %s: %w", reflect.TypeOf(v).Elem().Name(), err)
+		err = fmt.Errorf("unmarshalling type %T: %s", v, err)
 	}
 	return err
 }
 
 // UnmarshalAsXML calls xml.Unmarshal() to unmarshal the received payload into the value pointed to by v.
-// If no payload was received a RequestError is returned.  If xml.Unmarshal fails a UnmarshalError is returned.
 func (r *Response) UnmarshalAsXML(v interface{}) error {
 	payload, err := r.payload()
 	if err != nil {
@@ -127,7 +124,7 @@ func (r *Response) UnmarshalAsXML(v interface{}) error {
 	}
 	err = xml.Unmarshal(payload, v)
 	if err != nil {
-		err = fmt.Errorf("unmarshalling type %s: %w", reflect.TypeOf(v).Elem().Name(), err)
+		err = fmt.Errorf("unmarshalling type %T: %s", v, err)
 	}
 	return err
 }


### PR DESCRIPTION
This adds NullValue() and IsNullValue() functions for setting and
detecting sentinel values used for encoding a JSON null.
Cleaned up some improper error wrapping and removed out-dated comments.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
