### PR TITLE
Mark ResponseError as NonRetriable()

### DIFF
--- a/sdk/internal/runtime/response_error.go
+++ b/sdk/internal/runtime/response_error.go
@@ -36,3 +36,8 @@ func (e *ResponseError) Unwrap() error {
 func (e *ResponseError) RawResponse() *http.Response {
 	return e.resp
 }
+
+// NonRetriable indicates this error is non-transient.
+func (e *ResponseError) NonRetriable() {
+	// marker method
+}


### PR DESCRIPTION
ResponseError types are returned from failed API calls, e.g. the caller
provided invalid inputs.  Since these errors are not transient they
should be marked as NonRetriable() so customers can test for this.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
