### PR TITLE
Remove coverage goal parameter reference

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -58,7 +58,6 @@ stages:
           Scope: $(SCOPE)
           Image: $(vm.image)
           GoVersion: $(go.version)
-          CoverageGoal: ${{ parameters.CoverageGoal }}
           RunTests: ${{ parameters.RunTests }}
 
     - job: Analyze


### PR DESCRIPTION
I missed the extra reference when addressing a PR comment: https://github.com/Azure/azure-sdk-for-go/pull/15382