### PR TITLE
Remove credential exclusion switches from DefaultAzureCredentialOptions

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -13,6 +13,11 @@
   // after
   cred, err := NewChainedTokenCredential([]azcore.TokenCredential{credA, credB}, nil)
   ```
+* Removed `ExcludeAzureCLICredential`, `ExcludeEnvironmentCredential`, and `ExcludeMSICredential`
+  from `DefaultAzureCredentialOptions`
+
+### Features Added
+* Added connection configuration options to `DefaultAzureCredentialOptions`
 
 
 ## 0.11.0 (2021-09-08)

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -14,17 +14,7 @@ const (
 )
 
 // DefaultAzureCredentialOptions contains options for configuring how credentials are acquired.
-type DefaultAzureCredentialOptions struct {
-	// set this field to true in order to exclude the AzureCLICredential from the set of
-	// credentials that will be used to authenticate with
-	ExcludeAzureCLICredential bool
-	// set this field to true in order to exclude the EnvironmentCredential from the set of
-	// credentials that will be used to authenticate with
-	ExcludeEnvironmentCredential bool
-	// set this field to true in order to exclude the ManagedIdentityCredential from the set of
-	// credentials that will be used to authenticate with
-	ExcludeMSICredential bool
-}
+type DefaultAzureCredentialOptions struct{}
 
 // NewDefaultAzureCredential provides a default ChainedTokenCredential configuration for applications that will be deployed to Azure.  The following credential
 // types will be tried, in the following order:
@@ -40,31 +30,25 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Chained
 		options = &DefaultAzureCredentialOptions{}
 	}
 
-	if !options.ExcludeEnvironmentCredential {
-		envCred, err := NewEnvironmentCredential(nil)
-		if err == nil {
-			creds = append(creds, envCred)
-		} else {
-			errMsg += err.Error()
-		}
+	envCred, err := NewEnvironmentCredential(nil)
+	if err == nil {
+		creds = append(creds, envCred)
+	} else {
+		errMsg += err.Error()
 	}
 
-	if !options.ExcludeMSICredential {
-		msiCred, err := NewManagedIdentityCredential("", nil)
-		if err == nil {
-			creds = append(creds, msiCred)
-		} else {
-			errMsg += err.Error()
-		}
+	msiCred, err := NewManagedIdentityCredential("", nil)
+	if err == nil {
+		creds = append(creds, msiCred)
+	} else {
+		errMsg += err.Error()
 	}
 
-	if !options.ExcludeAzureCLICredential {
-		cliCred, err := NewAzureCLICredential(nil)
-		if err == nil {
-			creds = append(creds, cliCred)
-		} else {
-			errMsg += err.Error()
-		}
+	cliCred, err := NewAzureCLICredential(nil)
+	if err == nil {
+		creds = append(creds, cliCred)
+	} else {
+		errMsg += err.Error()
 	}
 
 	// if no credentials are added to the slice of TokenCredentials then return a CredentialUnavailableError

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -5,7 +5,6 @@ package azidentity
 
 import (
 	"errors"
-	"os"
 	"testing"
 )
 
@@ -13,69 +12,6 @@ const (
 	lengthOfChainOneExcluded = 2
 	lengthOfChainFull        = 3
 )
-
-func TestDefaultAzureCredential_ExcludeEnvCredential(t *testing.T) {
-	resetEnvironmentVarsForTest()
-	_ = os.Setenv("MSI_ENDPOINT", "http://localhost:3000")
-	cred, err := NewDefaultAzureCredential(&DefaultAzureCredentialOptions{ExcludeEnvironmentCredential: true})
-	if err != nil {
-		t.Fatalf("Did not expect to receive an error in creating the credential")
-	}
-
-	if len(cred.sources) != lengthOfChainOneExcluded {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainOneExcluded, len(cred.sources))
-	}
-	_ = os.Setenv("MSI_ENDPOINT", "")
-}
-
-func TestDefaultAzureCredential_ExcludeMSICredential(t *testing.T) {
-	err := initEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
-	}
-	cred, err := NewDefaultAzureCredential(&DefaultAzureCredentialOptions{ExcludeMSICredential: true})
-	if err != nil {
-		t.Fatalf("Did not expect to receive an error in creating the credential")
-	}
-	if len(cred.sources) != lengthOfChainOneExcluded {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainOneExcluded, len(cred.sources))
-	}
-}
-
-func TestDefaultAzureCredential_ExcludeAzureCLICredential(t *testing.T) {
-	err := initEnvironmentVarsForTest()
-	if err != nil {
-		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
-	}
-	_ = os.Setenv("MSI_ENDPOINT", "http://localhost:3000")
-	cred, err := NewDefaultAzureCredential(&DefaultAzureCredentialOptions{ExcludeAzureCLICredential: true})
-	if err != nil {
-		t.Fatalf("Did not expect to receive an error in creating the credential")
-	}
-
-	if len(cred.sources) != lengthOfChainOneExcluded {
-		t.Fatalf("Length of ChainedTokenCredential sources for DefaultAzureCredential. Expected: %d, Received: %d", lengthOfChainOneExcluded, len(cred.sources))
-	}
-	clearEnvVars("MSI_ENDPOINT")
-	resetEnvironmentVarsForTest()
-}
-
-func TestDefaultAzureCredential_ExcludeAllCredentials(t *testing.T) {
-	resetEnvironmentVarsForTest()
-	var credUnavailable *CredentialUnavailableError
-	_, err := NewDefaultAzureCredential(&DefaultAzureCredentialOptions{
-		ExcludeEnvironmentCredential: true,
-		ExcludeMSICredential:         true,
-		ExcludeAzureCLICredential:    true,
-	})
-	if err == nil {
-		t.Fatalf("Expected an error but received nil")
-	}
-	if !errors.As(err, &credUnavailable) {
-		t.Fatalf("Expected: CredentialUnavailableError, Received: %T", err)
-	}
-
-}
 
 func TestDefaultAzureCredential_NilOptions(t *testing.T) {
 	resetEnvironmentVarsForTest()


### PR DESCRIPTION
Per our last API review, this removes credential exclusion switches from, and adds common connection options to, `DefaultAzureCredentialOptions`. These exclusion switches shipped only in .NET and Python, where they've been useful for working around problems with `SharedTokenCacheCredential`, but not so useful that we added them to Java* SDKs. We don't plan to add `SharedTokenCacheCredential` to Go, and since 1.0 have come to prefer keeping `DefaultAzureCredential` simple, presenting it as a set of reasonable defaults for getting started and encouraging users to choose other credential types when it isn't a good fit, so it's best not to have these switches in the first stable `azidentity`.