### PR TITLE
Improved support for byte arrays

### DIFF
--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -118,15 +118,9 @@ func (req *Request) Next() (*Response, error) {
 // MarshalAsByteArray will base-64 encode the byte slice v, then calls SetBody.
 // The encoded value is treated as a JSON string.
 func (req *Request) MarshalAsByteArray(v []byte, format Base64Encoding) error {
-	var encode string
-	switch format {
-	case Base64StdFormat:
-		encode = base64.StdEncoding.EncodeToString(v)
-	case Base64URLFormat:
-		// use raw encoding so that '=' characters are omitted as they have special meaning in URLs
-		encode = base64.RawURLEncoding.EncodeToString(v)
-	default:
-		return fmt.Errorf("unrecognized byte array format: %d", format)
+	encode, err := EncodeByteArray(v, format)
+	if err != nil {
+		return err
 	}
 	// send as a JSON string
 	encode = fmt.Sprintf("\"%s\"", encode)
@@ -307,6 +301,19 @@ func (req *Request) writeBody(b *bytes.Buffer) error {
 	}
 	logBody(b, body)
 	return nil
+}
+
+// EncodeByteArray will base-64 encode the byte slice v.
+func EncodeByteArray(v []byte, format Base64Encoding) (string, error) {
+	switch format {
+	case Base64StdFormat:
+		return base64.StdEncoding.EncodeToString(v), nil
+	case Base64URLFormat:
+		// use raw encoding so that '=' characters are omitted as they have special meaning in URLs
+		return base64.RawURLEncoding.EncodeToString(v), nil
+	default:
+		return "", fmt.Errorf("unrecognized byte array format: %d", format)
+	}
 }
 
 // returns a clone of the object graph pointed to by v, omitting values of all read-only

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -118,12 +118,8 @@ func (req *Request) Next() (*Response, error) {
 // MarshalAsByteArray will base-64 encode the byte slice v, then calls SetBody.
 // The encoded value is treated as a JSON string.
 func (req *Request) MarshalAsByteArray(v []byte, format Base64Encoding) error {
-	encode, err := EncodeByteArray(v, format)
-	if err != nil {
-		return err
-	}
 	// send as a JSON string
-	encode = fmt.Sprintf("\"%s\"", encode)
+	encode := fmt.Sprintf("\"%s\"", EncodeByteArray(v, format))
 	return req.SetBody(NopCloser(strings.NewReader(encode)), contentTypeAppJSON)
 }
 
@@ -304,16 +300,11 @@ func (req *Request) writeBody(b *bytes.Buffer) error {
 }
 
 // EncodeByteArray will base-64 encode the byte slice v.
-func EncodeByteArray(v []byte, format Base64Encoding) (string, error) {
-	switch format {
-	case Base64StdFormat:
-		return base64.StdEncoding.EncodeToString(v), nil
-	case Base64URLFormat:
-		// use raw encoding so that '=' characters are omitted as they have special meaning in URLs
-		return base64.RawURLEncoding.EncodeToString(v), nil
-	default:
-		return "", fmt.Errorf("unrecognized byte array format: %d", format)
+func EncodeByteArray(v []byte, format Base64Encoding) string {
+	if format == Base64URLFormat {
+		return base64.RawURLEncoding.EncodeToString(v)
 	}
+	return base64.StdEncoding.EncodeToString(v)
 }
 
 // returns a clone of the object graph pointed to by v, omitting values of all read-only

--- a/sdk/azcore/response.go
+++ b/sdk/azcore/response.go
@@ -60,33 +60,7 @@ func (r *Response) UnmarshalAsByteArray(v *[]byte, format Base64Encoding) error 
 	if err != nil {
 		return err
 	}
-	if len(p) == 0 {
-		return nil
-	}
-	payload := string(p)
-	if payload[0] == '"' {
-		// remove surrounding quotes
-		payload = payload[1 : len(payload)-1]
-	}
-	switch format {
-	case Base64StdFormat:
-		decoded, err := base64.StdEncoding.DecodeString(payload)
-		if err == nil {
-			*v = decoded
-			return nil
-		}
-		return err
-	case Base64URLFormat:
-		// use raw encoding as URL format should not contain any '=' characters
-		decoded, err := base64.RawURLEncoding.DecodeString(payload)
-		if err == nil {
-			*v = decoded
-			return nil
-		}
-		return err
-	default:
-		return fmt.Errorf("unrecognized byte array format: %d", format)
-	}
+	return DecodeByteArray(string(p), v, format)
 }
 
 // UnmarshalAsJSON calls json.Unmarshal() to unmarshal the received payload into the value pointed to by v.
@@ -196,6 +170,37 @@ func RetryAfter(resp *http.Response) time.Duration {
 		return time.Until(t)
 	}
 	return 0
+}
+
+// DecodeByteArray will base-64 decode the provided string into v.
+func DecodeByteArray(s string, v *[]byte, format Base64Encoding) error {
+	if len(s) == 0 {
+		return nil
+	}
+	payload := string(s)
+	if payload[0] == '"' {
+		// remove surrounding quotes
+		payload = payload[1 : len(payload)-1]
+	}
+	switch format {
+	case Base64StdFormat:
+		decoded, err := base64.StdEncoding.DecodeString(payload)
+		if err == nil {
+			*v = decoded
+			return nil
+		}
+		return err
+	case Base64URLFormat:
+		// use raw encoding as URL format should not contain any '=' characters
+		decoded, err := base64.RawURLEncoding.DecodeString(payload)
+		if err == nil {
+			*v = decoded
+			return nil
+		}
+		return err
+	default:
+		return fmt.Errorf("unrecognized byte array format: %d", format)
+	}
 }
 
 // writeRequestWithResponse appends a formatted HTTP request into a Buffer. If request and/or err are

--- a/sdk/azcore/version.go
+++ b/sdk/azcore/version.go
@@ -10,5 +10,5 @@ const (
 	UserAgent = "azcore/" + Version
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v0.16.1"
+	Version = "v0.16.2"
 )


### PR DESCRIPTION
Moved guts of MarshalAsByteArray() and UnmarshalAsByteArray() into
stand-alone funcs to be used in code generation.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
