### PR TITLE
update dependency in every tool to use the official sdk

### DIFF
--- a/tools/apidiff/go.mod
+++ b/tools/apidiff/go.mod
@@ -4,8 +4,6 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go v54.2.1+incompatible
-	github.com/Azure/azure-sdk-for-go/tools/internal v0.0.0
+	github.com/Azure/azure-sdk-for-go/tools/internal v0.1.0
 	github.com/spf13/cobra v1.1.3
 )
-
-replace github.com/Azure/azure-sdk-for-go/tools/internal => ../internal

--- a/tools/apidiff/go.mod
+++ b/tools/apidiff/go.mod
@@ -8,7 +8,4 @@ require (
 	github.com/spf13/cobra v1.1.3
 )
 
-replace (
-	github.com/Azure/azure-sdk-for-go => github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible
-	github.com/Azure/azure-sdk-for-go/tools/internal => ../internal
-)
+replace github.com/Azure/azure-sdk-for-go/tools/internal => ../internal

--- a/tools/apidiff/go.sum
+++ b/tools/apidiff/go.sum
@@ -11,10 +11,18 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible h1:gnEJNzQKM8OgR7hUQ9GSRI1Q26gfoKzYEeQeb6CgzVE=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:DZwTZx5ZhsPoRm5MrF6MYm5kd+ff6XxwA/IJ1zHScdk=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible h1:RiwBAqYP8Xz2yTPNzrwiHX5+lfPkRlHuk/x4BOAyAjA=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
+github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
+github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
+github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
+github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -38,6 +46,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -174,6 +183,7 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/tools/deprecate/go.mod
+++ b/tools/deprecate/go.mod
@@ -6,5 +6,3 @@ require (
 	github.com/Azure/azure-sdk-for-go v54.2.1+incompatible
 	github.com/spf13/cobra v1.1.3
 )
-
-replace github.com/Azure/azure-sdk-for-go => github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible

--- a/tools/deprecate/go.sum
+++ b/tools/deprecate/go.sum
@@ -11,8 +11,8 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible h1:gnEJNzQKM8OgR7hUQ9GSRI1Q26gfoKzYEeQeb6CgzVE=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:DZwTZx5ZhsPoRm5MrF6MYm5kd+ff6XxwA/IJ1zHScdk=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible h1:RiwBAqYP8Xz2yTPNzrwiHX5+lfPkRlHuk/x4BOAyAjA=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/tools/generator/go.mod
+++ b/tools/generator/go.mod
@@ -4,8 +4,6 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go v54.2.1+incompatible
-	github.com/Azure/azure-sdk-for-go/tools/internal v0.0.0
+	github.com/Azure/azure-sdk-for-go/tools/internal v0.1.0
 	github.com/spf13/cobra v1.1.3
 )
-
-replace github.com/Azure/azure-sdk-for-go/tools/internal => ../internal

--- a/tools/generator/go.mod
+++ b/tools/generator/go.mod
@@ -8,7 +8,4 @@ require (
 	github.com/spf13/cobra v1.1.3
 )
 
-replace (
-	github.com/Azure/azure-sdk-for-go => github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible
-	github.com/Azure/azure-sdk-for-go/tools/internal => ../internal
-)
+replace github.com/Azure/azure-sdk-for-go/tools/internal => ../internal

--- a/tools/generator/go.sum
+++ b/tools/generator/go.sum
@@ -11,10 +11,18 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible h1:gnEJNzQKM8OgR7hUQ9GSRI1Q26gfoKzYEeQeb6CgzVE=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:DZwTZx5ZhsPoRm5MrF6MYm5kd+ff6XxwA/IJ1zHScdk=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible h1:RiwBAqYP8Xz2yTPNzrwiHX5+lfPkRlHuk/x4BOAyAjA=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
+github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
+github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
+github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
+github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -38,6 +46,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -174,6 +183,7 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/tools/indexer/go.mod
+++ b/tools/indexer/go.mod
@@ -3,5 +3,3 @@ module github.com/Azure/azure-sdk-for-go/tools/indexer
 go 1.13
 
 require github.com/Azure/azure-sdk-for-go v54.2.1+incompatible
-
-replace github.com/Azure/azure-sdk-for-go => github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible

--- a/tools/indexer/go.sum
+++ b/tools/indexer/go.sum
@@ -1,2 +1,2 @@
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible h1:gnEJNzQKM8OgR7hUQ9GSRI1Q26gfoKzYEeQeb6CgzVE=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:DZwTZx5ZhsPoRm5MrF6MYm5kd+ff6XxwA/IJ1zHScdk=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible h1:RiwBAqYP8Xz2yTPNzrwiHX5+lfPkRlHuk/x4BOAyAjA=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=

--- a/tools/internal/go.mod
+++ b/tools/internal/go.mod
@@ -7,5 +7,3 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Masterminds/semver v1.5.0
 )
-
-replace github.com/Azure/azure-sdk-for-go => github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible

--- a/tools/internal/go.sum
+++ b/tools/internal/go.sum
@@ -1,5 +1,5 @@
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible h1:gnEJNzQKM8OgR7hUQ9GSRI1Q26gfoKzYEeQeb6CgzVE=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:DZwTZx5ZhsPoRm5MrF6MYm5kd+ff6XxwA/IJ1zHScdk=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible h1:RiwBAqYP8Xz2yTPNzrwiHX5+lfPkRlHuk/x4BOAyAjA=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.18 h1:90Y4srNYrwOtAgVo3ndrQkTYn6kf1Eg/AjTFJ8Is2aM=

--- a/tools/pkgchk/go.mod
+++ b/tools/pkgchk/go.mod
@@ -4,8 +4,6 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go v54.2.1+incompatible
-	github.com/Azure/azure-sdk-for-go/tools/internal v0.0.0
+	github.com/Azure/azure-sdk-for-go/tools/internal v0.1.0
 	github.com/spf13/cobra v1.1.3
 )
-
-replace github.com/Azure/azure-sdk-for-go/tools/internal => ../internal

--- a/tools/pkgchk/go.mod
+++ b/tools/pkgchk/go.mod
@@ -8,7 +8,4 @@ require (
 	github.com/spf13/cobra v1.1.3
 )
 
-replace (
-	github.com/Azure/azure-sdk-for-go => github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible
-	github.com/Azure/azure-sdk-for-go/tools/internal => ../internal
-)
+replace github.com/Azure/azure-sdk-for-go/tools/internal => ../internal

--- a/tools/pkgchk/go.sum
+++ b/tools/pkgchk/go.sum
@@ -11,8 +11,8 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible h1:gnEJNzQKM8OgR7hUQ9GSRI1Q26gfoKzYEeQeb6CgzVE=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:DZwTZx5ZhsPoRm5MrF6MYm5kd+ff6XxwA/IJ1zHScdk=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible h1:RiwBAqYP8Xz2yTPNzrwiHX5+lfPkRlHuk/x4BOAyAjA=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=

--- a/tools/profileBuilder/go.mod
+++ b/tools/profileBuilder/go.mod
@@ -9,7 +9,4 @@ require (
 	golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc
 )
 
-replace (
-	github.com/Azure/azure-sdk-for-go => github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible
-	github.com/Azure/azure-sdk-for-go/tools/internal => ../internal
-)
+replace github.com/Azure/azure-sdk-for-go/tools/internal => ../internal

--- a/tools/profileBuilder/go.mod
+++ b/tools/profileBuilder/go.mod
@@ -4,9 +4,7 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go v54.2.1+incompatible
-	github.com/Azure/azure-sdk-for-go/tools/internal v0.0.0
+	github.com/Azure/azure-sdk-for-go/tools/internal v0.1.0
 	github.com/spf13/cobra v1.1.3
 	golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc
 )
-
-replace github.com/Azure/azure-sdk-for-go/tools/internal => ../internal

--- a/tools/profileBuilder/go.sum
+++ b/tools/profileBuilder/go.sum
@@ -11,8 +11,8 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible h1:gnEJNzQKM8OgR7hUQ9GSRI1Q26gfoKzYEeQeb6CgzVE=
-github.com/ArcturusZhang/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:DZwTZx5ZhsPoRm5MrF6MYm5kd+ff6XxwA/IJ1zHScdk=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible h1:RiwBAqYP8Xz2yTPNzrwiHX5+lfPkRlHuk/x4BOAyAjA=
+github.com/Azure/azure-sdk-for-go v54.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=


### PR DESCRIPTION
Step 2: switch everything to use the new released azure-sdk-for-go which does not contain `tools`
