### PR TITLE
Add prepare pipelines pipeline

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -1,0 +1,10 @@
+trigger: none
+
+extends:
+  template: /eng/common/pipelines/templates/steps/prepare-pipelines.yml
+  parameters:
+    Repository: $(Build.Repository.Name)
+    Prefix: go
+    CIConventionOptions: ''
+    UPConventionOptions: '--variablegroup 58 --variablegroup 76 --variablegroup 56 --variablegroup 93'
+    TestsConventionOptions: '--variablegroup 64'


### PR DESCRIPTION
In order to automatically create new pipelines from PRs with pipeline yaml, we first need to define a repo-specific `prepare pipelines` pipeline (how many times can I say pipeline in one sentence...).