### PR TITLE
Use verify-links template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 | Package Path | Changelog |
 | :--- | :---: |
-| `github.com/Azure/azure-sdk-for-go/services/preview/securityinsight/mgmt/2019-01-01-preview/securityinsight` | [details](services/preview/securityinsight/mgmt/2019-01-01-preview/securityinsight/CHANGELOG.md) |
+| `github.com/Azure/azure-sdk-for-go/services/preview/securityinsight/mgmt/2019-01-01-preview/securityinsight` | [details](https://github.com/Azure/azure-sdk-for-go/blob/v53.4.0/services/preview/securityinsight/mgmt/2019-01-01-preview/securityinsight/CHANGELOG.md) |
 
 ## `v53.3.0`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Also please see these [guidelines][] about contributing to Azure projects.
 
 This project follows the [Microsoft Open Source Code of Conduct][coc]. For more information see the [Code of Conduct FAQ][cocfaq]. Contact [opencode@microsoft.com][cocmail] with questions and comments.
 
-[guidelines]: http://azure.github.io/guidelines/
+[guidelines]: https://opensource.microsoft.com/collaborate/
 [coc]: https://opensource.microsoft.com/codeofconduct/
 [cocfaq]: https://opensource.microsoft.com/codeofconduct/faq/
 [cocmail]: mailto:opencode@microsoft.com

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,8 @@ jobs:
       displayName: 'Run Tests'
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
       parameters:
-        Directory: '$(sdkPath)'
+        Directory: '.'
+        workingDirectory: '$(sdkPath)'
         Urls: $(Get-ChildItem -Path '$(sdkPath)/*.md' -Recurse | Where {$_.FullName -notlike "*/vendor/*" -and $_.FullName -notlike "*/sdk/*"})
     - script: go run ./tools/apidiff/main.go packages ./services FETCH_HEAD~1 FETCH_HEAD --copyrepo --breakingchanges || $IGNORE_BREAKING_CHANGES
       workingDirectory: '$(sdkPath)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
       parameters:
         Directory: '.'
-        ScriptDirectory: '$(sdkPath)'
+        ScriptDirectory: '$(sdkPath)/eng/common/scripts'
         WorkingDirectory: '$(sdkPath)'
         Urls: $(Get-ChildItem -Path '$(sdkPath)/*.md' -Recurse | Where {$_.FullName -notlike "*/vendor/*" -and $_.FullName -notlike "*/sdk/*"})
     - script: go run ./tools/apidiff/main.go packages ./services FETCH_HEAD~1 FETCH_HEAD --copyrepo --breakingchanges || $IGNORE_BREAKING_CHANGES

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,8 @@ jobs:
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
       parameters:
         Directory: '.'
-        workingDirectory: '$(sdkPath)'
+        ScriptDirectory: '$(sdkPath)'
+        WorkingDirectory: '$(sdkPath)'
         Urls: $(Get-ChildItem -Path '$(sdkPath)/*.md' -Recurse | Where {$_.FullName -notlike "*/vendor/*" -and $_.FullName -notlike "*/sdk/*"})
     - script: go run ./tools/apidiff/main.go packages ./services FETCH_HEAD~1 FETCH_HEAD --copyrepo --breakingchanges || $IGNORE_BREAKING_CHANGES
       workingDirectory: '$(sdkPath)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,14 +59,10 @@ jobs:
     - script: go test $(dirname $(find . -path ./vendor -prune -o -path ./sdk -prune -o -path ./sdk -prune -o -name '*_test.go' -print) | sort -u)
       workingDirectory: '$(sdkPath)'
       displayName: 'Run Tests'
-    - task: PowerShell@2
-      displayName: Link verification check
-      inputs:
-        pwsh: true
-        workingDirectory: '$(sdkPath)'
-        filePath: '$(sdkPath)/eng/common/scripts/Verify-Links.ps1'
-        arguments: 
-          -urls $(Get-ChildItem -Path '$(sdkPath)/*.md' -Recurse | Where {$_.FullName -notlike "*/vendor/*" -and $_.FullName -notlike "*/sdk/*"}) -rootUrl 'file://$(sdkPath)' -recursive:$false
+    - template: /eng/common/pipelines/templates/steps/verify-links.yml
+      parameters:
+        Directory: '$(sdkPath)'
+        Urls: $(Get-ChildItem -Path '$(sdkPath)/*.md' -Recurse | Where {$_.FullName -notlike "*/vendor/*" -and $_.FullName -notlike "*/sdk/*"})
     - script: go run ./tools/apidiff/main.go packages ./services FETCH_HEAD~1 FETCH_HEAD --copyrepo --breakingchanges || $IGNORE_BREAKING_CHANGES
       workingDirectory: '$(sdkPath)'
       displayName: 'Display Breaking Changes'


### PR DESCRIPTION
Adjust to use the verify-links template instead of directly calling the script to get benefits like link caching. 