### PR TITLE
Add support for multi-part form data

### DIFF
--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -184,6 +185,44 @@ func (req *Request) SetBody(body ReadSeekCloser, contentType string) error {
 	req.Request.ContentLength = size
 	req.Header.Set(HeaderContentType, contentType)
 	req.Header.Set(HeaderContentLength, strconv.FormatInt(size, 10))
+	return nil
+}
+
+// WriteMultipartFormData writes the specified keys/values as multi-part form
+// fields with the specified value.  File content must be specified as a ReadSeekCloser.
+// All other values are treated as string values.
+func (req *Request) WriteMultipartFormData(formData map[string]interface{}) error {
+	body := bytes.Buffer{}
+	writer := multipart.NewWriter(&body)
+	for k, v := range formData {
+		if rsc, ok := v.(ReadSeekCloser); ok {
+			// this is the body to upload, the key is its file name
+			fd, err := writer.CreateFormFile(k, k)
+			if err != nil {
+				return err
+			}
+			// copy the data to the form file
+			if _, err = io.Copy(fd, rsc); err != nil {
+				return err
+			}
+			continue
+		}
+		// ensure the value is in string format
+		s, ok := v.(string)
+		if !ok {
+			s = fmt.Sprintf("%v", v)
+		}
+		if err := writer.WriteField(k, s); err != nil {
+			return err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+	req.Body = NopCloser(bytes.NewReader(body.Bytes()))
+	req.ContentLength = int64(body.Len())
+	req.Header.Set(HeaderContentType, writer.FormDataContentType())
+	req.Header.Set(HeaderContentLength, strconv.FormatInt(req.ContentLength, 10))
 	return nil
 }
 

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -188,10 +188,10 @@ func (req *Request) SetBody(body ReadSeekCloser, contentType string) error {
 	return nil
 }
 
-// WriteMultipartFormData writes the specified keys/values as multi-part form
+// SetMultipartFormData writes the specified keys/values as multi-part form
 // fields with the specified value.  File content must be specified as a ReadSeekCloser.
 // All other values are treated as string values.
-func (req *Request) WriteMultipartFormData(formData map[string]interface{}) error {
+func (req *Request) SetMultipartFormData(formData map[string]interface{}) error {
 	body := bytes.Buffer{}
 	writer := multipart.NewWriter(&body)
 	for k, v := range formData {

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -10,10 +10,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"unsafe"
 )
@@ -535,5 +539,67 @@ func TestRequestValidFail(t *testing.T) {
 	}
 	if resp != nil {
 		t.Fatal("unexpected response")
+	}
+}
+
+func TestWriteMultipartFormData(t *testing.T) {
+	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = req.WriteMultipartFormData(map[string]interface{}{
+		"string": "value",
+		"int":    1,
+		"data":   NopCloser(strings.NewReader("some data")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mt, params, err := mime.ParseMediaType(req.Header.Get(HeaderContentType))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mt != "multipart/form-data" {
+		t.Fatalf("unexpected media type %s", mt)
+	}
+	reader := multipart.NewReader(req.Body, params["boundary"])
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		switch fn := part.FormName(); fn {
+		case "string":
+			strPart := make([]byte, 16)
+			_, err = part.Read(strPart)
+			if err != io.EOF {
+				t.Fatal(err)
+			}
+			if tr := string(strPart[:5]); tr != "value" {
+				t.Fatalf("unexpected value %s", tr)
+			}
+		case "int":
+			intPart := make([]byte, 16)
+			_, err = part.Read(intPart)
+			if err != io.EOF {
+				t.Fatal(err)
+			}
+			if tr := string(intPart[:1]); tr != "1" {
+				t.Fatalf("unexpected value %s", tr)
+			}
+		case "data":
+			dataPart := make([]byte, 16)
+			_, err = part.Read(dataPart)
+			if err != io.EOF {
+				t.Fatal(err)
+			}
+			if tr := string(dataPart[:9]); tr != "some data" {
+				t.Fatalf("unexpected value %s", tr)
+			}
+		default:
+			t.Fatalf("unexpected part %s", fn)
+		}
 	}
 }

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -542,12 +542,12 @@ func TestRequestValidFail(t *testing.T) {
 	}
 }
 
-func TestWriteMultipartFormData(t *testing.T) {
+func TestSetMultipartFormData(t *testing.T) {
 	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = req.WriteMultipartFormData(map[string]interface{}{
+	err = req.SetMultipartFormData(map[string]interface{}{
 		"string": "value",
 		"int":    1,
 		"data":   NopCloser(strings.NewReader("some data")),


### PR DESCRIPTION
Added method WriteMultipartFormData() to Request.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
