### PR TITLE
Remove azidentity.AADAuthenticationFailedError

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -26,9 +26,12 @@
   cred, err := NewClientCertificateCredential("tenant", "client-id", certData, nil)
   ```
 * Removed `InteractiveBrowserCredentialOptions.ClientSecret` and `.Port`
+* Removed `AADAuthenticationFailedError`
 
 ### Features Added
 * Added connection configuration options to `DefaultAzureCredentialOptions`
+* `AuthenticationFailedError.RawResponse()` returns the HTTP response motivating the error,
+  if available
 
 
 ## 0.11.0 (2021-09-08)

--- a/sdk/azidentity/authorization_code_credential_test.go
+++ b/sdk/azidentity/authorization_code_credential_test.go
@@ -112,33 +112,9 @@ func TestAuthorizationCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
 	var authFailed *AuthenticationFailedError
 	if !errors.As(err, &authFailed) {
 		t.Fatalf("Expected: AuthenticationFailedError, Received: %T", err)
-	} else {
-		var respError *AADAuthenticationFailedError
-		if !errors.As(authFailed.Unwrap(), &respError) {
-			t.Fatalf("Expected: AADAuthenticationFailedError, Received: %T", err)
-		} else {
-			if len(respError.Message) == 0 {
-				t.Fatalf("Did not receive an error message")
-			}
-			if len(respError.Description) == 0 {
-				t.Fatalf("Did not receive an error description")
-			}
-			if len(respError.Timestamp) == 0 {
-				t.Fatalf("Did not receive a timestamp")
-			}
-			if len(respError.TraceID) == 0 {
-				t.Fatalf("Did not receive a TraceID")
-			}
-			if len(respError.CorrelationID) == 0 {
-				t.Fatalf("Did not receive a CorrelationID")
-			}
-			if len(respError.URL) == 0 {
-				t.Fatalf("Did not receive an error URL")
-			}
-			if respError.Response == nil {
-				t.Fatalf("Did not receive an error response")
-			}
-		}
+	}
+	if authFailed.RawResponse() == nil {
+		t.Fatalf("Expected error to include a response")
 	}
 }
 

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -113,33 +113,9 @@ func TestClientSecretCredential_GetTokenInvalidCredentials(t *testing.T) {
 	var authFailed *AuthenticationFailedError
 	if !errors.As(err, &authFailed) {
 		t.Fatalf("Expected: AuthenticationFailedError, Received: %T", err)
-	} else {
-		var respError *AADAuthenticationFailedError
-		if !errors.As(authFailed.Unwrap(), &respError) {
-			t.Fatalf("Expected: AADAuthenticationFailedError, Received: %T", err)
-		} else {
-			if len(respError.Message) == 0 {
-				t.Fatalf("Did not receive an error message")
-			}
-			if len(respError.Description) == 0 {
-				t.Fatalf("Did not receive an error description")
-			}
-			if len(respError.Timestamp) == 0 {
-				t.Fatalf("Did not receive a timestamp")
-			}
-			if len(respError.TraceID) == 0 {
-				t.Fatalf("Did not receive a TraceID")
-			}
-			if len(respError.CorrelationID) == 0 {
-				t.Fatalf("Did not receive a CorrelationID")
-			}
-			if len(respError.URL) == 0 {
-				t.Fatalf("Did not receive an error URL")
-			}
-			if respError.Response == nil {
-				t.Fatalf("Did not receive an error response")
-			}
-		}
+	}
+	if authFailed.RawResponse() == nil {
+		t.Fatalf("Expected error to include a response")
 	}
 }
 

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -158,7 +159,8 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 		}
 		// if there is an error, check for an AADAuthenticationFailedError in order to check the status for token retrieval
 		// if the error is not an AADAuthenticationFailedError, then fail here since something unexpected occurred
-		if authRespErr := (*AADAuthenticationFailedError)(nil); errors.As(err, &authRespErr) && authRespErr.Message == "authorization_pending" {
+		var authFailed *AuthenticationFailedError
+		if errors.As(err, &authFailed) && strings.Contains(authFailed.msg, "authorization_pending") {
 			// wait for the interval specified from the initial device code endpoint and then poll for the token again
 			time.Sleep(time.Duration(dc.Interval) * time.Second)
 		} else {

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -272,9 +272,12 @@ func TestDeviceCodeCredential_GetTokenWithRefreshTokenFailure(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
-	var aadErr *AADAuthenticationFailedError
-	if !errors.As(err, &aadErr) {
-		t.Fatalf("Did not receive an AADAuthenticationFailedError but was expecting one")
+	var authFailed *AuthenticationFailedError
+	if !errors.As(err, &authFailed) {
+		t.Fatalf("Expected AuthenticationFailedError, got %T", err)
+	}
+	if authFailed.RawResponse() == nil {
+		t.Fatalf("Expected error to include a response")
 	}
 }
 

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -109,29 +109,7 @@ func TestInteractiveBrowserCredential_GetTokenInvalidCredentials(t *testing.T) {
 	if !errors.As(err, &authFailed) {
 		t.Fatalf("Expected: AuthenticationFailedError, Received: %T", err)
 	}
-	var respError *AADAuthenticationFailedError
-	if !errors.As(authFailed.Unwrap(), &respError) {
-		t.Fatalf("Expected: AADAuthenticationFailedError, Received: %T", err)
-	}
-	if len(respError.Message) == 0 {
-		t.Fatalf("Did not receive an error message")
-	}
-	if len(respError.Description) == 0 {
-		t.Fatalf("Did not receive an error description")
-	}
-	if len(respError.Timestamp) == 0 {
-		t.Fatalf("Did not receive a timestamp")
-	}
-	if len(respError.TraceID) == 0 {
-		t.Fatalf("Did not receive a TraceID")
-	}
-	if len(respError.CorrelationID) == 0 {
-		t.Fatalf("Did not receive a CorrelationID")
-	}
-	if len(respError.URL) == 0 {
-		t.Fatalf("Did not receive an error URL")
-	}
-	if respError.Response == nil {
-		t.Fatalf("Did not receive an error response")
+	if authFailed.RawResponse() == nil {
+		t.Fatalf("Expected error to include a response")
 	}
 }

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -173,7 +173,7 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, clientID 
 		// need to perform preliminary request to retreive the secret key challenge provided by the HIMDS service
 		key, err := c.getAzureArcSecretKey(ctx, scopes)
 		if err != nil {
-			return nil, &AuthenticationFailedError{msg: "Failed to retreive secret key from the identity endpoint."}
+			return nil, &AuthenticationFailedError{msg: "failed to retreive secret key from the identity endpoint"}
 		}
 		return c.createAzureArcAuthRequest(ctx, key, scopes)
 	case msiTypeServiceFabric:
@@ -188,7 +188,7 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, clientID 
 		default:
 			errorMsg = "unknown"
 		}
-		c.unavailableMessage = "Make sure you are running in a valid Managed Identity environment. Status: " + errorMsg
+		c.unavailableMessage = "managed identity support is " + errorMsg
 		return nil, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: c.unavailableMessage}
 	}
 }
@@ -278,7 +278,7 @@ func (c *managedIdentityClient) getAzureArcSecretKey(ctx context.Context, resour
 	// the endpoint is expected to return a 401 with the WWW-Authenticate header set to the location
 	// of the secret key file. Any other status code indicates an error in the request.
 	if response.StatusCode != 401 {
-		return "", &AuthenticationFailedError{resp: response, msg: fmt.Sprintf("Expected a 401 Unauthorized response, received: %d", response.StatusCode)}
+		return "", &AuthenticationFailedError{resp: response, msg: fmt.Sprintf("expected a 401 response, received %d", response.StatusCode)}
 	}
 	header := response.Header.Get("WWW-Authenticate")
 	if len(header) == 0 {
@@ -349,14 +349,14 @@ func (c *managedIdentityClient) getMSIType() (msiType, error) {
 				c.msiType = msiTypeAzureArc
 			} else {
 				c.msiType = msiTypeUnavailable
-				return c.msiType, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: "This Managed Identity Environment is not supported yet"}
+				return c.msiType, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: "this environment is not supported yet"}
 			}
 		} else if c.imdsAvailable() { // if MSI_ENDPOINT is NOT set AND the IMDS endpoint is available the msiType is IMDS. This will timeout after 500 milliseconds
 			c.endpoint = imdsEndpoint
 			c.msiType = msiTypeIMDS
 		} else { // if MSI_ENDPOINT is NOT set and IMDS endpoint is not available Managed Identity is not available
 			c.msiType = msiTypeUnavailable
-			return c.msiType, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: "Make sure you are running in a valid Managed Identity Environment"}
+			return c.msiType, &CredentialUnavailableError{credentialType: "Managed Identity Credential", message: "no managed identity endpoint is available"}
 		}
 	}
 	return c.msiType, nil

--- a/sdk/azidentity/version.go
+++ b/sdk/azidentity/version.go
@@ -11,5 +11,5 @@ const (
 	component = "azidentity"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	version = "v0.11.0"
+	version = "v0.12.0"
 )


### PR DESCRIPTION
This removes `AADAuthenticationFailedError` so AAD response structure isn't part of our API, and because we don't need it; `AuthenticationFailedError` can encompass errors arising specifically from AAD auth failures. In practical terms, this change makes getting low-level details such as a correlation ID a bit more work. I think that's okay because this change also makes AAD's detailed error description part of `AuthenticationFailedError.Error()`, so the most important information is the most visible, and exposes the underlying `*http.Response` via `AuthenticationFailedError.RawResponse()`, so no information is lost.