### PR TITLE
[SDK Automation] generator no longer returns breaking change items with the `-` prefix

### DIFF
--- a/tools/apidiff/markdown/markdown.go
+++ b/tools/apidiff/markdown/markdown.go
@@ -65,6 +65,11 @@ func (md *Writer) WriteLine(s string) {
 	md.sb.WriteString("\n")
 }
 
+// WriteListItem writes a line in a list
+func (md *Writer) WriteListItem(item string) {
+	md.WriteLine(fmt.Sprintf("- %s", item))
+}
+
 // WriteTable writes a table to the markdown document
 func (md *Writer) WriteTable(table Table) {
 	md.WriteLine(table.String())

--- a/tools/generator/autorest/model/changelog.go
+++ b/tools/generator/autorest/model/changelog.go
@@ -72,13 +72,13 @@ func writeChangelogForPackage(r *report.Package) string {
 	// write breaking changes
 	md.WriteHeader("Breaking Changes")
 	for _, item := range getBreakingChanges(r.BreakingChanges) {
-		md.WriteLine(item)
+		md.WriteListItem(item)
 	}
 
 	// write additional changes
 	md.WriteHeader("New Content")
 	for _, item := range getNewContents(r.AdditiveChanges) {
-		md.WriteLine(item)
+		md.WriteListItem(item)
 	}
 
 	md.EmptyLine()
@@ -110,7 +110,7 @@ func getNewContents(c *delta.Content) []string {
 
 	if len(c.Consts) > 0 {
 		for k := range c.Consts {
-			line := fmt.Sprintf("- New const `%s`", k)
+			line := fmt.Sprintf("New const `%s`", k)
 			items = append(items, line)
 		}
 	}
@@ -127,13 +127,13 @@ func getNewContents(c *delta.Content) []string {
 					returns = fmt.Sprintf("(%s)", returns)
 				}
 			}
-			line := fmt.Sprintf("- New function `%s(%s) %s`", k, params, returns)
+			line := fmt.Sprintf("New function `%s(%s) %s`", k, params, returns)
 			items = append(items, line)
 		}
 	}
 	if len(c.CompleteStructs) > 0 {
 		for _, v := range c.CompleteStructs {
-			line := fmt.Sprintf("- New struct `%s`", v)
+			line := fmt.Sprintf("New struct `%s`", v)
 			items = append(items, line)
 		}
 	}
@@ -141,11 +141,11 @@ func getNewContents(c *delta.Content) []string {
 		modified := c.GetModifiedStructs()
 		for s, f := range modified {
 			for _, af := range f.AnonymousFields {
-				line := fmt.Sprintf("- New anonymous field `%s` in struct `%s`", af, s)
+				line := fmt.Sprintf("New anonymous field `%s` in struct `%s`", af, s)
 				items = append(items, line)
 			}
 			for f := range f.Fields {
-				line := fmt.Sprintf("- New field `%s` in struct `%s`", f, s)
+				line := fmt.Sprintf("New field `%s` in struct `%s`", f, s)
 				items = append(items, line)
 			}
 		}
@@ -179,7 +179,7 @@ func getSignatureChangeItems(b *report.BreakingChanges) []string {
 	// write const changes
 	if len(b.Consts) > 0 {
 		for k, v := range b.Consts {
-			line := fmt.Sprintf("- Const `%s` type has been changed from `%s` to `%s`", k, v.From, v.To)
+			line := fmt.Sprintf("Const `%s` type has been changed from `%s` to `%s`", k, v.From, v.To)
 			items = append(items, line)
 		}
 		// TODO -- sort?
@@ -188,11 +188,11 @@ func getSignatureChangeItems(b *report.BreakingChanges) []string {
 	if len(b.Funcs) > 0 {
 		for k, v := range b.Funcs {
 			if v.Params != nil {
-				line := fmt.Sprintf("- Function `%s` parameter(s) have been changed from `(%s)` to `(%s)`", k, v.Params.From, v.Params.To)
+				line := fmt.Sprintf("Function `%s` parameter(s) have been changed from `(%s)` to `(%s)`", k, v.Params.From, v.Params.To)
 				items = append(items, line)
 			}
 			if v.Returns != nil {
-				line := fmt.Sprintf("- Function `%s` return value(s) have been changed from `(%s)` to `(%s)`", k, v.Returns.From, v.Returns.To)
+				line := fmt.Sprintf("Function `%s` return value(s) have been changed from `(%s)` to `(%s)`", k, v.Returns.From, v.Returns.To)
 				items = append(items, line)
 			}
 		}
@@ -201,7 +201,7 @@ func getSignatureChangeItems(b *report.BreakingChanges) []string {
 	if len(b.Structs) > 0 {
 		for k, v := range b.Structs {
 			for f, d := range v.Fields {
-				line := fmt.Sprintf("- Type of `%s.%s` has been changed from `%s` to `%s`", k, f, d.From, d.To)
+				line := fmt.Sprintf("Type of `%s.%s` has been changed from `%s` to `%s`", k, f, d.From, d.To)
 				items = append(items, line)
 			}
 		}
@@ -220,21 +220,21 @@ func getRemovedContent(removed *delta.Content) []string {
 	// write constants
 	if len(removed.Consts) > 0 {
 		for k := range removed.Consts {
-			line := fmt.Sprintf("- Const `%s` has been removed", k)
+			line := fmt.Sprintf("Const `%s` has been removed", k)
 			items = append(items, line)
 		}
 	}
 	// write functions
 	if len(removed.Funcs) > 0 {
 		for k := range removed.Funcs {
-			line := fmt.Sprintf("- Function `%s` has been removed", k)
+			line := fmt.Sprintf("Function `%s` has been removed", k)
 			items = append(items, line)
 		}
 	}
 	// write complete struct removal
 	if len(removed.CompleteStructs) > 0 {
 		for _, v := range removed.CompleteStructs {
-			line := fmt.Sprintf("- Struct `%s` has been removed", v)
+			line := fmt.Sprintf("Struct `%s` has been removed", v)
 			items = append(items, line)
 		}
 	}
@@ -243,11 +243,11 @@ func getRemovedContent(removed *delta.Content) []string {
 	if len(modified) > 0 {
 		for s, f := range modified {
 			for _, af := range f.AnonymousFields {
-				line := fmt.Sprintf("- Field `%s` of struct `%s` has been removed", af, s)
+				line := fmt.Sprintf("Field `%s` of struct `%s` has been removed", af, s)
 				items = append(items, line)
 			}
 			for f := range f.Fields {
-				line := fmt.Sprintf("- Field `%s` of struct `%s` has been removed", f, s)
+				line := fmt.Sprintf("Field `%s` of struct `%s` has been removed", f, s)
 				items = append(items, line)
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
