### PR TITLE
[service-bus] Rename refactored ReceiveMode constants but didn't push the other files

### DIFF
--- a/sdk/servicebus/azservicebus/processor.go
+++ b/sdk/servicebus/azservicebus/processor.go
@@ -80,7 +80,7 @@ func ProcessorWithSubQueue(subQueue SubQueue) ProcessorOption {
 // ProcessorWithReceiveMode controls the receive mode for the processor.
 func ProcessorWithReceiveMode(receiveMode ReceiveMode) ProcessorOption {
 	return func(processor *Processor) error {
-		if receiveMode != ReceiveModePeekLock && receiveMode != ReceiveModeReceiveAndDelete {
+		if receiveMode != PeekLock && receiveMode != ReceiveAndDelete {
 			return fmt.Errorf("invalid receive mode specified %d", receiveMode)
 		}
 
@@ -132,7 +132,7 @@ type legacyNamespace interface {
 func newProcessor(ns legacyNamespace, options ...ProcessorOption) (*Processor, error) {
 	processor := &Processor{
 		config: processorConfig{
-			ReceiveMode:        ReceiveModePeekLock,
+			ReceiveMode:        PeekLock,
 			ShouldAutoComplete: true,
 			MaxConcurrentCalls: 1,
 			RetryOptions: struct {

--- a/sdk/servicebus/azservicebus/samples/processor/processor_sample.go
+++ b/sdk/servicebus/azservicebus/samples/processor/processor_sample.go
@@ -57,7 +57,7 @@ func main() {
 		azservicebus.ProcessorWithQueue(queue),
 		// or for a subscription
 		// azservicebus.ProcessorWithSubscription("topic", "subscription"),
-		azservicebus.ProcessorWithReceiveMode(azservicebus.ReceiveModePeekLock),
+		azservicebus.ProcessorWithReceiveMode(azservicebus.PeekLock),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Fixing build break. I had renamed some constants but not pushed the rest of the code changes.