### PR TITLE
[EngSys] adding triggers on eng for internal and azcore

### DIFF
--- a/eng/.golangci.yml
+++ b/eng/.golangci.yml
@@ -3,3 +3,5 @@ run:
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true
+  # Do not include test files
+  tests: false

--- a/eng/.golangci.yml
+++ b/eng/.golangci.yml
@@ -3,5 +3,3 @@ run:
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true
-  # Do not include test files
-  tests: false

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -47,7 +47,7 @@ steps:
       env:
         GO111MODULE: 'on'
 
-    - pwsh: ../eng/scripts/create_coverage.ps1 -serviceDirectory=${{parameters.ServiceDirectory}}
+    - pwsh: ../eng/scripts/create_coverage.ps1 ${{parameters.ServiceDirectory}}
       displayName: 'Generate Coverage XML'
       workingDirectory: '${{parameters.GoWorkspace}}sdk'
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -47,7 +47,7 @@ steps:
       env:
         GO111MODULE: 'on'
 
-    - pwsh: ../eng/scripts/create_coverage.ps1
+    - pwsh: ../eng/scripts/create_coverage.ps1 -serviceDirectory=${{parameters.ServiceDirectory}}
       displayName: 'Generate Coverage XML'
       workingDirectory: '${{parameters.GoWorkspace}}sdk'
 

--- a/eng/scripts/create_coverage.ps1
+++ b/eng/scripts/create_coverage.ps1
@@ -22,4 +22,4 @@ Get-Content ./coverage.json | gocov-xml > ./coverage.xml
 Get-Content ./coverage.json | gocov-html > ./coverage.html
 
 # use internal tool to fail if coverage is too low
-go run ../tools/internal/coverage/main.go  --serviceDirectory $serviceDirectory
+go run ../tools/internal/coverage/main.go  -serviceDirectory $serviceDirectory

--- a/eng/scripts/create_coverage.ps1
+++ b/eng/scripts/create_coverage.ps1
@@ -1,5 +1,11 @@
 #Requires -Version 7.0
 
+Param(
+    [string] $serviceDirectory
+)
+
+Write-Host $serviceDirectory
+
 $coverageFiles = [Collections.Generic.List[String]]@()
 Get-ChildItem -recurse -path . -filter coverage.txt | ForEach-Object {
   $covFile = $_.FullName
@@ -16,4 +22,4 @@ Get-Content ./coverage.json | gocov-xml > ./coverage.xml
 Get-Content ./coverage.json | gocov-html > ./coverage.html
 
 # use internal tool to fail if coverage is too low
-go run ../tools/internal/coverage/main.go
+go run ../tools/internal/coverage/main.go  --serviceDirectory $serviceDirectory

--- a/sdk/azcore/ci.yml
+++ b/sdk/azcore/ci.yml
@@ -3,11 +3,13 @@ trigger:
   paths:
     include:
     - sdk/azcore/
+    - eng/
 
 pr:
   paths:
     include:
     - sdk/azcore/
+    - eng/
 
 
 stages:

--- a/sdk/azcore/log.go
+++ b/sdk/azcore/log.go
@@ -92,8 +92,8 @@ func (l *Logger) Writef(cls LogClassification, format string, a ...interface{}) 
 	l.lst(cls, fmt.Sprintf(format, a...))
 }
 
-// for testing purposes
-func (l *Logger) resetClassifications() {
+// for testing purposes, nolint is a false positive
+func (l *Logger) resetClassifications() { //nolint:unused
 	l.cls = nil
 }
 

--- a/sdk/internal/ci.yml
+++ b/sdk/internal/ci.yml
@@ -3,12 +3,14 @@ trigger:
   paths:
     include:
     - sdk/internal/
+    - eng/
 
 pr:
   paths:
     include:
     - sdk/internal/
-    
+    - eng/
+
 stages:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:

--- a/tools/internal/coverage/main.go
+++ b/tools/internal/coverage/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -79,6 +80,10 @@ func findCoverageGoal(covFiles []string, configData *CodeCoverage) float64 {
 }
 
 func main() {
+
+	serviceDir := flag.String("serviceDirectory", "", "Service Directory")
+	flag.Parse()
+
 	coverageFiles = make([]string, 0)
 	rootPath, err := filepath.Abs(".")
 	check(err)
@@ -86,7 +91,7 @@ func main() {
 	FindCoverageFiles(rootPath)
 
 	configData := ReadConfigData()
-	coverageGoal := findCoverageGoal(coverageFiles, configData)
+	coverageGoal := findCoverageGoal([]string{*serviceDir}, configData)
 
 	fmt.Printf("Failing if the coverage is below %.2f\n", coverageGoal)
 


### PR DESCRIPTION
 - [ ] This will run validation of `eng` changes on the azcore and internal packages to verify if any of the changes are breaking.
 - [ ] Fixes an issue with code coverage tool not correctly identifying paths, adds a flag for the service directory to the `internal/coverage/main.go` tool