### PR TITLE
move verify link to the last step

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -7,11 +7,6 @@ parameters:
 
 steps:
 
-  - template: /eng/common/pipelines/templates/steps/verify-links.yml
-    parameters:
-      Directory: sdk/${{ parameters.ServiceDirectory }}
-      CheckLinkGuidance: $true
-
   - script: |
       curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${{parameters.LintVersion}}
       golangci-lint --version
@@ -44,5 +39,10 @@ steps:
     condition: succeededOrFailed()
     failOnStderr: true
     workingDirectory: 'sdk/${{parameters.ServiceDirectory}}'
+
+  - template: /eng/common/pipelines/templates/steps/verify-links.yml
+    parameters:
+      Directory: sdk/${{ parameters.ServiceDirectory }}
+      CheckLinkGuidance: $true
 
   - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

Move the verify link step to the last. I notice that the failure of this step will make the CI to skip the following step (Linter check). We definitely do not want that. Therefore moving this step to the last so that we can check those important aspect for go code first.

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
