### PR TITLE
Don't overwrite final get URI with empty string

### DIFF
--- a/sdk/armcore/LICENSE.txt
+++ b/sdk/armcore/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/armcore/poller.go
+++ b/sdk/armcore/poller.go
@@ -623,13 +623,17 @@ func (pt *pollingTrackerBase) setFinalState() error {
 		if err != nil {
 			return err
 		}
-		pt.FinalGetURI = ao
+		if ao != "" {
+			pt.FinalGetURI = ao
+		}
 	} else if pt.FinalStateVia == "location" {
 		lh, err := getURLFromLocationHeader(pt.latestResponse())
 		if err != nil {
 			return err
 		}
-		pt.FinalGetURI = lh
+		if lh != "" {
+			pt.FinalGetURI = lh
+		}
 	} else if pt.FinalStateVia == "original-uri" {
 		pt.FinalGetURI = pt.OriginalURI
 	}

--- a/sdk/armcore/version.go
+++ b/sdk/armcore/version.go
@@ -10,5 +10,5 @@ const (
 	UserAgent = "armcore/" + Version
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v0.7.0"
+	Version = "v0.7.1"
 )


### PR DESCRIPTION
If the success response doesn't return a final get URI used the value
that was previously calculated.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
