### PR TITLE
Simplify injecting custom pipeline policies

### DIFF
--- a/sdk/armcore/version.go
+++ b/sdk/armcore/version.go
@@ -10,5 +10,5 @@ const (
 	UserAgent = "armcore/" + Version
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v0.5.1"
+	Version = "v0.7.0"
 )


### PR DESCRIPTION
Removed NewConnectionWithPipeline() in favor of policy slices in
ConnectionOptions.  The slices are to control where the policies are
injected in the pipeline, either before or after the retry policy.
Update version number for pending release.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] Apache v2 license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
