### PR TITLE
Update to latest internal module

### DIFF
--- a/sdk/azcore/error.go
+++ b/sdk/azcore/error.go
@@ -50,3 +50,5 @@ type NonRetriableError interface {
 func NewResponseError(inner error, resp *http.Response) error {
 	return sdkruntime.NewResponseError(inner, resp)
 }
+
+var _ NonRetriableError = (*sdkruntime.ResponseError)(nil)

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -1,7 +1,7 @@
 module github.com/Azure/azure-sdk-for-go/sdk/azcore
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1
 	golang.org/x/net v0.0.0-20201010224723-4f7140c49acb
 )
 

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
Ensure that ResponseError is a NonRetriableError

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
