### PR TITLE
azidentity: Adding Resource ID support in ManagedIdentityCredential

### DIFF
--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -31,6 +31,7 @@ const (
 	qpPassword            = "password"
 	qpRedirectURI         = "redirect_uri"
 	qpRefreshToken        = "refresh_token"
+	qpResID               = "mi_res_id"
 	qpResponseType        = "response_type"
 	qpScope               = "scope"
 	qpUsername            = "username"

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -53,7 +53,7 @@ type managedIdentityClient struct {
 	imdsAvailableTimeoutMS time.Duration
 	msiType                msiType
 	endpoint               string
-	id                     IDKind
+	id                     ManagedIdentityIDKind
 }
 
 type wrappedNumber json.Number

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -45,10 +45,6 @@ const (
 	msiTypeAzureArc            msiType = 6
 )
 
-const (
-	qpResID string = "mi_res_id"
-)
-
 // managedIdentityClient provides the base for authenticating in managed identity environments
 // This type includes an azcore.Pipeline and TokenCredentialOptions.
 type managedIdentityClient struct {
@@ -168,7 +164,7 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, clientID 
 	}
 }
 
-func (c *managedIdentityClient) createIMDSAuthRequest(ctx context.Context, clientID string, scopes []string) (*azcore.Request, error) {
+func (c *managedIdentityClient) createIMDSAuthRequest(ctx context.Context, id string, scopes []string) (*azcore.Request, error) {
 	request, err := azcore.NewRequest(ctx, http.MethodGet, c.endpoint)
 	if err != nil {
 		return nil, err
@@ -178,15 +174,15 @@ func (c *managedIdentityClient) createIMDSAuthRequest(ctx context.Context, clien
 	q.Add("api-version", c.imdsAPIVersion)
 	q.Add("resource", strings.Join(scopes, " "))
 	if c.id == ResourceID {
-		q.Add(string(qpResID), clientID)
-	} else if clientID != "" {
-		q.Add(qpClientID, clientID)
+		q.Add(string(qpResID), id)
+	} else if id != "" {
+		q.Add(qpClientID, id)
 	}
 	request.URL.RawQuery = q.Encode()
 	return request, nil
 }
 
-func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context, clientID string, scopes []string) (*azcore.Request, error) {
+func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context, id string, scopes []string) (*azcore.Request, error) {
 	request, err := azcore.NewRequest(ctx, http.MethodGet, c.endpoint)
 	if err != nil {
 		return nil, err
@@ -197,19 +193,19 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context,
 		q.Add("api-version", "2017-09-01")
 		q.Add("resource", strings.Join(scopes, " "))
 		if c.id == ResourceID {
-			q.Add(string(qpResID), clientID)
-		} else if clientID != "" {
+			q.Add(string(qpResID), id)
+		} else if id != "" {
 			// the legacy 2017 API version specifically specifies "clientid" and not "client_id" as a query param
-			q.Add("clientid", clientID)
+			q.Add("clientid", id)
 		}
 	} else if c.msiType == msiTypeAppServiceV20190801 {
 		request.Header.Set("X-IDENTITY-HEADER", os.Getenv(identityHeader))
 		q.Add("api-version", "2019-08-01")
 		q.Add("resource", scopes[0])
 		if c.id == ResourceID {
-			q.Add(string(qpResID), clientID)
-		} else if clientID != "" {
-			q.Add(qpClientID, clientID)
+			q.Add(string(qpResID), id)
+		} else if id != "" {
+			q.Add(qpClientID, id)
 		}
 	}
 

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -174,7 +174,7 @@ func (c *managedIdentityClient) createIMDSAuthRequest(ctx context.Context, id st
 	q.Add("api-version", c.imdsAPIVersion)
 	q.Add("resource", strings.Join(scopes, " "))
 	if c.id == ResourceID {
-		q.Add(string(qpResID), id)
+		q.Add(qpResID, id)
 	} else if id != "" {
 		q.Add(qpClientID, id)
 	}
@@ -193,7 +193,7 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context,
 		q.Add("api-version", "2017-09-01")
 		q.Add("resource", strings.Join(scopes, " "))
 		if c.id == ResourceID {
-			q.Add(string(qpResID), id)
+			q.Add(qpResID, id)
 		} else if id != "" {
 			// the legacy 2017 API version specifically specifies "clientid" and not "client_id" as a query param
 			q.Add("clientid", id)
@@ -203,7 +203,7 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context,
 		q.Add("api-version", "2019-08-01")
 		q.Add("resource", scopes[0])
 		if c.id == ResourceID {
-			q.Add(string(qpResID), id)
+			q.Add(qpResID, id)
 		} else if id != "" {
 			q.Add(qpClientID, id)
 		}

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -11,10 +11,13 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
+// IDKind is used to specify the type of identifier that is passed in for a user-assigned managed identity.
 type IDKind int
 
 const (
-	ClientID   IDKind = 0
+	// ClientID is the default identifier for a user-assigned managed identity.
+	ClientID IDKind = 0
+	// ResourceID is set when the resource ID of the user-assigned managed identity is to be used.
 	ResourceID IDKind = 1
 )
 

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -21,9 +21,10 @@ const (
 // ManagedIdentityCredentialOptions contains parameters that can be used to configure the pipeline used with Managed Identity Credential.
 // All zero-value fields will be initialized with their default values.
 type ManagedIdentityCredentialOptions struct {
-	// ID helps to configure using an alternate user-assigned identity identifier. The default is client ID.
-	// Select the identifier to be used and pass the ID value in the string param on the ManagedIdentityCredential constructor.
-	// Hint: Choose from the exported list of allowed AlternateUserAssignedIdentifier values.
+	// ID is used to configure an alternate identifier for a user-assigned identity. The default is client ID.
+	// Select the identifier to be used and pass the corresponding ID value in the string param in
+	// NewManagedIdentityCredential().
+	// Hint: Choose from the list of allowed IDKind values.
 	ID IDKind
 
 	// HTTPClient sets the transport for making HTTP requests.
@@ -46,8 +47,8 @@ type ManagedIdentityCredential struct {
 }
 
 // NewManagedIdentityCredential creates an instance of the ManagedIdentityCredential capable of authenticating a resource that has a managed identity.
-// id: The ID that will be used to authenticate for a user assigned managed identity. Defaults to client ID. To use another identifier, pass in the value for the identifier here AND choose the
-// correct ID kind to be used in the request by setting IDKind in the options.
+// id: The ID that corresponds to the user assigned managed identity. Defaults to the identity's client ID. To use another identifier,
+// pass in the value for the identifier here AND choose the correct ID kind to be used in the request by setting IDKind in the options.
 // options: ManagedIdentityCredentialOptions that configure the pipeline for requests sent to Azure Active Directory.
 // More information on user assigned managed identities cam be found here:
 // https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -11,9 +11,20 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
+type AlternateUserAssignedIdentifier string
+
+const (
+	ResourceID AlternateUserAssignedIdentifier = "mi_res_id"
+)
+
 // ManagedIdentityCredentialOptions contains parameters that can be used to configure the pipeline used with Managed Identity Credential.
 // All zero-value fields will be initialized with their default values.
 type ManagedIdentityCredentialOptions struct {
+	// AlternateID enables using an alternate user-assigned identity identifier instead of the default client ID.
+	// Select the identifier to be used and pass the value in the string param on the ManagedIdentityCredential constructor.
+	// Hint: Choose from the exported list of allowed AlternateUserAssignedIdentifier values.
+	AlternateID AlternateUserAssignedIdentifier
+
 	// HTTPClient sets the transport for making HTTP requests.
 	// Leave this as nil to use the default HTTP transport.
 	HTTPClient azcore.Transport

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -11,14 +11,14 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-// IDKind is used to specify the type of identifier that is passed in for a user-assigned managed identity.
-type IDKind int
+// ManagedIdentityIDKind is used to specify the type of identifier that is passed in for a user-assigned managed identity.
+type ManagedIdentityIDKind int
 
 const (
 	// ClientID is the default identifier for a user-assigned managed identity.
-	ClientID IDKind = 0
+	ClientID ManagedIdentityIDKind = 0
 	// ResourceID is set when the resource ID of the user-assigned managed identity is to be used.
-	ResourceID IDKind = 1
+	ResourceID ManagedIdentityIDKind = 1
 )
 
 // ManagedIdentityCredentialOptions contains parameters that can be used to configure the pipeline used with Managed Identity Credential.
@@ -27,8 +27,8 @@ type ManagedIdentityCredentialOptions struct {
 	// ID is used to configure an alternate identifier for a user-assigned identity. The default is client ID.
 	// Select the identifier to be used and pass the corresponding ID value in the string param in
 	// NewManagedIdentityCredential().
-	// Hint: Choose from the list of allowed IDKind values.
-	ID IDKind
+	// Hint: Choose from the list of allowed ManagedIdentityIDKind values.
+	ID ManagedIdentityIDKind
 
 	// HTTPClient sets the transport for making HTTP requests.
 	// Leave this as nil to use the default HTTP transport.
@@ -51,7 +51,7 @@ type ManagedIdentityCredential struct {
 
 // NewManagedIdentityCredential creates an instance of the ManagedIdentityCredential capable of authenticating a resource that has a managed identity.
 // id: The ID that corresponds to the user assigned managed identity. Defaults to the identity's client ID. To use another identifier,
-// pass in the value for the identifier here AND choose the correct ID kind to be used in the request by setting IDKind in the options.
+// pass in the value for the identifier here AND choose the correct ID kind to be used in the request by setting ManagedIdentityIDKind in the options.
 // options: ManagedIdentityCredentialOptions that configure the pipeline for requests sent to Azure Active Directory.
 // More information on user assigned managed identities cam be found here:
 // https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm


### PR DESCRIPTION
Fixes #12184

Adding support for passing in a resource ID instead of a client ID for managed identities. 
