### PR TITLE
Remove Response type

### DIFF
--- a/sdk/azcore/policy_anonymous_credential.go
+++ b/sdk/azcore/policy_anonymous_credential.go
@@ -5,11 +5,13 @@
 
 package azcore
 
+import "net/http"
+
 func anonCredAuthPolicyFunc(AuthenticationOptions) Policy {
 	return policyFunc(anonCredPolicyFunc)
 }
 
-func anonCredPolicyFunc(req *Request) (*Response, error) {
+func anonCredPolicyFunc(req *Request) (*http.Response, error) {
 	return req.Next()
 }
 

--- a/sdk/azcore/policy_body_download.go
+++ b/sdk/azcore/policy_body_download.go
@@ -15,7 +15,7 @@ import (
 )
 
 // bodyDownloadPolicy creates a policy object that downloads the response's body to a []byte.
-func bodyDownloadPolicy(req *Request) (*Response, error) {
+func bodyDownloadPolicy(req *Request) (*http.Response, error) {
 	resp, err := req.Next()
 	if err != nil {
 		return resp, err

--- a/sdk/azcore/policy_body_download_test.go
+++ b/sdk/azcore/policy_body_download_test.go
@@ -29,7 +29,7 @@ func TestDownloadBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestSkipBodyDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestDownloadBodyFail(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -106,7 +106,7 @@ func TestDownloadBodyWithRetryGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestDownloadBodyWithRetryDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestDownloadBodyWithRetryPut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestDownloadBodyWithRetryPatch(t *testing.T) {
 	if _, ok := err.(*bodyDownloadError); !ok {
 		t.Fatal("expected *bodyDownloadError type")
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -235,7 +235,7 @@ func TestDownloadBodyWithRetryPost(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -264,7 +264,7 @@ func TestSkipBodyDownloadWith400(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestReadBodyAfterSeek(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	payload, err := resp.Payload()
+	payload, err := Payload(resp)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azcore/policy_http_header.go
+++ b/sdk/azcore/policy_http_header.go
@@ -14,7 +14,7 @@ import (
 type ctxWithHTTPHeader struct{}
 
 // newHTTPHeaderPolicy creates a policy object that adds custom HTTP headers to a request
-func httpHeaderPolicy(req *Request) (*Response, error) {
+func httpHeaderPolicy(req *Request) (*http.Response, error) {
 	// check if any custom HTTP headers have been specified
 	if header := req.Context().Value(ctxWithHTTPHeader{}); header != nil {
 		for k, v := range header.(http.Header) {

--- a/sdk/azcore/policy_logging.go
+++ b/sdk/azcore/policy_logging.go
@@ -8,6 +8,7 @@ package azcore
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -42,7 +43,7 @@ type logPolicyOpValues struct {
 	start time.Time
 }
 
-func (p *logPolicy) Do(req *Request) (*Response, error) {
+func (p *logPolicy) Do(req *Request) (*http.Response, error) {
 	// Get the per-operation values. These are saved in the Message's map so that they persist across each retry calling into this policy object.
 	var opValues logPolicyOpValues
 	if req.OperationValue(&opValues); opValues.start.IsZero() {
@@ -88,7 +89,7 @@ func (p *logPolicy) Do(req *Request) (*Response, error) {
 			// skip frames runtime.Callers() and runtime.StackTrace()
 			b.WriteString(diag.StackTrace(2, StackFrameCount))
 		} else if p.options.IncludeBody {
-			err = response.writeBody(b)
+			err = writeBody(response, b)
 		}
 		log.Write(log.Response, b.String())
 	}

--- a/sdk/azcore/policy_retry_test.go
+++ b/sdk/azcore/policy_retry_test.go
@@ -91,7 +91,7 @@ func TestRetryPolicyFailOnStatusCodeRespBodyPreserved(t *testing.T) {
 	srv.SetResponse(mock.WithStatusCode(http.StatusInternalServerError), mock.WithBody([]byte(respBody)))
 	// add a per-request policy that reads and restores the request body.
 	// this is to simulate how something like httputil.DumpRequest works.
-	pl := NewPipeline(srv, policyFunc(func(r *Request) (*Response, error) {
+	pl := NewPipeline(srv, policyFunc(func(r *Request) (*http.Response, error) {
 		b, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)

--- a/sdk/azcore/policy_telemetry.go
+++ b/sdk/azcore/policy_telemetry.go
@@ -8,6 +8,7 @@ package azcore
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"os"
 	"runtime"
 	"strings"
@@ -64,7 +65,7 @@ func NewTelemetryPolicy(o *TelemetryOptions) Policy {
 	return &tp
 }
 
-func (p telemetryPolicy) Do(req *Request) (*Response, error) {
+func (p telemetryPolicy) Do(req *Request) (*http.Response, error) {
 	if p.telemetryValue == "" {
 		return req.Next()
 	}

--- a/sdk/azcore/poller_test.go
+++ b/sdk/azcore/poller_test.go
@@ -25,9 +25,9 @@ func (p pollerError) Error() string {
 	return p.Err
 }
 
-func errUnmarshall(resp *Response) error {
+func errUnmarshall(resp *http.Response) error {
 	var pe pollerError
-	if err := resp.UnmarshalAsJSON(&pe); err != nil {
+	if err := UnmarshalAsJSON(resp, &pe); err != nil {
 		panic(err)
 	}
 	return pe
@@ -38,10 +38,8 @@ type widget struct {
 }
 
 func TestNewPollerFail(t *testing.T) {
-	p, err := NewPoller("fake.poller", &Response{
-		&http.Response{
-			StatusCode: http.StatusBadRequest,
-		},
+	p, err := NewPoller("fake.poller", &http.Response{
+		StatusCode: http.StatusBadRequest,
 	}, NewPipeline(nil), errUnmarshall)
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -87,17 +85,15 @@ func TestOpPollerSimple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Operation-Location": []string{srv.URL()},
-				"Retry-After":        []string{"1"},
-			},
-			Request: &http.Request{
-				Method: http.MethodPut,
-				URL:    reqURL,
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Operation-Location": []string{srv.URL()},
+			"Retry-After":        []string{"1"},
+		},
+		Request: &http.Request{
+			Method: http.MethodPut,
+			URL:    reqURL,
 		},
 	}
 	pl := NewPipeline(srv)
@@ -127,17 +123,15 @@ func TestOpPollerWithWidgetPUT(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Operation-Location": []string{srv.URL()},
-				"Retry-After":        []string{"1"},
-			},
-			Request: &http.Request{
-				Method: http.MethodPut,
-				URL:    reqURL,
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Operation-Location": []string{srv.URL()},
+			"Retry-After":        []string{"1"},
+		},
+		Request: &http.Request{
+			Method: http.MethodPut,
+			URL:    reqURL,
 		},
 	}
 	pl := NewPipeline(srv)
@@ -171,18 +165,16 @@ func TestOpPollerWithWidgetPOSTLocation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Operation-Location": []string{srv.URL()},
-				"Location":           []string{srv.URL()},
-				"Retry-After":        []string{"1"},
-			},
-			Request: &http.Request{
-				Method: http.MethodPost,
-				URL:    reqURL,
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Operation-Location": []string{srv.URL()},
+			"Location":           []string{srv.URL()},
+			"Retry-After":        []string{"1"},
+		},
+		Request: &http.Request{
+			Method: http.MethodPost,
+			URL:    reqURL,
 		},
 	}
 	pl := NewPipeline(srv)
@@ -215,17 +207,15 @@ func TestOpPollerWithWidgetPOST(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Operation-Location": []string{srv.URL()},
-				"Retry-After":        []string{"1"},
-			},
-			Request: &http.Request{
-				Method: http.MethodPost,
-				URL:    reqURL,
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Operation-Location": []string{srv.URL()},
+			"Retry-After":        []string{"1"},
+		},
+		Request: &http.Request{
+			Method: http.MethodPost,
+			URL:    reqURL,
 		},
 	}
 	pl := NewPipeline(srv)
@@ -260,18 +250,16 @@ func TestOpPollerWithWidgetResourceLocation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Operation-Location": []string{srv.URL()},
-				"Location":           []string{srv.URL()},
-				"Retry-After":        []string{"1"},
-			},
-			Request: &http.Request{
-				Method: http.MethodPatch,
-				URL:    reqURL,
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Operation-Location": []string{srv.URL()},
+			"Location":           []string{srv.URL()},
+			"Retry-After":        []string{"1"},
+		},
+		Request: &http.Request{
+			Method: http.MethodPatch,
+			URL:    reqURL,
 		},
 	}
 	pl := NewPipeline(srv)
@@ -303,17 +291,15 @@ func TestOpPollerWithResumeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Operation-Location": []string{srv.URL()},
-				"Retry-After":        []string{"1"},
-			},
-			Request: &http.Request{
-				Method: http.MethodPut,
-				URL:    reqURL,
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Operation-Location": []string{srv.URL()},
+			"Retry-After":        []string{"1"},
+		},
+		Request: &http.Request{
+			Method: http.MethodPut,
+			URL:    reqURL,
 		},
 	}
 	pl := NewPipeline(srv)
@@ -362,13 +348,11 @@ func TestLocPollerSimple(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Location":    []string{srv.URL()},
-				"Retry-After": []string{"1"},
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Location":    []string{srv.URL()},
+			"Retry-After": []string{"1"},
 		},
 	}
 	pl := NewPipeline(srv)
@@ -392,13 +376,11 @@ func TestLocPollerWithWidget(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"size": 3}`)))
 
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Location":    []string{srv.URL()},
-				"Retry-After": []string{"1"},
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Location":    []string{srv.URL()},
+			"Retry-After": []string{"1"},
 		},
 	}
 	pl := NewPipeline(srv)
@@ -426,13 +408,11 @@ func TestLocPollerCancelled(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(`{"error": "cancelled"}`)))
 
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Location":    []string{srv.URL()},
-				"Retry-After": []string{"1"},
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Location":    []string{srv.URL()},
+			"Retry-After": []string{"1"},
 		},
 	}
 	pl := NewPipeline(srv)
@@ -463,13 +443,11 @@ func TestLocPollerWithError(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
 	srv.AppendError(errors.New("oops"))
 
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Location":    []string{srv.URL()},
-				"Retry-After": []string{"1"},
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Location":    []string{srv.URL()},
+			"Retry-After": []string{"1"},
 		},
 	}
 	pl := NewPipeline(srv)
@@ -500,13 +478,11 @@ func TestLocPollerWithResumeToken(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	defer close()
 
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Location":    []string{srv.URL()},
-				"Retry-After": []string{"1"},
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Location":    []string{srv.URL()},
+			"Retry-After": []string{"1"},
 		},
 	}
 	pl := NewPipeline(srv)
@@ -555,12 +531,10 @@ func TestLocPollerWithTimeout(t *testing.T) {
 	srv.AppendResponse(mock.WithSlowResponse(2 * time.Second))
 	defer close()
 
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusAccepted,
-			Header: http.Header{
-				"Location": []string{srv.URL()},
-			},
+	firstResp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header: http.Header{
+			"Location": []string{srv.URL()},
 		},
 	}
 	pl := NewPipeline(srv)
@@ -580,10 +554,8 @@ func TestLocPollerWithTimeout(t *testing.T) {
 }
 
 func TestNopPoller(t *testing.T) {
-	firstResp := &Response{
-		&http.Response{
-			StatusCode: http.StatusOK,
-		},
+	firstResp := &http.Response{
+		StatusCode: http.StatusOK,
 	}
 	pl := NewPipeline(nil)
 	lro, err := NewPoller("fake.poller", firstResp, pl, errUnmarshall)
@@ -600,21 +572,21 @@ func TestNopPoller(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp != firstResp.Response {
+	if resp != firstResp {
 		t.Fatal("unexpected response")
 	}
 	resp, err = lro.Poll(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp != firstResp.Response {
+	if resp != firstResp {
 		t.Fatal("unexpected response")
 	}
 	resp, err = lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp != firstResp.Response {
+	if resp != firstResp {
 		t.Fatal("unexpected response")
 	}
 	tk, err := lro.ResumeToken()

--- a/sdk/azcore/request.go
+++ b/sdk/azcore/request.go
@@ -114,7 +114,7 @@ func NewRequest(ctx context.Context, httpMethod string, endpoint string) (*Reque
 // If there are no more policies, nil and ErrNoMorePolicies are returned.
 // This method is intended to be called from pipeline policies.
 // To send a request through a pipeline call Pipeline.Do().
-func (req *Request) Next() (*Response, error) {
+func (req *Request) Next() (*http.Response, error) {
 	if len(req.policies) == 0 {
 		return nil, errors.New("no more policies")
 	}

--- a/sdk/azcore/response.go
+++ b/sdk/azcore/response.go
@@ -20,34 +20,29 @@ import (
 	"time"
 )
 
-// Response represents the response from an HTTP request.
-type Response struct {
-	*http.Response
-}
-
 // Payload reads and returns the response body or an error.
 // On a successful read, the response body is cached.
-func (r *Response) Payload() ([]byte, error) {
+func Payload(resp *http.Response) ([]byte, error) {
 	// r.Body won't be a nopClosingBytesReader if downloading was skipped
-	if buf, ok := r.Body.(*nopClosingBytesReader); ok {
+	if buf, ok := resp.Body.(*nopClosingBytesReader); ok {
 		return buf.Bytes(), nil
 	}
-	bytesBody, err := ioutil.ReadAll(r.Body)
-	r.Body.Close()
+	bytesBody, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
-	r.Body = &nopClosingBytesReader{s: bytesBody, i: 0}
+	resp.Body = &nopClosingBytesReader{s: bytesBody, i: 0}
 	return bytesBody, nil
 }
 
 // HasStatusCode returns true if the Response's status code is one of the specified values.
-func (r *Response) HasStatusCode(statusCodes ...int) bool {
-	if r == nil {
+func HasStatusCode(resp *http.Response, statusCodes ...int) bool {
+	if resp == nil {
 		return false
 	}
 	for _, sc := range statusCodes {
-		if r.StatusCode == sc {
+		if resp.StatusCode == sc {
 			return true
 		}
 	}
@@ -55,8 +50,8 @@ func (r *Response) HasStatusCode(statusCodes ...int) bool {
 }
 
 // UnmarshalAsByteArray will base-64 decode the received payload and place the result into the value pointed to by v.
-func (r *Response) UnmarshalAsByteArray(v *[]byte, format Base64Encoding) error {
-	p, err := r.Payload()
+func UnmarshalAsByteArray(resp *http.Response, v *[]byte, format Base64Encoding) error {
+	p, err := Payload(resp)
 	if err != nil {
 		return err
 	}
@@ -64,8 +59,8 @@ func (r *Response) UnmarshalAsByteArray(v *[]byte, format Base64Encoding) error 
 }
 
 // UnmarshalAsJSON calls json.Unmarshal() to unmarshal the received payload into the value pointed to by v.
-func (r *Response) UnmarshalAsJSON(v interface{}) error {
-	payload, err := r.Payload()
+func UnmarshalAsJSON(resp *http.Response, v interface{}) error {
+	payload, err := Payload(resp)
 	if err != nil {
 		return err
 	}
@@ -73,7 +68,7 @@ func (r *Response) UnmarshalAsJSON(v interface{}) error {
 	if len(payload) == 0 {
 		return nil
 	}
-	err = r.removeBOM()
+	err = removeBOM(resp)
 	if err != nil {
 		return err
 	}
@@ -85,8 +80,8 @@ func (r *Response) UnmarshalAsJSON(v interface{}) error {
 }
 
 // UnmarshalAsXML calls xml.Unmarshal() to unmarshal the received payload into the value pointed to by v.
-func (r *Response) UnmarshalAsXML(v interface{}) error {
-	payload, err := r.Payload()
+func UnmarshalAsXML(resp *http.Response, v interface{}) error {
+	payload, err := Payload(resp)
 	if err != nil {
 		return err
 	}
@@ -94,7 +89,7 @@ func (r *Response) UnmarshalAsXML(v interface{}) error {
 	if len(payload) == 0 {
 		return nil
 	}
-	err = r.removeBOM()
+	err = removeBOM(resp)
 	if err != nil {
 		return err
 	}
@@ -106,45 +101,37 @@ func (r *Response) UnmarshalAsXML(v interface{}) error {
 }
 
 // Drain reads the response body to completion then closes it.  The bytes read are discarded.
-func (r *Response) Drain() {
-	if r != nil && r.Body != nil {
-		_, _ = io.Copy(ioutil.Discard, r.Body)
-		r.Body.Close()
+func Drain(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
 	}
 }
 
 // removeBOM removes any byte-order mark prefix from the payload if present.
-func (r *Response) removeBOM() error {
-	payload, err := r.Payload()
+func removeBOM(resp *http.Response) error {
+	payload, err := Payload(resp)
 	if err != nil {
 		return err
 	}
 	// UTF8
 	trimmed := bytes.TrimPrefix(payload, []byte("\xef\xbb\xbf"))
 	if len(trimmed) < len(payload) {
-		r.Body.(*nopClosingBytesReader).Set(trimmed)
+		resp.Body.(*nopClosingBytesReader).Set(trimmed)
 	}
 	return nil
 }
 
-// helper to reduce nil Response checks
-func (r *Response) retryAfter() time.Duration {
-	if r == nil {
-		return 0
-	}
-	return RetryAfter(r.Response)
-}
-
 // writes to a buffer, used for logging purposes
-func (r *Response) writeBody(b *bytes.Buffer) error {
-	ct := r.Header.Get(headerContentType)
+func writeBody(resp *http.Response, b *bytes.Buffer) error {
+	ct := resp.Header.Get(headerContentType)
 	if ct == "" {
 		fmt.Fprint(b, "   Response contained no body\n")
 		return nil
 	} else if !shouldLogBody(b, ct) {
 		return nil
 	}
-	body, err := r.Payload()
+	body, err := Payload(resp)
 	if err != nil {
 		fmt.Fprintf(b, "   Failed to read response body: %s\n", err.Error())
 		return err
@@ -209,14 +196,14 @@ func DecodeByteArray(s string, v *[]byte, format Base64Encoding) error {
 
 // writeRequestWithResponse appends a formatted HTTP request into a Buffer. If request and/or err are
 // not nil, then these are also written into the Buffer.
-func writeRequestWithResponse(b *bytes.Buffer, request *Request, response *Response, err error) {
+func writeRequestWithResponse(b *bytes.Buffer, request *Request, resp *http.Response, err error) {
 	// Write the request into the buffer.
 	fmt.Fprint(b, "   "+request.Method+" "+request.URL.String()+"\n")
 	writeHeader(b, request.Header)
-	if response != nil {
+	if resp != nil {
 		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
-		fmt.Fprint(b, "   RESPONSE Status: "+response.Status+"\n")
-		writeHeader(b, response.Header)
+		fmt.Fprint(b, "   RESPONSE Status: "+resp.Status+"\n")
+		writeHeader(b, resp.Header)
 	}
 	if err != nil {
 		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")

--- a/sdk/azcore/response_test.go
+++ b/sdk/azcore/response_test.go
@@ -28,11 +28,11 @@ func TestResponseUnmarshalXML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !HasStatusCode(resp, http.StatusOK) {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
 	var tx testXML
-	if err := resp.UnmarshalAsXML(&tx); err != nil {
+	if err := UnmarshalAsXML(resp, &tx); err != nil {
 		t.Fatalf("unexpected error unmarshalling: %v", err)
 	}
 	if tx.SomeInt != 1 || tx.SomeString != "s" {
@@ -53,7 +53,7 @@ func TestResponseFailureStatusCode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resp.HasStatusCode(http.StatusOK) {
+	if HasStatusCode(resp, http.StatusOK) {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
 }
@@ -71,11 +71,11 @@ func TestResponseUnmarshalJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !HasStatusCode(resp, http.StatusOK) {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
 	var tx testJSON
-	if err := resp.UnmarshalAsJSON(&tx); err != nil {
+	if err := UnmarshalAsJSON(resp, &tx); err != nil {
 		t.Fatalf("unexpected error unmarshalling: %v", err)
 	}
 	if tx.SomeInt != 1 || tx.SomeString != "s" {
@@ -97,11 +97,11 @@ func TestResponseUnmarshalJSONskipDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !HasStatusCode(resp, http.StatusOK) {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
 	var tx testJSON
-	if err := resp.UnmarshalAsJSON(&tx); err != nil {
+	if err := UnmarshalAsJSON(resp, &tx); err != nil {
 		t.Fatalf("unexpected error unmarshalling: %v", err)
 	}
 	if tx.SomeInt != 1 || tx.SomeString != "s" {
@@ -122,10 +122,10 @@ func TestResponseUnmarshalJSONNoBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !HasStatusCode(resp, http.StatusOK) {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	if err := resp.UnmarshalAsJSON(nil); err != nil {
+	if err := UnmarshalAsJSON(resp, nil); err != nil {
 		t.Fatalf("unexpected error unmarshalling: %v", err)
 	}
 }
@@ -143,24 +143,23 @@ func TestResponseUnmarshalXMLNoBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !HasStatusCode(resp, http.StatusOK) {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	if err := resp.UnmarshalAsXML(nil); err != nil {
+	if err := UnmarshalAsXML(resp, nil); err != nil {
 		t.Fatalf("unexpected error unmarshalling: %v", err)
 	}
 }
 
 func TestRetryAfter(t *testing.T) {
-	raw := &http.Response{
+	resp := &http.Response{
 		Header: http.Header{},
 	}
-	resp := Response{raw}
-	if d := resp.retryAfter(); d > 0 {
+	if d := RetryAfter(resp); d > 0 {
 		t.Fatalf("unexpected retry-after value %d", d)
 	}
-	raw.Header.Set(headerRetryAfter, "300")
-	d := resp.retryAfter()
+	resp.Header.Set(headerRetryAfter, "300")
+	d := RetryAfter(resp)
 	if d <= 0 {
 		t.Fatal("expected retry-after value from seconds")
 	}
@@ -168,8 +167,8 @@ func TestRetryAfter(t *testing.T) {
 		t.Fatalf("expected 300 seconds, got %d", d/time.Second)
 	}
 	atDate := time.Now().Add(600 * time.Second)
-	raw.Header.Set(headerRetryAfter, atDate.Format(time.RFC1123))
-	d = resp.retryAfter()
+	resp.Header.Set(headerRetryAfter, atDate.Format(time.RFC1123))
+	d = RetryAfter(resp)
 	if d <= 0 {
 		t.Fatal("expected retry-after value from date")
 	}
@@ -192,11 +191,11 @@ func TestResponseUnmarshalAsByteArrayURLFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !HasStatusCode(resp, http.StatusOK) {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
 	var ba []byte
-	if err := resp.UnmarshalAsByteArray(&ba, Base64URLFormat); err != nil {
+	if err := UnmarshalAsByteArray(resp, &ba, Base64URLFormat); err != nil {
 		t.Fatalf("unexpected error unmarshalling: %v", err)
 	}
 	if string(ba) != "a string that gets encoded with base64url" {
@@ -217,11 +216,11 @@ func TestResponseUnmarshalAsByteArrayStdFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !HasStatusCode(resp, http.StatusOK) {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
 	var ba []byte
-	if err := resp.UnmarshalAsByteArray(&ba, Base64StdFormat); err != nil {
+	if err := UnmarshalAsByteArray(resp, &ba, Base64StdFormat); err != nil {
 		t.Fatalf("unexpected error unmarshalling: %v", err)
 	}
 	if string(ba) != "a string that gets encoded with base64url" {


### PR DESCRIPTION
Just return an *http.Response instead.
Changed Response methods to functions.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
