### PR TITLE
Add ChainedTokenCredentialOptions

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -4,6 +4,15 @@
 ### Breaking Changes
 * The `AuthorityHost` field in credential options structs is now a custom type,
   `AuthorityHost`, with underlying type `string`
+* `NewChainedTokenCredential` has a new signature to accommodate a placeholder
+  options struct:
+  ```go
+  // before
+  cred, err := NewChainedTokenCredential(credA, credB)
+
+  // after
+  cred, err := NewChainedTokenCredential([]azcore.TokenCredential{credA, credB}, nil)
+  ```
 
 
 ## 0.11.0 (2021-09-08)

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -12,6 +12,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
+// ChainedTokenCredentialOptions contains optional parameters for ChainedTokenCredential
+type ChainedTokenCredentialOptions struct {
+	// placeholder for future options
+}
+
 // ChainedTokenCredential provides a TokenCredential implementation that chains multiple TokenCredential sources to be tried in order
 // and returns the token from the first successful call to GetToken().
 type ChainedTokenCredential struct {
@@ -19,7 +24,7 @@ type ChainedTokenCredential struct {
 }
 
 // NewChainedTokenCredential creates an instance of ChainedTokenCredential with the specified TokenCredential sources.
-func NewChainedTokenCredential(sources ...azcore.TokenCredential) (*ChainedTokenCredential, error) {
+func NewChainedTokenCredential(options *ChainedTokenCredentialOptions, sources ...azcore.TokenCredential) (*ChainedTokenCredential, error) {
 	if len(sources) == 0 {
 		credErr := &CredentialUnavailableError{credentialType: "Chained Token Credential", message: "Length of sources cannot be 0"}
 		logCredentialError(credErr.credentialType, credErr)

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -24,7 +24,7 @@ type ChainedTokenCredential struct {
 }
 
 // NewChainedTokenCredential creates an instance of ChainedTokenCredential with the specified TokenCredential sources.
-func NewChainedTokenCredential(options *ChainedTokenCredentialOptions, sources ...azcore.TokenCredential) (*ChainedTokenCredential, error) {
+func NewChainedTokenCredential(sources []azcore.TokenCredential, options *ChainedTokenCredentialOptions) (*ChainedTokenCredential, error) {
 	if len(sources) == 0 {
 		credErr := &CredentialUnavailableError{credentialType: "Chained Token Credential", message: "Length of sources cannot be 0"}
 		logCredentialError(credErr.credentialType, credErr)
@@ -37,7 +37,9 @@ func NewChainedTokenCredential(options *ChainedTokenCredentialOptions, sources .
 			return nil, credErr
 		}
 	}
-	return &ChainedTokenCredential{sources: sources}, nil
+	cp := make([]azcore.TokenCredential, len(sources))
+	copy(cp, sources)
+	return &ChainedTokenCredential{sources: cp}, nil
 }
 
 // GetToken sequentially calls TokenCredential.GetToken on all the specified sources, returning the token from the first successful call to GetToken().

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
@@ -27,7 +28,7 @@ func TestChainedTokenCredential_InstantiateSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not find appropriate environment credentials")
 	}
-	cred, err := NewChainedTokenCredential(nil, secCred, envCred)
+	cred, err := NewChainedTokenCredential([]azcore.TokenCredential{secCred, envCred}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -43,7 +44,7 @@ func TestChainedTokenCredential_InstantiateFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	_, err = NewChainedTokenCredential(nil, secCred, nil)
+	_, err = NewChainedTokenCredential([]azcore.TokenCredential{secCred, nil}, nil)
 	if err == nil {
 		t.Fatalf("Expected an error for sending a nil credential in the chain")
 	}
@@ -51,7 +52,7 @@ func TestChainedTokenCredential_InstantiateFailure(t *testing.T) {
 	if !errors.As(err, &credErr) {
 		t.Fatalf("Expected a CredentialUnavailableError, but received: %T", credErr)
 	}
-	_, err = NewChainedTokenCredential(nil)
+	_, err = NewChainedTokenCredential([]azcore.TokenCredential{}, nil)
 	if err == nil {
 		t.Fatalf("Expected an error for not sending any credential sources")
 	}
@@ -79,7 +80,7 @@ func TestChainedTokenCredential_GetTokenSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create environment credential: %v", err)
 	}
-	cred, err := NewChainedTokenCredential(nil, secCred, envCred)
+	cred, err := NewChainedTokenCredential([]azcore.TokenCredential{secCred, envCred}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -106,7 +107,7 @@ func TestChainedTokenCredential_GetTokenFail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	cred, err := NewChainedTokenCredential(nil, secCred)
+	cred, err := NewChainedTokenCredential([]azcore.TokenCredential{secCred}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -140,7 +141,7 @@ func TestChainedTokenCredential_GetTokenWithUnavailableCredentialInChain(t *test
 	// CredentialUnavailable error from the constructor. In order to test the CredentialUnavailable functionality for
 	// ChainedTokenCredential we have to mock with two valid credentials, but the first will fail since the first response queued
 	// in the test server is a CredentialUnavailable error.
-	cred, err := NewChainedTokenCredential(nil, secCred, secCred)
+	cred, err := NewChainedTokenCredential([]azcore.TokenCredential{secCred, secCred}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -172,7 +173,7 @@ func TestBearerPolicy_ChainedTokenCredential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	chainedCred, err := NewChainedTokenCredential(nil, cred)
+	chainedCred, err := NewChainedTokenCredential([]azcore.TokenCredential{cred}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -27,7 +27,7 @@ func TestChainedTokenCredential_InstantiateSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not find appropriate environment credentials")
 	}
-	cred, err := NewChainedTokenCredential(secCred, envCred)
+	cred, err := NewChainedTokenCredential(nil, secCred, envCred)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestChainedTokenCredential_InstantiateFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	_, err = NewChainedTokenCredential(secCred, nil)
+	_, err = NewChainedTokenCredential(nil, secCred, nil)
 	if err == nil {
 		t.Fatalf("Expected an error for sending a nil credential in the chain")
 	}
@@ -51,7 +51,7 @@ func TestChainedTokenCredential_InstantiateFailure(t *testing.T) {
 	if !errors.As(err, &credErr) {
 		t.Fatalf("Expected a CredentialUnavailableError, but received: %T", credErr)
 	}
-	_, err = NewChainedTokenCredential()
+	_, err = NewChainedTokenCredential(nil)
 	if err == nil {
 		t.Fatalf("Expected an error for not sending any credential sources")
 	}
@@ -79,7 +79,7 @@ func TestChainedTokenCredential_GetTokenSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create environment credential: %v", err)
 	}
-	cred, err := NewChainedTokenCredential(secCred, envCred)
+	cred, err := NewChainedTokenCredential(nil, secCred, envCred)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestChainedTokenCredential_GetTokenFail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	cred, err := NewChainedTokenCredential(secCred)
+	cred, err := NewChainedTokenCredential(nil, secCred)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestChainedTokenCredential_GetTokenWithUnavailableCredentialInChain(t *test
 	// CredentialUnavailable error from the constructor. In order to test the CredentialUnavailable functionality for
 	// ChainedTokenCredential we have to mock with two valid credentials, but the first will fail since the first response queued
 	// in the test server is a CredentialUnavailable error.
-	cred, err := NewChainedTokenCredential(secCred, secCred)
+	cred, err := NewChainedTokenCredential(nil, secCred, secCred)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestBearerPolicy_ChainedTokenCredential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)
 	}
-	chainedCred, err := NewChainedTokenCredential(cred)
+	chainedCred, err := NewChainedTokenCredential(nil, cred)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -74,5 +74,5 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Chained
 		return nil, err
 	}
 	log.Write(LogCredential, "Azure Identity => NewDefaultAzureCredential() invoking NewChainedTokenCredential()")
-	return NewChainedTokenCredential(creds...)
+	return NewChainedTokenCredential(nil, creds...)
 }

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -74,5 +74,5 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Chained
 		return nil, err
 	}
 	log.Write(LogCredential, "Azure Identity => NewDefaultAzureCredential() invoking NewChainedTokenCredential()")
-	return NewChainedTokenCredential(nil, creds...)
+	return NewChainedTokenCredential(creds, nil)
 }


### PR DESCRIPTION
Per our last API review, this adds a placeholder options struct for ChainedTokenCredential. I opened this as a draft to get opinions on replacing NewChainedTokenCredential's variadic `sources` parameter with a slice. I think this is a better type because the variadic parameter doesn't do anything useful here; it just makes possible calling `NewChainedTokenCredential(nil)` to get a runtime error.