### PR TITLE
[Identity] fixing lint step for azidentity

### DIFF
--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -140,7 +140,7 @@ func interactiveBrowserLogin(ctx context.Context, authorityHost string, opts *In
 	cv := ""
 	// the code verifier is a random 32-byte sequence that's been base-64 encoded without padding.
 	// it's used to prevent MitM attacks during auth code flow, see https://tools.ietf.org/html/rfc7636
-	b := make([]byte, 32, 32)
+	b := make([]byte, 32, 32) // nolint:gosimple
 	if _, err := rand.Read(b); err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/interactive_browser_server.go
+++ b/sdk/azidentity/interactive_browser_server.go
@@ -70,7 +70,7 @@ func (s *server) Start(reqState string, port int) string {
 			if s.err != nil {
 				page = failPage
 			}
-			w.Write([]byte(page))
+			w.Write([]byte(page)) // nolint:errcheck
 		}()
 
 		qp := r.URL.Query()
@@ -94,14 +94,14 @@ func (s *server) Start(reqState string, port int) string {
 		}
 		s.code = code
 	})
-	go s.s.ListenAndServe()
+	go s.s.ListenAndServe() // nolint:errcheck
 	return fmt.Sprintf("http://localhost:%d", port)
 }
 
 // Stop will shut down the local HTTP server.
 func (s *server) Stop() {
 	close(s.done)
-	s.s.Shutdown(context.Background())
+	s.s.Shutdown(context.Background()) // nolint:errcheck
 }
 
 // WaitForCallback will wait until Azure interactive login has called us back with an authorization code or error.


### PR DESCRIPTION
Fixes lint step. For now skipping `golangci-lint` step on the four issues that are flagged by the linter