### PR TITLE
Migrate license to MIT

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Please verify the following before submitting your PR, thank you!
    - These files are managed by the codegen framework at [Azure/autorest.go][].
 - [ ] Tests are included and/or updated for code changes.
 - [ ] Updates to [CHANGELOG.md][] are included.
-- [ ] Apache v2 license headers are included in each file.
+- [ ] MIT license headers are included in each file.
  
 [Azure/autorest.go]: https://github.com/Azure/autorest.go
 [CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md


### PR DESCRIPTION
Update a license to MIT at a line of license headers check.