### PR TITLE
Testframework: various sanitizer fixes

### DIFF
--- a/sdk/internal/testframework/recording.go
+++ b/sdk/internal/testframework/recording.go
@@ -33,7 +33,7 @@ type Recording struct {
 	recorder                 *recorder.Recorder
 	src                      rand.Source
 	now                      *time.Time
-	sanitizer                *RecordingSanitizer
+	Sanitizer                *RecordingSanitizer
 	c                        TestContext
 }
 
@@ -104,7 +104,7 @@ func NewRecording(c TestContext, mode RecordMode) (*Recording, error) {
 	rec.SetMatcher(recording.matchRequest)
 
 	// wire up the sanitizer
-	DefaultSanitizer(rec)
+	recording.Sanitizer = DefaultSanitizer(rec)
 
 	return recording, err
 }


### PR DESCRIPTION
- Separate sanitizer for request bodies and response bodies (NOTE: I'm open to having just one body sanitizer with a field that specifies if it's meant to be used for the request, response or both. Let me know!)
- Assign default sanitizer to the recording sanitizer
- Export sanitizer on the recording to allow sanitizer customization