### PR TITLE
Fix armresources documentation link

### DIFF
--- a/sdk/resources/armresources/README.md
+++ b/sdk/resources/armresources/README.md
@@ -23,7 +23,7 @@ Install the Azure Resources module:
 go get github.com/Azure/azure-sdk-for-go/sdk/resources/armresources
 ```
 
-Documentation and examples are available at [pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resources/armresources](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resources/armresources)
+Documentation and examples are available at [pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resources/armresources](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resources/armresources)
 
 ## Authorization
 


### PR DESCRIPTION
Should link to pkg.go.dev's page for the package instead of its badge. grep didn't find another instance in the repo.