### PR TITLE
Create a default transport

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Release History
 
-## v0.20.0 (Unreleased)
+## v0.19.1 (Unreleased)
 
 ### Features Added
 * Updating Documentation
 
+### Bug Fixes
+* Fixed a potential panic when creating the default Transporter.
 
 ## v0.19.0 (2021-08-25)
 

--- a/sdk/azcore/runtime/transport_default_http_client.go
+++ b/sdk/azcore/runtime/transport_default_http_client.go
@@ -8,7 +8,9 @@ package runtime
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
@@ -16,8 +18,21 @@ import (
 var defaultHTTPClient *http.Client
 
 func init() {
-	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
-	defaultTransport.TLSClientConfig.MinVersion = tls.VersionTLS12
+	defaultTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+	}
 	defaultHTTPClient = &http.Client{
 		Transport: defaultTransport,
 	}


### PR DESCRIPTION
Type-asserting the http.DefaultTransport can fail if it was replaced
with a custom RoundTripper.  Instead, create a new http.Transport with
the settings copied from http.DefaultTransport.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
