### PR TITLE
Support for basic LRO polling

### DIFF
--- a/sdk/azcore/headers.go
+++ b/sdk/azcore/headers.go
@@ -28,3 +28,8 @@ const (
 	HeaderXmsDate            = "x-ms-date"
 	HeaderXmsVersion         = "x-ms-version"
 )
+
+const (
+	headerOperationLocation = "Operation-Location"
+	headerLocation          = "Location"
+)

--- a/sdk/azcore/policy_logging.go
+++ b/sdk/azcore/policy_logging.go
@@ -98,8 +98,8 @@ func (p *logPolicy) Do(req *Request) (*Response, error) {
 // this is determined by looking at the content-type header value.
 func shouldLogBody(b *bytes.Buffer, contentType string) bool {
 	if strings.HasPrefix(contentType, "text") ||
-		strings.HasSuffix(contentType, "json") ||
-		strings.HasSuffix(contentType, "xml") {
+		strings.Contains(contentType, "json") ||
+		strings.Contains(contentType, "xml") {
 		return true
 	}
 	fmt.Fprintf(b, "   Skip logging body for %s\n", contentType)

--- a/sdk/azcore/policy_logging.go
+++ b/sdk/azcore/policy_logging.go
@@ -97,6 +97,7 @@ func (p *logPolicy) Do(req *Request) (*Response, error) {
 // returns true if the request/response body should be logged.
 // this is determined by looking at the content-type header value.
 func shouldLogBody(b *bytes.Buffer, contentType string) bool {
+	contentType = strings.ToLower(contentType)
 	if strings.HasPrefix(contentType, "text") ||
 		strings.Contains(contentType, "json") ||
 		strings.Contains(contentType, "xml") {

--- a/sdk/azcore/poller.go
+++ b/sdk/azcore/poller.go
@@ -18,11 +18,6 @@ import (
 	"time"
 )
 
-const (
-	headerOperationLocation = "Operation-Location"
-	headerLocation          = "Location"
-)
-
 // ErrorUnmarshaller is the func to invoke when the endpoint returns an error response that requires unmarshalling.
 type ErrorUnmarshaller func(*Response) error
 

--- a/sdk/azcore/poller.go
+++ b/sdk/azcore/poller.go
@@ -1,0 +1,453 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	headerOperationLocation = "Operation-Location"
+	headerLocation          = "Location"
+)
+
+// ErrorUnmarshaller is the func to invoke when the endpoint returns an error response that requires unmarshalling.
+type ErrorUnmarshaller func(*Response) error
+
+// NewLROPoller creates an LROPoller based on the provided initial response.
+// NOTE: this is only meant for internal use in generated code.
+func NewLROPoller(pollerType string, resp *Response, pl Pipeline, eu ErrorUnmarshaller) (*LROPoller, error) {
+	// this is a back-stop in case the swagger is incorrect (i.e. missing one or more status codes for success).
+	// ideally the codegen should return an error if the initial response failed and not even create a poller.
+	if !lroStatusCodeValid(resp) {
+		return nil, errors.New("the operation failed or was cancelled")
+	}
+	opLoc := resp.Header.Get(headerOperationLocation)
+	loc := resp.Header.Get(headerLocation)
+	// in the case of both headers, always prefer the operation-location header
+	if opLoc != "" {
+		return &LROPoller{
+			lro:  newOpPoller(pollerType, opLoc, loc, resp),
+			pl:   pl,
+			eu:   eu,
+			resp: resp,
+		}, nil
+	}
+	if loc != "" {
+		return &LROPoller{
+			lro:  newLocPoller(pollerType, loc, resp.StatusCode),
+			pl:   pl,
+			eu:   eu,
+			resp: resp,
+		}, nil
+	}
+	return &LROPoller{lro: &nopPoller{}, resp: resp}, nil
+}
+
+// NewLROPollerFromResumeToken creates an LROPoller from a resume token string.
+// NOTE: this is only meant for internal use in generated code.
+func NewLROPollerFromResumeToken(pollerType string, token string, pl Pipeline, eu ErrorUnmarshaller) (*LROPoller, error) {
+	// unmarshal into JSON object to determine the poller type
+	obj := map[string]interface{}{}
+	err := json.Unmarshal([]byte(token), &obj)
+	if err != nil {
+		return nil, err
+	}
+	t, ok := obj["type"]
+	if !ok {
+		return nil, errors.New("missing type field")
+	}
+	tt, ok := t.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid type format %T", t)
+	}
+	// the type is encoded as "pollerType;lroPoller"
+	sem := strings.LastIndex(tt, ";")
+	if sem < 0 {
+		return nil, fmt.Errorf("invalid poller type %s", tt)
+	}
+	// ensure poller types match
+	if received := tt[:sem]; received != pollerType {
+		return nil, fmt.Errorf("cannot resume from this poller token.  expected %s, received %s", pollerType, received)
+	}
+	// now rehydrate the poller based on the encoded poller type
+	var lro lroPoller
+	switch pt := tt[sem+1:]; pt {
+	case "opPoller":
+		lro = &opPoller{}
+	case "locPoller":
+		lro = &locPoller{}
+	default:
+		return nil, fmt.Errorf("unhandled lroPoller type %s", pt)
+	}
+	if err = json.Unmarshal([]byte(token), lro); err != nil {
+		return nil, err
+	}
+	return &LROPoller{lro: lro, pl: pl, eu: eu}, nil
+}
+
+// LROPoller encapsulates state and logic for polling on long-running operations.
+// NOTE: this is only meant for internal use in generated code.
+type LROPoller struct {
+	lro  lroPoller
+	pl   Pipeline
+	eu   ErrorUnmarshaller
+	resp *Response
+	err  error
+}
+
+// Done returns true if the LRO has reached a terminal state.
+func (l *LROPoller) Done() bool {
+	if l.err != nil {
+		return true
+	}
+	return l.lro.Done()
+}
+
+// Poll sends a polling request to the polling endpoint and returns the response or error.
+func (l *LROPoller) Poll(ctx context.Context) (*http.Response, error) {
+	if l.Done() {
+		// the LRO has reached a terminal state, don't poll again
+		if l.resp != nil {
+			return l.resp.Response, nil
+		}
+		return nil, l.err
+	}
+	req, err := NewRequest(ctx, http.MethodGet, l.lro.URL())
+	if err != nil {
+		return nil, err
+	}
+	resp, err := l.pl.Do(req)
+	if err != nil {
+		// don't update the poller for failed requests
+		return nil, err
+	}
+	if !lroStatusCodeValid(resp) {
+		// the LRO failed.  unmarshall the error and update state
+		l.err = l.eu(resp)
+		l.resp = nil
+		return nil, l.err
+	}
+	if err = l.lro.Update(resp); err != nil {
+		return nil, err
+	}
+	l.resp = resp
+	return l.resp.Response, nil
+}
+
+// ResumeToken returns a token string that can be used to resume a poller that has not yet reached a terminal state.
+func (l *LROPoller) ResumeToken() (string, error) {
+	if l.Done() {
+		return "", errors.New("cannot create a ResumeToken from a poller in a terminal state")
+	}
+	b, err := json.Marshal(l.lro)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// FinalResponse will perform a final GET request and return the final HTTP response for the polling
+// operation and unmarshall the content of the payload into the respType interface that is provided.
+func (l *LROPoller) FinalResponse(ctx context.Context, respType interface{}) (*http.Response, error) {
+	if !l.Done() {
+		return nil, errors.New("cannot return a final response from a poller in a non-terminal state")
+	}
+	// if there's nothing to unmarshall into just return the final response
+	if respType == nil {
+		return l.resp.Response, nil
+	}
+	u, err := l.lro.FinalGetURL(l.resp)
+	if err != nil {
+		return nil, err
+	}
+	if u != "" {
+		req, err := NewRequest(ctx, http.MethodGet, u)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := l.pl.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if !lroStatusCodeValid(resp) {
+			return nil, l.eu(resp)
+		}
+		l.resp = resp
+	}
+	body, err := ioutil.ReadAll(l.resp.Body)
+	l.resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	if err = json.Unmarshal(body, respType); err != nil {
+		return nil, err
+	}
+	return l.resp.Response, nil
+}
+
+// PollUntilDone will handle the entire span of the polling operation until a terminal state is reached,
+// then return the final HTTP response for the polling operation and unmarshal the content of the payload
+// into the respType interface that is provided.
+func (l *LROPoller) PollUntilDone(ctx context.Context, freq time.Duration, respType interface{}) (*http.Response, error) {
+	logPollUntilDoneExit := func(v interface{}) {
+		Log().Writef(LogLongRunningOperation, "END PollUntilDone() for %T: %v", l.lro, v)
+	}
+	Log().Writef(LogLongRunningOperation, "BEGIN PollUntilDone() for %T", l.lro)
+	if l.resp != nil {
+		// initial check for a retry-after header existing on the initial response
+		if retryAfter := RetryAfter(l.resp.Response); retryAfter > 0 {
+			Log().Writef(LogLongRunningOperation, "initial Retry-After delay for %s", retryAfter.String())
+			if err := delay(ctx, retryAfter); err != nil {
+				logPollUntilDoneExit(err)
+				return nil, err
+			}
+		}
+	}
+	// begin polling the endpoint until a terminal state is reached
+	for {
+		resp, err := l.Poll(ctx)
+		if err != nil {
+			logPollUntilDoneExit(err)
+			return nil, err
+		}
+		if l.Done() {
+			logPollUntilDoneExit(l.lro.State())
+			if !l.lro.Succeeded() {
+				return nil, l.eu(&Response{resp})
+			}
+			return l.FinalResponse(ctx, respType)
+		}
+		d := freq
+		if retryAfter := RetryAfter(resp); retryAfter > 0 {
+			Log().Writef(LogLongRunningOperation, "Retry-After delay for %s", retryAfter.String())
+			d = retryAfter
+		} else {
+			Log().Writef(LogLongRunningOperation, "delay for %s", d.String())
+		}
+		if err = delay(ctx, d); err != nil {
+			logPollUntilDoneExit(err)
+			return nil, err
+		}
+	}
+}
+
+var _ Poller = (*LROPoller)(nil)
+
+// abstracts the differences between concrete poller types
+type lroPoller interface {
+	Done() bool
+	Update(resp *Response) error
+	FinalGetURL(resp *Response) (string, error)
+	URL() string
+	State() string
+	Succeeded() bool
+}
+
+// ====================================================================================================
+
+// polls on the operation-location header
+type opPoller struct {
+	Type      string `json:"type"`
+	ReqMethod string `json:"reqMethod"`
+	ReqURL    string `json:"reqURL"`
+	PollURL   string `json:"pollURL"`
+	LocURL    string `json:"locURL"`
+	Status    string `json:"status"`
+}
+
+func newOpPoller(pollerType, pollingURL, locationURL string, initialResponse *Response) *opPoller {
+	return &opPoller{
+		Type:      fmt.Sprintf("%s;opPoller", pollerType),
+		ReqMethod: initialResponse.Request.Method,
+		ReqURL:    initialResponse.Request.URL.String(),
+		PollURL:   pollingURL,
+		LocURL:    locationURL,
+		Status:    "InProgress",
+	}
+}
+
+func (p *opPoller) URL() string {
+	return p.PollURL
+}
+
+func (p *opPoller) Done() bool {
+	return strings.EqualFold(p.Status, "succeeded") ||
+		strings.EqualFold(p.Status, "failed") ||
+		strings.EqualFold(p.Status, "cancelled")
+}
+
+func (p *opPoller) Succeeded() bool {
+	return strings.EqualFold(p.Status, "succeeded")
+}
+
+func (p *opPoller) Update(resp *Response) error {
+	status, err := extractJSONValue(resp, "status")
+	if err != nil {
+		return err
+	}
+	if status == "" {
+		return errors.New("no status found in body")
+	}
+	p.Status = status
+	// if the endpoint returned an operation-location header, update cached value
+	if opLoc := resp.Header.Get(headerOperationLocation); opLoc != "" {
+		p.PollURL = opLoc
+	}
+	return nil
+}
+
+func (p *opPoller) FinalGetURL(resp *Response) (string, error) {
+	if !p.Done() {
+		return "", errors.New("cannot return a final response from a poller in a non-terminal state")
+	}
+	resLoc, err := extractJSONValue(resp, "resourceLocation")
+	if err != nil {
+		return "", err
+	}
+	if resLoc != "" {
+		return resLoc, nil
+	}
+	if p.ReqMethod == http.MethodPatch || p.ReqMethod == http.MethodPut {
+		return p.ReqURL, nil
+	}
+	if p.ReqMethod == http.MethodPost && p.LocURL != "" {
+		return p.LocURL, nil
+	}
+	return "", nil
+}
+
+func (p *opPoller) State() string {
+	return p.Status
+}
+
+// ====================================================================================================
+
+// polls on the location header
+type locPoller struct {
+	Type    string `json:"type"`
+	PollURL string `json:"pollURL"`
+	Status  int    `json:"status"`
+}
+
+func newLocPoller(pollerType, pollingURL string, initialStatus int) *locPoller {
+	return &locPoller{
+		Type:    fmt.Sprintf("%s;locPoller", pollerType),
+		PollURL: pollingURL,
+		Status:  initialStatus,
+	}
+}
+
+func (p *locPoller) URL() string {
+	return p.PollURL
+}
+
+func (p *locPoller) Done() bool {
+	// a 202 means the operation is still in progress
+	return p.Status != http.StatusAccepted
+}
+
+func (p *locPoller) Succeeded() bool {
+	// any 2xx status code indicates success
+	return p.Status >= 200 && p.Status < 300
+}
+
+func (p *locPoller) Update(resp *Response) error {
+	// if the endpoint returned a location header, update cached value
+	if loc := resp.Header.Get(headerLocation); loc != "" {
+		p.PollURL = loc
+	}
+	p.Status = resp.StatusCode
+	return nil
+}
+
+func (*locPoller) FinalGetURL(*Response) (string, error) {
+	return "", nil
+}
+
+func (p *locPoller) State() string {
+	return strconv.Itoa(p.Status)
+}
+
+// ====================================================================================================
+
+// used if the endpoint didn't return any polling headers (synchronous completion)
+type nopPoller struct{}
+
+func (*nopPoller) URL() string {
+	return ""
+}
+
+func (*nopPoller) Done() bool {
+	return true
+}
+
+func (*nopPoller) Succeeded() bool {
+	return true
+}
+
+func (*nopPoller) Update(*Response) error {
+	return nil
+}
+
+func (*nopPoller) FinalGetURL(*Response) (string, error) {
+	return "", nil
+}
+
+func (*nopPoller) State() string {
+	return "succeeded"
+}
+
+// returns true if the LRO response contains a valid HTTP status code
+func lroStatusCodeValid(resp *Response) bool {
+	return resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusCreated, http.StatusNoContent)
+}
+
+// extracs a JSON value from the provided reader
+func extractJSONValue(resp *Response, val string) (string, error) {
+	if resp.ContentLength == 0 {
+		return "", errors.New("the response does not contain a body")
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	// put the body back so it's available to our callers
+	resp.Body = ioutil.NopCloser(bytes.NewReader(body))
+	// unmarshall the body to get the value
+	var jsonBody map[string]interface{}
+	if err = json.Unmarshal(body, &jsonBody); err != nil {
+		return "", err
+	}
+	v, ok := jsonBody[val]
+	if !ok {
+		// it might be ok if the field doesn't exist, the caller must make that determination
+		return "", nil
+	}
+	vv, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("the %s value %v was not in string format", val, v)
+	}
+	return vv, nil
+}
+
+func delay(ctx context.Context, delay time.Duration) error {
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/sdk/azcore/poller_test.go
+++ b/sdk/azcore/poller_test.go
@@ -1,0 +1,627 @@
+// +build go1.13
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+)
+
+type pollerError struct {
+	Err string `json:"error"`
+}
+
+func (p pollerError) Error() string {
+	return p.Err
+}
+
+func errUnmarshall(resp *Response) error {
+	var pe pollerError
+	if err := resp.UnmarshalAsJSON(&pe); err != nil {
+		panic(err)
+	}
+	return pe
+}
+
+type widget struct {
+	Size int `json:"size"`
+}
+
+func TestNewLROPollerFail(t *testing.T) {
+	p, err := NewLROPoller("fake.poller", &Response{
+		&http.Response{
+			StatusCode: http.StatusBadRequest,
+		},
+	}, NewPipeline(nil), errUnmarshall)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if p != nil {
+		t.Fatal("expected nil poller")
+	}
+}
+
+func TestNewLROPollerFromResumeTokenFail(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{"invalid", "invalid"},
+		{"empty", "{}"},
+		{"wrong type", `{"type": 1}`},
+		{"missing type", `{"type": "fake.poller"}`},
+		{"mismatched type", `{"type": "faker.poller;opPoller"}`},
+		{"malformed type", `{"type": "fake.poller;dummy"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p, err := NewLROPollerFromResumeToken("fake.poller", test.token, NewPipeline(nil), errUnmarshall)
+			if err == nil {
+				t.Fatal("unexpected nil error")
+			}
+			if p != nil {
+				t.Fatal("expected nil poller")
+			}
+		})
+	}
+}
+
+func TestOpPollerSimple(t *testing.T) {
+	srv, close := mock.NewServer()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{ "status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{ "status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{ "status": "Succeeded"}`)))
+	defer close()
+
+	reqURL, err := url.Parse(srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Operation-Location": []string{srv.URL()},
+				"Retry-After":        []string{"1"},
+			},
+			Request: &http.Request{
+				Method: http.MethodPut,
+				URL:    reqURL,
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+}
+
+func TestOpPollerWithWidgetPUT(t *testing.T) {
+	srv, close := mock.NewServer()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"status": "Succeeded"}`)))
+	// PUT and PATCH state that a final GET will happen
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"size": 2}`)))
+	defer close()
+
+	reqURL, err := url.Parse(srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Operation-Location": []string{srv.URL()},
+				"Retry-After":        []string{"1"},
+			},
+			Request: &http.Request{
+				Method: http.MethodPut,
+				URL:    reqURL,
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w widget
+	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+	if w.Size != 2 {
+		t.Fatalf("unexpected widget size %d", w.Size)
+	}
+}
+
+func TestOpPollerWithWidgetPOSTLocation(t *testing.T) {
+	srv, close := mock.NewServer()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"status": "Succeeded"}`)))
+	// POST state that a final GET will happen from the URL provided in the Location header if available
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"size": 2}`)))
+	defer close()
+
+	reqURL, err := url.Parse(srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Operation-Location": []string{srv.URL()},
+				"Location":           []string{srv.URL()},
+				"Retry-After":        []string{"1"},
+			},
+			Request: &http.Request{
+				Method: http.MethodPost,
+				URL:    reqURL,
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w widget
+	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+	if w.Size != 2 {
+		t.Fatalf("unexpected widget size %d", w.Size)
+	}
+}
+
+func TestOpPollerWithWidgetPOST(t *testing.T) {
+	srv, close := mock.NewServer()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
+	// POST with no location header means the success response returns the model
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"status": "Succeeded", "size": 2}`)))
+	defer close()
+
+	reqURL, err := url.Parse(srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Operation-Location": []string{srv.URL()},
+				"Retry-After":        []string{"1"},
+			},
+			Request: &http.Request{
+				Method: http.MethodPost,
+				URL:    reqURL,
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w widget
+	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+	if w.Size != 2 {
+		t.Fatalf("unexpected widget size %d", w.Size)
+	}
+}
+
+func TestOpPollerWithWidgetResourceLocation(t *testing.T) {
+	srv, close := mock.NewServer()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(
+		fmt.Sprintf(`{"status": "Succeeded", "resourceLocation": "%s"}`, srv.URL()))))
+	// final GET will happen from the URL provided in the resourceLocation
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"size": 2}`)))
+	defer close()
+
+	reqURL, err := url.Parse(srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Operation-Location": []string{srv.URL()},
+				"Location":           []string{srv.URL()},
+				"Retry-After":        []string{"1"},
+			},
+			Request: &http.Request{
+				Method: http.MethodPatch,
+				URL:    reqURL,
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w widget
+	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+	if w.Size != 2 {
+		t.Fatalf("unexpected widget size %d", w.Size)
+	}
+}
+
+func TestOpPollerWithResumeToken(t *testing.T) {
+	srv, close := mock.NewServer()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{ "status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{ "status": "InProgress"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{ "status": "Succeeded"}`)))
+	defer close()
+
+	reqURL, err := url.Parse(srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Operation-Location": []string{srv.URL()},
+				"Retry-After":        []string{"1"},
+			},
+			Request: &http.Request{
+				Method: http.MethodPut,
+				URL:    reqURL,
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := lro.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+	if lro.Done() {
+		t.Fatal("poller shouldn't be done yet")
+	}
+	resp, err = lro.FinalResponse(context.Background(), nil)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response")
+	}
+	tk, err := lro.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lro, err = NewLROPollerFromResumeToken("fake.poller", tk, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+}
+
+func TestLocPollerSimple(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Location":    []string{srv.URL()},
+				"Retry-After": []string{"1"},
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+}
+
+func TestLocPollerWithWidget(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"size": 3}`)))
+
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Location":    []string{srv.URL()},
+				"Retry-After": []string{"1"},
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w widget
+	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+	if w.Size != 3 {
+		t.Fatalf("unexpected widget size %d", w.Size)
+	}
+}
+
+func TestLocPollerCancelled(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(`{"error": "cancelled"}`)))
+
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Location":    []string{srv.URL()},
+				"Retry-After": []string{"1"},
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w widget
+	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if _, ok := err.(pollerError); !ok {
+		t.Fatal("expected pollerError")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response")
+	}
+	if w.Size != 0 {
+		t.Fatalf("unexpected widget size %d", w.Size)
+	}
+}
+
+func TestLocPollerWithError(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendError(errors.New("oops"))
+
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Location":    []string{srv.URL()},
+				"Retry-After": []string{"1"},
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w widget
+	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if e := err.Error(); e != "oops" {
+		t.Fatalf("expected error %s", e)
+	}
+	if resp != nil {
+		t.Fatal("expected nil response")
+	}
+	if w.Size != 0 {
+		t.Fatalf("unexpected widget size %d", w.Size)
+	}
+}
+
+func TestLocPollerWithResumeToken(t *testing.T) {
+	srv, close := mock.NewServer()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+	defer close()
+
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Location":    []string{srv.URL()},
+				"Retry-After": []string{"1"},
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := lro.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+	if lro.Done() {
+		t.Fatal("poller shouldn't be done yet")
+	}
+	resp, err = lro.FinalResponse(context.Background(), nil)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response")
+	}
+	tk, err := lro.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lro, err = NewLROPollerFromResumeToken("fake.poller", tk, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d", resp.StatusCode)
+	}
+}
+
+func TestLocPollerWithTimeout(t *testing.T) {
+	srv, close := mock.NewServer()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+	srv.AppendResponse(mock.WithSlowResponse(2 * time.Second))
+	defer close()
+
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Location": []string{srv.URL()},
+			},
+		},
+	}
+	pl := NewPipeline(srv)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	resp, err := lro.PollUntilDone(ctx, 5*time.Millisecond, nil)
+	cancel()
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response")
+	}
+}
+
+func TestNopPoller(t *testing.T) {
+	firstResp := &Response{
+		&http.Response{
+			StatusCode: http.StatusOK,
+		},
+	}
+	pl := NewPipeline(nil)
+	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := lro.lro.(*nopPoller); !ok {
+		t.Fatalf("unexpected poller type %T", lro.lro)
+	}
+	if !lro.Done() {
+		t.Fatal("expected Done() for nopPoller")
+	}
+	resp, err := lro.FinalResponse(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != firstResp.Response {
+		t.Fatal("unexpected response")
+	}
+	resp, err = lro.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != firstResp.Response {
+		t.Fatal("unexpected response")
+	}
+	resp, err = lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != firstResp.Response {
+		t.Fatal("unexpected response")
+	}
+	tk, err := lro.ResumeToken()
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if tk != "" {
+		t.Fatal("expected empty token")
+	}
+}


### PR DESCRIPTION
Added type LROPoller and supporting types for basic polling on long
running operations.
Fixed content type detection bug in logging.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
