### PR TITLE
Send the -d switch to gofmt

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
       displayName: 'Copyright Header Check'
       failOnStderr: true
       condition: succeededOrFailed()
-    - script: gofmt -s -l -w $(find . -path ./vendor -prune -o -name '*.go' -print) >&2
+    - script: gofmt -s -l -d $(find . -path ./vendor -prune -o -name '*.go' -print) >&2
       workingDirectory: '$(sdkPath)'
       displayName: 'Format Check'
       failOnStderr: true

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -40,7 +40,7 @@ steps:
 
   - script: |
       echo check source file formatting in $(pwd)
-      gofmt -s -l -w $(find . -name '*.go' -print) >&2
+      gofmt -s -l -d $(find . -name '*.go' -print) >&2
     displayName: 'Format Check'
     condition: succeededOrFailed()
     failOnStderr: true


### PR DESCRIPTION
Sending the -d switch to gofmt makes the build failure output more useful. Rather than just listing the file names that failed format checks, the file diffs will be displayed indicating what needs to be changed. Ex.

```bash
gofmt -s -l -d $(find . -name '*.go' -print)
./testcontext.go
diff -u ./testcontext.go.orig ./testcontext.go
--- ./testcontext.go.orig       2021-04-06 13:46:59.500000000 -0500
+++ ./testcontext.go    2021-04-06 13:46:59.500000000 -0500
@@ -34,4 +34,4 @@
 }
 func (c *testContext) Name() string {
        return c.name
-}
+}
```