### PR TITLE
Deprecate armcore module

### DIFF
--- a/sdk/armcore/connection.go
+++ b/sdk/armcore/connection.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/connection_test.go
+++ b/sdk/armcore/connection_test.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/doc.go
+++ b/sdk/armcore/doc.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright 2017 Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/go.mod
+++ b/sdk/armcore/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: The contents of this module have moved to github.com/Azure/azure-sdk-for-go/sdk/azcore/arm
 module github.com/Azure/azure-sdk-for-go/sdk/armcore
 
 go 1.14

--- a/sdk/armcore/internal/pollers/async/async.go
+++ b/sdk/armcore/internal/pollers/async/async.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/internal/pollers/async/async_test.go
+++ b/sdk/armcore/internal/pollers/async/async_test.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/internal/pollers/body/body.go
+++ b/sdk/armcore/internal/pollers/body/body.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/internal/pollers/body/body_test.go
+++ b/sdk/armcore/internal/pollers/body/body_test.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/internal/pollers/loc/loc.go
+++ b/sdk/armcore/internal/pollers/loc/loc.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/internal/pollers/loc/loc_test.go
+++ b/sdk/armcore/internal/pollers/loc/loc_test.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/internal/pollers/pollers.go
+++ b/sdk/armcore/internal/pollers/pollers.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/internal/pollers/pollers_test.go
+++ b/sdk/armcore/internal/pollers/pollers_test.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/policy_register_rp.go
+++ b/sdk/armcore/policy_register_rp.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/policy_register_rp_test.go
+++ b/sdk/armcore/policy_register_rp_test.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/poller.go
+++ b/sdk/armcore/poller.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/poller_test.go
+++ b/sdk/armcore/poller_test.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/armcore/version.go
+++ b/sdk/armcore/version.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -10,5 +11,5 @@ const (
 	UserAgent = "armcore/" + Version
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v0.8.0"
+	Version = "v0.8.1"
 )


### PR DESCRIPTION
Update build constraints per Go 1.17.
Bump patch version.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
