### PR TITLE
Removed and renamed some content

### DIFF
--- a/sdk/azcore/error.go
+++ b/sdk/azcore/error.go
@@ -6,15 +6,7 @@
 package azcore
 
 import (
-	"errors"
 	"net/http"
-
-	sdkruntime "github.com/Azure/azure-sdk-for-go/sdk/internal/runtime"
-)
-
-var (
-	// ErrNoMorePolicies is returned from Request.Next() if there are no more policies in the pipeline.
-	ErrNoMorePolicies = errors.New("no more policies")
 )
 
 var (
@@ -31,9 +23,6 @@ type HTTPResponse interface {
 	RawResponse() *http.Response
 }
 
-// ensure our internal ResponseError type implements HTTPResponse
-var _ HTTPResponse = (*sdkruntime.ResponseError)(nil)
-
 // NonRetriableError represents a non-transient error.  This works in
 // conjunction with the retry policy, indicating that the error condition
 // is idempotent, so no retries will be attempted.
@@ -48,7 +37,33 @@ type NonRetriableError interface {
 // in this error type so that callers can access the underlying *http.Response as required.
 // DO NOT wrap failed HTTP requests that returned an error and no response with this type.
 func NewResponseError(inner error, resp *http.Response) error {
-	return sdkruntime.NewResponseError(inner, resp)
+	return &responseError{inner: inner, resp: resp}
 }
 
-var _ NonRetriableError = (*sdkruntime.ResponseError)(nil)
+type responseError struct {
+	inner error
+	resp  *http.Response
+}
+
+// Error implements the error interface for type ResponseError.
+func (e *responseError) Error() string {
+	return e.inner.Error()
+}
+
+// Unwrap returns the inner error.
+func (e *responseError) Unwrap() error {
+	return e.inner
+}
+
+// RawResponse returns the HTTP response associated with this error.
+func (e *responseError) RawResponse() *http.Response {
+	return e.resp
+}
+
+// NonRetriable indicates this error is non-transient.
+func (e *responseError) NonRetriable() {
+	// marker method
+}
+
+var _ HTTPResponse = (*responseError)(nil)
+var _ NonRetriableError = (*responseError)(nil)

--- a/sdk/azcore/example_test.go
+++ b/sdk/azcore/example_test.go
@@ -49,15 +49,15 @@ func ExampleRequest_SetBody() {
 }
 
 // false positive by linter
-func ExampleLogger_SetClassifications() { //nolint:govet
+func ExampleLogSetClassifications() { //nolint:govet
 	// only log HTTP requests and responses
-	azcore.SetClassifications(azcore.LogRequest, azcore.LogResponse)
+	azcore.LogSetClassifications(azcore.LogRequest, azcore.LogResponse)
 }
 
 // false positive by linter
-func ExampleLogger_SetListener() { //nolint:govet
+func ExampleLogSetListener() { //nolint:govet
 	// a simple logger that writes to stdout
-	azcore.SetListener(func(cls azcore.LogClassification, msg string) {
+	azcore.LogSetListener(func(cls azcore.LogClassification, msg string) {
 		fmt.Printf("%s: %s\n", cls, msg)
 	})
 }

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -1,8 +1,8 @@
 module github.com/Azure/azure-sdk-for-go/sdk/azcore
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.2
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.6.0
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b
 )
 

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.2 h1:E2xwjsWU81O/XuSaxAGa8Jmqz4Vm4NmrpMSO9/XevDg=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.2/go.mod h1:Hl9Vte0DDolj9zqzmfnmY9/zfZbiT5KnvXqVwAvnR8Q=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.6.0 h1:Lozt96x50m14Kb7U9FgYkI44AYXVa4lVhRF6exoLlqE=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.6.0/go.mod h1:Hl9Vte0DDolj9zqzmfnmY9/zfZbiT5KnvXqVwAvnR8Q=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -18,6 +18,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/sdk/azcore/log.go
+++ b/sdk/azcore/log.go
@@ -6,62 +6,41 @@
 package azcore
 
 import (
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/logger"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
-// LogClassification is used to group entries.  Each group can be toggled on or off
-type LogClassification logger.LogClassification
+// LogClassification is used to group entries.  Each group can be toggled on or off.
+type LogClassification = log.Classification
 
 const (
 	// LogRequest entries contain information about HTTP requests.
 	// This includes information like the URL, query parameters, and headers.
-	LogRequest LogClassification = "Request"
+	LogRequest = log.Request
 
 	// LogResponse entries contain information about HTTP responses.
 	// This includes information like the HTTP status code, headers, and request URL.
-	LogResponse LogClassification = "Response"
+	LogResponse = log.Response
 
 	// LogRetryPolicy entries contain information specific to the retry policy in use.
-	LogRetryPolicy LogClassification = "RetryPolicy"
+	LogRetryPolicy = log.RetryPolicy
 
 	// LogLongRunningOperation entries contain information specific to long-running operations.
 	// This includes information like polling location, operation state and sleep intervals.
-	LogLongRunningOperation LogClassification = "LongRunningOperation"
+	LogLongRunningOperation = log.LongRunningOperation
 )
 
-// SetClassifications is used to control which classifications are written to
+// LogSetClassifications is used to control which classifications are written to
 // the log.  By default all log classifications are writen.
-func SetClassifications(cls ...LogClassification) {
-	input := make([]logger.LogClassification, 0)
-	for _, l := range cls {
-		input = append(input, logger.LogClassification(l))
-	}
-	logger.Log().SetClassifications(input...)
-}
-
-// Listener is the function signature invoked when writing log entries.
-// A Listener is required to perform its own synchronization if it's expected to be called
-// from multiple Go routines
-type Listener func(LogClassification, string)
-
-// transform to convert the azcore.Listener type into a usable one for internal.logger module
-func transform(lst Listener) logger.Listener {
-	return func(l logger.LogClassification, msg string) {
-		azcoreL := LogClassification(l)
-		lst(azcoreL, msg)
-	}
+func LogSetClassifications(cls ...LogClassification) {
+	log.SetClassifications(cls...)
 }
 
 // SetListener will set the Logger to write to the specified Listener.
-func SetListener(lst Listener) {
-	if lst == nil {
-		logger.Log().SetListener(nil)
-	} else {
-		logger.Log().SetListener(transform(lst))
-	}
+func LogSetListener(lst func(log.Classification, string)) {
+	log.SetListener(lst)
 }
 
 // for testing purposes
 func resetClassifications() {
-	logger.Log().SetClassifications([]logger.LogClassification{}...)
+	log.TestResetClassifications()
 }

--- a/sdk/azcore/log_test.go
+++ b/sdk/azcore/log_test.go
@@ -10,47 +10,47 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/logger"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
 func TestLoggingDefault(t *testing.T) {
 	// ensure logging with nil listener doesn't fail
-	SetListener(nil)
-	logger.Log().Write(logger.LogRequest, "this should work just fine")
+	LogSetListener(nil)
+	log.Write(log.Request, "this should work just fine")
 
-	log := map[LogClassification]string{}
-	SetListener(func(cls LogClassification, msg string) {
-		log[cls] = msg
+	testlog := map[LogClassification]string{}
+	LogSetListener(func(cls LogClassification, msg string) {
+		testlog[cls] = msg
 	})
 	const req = "this is a request"
-	logger.Log().Write(logger.LogRequest, req)
+	log.Write(log.Request, req)
 	const resp = "this is a response: %d"
-	logger.Log().Writef(logger.LogResponse, resp, http.StatusOK)
-	if l := len(log); l != 2 {
+	log.Writef(log.Response, resp, http.StatusOK)
+	if l := len(testlog); l != 2 {
 		t.Fatalf("unexpected log entry count: %d", l)
 	}
-	if log[LogRequest] != req {
-		t.Fatalf("unexpected log request: %s", log[LogRequest])
+	if testlog[LogRequest] != req {
+		t.Fatalf("unexpected log request: %s", testlog[LogRequest])
 	}
-	if log[LogResponse] != fmt.Sprintf(resp, http.StatusOK) {
-		t.Fatalf("unexpected log response: %s", log[LogResponse])
+	if testlog[LogResponse] != fmt.Sprintf(resp, http.StatusOK) {
+		t.Fatalf("unexpected log response: %s", testlog[LogResponse])
 	}
 }
 
 func TestLoggingClassification(t *testing.T) {
-	log := map[LogClassification]string{}
-	SetListener(func(cls LogClassification, msg string) {
-		log[cls] = msg
+	testlog := map[LogClassification]string{}
+	LogSetListener(func(cls LogClassification, msg string) {
+		testlog[cls] = msg
 	})
-	SetClassifications(LogRequest)
+	LogSetClassifications(LogRequest)
 	defer resetClassifications()
-	logger.Log().Write(logger.LogResponse, "this shouldn't be in the log")
-	if s, ok := log[LogResponse]; ok {
+	log.Write(log.Response, "this shouldn't be in the log")
+	if s, ok := testlog[LogResponse]; ok {
 		t.Fatalf("unexpected log entry %s", s)
 	}
 	const req = "this is a request"
-	logger.Log().Write(logger.LogRequest, req)
-	if log[LogRequest] != req {
-		t.Fatalf("unexpected log entry: %s", log[LogRequest])
+	log.Write(log.Request, req)
+	if testlog[LogRequest] != req {
+		t.Fatalf("unexpected log entry: %s", testlog[LogRequest])
 	}
 }

--- a/sdk/azcore/policy_anonymous_credential.go
+++ b/sdk/azcore/policy_anonymous_credential.go
@@ -6,7 +6,7 @@
 package azcore
 
 func anonCredAuthPolicyFunc(AuthenticationOptions) Policy {
-	return PolicyFunc(anonCredPolicyFunc)
+	return policyFunc(anonCredPolicyFunc)
 }
 
 func anonCredPolicyFunc(req *Request) (*Response, error) {

--- a/sdk/azcore/policy_logging.go
+++ b/sdk/azcore/policy_logging.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/logger"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/diag"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
 // LogOptions configures the logging policy's behavior.
@@ -52,7 +52,7 @@ func (p *logPolicy) Do(req *Request) (*Response, error) {
 	req.SetOperationValue(opValues)
 
 	// Log the outgoing request as informational
-	if logger.Log().Should(logger.LogRequest) {
+	if log.Should(log.Request) {
 		b := &bytes.Buffer{}
 		fmt.Fprintf(b, "==> OUTGOING REQUEST (Try=%d)\n", opValues.try)
 		writeRequestWithResponse(b, req, nil, nil)
@@ -60,7 +60,7 @@ func (p *logPolicy) Do(req *Request) (*Response, error) {
 		if p.options.IncludeBody {
 			err = req.writeBody(b)
 		}
-		logger.Log().Write(logger.LogRequest, b.String())
+		log.Write(log.Request, b.String())
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +73,7 @@ func (p *logPolicy) Do(req *Request) (*Response, error) {
 	tryDuration := tryEnd.Sub(tryStart)
 	opDuration := tryEnd.Sub(opValues.start)
 
-	if logger.Log().Should(logger.LogResponse) {
+	if log.Should(log.Response) {
 		// We're going to log this; build the string to log
 		b := &bytes.Buffer{}
 		fmt.Fprintf(b, "==> REQUEST/RESPONSE (Try=%d/%v, OpTime=%v) -- ", opValues.try, tryDuration, opDuration)
@@ -86,11 +86,11 @@ func (p *logPolicy) Do(req *Request) (*Response, error) {
 		writeRequestWithResponse(b, req, response, err)
 		if err != nil {
 			// skip frames runtime.Callers() and runtime.StackTrace()
-			b.WriteString(runtime.StackTrace(2, StackFrameCount))
+			b.WriteString(diag.StackTrace(2, StackFrameCount))
 		} else if p.options.IncludeBody {
 			err = response.writeBody(b)
 		}
-		logger.Log().Write(logger.LogResponse, b.String())
+		log.Write(log.Response, b.String())
 	}
 	return response, err
 }

--- a/sdk/azcore/policy_logging_test.go
+++ b/sdk/azcore/policy_logging_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestPolicyLoggingSuccess(t *testing.T) {
 	log := map[LogClassification]string{}
-	SetListener(func(cls LogClassification, s string) {
+	LogSetListener(func(cls LogClassification, s string) {
 		log[cls] = s
 	})
 	srv, close := mock.NewServer()
@@ -68,7 +68,7 @@ func TestPolicyLoggingSuccess(t *testing.T) {
 
 func TestPolicyLoggingError(t *testing.T) {
 	log := map[LogClassification]string{}
-	SetListener(func(cls LogClassification, s string) {
+	LogSetListener(func(cls LogClassification, s string) {
 		log[cls] = s
 	})
 	srv, close := mock.NewServer()

--- a/sdk/azcore/policy_retry_test.go
+++ b/sdk/azcore/policy_retry_test.go
@@ -91,7 +91,7 @@ func TestRetryPolicyFailOnStatusCodeRespBodyPreserved(t *testing.T) {
 	srv.SetResponse(mock.WithStatusCode(http.StatusInternalServerError), mock.WithBody([]byte(respBody)))
 	// add a per-request policy that reads and restores the request body.
 	// this is to simulate how something like httputil.DumpRequest works.
-	pl := NewPipeline(srv, PolicyFunc(func(r *Request) (*Response, error) {
+	pl := NewPipeline(srv, policyFunc(func(r *Request) (*Response, error) {
 		b, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -612,7 +612,7 @@ func (r *rewindTrackingBody) Seek(offset int64, whence int) (int64, error) {
 
 // used to inject a nil response
 type nilRespInjector struct {
-	t Transport
+	t Transporter
 	c int   // the current request number
 	r []int // the list of request numbers to return a nil response (one-based)
 }

--- a/sdk/azcore/poller_test.go
+++ b/sdk/azcore/poller_test.go
@@ -37,8 +37,8 @@ type widget struct {
 	Size int `json:"size"`
 }
 
-func TestNewLROPollerFail(t *testing.T) {
-	p, err := NewLROPoller("fake.poller", &Response{
+func TestNewPollerFail(t *testing.T) {
+	p, err := NewPoller("fake.poller", &Response{
 		&http.Response{
 			StatusCode: http.StatusBadRequest,
 		},
@@ -51,7 +51,7 @@ func TestNewLROPollerFail(t *testing.T) {
 	}
 }
 
-func TestNewLROPollerFromResumeTokenFail(t *testing.T) {
+func TestNewPollerFromResumeTokenFail(t *testing.T) {
 	tests := []struct {
 		name  string
 		token string
@@ -65,7 +65,7 @@ func TestNewLROPollerFromResumeTokenFail(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p, err := NewLROPollerFromResumeToken("fake.poller", test.token, NewPipeline(nil), errUnmarshall)
+			p, err := NewPollerFromResumeToken("fake.poller", test.token, NewPipeline(nil), errUnmarshall)
 			if err == nil {
 				t.Fatal("unexpected nil error")
 			}
@@ -101,7 +101,7 @@ func TestOpPollerSimple(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestOpPollerWithWidgetPUT(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +186,7 @@ func TestOpPollerWithWidgetPOSTLocation(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +229,7 @@ func TestOpPollerWithWidgetPOST(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestOpPollerWithWidgetResourceLocation(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -317,7 +317,7 @@ func TestOpPollerWithResumeToken(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -342,7 +342,7 @@ func TestOpPollerWithResumeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lro, err = NewLROPollerFromResumeToken("fake.poller", tk, pl, errUnmarshall)
+	lro, err = NewPollerFromResumeToken("fake.poller", tk, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -372,7 +372,7 @@ func TestLocPollerSimple(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -402,7 +402,7 @@ func TestLocPollerWithWidget(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,7 +436,7 @@ func TestLocPollerCancelled(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,7 +473,7 @@ func TestLocPollerWithError(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -510,7 +510,7 @@ func TestLocPollerWithResumeToken(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -535,7 +535,7 @@ func TestLocPollerWithResumeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lro, err = NewLROPollerFromResumeToken("fake.poller", tk, pl, errUnmarshall)
+	lro, err = NewPollerFromResumeToken("fake.poller", tk, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -564,7 +564,7 @@ func TestLocPollerWithTimeout(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(srv)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -586,7 +586,7 @@ func TestNopPoller(t *testing.T) {
 		},
 	}
 	pl := NewPipeline(nil)
-	lro, err := NewLROPoller("fake.poller", firstResp, pl, errUnmarshall)
+	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azcore/progress.go
+++ b/sdk/azcore/progress.go
@@ -9,19 +9,15 @@ import (
 	"io"
 )
 
-// ProgressReceiver defines the signature of a callback function invoked as progress is reported.
-// Note that bytesTransferred resets to 0 if the stream is reset when retrying a network operation.
-type ProgressReceiver func(bytesTransferred int64)
-
 type progress struct {
 	rc     io.ReadCloser
 	rsc    ReadSeekCloser
-	pr     ProgressReceiver
+	pr     func(bytesTransferred int64)
 	offset int64
 }
 
 // NewRequestProgress adds progress reporting to an HTTP request's body stream.
-func NewRequestProgress(body ReadSeekCloser, pr ProgressReceiver) ReadSeekCloser {
+func NewRequestProgress(body ReadSeekCloser, pr func(bytesTransferred int64)) ReadSeekCloser {
 	return &progress{
 		rc:     body,
 		rsc:    body,
@@ -31,7 +27,7 @@ func NewRequestProgress(body ReadSeekCloser, pr ProgressReceiver) ReadSeekCloser
 }
 
 // NewResponseProgress adds progress reporting to an HTTP response's body stream.
-func NewResponseProgress(body io.ReadCloser, pr ProgressReceiver) io.ReadCloser {
+func NewResponseProgress(body io.ReadCloser, pr func(bytesTransferred int64)) io.ReadCloser {
 	return &progress{
 		rc:     body,
 		rsc:    nil,

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -107,7 +107,7 @@ func NewRequest(ctx context.Context, httpMethod string, endpoint string) (*Reque
 // To send a request through a pipeline call Pipeline.Do().
 func (req *Request) Next() (*Response, error) {
 	if len(req.policies) == 0 {
-		return nil, ErrNoMorePolicies
+		return nil, errors.New("no more policies")
 	}
 	nextPolicy := req.policies[0]
 	nextReq := *req

--- a/sdk/azcore/request_test.go
+++ b/sdk/azcore/request_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -61,8 +60,8 @@ func TestRequestEmptyPipeline(t *testing.T) {
 	if resp != nil {
 		t.Fatal("expected nil response")
 	}
-	if !errors.Is(err, ErrNoMorePolicies) {
-		t.Fatalf("expected ErrNoMorePolicies, got %v", err)
+	if err == nil {
+		t.Fatal("unexpected nil error")
 	}
 }
 


### PR DESCRIPTION
Unexported policyFunc
Renamed Transport to Transporter
Removed TransportFunc, Pager, and Poller interfaces
Added responseError (removed from internal)
Fixed logging type aliases
Updated logging usage based on internal/log refactor
Removed StatusCodesForRetry, ProgressReceiver, ErrNoMorePolicies
Renamed LROPoller to Poller

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
