### PR TITLE
feat: remove 'v' and add release date for changelog generation

### DIFF
--- a/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/tools/generator/cmd/v2/common/fileProcessor.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/tools/generator/autorest/model"
 	"github.com/Azure/azure-sdk-for-go/tools/generator/common"
@@ -219,7 +220,7 @@ func CalculateNewVersion(changelog *model.Changelog, packageRootPath string) (*s
 }
 
 // add new changelog md to changelog file
-func AddChangelogToFile(changelog *model.Changelog, version *semver.Version, packageRootPath string) (string, error) {
+func AddChangelogToFile(changelog *model.Changelog, version *semver.Version, packageRootPath, releaseDate string) (string, error) {
 	path := filepath.Join(packageRootPath, common.ChangelogFilename)
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -228,7 +229,10 @@ func AddChangelogToFile(changelog *model.Changelog, version *semver.Version, pac
 	oldChangelog := string(b)
 	insertPos := strings.Index(oldChangelog, "##")
 	additionalChangelog := changelog.ToCompactMarkdown()
-	newChangelog := oldChangelog[:insertPos] + "## v" + version.String() + " (released)\n" + additionalChangelog + "\n\n" + oldChangelog[insertPos:]
+	if releaseDate == "" {
+		releaseDate = time.Now().Format("2006-01-02")
+	}
+	newChangelog := oldChangelog[:insertPos] + "## " + version.String() + " (" + releaseDate + ")\n" + additionalChangelog + "\n\n" + oldChangelog[insertPos:]
 	err = ioutil.WriteFile(path, []byte(newChangelog), 0644)
 	if err != nil {
 		return "", err

--- a/tools/generator/cmd/v2/common/generation.go
+++ b/tools/generator/cmd/v2/common/generation.go
@@ -42,6 +42,7 @@ type GenerateParam struct {
 	SpecficVersion      string
 	SpecficPackageTitle string
 	SpecRPName          string
+	ReleaseDate         string
 }
 
 func (ctx GenerateContext) GenerateForAutomation(readme, repo string) ([]GenerateResult, []error) {
@@ -191,7 +192,7 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(generateParam *GenerateP
 		}
 
 		log.Printf("Add changelog to file...")
-		changelogMd, err := AddChangelogToFile(changelog, version, packagePath)
+		changelogMd, err := AddChangelogToFile(changelog, version, packagePath, generateParam.ReleaseDate)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/tools/generator/cmd/v2/release/releaseCmd.go
@@ -63,6 +63,7 @@ type Flags struct {
 	PackageTitle  string
 	SDKRepo       string
 	SpecRPName    string
+	ReleaseDate   string
 }
 
 func BindFlags(flagSet *pflag.FlagSet) {
@@ -71,6 +72,7 @@ func BindFlags(flagSet *pflag.FlagSet) {
 	flagSet.String("sdk-repo", "https://github.com/Azure/azure-sdk-for-go", "Specifies the sdk repo URL for generation")
 	flagSet.String("spec-repo", "https://github.com/Azure/azure-rest-api-specs", "Specifies the swagger repo URL for generation")
 	flagSet.String("spec-rp-name", "", "Specifies the swagger spec RP name, default is RP name")
+	flagSet.String("release-date", "", "Specifies the release date in changelog")
 }
 
 func ParseFlags(flagSet *pflag.FlagSet) Flags {
@@ -80,6 +82,7 @@ func ParseFlags(flagSet *pflag.FlagSet) Flags {
 		SDKRepo:       flags.GetString(flagSet, "sdk-repo"),
 		SwaggerRepo:   flags.GetString(flagSet, "spec-repo"),
 		SpecRPName:    flags.GetString(flagSet, "spec-rp-name"),
+		ReleaseDate:   flags.GetString(flagSet, "release-date"),
 	}
 }
 
@@ -146,6 +149,7 @@ func (c *commandContext) execute(sdkRepoParam, specRepoParam string) error {
 		SpecficPackageTitle: c.flags.PackageTitle,
 		SpecficVersion:      c.flags.VersionNumber,
 		SpecRPName:          c.flags.SpecRPName,
+		ReleaseDate:         c.flags.ReleaseDate,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to finish release generation process: %+v", err)

--- a/tools/generator/template/rpName/packageName/CHANGELOG.md.tpl
+++ b/tools/generator/template/rpName/packageName/CHANGELOG.md.tpl
@@ -1,3 +1,3 @@
 # Release History
 
-## v0.1.0 (released)
+## 0.1.0 ({{releaseDate}})


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
