### PR TITLE
Return CredentialUnavailableError when IMDS has no assigned identity

### DIFF
--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -60,6 +60,7 @@ type managedIdentityClient struct {
 	msiType              msiType
 	endpoint             string
 	id                   ManagedIdentityIDKind
+	unavailableMessage   string
 }
 
 type wrappedNumber json.Number
@@ -92,6 +93,10 @@ func newManagedIdentityClient(options *ManagedIdentityCredentialOptions) *manage
 // clientID: The client (application) ID of the service principal.
 // scopes: The scopes required for the token.
 func (c *managedIdentityClient) authenticate(ctx context.Context, clientID string, scopes []string) (*azcore.AccessToken, error) {
+	if len(c.unavailableMessage) > 0 {
+		return nil, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: c.unavailableMessage}
+	}
+
 	msg, err := c.createAuthRequest(ctx, clientID, scopes)
 	if err != nil {
 		return nil, err
@@ -104,6 +109,11 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, clientID strin
 
 	if runtime.HasStatusCode(resp, successStatusCodes[:]...) {
 		return c.createAccessToken(resp)
+	}
+
+	if c.msiType == msiTypeIMDS && resp.StatusCode == 400 {
+		c.unavailableMessage = "The requested identity isn't assigned to this resource."
+		return nil, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: c.unavailableMessage}
 	}
 
 	return nil, &AuthenticationFailedError{inner: newAADAuthenticationFailedError(resp)}
@@ -175,7 +185,8 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, clientID 
 		default:
 			errorMsg = "unknown"
 		}
-		return nil, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: "Make sure you are running in a valid Managed Identity Environment. Status: " + errorMsg}
+		c.unavailableMessage = "Make sure you are running in a valid Managed Identity environment. Status: " + errorMsg
+		return nil, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: c.unavailableMessage}
 	}
 }
 

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -113,10 +113,9 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, clientID strin
 
 	if c.msiType == msiTypeIMDS && resp.StatusCode == 400 {
 		if len(clientID) > 0 {
-			c.unavailableMessage = "The requested identity isn't assigned to this resource."
-		} else {
-			c.unavailableMessage = "No default identity is assigned to this resource."
+			return nil, &AuthenticationFailedError{msg: "The requested identity isn't assigned to this resource."}
 		}
+		c.unavailableMessage = "No default identity is assigned to this resource."
 		return nil, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: c.unavailableMessage}
 	}
 

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -112,7 +112,11 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, clientID strin
 	}
 
 	if c.msiType == msiTypeIMDS && resp.StatusCode == 400 {
-		c.unavailableMessage = "The requested identity isn't assigned to this resource."
+		if len(clientID) > 0 {
+			c.unavailableMessage = "The requested identity isn't assigned to this resource."
+		} else {
+			c.unavailableMessage = "No default identity is assigned to this resource."
+		}
 		return nil, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: c.unavailableMessage}
 	}
 

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -4,10 +4,14 @@
 package azidentity
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -29,6 +33,26 @@ func clearEnvVars(envVars ...string) {
 		_ = os.Setenv(ev, "")
 	}
 }
+
+// A simple fake IMDS. Similar to mock.Server but doesn't wrap httptest.Server. That's
+// important because IMDS is at 169.254.169.254, not httptest.Server's default 127.0.0.1.
+type mockIMDS struct {
+	resp []http.Response
+}
+
+func newMockImds(responses ...http.Response) (m *mockIMDS) {
+	return &mockIMDS{resp: responses}
+}
+
+func (m *mockIMDS) Do(req *http.Request) (*http.Response, error) {
+	if len(m.resp) > 0 {
+		resp := m.resp[0]
+		m.resp = m.resp[1:]
+		return &resp, nil
+	}
+	panic("no more responses")
+}
+
 func TestManagedIdentityCredential_GetTokenInAzureArcLive(t *testing.T) {
 	if len(os.Getenv(arcIMDSEndpoint)) == 0 {
 		t.Skip()
@@ -333,6 +357,31 @@ func TestManagedIdentityCredential_GetTokenInAppServiceMockFail(t *testing.T) {
 	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
+	}
+}
+
+func TestManagedIdentityCredential_GetTokenIMDS400(t *testing.T) {
+	resetEnvironmentVarsForTest()
+	options := ManagedIdentityCredentialOptions{}
+	res1 := http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+	}
+	res2 := res1
+	options.HTTPClient = newMockImds(res1, res2)
+	cred, err := NewManagedIdentityCredential("", &options)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// cred should return CredentialUnavailableError when IMDS responds 400 to a token request.
+	// Also, it shouldn't send another token request (mockIMDS will appropriately panic if it does).
+	var expected *CredentialUnavailableError
+	for i := 0; i < 3; i++ {
+		_, err = cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+		if !errors.As(err, &expected) {
+			t.Fatalf("Expected CredentialUnavailableError, got %s", reflect.TypeOf(err))
+		}
 	}
 }
 

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -336,35 +336,6 @@ func TestManagedIdentityCredential_GetTokenInAppServiceMockFail(t *testing.T) {
 	}
 }
 
-// func TestManagedIdentityCredential_GetTokenIMDSMock(t *testing.T) {
-// 	timeout := time.After(5 * time.Second)
-// 	done := make(chan bool)
-// 	go func() {
-// 		err := resetEnvironmentVarsForTest()
-// 		if err != nil {
-// 			t.Fatalf("Unable to set environment variables")
-// 		}
-// 		srv, close := mock.NewServer()
-// 		defer close()
-// 		srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-//		options := DefaultManagedIdentityCredentialOptions()
-//		options.HTTPClient = srv
-// 		msiCred := NewManagedIdentityCredential("", &options)
-// 		_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
-// 		if err == nil {
-// 			t.Fatalf("Cannot run IMDS test in this environment")
-// 		}
-// 		time.Sleep(550 * time.Millisecond)
-// 		done <- true
-// 	}()
-
-// 	select {
-// 	case <-timeout:
-// 		t.Fatal("Test didn't finish in time")
-// 	case <-done:
-// 	}
-// }
-
 func TestManagedIdentityCredential_NewManagedIdentityCredentialFail(t *testing.T) {
 	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer()

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -380,7 +379,7 @@ func TestManagedIdentityCredential_GetTokenIMDS400(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		_, err = cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
 		if !errors.As(err, &expected) {
-			t.Fatalf("Expected CredentialUnavailableError, got %s", reflect.TypeOf(err))
+			t.Fatalf("Expected %T, got %T", expected, err)
 		}
 	}
 }


### PR DESCRIPTION
IMDS is always available to a VM in that it responds to requests but, when the VM has no assigned identity, it responds 400 to token requests: IMDS is available but managed identity authentication is not. ManagedIdentityCredential doesn't make this distinction today. It considers managed identity available whenever IMDS responds and treats the lack of an assigned identity as an authentication error, i.e. it returns ClientAuthenticationError. That error causes DefaultAzureCredential (ChainedTokenCredential) to halt when it should instead try the next credential in the chain. With this PR ManagedIdentityCredential does that and, after receiving a 400 from IMDS, doesn't attempt another token request. The motivation for the latter change is that there's no reason to believe another token request would succeed and, if it did succeed because someone assigned an identity while an application is running, that application could unexpectedly change its authenticated identity.

Closes #14214