### PR TITLE
QueryFilter json field dimension-->dimensions

### DIFF
--- a/services/costmanagement/mgmt/2019-10-01/costmanagement/models.go
+++ b/services/costmanagement/mgmt/2019-10-01/costmanagement/models.go
@@ -9,11 +9,12 @@ package costmanagement
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/Azure/go-autorest/tracing"
-	"net/http"
 )
 
 // The package's fully qualified name.
@@ -724,7 +725,7 @@ type QueryFilter struct {
 	// Not - The logical "NOT" expression.
 	Not *QueryFilter `json:"not,omitempty"`
 	// Dimension - Has comparison expression for a dimension
-	Dimension *QueryComparisonExpression `json:"dimension,omitempty"`
+	Dimension *QueryComparisonExpression `json:"dimensions,omitempty"`
 	// Tag - Has comparison expression for a tag
 	Tag *QueryComparisonExpression `json:"tag,omitempty"`
 }


### PR DESCRIPTION
[referenced issue
](https://github.com/Azure/azure-sdk-for-go/issues/11869)

[same issue for the version of python sdk](https://github.com/Azure/azure-sdk-for-python/issues/14923)

so, try using dimensions instead of dimension.


- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
