### PR TITLE
fix: use abs spec path in sdk automation script for track2

### DIFF
--- a/tools/generator/cmd/v2/automation/automationCmd.go
+++ b/tools/generator/cmd/v2/automation/automationCmd.go
@@ -94,10 +94,9 @@ func (ctx *automationContext) generate(input *pipeline.GenerateInput) (*pipeline
 	for _, readme := range input.RelatedReadmeMdFiles {
 		log.Printf("Start to process readme file: %s", readme)
 		generateCtx := common.GenerateContext{
-			SDKPath:        sdkRepo.Root(),
-			SDKRepo:        &sdkRepo,
-			SpecPath:       ctx.specRoot,
-			SpecCommitHash: "",
+			SDKPath:  sdkRepo.Root(),
+			SDKRepo:  &sdkRepo,
+			SpecPath: ctx.specRoot,
 		}
 
 		namespaceResults, errors := generateCtx.GenerateForAutomation(readme, input.RepoHTTPSURL)

--- a/tools/generator/cmd/v2/automation/automationCmd.go
+++ b/tools/generator/cmd/v2/automation/automationCmd.go
@@ -100,8 +100,7 @@ func (ctx *automationContext) generate(input *pipeline.GenerateInput) (*pipeline
 			SpecCommitHash: "",
 		}
 
-		specFolderName := strings.Split(input.RelatedReadmeMdFiles[0], "/")[1]
-		namespaceResults, errors := generateCtx.GenerateForAutomation(readme, input.RepoHTTPSURL, specFolderName)
+		namespaceResults, errors := generateCtx.GenerateForAutomation(readme, input.RepoHTTPSURL)
 		if len(errors) != 0 {
 			errorBuilder.add(errors...)
 			continue

--- a/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/tools/generator/cmd/v2/common/fileProcessor.go
@@ -106,9 +106,14 @@ func CleanSDKGeneratedFiles(path string) error {
 }
 
 // replace repo commit with local path in autorest.md files
-func ChangeConfigWithLocalPath(path, specPath, specFolder string) error {
+func ChangeConfigWithLocalPath(path, specPath, specRPName string) error {
 	log.Printf("Replacing repo commit with local path in autorest.md ...")
 	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	specPath, err = filepath.Abs(specPath)
 	if err != nil {
 		return err
 	}
@@ -116,8 +121,8 @@ func ChangeConfigWithLocalPath(path, specPath, specFolder string) error {
 	lines := strings.Split(string(b), "\n")
 	for i, line := range lines {
 		if strings.Contains(line, autorest_md_file_suffix) {
-			lines[i] = fmt.Sprintf("- %s", filepath.Join(specPath, "specification", specFolder, "resource-manager", "readme.md"))
-			lines[i+1] = fmt.Sprintf("- %s", filepath.Join(specPath, "specification", specFolder, "resource-manager", "readme.go.md"))
+			lines[i] = fmt.Sprintf("- %s", filepath.Join(specPath, "specification", specRPName, "resource-manager", "readme.md"))
+			lines[i+1] = fmt.Sprintf("- %s", filepath.Join(specPath, "specification", specRPName, "resource-manager", "readme.go.md"))
 			break
 		}
 	}
@@ -126,7 +131,7 @@ func ChangeConfigWithLocalPath(path, specPath, specFolder string) error {
 }
 
 // replace repo URL and commit id in autorest.md files
-func ChangeConfigWithCommitID(path, repoURL, commitID, specFolder string) error {
+func ChangeConfigWithCommitID(path, repoURL, commitID, specRPName string) error {
 	log.Printf("Replacing repo URL and commit id in autorest.md ...")
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -136,8 +141,8 @@ func ChangeConfigWithCommitID(path, repoURL, commitID, specFolder string) error 
 	lines := strings.Split(string(b), "\n")
 	for i, line := range lines {
 		if strings.Contains(line, autorest_md_file_suffix) {
-			lines[i] = fmt.Sprintf("- %s/blob/%s/specification/%s/resource-manager/readme.md", repoURL, commitID, specFolder)
-			lines[i+1] = fmt.Sprintf("- %s/blob/%s/specification/%s/resource-manager/readme.go.md", repoURL, commitID, specFolder)
+			lines[i] = fmt.Sprintf("- %s/blob/%s/specification/%s/resource-manager/readme.md", repoURL, commitID, specRPName)
+			lines[i+1] = fmt.Sprintf("- %s/blob/%s/specification/%s/resource-manager/readme.go.md", repoURL, commitID, specRPName)
 			break
 		}
 	}

--- a/tools/generator/cmd/v2/common/generation.go
+++ b/tools/generator/cmd/v2/common/generation.go
@@ -24,6 +24,7 @@ type GenerateContext struct {
 	SDKRepo        *repo.SDKRepository
 	SpecPath       string
 	SpecCommitHash string
+	SpecRepoURL    string
 }
 
 type GenerateResult struct {
@@ -33,6 +34,14 @@ type GenerateResult struct {
 	PackageAbsPath string
 	Changelog      model.Changelog
 	ChangelogMD    string
+}
+
+type GenerateParam struct {
+	RPName              string
+	NamespaceName       string
+	SpecficVersion      string
+	SpecficPackageTitle string
+	SpecRPName          string
 }
 
 func (ctx GenerateContext) GenerateForAutomation(readme, repo string) ([]GenerateResult, []error) {
@@ -54,7 +63,11 @@ func (ctx GenerateContext) GenerateForAutomation(readme, repo string) ([]Generat
 	for rpName, namespaceNames := range rpMap {
 		for _, namespaceName := range namespaceNames {
 			log.Printf("Process rp: %s, namespace: %s", rpName, namespaceName)
-			singleResult, err := ctx.GenerateForSingleRPNamespace(rpName, namespaceName, "", "", "", specRPName)
+			singleResult, err := ctx.GenerateForSingleRPNamespace(&GenerateParam{
+				RPName:        rpName,
+				NamespaceName: namespaceName,
+				SpecRPName:    specRPName,
+			})
 			if err != nil {
 				errors = append(errors, err)
 				continue
@@ -65,8 +78,8 @@ func (ctx GenerateContext) GenerateForAutomation(readme, repo string) ([]Generat
 	return result, errors
 }
 
-func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, specficPackageTitle, specficVersion, specficRepoURL, specRPName string) (*GenerateResult, error) {
-	packagePath := filepath.Join(ctx.SDKPath, "sdk", rpName, namespaceName)
+func (ctx GenerateContext) GenerateForSingleRPNamespace(generateParam *GenerateParam) (*GenerateResult, error) {
+	packagePath := filepath.Join(ctx.SDKPath, "sdk", generateParam.RPName, generateParam.NamespaceName)
 	changelogPath := filepath.Join(packagePath, common.ChangelogFilename)
 
 	onBoard := false
@@ -75,15 +88,15 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, s
 		onBoard = true
 		log.Printf("Package '%s' changelog not exist, do onboard process", packagePath)
 
-		if specficPackageTitle == "" {
-			specficPackageTitle = strings.Title(rpName)
+		if generateParam.SpecficPackageTitle == "" {
+			generateParam.SpecficPackageTitle = strings.Title(generateParam.RPName)
 		}
 
 		log.Printf("Use template to generate new rp folder and basic package files...")
-		if err = template.GeneratePackageByTemplate(rpName, namespaceName, template.Flags{
+		if err = template.GeneratePackageByTemplate(generateParam.RPName, generateParam.NamespaceName, template.Flags{
 			SDKRoot:      ctx.SDKPath,
 			TemplatePath: "tools/generator/template/rpName/packageName",
-			PackageTitle: specficPackageTitle,
+			PackageTitle: generateParam.SpecficPackageTitle,
 			Commit:       ctx.SpecCommitHash,
 		}); err != nil {
 			return nil, err
@@ -92,7 +105,7 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, s
 		log.Printf("Package '%s' existed, do update process", packagePath)
 
 		log.Printf("Get ori exports for changelog generation...")
-		if err := (*ctx.SDKRepo).Add(fmt.Sprintf("sdk\\%s\\%s", rpName, namespaceName)); err != nil {
+		if err := (*ctx.SDKRepo).Add(fmt.Sprintf("sdk\\%s\\%s", generateParam.RPName, generateParam.NamespaceName)); err != nil {
 			return nil, err
 		}
 		if err := (*ctx.SDKRepo).Stash(); err != nil {
@@ -116,13 +129,13 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, s
 	if ctx.SpecCommitHash == "" {
 		log.Printf("Change swagger config in `autorest.md` according to local path...")
 		autorestMdPath := filepath.Join(packagePath, "autorest.md")
-		if err := ChangeConfigWithLocalPath(autorestMdPath, ctx.SpecPath, specRPName); err != nil {
+		if err := ChangeConfigWithLocalPath(autorestMdPath, ctx.SpecPath, generateParam.SpecRPName); err != nil {
 			return nil, err
 		}
 	} else {
 		log.Printf("Change swagger config in `autorest.md` according to repo URL and commit ID...")
 		autorestMdPath := filepath.Join(packagePath, "autorest.md")
-		if err := ChangeConfigWithCommitID(autorestMdPath, specficRepoURL, ctx.SpecCommitHash, specRPName); err != nil {
+		if err := ChangeConfigWithCommitID(autorestMdPath, ctx.SpecRepoURL, ctx.SpecCommitHash, generateParam.SpecRPName); err != nil {
 			return nil, err
 		}
 	}
@@ -155,8 +168,8 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, s
 
 		return &GenerateResult{
 			Version:        "0.1.0",
-			RPName:         rpName,
-			PackageName:    namespaceName,
+			RPName:         generateParam.RPName,
+			PackageName:    generateParam.NamespaceName,
 			PackageAbsPath: packagePath,
 			Changelog:      *changelog,
 			ChangelogMD:    changelog.ToCompactMarkdown(),
@@ -164,14 +177,14 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, s
 	} else {
 		log.Printf("Calculate new version...")
 		var version *semver.Version
-		if specficVersion == "" {
+		if generateParam.SpecficVersion == "" {
 			version, err = CalculateNewVersion(changelog, packagePath)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			log.Printf("Use specfic version: %s", specficVersion)
-			version, err = semver.NewVersion(specficVersion)
+			log.Printf("Use specfic version: %s", generateParam.SpecficVersion)
+			version, err = semver.NewVersion(generateParam.SpecficVersion)
 			if err != nil {
 				return nil, err
 			}
@@ -200,8 +213,8 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, s
 
 		return &GenerateResult{
 			Version:        version.String(),
-			RPName:         rpName,
-			PackageName:    namespaceName,
+			RPName:         generateParam.RPName,
+			PackageName:    generateParam.NamespaceName,
 			PackageAbsPath: packagePath,
 			Changelog:      *changelog,
 			ChangelogMD:    changelogMd,

--- a/tools/generator/cmd/v2/common/generation.go
+++ b/tools/generator/cmd/v2/common/generation.go
@@ -35,9 +35,10 @@ type GenerateResult struct {
 	ChangelogMD    string
 }
 
-func (ctx GenerateContext) GenerateForAutomation(readme, repo, specFolderName string) ([]GenerateResult, []error) {
+func (ctx GenerateContext) GenerateForAutomation(readme, repo string) ([]GenerateResult, []error) {
 	absReadme := filepath.Join(ctx.SpecPath, readme)
 	absReadmeGo := filepath.Join(filepath.Dir(absReadme), "readme.go.md")
+	specRPName := strings.Split(readme, "/")[1]
 
 	var result []GenerateResult
 	var errors []error
@@ -53,7 +54,7 @@ func (ctx GenerateContext) GenerateForAutomation(readme, repo, specFolderName st
 	for rpName, namespaceNames := range rpMap {
 		for _, namespaceName := range namespaceNames {
 			log.Printf("Process rp: %s, namespace: %s", rpName, namespaceName)
-			singleResult, err := ctx.GenerateForSingleRPNamespace(rpName, namespaceName, "", "", repo, specFolderName)
+			singleResult, err := ctx.GenerateForSingleRPNamespace(rpName, namespaceName, "", "", "", specRPName)
 			if err != nil {
 				errors = append(errors, err)
 				continue
@@ -64,7 +65,7 @@ func (ctx GenerateContext) GenerateForAutomation(readme, repo, specFolderName st
 	return result, errors
 }
 
-func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, specficPackageTitle, specficVersion, specficRepoURL, specFolderName string) (*GenerateResult, error) {
+func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, specficPackageTitle, specficVersion, specficRepoURL, specRPName string) (*GenerateResult, error) {
 	packagePath := filepath.Join(ctx.SDKPath, "sdk", rpName, namespaceName)
 	changelogPath := filepath.Join(packagePath, common.ChangelogFilename)
 
@@ -115,13 +116,13 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(rpName, namespaceName, s
 	if ctx.SpecCommitHash == "" {
 		log.Printf("Change swagger config in `autorest.md` according to local path...")
 		autorestMdPath := filepath.Join(packagePath, "autorest.md")
-		if err := ChangeConfigWithLocalPath(autorestMdPath, ctx.SpecPath, specFolderName); err != nil {
+		if err := ChangeConfigWithLocalPath(autorestMdPath, ctx.SpecPath, specRPName); err != nil {
 			return nil, err
 		}
 	} else {
 		log.Printf("Change swagger config in `autorest.md` according to repo URL and commit ID...")
 		autorestMdPath := filepath.Join(packagePath, "autorest.md")
-		if err := ChangeConfigWithCommitID(autorestMdPath, specficRepoURL, ctx.SpecCommitHash, specFolderName); err != nil {
+		if err := ChangeConfigWithCommitID(autorestMdPath, specficRepoURL, ctx.SpecCommitHash, specRPName); err != nil {
 			return nil, err
 		}
 	}

--- a/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/tools/generator/cmd/v2/release/releaseCmd.go
@@ -58,28 +58,28 @@ namespaceName: name of namespace to be released, default value is arm+rp-name
 }
 
 type Flags struct {
-	VersionNumber  string
-	SwaggerRepo    string
-	PackageTitle   string
-	SDKRepo        string
-	SpecFolderName string
+	VersionNumber string
+	SwaggerRepo   string
+	PackageTitle  string
+	SDKRepo       string
+	SpecRPName    string
 }
 
 func BindFlags(flagSet *pflag.FlagSet) {
 	flagSet.String("version-number", "", "Specify the version number of this release")
 	flagSet.String("package-title", "", "Specifies the title of this package")
-	flagSet.String("sdk-repo", "https://github.com/Azure/azure-sdk-for-go", "Specifies the sdk repo url for generation")
-	flagSet.String("spec-repo", "https://github.com/Azure/azure-rest-api-specs", "Specifies the swagger repo url for generation")
-	flagSet.String("spec-folder-name", "", "Specifies the swagger spec folder name, default is rp name")
+	flagSet.String("sdk-repo", "https://github.com/Azure/azure-sdk-for-go", "Specifies the sdk repo URL for generation")
+	flagSet.String("spec-repo", "https://github.com/Azure/azure-rest-api-specs", "Specifies the swagger repo URL for generation")
+	flagSet.String("spec-rp-name", "", "Specifies the swagger spec RP name, default is RP name")
 }
 
 func ParseFlags(flagSet *pflag.FlagSet) Flags {
 	return Flags{
-		VersionNumber:  flags.GetString(flagSet, "version-number"),
-		PackageTitle:   flags.GetString(flagSet, "package-title"),
-		SDKRepo:        flags.GetString(flagSet, "sdk-repo"),
-		SwaggerRepo:    flags.GetString(flagSet, "spec-repo"),
-		SpecFolderName: flags.GetString(flagSet, "spec-folder-name"),
+		VersionNumber: flags.GetString(flagSet, "version-number"),
+		PackageTitle:  flags.GetString(flagSet, "package-title"),
+		SDKRepo:       flags.GetString(flagSet, "sdk-repo"),
+		SwaggerRepo:   flags.GetString(flagSet, "spec-repo"),
+		SpecRPName:    flags.GetString(flagSet, "spec-folder-name"),
 	}
 }
 
@@ -137,10 +137,10 @@ func (c *commandContext) execute(sdkRepoParam, specRepoParam string) error {
 		SpecCommitHash: specCommitHash,
 	}
 
-	if c.flags.SpecFolderName == "" {
-		c.flags.SpecFolderName = c.rpName
+	if c.flags.SpecRPName == "" {
+		c.flags.SpecRPName = c.rpName
 	}
-	result, err := generateCtx.GenerateForSingleRPNamespace(c.rpName, c.namespaceName, c.flags.PackageTitle, c.flags.VersionNumber, c.flags.SwaggerRepo, c.flags.SpecFolderName)
+	result, err := generateCtx.GenerateForSingleRPNamespace(c.rpName, c.namespaceName, c.flags.PackageTitle, c.flags.VersionNumber, c.flags.SwaggerRepo, c.flags.SpecRPName)
 	if err != nil {
 		return fmt.Errorf("failed to finish release generation process: %+v", err)
 	}

--- a/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/tools/generator/cmd/v2/release/releaseCmd.go
@@ -79,7 +79,7 @@ func ParseFlags(flagSet *pflag.FlagSet) Flags {
 		PackageTitle:  flags.GetString(flagSet, "package-title"),
 		SDKRepo:       flags.GetString(flagSet, "sdk-repo"),
 		SwaggerRepo:   flags.GetString(flagSet, "spec-repo"),
-		SpecRPName:    flags.GetString(flagSet, "spec-folder-name"),
+		SpecRPName:    flags.GetString(flagSet, "spec-rp-name"),
 	}
 }
 
@@ -133,14 +133,20 @@ func (c *commandContext) execute(sdkRepoParam, specRepoParam string) error {
 	generateCtx := common.GenerateContext{
 		SDKPath:        sdkRepo.Root(),
 		SDKRepo:        &sdkRepo,
-		SpecPath:       "",
 		SpecCommitHash: specCommitHash,
+		SpecRepoURL:    c.flags.SwaggerRepo,
 	}
 
 	if c.flags.SpecRPName == "" {
 		c.flags.SpecRPName = c.rpName
 	}
-	result, err := generateCtx.GenerateForSingleRPNamespace(c.rpName, c.namespaceName, c.flags.PackageTitle, c.flags.VersionNumber, c.flags.SwaggerRepo, c.flags.SpecRPName)
+	result, err := generateCtx.GenerateForSingleRPNamespace(&common.GenerateParam{
+		RPName:              c.rpName,
+		NamespaceName:       c.namespaceName,
+		SpecficPackageTitle: c.flags.PackageTitle,
+		SpecficVersion:      c.flags.VersionNumber,
+		SpecRPName:          c.flags.SpecRPName,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to finish release generation process: %+v", err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
