### PR TITLE
Unexport AzureCLITokenProvider

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Features Added
 
 ### Breaking Changes
+* Unexported `AzureCLICredentialOptions.TokenProvider` and its type,
+  `AzureCLITokenProvider`
 
 ### Bug Fixes
 

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -20,25 +20,25 @@ import (
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-// AzureCLITokenProvider can be used to supply the AzureCLICredential with an alternate token provider
-type AzureCLITokenProvider func(ctx context.Context, resource string) ([]byte, error)
+// used by tests to fake invoking the CLI
+type azureCLITokenProvider func(ctx context.Context, resource string) ([]byte, error)
 
 // AzureCLICredentialOptions contains options used to configure the AzureCLICredential
 // All zero-value fields will be initialized with their default values.
 type AzureCLICredentialOptions struct {
-	TokenProvider AzureCLITokenProvider
+	tokenProvider azureCLITokenProvider
 }
 
 // init returns an instance of AzureCLICredentialOptions initialized with default values.
 func (o *AzureCLICredentialOptions) init() {
-	if o.TokenProvider == nil {
-		o.TokenProvider = defaultTokenProvider()
+	if o.tokenProvider == nil {
+		o.tokenProvider = defaultTokenProvider()
 	}
 }
 
 // AzureCLICredential enables authentication to Azure Active Directory using the Azure CLI command "az account get-access-token".
 type AzureCLICredential struct {
-	tokenProvider AzureCLITokenProvider
+	tokenProvider azureCLITokenProvider
 }
 
 // NewAzureCLICredential constructs a new AzureCLICredential with the details needed to authenticate against Azure Active Directory
@@ -50,7 +50,7 @@ func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredent
 	}
 	cp.init()
 	return &AzureCLICredential{
-		tokenProvider: cp.TokenProvider,
+		tokenProvider: cp.tokenProvider,
 	}, nil
 }
 

--- a/sdk/azidentity/azure_cli_credential_test.go
+++ b/sdk/azidentity/azure_cli_credential_test.go
@@ -29,7 +29,7 @@ var (
 
 func TestAzureCLICredential_GetTokenSuccess(t *testing.T) {
 	options := AzureCLICredentialOptions{}
-	options.TokenProvider = mockCLITokenProviderSuccess
+	options.tokenProvider = mockCLITokenProviderSuccess
 	cred, err := NewAzureCLICredential(&options)
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
@@ -48,7 +48,7 @@ func TestAzureCLICredential_GetTokenSuccess(t *testing.T) {
 
 func TestAzureCLICredential_GetTokenInvalidToken(t *testing.T) {
 	options := AzureCLICredentialOptions{}
-	options.TokenProvider = mockCLITokenProviderFailure
+	options.tokenProvider = mockCLITokenProviderFailure
 	cred, err := NewAzureCLICredential(&options)
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
@@ -64,7 +64,7 @@ func TestBearerPolicy_AzureCLICredential(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	options := AzureCLICredentialOptions{}
-	options.TokenProvider = mockCLITokenProviderSuccess
+	options.tokenProvider = mockCLITokenProviderSuccess
 	cred, err := NewAzureCLICredential(&options)
 	if err != nil {
 		t.Fatalf("Did not expect an error but received: %v", err)


### PR DESCRIPTION
`AzureCLICredentialOptions.TokenProvider` is a callback the credential invokes to acquire a token. It's needed in tests to fake invoking the CLI but we don't want it in the public API (~`ArbitraryCallbackCredential`~ `AzureCLICredential` 😉) so this PR makes it and its type unexported.