### PR TITLE
redirect the output to stderr in gofmt checking so that we can give errors when the code is not formatted

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -37,8 +37,8 @@ steps:
     failOnStderr: true
     workingDirectory: 'sdk/${{parameters.ServiceDirectory}}'
 
-  - pwsh: |
-      Write-Host "##[command]Check source file formatting in $(pwd)"
+  - script: |
+      echo Check source file formatting in $(pwd)
       gofmt -s -l -d . | tee >&2
     displayName: 'Format Check'
     condition: succeededOrFailed()

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -39,7 +39,7 @@ steps:
 
   - pwsh: |
       Write-Host "##[command]Check source file formatting in $(pwd)"
-      gofmt -s -l -d .
+      gofmt -s -l -d . >&2
     displayName: 'Format Check'
     condition: succeededOrFailed()
     failOnStderr: true

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -39,7 +39,7 @@ steps:
 
   - pwsh: |
       Write-Host "##[command]Check source file formatting in $(pwd)"
-      gofmt -s -l -d . >&2
+      gofmt -s -l -d . | tee >&2
     displayName: 'Format Check'
     condition: succeededOrFailed()
     failOnStderr: true


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
