### PR TITLE
add clear output flag to build.ps1

### DIFF
--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 7.0
-param([string]$filter, [switch]$clean, [switch]$vet, [switch]$generate, [switch]$skipBuild, [switch]$format, [switch]$tidy, [string]$config = "autorest.md", [string]$outputFolder)
+param([string]$filter, [switch]$clean, [switch]$vet, [switch]$generate, [switch]$skipBuild, [switch]$clearOutput, [switch]$format, [switch]$tidy, [string]$config = "autorest.md", [string]$outputFolder)
 
 . $PSScriptRoot/meta_generation.ps1
 . $PSScriptRoot/get_module_dirs.ps1
@@ -9,6 +9,11 @@ function Process-Sdk ($path) {
     if ($clean) {
         Write-Host "##[command]Executing go clean -v ./... in " $path
         go clean -v ./...
+    }
+
+    if ($clearOutput) {
+        Write-Host "##[command]Cleaning auto-generated files in" $path
+        rm "zz_generated_*"
     }
 
     if ($generate) {

--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -5,20 +5,21 @@ param([string]$filter, [switch]$clean, [switch]$vet, [switch]$generate, [switch]
 . $PSScriptRoot/get_module_dirs.ps1
 
 
-function Process-Sdk ($path) {
+function Process-Sdk () {
+    $currentDirectory = Get-Location
     if ($clean) {
-        Write-Host "##[command]Executing go clean -v ./... in " $path
+        Write-Host "##[command]Executing go clean -v ./... in " $currentDirectory
         go clean -v ./...
     }
 
     if ($clearOutput) {
-        Write-Host "##[command]Cleaning auto-generated files in" $path
+        Write-Host "##[command]Cleaning auto-generated files in" $currentDirectory
         rm "zz_generated_*"
     }
 
     if ($generate) {
-        Write-Host "##[command]Executing autorest.go in " $path
-        $autorestPath = $path + "/" + $config
+        Write-Host "##[command]Executing autorest.go in " $currentDirectory
+        $autorestPath = "./" + $config
 
         if (ShouldGenerate-AutorestConfig $autorestPath) {
             Generate-AutorestConfig $autorestPath
@@ -27,7 +28,7 @@ function Process-Sdk ($path) {
 
         $autorestVersion = "@autorest/go@4.0.0-preview.25"
         if ($outputFolder -eq '') {
-            $outputFolder = $path
+            $outputFolder = $currentDirectory
         }
         autorest --use=$autorestVersion --go --track2 --go-sdk-folder=$root --output-folder=$outputFolder --file-prefix="zz_generated_" --clear-output-folder=false $autorestPath
         if ($LASTEXITCODE) {
@@ -40,24 +41,24 @@ function Process-Sdk ($path) {
     }
 
     if ($format) {
-        Write-Host "##[command]Executing gofmt -s -w . in " $path
-        gofmt -s -w $path
+        Write-Host "##[command]Executing gofmt -s -w . in " $currentDirectory
+        gofmt -s -w .
     }
 
     if ($tidy) {
-        Write-Host "##[command]Executing go mod tidy in " $path
+        Write-Host "##[command]Executing go mod tidy in " $currentDirectory
         go mod tidy
     }
 
     if (!$skipBuild) {
-        Write-Host "##[command]Executing go build -x -v ./... in " $path
+        Write-Host "##[command]Executing go build -x -v ./... in " $currentDirectory
         go build -x -v ./...
         Write-Host "##[command]Build Complete!"
 
     }
 
     if ($vet) {
-        Write-Host "##[command]Executing go vet ./... in " $path
+        Write-Host "##[command]Executing go vet ./... in " $currentDirectory
         go vet ./...
     }
 
@@ -84,7 +85,7 @@ if (![string]::IsNullOrWhiteSpace($filter)) {
 try {
     $keys | ForEach-Object { $sdks[$_] } | ForEach-Object {
         Push-Location $_.path
-        Process-Sdk $_.path
+        Process-Sdk
         Pop-Location
     }
 }

--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 7.0
-param([string]$filter, [switch]$clean, [switch]$vet, [switch]$generate, [switch]$skipBuild, [switch]$clearOutput, [switch]$format, [switch]$tidy, [string]$config = "autorest.md", [string]$outputFolder)
+param([string]$filter, [switch]$clean, [switch]$vet, [switch]$generate, [switch]$skipBuild, [switch]$cleanGenerated, [switch]$format, [switch]$tidy, [string]$config = "autorest.md", [string]$outputFolder)
 
 . $PSScriptRoot/meta_generation.ps1
 . $PSScriptRoot/get_module_dirs.ps1
@@ -12,9 +12,9 @@ function Process-Sdk () {
         go clean -v ./...
     }
 
-    if ($clearOutput) {
+    if ($cleanGenerated) {
         Write-Host "##[command]Cleaning auto-generated files in" $currentDirectory
-        rm "zz_generated_*"
+        Remove-Item "zz_generated_*"
     }
 
     if ($generate) {


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->
Add a `clearOutput` flag in `build.ps1` flag to allow us first clear all the auto-generated files before we generate anything new.
The option of `autorest` `--clear-output-folder` is not acceptable because it will remove everything in this directory.

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
