### PR TITLE
Fix `azidentity` for `azcore/v0.17.0`

### DIFF
--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -198,7 +198,7 @@ func (c *aadIdentityClient) createRefreshTokenRequest(ctx context.Context, tenan
 	if err != nil {
 		return nil, err
 	}
-	if err := req.SetBody(body, azcore.HeaderURLEncoded); err != nil {
+	if err := req.SetBody(body, HeaderURLEncoded); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -216,7 +216,7 @@ func (c *aadIdentityClient) createClientSecretAuthRequest(ctx context.Context, t
 	if err != nil {
 		return nil, err
 	}
-	if err := req.SetBody(body, azcore.HeaderURLEncoded); err != nil {
+	if err := req.SetBody(body, HeaderURLEncoded); err != nil {
 		return nil, err
 	}
 
@@ -242,7 +242,7 @@ func (c *aadIdentityClient) createClientCertificateAuthRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := req.SetBody(body, azcore.HeaderURLEncoded); err != nil {
+	if err := req.SetBody(body, HeaderURLEncoded); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -288,7 +288,7 @@ func (c *aadIdentityClient) createUsernamePasswordAuthRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := req.SetBody(body, azcore.HeaderURLEncoded); err != nil {
+	if err := req.SetBody(body, HeaderURLEncoded); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -339,7 +339,7 @@ func (c *aadIdentityClient) createDeviceCodeAuthRequest(ctx context.Context, ten
 	if err != nil {
 		return nil, err
 	}
-	if err := req.SetBody(body, azcore.HeaderURLEncoded); err != nil {
+	if err := req.SetBody(body, HeaderURLEncoded); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -373,7 +373,7 @@ func (c *aadIdentityClient) createDeviceCodeNumberRequest(ctx context.Context, t
 	if err != nil {
 		return nil, err
 	}
-	if err := req.SetBody(body, azcore.HeaderURLEncoded); err != nil {
+	if err := req.SetBody(body, HeaderURLEncoded); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -436,7 +436,7 @@ func (c *aadIdentityClient) createAuthorizationCodeAuthRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := req.SetBody(body, azcore.HeaderURLEncoded); err != nil {
+	if err := req.SetBody(body, HeaderURLEncoded); err != nil {
 		return nil, err
 	}
 	return req, nil

--- a/sdk/azidentity/authorization_code_credential.go
+++ b/sdk/azidentity/authorization_code_credential.go
@@ -78,8 +78,8 @@ func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts azcore.
 	return tk, nil
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on AuthorizationCodeCredential.
-func (c *AuthorizationCodeCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+// NewAuthenticationPolicy implements the azcore.Credential interface on AuthorizationCodeCredential.
+func (c *AuthorizationCodeCredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }
 

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -39,6 +39,8 @@ type AzureCLICredential struct {
 	tokenProvider AzureCLITokenProvider
 }
 
+var _ azcore.TokenCredential = (*AzureCLICredential)(nil)
+
 // NewAzureCLICredential constructs a new AzureCLICredential with the details needed to authenticate against Azure Active Directory
 // options: configure the management of the requests sent to Azure Active Directory.
 func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredential, error) {
@@ -68,8 +70,8 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts azcore.TokenRequ
 	return at, nil
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on AzureCLICredential.
-func (c *AzureCLICredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+// NewAuthenticationPolicy implements the azcore.Credential interface on AzureCLICredential.
+func (c *AzureCLICredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }
 

--- a/sdk/azidentity/bearer_token_policy.go
+++ b/sdk/azidentity/bearer_token_policy.go
@@ -34,11 +34,11 @@ type bearerTokenPolicy struct {
 	options azcore.TokenRequestOptions
 }
 
-func newBearerTokenPolicy(creds azcore.TokenCredential, opts azcore.AuthenticationPolicyOptions) *bearerTokenPolicy {
+func newBearerTokenPolicy(creds azcore.TokenCredential, opts azcore.AuthenticationOptions) *bearerTokenPolicy {
 	return &bearerTokenPolicy{
 		cond:    sync.NewCond(&sync.Mutex{}),
 		creds:   creds,
-		options: opts.Options,
+		options: opts.TokenRequest,
 	}
 }
 
@@ -100,8 +100,8 @@ func (b *bearerTokenPolicy) Do(req *azcore.Request) (*azcore.Response, error) {
 		b.expiresOn = tk.ExpiresOn
 		b.unlock()
 	}
-	req.Request.Header.Set(azcore.HeaderXmsDate, time.Now().UTC().Format(http.TimeFormat))
-	req.Request.Header.Set(azcore.HeaderAuthorization, header)
+	req.Request.Header.Set(HeaderXmsDate, time.Now().UTC().Format(http.TimeFormat))
+	req.Request.Header.Set(HeaderAuthorization, header)
 	return req.Next()
 }
 

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -16,6 +16,8 @@ type ChainedTokenCredential struct {
 	sources []azcore.TokenCredential
 }
 
+var _ azcore.TokenCredential = (*ChainedTokenCredential)(nil)
+
 // NewChainedTokenCredential creates an instance of ChainedTokenCredential with the specified TokenCredential sources.
 func NewChainedTokenCredential(sources ...azcore.TokenCredential) (*ChainedTokenCredential, error) {
 	if len(sources) == 0 {
@@ -68,8 +70,8 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts azcore.Token
 	return nil, credErr
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on ChainedTokenCredential and sets the bearer token
-func (c *ChainedTokenCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+// NewAuthenticationPolicy implements the azcore.Credential interface on ChainedTokenCredential and sets the bearer token
+func (c *ChainedTokenCredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }
 

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -51,6 +51,8 @@ type ClientCertificateCredential struct {
 	sendCertificateChain bool          // Determines whether to include the certificate chain in the claims to retreive a token
 }
 
+var _ azcore.TokenCredential = (*ClientCertificateCredential)(nil)
+
 // NewClientCertificateCredential creates an instance of ClientCertificateCredential with the details needed to authenticate against Azure Active Directory with the specified certificate.
 // tenantID: The Azure Active Directory tenant (directory) ID of the service principal.
 // clientID: The client (application) ID of the service principal.
@@ -216,7 +218,7 @@ func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts azcore.
 	return tk, nil
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on ClientCertificateCredential.
-func (c *ClientCertificateCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+// NewAuthenticationPolicy implements the azcore.Credential interface on ClientCertificateCredential.
+func (c *ClientCertificateCredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -36,6 +36,8 @@ type ClientSecretCredential struct {
 	clientSecret string // Gets the client secret that was generated for the App Registration used to authenticate the client.
 }
 
+var _ azcore.TokenCredential = (*ClientCertificateCredential)(nil)
+
 // NewClientSecretCredential constructs a new ClientSecretCredential with the details needed to authenticate against Azure Active Directory with a client secret.
 // tenantID: The Azure Active Directory tenant (directory) ID of the service principal.
 // clientID: The client (application) ID of the service principal.
@@ -73,9 +75,9 @@ func (c *ClientSecretCredential) GetToken(ctx context.Context, opts azcore.Token
 	return tk, nil
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential and calls the Bearer Token policy
+// NewAuthenticationPolicy implements the azcore.Credential interface on ClientSecretCredential and calls the Bearer Token policy
 // to get the bearer token.
-func (c *ClientSecretCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+func (c *ClientSecretCredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }
 

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -167,8 +167,8 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts azcore.TokenRe
 	}
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on DeviceCodeCredential.
-func (c *DeviceCodeCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+// NewAuthenticationPolicy implements the azcore.Credential interface on DeviceCodeCredential.
+func (c *DeviceCodeCredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }
 

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -99,8 +99,8 @@ func (c *EnvironmentCredential) GetToken(ctx context.Context, opts azcore.TokenR
 	return c.cred.GetToken(ctx, opts)
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on EnvironmentCredential.
-func (c *EnvironmentCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+// NewAuthenticationPolicy implements the azcore.Credential interface on EnvironmentCredential.
+func (c *EnvironmentCredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c.cred, options)
 }
 

--- a/sdk/azidentity/go.mod
+++ b/sdk/azidentity/go.mod
@@ -3,8 +3,8 @@ module github.com/Azure/azure-sdk-for-go/sdk/azidentity
 go 1.14
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.17.0
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0 h1:4HBTI/9UDZN7tsXyB5TYP3xCv5xVHIUTbvHHH2HFxQY=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.17.0 h1:j9ra6YGWu3TqNmCprpWYFCqQ3aizqujxrqhI7KLu6qg=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.17.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -9,14 +9,12 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20201010224723-4f7140c49acb h1:mUVeFHoDKis5nxCAzoAi7E8Ghb86EXh/RK6wtvJIqRY=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/sdk/azidentity/headers.go
+++ b/sdk/azidentity/headers.go
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+const (
+	HeaderAuthorization      = "Authorization"
+	HeaderCacheControl       = "Cache-Control"
+	HeaderContentEncoding    = "Content-Encoding"
+	HeaderContentDisposition = "Content-Disposition"
+	HeaderContentLanguage    = "Content-Language"
+	HeaderContentLength      = "Content-Length"
+	HeaderContentMD5         = "Content-MD5"
+	HeaderContentType        = "Content-Type"
+	HeaderDate               = "Date"
+	HeaderIfMatch            = "If-Match"
+	HeaderIfModifiedSince    = "If-Modified-Since"
+	HeaderIfNoneMatch        = "If-None-Match"
+	HeaderIfUnmodifiedSince  = "If-Unmodified-Since"
+	HeaderMetadata           = "Metadata"
+	HeaderRange              = "Range"
+	HeaderRetryAfter         = "Retry-After"
+	HeaderURLEncoded         = "application/x-www-form-urlencoded"
+	HeaderUserAgent          = "User-Agent"
+	HeaderXmsDate            = "x-ms-date"
+	HeaderXmsVersion         = "x-ms-version"
+)

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -102,8 +102,8 @@ func (c *InteractiveBrowserCredential) GetToken(ctx context.Context, opts azcore
 	return tk, nil
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on InteractiveBrowserCredential.
-func (c *InteractiveBrowserCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+// NewAuthenticationPolicy implements the azcore.Credential interface on InteractiveBrowserCredential.
+func (c *InteractiveBrowserCredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }
 

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -181,7 +181,7 @@ func (c *managedIdentityClient) createIMDSAuthRequest(ctx context.Context, id st
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Set(azcore.HeaderMetadata, "true")
+	request.Header.Set(HeaderMetadata, "true")
 	q := request.URL.Query()
 	q.Add("api-version", c.imdsAPIVersion)
 	q.Add("resource", strings.Join(scopes, " "))
@@ -248,7 +248,7 @@ func (c *managedIdentityClient) getAzureArcSecretKey(ctx context.Context, resour
 	if err != nil {
 		return "", err
 	}
-	request.Header.Set(azcore.HeaderMetadata, "true")
+	request.Header.Set(HeaderMetadata, "true")
 	q := request.URL.Query()
 	q.Add("api-version", azureArcAPIVersion)
 	q.Add("resource", strings.Join(resources, " "))
@@ -284,8 +284,8 @@ func (c *managedIdentityClient) createAzureArcAuthRequest(ctx context.Context, k
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Set(azcore.HeaderMetadata, "true")
-	request.Header.Set(azcore.HeaderAuthorization, fmt.Sprintf("Basic %s", key))
+	request.Header.Set(HeaderMetadata, "true")
+	request.Header.Set(HeaderAuthorization, fmt.Sprintf("Basic %s", key))
 	q := request.URL.Query()
 	q.Add("api-version", azureArcAPIVersion)
 	q.Add("resource", strings.Join(resources, " "))
@@ -298,7 +298,7 @@ func (c *managedIdentityClient) createCloudShellAuthRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Set(azcore.HeaderMetadata, "true")
+	request.Header.Set(HeaderMetadata, "true")
 	data := url.Values{}
 	data.Set("resource", strings.Join(scopes, " "))
 	if clientID != "" {
@@ -306,7 +306,7 @@ func (c *managedIdentityClient) createCloudShellAuthRequest(ctx context.Context,
 	}
 	dataEncoded := data.Encode()
 	body := azcore.NopCloser(strings.NewReader(dataEncoded))
-	if err := request.SetBody(body, azcore.HeaderURLEncoded); err != nil {
+	if err := request.SetBody(body, HeaderURLEncoded); err != nil {
 		return nil, err
 	}
 	return request, nil

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -49,6 +49,8 @@ type ManagedIdentityCredential struct {
 	client *managedIdentityClient
 }
 
+var _ azcore.TokenCredential = (*ManagedIdentityCredential)(nil)
+
 // NewManagedIdentityCredential creates an instance of the ManagedIdentityCredential capable of authenticating a resource that has a managed identity.
 // id: The ID that corresponds to the user assigned managed identity. Defaults to the identity's client ID. To use another identifier,
 // pass in the value for the identifier here AND choose the correct ID kind to be used in the request by setting ManagedIdentityIDKind in the options.
@@ -107,8 +109,8 @@ func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts azcore.To
 	return tk, err
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on ManagedIdentityCredential.
+// NewAuthenticationPolicy implements the azcore.Credential interface on ManagedIdentityCredential.
 // NOTE: The TokenRequestOptions included in AuthenticationPolicyOptions must be a slice of resources in this case and not scopes.
-func (c *ManagedIdentityCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+func (c *ManagedIdentityCredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -38,6 +38,8 @@ type UsernamePasswordCredential struct {
 	password string // Gets the user account's password
 }
 
+var _ azcore.TokenCredential = (*UsernamePasswordCredential)(nil)
+
 // NewUsernamePasswordCredential constructs a new UsernamePasswordCredential with the details needed to authenticate against Azure Active Directory with
 // a simple username and password.
 // tenantID: The Azure Active Directory tenant (directory) ID of the service principal.
@@ -77,7 +79,7 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts azcore.T
 	return tk, err
 }
 
-// AuthenticationPolicy implements the azcore.Credential interface on UsernamePasswordCredential.
-func (c *UsernamePasswordCredential) AuthenticationPolicy(options azcore.AuthenticationPolicyOptions) azcore.Policy {
+// NewAuthenticationPolicy implements the azcore.Credential interface on UsernamePasswordCredential.
+func (c *UsernamePasswordCredential) NewAuthenticationPolicy(options azcore.AuthenticationOptions) azcore.Policy {
 	return newBearerTokenPolicy(c, options)
 }


### PR DESCRIPTION
Since we are currently in preview, and go get will automatically bump minor versions, it will break our applications if not all of the libraries are updated accordingly when one receives a breaking change

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
