### PR TITLE
Use a typedef for ARM endpoints

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
-## 0.19.1 (Unreleased)
+## v0.20.0 (Unreleased)
+
+### Breaking Changes
+* The endpoint parameter for `arm/Connection` constructors has changed to a string typedef in order to provide a hint for applicable values.
 
 ### Features Added
 * Updating Documentation

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## v0.20.0 (Unreleased)
+## 0.20.0 (Unreleased)
 
 ### Breaking Changes
 * The endpoint parameter for `arm/Connection` constructors has changed to a string typedef in order to provide a hint for applicable values.

--- a/sdk/azcore/arm/connection_test.go
+++ b/sdk/azcore/arm/connection_test.go
@@ -72,8 +72,8 @@ func TestNewConnectionWithOptions(t *testing.T) {
 	srv.AppendResponse()
 	opt := ConnectionOptions{}
 	opt.HTTPClient = srv
-	con := NewConnection(srv.URL(), mockTokenCred{}, &opt)
-	if ep := con.Endpoint(); ep != srv.URL() {
+	con := NewConnection(Endpoint(srv.URL()), mockTokenCred{}, &opt)
+	if ep := con.Endpoint(); ep != Endpoint(srv.URL()) {
 		t.Fatalf("unexpected endpoint %s", ep)
 	}
 	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
@@ -100,8 +100,8 @@ func TestNewConnectionWithCustomTelemetry(t *testing.T) {
 	opt := ConnectionOptions{}
 	opt.HTTPClient = srv
 	opt.Telemetry.ApplicationID = myTelemetry
-	con := NewConnection(srv.URL(), mockTokenCred{}, &opt)
-	if ep := con.Endpoint(); ep != srv.URL() {
+	con := NewConnection(Endpoint(srv.URL()), mockTokenCred{}, &opt)
+	if ep := con.Endpoint(); ep != Endpoint(srv.URL()) {
 		t.Fatalf("unexpected endpoint %s", ep)
 	}
 	if opt.Telemetry.ApplicationID != myTelemetry {
@@ -128,8 +128,8 @@ func TestDisableAutoRPRegistration(t *testing.T) {
 	defer close()
 	// initial response that RP is unregistered
 	srv.SetResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
-	con := NewConnection(srv.URL(), mockTokenCred{}, &ConnectionOptions{DisableRPRegistration: true})
-	if ep := con.Endpoint(); ep != srv.URL() {
+	con := NewConnection(Endpoint(srv.URL()), mockTokenCred{}, &ConnectionOptions{DisableRPRegistration: true})
+	if ep := con.Endpoint(); ep != Endpoint(srv.URL()) {
 		t.Fatalf("unexpected endpoint %s", ep)
 	}
 	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
@@ -177,7 +177,7 @@ func TestConnectionWithCustomPolicies(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	perCallPolicy := countingPolicy{}
 	perRetryPolicy := countingPolicy{}
-	con := NewConnection(srv.URL(), mockTokenCred{}, &ConnectionOptions{
+	con := NewConnection(Endpoint(srv.URL()), mockTokenCred{}, &ConnectionOptions{
 		DisableRPRegistration: true,
 		PerCallPolicies:       []policy.Policy{&perCallPolicy},
 		PerRetryPolicies:      []policy.Policy{&perRetryPolicy},

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -30,5 +30,5 @@ const (
 	Module = "azcore"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v0.19.1"
+	Version = "v0.20.0"
 )


### PR DESCRIPTION
This provides a clue for what values callers are supposed to pass.
Since the underlying type is a string, callers can still pass custom
endpoint strings using a cast.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
