### PR TITLE
Remove ClientSecret and Port from browser credential options

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -25,6 +25,7 @@
   certData, err := os.ReadFile("/cert.pem")
   cred, err := NewClientCertificateCredential("tenant", "client-id", certData, nil)
   ```
+* Removed `InteractiveBrowserCredentialOptions.ClientSecret` and `.Port`
 
 ### Features Added
 * Added connection configuration options to `DefaultAzureCredentialOptions`

--- a/sdk/azidentity/aad_identity_client.go
+++ b/sdk/azidentity/aad_identity_client.go
@@ -384,7 +384,7 @@ func (c *aadIdentityClient) authenticateInteractiveBrowser(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	return c.authenticateAuthCode(ctx, opts.TenantID, opts.ClientID, cfg.authCode, opts.ClientSecret, cfg.codeVerifier, cfg.redirectURI, scopes)
+	return c.authenticateAuthCode(ctx, opts.TenantID, opts.ClientID, cfg.authCode, "", cfg.codeVerifier, cfg.redirectURI, scopes)
 }
 
 // authenticateAuthCode requests an Access Token with the authorization code and returns the token or an error in case of authentication failure.

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -19,24 +19,18 @@ import (
 	"github.com/pkg/browser"
 )
 
-// InteractiveBrowserCredentialOptions can be used when providing additional credential information, such as a client secret.
+// InteractiveBrowserCredentialOptions provides optional configuration.
 // Use these options to modify the default pipeline behavior if necessary.
 // All zero-value fields will be initialized with their default values. Please note, that both the TenantID or ClientID fields should
 // changed together if default values are not desired.
 type InteractiveBrowserCredentialOptions struct {
-	// The Azure Active Directory tenant (directory) ID of the service principal.
-	// The default value is "organizations". If this value is changed, then also change ClientID to the corresponding value.
+	// The Azure Active Directory tenant (directory) ID of the application. Defaults to "organizations".
 	TenantID string
-	// The client (application) ID of the service principal.
-	// The default value is the developer sign on ID for the corresponding "organizations" TenantID.
+	// The ID of the application the user will sign in to. When not set, users will sign in to an Azure development application.
 	ClientID string
-	// The client secret that was generated for the App Registration used to authenticate the client. Only applies for web apps.
-	ClientSecret string
-	// The redirect URL used to request the authorization code. Must be the same URL that is configured for the App Registration.
+	// RedirectURL will be supported in a future version but presently doesn't work: https://github.com/Azure/azure-sdk-for-go/issues/15632.
+	// Applications which have "http://localhost" registered as a redirect URL need not set this option.
 	RedirectURL string
-	// The localhost port for the local server that will be used to redirect back.
-	// By default, a random port number will be selected.
-	Port int
 	// The host of the Azure Active Directory authority. The default is AzurePublicCloud.
 	// Leave empty to allow overriding the value from the AZURE_AUTHORITY_HOST environment variable.
 	AuthorityHost AuthorityHost
@@ -125,10 +119,7 @@ func interactiveBrowserLogin(ctx context.Context, authorityHost string, opts *In
 	if err != nil {
 		return nil, err
 	}
-	redirectURL := opts.RedirectURL
-	if redirectURL == "" {
-		redirectURL = rs.Start(state.String(), opts.Port)
-	}
+	redirectURL := rs.Start(state.String())
 	defer rs.Stop()
 	u, err := url.Parse(authorityHost)
 	if err != nil {

--- a/sdk/azidentity/interactive_browser_server.go
+++ b/sdk/azidentity/interactive_browser_server.go
@@ -57,10 +57,8 @@ func newServer() *server {
 
 // Start starts the local HTTP server on a separate go routine.
 // The return value is the full URL plus port number.
-func (s *server) Start(reqState string, port int) string {
-	if port == 0 {
-		port = rand.Intn(600) + 8400
-	}
+func (s *server) Start(reqState string) string {
+	port := rand.Intn(600) + 8400
 	s.s.Addr = fmt.Sprintf(":%d", port)
 	s.s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {


### PR DESCRIPTION
Removes a couple fields from InteractiveBrowserCredentialOptions:
- ClientSecret: not part of this credential's mainline scenario. We don't support it in other languages; neither does MSAL for Go.
- Port: redundant given we have RedirectURL, which is what we really need. Also not supported by MSAL for Go.

Speaking of RedirectURL, while doing this I discovered it doesn't work. I don't want to remove it, because we do need it, but neither do I want to fix it, because adopting MSAL entails deleting the code that needs fixing. So I instead documented that it doesn't work, and opened #15632 to track fixing it.