### PR TITLE
Add mock.NewTrackedCloser to help test when Close is called

### DIFF
--- a/sdk/internal/mock/closer.go
+++ b/sdk/internal/mock/closer.go
@@ -1,0 +1,34 @@
+//go:build go1.16
+// +build go1.16
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package mock
+
+import "io"
+
+type trackedCloser struct {
+	io.Reader
+	closed bool
+}
+
+// Close records that Close was called.
+func (t *trackedCloser) Close() error {
+	t.closed = true
+	return nil
+}
+
+// Closed returns true if Close was called.
+func (t *trackedCloser) Closed() bool {
+	return t.closed
+}
+
+// NewTrackedCloser is similar to io.NopCloser but tracks that Close
+// was called.  Call TrackedClose to check if Close has been called.
+func NewTrackedCloser(r io.Reader) (io.ReadCloser, TrackedClose) {
+	tc := &trackedCloser{Reader: r}
+	return tc, tc.Closed
+}
+
+// TrackedClose, when invoked, returns true if Close was called.
+type TrackedClose func() bool

--- a/sdk/internal/mock/closer_test.go
+++ b/sdk/internal/mock/closer_test.go
@@ -1,0 +1,24 @@
+//go:build go1.16
+// +build go1.16
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package mock
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNewTrackedCloser(t *testing.T) {
+	body, closed := NewTrackedCloser(bytes.NewReader([]byte{}))
+	if closed() {
+		t.Fatal("body wasn't closed yet")
+	}
+	if err := body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !closed() {
+		t.Fatal("body should be closed")
+	}
+}


### PR DESCRIPTION
It behaves like a io.NopCloser but returns a tracker that, when invoked,
returns true if Close was called on the io.ReadCloser.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
