### PR TITLE
Don't rewind if request Body is http.NoBody

### DIFF
--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -233,7 +233,7 @@ func (req *Request) SkipBodyDownload() {
 
 // RewindBody seeks the request's Body stream back to the beginning so it can be resent when retrying an operation.
 func (req *Request) RewindBody() error {
-	if req.Body != nil {
+	if req.Body != nil && req.Body != http.NoBody {
 		// Reset the stream back to the beginning
 		_, err := req.Body.(io.Seeker).Seek(0, io.SeekStart)
 		return err


### PR DESCRIPTION
It should be treated the same as a nil body.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
