### PR TITLE
Cosmos DB - Adding errors on failed responses

### DIFF
--- a/sdk/cosmos/azcosmos/cosmos_client_connection.go
+++ b/sdk/cosmos/azcosmos/cosmos_client_connection.go
@@ -52,7 +52,7 @@ func (c *cosmosClientConnection) sendPostRequest(
 		return nil, err
 	}
 
-	return c.Pipeline.Do(req)
+	return c.executeAndEnsureSuccessResponse(req)
 }
 
 func (c *cosmosClientConnection) sendPutRequest(
@@ -71,7 +71,7 @@ func (c *cosmosClientConnection) sendPutRequest(
 		return nil, err
 	}
 
-	return c.Pipeline.Do(req)
+	return c.executeAndEnsureSuccessResponse(req)
 }
 
 func (c *cosmosClientConnection) sendGetRequest(
@@ -84,7 +84,7 @@ func (c *cosmosClientConnection) sendGetRequest(
 		return nil, err
 	}
 
-	return c.Pipeline.Do(req)
+	return c.executeAndEnsureSuccessResponse(req)
 }
 
 func (c *cosmosClientConnection) sendDeleteRequest(
@@ -97,7 +97,7 @@ func (c *cosmosClientConnection) sendDeleteRequest(
 		return nil, err
 	}
 
-	return c.Pipeline.Do(req)
+	return c.executeAndEnsureSuccessResponse(req)
 }
 
 func (c *cosmosClientConnection) createRequest(
@@ -131,4 +131,18 @@ func (c *cosmosClientConnection) createRequest(
 
 	req.SetOperationValue(operationContext)
 	return req, nil
+}
+
+func (c *cosmosClientConnection) executeAndEnsureSuccessResponse(request *azcore.Request) (*azcore.Response, error) {
+	response, err := c.Pipeline.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	successResponse := (response.StatusCode >= 200 && response.StatusCode < 300) || response.StatusCode == 304
+	if successResponse {
+		return response, nil
+	}
+
+	return nil, azcore.NewResponseError(newCosmosError(response), response.Response)
 }

--- a/sdk/cosmos/azcosmos/cosmos_client_connection_test.go
+++ b/sdk/cosmos/azcosmos/cosmos_client_connection_test.go
@@ -1,0 +1,71 @@
+// +build !emulator
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/runtime"
+)
+
+func TestEnsureErrorIsGeneratedOnResponse(t *testing.T) {
+	someError := &cosmosError{
+		Code:    "SomeCode",
+		Message: "SomeMessage",
+	}
+
+	jsonString, err := json.Marshal(someError)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithBody(jsonString),
+		mock.WithStatusCode(404))
+
+	pl := azcore.NewPipeline(srv)
+	connection := &cosmosClientConnection{endpoint: srv.URL(), Pipeline: pl}
+	operationContext := cosmosOperationContext{
+		resourceType:    resourceTypeDatabase,
+		resourceAddress: "",
+	}
+	_, err = connection.sendGetRequest("/", context.Background(), operationContext, &CosmosContainerRequestOptions{})
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+
+	asRuntimeError := err.(*runtime.ResponseError)
+	asError := asRuntimeError.Unwrap().(*cosmosError)
+	if asError.Code != someError.Code {
+		t.Errorf("Expected %v, but got %v", someError.Code, asError.Code)
+	}
+	if asError.Message != someError.Message {
+		t.Errorf("Expected %v, but got %v", someError.Message, asError.Message)
+	}
+}
+
+func TestEnsureErrorIsNotGeneratedOnResponse(t *testing.T) {
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithStatusCode(200))
+
+	pl := azcore.NewPipeline(srv)
+	connection := &cosmosClientConnection{endpoint: srv.URL(), Pipeline: pl}
+	operationContext := cosmosOperationContext{
+		resourceType:    resourceTypeDatabase,
+		resourceAddress: "",
+	}
+	_, err := connection.sendGetRequest("/", context.Background(), operationContext, &CosmosContainerRequestOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sdk/cosmos/azcosmos/cosmos_client_connection_test.go
+++ b/sdk/cosmos/azcosmos/cosmos_client_connection_test.go
@@ -50,6 +50,10 @@ func TestEnsureErrorIsGeneratedOnResponse(t *testing.T) {
 	if asError.Message != someError.Message {
 		t.Errorf("Expected %v, but got %v", someError.Message, asError.Message)
 	}
+
+	if err.Error() != asError.Error() {
+		t.Errorf("Expected %v, but got %v", err.Error(), asError.Error())
+	}
 }
 
 func TestEnsureErrorIsNotGeneratedOnResponse(t *testing.T) {

--- a/sdk/cosmos/azcosmos/cosmos_error.go
+++ b/sdk/cosmos/azcosmos/cosmos_error.go
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// cosmosError is used as base error for any error response from the Cosmos service.
+type cosmosError struct {
+	Code    string `json:"Code"`
+	Message string `json:"Message"`
+}
+
+func newCosmosError(response *azcore.Response) error {
+	defer response.Body.Close()
+
+	var cError cosmosError
+	err := json.NewDecoder(response.Body).Decode(&cError)
+	switch {
+	case err == io.EOF:
+		return errors.New("request failed")
+	case err != nil:
+		return err
+	}
+
+	return &cError
+}
+
+func (e *cosmosError) Error() string {
+	return fmt.Sprintf("Code: %v, Message %v", e.Code, e.Message)
+}

--- a/sdk/cosmos/azcosmos/cosmos_error.go
+++ b/sdk/cosmos/azcosmos/cosmos_error.go
@@ -23,13 +23,10 @@ func newCosmosError(response *azcore.Response) error {
 	if err != nil {
 		return err
 	}
-	if !json.Valid(bytesRead) {
-		return errors.New(string(bytesRead))
-	}
 
 	err = json.Unmarshal(bytesRead, &cError)
 	if err != nil {
-		return err
+		return errors.New(string(bytesRead))
 	}
 
 	return &cError

--- a/sdk/cosmos/azcosmos/cosmos_error_test.go
+++ b/sdk/cosmos/azcosmos/cosmos_error_test.go
@@ -1,0 +1,91 @@
+// +build !emulator
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+)
+
+func TestCosmosErrorOnEmptyResponse(t *testing.T) {
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithStatusCode(404))
+
+	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pl := azcore.NewPipeline(srv)
+	resp, _ := pl.Do(req)
+
+	cError := newCosmosError(resp)
+	if cError.Error() != "" {
+		t.Errorf("Expected empty error, but got %v", cError)
+	}
+}
+
+func TestCosmosErrorOnNonJsonBody(t *testing.T) {
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithBody([]byte("This is not JSON")),
+		mock.WithStatusCode(404))
+
+	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pl := azcore.NewPipeline(srv)
+	resp, _ := pl.Do(req)
+
+	cError := newCosmosError(resp)
+	if cError.Error() != "This is not JSON" {
+		t.Errorf("Expected This is not JSON, but got %v", cError)
+	}
+}
+
+func TestCosmosErrorOnJsonBody(t *testing.T) {
+	someError := &cosmosError{
+		Code:    "SomeCode",
+		Message: "SomeMessage",
+	}
+
+	jsonString, err := json.Marshal(someError)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithBody(jsonString),
+		mock.WithStatusCode(404))
+
+	req, err := azcore.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pl := azcore.NewPipeline(srv)
+	resp, _ := pl.Do(req)
+
+	cError := newCosmosError(resp)
+	asError := cError.(*cosmosError)
+	if asError.Code != someError.Code {
+		t.Errorf("Expected %v, but got %v", someError.Code, asError.Code)
+	}
+	if asError.Message != someError.Message {
+		t.Errorf("Expected %v, but got %v", someError.Message, asError.Message)
+	}
+}

--- a/sdk/cosmos/azcosmos/emulator_cosmos_container_test.go
+++ b/sdk/cosmos/azcosmos/emulator_cosmos_container_test.go
@@ -37,10 +37,6 @@ func TestContainerCRUD(t *testing.T) {
 		t.Fatalf("Failed to create container2: %v", err)
 	}
 
-	if resp.RawResponse.StatusCode != 201 {
-		t.Fatal(emulatorTests.parseErrorResponse(resp.RawResponse))
-	}
-
 	if resp.ContainerProperties.Id != properties.Id {
 		t.Errorf("Unexpected id match: %v", resp.ContainerProperties)
 	}
@@ -53,10 +49,6 @@ func TestContainerCRUD(t *testing.T) {
 	resp, err = container.Get(context.TODO(), nil)
 	if err != nil {
 		t.Fatalf("Failed to read container: %v", err)
-	}
-
-	if resp.RawResponse.StatusCode != 200 {
-		t.Fatal(emulatorTests.parseErrorResponse(resp.RawResponse))
 	}
 
 	updatedProperties := CosmosContainerProperties{
@@ -77,16 +69,8 @@ func TestContainerCRUD(t *testing.T) {
 		t.Fatalf("Failed to update container: %v", err)
 	}
 
-	if resp.RawResponse.StatusCode != 200 {
-		t.Fatal(emulatorTests.parseErrorResponse(resp.RawResponse))
-	}
-
 	resp, err = container.Delete(context.TODO(), nil)
 	if err != nil {
 		t.Fatalf("Failed to delete container: %v", err)
-	}
-
-	if resp.RawResponse.StatusCode != 204 {
-		t.Fatal(emulatorTests.parseErrorResponse(resp.RawResponse))
 	}
 }

--- a/sdk/cosmos/azcosmos/emulator_cosmos_database_test.go
+++ b/sdk/cosmos/azcosmos/emulator_cosmos_database_test.go
@@ -19,10 +19,6 @@ func TestDatabaseCRUD(t *testing.T) {
 		t.Fatalf("Failed to create database: %v", err)
 	}
 
-	if resp.RawResponse.StatusCode != 201 {
-		t.Fatal(emulatorTests.parseErrorResponse(resp.RawResponse))
-	}
-
 	if resp.DatabaseProperties.Id != database.Id {
 		t.Errorf("Unexpected id match: %v", resp.DatabaseProperties)
 	}
@@ -32,10 +28,6 @@ func TestDatabaseCRUD(t *testing.T) {
 		t.Fatalf("Failed to read database: %v", err)
 	}
 
-	if resp.RawResponse.StatusCode != 200 {
-		t.Fatal(emulatorTests.parseErrorResponse(resp.RawResponse))
-	}
-
 	if resp.DatabaseProperties.Id != database.Id {
 		t.Errorf("Unexpected id match: %v", resp.DatabaseProperties)
 	}
@@ -43,9 +35,5 @@ func TestDatabaseCRUD(t *testing.T) {
 	resp, err = resp.DatabaseProperties.Database.Delete(context.TODO(), nil)
 	if err != nil {
 		t.Fatalf("Failed to delete database: %v", err)
-	}
-
-	if resp.RawResponse.StatusCode != 204 {
-		t.Fatal(emulatorTests.parseErrorResponse(resp.RawResponse))
 	}
 }

--- a/sdk/cosmos/azcosmos/emulator_tests.go
+++ b/sdk/cosmos/azcosmos/emulator_tests.go
@@ -45,10 +45,6 @@ func (e *emulatorTests) createDatabase(
 		t.Fatalf("Failed to create database: %v", err)
 	}
 
-	if resp.RawResponse.StatusCode != 201 {
-		t.Fatal(e.parseErrorResponse(resp.RawResponse))
-	}
-
 	if resp.DatabaseProperties.Id != database.Id {
 		t.Errorf("Unexpected id match: %v", resp.DatabaseProperties)
 	}
@@ -64,18 +60,4 @@ func (e *emulatorTests) deleteDatabase(
 	if err != nil {
 		t.Fatalf("Failed to delete database: %v", err)
 	}
-
-	if resp.RawResponse.StatusCode != 204 {
-		t.Fatal(e.parseErrorResponse(resp.RawResponse))
-	}
-}
-
-func (e *emulatorTests) parseErrorResponse(response *http.Response) error {
-	defer response.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return err
-	}
-	bodyString := string(bodyBytes)
-	return fmt.Errorf("Failed request with %v. \n Body %v", response, bodyString)
 }


### PR DESCRIPTION
This PR converts error responses (statusCode < 200 or statusCode >= 300 excluding 304) to proper errors, following the pattern provided by `azcore.NewResponseError`.

The error includes the raw response and attempts to deserialize the Cosmos DB error body and expose it in the `Error()` call.

Closes #15351