### PR TITLE
[Core] Renamings for AuthPolicies

### DIFF
--- a/sdk/azcore/credential.go
+++ b/sdk/azcore/credential.go
@@ -10,26 +10,26 @@ import (
 	"time"
 )
 
-// AuthenticationPolicyOptions contains various options used to create a credential policy.
-type AuthenticationPolicyOptions struct {
+// AuthenticationOptions contains various options used to create a credential policy.
+type AuthenticationOptions struct {
 	// Options contains the TokenRequestOptions that includes a scopes field which contains
 	// the list of OAuth2 authentication scopes used when requesting a token.
 	// This field is ignored for other forms of authentication (e.g. shared key).
-	Options TokenRequestOptions
+	TokenRequest TokenRequestOptions
 }
 
 // Credential represents any credential type.
 type Credential interface {
 	// AuthenticationPolicy returns a policy that requests the credential and applies it to the HTTP request.
-	AuthenticationPolicy(options AuthenticationPolicyOptions) Policy
+	NewAuthenticationPolicy(options AuthenticationOptions) Policy
 }
 
 // credentialFunc is a type that implements the Credential interface.
 // Use this type when implementing a stateless credential as a first-class function.
-type credentialFunc func(options AuthenticationPolicyOptions) Policy
+type credentialFunc func(options AuthenticationOptions) Policy
 
 // AuthenticationPolicy implements the Credential interface on credentialFunc.
-func (cf credentialFunc) AuthenticationPolicy(options AuthenticationPolicyOptions) Policy {
+func (cf credentialFunc) NewAuthenticationPolicy(options AuthenticationOptions) Policy {
 	return cf(options)
 }
 

--- a/sdk/azcore/policy_anonymous_credential.go
+++ b/sdk/azcore/policy_anonymous_credential.go
@@ -5,7 +5,7 @@
 
 package azcore
 
-func anonCredAuthPolicyFunc(AuthenticationPolicyOptions) Policy {
+func anonCredAuthPolicyFunc(AuthenticationOptions) Policy {
 	return PolicyFunc(anonCredPolicyFunc)
 }
 

--- a/sdk/azcore/policy_anonymous_credential_test.go
+++ b/sdk/azcore/policy_anonymous_credential_test.go
@@ -18,7 +18,7 @@ func TestAnonymousCredential(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
-	pl := NewPipeline(srv, AnonymousCredential().AuthenticationPolicy(AuthenticationPolicyOptions{}))
+	pl := NewPipeline(srv, AnonymousCredential().NewAuthenticationPolicy(AuthenticationOptions{}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -471,12 +471,15 @@ func TestRequestSetBodyContentLengthHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	buff := make([]byte, 768, 768)
+	buff := make([]byte, 768)
 	const buffLen = 768
 	for i := 0; i < buffLen; i++ {
 		buff[i] = 1
 	}
-	req.SetBody(NopCloser(bytes.NewReader(buff)), "application/octet-stream")
+	err = req.SetBody(NopCloser(bytes.NewReader(buff)), "application/octet-stream")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if req.Header.Get(headerContentLength) != strconv.FormatInt(buffLen, 10) {
 		t.Fatalf("expected content-length %d, got %s", buffLen, req.Header.Get(headerContentLength))
 	}


### PR DESCRIPTION
- [ ] Renames `AuthenticationPolicy` -> `NewAuthenticationPolicy`
- [ ] Renames `AuthenticationPolicyOptions.Options` -> `AuthenticationPolicyOptions.TokenRequest`
- [ ] Renames `AuthenticationPolicyOptions` -> `AuthenticationOptions`