### PR TITLE
[service-bus] Adding in PeekMessages, DeferMessage+ReceiveDeferredMessages support

### DIFF
--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -5,8 +5,8 @@ package azservicebus
 
 import (
 	"context"
-	"errors"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -31,7 +31,7 @@ type clientConfig struct {
 	credential       azcore.TokenCredential
 	// the Service Bus namespace name (ex: myservicebus.servicebus.windows.net)
 	fullyQualifiedNamespace string
-	tlsConfig        *tls.Config
+	tlsConfig               *tls.Config
 }
 
 // ClientOption is the type for an option that can configure Client.
@@ -101,9 +101,10 @@ func newClientImpl(config clientConfig, options ...ClientOption) (*Client, error
 			client.config.credential)
 
 		nsOptions = append(nsOptions, option)
-	
-	if client.config.tlsConfig != nil {
-		nsOptions = append(nsOptions, internal.NamespaceWithTLSConfig(client.config.tlsConfig))
+
+		if client.config.tlsConfig != nil {
+			nsOptions = append(nsOptions, internal.NamespaceWithTLSConfig(client.config.tlsConfig))
+		}
 	}
 
 	client.namespace, err = internal.NewNamespace(nsOptions...)

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -6,6 +6,7 @@ package azservicebus
 import (
 	"context"
 	"errors"
+	"crypto/tls"
 	"fmt"
 	"sync"
 
@@ -30,6 +31,7 @@ type clientConfig struct {
 	credential       azcore.TokenCredential
 	// the Service Bus namespace name (ex: myservicebus.servicebus.windows.net)
 	fullyQualifiedNamespace string
+	tlsConfig        *tls.Config
 }
 
 // ClientOption is the type for an option that can configure Client.
@@ -68,6 +70,14 @@ func NewClientWithConnectionString(connectionString string, options ...ClientOpt
 	}, options...)
 }
 
+// WithTLSConfig configures a client with a custom *tls.Config.
+func WithTLSConfig(tlsConfig *tls.Config) ClientOption {
+	return func(client *Client) error {
+		client.config.tlsConfig = tlsConfig
+		return nil
+	}
+}
+
 func newClientImpl(config clientConfig, options ...ClientOption) (*Client, error) {
 	client := &Client{
 		linksMu: &sync.Mutex{},
@@ -91,6 +101,9 @@ func newClientImpl(config clientConfig, options ...ClientOption) (*Client, error
 			client.config.credential)
 
 		nsOptions = append(nsOptions, option)
+	
+	if client.config.tlsConfig != nil {
+		nsOptions = append(nsOptions, internal.NamespaceWithTLSConfig(client.config.tlsConfig))
 	}
 
 	client.namespace, err = internal.NewNamespace(nsOptions...)

--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -22,3 +22,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	nhooyr.io/websocket v1.8.6
 )
+
+// remove after go-amqp releases https://github.com/Azure/go-amqp/pull/72
+replace github.com/Azure/go-amqp v0.15.0 => github.com/Azure/go-amqp v0.15.1-0.20210923181113-8f9a02b39d60

--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -7,13 +7,12 @@ require (
 	github.com/Azure/azure-sdk-for-go v51.1.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1
 	github.com/Azure/go-amqp v0.15.0
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/adal v0.9.13
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/devigned/tab v0.1.1
-	github.com/google/uuid v1.3.0
 	github.com/joho/godotenv v1.3.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/microsoft/ApplicationInsights-Go v0.4.4

--- a/sdk/messaging/azservicebus/go.sum
+++ b/sdk/messaging/azservicebus/go.sum
@@ -11,8 +11,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJc
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0 h1:v9p9TfTbf7AwNb5NYQt7hI41IfPoLFiFkLtb+bmGjT0=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/go-amqp v0.13.13/go.mod h1:D5ZrjQqB1dyp1A+G73xeL/kNn7D5qHJIIsNNps7YNmk=
-github.com/Azure/go-amqp v0.15.0 h1:YcB++F5msgyl8htdsjjlhK132YFca31FBPB7lObE/p0=
-github.com/Azure/go-amqp v0.15.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
+github.com/Azure/go-amqp v0.15.1-0.20210923181113-8f9a02b39d60 h1:W/dYCEowHl7kz6bxw72LIzRGi/lWk+z8WQEXAU5hxJ0=
+github.com/Azure/go-amqp v0.15.1-0.20210923181113-8f9a02b39d60/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.18 h1:90Y4srNYrwOtAgVo3ndrQkTYn6kf1Eg/AjTFJ8Is2aM=

--- a/sdk/messaging/azservicebus/go.sum
+++ b/sdk/messaging/azservicebus/go.sum
@@ -8,8 +8,9 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0 h1:lhSJz9RMbJcTgxifR1hUNJnn
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0 h1:OYa9vmRX2XC5GXRAzeggG12sF/z5D9Ahtdm9EJ00WN4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0 h1:v9p9TfTbf7AwNb5NYQt7hI41IfPoLFiFkLtb+bmGjT0=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1 h1:8XSiy/LSvjtFwpguk7m6yGLgGkWocluo8hLM5vtcpcg=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/Azure/go-amqp v0.13.13/go.mod h1:D5ZrjQqB1dyp1A+G73xeL/kNn7D5qHJIIsNNps7YNmk=
 github.com/Azure/go-amqp v0.15.1-0.20210923181113-8f9a02b39d60 h1:W/dYCEowHl7kz6bxw72LIzRGi/lWk+z8WQEXAU5hxJ0=
 github.com/Azure/go-amqp v0.15.1-0.20210923181113-8f9a02b39d60/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
@@ -36,6 +37,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/devigned/tab v0.1.1 h1:3mD6Kb1mUOYeLpJvTVSDwSg5ZsfSxfvxGRTxRsJsITA=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
+github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -69,8 +71,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -118,11 +118,13 @@ github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVM
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b h1:k+E048sYJHyVnsr1GDrRZWQ32D2C7lWs9JRc0bel53A=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -130,6 +132,7 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 h1:xrCZDmdtoloIiooiA9q0OQb9r8HejIHYoHGhGCe1pGg=
@@ -137,6 +140,7 @@ golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -222,7 +222,9 @@ func (l *amqpLinks) closeWithoutLocking(ctx context.Context, permanent bool) err
 	}
 
 	defer func() {
-		l.closedPermanently = true
+		if permanent {
+			l.closedPermanently = true
+		}
 	}()
 
 	var messages []string

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -112,10 +112,20 @@ func TestAMQPLinks(t *testing.T) {
 	require.EqualValues(t, 1, *createLinkCallCount, "No create call needed since an instance was cached")
 
 	// closing multiple times is fine.
+	asAMQPLinks, ok := links.(*amqpLinks)
+	require.True(t, ok)
+
 	require.NoError(t, links.Close(context.Background(), false))
+	require.False(t, asAMQPLinks.closedPermanently)
+
 	require.NoError(t, links.Close(context.Background(), true))
+	require.True(t, asAMQPLinks.closedPermanently)
+
 	require.NoError(t, links.Close(context.Background(), true))
+	require.True(t, asAMQPLinks.closedPermanently)
+
 	require.NoError(t, links.Close(context.Background(), false))
+	require.True(t, asAMQPLinks.closedPermanently)
 
 	// and the individual links are closed as well
 	require.EqualValues(t, 1, fakeSender.closed)
@@ -129,7 +139,7 @@ func TestAMQPLinks(t *testing.T) {
 	require.Nil(t, mgmt)
 	require.EqualValues(t, 0, linkRevision)
 
-	_, ok := err.(NonRetriable)
+	_, ok = err.(NonRetriable)
 	require.True(t, ok)
 }
 

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -5,76 +5,10 @@ package internal
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-type fakeNS struct {
-	claimNegotiated int
-	MgmtClient      MgmtClient
-	Session         AMQPSessionCloser
-}
-
-type fakeAMQPSender struct {
-	closed int
-	AMQPSender
-}
-
-type fakeAMQPSession struct {
-	AMQPSessionCloser
-	closed int
-}
-
-type fakeMgmtClient struct {
-	MgmtClient
-	closed int
-}
-
-func (s *fakeAMQPSender) Close(ctx context.Context) error {
-	s.closed++
-	return nil
-}
-
-func (s *fakeAMQPSession) Close(ctx context.Context) error {
-	s.closed++
-	return nil
-}
-
-func (m *fakeMgmtClient) Close(ctx context.Context) error {
-	m.closed++
-	return nil
-}
-
-func (ns *fakeNS) NegotiateClaim(ctx context.Context, entityPath string) (func() <-chan struct{}, error) {
-	ch := make(chan struct{})
-	close(ch)
-
-	ns.claimNegotiated++
-
-	return func() <-chan struct{} {
-		return ch
-	}, nil
-}
-
-func (ns *fakeNS) GetEntityAudience(entityPath string) string {
-	return fmt.Sprintf("audience: %s", entityPath)
-}
-
-func (ns *fakeNS) NewAMQPSession(ctx context.Context) (AMQPSessionCloser, error) {
-	return ns.Session, nil
-}
-
-func (ns *fakeNS) NewMgmtClient(ctx context.Context, managementPath string) (MgmtClient, error) {
-	return ns.MgmtClient, nil
-}
-
-type createLinkResponse struct {
-	sender   AMQPSenderCloser
-	receiver AMQPReceiverCloser
-	err      error
-}
 
 func TestAMQPLinks(t *testing.T) {
 	fakeSender := &fakeAMQPSender{}

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+)
+
+type fakeNS struct {
+	claimNegotiated int
+	MgmtClient      MgmtClient
+	Session         AMQPSessionCloser
+}
+
+type fakeAMQPSender struct {
+	closed int
+	AMQPSender
+}
+
+type fakeAMQPSession struct {
+	AMQPSessionCloser
+	closed int
+}
+
+type fakeMgmtClient struct {
+	MgmtClient
+	closed int
+}
+
+type FakeAMQPLinks struct {
+	AMQPLinks
+
+	// values to be returned for each `Get` call
+	Revision uint64
+	Receiver AMQPReceiver
+	Sender   AMQPSender
+	Mgmt     MgmtClient
+	Err      error
+}
+
+func (l FakeAMQPLinks) Get(ctx context.Context) (AMQPSender, AMQPReceiver, MgmtClient, uint64, error) {
+	return l.Sender, l.Receiver, l.Mgmt, l.Revision, l.Err
+}
+
+func (s *fakeAMQPSender) Close(ctx context.Context) error {
+	s.closed++
+	return nil
+}
+
+func (s *fakeAMQPSession) Close(ctx context.Context) error {
+	s.closed++
+	return nil
+}
+
+func (m *fakeMgmtClient) Close(ctx context.Context) error {
+	m.closed++
+	return nil
+}
+
+func (ns *fakeNS) NegotiateClaim(ctx context.Context, entityPath string) (func() <-chan struct{}, error) {
+	ch := make(chan struct{})
+	close(ch)
+
+	ns.claimNegotiated++
+
+	return func() <-chan struct{} {
+		return ch
+	}, nil
+}
+
+func (ns *fakeNS) GetEntityAudience(entityPath string) string {
+	return fmt.Sprintf("audience: %s", entityPath)
+}
+
+func (ns *fakeNS) NewAMQPSession(ctx context.Context) (AMQPSessionCloser, error) {
+	return ns.Session, nil
+}
+
+func (ns *fakeNS) NewMgmtClient(ctx context.Context, managementPath string) (MgmtClient, error) {
+	return ns.MgmtClient, nil
+}
+
+type createLinkResponse struct {
+	sender   AMQPSenderCloser
+	receiver AMQPReceiverCloser
+	err      error
+}

--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -38,6 +38,9 @@ type (
 		// the 'revision' of the link we received on (ie, if it was recovered it won't match)
 		linkRevision uint64
 
+		// deferred indicates we received it using ReceiveDeferredMessages. These messages
+		// will still go through the normal Receiver.Settle functions but internally will
+		// always be settled with the management link.
 		deferred bool
 	}
 

--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -37,6 +37,8 @@ type (
 
 		// the 'revision' of the link we received on (ie, if it was recovered it won't match)
 		linkRevision uint64
+
+		deferred bool
 	}
 
 	// Message is a SendableMessage which can be sent using a Client.NewSender().

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -84,7 +84,7 @@ func (s *messageSettler) DeferMessage(ctx context.Context, message *ReceivedMess
 		d := internal.Disposition{
 			Status: internal.DeferredDisposition,
 		}
-		return mgmt.SendDisposition(ctx, message.LockToken, d)
+		return mgmt.SendDisposition(ctx, bytesToAMQPUUID(message.LockToken), d)
 	}
 
 	return message.RawAMQPMessage.Modify(ctx, false, true, nil)

--- a/sdk/messaging/azservicebus/messageSettler_test.go
+++ b/sdk/messaging/azservicebus/messageSettler_test.go
@@ -157,8 +157,8 @@ func TestMessageSettlementUsingOnlyBackupSettlement(t *testing.T) {
 	testStuff := newTestStuff(t)
 	defer testStuff.Close()
 
-	testStuff.Receiver.onlyDoBackupSettlement = true
-	testStuff.DeadLetterReceiver.onlyDoBackupSettlement = true
+	testStuff.Receiver.settler.onlyDoBackupSettlement = true
+	testStuff.DeadLetterReceiver.settler.onlyDoBackupSettlement = true
 
 	receiver, deadLetterReceiver := testStuff.Receiver, testStuff.DeadLetterReceiver
 	ctx := context.TODO()

--- a/sdk/messaging/azservicebus/message_test.go
+++ b/sdk/messaging/azservicebus/message_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/go-amqp"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -146,7 +145,7 @@ func TestAMQPMessageToMessage(t *testing.T) {
 
 	expectedAMQPEncodedLockTokenGUID := [16]byte{187, 49, 89, 205, 253, 254, 205, 77, 162, 38, 172, 76, 45, 235, 91, 225}
 
-	require.EqualValues(t, msg.LockToken, uuid.UUID(expectedAMQPEncodedLockTokenGUID), "locktoken")
+	require.EqualValues(t, msg.LockToken, expectedAMQPEncodedLockTokenGUID, "locktoken")
 
 	require.EqualValues(t, map[string]interface{}{
 		"test": "foo",

--- a/sdk/messaging/azservicebus/processor.go
+++ b/sdk/messaging/azservicebus/processor.go
@@ -60,14 +60,11 @@ type ProcessorOption func(processor *Processor) error
 // ProcessorWithSubQueue allows you to open the sub queue (ie: dead letter queues, transfer dead letter queues)
 // for a queue or subscription.
 func ProcessorWithSubQueue(subQueue SubQueue) ProcessorOption {
-	return func(receiver *Processor) error {
-		switch subQueue {
-		case SubQueueDeadLetter:
-		case SubQueueTransfer:
-		case "":
-			receiver.config.Entity.Subqueue = subQueue
-		default:
-			return fmt.Errorf("unknown SubQueue %s", subQueue)
+	return func(p *Processor) error {
+		if subQueue == SubQueueDeadLetter || subQueue == SubQueueTransfer {
+			p.config.Entity.Subqueue = subQueue
+		} else {
+			return fmt.Errorf("unknown SubQueue %d", subQueue)
 		}
 
 		return nil

--- a/sdk/messaging/azservicebus/processor.go
+++ b/sdk/messaging/azservicebus/processor.go
@@ -61,13 +61,7 @@ type ProcessorOption func(processor *Processor) error
 // for a queue or subscription.
 func ProcessorWithSubQueue(subQueue SubQueue) ProcessorOption {
 	return func(p *Processor) error {
-		if subQueue == SubQueueDeadLetter || subQueue == SubQueueTransfer {
-			p.config.Entity.Subqueue = subQueue
-		} else {
-			return fmt.Errorf("unknown SubQueue %d", subQueue)
-		}
-
-		return nil
+		return p.config.Entity.SetSubQueue(subQueue)
 	}
 }
 

--- a/sdk/messaging/azservicebus/processor_test.go
+++ b/sdk/messaging/azservicebus/processor_test.go
@@ -145,11 +145,11 @@ func TestProcessorReceiveWith100MessagesWithMaxConcurrency(t *testing.T) {
 func TestProcessorUnitTests(t *testing.T) {
 	p := &Processor{}
 	require.NoError(t, ProcessorWithSubQueue(SubQueueDeadLetter)(p))
-	require.EqualValues(t, SubQueueDeadLetter, p.config.Entity.Subqueue)
+	require.EqualValues(t, SubQueueDeadLetter, p.config.Entity.subqueue)
 
 	p = &Processor{}
 	require.NoError(t, ProcessorWithSubQueue(SubQueueTransfer)(p))
-	require.EqualValues(t, SubQueueTransfer, p.config.Entity.Subqueue)
+	require.EqualValues(t, SubQueueTransfer, p.config.Entity.subqueue)
 
 	p = &Processor{}
 	require.NoError(t, ProcessorWithQueue("queue1")(p))

--- a/sdk/messaging/azservicebus/processor_test.go
+++ b/sdk/messaging/azservicebus/processor_test.go
@@ -142,6 +142,34 @@ func TestProcessorReceiveWith100MessagesWithMaxConcurrency(t *testing.T) {
 	require.NoError(t, processor.Close(ctx))
 }
 
+func TestProcessorUnitTests(t *testing.T) {
+	p := &Processor{}
+	require.NoError(t, ProcessorWithSubQueue(SubQueueDeadLetter)(p))
+	require.EqualValues(t, SubQueueDeadLetter, p.config.Entity.Subqueue)
+
+	p = &Processor{}
+	require.NoError(t, ProcessorWithSubQueue(SubQueueTransfer)(p))
+	require.EqualValues(t, SubQueueTransfer, p.config.Entity.Subqueue)
+
+	p = &Processor{}
+	require.NoError(t, ProcessorWithQueue("queue1")(p))
+	require.EqualValues(t, "queue1", p.config.Entity.Queue)
+
+	p = &Processor{}
+	require.NoError(t, ProcessorWithSubscription("topic1", "subscription1")(p))
+	require.EqualValues(t, "topic1", p.config.Entity.Topic)
+	require.EqualValues(t, "subscription1", p.config.Entity.Subscription)
+
+	p = &Processor{}
+	require.NoError(t, ProcessorWithReceiveMode(PeekLock)(p))
+	require.EqualValues(t, PeekLock, p.config.ReceiveMode)
+
+	p = &Processor{}
+	require.NoError(t, ProcessorWithReceiveMode(ReceiveAndDelete)(p))
+	require.EqualValues(t, ReceiveAndDelete, p.config.ReceiveMode)
+
+}
+
 // func TestProcessorUnitTests(t *testing.T) {
 // 	t.Run("Processor", func(t *testing.T) {
 // 		t.Run("StartAndClose", func(t *testing.T) {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -338,6 +338,10 @@ func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options
 func (r *Receiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers []int64) ([]*ReceivedMessage, error) {
 	_, _, mgmt, _, err := r.amqpLinks.Get(ctx)
 
+	if err != nil {
+		return nil, err
+	}
+
 	amqpMessages, err := mgmt.ReceiveDeferred(ctx, r.config.ReceiveMode, sequenceNumbers)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -283,11 +283,11 @@ func TestReceiverPeek(t *testing.T) {
 func TestReceiverOptions(t *testing.T) {
 	receiver := &Receiver{}
 	require.NoError(t, ReceiverWithSubQueue(SubQueueDeadLetter)(receiver))
-	require.EqualValues(t, SubQueueDeadLetter, receiver.config.Entity.Subqueue)
+	require.EqualValues(t, SubQueueDeadLetter, receiver.config.Entity.subqueue)
 
 	receiver = &Receiver{}
 	require.NoError(t, ReceiverWithSubQueue(SubQueueTransfer)(receiver))
-	require.EqualValues(t, SubQueueTransfer, receiver.config.Entity.Subqueue)
+	require.EqualValues(t, SubQueueTransfer, receiver.config.Entity.subqueue)
 
 	receiver = &Receiver{}
 	require.NoError(t, ReceiverWithQueue("queue1")(receiver))

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -205,6 +205,7 @@ func TestReceiverDeferAndReceiveDeferredMessages(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, []string{"deferring a message"}, getSortedBodies(deferredMessages))
+	require.True(t, deferredMessages[0].deferred, "internal flag indicating it was from a deferred receiver method is set")
 
 	for _, m := range deferredMessages {
 		err = receiver.CompleteMessage(ctx, m)


### PR DESCRIPTION
Adding in some of the critical receiver methods for deferring and retrieving deferred messages. Also, added in the track 2 compliant PeekMessages function.

There were also some bugs in how we were handling ReceiveMessages, which were found in some tests that I added.

This PR is built on top of a pending PR (https://github.com/Azure/azure-sdk-for-go/pull/15611) so you'll want to start reviewing this code from commit 0f3d40327b9339c2b6ff05d3eb1767faa848761e (my linkageddon commit) to see the relevant bits.

I've added in a temporary `replace` in the go.mod file so I can pick up this fix in go-amqp that hasn't yet released: https://github.com/Azure/go-amqp/pull/72). 