### PR TITLE
Track2: azcore log remove some duplicate code

### DIFF
--- a/sdk/azcore/log.go
+++ b/sdk/azcore/log.go
@@ -77,16 +77,13 @@ func (l *Logger) Should(cls LogClassification) bool {
 // Write invokes the underlying Listener with the specified classification and message.
 // If the classification shouldn't be logged or there is no listener then Write does nothing.
 func (l *Logger) Write(cls LogClassification, message string) {
-	if l.lst == nil || !l.Should(cls) {
-		return
-	}
-	l.lst(cls, message)
+	l.Writef(cls, "%s", message)
 }
 
 // Writef invokes the underlying Listener with the specified classification and formatted message.
 // If the classification shouldn't be logged or there is no listener then Writef does nothing.
 func (l *Logger) Writef(cls LogClassification, format string, a ...interface{}) {
-	if l.lst == nil || !l.Should(cls) {
+	if !l.Should(cls) {
 		return
 	}
 	l.lst(cls, fmt.Sprintf(format, a...))

--- a/sdk/azcore/log.go
+++ b/sdk/azcore/log.go
@@ -77,7 +77,10 @@ func (l *Logger) Should(cls LogClassification) bool {
 // Write invokes the underlying Listener with the specified classification and message.
 // If the classification shouldn't be logged or there is no listener then Write does nothing.
 func (l *Logger) Write(cls LogClassification, message string) {
-	l.Writef(cls, "%s", message)
+	if !l.Should(cls) {
+		return
+	}
+	l.lst(cls, message)
 }
 
 // Writef invokes the underlying Listener with the specified classification and formatted message.


### PR DESCRIPTION
The PR removes some duplicate code in azcore log.go:

- Remove the check on `l.lst` in `Logger.Writef` as it is checked in `Logger.Should` already
- Reuse `Logger.Writef` in `Logger.Write` to DRY.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
