### PR TITLE
Fix gosimple linter warnings

### DIFF
--- a/sdk/armcore/connection.go
+++ b/sdk/armcore/connection.go
@@ -82,7 +82,7 @@ func NewConnection(endpoint string, cred azcore.TokenCredential, options *Connec
 	policies := []azcore.Policy{
 		azcore.NewTelemetryPolicy(&options.Telemetry),
 	}
-	if options.DisableRPRegistration == false {
+	if !options.DisableRPRegistration {
 		regRPOpts := RegistrationOptions{
 			HTTPClient: options.HTTPClient,
 			Logging:    options.Logging,

--- a/sdk/armcore/poller.go
+++ b/sdk/armcore/poller.go
@@ -912,7 +912,7 @@ func (pt *pollingTrackerPut) provisioningStateApplicable() bool {
 // gets the polling URL from the Azure-AsyncOperation header.
 // ensures the URL is well-formed and absolute.
 func getURLFromAsyncOpHeader(resp *azcore.Response) (string, error) {
-	s := resp.Header.Get(http.CanonicalHeaderKey(headerAsyncOperation))
+	s := resp.Header.Get(headerAsyncOperation)
 	if s == "" {
 		return "", nil
 	}
@@ -925,7 +925,7 @@ func getURLFromAsyncOpHeader(resp *azcore.Response) (string, error) {
 // gets the polling URL from the Location header.
 // ensures the URL is well-formed and absolute.
 func getURLFromLocationHeader(resp *azcore.Response) (string, error) {
-	s := resp.Header.Get(http.CanonicalHeaderKey(headerLocation))
+	s := resp.Header.Get(headerLocation)
 	if s == "" {
 		return "", nil
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

This PR fixes linter warnings from gosimple.

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
