### PR TITLE
Cache the original request body on Request

### DIFF
--- a/sdk/azcore/policy_retry.go
+++ b/sdk/azcore/policy_retry.go
@@ -136,9 +136,9 @@ func (p *retryPolicy) Do(req *Request) (resp *Response, err error) {
 	}
 	// Exponential retry algorithm: ((2 ^ attempt) - 1) * delay * random(0.8, 1.2)
 	// When to retry: connection failure or temporary/timeout.
-	if req.Body != nil {
+	if req.body != nil {
 		// wrap the body so we control when it's actually closed
-		rwbody := &retryableRequestBody{body: req.Body.(ReadSeekCloser)}
+		rwbody := &retryableRequestBody{body: req.body}
 		req.Body = rwbody
 		req.Request.GetBody = func() (io.ReadCloser, error) {
 			_, err := rwbody.Seek(0, io.SeekStart) // Seek back to the beginning of the stream


### PR DESCRIPTION
This is to handle the case where a pipeline policy reads and restores a
request body without preserving the io.Seeker interface.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
