### PR TITLE
[build.ps1] Add support for converting _meta.json to autorest.md during build

### DIFF
--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -36,7 +36,7 @@ $keys | ForEach-Object { $sdks[$_] } | ForEach-Object {
 
     if ($_.generate) {
         Write-Host "##[command]Executing autorest.go in " $_.path
-        $autorestPath = $_.path + "\autorest.md"
+        $autorestPath = $_.path + "/autorest.md"
 
         if (ShouldGenerate-AutorestConfig $autorestPath) {
             Generate-AutorestConfig $autorestPath

--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 7.0
 param($filter, [switch]$clean, [switch]$vet, [switch]$generate, [switch]$skipBuild)
 
-. $PSScriptRoot\meta_generation.ps1
+. $PSScriptRoot/meta_generation.ps1
 
 $startingDirectory = Get-Location
 $root = Resolve-Path ($PSScriptRoot + "/../..")
@@ -38,7 +38,7 @@ $keys | ForEach-Object { $sdks[$_] } | ForEach-Object {
         Write-Host "##[command]Executing autorest.go in " $_.path
         $autorestPath = $_.path + "\autorest.md"
 
-        if (ShouldGenerate-AutorestConfig($autorestPath) ) {
+        if (ShouldGenerate-AutorestConfig $autorestPath) {
             Generate-AutorestConfig($autorestPath)
             $removeAutorestFile = $true
         }

--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -39,7 +39,7 @@ $keys | ForEach-Object { $sdks[$_] } | ForEach-Object {
         $autorestPath = $_.path + "\autorest.md"
 
         if (ShouldGenerate-AutorestConfig $autorestPath) {
-            Generate-AutorestConfig($autorestPath)
+            Generate-AutorestConfig $autorestPath
             $removeAutorestFile = $true
         }
 

--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -1,6 +1,8 @@
 #Requires -Version 7.0
 param($filter, [switch]$clean, [switch]$vet, [switch]$generate, [switch]$skipBuild)
 
+. $PSScriptRoot\meta_generation.ps1
+
 $startingDirectory = Get-Location
 $root = Resolve-Path ($PSScriptRoot + "/../..")
 Set-Location $root
@@ -35,10 +37,19 @@ $keys | ForEach-Object { $sdks[$_] } | ForEach-Object {
     if ($_.generate) {
         Write-Host "##[command]Executing autorest.go in " $_.path
         $autorestPath = $_.path + "\autorest.md"
+
+        if (ShouldGenerate-AutorestConfig($autorestPath) ) {
+            Generate-AutorestConfig($autorestPath)
+            $removeAutorestFile = $true
+        }
+
         $autorestVersion = "@autorest/go@4.0.0-preview.23"
         $outputFolder = $_.path
         $root = $_.root
         autorest --use=$autorestVersion --go --track2 --go-sdk-folder=$root --output-folder=$outputFolder --file-prefix="zz_generated_" --clear-output-folder=false $autorestPath
+        if ($removeAutorestFile) {
+            Remove-Item $autorestPath
+        }
     }
     if (!$_.skipBuild) {
         Write-Host "##[command]Executing go build -v ./... in " $_.path

--- a/eng/scripts/meta_generation.ps1
+++ b/eng/scripts/meta_generation.ps1
@@ -1,0 +1,27 @@
+function ShouldGenerate-AutorestConfig {
+    Param(
+        [string] $autorestPath
+    )
+    $metaPath = $autorestPath.Replace("autorest.md", "_meta.json")
+    return !(Test-Path $autorestPath -PathType Leaf) && (Test-Path $metaPath -PathType Leaf)
+}
+
+function Generate-AutorestConfig {
+    Param(
+        [string] $autorestPath
+    )
+    $metaPath = $autorestPath.Replace("autorest.md", "_meta.json")
+    $meta = Get-Content $metaPath | ConvertFrom-Json
+    $readme = "https://github.com/Azure/azure-rest-api-specs/blob/" + $meta.commit + $meta.readme.Split("/azure-rest-api-specs")[1];
+
+    $contents = @'
+### AutoRest Configuration
+> see https://aka.ms/autorest
+``` yaml
+tag: {0}
+require:
+- {1}
+```
+'@;
+    $contents -f $meta.tag, $readme | Out-File -FilePath $autorestPath
+}

--- a/eng/scripts/meta_generation.ps1
+++ b/eng/scripts/meta_generation.ps1
@@ -1,15 +1,9 @@
-function ShouldGenerate-AutorestConfig {
-    Param(
-        [string] $autorestPath
-    )
+function ShouldGenerate-AutorestConfig([string]$autorestPath) {
     $metaPath = $autorestPath.Replace("autorest.md", "_meta.json")
-    return !(Test-Path $autorestPath -PathType Leaf) && (Test-Path $metaPath -PathType Leaf)
+    return !(Test-Path $autorestPath -PathType Leaf) -and (Test-Path $metaPath -PathType Leaf)
 }
 
-function Generate-AutorestConfig {
-    Param(
-        [string] $autorestPath
-    )
+function Generate-AutorestConfig([string]$autorestPath) {
     $metaPath = $autorestPath.Replace("autorest.md", "_meta.json")
     $meta = Get-Content $metaPath | ConvertFrom-Json
     $readme = "https://github.com/Azure/azure-rest-api-specs/blob/" + $meta.commit + $meta.readme.Split("/azure-rest-api-specs")[1];


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
