### PR TITLE
[armcore] Add auxiliary tenants to connection options

### DIFF
--- a/sdk/armcore/connection.go
+++ b/sdk/armcore/connection.go
@@ -25,6 +25,10 @@ const (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
+	// AuxiliaryTenants contains a list of additional tenants to be used to authenticate
+	// across multiple tenants.
+	AuxiliaryTenants []string
+
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
 
@@ -95,7 +99,14 @@ func NewConnection(endpoint string, cred azcore.TokenCredential, options *Connec
 	policies = append(policies, azcore.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies,
-		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{endpointToScope(endpoint)}}}),
+		cred.NewAuthenticationPolicy(
+			azcore.AuthenticationOptions{
+				TokenRequest: azcore.TokenRequestOptions{
+					Scopes: []string{endpointToScope(endpoint)},
+				},
+				AuxiliaryTenants: options.AuxiliaryTenants,
+			},
+		),
 		azcore.NewLogPolicy(&options.Logging))
 	p := azcore.NewPipeline(options.HTTPClient, policies...)
 	return &Connection{u: endpoint, p: p}

--- a/sdk/armcore/connection_test.go
+++ b/sdk/armcore/connection_test.go
@@ -18,7 +18,7 @@ import (
 
 type mockTokenCred struct{}
 
-func (mockTokenCred) AuthenticationPolicy(azcore.AuthenticationPolicyOptions) azcore.Policy {
+func (mockTokenCred) NewAuthenticationPolicy(azcore.AuthenticationOptions) azcore.Policy {
 	return azcore.PolicyFunc(func(req *azcore.Request) (*azcore.Response, error) {
 		return req.Next()
 	})
@@ -68,7 +68,7 @@ func TestNewConnectionWithOptions(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	if ua := resp.Request.Header.Get(azcore.HeaderUserAgent); !strings.HasPrefix(ua, UserAgent) {
+	if ua := resp.Request.Header.Get("User-Agent"); !strings.HasPrefix(ua, UserAgent) {
 		t.Fatalf("unexpected User-Agent %s", ua)
 	}
 }
@@ -99,7 +99,7 @@ func TestNewConnectionWithCustomTelemetry(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	if ua := resp.Request.Header.Get(azcore.HeaderUserAgent); !strings.HasPrefix(ua, myTelemetry+" "+UserAgent) {
+	if ua := resp.Request.Header.Get("User-Agent"); !strings.HasPrefix(ua, myTelemetry+" "+UserAgent) {
 		t.Fatalf("unexpected User-Agent %s", ua)
 	}
 }

--- a/sdk/armcore/go.mod
+++ b/sdk/armcore/go.mod
@@ -3,6 +3,6 @@ module github.com/Azure/azure-sdk-for-go/sdk/armcore
 go 1.14
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.17.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1
 )

--- a/sdk/armcore/go.sum
+++ b/sdk/armcore/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2 h1:UC4vfOhW2l0f2QOCQpOxJS4/K6oKFy2tQZE+uWU1MEo=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.17.0 h1:j9ra6YGWu3TqNmCprpWYFCqQ3aizqujxrqhI7KLu6qg=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.17.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/sdk/armcore/internal/pollers/async/async.go
+++ b/sdk/armcore/internal/pollers/async/async.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	finalStateAsync = "azure-async-operation"
-	finalStateLoc   = "location"
+	finalStateLoc   = "location" //nolint:deadcode
 	finalStateOrig  = "original-uri"
 )
 

--- a/sdk/armcore/internal/pollers/async/async.go
+++ b/sdk/armcore/internal/pollers/async/async.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	finalStateAsync = "azure-async-operation"
-	finalStateLoc   = "location" //nolint:deadcode
+	finalStateLoc   = "location" //nolint
 	finalStateOrig  = "original-uri"
 )
 

--- a/sdk/armcore/internal/pollers/loc/loc_test.go
+++ b/sdk/armcore/internal/pollers/loc/loc_test.go
@@ -19,7 +19,6 @@ import (
 const (
 	fakePollingURL1 = "https://foo.bar.baz/status"
 	fakePollingURL2 = "https://foo.bar.baz/updated"
-	fakeResourceURL = "https://foo.bar.baz/resource"
 )
 
 func initialResponse(method string) *azcore.Response {

--- a/sdk/armcore/internal/pollers/pollers_test.go
+++ b/sdk/armcore/internal/pollers/pollers_test.go
@@ -133,27 +133,27 @@ func TestMakeID(t *testing.T) {
 }
 
 func TestDecodeID(t *testing.T) {
-	id, kind, err := DecodeID("")
+	_, _, err := DecodeID("")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	id, kind, err = DecodeID("invalid_token")
+	_, _, err = DecodeID("invalid_token")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	id, kind, err = DecodeID("invalid_token;")
+	_, _, err = DecodeID("invalid_token;")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	id, kind, err = DecodeID("  ;invalid_token")
+	_, _, err = DecodeID("  ;invalid_token")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	id, kind, err = DecodeID("invalid;token;too")
+	_, _, err = DecodeID("invalid;token;too")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	id, kind, err = DecodeID("pollerID;kind")
+	id, kind, err := DecodeID("pollerID;kind")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/armcore/policy_register_rp.go
+++ b/sdk/armcore/policy_register_rp.go
@@ -87,7 +87,7 @@ func NewRPRegistrationPolicy(endpoint string, cred azcore.Credential, o *Registr
 		pipeline: azcore.NewPipeline(o.HTTPClient,
 			azcore.NewTelemetryPolicy(&o.Telemetry),
 			azcore.NewRetryPolicy(&o.Retry),
-			cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{endpointToScope(endpoint)}}}),
+			cred.NewAuthenticationPolicy(azcore.AuthenticationOptions{TokenRequest: azcore.TokenRequestOptions{Scopes: []string{endpointToScope(endpoint)}}}),
 			azcore.NewLogPolicy(&o.Logging)),
 		options: *o,
 	}

--- a/sdk/armcore/policy_register_rp_test.go
+++ b/sdk/armcore/policy_register_rp_test.go
@@ -108,7 +108,7 @@ func TestRPRegistrationPolicyNA(t *testing.T) {
 	defer close()
 	// response indicates no RP registration is required, policy does nothing
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.AnonymousCredential(), testRPRegistrationOptions(srv)))
+	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.NewAnonymousCredential(), testRPRegistrationOptions(srv)))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)
@@ -147,7 +147,7 @@ func TestRPRegistrationPolicy409Other(t *testing.T) {
 	defer close()
 	// test getting a 409 but not due to registration required
 	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(failedResp)))
-	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.AnonymousCredential(), testRPRegistrationOptions(srv)))
+	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.NewAnonymousCredential(), testRPRegistrationOptions(srv)))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatal(err)
@@ -178,7 +178,7 @@ func TestRPRegistrationPolicyTimesOut(t *testing.T) {
 	// polling responses to Register() and Get(), in progress but slow
 	// tests registration takes too long, times out
 	srv.RepeatResponse(10, mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(rpRegisteringResp)), mock.WithSlowResponse(400*time.Millisecond))
-	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.AnonymousCredential(), testRPRegistrationOptions(srv)))
+	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.NewAnonymousCredential(), testRPRegistrationOptions(srv)))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, azcore.JoinPaths(srv.URL(), requestEndpoint))
 	if err != nil {
 		t.Fatal(err)
@@ -222,7 +222,7 @@ func TestRPRegistrationPolicyExceedsAttempts(t *testing.T) {
 		// polling response, successful registration
 		srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(rpRegisteredResp)))
 	}
-	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.AnonymousCredential(), testRPRegistrationOptions(srv)))
+	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.NewAnonymousCredential(), testRPRegistrationOptions(srv)))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, azcore.JoinPaths(srv.URL(), requestEndpoint))
 	if err != nil {
 		t.Fatal(err)
@@ -270,7 +270,7 @@ func TestRPRegistrationPolicyCanCancel(t *testing.T) {
 	srv.RepeatResponse(10, mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(rpRegisteringResp)), mock.WithSlowResponse(300*time.Millisecond))
 	opts := RegistrationOptions{}
 	opts.HTTPClient = srv
-	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.AnonymousCredential(), &opts))
+	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.NewAnonymousCredential(), &opts))
 	// log only RP registration
 	azcore.Log().SetClassifications(LogRPRegistration)
 	defer func() {
@@ -323,7 +323,7 @@ func TestRPRegistrationPolicyDisabled(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
 	ops := testRPRegistrationOptions(srv)
 	ops.MaxAttempts = -1
-	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.AnonymousCredential(), ops))
+	pl := azcore.NewPipeline(srv, NewRPRegistrationPolicy(srv.URL(), azcore.NewAnonymousCredential(), ops))
 	req, err := azcore.NewRequest(context.Background(), http.MethodGet, azcore.JoinPaths(srv.URL(), requestEndpoint))
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/armcore/poller.go
+++ b/sdk/armcore/poller.go
@@ -219,7 +219,7 @@ func (l *LROPoller) FinalResponse(ctx context.Context, respType interface{}) (*h
 func (l *LROPoller) PollUntilDone(ctx context.Context, freq time.Duration, respType interface{}) (*http.Response, error) {
 	start := time.Now()
 	logPollUntilDoneExit := func(v interface{}) {
-		azcore.Log().Writef(azcore.LogLongRunningOperation, "END PollUntilDone() for %T: %v, total time: %s", l.lro, v, time.Now().Sub(start))
+		azcore.Log().Writef(azcore.LogLongRunningOperation, "END PollUntilDone() for %T: %v, total time: %s", l.lro, v, time.Since(start))
 	}
 	azcore.Log().Writef(azcore.LogLongRunningOperation, "BEGIN PollUntilDone() for %T", l.lro)
 	if l.resp != nil {

--- a/sdk/armcore/poller_test.go
+++ b/sdk/armcore/poller_test.go
@@ -26,7 +26,7 @@ const (
 	provStateStarted   = `{ "properties": { "provisioningState": "Started" } }`
 	provStateUpdating  = `{ "properties": { "provisioningState": "Updating" } }`
 	provStateSucceeded = `{ "properties": { "provisioningState": "Succeeded" }, "field": "value" }`
-	provStateFailed    = `{ "properties": { "provisioningState": "Failed" } }`
+	provStateFailed    = `{ "properties": { "provisioningState": "Failed" } }` //nolint:deadcode
 	statusInProgress   = `{ "status": "InProgress" }`
 	statusSucceeded    = `{ "status": "Succeeded" }`
 	statusCanceled     = `{ "status": "Canceled" }`
@@ -97,6 +97,9 @@ func TestNewLROPollerAsync(t *testing.T) {
 		t.Fatal(err)
 	}
 	poller, err = NewLROPollerFromResumeToken("pollerID", tk, pl, handleError)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var result mockType
 	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
 	if err != nil {
@@ -127,6 +130,9 @@ func TestNewLROPollerBody(t *testing.T) {
 		t.Fatal(err)
 	}
 	poller, err = NewLROPollerFromResumeToken("pollerID", tk, pl, handleError)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var result mockType
 	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
 	if err != nil {
@@ -158,6 +164,9 @@ func TestNewLROPollerLoc(t *testing.T) {
 		t.Fatal(err)
 	}
 	poller, err = NewLROPollerFromResumeToken("pollerID", tk, pl, handleError)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var result mockType
 	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
 	if err != nil {

--- a/sdk/armcore/poller_test.go
+++ b/sdk/armcore/poller_test.go
@@ -26,7 +26,7 @@ const (
 	provStateStarted   = `{ "properties": { "provisioningState": "Started" } }`
 	provStateUpdating  = `{ "properties": { "provisioningState": "Updating" } }`
 	provStateSucceeded = `{ "properties": { "provisioningState": "Succeeded" }, "field": "value" }`
-	provStateFailed    = `{ "properties": { "provisioningState": "Failed" } }` //nolint:deadcode
+	provStateFailed    = `{ "properties": { "provisioningState": "Failed" } }` //nolint
 	statusInProgress   = `{ "status": "InProgress" }`
 	statusSucceeded    = `{ "status": "Succeeded" }`
 	statusCanceled     = `{ "status": "Canceled" }`
@@ -306,6 +306,9 @@ func TestNewLROPollerSuccessNoContent(t *testing.T) {
 		t.Fatal(err)
 	}
 	poller, err = NewLROPollerFromResumeToken("pollerID", tk, pl, handleError)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var result mockType
 	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
 	if err != nil {


### PR DESCRIPTION
Add AuxiliaryTenants in options for ARM clients, update code that depends on the latest changes in azcore, and fixing linting errors

Issue for checking linter comments: https://github.com/Azure/azure-sdk-for-go/issues/15173

Part of #14360