### PR TITLE
Cosmos DB - Using azcore.ETag instead of strings

### DIFF
--- a/sdk/data/azcosmos/cosmos_container_properties.go
+++ b/sdk/data/azcosmos/cosmos_container_properties.go
@@ -3,12 +3,14 @@
 
 package azcosmos
 
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
 // CosmosContainerProperties represents the properties of a container.
 type CosmosContainerProperties struct {
 	// Id contains the unique id of the container.
 	Id string `json:"id"`
 	// ETag contains the entity etag of the container.
-	ETag string `json:"_etag,omitempty"`
+	ETag azcore.ETag `json:"_etag,omitempty"`
 	// SelfLink contains the self-link of the container.
 	SelfLink string `json:"_self,omitempty"`
 	// ResourceId contains the resource id of the container.

--- a/sdk/data/azcosmos/cosmos_database_properties.go
+++ b/sdk/data/azcosmos/cosmos_database_properties.go
@@ -3,12 +3,14 @@
 
 package azcosmos
 
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
 // CosmosDatabaseProperties represents the properties of a database.
 type CosmosDatabaseProperties struct {
 	// Id contains the unique id of the database.
 	Id string `json:"id"`
 	// ETag contains the entity etag of the database
-	ETag string `json:"_etag,omitempty"`
+	ETag azcore.ETag `json:"_etag,omitempty"`
 	// SelfLink contains the self-link of the database
 	SelfLink string `json:"_self,omitempty"`
 	// ResourceId contains the resource id of the database

--- a/sdk/data/azcosmos/cosmos_database_request_options.go
+++ b/sdk/data/azcosmos/cosmos_database_request_options.go
@@ -3,23 +3,25 @@
 
 package azcosmos
 
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
 // CosmosDatabaseRequestOptions includes options for operations against a database.
 type CosmosDatabaseRequestOptions struct {
-	IfMatchEtag     string
-	IfNoneMatchEtag string
+	IfMatchEtag     *azcore.ETag
+	IfNoneMatchEtag *azcore.ETag
 }
 
 func (options *CosmosDatabaseRequestOptions) toHeaders() *map[string]string {
-	if options.IfMatchEtag == "" && options.IfNoneMatchEtag == "" {
+	if options.IfMatchEtag == nil && options.IfNoneMatchEtag == nil {
 		return nil
 	}
 
 	headers := make(map[string]string)
-	if options.IfMatchEtag != "" {
-		headers[headerIfMatch] = options.IfMatchEtag
+	if options.IfMatchEtag != nil {
+		headers[headerIfMatch] = string(*options.IfMatchEtag)
 	}
-	if options.IfNoneMatchEtag != "" {
-		headers[headerIfNoneMatch] = options.IfNoneMatchEtag
+	if options.IfNoneMatchEtag != nil {
+		headers[headerIfNoneMatch] = string(*options.IfNoneMatchEtag)
 	}
 	return &headers
 }

--- a/sdk/data/azcosmos/cosmos_database_request_options_test.go
+++ b/sdk/data/azcosmos/cosmos_database_request_options_test.go
@@ -5,6 +5,8 @@ package azcosmos
 
 import (
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 func TestDatabaseRequestOptionsToHeaders(t *testing.T) {
@@ -13,18 +15,20 @@ func TestDatabaseRequestOptionsToHeaders(t *testing.T) {
 		t.Error("toHeaders should return nil")
 	}
 
-	options.IfMatchEtag = "etag"
-	options.IfNoneMatchEtag = "noneetag"
+	etagValue := azcore.ETag("etag")
+	noneEtagValue := azcore.ETag("noneetag")
+	options.IfMatchEtag = &etagValue
+	options.IfNoneMatchEtag = &noneEtagValue
 	header := options.toHeaders()
 	if header == nil {
 		t.Error("toHeaders should return non-nil")
 	}
 
 	headers := *header
-	if headers[headerIfMatch] != options.IfMatchEtag {
+	if headers[headerIfMatch] != string(*options.IfMatchEtag) {
 		t.Errorf("IfMatchEtag not set matching expected %v got %v", options.IfMatchEtag, headers[headerIfMatch])
 	}
-	if headers[headerIfNoneMatch] != options.IfNoneMatchEtag {
+	if headers[headerIfNoneMatch] != string(*options.IfNoneMatchEtag) {
 		t.Errorf("IfNoneMatchEtag not set matching expected %v got %v", options.IfNoneMatchEtag, headers[headerIfNoneMatch])
 	}
 }

--- a/sdk/data/azcosmos/cosmos_response.go
+++ b/sdk/data/azcosmos/cosmos_response.go
@@ -6,6 +6,8 @@ package azcosmos
 import (
 	"net/http"
 	"strconv"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 // CosmosResponse is the base response type for all responses from the Azure Cosmos DB database service.
@@ -34,6 +36,6 @@ func (c *CosmosResponse) ActivityId() string {
 }
 
 // ETag contains the value from the ETag header.
-func (c *CosmosResponse) ETag() string {
-	return c.RawResponse.Header.Get(cosmosHeaderEtag)
+func (c *CosmosResponse) ETag() azcore.ETag {
+	return azcore.ETag(c.RawResponse.Header.Get(cosmosHeaderEtag))
 }

--- a/sdk/data/azcosmos/throughput_properties.go
+++ b/sdk/data/azcosmos/throughput_properties.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
@@ -18,7 +19,7 @@ const (
 
 // ThroughputProperties describes the throughput configuration of a resource.
 type ThroughputProperties struct {
-	ETag         string
+	ETag         azcore.ETag
 	LastModified *UnixTime
 
 	version         string


### PR DESCRIPTION
Following other SDKs public surface, ETags are represented as `azcore.ETag` instead of `string`