### PR TITLE
Add support for null map and slice

### DIFF
--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -154,13 +154,19 @@ var nullables map[reflect.Type]interface{} = map[reflect.Type]interface{}{}
 // This is typically used in JSON-MERGE-PATCH operations to delete a value.
 func NullValue(v interface{}) interface{} {
 	t := reflect.TypeOf(v)
-	if t.Kind() != reflect.Ptr {
+	if k := t.Kind(); k != reflect.Ptr && k != reflect.Slice && k != reflect.Map {
 		// t is not of pointer type, make it be of pointer type
 		t = reflect.PtrTo(t)
 	}
 	v, found := nullables[t]
 	if !found {
-		o := reflect.New(t.Elem())
+		var o reflect.Value
+		if k := t.Kind(); k == reflect.Slice || k == reflect.Map {
+			o = reflect.New(t) // *[]type
+			o = o.Elem()       // []type
+		} else {
+			o = reflect.New(t.Elem())
+		}
 		v = o.Interface()
 		nullables[t] = v
 	}
@@ -173,13 +179,15 @@ func NullValue(v interface{}) interface{} {
 func IsNullValue(v interface{}) bool {
 	// see if our map has a sentinel object for this *T
 	t := reflect.TypeOf(v)
-	if t.Kind() != reflect.Ptr {
+	if k := t.Kind(); k != reflect.Ptr && k != reflect.Slice && k != reflect.Map {
 		// v isn't a pointer type so it can never be a null
 		return false
 	}
 	if o, found := nullables[t]; found {
+		o1 := reflect.ValueOf(o)
+		v1 := reflect.ValueOf(v)
 		// we found it; return true if v points to the sentinel object
-		return o == v
+		return o1.Pointer() == v1.Pointer()
 	}
 	// no sentinel object for this *t
 	return false

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -186,7 +186,9 @@ func IsNullValue(v interface{}) bool {
 	if o, found := nullables[t]; found {
 		o1 := reflect.ValueOf(o)
 		v1 := reflect.ValueOf(v)
-		// we found it; return true if v points to the sentinel object
+		// we found it; return true if v points to the sentinel object.
+		// NOTE: maps and slices can only be compared to nil, else you get
+		// a runtime panic.  so we compare addresses instead.
 		return o1.Pointer() == v1.Pointer()
 	}
 	// no sentinel object for this *t

--- a/sdk/azcore/core_test.go
+++ b/sdk/azcore/core_test.go
@@ -5,7 +5,10 @@
 
 package azcore
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestNullValue(t *testing.T) {
 	v := NullValue("")
@@ -48,5 +51,43 @@ func TestIsNullValue(t *testing.T) {
 	i = &i2
 	if IsNullValue(i) {
 		t.Fatal("i should no longer be null value")
+	}
+}
+
+func TestNullValueMapSlice(t *testing.T) {
+	v := NullValue([]string{})
+	if _, ok := v.([]string); !ok {
+		t.Fatalf("unexpected type %T", v)
+	}
+	vv := NullValue(([]string)(nil))
+	if _, ok := vv.([]string); !ok {
+		t.Fatalf("unexpected type %T", vv)
+	}
+	if reflect.TypeOf(v) != reflect.TypeOf(vv) {
+		t.Fatal("null values should match for the same types")
+	}
+	m := NullValue(map[string]int{})
+	if _, ok := m.(map[string]int); !ok {
+		t.Fatalf("unexpected type %T", m)
+	}
+	if reflect.TypeOf(v) == reflect.TypeOf(m) {
+		t.Fatal("null values for string and int should not match")
+	}
+}
+
+func TestIsNullValueMapSlice(t *testing.T) {
+	if IsNullValue([]string{}) {
+		t.Fatal("slice literal can't be a null value")
+	}
+	if IsNullValue(map[int]string{}) {
+		t.Fatal("map literal can't be a null value")
+	}
+	s := NullValue([]int{}).([]int)
+	if !IsNullValue(s) {
+		t.Fatal("expected null value for s")
+	}
+	m := NullValue(map[string]interface{}{}).(map[string]interface{})
+	if !IsNullValue(m) {
+		t.Fatal("expected null value for s")
 	}
 }

--- a/sdk/azcore/policy_body_download_test.go
+++ b/sdk/azcore/policy_body_download_test.go
@@ -29,7 +29,7 @@ func TestDownloadBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestSkipBodyDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestDownloadBodyFail(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -106,7 +106,7 @@ func TestDownloadBodyWithRetryGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestDownloadBodyWithRetryDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestDownloadBodyWithRetryPut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestDownloadBodyWithRetryPatch(t *testing.T) {
 	if _, ok := err.(*bodyDownloadError); !ok {
 		t.Fatal("expected *bodyDownloadError type")
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -235,7 +235,7 @@ func TestDownloadBodyWithRetryPost(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -264,7 +264,7 @@ func TestSkipBodyDownloadWith400(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestReadBodyAfterSeek(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.payload()
+	payload, err := resp.Payload()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/response.go
+++ b/sdk/azcore/response.go
@@ -25,7 +25,9 @@ type Response struct {
 	*http.Response
 }
 
-func (r *Response) payload() ([]byte, error) {
+// Payload reads and returns the response body or an error.
+// On a successful read, the response body is cached.
+func (r *Response) Payload() ([]byte, error) {
 	// r.Body won't be a nopClosingBytesReader if downloading was skipped
 	if buf, ok := r.Body.(*nopClosingBytesReader); ok {
 		return buf.Bytes(), nil
@@ -54,7 +56,7 @@ func (r *Response) HasStatusCode(statusCodes ...int) bool {
 
 // UnmarshalAsByteArray will base-64 decode the received payload and place the result into the value pointed to by v.
 func (r *Response) UnmarshalAsByteArray(v **[]byte, format Base64Encoding) error {
-	p, err := r.payload()
+	p, err := r.Payload()
 	if err != nil {
 		return err
 	}
@@ -89,7 +91,7 @@ func (r *Response) UnmarshalAsByteArray(v **[]byte, format Base64Encoding) error
 
 // UnmarshalAsJSON calls json.Unmarshal() to unmarshal the received payload into the value pointed to by v.
 func (r *Response) UnmarshalAsJSON(v interface{}) error {
-	payload, err := r.payload()
+	payload, err := r.Payload()
 	if err != nil {
 		return err
 	}
@@ -110,7 +112,7 @@ func (r *Response) UnmarshalAsJSON(v interface{}) error {
 
 // UnmarshalAsXML calls xml.Unmarshal() to unmarshal the received payload into the value pointed to by v.
 func (r *Response) UnmarshalAsXML(v interface{}) error {
-	payload, err := r.payload()
+	payload, err := r.Payload()
 	if err != nil {
 		return err
 	}
@@ -132,7 +134,7 @@ func (r *Response) UnmarshalAsXML(v interface{}) error {
 // UnmarshalError will combine information from the service error payload along with the corresponding unmarshal error into a new error.
 // NOTE: this method is only meant to be called when handling a service error.
 func (r *Response) UnmarshalError(unmarshalErr error) error {
-	payload, err := r.payload()
+	payload, err := r.Payload()
 	if err != nil {
 		return err
 	}
@@ -152,7 +154,7 @@ func (r *Response) Drain() {
 
 // removeBOM removes any byte-order mark prefix from the payload if present.
 func (r *Response) removeBOM() error {
-	payload, err := r.payload()
+	payload, err := r.Payload()
 	if err != nil {
 		return err
 	}
@@ -177,7 +179,7 @@ func (r *Response) writeBody(b *bytes.Buffer) error {
 	if ct := r.Header.Get(HeaderContentType); !shouldLogBody(b, ct) {
 		return nil
 	}
-	body, err := r.payload()
+	body, err := r.Payload()
 	if err != nil {
 		fmt.Fprintf(b, "   Failed to read response body: %s\n", err.Error())
 		return err

--- a/sdk/azcore/response.go
+++ b/sdk/azcore/response.go
@@ -131,19 +131,6 @@ func (r *Response) UnmarshalAsXML(v interface{}) error {
 	return err
 }
 
-// UnmarshalError will combine information from the service error payload along with the corresponding unmarshal error into a new error.
-// NOTE: this method is only meant to be called when handling a service error.
-func (r *Response) UnmarshalError(unmarshalErr error) error {
-	payload, err := r.Payload()
-	if err != nil {
-		return err
-	}
-	if len(payload) == 0 {
-		return fmt.Errorf("empty error body\n%s", unmarshalErr)
-	}
-	return fmt.Errorf("raw service error: %s\n%s", payload, unmarshalErr)
-}
-
 // Drain reads the response body to completion then closes it.  The bytes read are discarded.
 func (r *Response) Drain() {
 	if r != nil && r.Body != nil {

--- a/sdk/azcore/response_test.go
+++ b/sdk/azcore/response_test.go
@@ -7,7 +7,6 @@ package azcore
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -227,59 +226,5 @@ func TestResponseUnmarshalAsByteArrayStdFormat(t *testing.T) {
 	}
 	if string(*ba) != "a string that gets encoded with base64url" {
 		t.Fatalf("bad payload, got %s", string(*ba))
-	}
-}
-
-func TestResponseUnmarshalError(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	srv.SetResponse(mock.WithBody([]byte(`{ "someInt": 1, "someString": "s" }`)))
-	pl := NewPipeline(srv)
-	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	resp, err := pl.Do(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !resp.HasStatusCode(http.StatusOK) {
-		t.Fatalf("unexpected status code: %d", resp.StatusCode)
-	}
-	testErr := errors.New("test error")
-	expected := `raw service error: { "someInt": 1, "someString": "s" }
-test error`
-	if err = resp.UnmarshalError(testErr); err == nil {
-		t.Fatalf("unexpected nil error when unmarshalling")
-	}
-	if expected != err.Error() {
-		t.Fatal("unexpected value")
-	}
-}
-
-func TestResponseUnmarshalErrorEmptyResponseBody(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	srv.SetResponse(mock.WithStatusCode(400))
-	pl := NewPipeline(srv)
-	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	resp, err := pl.Do(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !resp.HasStatusCode(http.StatusBadRequest) {
-		t.Fatalf("unexpected status code: %d", resp.StatusCode)
-	}
-	testErr := errors.New("test error")
-	expected := `empty error body
-test error`
-	if err = resp.UnmarshalError(testErr); err == nil {
-		t.Fatalf("unexpected nil error when unmarshalling")
-	}
-	if expected != err.Error() {
-		t.Fatal("unexpected value")
 	}
 }


### PR DESCRIPTION
Also export the `payload()` method on `Response`
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
