### PR TITLE
Bump test proxy windows image tag

### DIFF
--- a/eng/common/testproxy/docker-start-proxy.ps1
+++ b/eng/common/testproxy/docker-start-proxy.ps1
@@ -25,7 +25,7 @@ catch {
     Write-Error "Please check your docker invocation and try running the script again."
 }
 
-$SELECTED_IMAGE_TAG = "1084681"
+$SELECTED_IMAGE_TAG = "1091180"
 $CONTAINER_NAME = "ambitious_azsdk_test_proxy"
 $LINUX_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-lin:${SELECTED_IMAGE_TAG}"
 $WINDOWS_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-win:${SELECTED_IMAGE_TAG}"


### PR DESCRIPTION
The latest test proxy windows image is much smaller than the previous ones (see https://github.com/Azure/azure-sdk-tools/pull/2001). This should reduce CI pipeline test times by a couple minutes.