### PR TITLE
Skip live test generation in prepare-pipelines

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -7,4 +7,5 @@ extends:
     Prefix: go
     CIConventionOptions: ''
     UPConventionOptions: '--variablegroup 58 --variablegroup 76 --variablegroup 56 --variablegroup 93'
-    TestsConventionOptions: '--variablegroup 64'
+    # Uncomment once live tests (tests.yml) are added to the repository
+    # TestsConventionOptions: '--variablegroup 64'


### PR DESCRIPTION
I added support for `/azp run prepare-pipelines` with https://github.com/Azure/azure-sdk-for-go/pull/14947, but the config was set to generate live test pipelines. Since none are currently defined for the repo, this will cause that step of the pipeline to fail (and therefore block the PR it was run for).

Commenting out the `TestsConventionOptions` parameter has the effect of skipping live test generation (https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/pipelines/templates/steps/prepare-pipelines.yml#L74).