### PR TITLE
fix: three dots in path in build script not work on linux

### DIFF
--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -63,7 +63,7 @@ $root = Resolve-Path ($PSScriptRoot + "/../..")
 Set-Location $root
 $sdks = @{};
 
-foreach ($sdk in (Get-ModuleDirs 'sdk/...')) {
+foreach ($sdk in (Get-ModuleDirs 'sdk/')) {
     $name = $sdk | split-path -leaf
     $sdks[$name] = @{
         'path' = $sdk;


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
