### PR TITLE
[service-bus] Azure Identity support

### DIFF
--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -27,7 +27,7 @@ type Client struct {
 
 type clientConfig struct {
 	connectionString string
-	tokenCredential  azcore.TokenCredential
+	credential       azcore.TokenCredential
 	// the Service Bus namespace name (ex: myservicebus.servicebus.windows.net)
 	fullyQualifiedNamespace string
 }
@@ -39,10 +39,10 @@ type ClientOption func(client *Client) error
 // NewClient creates a new Client for a Service Bus namespace, using a TokenCredential.
 // A Client allows you create receivers (for queues or subscriptions) and senders (for queues and topics).
 // fullyQualifiedNamespace is the Service Bus namespace name (ex: myservicebus.servicebus.windows.net)
-// tokenCredential is one of the credentials in the `github.com/Azure/azure-sdk-for-go/sdk/azidentity` package.
-func NewClient(fullyQualifiedNamespace string, tokenCredential azcore.TokenCredential, options ...ClientOption) (*Client, error) {
+// credential is one of the credentials in the `github.com/Azure/azure-sdk-for-go/sdk/azidentity` package.
+func NewClient(fullyQualifiedNamespace string, credential azcore.TokenCredential, options ...ClientOption) (*Client, error) {
 	return newClientImpl(clientConfig{
-		tokenCredential:         tokenCredential,
+		credential:              credential,
 		fullyQualifiedNamespace: fullyQualifiedNamespace,
 	}, options...)
 }
@@ -73,10 +73,10 @@ func newClientImpl(config clientConfig, options ...ClientOption) (*Client, error
 
 	if client.config.connectionString != "" {
 		nsOptions = append(nsOptions, internal.NamespaceWithConnectionString(client.config.connectionString))
-	} else if client.config.tokenCredential != nil {
+	} else if client.config.credential != nil {
 		option := internal.NamespacesWithTokenCredential(
 			client.config.fullyQualifiedNamespace,
-			client.config.tokenCredential)
+			client.config.credential)
 
 		nsOptions = append(nsOptions, option)
 	} else {

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -5,9 +5,11 @@ package azservicebus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
 	"github.com/devigned/tab"
 )
@@ -15,9 +17,7 @@ import (
 // Client provides methods to create Sender, Receiver and Processor
 // instances to send and receive messages from Service Bus.
 type Client struct {
-	config struct {
-		connectionString string
-	}
+	config    clientConfig
 	namespace *internal.Namespace
 	linksMu   *sync.Mutex
 	links     []interface {
@@ -25,26 +25,41 @@ type Client struct {
 	}
 }
 
+type clientConfig struct {
+	connectionString string
+	tokenCredential  azcore.TokenCredential
+	// the Service Bus namespace name (ex: myservicebus.servicebus.windows.net)
+	fullyQualifiedNamespace string
+}
+
 // ClientOption is the type for an option that can configure Client.
 // For an example option, see `WithConnectionString`
 type ClientOption func(client *Client) error
 
-// WithConnectionString configures a namespace with the information provided in a Service Bus connection string
-func WithConnectionString(connStr string) ClientOption {
-	return func(client *Client) error {
-		client.config.connectionString = connStr
-		return nil
-	}
+// NewClient creates a new Client for a Service Bus namespace, using a TokenCredential.
+// A Client allows you create receivers (for queues or subscriptions) and senders (for queues and topics).
+// fullyQualifiedNamespace is the Service Bus namespace name (ex: myservicebus.servicebus.windows.net)
+// tokenCredential is one of the credentials in the `github.com/Azure/azure-sdk-for-go/sdk/azidentity` package.
+func NewClient(fullyQualifiedNamespace string, tokenCredential azcore.TokenCredential, options ...ClientOption) (*Client, error) {
+	return newClientImpl(clientConfig{
+		tokenCredential:         tokenCredential,
+		fullyQualifiedNamespace: fullyQualifiedNamespace,
+	}, options...)
 }
 
-// NewClient creates a new Client.
-// Client allows you create receivers (for queues or subscriptions) and
-// senders (for queues and topics).
-// For creating/deleting/updating queues, topics and subscriptions look at
-// `AdministrationClient`.
-func NewClient(options ...ClientOption) (*Client, error) {
+// NewClient creates a new Client for a Service Bus namespace, using a TokenCredential.
+// A Client allows you create receivers (for queues or subscriptions) and senders (for queues and topics).
+// connectionString is a Service Bus connection string for the namespace or for an entity.
+func NewClientWithConnectionString(connectionString string, options ...ClientOption) (*Client, error) {
+	return newClientImpl(clientConfig{
+		connectionString: connectionString,
+	}, options...)
+}
+
+func newClientImpl(config clientConfig, options ...ClientOption) (*Client, error) {
 	client := &Client{
 		linksMu: &sync.Mutex{},
+		config:  config,
 	}
 
 	for _, opt := range options {
@@ -54,7 +69,21 @@ func NewClient(options ...ClientOption) (*Client, error) {
 	}
 
 	var err error
-	client.namespace, err = internal.NewNamespace(internal.NamespaceWithConnectionString(client.config.connectionString))
+	var nsOptions []internal.NamespaceOption
+
+	if client.config.connectionString != "" {
+		nsOptions = append(nsOptions, internal.NamespaceWithConnectionString(client.config.connectionString))
+	} else if client.config.tokenCredential != nil {
+		option := internal.NamespacesWithTokenCredential(
+			client.config.fullyQualifiedNamespace,
+			client.config.tokenCredential)
+
+		nsOptions = append(nsOptions, option)
+	} else {
+		return nil, errors.New("credentials not specified - use `WithTokenCredential` or `WithConnectionString` to pass in credentials")
+	}
+
+	client.namespace, err = internal.NewNamespace(nsOptions...)
 	return client, err
 }
 

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -41,6 +41,14 @@ type ClientOption func(client *Client) error
 // fullyQualifiedNamespace is the Service Bus namespace name (ex: myservicebus.servicebus.windows.net)
 // credential is one of the credentials in the `github.com/Azure/azure-sdk-for-go/sdk/azidentity` package.
 func NewClient(fullyQualifiedNamespace string, credential azcore.TokenCredential, options ...ClientOption) (*Client, error) {
+	if fullyQualifiedNamespace == "" {
+		return nil, errors.New("fullyQualifiedNamespace must not be empty")
+	}
+
+	if credential == nil {
+		return nil, errors.New("credential was nil")
+	}
+
 	return newClientImpl(clientConfig{
 		credential:              credential,
 		fullyQualifiedNamespace: fullyQualifiedNamespace,
@@ -51,6 +59,10 @@ func NewClient(fullyQualifiedNamespace string, credential azcore.TokenCredential
 // A Client allows you create receivers (for queues or subscriptions) and senders (for queues and topics).
 // connectionString is a Service Bus connection string for the namespace or for an entity.
 func NewClientWithConnectionString(connectionString string, options ...ClientOption) (*Client, error) {
+	if connectionString == "" {
+		return nil, errors.New("connectionString must not be empty")
+	}
+
 	return newClientImpl(clientConfig{
 		connectionString: connectionString,
 	}, options...)
@@ -79,8 +91,6 @@ func newClientImpl(config clientConfig, options ...ClientOption) (*Client, error
 			client.config.credential)
 
 		nsOptions = append(nsOptions, option)
-	} else {
-		return nil, errors.New("credentials not specified - use `WithTokenCredential` or `WithConnectionString` to pass in credentials")
 	}
 
 	client.namespace, err = internal.NewNamespace(nsOptions...)

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -68,6 +68,15 @@ func TestNewClientUnitTests(t *testing.T) {
 		require.EqualValues(t, fakeTokenCredential, client.config.credential)
 		require.EqualValues(t, "mysb.windows.servicebus.net", client.config.fullyQualifiedNamespace)
 
+		client, err = NewClientWithConnectionString("")
+		require.EqualError(t, err, "connectionString must not be empty")
+
+		client, err = NewClient("", fakeTokenCredential)
+		require.EqualError(t, err, "fullyQualifiedNamespace must not be empty")
+
+		client, err = NewClient("fake.something", nil)
+		require.EqualError(t, err, "credential was nil")
+
 		// (really all part of the same functionality)
 		ns := &internal.Namespace{}
 		require.NoError(t, internal.NamespacesWithTokenCredential("mysb.windows.servicebus.net",

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azservicebus
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientWithAzureIdentity(t *testing.T) {
+	queue, cleanup := createQueue(t, getConnectionString(t), nil)
+	defer cleanup()
+
+	// test with azure identity support
+	ns := os.Getenv("SERVICEBUS_FQDN")
+	dac, err := azidentity.NewDefaultAzureCredential(nil)
+
+	if err != nil || ns == "" {
+		t.Skip("Azure Identity compatible credentials not configured")
+	}
+
+	client, err := NewClient(ns, dac)
+	require.NoError(t, err)
+
+	sender, err := client.NewSender(queue)
+	require.NoError(t, err)
+
+	err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")})
+	require.NoError(t, err)
+
+	receiver, err := client.NewReceiver(ReceiverWithQueue(queue))
+	require.NoError(t, err)
+	receiver.settler.onlyDoBackupSettlement = true // this'll also exercise the management link
+
+	messages, err := receiver.ReceiveMessages(context.TODO(), 1)
+	require.NoError(t, err)
+
+	require.EqualValues(t, []string{"hello - authenticating with a TokenCredential"}, getSortedBodies(messages))
+
+	for _, m := range messages {
+		err = receiver.CompleteMessage(context.TODO(), m)
+		require.NoError(t, err)
+	}
+
+	client.Close(context.TODO())
+}
+
+func TestNewClientUnitTests(t *testing.T) {
+	t.Run("WithTokenCredential", func(t *testing.T) {
+		fakeTokenCredential := struct{ azcore.TokenCredential }{}
+
+		client, err := NewClient("fake.something", fakeTokenCredential)
+		require.NoError(t, err)
+
+		require.NoError(t, err)
+		require.EqualValues(t, fakeTokenCredential, client.config.tokenCredential)
+		require.EqualValues(t, "fake.something", client.config.fullyQualifiedNamespace)
+
+		client, err = NewClient("mysb.windows.servicebus.net", fakeTokenCredential)
+		require.NoError(t, err)
+		require.EqualValues(t, fakeTokenCredential, client.config.tokenCredential)
+		require.EqualValues(t, "mysb.windows.servicebus.net", client.config.fullyQualifiedNamespace)
+
+		// (really all part of the same functionality)
+		ns := &internal.Namespace{}
+		require.NoError(t, internal.NamespacesWithTokenCredential("mysb.windows.servicebus.net",
+			fakeTokenCredential)(ns))
+
+		require.EqualValues(t, ns.Name, "mysb")
+		require.EqualValues(t, ns.Suffix, "windows.servicebus.net")
+	})
+}

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -60,12 +60,12 @@ func TestNewClientUnitTests(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, err)
-		require.EqualValues(t, fakeTokenCredential, client.config.tokenCredential)
+		require.EqualValues(t, fakeTokenCredential, client.config.credential)
 		require.EqualValues(t, "fake.something", client.config.fullyQualifiedNamespace)
 
 		client, err = NewClient("mysb.windows.servicebus.net", fakeTokenCredential)
 		require.NoError(t, err)
-		require.EqualValues(t, fakeTokenCredential, client.config.tokenCredential)
+		require.EqualValues(t, fakeTokenCredential, client.config.credential)
 		require.EqualValues(t, "mysb.windows.servicebus.net", client.config.fullyQualifiedNamespace)
 
 		// (really all part of the same functionality)

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -68,16 +68,16 @@ func TestNewClientUnitTests(t *testing.T) {
 		require.EqualValues(t, fakeTokenCredential, client.config.credential)
 		require.EqualValues(t, "mysb.windows.servicebus.net", client.config.fullyQualifiedNamespace)
 
-		client, err = NewClientWithConnectionString("")
+		_, err = NewClientWithConnectionString("")
 		require.EqualError(t, err, "connectionString must not be empty")
 
-		client, err = NewClient("", fakeTokenCredential)
+		_, err = NewClient("", fakeTokenCredential)
 		require.EqualError(t, err, "fullyQualifiedNamespace must not be empty")
 
-		client, err = NewClient("mysb", fakeTokenCredential)
+		_, err = NewClient("mysb", fakeTokenCredential)
 		require.EqualError(t, err, "fullyQualifiedNamespace is not properly formed. Should be similar to 'myservicebus.servicebus.windows.net'")
 
-		client, err = NewClient("fake.something", nil)
+		_, err = NewClient("fake.something", nil)
 		require.EqualError(t, err, "credential was nil")
 
 		// (really all part of the same functionality)

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -74,6 +74,9 @@ func TestNewClientUnitTests(t *testing.T) {
 		client, err = NewClient("", fakeTokenCredential)
 		require.EqualError(t, err, "fullyQualifiedNamespace must not be empty")
 
+		client, err = NewClient("mysb", fakeTokenCredential)
+		require.EqualError(t, err, "fullyQualifiedNamespace is not properly formed. Should be similar to 'myservicebus.servicebus.windows.net'")
+
 		client, err = NewClient("fake.something", nil)
 		require.EqualError(t, err, "credential was nil")
 
@@ -84,5 +87,8 @@ func TestNewClientUnitTests(t *testing.T) {
 
 		require.EqualValues(t, ns.Name, "mysb")
 		require.EqualValues(t, ns.Suffix, "windows.servicebus.net")
+
+		err = internal.NamespacesWithTokenCredential("mysb", fakeTokenCredential)(&internal.Namespace{})
+		require.EqualError(t, err, "fullyQualifiedNamespace is not properly formed. Should be similar to 'myservicebus.servicebus.windows.net'")
 	})
 }

--- a/sdk/messaging/azservicebus/example_sending_message_batch_test.go
+++ b/sdk/messaging/azservicebus/example_sending_message_batch_test.go
@@ -32,9 +32,7 @@ func ExampleSender_NewMessageBatch() {
 		return
 	}
 
-	client, err := azservicebus.NewClient(
-		azservicebus.WithConnectionString(connectionString),
-	)
+	client, err := azservicebus.NewClientWithConnectionString(connectionString)
 	panicOnError("Failed to create client", err)
 
 	sender, err := client.NewSender(queueName)

--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/azure-amqp-common-go/v3 v3.2.0
 	github.com/Azure/azure-sdk-for-go v51.1.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0
 	github.com/Azure/go-amqp v0.15.0
 	github.com/Azure/go-autorest/autorest v0.11.18

--- a/sdk/messaging/azservicebus/go.sum
+++ b/sdk/messaging/azservicebus/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/azure-sdk-for-go v51.1.0+incompatible h1:7uk6GWtUqKg6weLv2dbKnz
 github.com/Azure/azure-sdk-for-go v51.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0 h1:lhSJz9RMbJcTgxifR1hUNJnn6CNYtbgEDtQV22/9RBA=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0 h1:OYa9vmRX2XC5GXRAzeggG12sF/z5D9Ahtdm9EJ00WN4=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0 h1:v9p9TfTbf7AwNb5NYQt7hI41IfPoLFiFkLtb+bmGjT0=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/go-amqp v0.13.13/go.mod h1:D5ZrjQqB1dyp1A+G73xeL/kNn7D5qHJIIsNNps7YNmk=
@@ -99,6 +101,8 @@ github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3P
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -114,10 +118,12 @@ github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVM
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20210610132358-84b48f89b13b h1:k+E048sYJHyVnsr1GDrRZWQ32D2C7lWs9JRc0bel53A=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -131,6 +137,7 @@ golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -464,7 +464,7 @@ func nextClaimRefreshDuration(expirationTime time.Time, currentTime time.Time) t
 		return min
 	} else if refreshDuration > max {
 		return max
-	} else {
-		return refreshDuration
 	}
+
+	return refreshDuration
 }

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -119,35 +119,6 @@ func NamespaceWithWebSocket() NamespaceOption {
 	}
 }
 
-// // NamespaceWithEnvironmentBinding configures a namespace using the environment details. It uses one of the following methods:
-// //
-// // 1. Client Credentials: attempt to authenticate with a Service Principal via "AZURE_TENANT_ID", "AZURE_CLIENT_ID" and
-// //    "AZURE_CLIENT_SECRET"
-// //
-// // 2. Client Certificate: attempt to authenticate with a Service Principal via "AZURE_TENANT_ID", "AZURE_CLIENT_ID",
-// //    "AZURE_CERTIFICATE_PATH" and "AZURE_CERTIFICATE_PASSWORD"
-// //
-// // 3. Managed Identity (MI): attempt to authenticate via the MI assigned to the Azure resource
-// //
-// //
-// // The Azure Environment used can be specified using the name of the Azure Environment set in "AZURE_ENVIRONMENT" var.
-// func NamespaceWithEnvironmentBinding(name string) NamespaceOption {
-// 	return func(ns *Namespace) error {
-// 		provider, err := aad.NewJWTProvider(
-// 			aad.JWTProviderWithEnvironmentVars(),
-// 			// TODO: fix bug upstream to use environment resourceURI
-// 			aad.JWTProviderWithResourceURI(ns.getResourceURI()),
-// 		)
-// 		if err != nil {
-// 			return err
-// 		}
-
-// 		ns.TokenProvider = provider
-// 		ns.Name = name
-// 		return nil
-// 	}
-// }
-
 // NamespaceWithAzureEnvironment sets the namespace's Environment, Suffix and ResourceURI parameters according
 // to the Azure Environment defined in "github.com/Azure/go-autorest/autorest/azure" package.
 // This allows to configure the library to be used in the different Azure clouds.

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -6,6 +6,7 @@ package internal
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -137,14 +138,15 @@ func NamespaceWithAzureEnvironment(namespaceName, environmentName string) Namesp
 }
 
 // NamespacesWithTokenCredential sets the token provider on the namespace
-func NamespacesWithTokenCredential(namespaceName string, tokenCredential azcore.TokenCredential) NamespaceOption {
+// fullyQualifiedNamespace is the Service Bus namespace name (ex: myservicebus.servicebus.windows.net)
+func NamespacesWithTokenCredential(fullyQualifiedNamespace string, tokenCredential azcore.TokenCredential) NamespaceOption {
 	return func(ns *Namespace) error {
 		ns.TokenProvider = newTokenProviderWithTokenCredential(tokenCredential)
 
-		parts := strings.SplitN(namespaceName, ".", 2)
+		parts := strings.SplitN(fullyQualifiedNamespace, ".", 2)
 
 		if len(parts) != 2 {
-			ns.Name = parts[0]
+			return errors.New("fullyQualifiedNamespace is not properly formed. Should be similar to 'myservicebus.servicebus.windows.net'")
 		} else {
 			ns.Name, ns.Suffix = parts[0], parts[1]
 		}

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -33,7 +33,7 @@ type (
 	Namespace struct {
 		Name          string
 		Suffix        string
-		TokenProvider *TokenProvider
+		TokenProvider *tokenProvider
 		Environment   azure.Environment
 		tlsConfig     *tls.Config
 		userAgent     string

--- a/sdk/messaging/azservicebus/internal/namespace_test.go
+++ b/sdk/messaging/azservicebus/internal/namespace_test.go
@@ -130,7 +130,7 @@ func TestNamespaceNegotiateClaim(t *testing.T) {
 		func(expirationTimeParam, currentTime time.Time) time.Duration {
 			require.EqualValues(t, expires, expirationTimeParam)
 			// wiggle room, but just want to check that they're passing me the time.Now() value (silly)
-			require.GreaterOrEqual(t, time.Minute, time.Now().Sub(currentTime))
+			require.GreaterOrEqual(t, time.Minute, time.Since(currentTime))
 
 			// we're going to cancel out pretty much immediately
 			return 24 * time.Hour

--- a/sdk/messaging/azservicebus/internal/token_provider.go
+++ b/sdk/messaging/azservicebus/internal/token_provider.go
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package internal
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/Azure/azure-amqp-common-go/v3/auth"
+	"github.com/Azure/azure-amqp-common-go/v3/sas"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// TokenProvider handles access tokens and expiration calculation for SAS
+// keys (via connection strings) or TokenCredentials from Azure Identity.
+type TokenProvider struct {
+	core azcore.TokenCredential
+	sas  *sas.TokenProvider
+}
+
+func newTokenProviderWithTokenCredential(tokenCredential azcore.TokenCredential) *TokenProvider {
+	return &TokenProvider{core: tokenCredential}
+}
+
+func newTokenProviderWithConnectionString(keyName string, key string) (*TokenProvider, error) {
+	provider, err := sas.NewTokenProvider(sas.TokenProviderWithKey(keyName, key))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &TokenProvider{sas: provider}, nil
+}
+
+// singleUseTokenProvider allows you to wrap an *auth.Token so it can be used
+// with functions that require a TokenProvider, but only actually should get
+// a single token (like cbs.NegotiateClaim)
+type singleUseTokenProvider auth.Token
+
+// GetToken will return this token.
+// This function makes us compatible with auth.TokenProvider.
+func (tp *singleUseTokenProvider) GetToken(uri string) (*auth.Token, error) {
+	return (*auth.Token)(tp), nil
+}
+
+// GetToken will retrieve a new token.
+// This function makes us compatible with auth.TokenProvider.
+func (tp *TokenProvider) GetToken(uri string) (*auth.Token, error) {
+	token, _, err := tp.getTokenImpl(uri)
+	return token, err
+}
+
+// GetToken returns a token (that is compatible as an auth.TokenProvider) and
+// the calculated time when you should renew your token.
+func (tp *TokenProvider) GetTokenAsTokenProvider(uri string) (*singleUseTokenProvider, time.Time, error) {
+
+	token, renewAt, err := tp.getTokenImpl(uri)
+
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	return (*singleUseTokenProvider)(token), renewAt, nil
+}
+
+func (tp *TokenProvider) getTokenImpl(uri string) (*auth.Token, time.Time, error) {
+	if tp.sas != nil {
+		return tp.getSASToken(uri)
+	} else {
+		return tp.getAZCoreToken()
+	}
+}
+
+func (tpa *TokenProvider) getAZCoreToken() (*auth.Token, time.Time, error) {
+	// not sure if URI plays in here.
+	accessToken, err := tpa.core.GetToken(context.TODO(), policy.TokenRequestOptions{
+		Scopes: []string{
+			"https://servicebus.azure.net//.default",
+		},
+	})
+
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	authToken := &auth.Token{
+		TokenType: auth.CBSTokenTypeJWT,
+		Token:     accessToken.Token,
+		Expiry:    strconv.FormatInt(accessToken.ExpiresOn.Unix(), 10),
+	}
+
+	return authToken,
+		// 2 minutes wiggle room to avoid possible early expiration
+		accessToken.ExpiresOn.Add(-time.Minute * 2),
+		nil
+}
+
+func (tpa *TokenProvider) getSASToken(uri string) (*auth.Token, time.Time, error) {
+	authToken, err := tpa.sas.GetToken(uri)
+
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	return authToken,
+		// expiration is hardcoded for SAS tokens
+		time.Now().Add(time.Minute * 15),
+		nil
+}

--- a/sdk/messaging/azservicebus/internal/token_provider.go
+++ b/sdk/messaging/azservicebus/internal/token_provider.go
@@ -93,8 +93,7 @@ func (tpa *tokenProvider) getAZCoreToken() (*auth.Token, time.Time, error) {
 	}
 
 	return authToken,
-		// 2 minutes wiggle room to avoid possible early expiration
-		accessToken.ExpiresOn.Add(-time.Minute * 2),
+		accessToken.ExpiresOn,
 		nil
 }
 

--- a/sdk/messaging/azservicebus/liveTestHelpers_test.go
+++ b/sdk/messaging/azservicebus/liveTestHelpers_test.go
@@ -17,7 +17,7 @@ import (
 func setupLiveTest(t *testing.T) (*Client, func(), string) {
 	cs := getConnectionString(t)
 
-	serviceBusClient, err := NewClient(WithConnectionString(cs))
+	serviceBusClient, err := NewClientWithConnectionString(cs)
 	require.NoError(t, err)
 
 	queueName, cleanupQueue := createQueue(t, cs, nil)

--- a/sdk/messaging/azservicebus/samples/processor/processor_sample.go
+++ b/sdk/messaging/azservicebus/samples/processor/processor_sample.go
@@ -24,7 +24,7 @@ func main() {
 		log.Fatalf("SERVICEBUS_CONNECTION_STRING and QUEUE_NAME must be defined in the environment for this sample")
 	}
 
-	serviceBusClient, err := azservicebus.NewClient(azservicebus.WithConnectionString(cs))
+	serviceBusClient, err := azservicebus.NewClientWithConnectionString(cs)
 
 	if err != nil {
 		log.Fatalf("Failed to create service bus client: %s", err.Error())

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -16,7 +16,7 @@ import (
 func TestSender(t *testing.T) {
 	cs := getConnectionString(t)
 
-	serviceBusClient, err := NewClient(WithConnectionString(cs))
+	serviceBusClient, err := NewClientWithConnectionString(cs)
 	require.NoError(t, err)
 
 	t.Run("testSendBatchOfTwo", func(t *testing.T) {

--- a/sdk/messaging/azservicebus/stress/stress.go
+++ b/sdk/messaging/azservicebus/stress/stress.go
@@ -88,7 +88,7 @@ func runBasicSendAndReceiveTest() {
 	ctx, cancel := context.WithTimeout(context.Background(), 24*5*time.Hour)
 	defer cancel()
 
-	serviceBusClient, err := azservicebus.NewClient(azservicebus.WithConnectionString(cs))
+	serviceBusClient, err := azservicebus.NewClientWithConnectionString(cs)
 	if err != nil {
 		trackException(telemetryClient, "Failed to create service bus client", err)
 		return


### PR DESCRIPTION
This PR allows you to pass in a azure identity TokenCredential and authenticate to Service Bus.

I also took this opportunity to fix our refresh calculation interval to be dynamic when we use TokenCredentials since they have a built in expiration date. JS had some nice "wiggle-room" calculations which I've also incorporated.

Note for reviewers: this PR is built on top of https://github.com/Azure/azure-sdk-for-go/pull/15611. You'll want to review the code after this commit: https://github.com/Azure/azure-sdk-for-go/commit/0f3d40327b9339c2b6ff05d3eb1767faa848761e to see the additions this PR is bringing in.

Fixes #15542
Fixes #15638