### PR TITLE
Fix dependency issues with `dep ensure`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -79,6 +79,30 @@
   version = "v4.0.0"
 
 [[projects]]
+  digest = "1:9e62e8886ca549ad17aa4db1783e469f10e424652595304fdc2c8ecda5d25476"
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  pruneopts = "UT"
+  revision = "ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"
+  version = "v1.5.2"
+
+[[projects]]
+  digest = "1:d06fbb4c29d4266211e7fa20d29b61469db346e6df1bea40a70cea066cf25019"
+  name = "github.com/hashicorp/errwrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "7b00e5db719c64d14dd0caaacbd13e76254d02c0"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:71c646a40ec9bcfcc93ce31cde043356cb95670203d219c7edede05779081fe4"
+  name = "github.com/hashicorp/go-multierror"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9974e9ec57696378079ecc3accd3d6f29401b3a0"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
@@ -174,9 +198,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ac468a38e9185df579ec927199704bb13a825417ac94d858387500762c29ae69"
+  digest = "1:60397b4be0f6f80cf41b1b29863778b5afcb7d9cf4ccfd2d00bf438738caa888"
   name = "golang.org/x/net"
   packages = [
+    "context",
+    "context/ctxhttp",
     "http/httpguts",
     "http2",
     "http2/hpack",
@@ -184,6 +210,17 @@
   ]
   pruneopts = "UT"
   revision = "e915ea6b2b7d7f3955e2d6d432eaebd7cf5921e7"
+
+[[projects]]
+  branch = "master"
+  digest = "1:f61fe67341c0aa7358c3050eb03d66e4484721526eef17c74e43bd648518492e"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "UT"
+  revision = "f6687ab2804cbebdfdeef385bee94918b1ce83de"
 
 [[projects]]
   branch = "master"
@@ -253,6 +290,58 @@
   revision = "5ec99f83aff198f5fbd629d6c8d8eb38a04218ca"
 
 [[projects]]
+  digest = "1:15bbb120d95283019f8891f2762fab3e735075b2cf9b378497277d2fe6c4abca"
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = "UT"
+  revision = "5d1c1d03f8703c2e81478d9a30e9afa2d3e4bd8a"
+  version = "v1.6.7"
+
+[[projects]]
+  digest = "1:bc8a58ba53d55c6c60aba097ba2981a37cf074c8c19e852763529dbc0ae0eb05"
+  name = "google.golang.org/protobuf"
+  packages = [
+    "encoding/prototext",
+    "encoding/protowire",
+    "internal/descfmt",
+    "internal/descopts",
+    "internal/detrand",
+    "internal/encoding/defval",
+    "internal/encoding/messageset",
+    "internal/encoding/tag",
+    "internal/encoding/text",
+    "internal/errors",
+    "internal/filedesc",
+    "internal/filetype",
+    "internal/flags",
+    "internal/genid",
+    "internal/impl",
+    "internal/order",
+    "internal/pragma",
+    "internal/set",
+    "internal/strs",
+    "internal/version",
+    "proto",
+    "reflect/protodesc",
+    "reflect/protoreflect",
+    "reflect/protoregistry",
+    "runtime/protoiface",
+    "runtime/protoimpl",
+    "types/descriptorpb",
+  ]
+  pruneopts = "UT"
+  revision = "f2d1f6cbe10b90d22296ea09a7217081c2798009"
+  version = "v1.26.0"
+
+[[projects]]
   branch = "v1"
   digest = "1:b39f3febddd151ee9993a0a10c20393efeddb1d31c0c706c9d03d054dbafd308"
   name = "gopkg.in/check.v1"
@@ -285,13 +374,16 @@
     "github.com/dnaeon/go-vcr/recorder",
     "github.com/globalsign/mgo",
     "github.com/gofrs/uuid",
+    "github.com/hashicorp/go-multierror",
     "github.com/jongio/azidext/go/azidext",
     "github.com/pkg/browser",
     "github.com/shopspring/decimal",
     "github.com/spf13/cobra",
+    "github.com/spf13/pflag",
     "golang.org/x/crypto/pkcs12",
     "golang.org/x/net/http/httpguts",
     "golang.org/x/net/http2",
+    "golang.org/x/oauth2",
     "golang.org/x/tools/imports",
     "gopkg.in/check.v1",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,6 +19,8 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
+ignored = ["github.com/ahmetb/go-linq/*", "github.com/google/go-github/*"]
+
 [prune]
   unused-packages = true
   go-tests = true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ jobs:
       sdkPath: '$(GOPATH)/src/github.com/$(build.repository.name)'
       IGNORE_BREAKING_CHANGES: true
       go.list.filter: '| grep -v vendor | grep -v azure-sdk-for-go/sdk | grep -v azure-sdk-for-go/tools/generator'
+      go.test.filter: '-path ./vendor -prune -o -path ./sdk -prune -o -path ./sdk -prune -o -path ./tools/generator -prune'
 
     steps:
     - task: GoTool@0
@@ -58,7 +59,7 @@ jobs:
     - script: go build -v $(go list ./... $(go.list.filter))
       workingDirectory: '$(sdkPath)'
       displayName: 'Build'
-    - script: go test $(dirname $(find . -path ./vendor -prune -o -path ./sdk -prune -o -path ./sdk -prune -o -name '*_test.go' -print) | sort -u)
+    - script: go test $(dirname $(find . $(go.test.filter) -name '*_test.go' -print) | sort -u)
       workingDirectory: '$(sdkPath)'
       displayName: 'Run Tests'
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
@@ -85,7 +86,6 @@ jobs:
       condition: succeededOrFailed()
     - script: |
         golint ./storage/... >&2
-        golint ./tools/... >&2
       workingDirectory: '$(sdkPath)'
       displayName: 'Linter Check'
       failOnStderr: true

--- a/initScript.sh
+++ b/initScript.sh
@@ -8,6 +8,7 @@ fi
 curl -sSL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 PATH=$PATH:$GOPATH/bin
 dep ensure
+go get github.com/Azure/azure-sdk-for-go/tools/generator@latest
 cat > $2 << EOF
 {
   "envs": {

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/documentation/sdkautomation/SwaggerToSdkConfigSchema.json",
   "generateOptions": {
     "generateScript": {
-      "path": "go run ./tools/generator/main.go automation",
+      "path": "generator automation",
       "stderr": {
         "showInComment": "^\\[AUTOREST\\]",
         "scriptError": "^\\[ERROR\\]",

--- a/tools/generator/cmd/root.go
+++ b/tools/generator/cmd/root.go
@@ -30,9 +30,6 @@ func Command() *cobra.Command {
 		automation.Command(),
 		issue.Command(),
 	)
-	rootCmd.AddCommand(
-		automation.Command(),
-	)
 
 	return rootCmd
 }


### PR DESCRIPTION
We are facing some failures in CI with `dep ensure` after we introduce some new command to `tools/generator`.

Now `tools/generator` imports some modules with the major version greater than `v1`. The `dep` cannot properly import them and give us errors when running `dep ensure`.

This PR adds ignore clauses in the `Gopkg.toml` file to explicitly ignore those modules with greater than v2 major version to fix this issue.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.
 
[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md
