### PR TITLE
Cosmos DB - Enabling emulator tests

### DIFF
--- a/sdk/data/azcosmos/ci.yml
+++ b/sdk/data/azcosmos/ci.yml
@@ -36,7 +36,7 @@ stages:
         Windows_Go115:
           pool.name: azsdk-pool-mms-win-2019-general
           image.name: MMS2019
-          go.version: '1.16'
+          go.version: '1.16.7'
         Windows_Go114:
           pool.name: azsdk-pool-mms-win-2019-general
           image.name: MMS2019
@@ -69,16 +69,12 @@ stages:
 
     - template: /eng/pipelines/templates/steps/create-go-workspace.yml
 
-    - template:  /eng/pipelines/templates/steps/set-scope.yml
-      parameters: 
-        ServiceDirectory: 'cosmos'
-        GoWorkspace: $(GO_WORKSPACE_PATH)
-
     - template:  /eng/pipelines/templates/steps/build-test.yml
       parameters: 
-        ServiceDirectory: 'cosmos'
+        ServiceDirectory: 'data/azcosmos'
         GoWorkspace: $(GO_WORKSPACE_PATH)
-        Scope: $(SCOPE)
         Image: $(vm.image)
         GoVersion: $(go.version)
-        Tags: 'emulator' 
+        RunTests: true
+        EnvVars: 
+          EMULATOR: 'true'

--- a/sdk/data/azcosmos/ci.yml
+++ b/sdk/data/azcosmos/ci.yml
@@ -25,3 +25,60 @@ stages:
   parameters:
     ServiceDirectory: 'data/azcosmos'
     RunTests: true
+- stage: Emulator
+  displayName: 'Cosmos Emulator'
+  jobs:
+  - job: DownloadAndRunCosmosEmulator
+    displayName: Download and run Cosmos Emulator
+
+    strategy:
+      matrix:
+        Windows_Go115:
+          pool.name: azsdk-pool-mms-win-2019-general
+          image.name: MMS2019
+          go.version: '1.16'
+        Windows_Go114:
+          pool.name: azsdk-pool-mms-win-2019-general
+          image.name: MMS2019
+          go.version: '1.17'
+    pool:
+      name: $(pool.name)
+      vmImage: $(image.name)
+
+    steps:
+    - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml
+      parameters:
+        StartParameters: '/noexplorer /noui /enablepreview /disableratelimiting /enableaadauthentication /partitioncount=50 /consistency=Strong'
+    - powershell: |
+        $Key = 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=='
+        $password = ConvertTo-SecureString -String $Key -Force -AsPlainText
+        $cert = Get-ChildItem cert:\LocalMachine\My | Where-Object { $_.FriendlyName -eq "DocumentDbEmulatorCertificate" }
+        Export-PfxCertificate -Cert $cert -FilePath ".\CosmosDbEmulatorCert.pfx" -Password $password | Out-Null
+        $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+        $cert.Import(".\CosmosDbEmulatorCert.pfx", $Key, "DefaultKeySet")
+        $cert | Export-Certificate -FilePath "$env:temp\CosmosDbEmulatorCert.cer" -Type CERT
+      displayName: 'Export Cosmos DB Emulator Certificate'
+    - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+      parameters:
+        AgentImage: $(image.name)
+
+    - task: GoTool@0
+      inputs:
+        version: '$(go.version)'
+      displayName: "Select Go Version"
+
+    - template: /eng/pipelines/templates/steps/create-go-workspace.yml
+
+    - template:  /eng/pipelines/templates/steps/set-scope.yml
+      parameters: 
+        ServiceDirectory: 'cosmos'
+        GoWorkspace: $(GO_WORKSPACE_PATH)
+
+    - template:  /eng/pipelines/templates/steps/build-test.yml
+      parameters: 
+        ServiceDirectory: 'cosmos'
+        GoWorkspace: $(GO_WORKSPACE_PATH)
+        Scope: $(SCOPE)
+        Image: $(vm.image)
+        GoVersion: $(go.version)
+        Tags: 'emulator' 

--- a/sdk/data/azcosmos/ci.yml
+++ b/sdk/data/azcosmos/ci.yml
@@ -33,11 +33,11 @@ stages:
 
     strategy:
       matrix:
-        Windows_Go115:
+        Windows_Go116:
           pool.name: azsdk-pool-mms-win-2019-general
           image.name: MMS2019
           go.version: '1.16.7'
-        Windows_Go114:
+        Windows_Go117:
           pool.name: azsdk-pool-mms-win-2019-general
           image.name: MMS2019
           go.version: '1.17'


### PR DESCRIPTION
Add Emulator tests into the CI to execute skipped tests.

The tests can only run on Windows and were being skipped if the environment variable was not set.

This PR adds a new step that runs only on Windows and sets the environment variable to enable running the emulator tests.