### PR TITLE
bumping Build_Test to 1.16 and 1.17

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
       workingDirectory: '$(sdkPath)'
       displayName: 'Format Check'
       failOnStderr: true
-      condition: succeededOrFailed()
+      condition: and(succeededOrFailed(), startsWith(variables['go.version'], '1.16'))
 
     - script: |
         golint ./storage/... >&2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ jobs:
     variables:
       GOPATH: '$(system.defaultWorkingDirectory)/work'
       sdkPath: '$(GOPATH)/src/github.com/$(build.repository.name)'
+      GO111MODULE: 'off'
       IGNORE_BREAKING_CHANGES: true
       go.list.filter: '| grep -v vendor | grep -v azure-sdk-for-go/sdk | grep -v azure-sdk-for-go/tools'
       go.test.filter: '-path ./vendor -prune -o -path ./sdk -prune -o -path ./tools -prune'
@@ -61,20 +62,14 @@ jobs:
     - script: go vet -v $(go list ./... $(go.list.filter))
       workingDirectory: '$(sdkPath)'
       displayName: 'Vet'
-      env:
-        GO111MODULE: 'off'
 
     - script: go build -v $(go list ./... $(go.list.filter))
       workingDirectory: '$(sdkPath)'
       displayName: 'Build'
-      env:
-        GO111MODULE: 'off'
 
     - script: go test $(dirname $(find . $(go.test.filter) -name '*_test.go' -print) | sort -u)
       workingDirectory: '$(sdkPath)'
       displayName: 'Run Tests'
-      env:
-        GO111MODULE: 'off'
 
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
       parameters:
@@ -86,14 +81,10 @@ jobs:
     - script: go run ./tools/apidiff/main.go packages ./services FETCH_HEAD~1 FETCH_HEAD --copyrepo --breakingchanges || $IGNORE_BREAKING_CHANGES
       workingDirectory: '$(sdkPath)'
       displayName: 'Display Breaking Changes'
-      env:
-        GO111MODULE: 'off'
 
     - script: go run ./tools/pkgchk/main.go ./services --exceptions ./tools/pkgchk/exceptions.txt
       workingDirectory: '$(sdkPath)'
       displayName: 'Verify Package Directory'
-      env:
-        GO111MODULE: 'off'
 
     - script: grep -L -r --include *.go --exclude-dir vendor -P "Copyright (\d{4}|\(c\)) Microsoft" ./ | tee >&2
       workingDirectory: '$(sdkPath)'
@@ -106,8 +97,6 @@ jobs:
       displayName: 'Format Check'
       failOnStderr: true
       condition: succeededOrFailed()
-      env:
-        GO111MODULE: 'off'
 
     - script: |
         golint ./storage/... >&2
@@ -115,5 +104,3 @@ jobs:
       displayName: 'Linter Check'
       failOnStderr: true
       condition: succeededOrFailed()
-      env:
-        GO111MODULE: 'off'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,7 @@ jobs:
       inputs:
         version: '$(go.version)'
       displayName: "Select Go Version"
+
     - script: |
         set -e
         mkdir -p '$(GOPATH)/bin'
@@ -47,6 +48,7 @@ jobs:
         echo '##vso[task.prependpath]$(GOROOT)/bin'
         echo '##vso[task.prependpath]$(GOPATH)/bin'
       displayName: 'Create Go Workspace'
+
     - script: |
         set -e
         go version
@@ -55,40 +57,63 @@ jobs:
         go get -u golang.org/x/lint/golint
       workingDirectory: '$(sdkPath)'
       displayName: 'Install Dependencies'
+
     - script: go vet -v $(go list ./... $(go.list.filter))
       workingDirectory: '$(sdkPath)'
       displayName: 'Vet'
+      env:
+        GO111MODULE: 'off'
+
     - script: go build -v $(go list ./... $(go.list.filter))
       workingDirectory: '$(sdkPath)'
       displayName: 'Build'
+      env:
+        GO111MODULE: 'off'
+
     - script: go test $(dirname $(find . $(go.test.filter) -name '*_test.go' -print) | sort -u)
       workingDirectory: '$(sdkPath)'
       displayName: 'Run Tests'
+      env:
+        GO111MODULE: 'off'
+
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
       parameters:
         Directory: '.'
         ScriptDirectory: '$(sdkPath)/eng/common/scripts'
         WorkingDirectory: '$(sdkPath)'
         Urls: $(Get-ChildItem -Path '$(sdkPath)/*.md' -Recurse | Where {$_.FullName -notlike "*/vendor/*" -and $_.FullName -notlike "*/sdk/*"})
+
     - script: go run ./tools/apidiff/main.go packages ./services FETCH_HEAD~1 FETCH_HEAD --copyrepo --breakingchanges || $IGNORE_BREAKING_CHANGES
       workingDirectory: '$(sdkPath)'
       displayName: 'Display Breaking Changes'
+      env:
+        GO111MODULE: 'off'
+
     - script: go run ./tools/pkgchk/main.go ./services --exceptions ./tools/pkgchk/exceptions.txt
       workingDirectory: '$(sdkPath)'
       displayName: 'Verify Package Directory'
+      env:
+        GO111MODULE: 'off'
+
     - script: grep -L -r --include *.go --exclude-dir vendor -P "Copyright (\d{4}|\(c\)) Microsoft" ./ | tee >&2
       workingDirectory: '$(sdkPath)'
       displayName: 'Copyright Header Check'
       failOnStderr: true
       condition: succeededOrFailed()
+
     - script: gofmt -s -l -d $(find . -path ./vendor -prune -o -name '*.go' -print) >&2
       workingDirectory: '$(sdkPath)'
       displayName: 'Format Check'
       failOnStderr: true
       condition: succeededOrFailed()
+      env:
+        GO111MODULE: 'off'
+
     - script: |
         golint ./storage/... >&2
       workingDirectory: '$(sdkPath)'
       displayName: 'Linter Check'
       failOnStderr: true
       condition: succeededOrFailed()
+      env:
+        GO111MODULE: 'off'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,12 +16,12 @@ jobs:
   - job: Build_Test
     strategy:
       matrix:
-        Linux_Go113:
+        Linux_Go116:
           pool.name: azsdk-pool-mms-ubuntu-1804-general
-          go.version: '1.14'
-        Linux_Go114:
+          go.version: '1.16.7'
+        Linux_Go117:
           pool.name: azsdk-pool-mms-ubuntu-1804-general
-          go.version: '1.15'
+          go.version: '1.17'
 
     pool:
       name: $(pool.name)


### PR DESCRIPTION
Build_Test was running older versions of Go, bumping to be in line with `eng/pipelines/templates/jobs/archetype-sdk-client.yml` versions