### PR TITLE
[service-bus] Improving recovery and error handling

### DIFF
--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -118,7 +118,7 @@ func newClientImpl(config clientConfig, options ...ClientOption) (*Client, error
 
 // NewProcessor creates a Processor for a queue.
 func (client *Client) NewProcessorForQueue(queue string, options ...ProcessorOption) (*Processor, error) {
-	options = append(options, ProcessorWithQueue(queue))
+	options = append(options, processorWithQueue(queue))
 	id, cleanupOnClose := client.getCleanupForCloseable()
 
 	processor, err := newProcessor(client.namespace, cleanupOnClose, options...)
@@ -133,7 +133,7 @@ func (client *Client) NewProcessorForQueue(queue string, options ...ProcessorOpt
 
 // NewProcessor creates a Processor for a subscription.
 func (client *Client) NewProcessorForSubscription(topic string, subscription string, options ...ProcessorOption) (*Processor, error) {
-	options = append(options, ProcessorWithSubscription(topic, subscription))
+	options = append(options, processorWithSubscription(topic, subscription))
 	id, cleanupOnClose := client.getCleanupForCloseable()
 
 	processor, err := newProcessor(client.namespace, cleanupOnClose, options...)

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -35,9 +35,10 @@ func TestNewClientWithAzureIdentity(t *testing.T) {
 	err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")})
 	require.NoError(t, err)
 
-	receiver, err := client.NewReceiver(ReceiverWithQueue(queue))
+	receiver, err := client.NewReceiverForQueue(queue)
 	require.NoError(t, err)
-	receiver.settler.onlyDoBackupSettlement = true // this'll also exercise the management link
+	actualSettler, _ := receiver.settler.(*messageSettler)
+	actualSettler.onlyDoBackupSettlement = true // this'll also exercise the management link
 
 	messages, err := receiver.ReceiveMessages(context.TODO(), 1)
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -92,4 +92,70 @@ func TestNewClientUnitTests(t *testing.T) {
 		err = internal.NamespacesWithTokenCredential("mysb", fakeTokenCredential)(&internal.Namespace{})
 		require.EqualError(t, err, "fullyQualifiedNamespace is not properly formed. Should be similar to 'myservicebus.servicebus.windows.net'")
 	})
+
+	t.Run("CloseAndLinkTracking", func(t *testing.T) {
+		setupClient := func() (*Client, *internal.FakeNS) {
+			client, err := NewClient("fake.something", struct{ azcore.TokenCredential }{})
+			require.NoError(t, err)
+
+			ns := &internal.FakeNS{
+				AMQPLinks: &internal.FakeAMQPLinks{
+					Receiver: &internal.FakeAMQPReceiver{},
+				},
+			}
+
+			client.namespace = ns
+			return client, ns
+		}
+
+		client, ns := setupClient()
+		_, err := client.NewSender("hello")
+
+		require.NoError(t, err)
+		require.EqualValues(t, 1, len(client.links))
+		require.NotNil(t, client.links[1])
+		require.NoError(t, client.Close(context.Background()))
+		require.Empty(t, client.links)
+		require.True(t, ns.AMQPLinks.ClosedPermanently())
+
+		client, ns = setupClient()
+		_, err = client.NewReceiverForQueue("hello")
+
+		require.NoError(t, err)
+		require.EqualValues(t, 1, len(client.links))
+		require.NotNil(t, client.links[1])
+		require.NoError(t, client.Close(context.Background()))
+		require.Empty(t, client.links)
+		require.True(t, ns.AMQPLinks.ClosedPermanently())
+
+		client, ns = setupClient()
+		_, err = client.NewReceiverForSubscription("hello", "world")
+
+		require.NoError(t, err)
+		require.EqualValues(t, 1, len(client.links))
+		require.NotNil(t, client.links[1])
+		require.NoError(t, client.Close(context.Background()))
+		require.Empty(t, client.links)
+		require.EqualValues(t, 1, ns.AMQPLinks.Closed)
+
+		client, ns = setupClient()
+		_, err = client.NewProcessorForQueue("hello")
+
+		require.NoError(t, err)
+		require.EqualValues(t, 1, len(client.links))
+		require.NotNil(t, client.links[1])
+		require.NoError(t, client.Close(context.Background()))
+		require.Empty(t, client.links)
+		require.EqualValues(t, 1, ns.AMQPLinks.Closed)
+
+		client, ns = setupClient()
+		_, err = client.NewProcessorForSubscription("hello", "world")
+
+		require.NoError(t, err)
+		require.EqualValues(t, 1, len(client.links))
+		require.NotNil(t, client.links[1])
+		require.NoError(t, client.Close(context.Background()))
+		require.Empty(t, client.links)
+		require.EqualValues(t, 1, ns.AMQPLinks.Closed)
+	})
 }

--- a/sdk/messaging/azservicebus/example_sending_message_batch_test.go
+++ b/sdk/messaging/azservicebus/example_sending_message_batch_test.go
@@ -47,22 +47,22 @@ func ExampleSender_NewMessageBatch() {
 	}
 
 	for i := 0; i < len(messagesToSend); i++ {
-		err = batch.Add(messagesToSend[i])
+		added, err := batch.Add(messagesToSend[i])
 
-		if err == nil {
+		if added {
 			continue
 		}
 
-		if _, ok := err.(azservicebus.MessageTooLarge); ok {
+		if err == nil {
 			// At this point you can do a few things:
 			// 1. Ignore this message
 			// 2. Send this batch (it's full) and create a new batch.
 			//
 			// The batch can still be used after this error.
-			panicOnError("Failed to add message to batch (batch is full)", err)
-		} else {
-			panicOnError("Failed to add message to batch", err)
+			log.Fatal("Failed to add message to batch (batch is full)")
 		}
+
+		panicOnError("Error while trying to add message to batch", err)
 	}
 
 	// now let's send the batch

--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -3,15 +3,17 @@ module github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus
 go 1.16
 
 require (
-	github.com/Azure/azure-amqp-common-go/v3 v3.2.0
+	github.com/Azure/azure-amqp-common-go/v3 v3.2.1
 	github.com/Azure/azure-sdk-for-go v51.1.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1 // indirect
-	github.com/Azure/go-amqp v0.15.0
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1
+	github.com/Azure/go-amqp v0.16.0
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/adal v0.9.13
 	github.com/Azure/go-autorest/autorest/date v0.3.0
+	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/devigned/tab v0.1.1
 	github.com/joho/godotenv v1.3.0
 	github.com/jpillora/backoff v1.0.0
@@ -21,6 +23,3 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	nhooyr.io/websocket v1.8.6
 )
-
-// remove after go-amqp releases https://github.com/Azure/go-amqp/pull/72
-replace github.com/Azure/go-amqp v0.15.0 => github.com/Azure/go-amqp v0.15.1-0.20210923181113-8f9a02b39d60

--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v51.1.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1 // indirect
 	github.com/Azure/go-amqp v0.15.0
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/adal v0.9.13

--- a/sdk/messaging/azservicebus/go.sum
+++ b/sdk/messaging/azservicebus/go.sum
@@ -1,7 +1,7 @@
 code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c h1:5eeuG0BHx1+DHeT3AP+ISKZ2ht1UjGhm581ljqYpVeQ=
 code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c/go.mod h1:QD9Lzhd/ux6eNQVUDVRJX/RKTigpewimNYBi7ivZKY8=
-github.com/Azure/azure-amqp-common-go/v3 v3.2.0 h1:BK/3P4TW4z2HLD6G5tMlHRvptOxxi4s9ee5r8sdHBUs=
-github.com/Azure/azure-amqp-common-go/v3 v3.2.0/go.mod h1:zN7QL/vfCsq3XQxQaTkg4ScO786CA2rQnZ1LXX7QryE=
+github.com/Azure/azure-amqp-common-go/v3 v3.2.1 h1:uQyDk81yn5hTP1pW4Za+zHzy97/f4vDz9o1d/exI4j4=
+github.com/Azure/azure-amqp-common-go/v3 v3.2.1/go.mod h1:O6X1iYHP7s2x7NjUKsXVhkwWrQhxrd+d8/3rRadj4CI=
 github.com/Azure/azure-sdk-for-go v51.1.0+incompatible h1:7uk6GWtUqKg6weLv2dbKnzwb0ml1Qn70AdtRccZ543w=
 github.com/Azure/azure-sdk-for-go v51.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0 h1:lhSJz9RMbJcTgxifR1hUNJnn6CNYtbgEDtQV22/9RBA=
@@ -11,9 +11,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJc
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1 h1:8XSiy/LSvjtFwpguk7m6yGLgGkWocluo8hLM5vtcpcg=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
-github.com/Azure/go-amqp v0.13.13/go.mod h1:D5ZrjQqB1dyp1A+G73xeL/kNn7D5qHJIIsNNps7YNmk=
-github.com/Azure/go-amqp v0.15.1-0.20210923181113-8f9a02b39d60 h1:W/dYCEowHl7kz6bxw72LIzRGi/lWk+z8WQEXAU5hxJ0=
-github.com/Azure/go-amqp v0.15.1-0.20210923181113-8f9a02b39d60/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
+github.com/Azure/go-amqp v0.16.0 h1:6mhxUxaKLjMtHlGqzeih/LKqjUPLZxbM6zwfz5/C4NQ=
+github.com/Azure/go-amqp v0.16.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.18 h1:90Y4srNYrwOtAgVo3ndrQkTYn6kf1Eg/AjTFJ8Is2aM=
@@ -103,7 +102,6 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/sdk/messaging/azservicebus/internal/amqpInterfaces.go
+++ b/sdk/messaging/azservicebus/internal/amqpInterfaces.go
@@ -16,6 +16,12 @@ type AMQPReceiver interface {
 	IssueCredit(credit uint32) error
 	DrainCredit(ctx context.Context) error
 	Receive(ctx context.Context) (*amqp.Message, error)
+
+	// settlement functions
+	AcceptMessage(ctx context.Context, msg *amqp.Message) error
+	RejectMessage(ctx context.Context, msg *amqp.Message, e *amqp.Error) error
+	ReleaseMessage(ctx context.Context, msg *amqp.Message) error
+	ModifyMessage(ctx context.Context, msg *amqp.Message, deliveryFailed, undeliverableHere bool, messageAnnotations amqp.Annotations) error
 }
 
 // AMQPReceiver is implemented by *amqp.Receiver

--- a/sdk/messaging/azservicebus/internal/amqpInterfaces.go
+++ b/sdk/messaging/azservicebus/internal/amqpInterfaces.go
@@ -59,3 +59,9 @@ type RPCLink interface {
 	Close(ctx context.Context) error
 	RetryableRPC(ctx context.Context, times int, delay time.Duration, msg *amqp.Message) (*rpc.Response, error)
 }
+
+// Closeable is implemented by pretty much any AMQP link/client
+// including our own higher level Receiver/Sender.
+type Closeable interface {
+	Close(ctx context.Context) error
+}

--- a/sdk/messaging/azservicebus/internal/amqpInterfaces.go
+++ b/sdk/messaging/azservicebus/internal/amqpInterfaces.go
@@ -5,7 +5,9 @@ package internal
 
 import (
 	"context"
+	"time"
 
+	"github.com/Azure/azure-amqp-common-go/v3/rpc"
 	"github.com/Azure/go-amqp"
 )
 
@@ -44,4 +46,10 @@ type AMQPSender interface {
 type AMQPSenderCloser interface {
 	AMQPSender
 	Close(ctx context.Context) error
+}
+
+// RPCLink is implemented by *rpc.Link
+type RPCLink interface {
+	Close(ctx context.Context) error
+	RetryableRPC(ctx context.Context, times int, delay time.Duration, msg *amqp.Message) (*rpc.Response, error)
 }

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -40,6 +40,9 @@ type AMQPLinks interface {
 	// If permanent is true the link will not be auto-recreated if Get/Recover
 	// are called. All functions will return `ErrLinksClosed`
 	Close(ctx context.Context, permanent bool) error
+
+	// ClosedPermanently is true if AMQPLinks.Close(ctx, true) has been called.
+	ClosedPermanently() bool
 }
 
 // amqpLinks manages the set of AMQP links (and detritus) typically needed to work
@@ -270,6 +273,13 @@ func (l *amqpLinks) EntityPath() string {
 // EntityPath is the audience for the queue/topic/subscription.
 func (l *amqpLinks) Audience() string {
 	return l.audience
+}
+
+// ClosedPermanently is true if AMQPLinks.Close(ctx, true) has been called.
+func (l *amqpLinks) ClosedPermanently() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.closedPermanently
 }
 
 // Close will close the the link permanently.

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -5,8 +5,10 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,10 +21,10 @@ func TestAMQPLinks(t *testing.T) {
 		{sender: fakeSender},
 	})
 
-	links := newAMQPLinks(&fakeNS{
+	links := newAMQPLinks(&FakeNS{
 		Session:    fakeSession,
 		MgmtClient: fakeMgmtClient,
-	}, "entityPath", createLinkFunc)
+	}, "entityPath", &fakeRetrier{}, createLinkFunc)
 
 	require.EqualValues(t, "entityPath", links.EntityPath())
 	require.EqualValues(t, "audience: entityPath", links.Audience())
@@ -75,6 +77,96 @@ func TestAMQPLinks(t *testing.T) {
 
 	_, ok = err.(NonRetriable)
 	require.True(t, ok)
+}
+
+type permanentNetError struct {
+	temp    bool
+	timeout bool
+}
+
+func (pe permanentNetError) Timeout() bool   { return pe.timeout }
+func (pe permanentNetError) Temporary() bool { return pe.temp }
+func (pe permanentNetError) Error() string   { return "Fake but very permanent error" }
+
+func TestAMQPLinksRecovery(t *testing.T) {
+	sess := &fakeAMQPSession{}
+	ns := &FakeNS{
+		Session: sess,
+	}
+	sender := &fakeAMQPSender{}
+
+	createLinkCalled := 0
+
+	tmpLinks := newAMQPLinks(ns, "entity path", NewBackoffRetrier(BackoffRetrierParams{}), func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+		createLinkCalled++
+		return sender, nil, nil
+	})
+
+	links, _ := tmpLinks.(*amqpLinks)
+
+	links.clientRevision = 2001
+	links.sender = sender
+
+	ctx := context.TODO()
+
+	require.Nil(t, links.RecoverIfNeeded(ctx, nil))
+	require.EqualValues(t, 0, sess.closed)
+	require.EqualValues(t, 0, ns.recovered)
+	require.EqualValues(t, 0, createLinkCalled, "new links aren't needed")
+	require.False(t, links.closedPermanently, "link should still be usable")
+	require.Empty(t, ns.clientRevisions, "no connection recoveries happened")
+
+	require.Nil(t, links.RecoverIfNeeded(ctx, errors.New("Passes through")))
+	require.EqualValues(t, 0, sess.closed)
+	require.EqualValues(t, 0, ns.recovered)
+	require.EqualValues(t, 0, createLinkCalled, "new links aren't needed")
+	require.False(t, links.closedPermanently, "link should still be usable")
+	require.Empty(t, ns.clientRevisions, "no connection recoveries happened")
+
+	// now let's initiate a recovery at the connection level
+	require.NoError(t, links.RecoverIfNeeded(ctx, permanentNetError{}), permanentNetError{}.Error())
+	require.EqualValues(t, 1, ns.recovered, "client gets recovered")
+	require.EqualValues(t, 1, sender.closed, "link is closed")
+	require.EqualValues(t, 1, createLinkCalled, "link is created")
+	require.False(t, links.closedPermanently, "link should still be usable")
+	require.EqualValues(t, []uint64{2001}, ns.clientRevisions, "links handed us the client revision it got last")
+
+	ns.recovered = 0
+	sender.closed = 0
+	createLinkCalled = 0
+
+	// let's do just a link level one
+	require.NoError(t, links.RecoverIfNeeded(ctx, amqp.ErrLinkDetached), amqp.ErrLinkDetached.Error())
+	require.EqualValues(t, 0, ns.recovered)
+	require.EqualValues(t, 1, sender.closed)
+	require.EqualValues(t, 1, createLinkCalled)
+
+	// cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ns.recovered = 0
+	sender.closed = 0
+	createLinkCalled = 0
+
+	// cancellation overrides any other logic.
+	require.Error(t, links.RecoverIfNeeded(ctx, amqp.ErrLinkDetached), amqp.ErrLinkDetached.Error())
+	require.EqualValues(t, 0, ns.recovered)
+	require.EqualValues(t, 0, sender.closed)
+	require.EqualValues(t, 0, createLinkCalled)
+}
+
+func TestAMQPLinks_Closed(t *testing.T) {
+	createLinks := func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+		return nil, nil, nil
+	}
+
+	links := newAMQPLinks(&FakeNS{}, "hello", &backoffRetrier{}, createLinks)
+	links.Close(context.Background(), true)
+
+	_, _, _, _, err := links.Get(context.Background())
+
+	require.True(t, IsNonRetriable(err))
 }
 
 func setupCreateLinkResponses(t *testing.T, responses []createLinkResponse) (CreateLinkFunc, *int) {

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -176,9 +176,6 @@ func isPermanentNetError(err error) bool {
 	return false
 }
 
-// 2021/09/30 20:46:14 [42] ERROR: error: amqp receiver close error: read tcp 192.168.1.16:50628->13.66.228.204:5671: wsarecv: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
-// amqp session close error: read tcp 192.168.1.16:50628->13.66.228.204:5671: wsarecv: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
-
 func isEOF(err error) bool {
 	return errors.Is(err, io.EOF)
 }

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -4,12 +4,15 @@
 package internal
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrMissingField_Error(t *testing.T) {
@@ -71,4 +74,86 @@ func TestErrNotFound_Error(t *testing.T) {
 
 	otherErr := errors.New("foo")
 	assert.False(t, IsErrNotFound(otherErr))
+}
+
+func Test_isPermanentNetError(t *testing.T) {
+	require.False(t, isPermanentNetError(&permanentNetError{
+		temp: true,
+	}))
+
+	require.False(t, isPermanentNetError(&permanentNetError{
+		timeout: true,
+	}))
+
+	require.False(t, isPermanentNetError(errors.New("not a net error")))
+
+	require.True(t, isPermanentNetError(&permanentNetError{}))
+}
+
+func Test_isRetryableAMQPError(t *testing.T) {
+	ctx := context.Background()
+
+	retryableCodes := []string{
+		string(amqp.ErrorInternalError),
+		string(errorServerBusy),
+		string(errorTimeout),
+		string(errorOperationCancelled),
+		"client.sender:not-enough-link-credit",
+		string(amqp.ErrorUnauthorizedAccess),
+		string(amqp.ErrorDetachForced),
+		string(amqp.ErrorConnectionForced),
+		string(amqp.ErrorTransferLimitExceeded),
+		"amqp: connection closed",
+		"unexpected frame",
+		string(amqp.ErrorNotFound),
+	}
+
+	for _, code := range retryableCodes {
+		require.True(t, isRetryableAMQPError(ctx, &amqp.Error{
+			Condition: amqp.ErrorCondition(code),
+		}))
+
+		// it works equally well if the error is just in the String().
+		// Need to narrow this down some more to see where the errors
+		// might not be getting converted properly.
+		require.True(t, isRetryableAMQPError(ctx, errors.New(code)))
+	}
+
+	require.False(t, isRetryableAMQPError(ctx, errors.New("some non-amqp related error")))
+}
+
+func Test_shouldRecreateLink(t *testing.T) {
+	require.False(t, shouldRecreateLink(nil))
+
+	require.True(t, shouldRecreateLink(amqp.ErrLinkDetached))
+	require.True(t, shouldRecreateLink(amqp.ErrLinkClosed))
+	require.True(t, shouldRecreateLink(amqp.ErrSessionClosed))
+}
+
+func Test_shouldRecreateConnection(t *testing.T) {
+	ctx := context.Background()
+
+	require.False(t, shouldRecreateConnection(ctx, nil))
+	require.True(t, shouldRecreateConnection(ctx, &permanentNetError{}))
+}
+
+// TODO: while testing it appeared there were some errors that were getting string-ized
+// We want to eliminate these. 'stress.go' reproduces most of these as you disconnect
+// and reconnect.
+func Test_stringErrorsToEliminate(t *testing.T) {
+	require.True(t, shouldRecreateLink(errors.New("detach frame link detached")))
+	require.True(t, isRetryableAMQPError(context.Background(), errors.New("amqp: connection closed")))
+	require.True(t, IsCancelError(errors.New("context canceled")))
+}
+
+func Test_IsCancelError(t *testing.T) {
+	require.False(t, IsCancelError(nil))
+	require.False(t, IsCancelError(errors.New("not a cancel error")))
+
+	require.True(t, IsCancelError(errors.New("context canceled")))
+
+	require.True(t, IsCancelError(context.Canceled))
+	require.True(t, IsCancelError(context.DeadlineExceeded))
+	require.True(t, IsCancelError(fmt.Errorf("wrapped: %w", context.Canceled)))
+	require.True(t, IsCancelError(fmt.Errorf("wrapped: %w", context.DeadlineExceeded)))
 }

--- a/sdk/messaging/azservicebus/internal/retrier_test.go
+++ b/sdk/messaging/azservicebus/internal/retrier_test.go
@@ -12,32 +12,53 @@ import (
 )
 
 func TestRetrier(t *testing.T) {
-	retrier := NewBackoffRetrier(struct {
-		MaxRetries int
-		Factor     float64
-		Jitter     bool
-		Min        time.Duration
-		Max        time.Duration
-	}{
-		MaxRetries: 5,
-		Factor:     0,
+	t.Run("Basic", func(t *testing.T) {
+		retrier := NewBackoffRetrier(struct {
+			MaxRetries int
+			Factor     float64
+			Jitter     bool
+			Min        time.Duration
+			Max        time.Duration
+		}{
+			MaxRetries: 5,
+			Factor:     0,
+		})
+
+		require := require.New(t)
+
+		// first iteration is always free (ie, that's not the
+		// retry part)
+		require.True(retrier.Try(context.Background()))
+
+		// now we're doing retries
+		require.True(retrier.Try(context.Background()))
+		require.True(retrier.Try(context.Background()))
+		require.True(retrier.Try(context.Background()))
+		require.True(retrier.Try(context.Background()))
+		require.True(retrier.Try(context.Background()))
+
+		// and it's the 6th retry that fails since we've exhausted
+		// the retries we're allotted.
+		require.False(retrier.Try(context.Background()))
+		require.True(retrier.Exhausted())
 	})
 
-	require := require.New(t)
+	t.Run("Cancellation", func(t *testing.T) {
+		retrier := NewBackoffRetrier(struct {
+			MaxRetries int
+			Factor     float64
+			Jitter     bool
+			Min        time.Duration
+			Max        time.Duration
+		}{
+			MaxRetries: 5,
+			Factor:     0,
+		})
 
-	// first iteration is always free (ie, that's not the
-	// retry part)
-	require.True(retrier.Try(context.Background()))
-
-	// now we're doing retries
-	require.True(retrier.Try(context.Background()))
-	require.True(retrier.Try(context.Background()))
-	require.True(retrier.Try(context.Background()))
-	require.True(retrier.Try(context.Background()))
-	require.True(retrier.Try(context.Background()))
-
-	// and it's the 6th retry that fails since we've exhausted
-	// the retries we're allotted.
-	require.False(retrier.Try(context.Background()))
-	require.True(retrier.Exhausted())
+		// first iteration is always free (ie, that's not the
+		// retry part)
+		cancelledContext, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.False(t, retrier.Try(cancelledContext))
+	})
 }

--- a/sdk/messaging/azservicebus/internal/tracing.go
+++ b/sdk/messaging/azservicebus/internal/tracing.go
@@ -11,6 +11,46 @@ import (
 	"github.com/devigned/tab"
 )
 
+// link/connection recovery spans
+const (
+	SpanRecoverLink   = "sb.recover.link"
+	SpanRecoverClient = "sb.recover.client"
+)
+
+// authentication
+const (
+	SpanNegotiateClaim = "sb.auth.negotiateClaim"
+)
+
+// settlement
+const (
+	SpanCompleteMessage = "sb.receiver.complete"
+)
+
+// processor
+const (
+	SpanProcessorLoop    = "sb.processor.main"
+	SpanProcessorMessage = "sb.processor.message"
+	SpanProcessorClose   = "sb.processor.close"
+)
+
+// mgmt client spans
+const (
+	spanNameRenewLock              = "sb.mgmt.RenewLock"
+	spanNameReceiveDeferred        = "sb.mgmt.ReceiveDeferred"
+	spanNameSendDisposition        = "sb.mgmt.SendDisposition"
+	spanNameScheduleMessage        = "sb.mgmt.Schedule"
+	spanNameCancelScheduledMessage = "sb.mgmt.CancelScheduled"
+	spanPeekFromSequenceNumber     = "sb.mgmt.PeekSequenceNumber"
+	spanNameRecover                = "sb.mgmt.Recover"
+	spanNameTryRecover             = "sb.mgmt.TryRecover"
+)
+
+// sender spans
+const (
+	SpanSendMessageFmt string = "sb.SendMessage.%s"
+)
+
 func (ns *Namespace) startSpanFromContext(ctx context.Context, operationName string) (context.Context, tab.Spanner) {
 	ctx, span := tab.StartSpan(ctx, operationName)
 	ApplyComponentInfo(span)
@@ -39,7 +79,7 @@ func applyResponseInfo(span tab.Spanner, res *http.Response) {
 
 func (mc *mgmtClient) startSpanFromContext(ctx context.Context, operationName string) (context.Context, tab.Spanner) {
 	ctx, span := startConsumerSpanFromContext(ctx, operationName)
-	span.AddAttributes(tab.StringAttribute("message_bus.destination", mc.managementPath))
+	span.AddAttributes(tab.StringAttribute("message_bus.destination", mc.links.ManagementPath()))
 	return ctx, span
 }
 
@@ -48,7 +88,7 @@ func (mc *mgmtClient) startProducerSpanFromContext(ctx context.Context, operatio
 	ApplyComponentInfo(span)
 	span.AddAttributes(
 		tab.StringAttribute("span.kind", "producer"),
-		tab.StringAttribute("message_bus.destination", mc.managementPath),
+		tab.StringAttribute("message_bus.destination", mc.links.ManagementPath()),
 	)
 	return ctx, span
 }

--- a/sdk/messaging/azservicebus/internal/utils/stderrTracer.go
+++ b/sdk/messaging/azservicebus/internal/utils/stderrTracer.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package utils
 
 import (

--- a/sdk/messaging/azservicebus/internal/utils/stderrTracer.go
+++ b/sdk/messaging/azservicebus/internal/utils/stderrTracer.go
@@ -1,0 +1,146 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync/atomic"
+
+	"github.com/devigned/tab"
+)
+
+// StderrTracer is a wrapper around a NoOpTracer so we can add in a
+// really simple stderr logger. Useful for seeing some of the internal
+// state changes (like retries) that aren't normally customer visible.
+// Ex:
+// tab.Register(&utils.StderrTracer{
+// 		Include: map[string]bool{
+// 			internal.SpanProcessorClose: true,
+// 			internal.SpanProcessorLoop:  true,
+// 			internal.SpanNegotiateClaim: true,
+// 			internal.SpanRecoverLink:    true,
+// 			internal.SpanRecoverClient:  true,
+// 		},
+// 	})
+type StderrTracer struct {
+	NoOpTracer  *tab.NoOpTracer
+	spanCounter int64
+	Include     map[string]bool
+}
+
+type spanOpKey string
+
+// StartSpan forwards to NoOpTracer.StartSpan.
+func (t *StderrTracer) StartSpan(ctx context.Context, operationName string, opts ...interface{}) (context.Context, tab.Spanner) {
+	id := t.getSpanID(operationName)
+
+	if id == -1 {
+		return t.NoOpTracer.StartSpan(ctx, operationName, opts...)
+	}
+
+	log.Printf("[%d] START(%s)", id, operationName)
+
+	ctx = context.WithValue(ctx, spanOpKey("operationName"), operationName)
+	return ctx, &stderrSpanner{name: operationName, id: id}
+}
+
+// StartSpanWithRemoteParent forwards to NoOpTracer.StartSpanWithRemoteParent.
+func (t *StderrTracer) StartSpanWithRemoteParent(ctx context.Context, operationName string, carrier tab.Carrier, opts ...interface{}) (context.Context, tab.Spanner) {
+	id := t.getSpanID(operationName)
+
+	if id == -1 {
+		return t.NoOpTracer.StartSpan(ctx, operationName, opts...)
+	}
+
+	log.Printf("[%d] START(%s), remote parent", id, operationName)
+	ctx = context.WithValue(ctx, spanOpKey("operationName"), operationName)
+
+	return ctx, &stderrSpanner{name: operationName, id: id}
+}
+
+// FromContext creates a stderrSpanner to allow for our stderrLogger to be created.
+func (t *StderrTracer) FromContext(ctx context.Context) tab.Spanner {
+	id := atomic.AddInt64(&t.spanCounter, 1)
+	operationName := ctx.Value(spanOpKey("operationName"))
+
+	val, ok := operationName.(string)
+
+	if !ok {
+		val = "<unknown>"
+	}
+
+	log.Printf("[%d] START(%s), from context", id, val)
+	return &stderrSpanner{name: val, id: id}
+}
+
+// NewContext forwards to NoOpTracer.NewContext
+func (t *StderrTracer) NewContext(parent context.Context, span tab.Spanner) context.Context {
+	return t.NoOpTracer.NewContext(parent, span)
+}
+
+func (t *StderrTracer) getSpanID(operationName string) int64 {
+	_, ok := t.Include[operationName]
+
+	if !ok {
+		return -1
+	}
+
+	return atomic.AddInt64(&t.spanCounter, 1)
+}
+
+type stderrSpanner struct {
+	id      int64
+	name    string
+	spanner tab.Spanner
+	attrs   []tab.Attribute
+}
+
+func (s *stderrSpanner) AddAttributes(attributes ...tab.Attribute) {
+	s.attrs = append(s.attrs, attributes...)
+}
+
+func (s *stderrSpanner) End() {
+	log.Printf("[%d] END(%s)\n%s", s.id, s.name, sprintfAttributes(s.attrs))
+}
+
+func (s *stderrSpanner) Logger() tab.Logger {
+	return &stderrLogger{id: s.id}
+}
+
+func (s *stderrSpanner) Inject(carrier tab.Carrier) error {
+	return nil
+}
+
+func (s *stderrSpanner) InternalSpan() interface{} {
+	return s.spanner.InternalSpan()
+}
+
+type stderrLogger struct {
+	id int64
+}
+
+func sprintfAttributes(attributes []tab.Attribute) string {
+	s := ""
+
+	for _, attr := range attributes {
+		s += fmt.Sprintf("  %s=%v\n", attr.Key, attr.Value)
+	}
+
+	return s
+}
+
+func (l *stderrLogger) Info(msg string, attributes ...tab.Attribute) {
+	log.Printf("[%d] INFO: %s\n%s", l.id, msg, sprintfAttributes(attributes))
+}
+
+func (l *stderrLogger) Error(err error, attributes ...tab.Attribute) {
+	log.Printf("[%d] ERROR: error: %v\n%s", l.id, err, sprintfAttributes(attributes))
+}
+
+func (l *stderrLogger) Fatal(msg string, attributes ...tab.Attribute) {
+	log.Printf("[%d] FATAL: %s\n%s", l.id, msg, sprintfAttributes(attributes))
+}
+
+func (l *stderrLogger) Debug(msg string, attributes ...tab.Attribute) {
+	log.Printf("[%d] DEBUG: %s\n%s", l.id, msg, sprintfAttributes(attributes))
+}

--- a/sdk/messaging/azservicebus/liveTestHelpers_test.go
+++ b/sdk/messaging/azservicebus/liveTestHelpers_test.go
@@ -14,17 +14,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupLiveTest(t *testing.T) (*Client, func(), string) {
+func setupLiveTest(t *testing.T, qd *internal.QueueDescription) (*Client, func(), string) {
 	cs := getConnectionString(t)
 
 	serviceBusClient, err := NewClientWithConnectionString(cs)
 	require.NoError(t, err)
 
-	queueName, cleanupQueue := createQueue(t, cs, nil)
+	queueName, cleanupQueue := createQueue(t, cs, qd)
 
 	testCleanup := func() {
 		require.NoError(t, serviceBusClient.Close(context.Background()))
 		cleanupQueue()
+		require.NoError(t, serviceBusClient.Close(context.Background()))
 	}
 
 	return serviceBusClient, testCleanup, queueName

--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -30,10 +30,7 @@ type (
 		// available in the raw AMQP message, but not exported by default
 		// GroupSequence  *uint32
 
-		// these are internal attributes and will no longer be exported
-		// after we merge jhendrix's refactor to move the settlement
-		// methods from the message to the receiver.
-		RawAMQPMessage *amqp.Message
+		rawAMQPMessage *amqp.Message
 
 		// the 'revision' of the link we received on (ie, if it was recovered it won't match)
 		linkRevision uint64
@@ -196,7 +193,7 @@ func newReceivedMessage(ctxForLogging context.Context, amqpMsg *amqp.Message) *R
 		Message: Message{
 			Body: amqpMsg.GetData(),
 		},
-		RawAMQPMessage: amqpMsg,
+		rawAMQPMessage: amqpMsg,
 	}
 
 	if amqpMsg.Properties != nil {

--- a/sdk/messaging/azservicebus/messageBatch_test.go
+++ b/sdk/messaging/azservicebus/messageBatch_test.go
@@ -13,11 +13,12 @@ func TestMessageBatchUnitTests(t *testing.T) {
 	t.Run("addMessages", func(t *testing.T) {
 		mb := newMessageBatch(1000)
 
-		err := mb.Add(&Message{
+		added, err := mb.Add(&Message{
 			Body: []byte("hello world"),
 		})
 
 		require.NoError(t, err)
+		require.True(t, added)
 		require.EqualValues(t, 1, mb.Len())
 		require.EqualValues(t, 195, mb.Size())
 	})
@@ -25,15 +26,11 @@ func TestMessageBatchUnitTests(t *testing.T) {
 	t.Run("addTooManyMessages", func(t *testing.T) {
 		mb := newMessageBatch(1)
 
-		err := mb.Add(&Message{
+		added, err := mb.Add(&Message{
 			Body: []byte("hello world"),
 		})
 
-		switch err.(type) {
-		case MessageTooLarge:
-			require.EqualValues(t, 0, mb.Len())
-		default:
-			require.Fail(t, "Incorrect error was returned")
-		}
+		require.False(t, added)
+		require.Nil(t, err)
 	})
 }

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -13,9 +13,24 @@ import (
 
 var errReceiveAndDeleteReceiver = errors.New("messages that are received in receiveAndDelete mode are not settlable")
 
+type settler interface {
+	CompleteMessage(ctx context.Context, message *ReceivedMessage) error
+	AbandonMessage(ctx context.Context, message *ReceivedMessage) error
+	DeferMessage(ctx context.Context, message *ReceivedMessage) error
+	DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options ...DeadLetterOption) error
+}
+
 type messageSettler struct {
 	links                  internal.AMQPLinks
 	onlyDoBackupSettlement bool
+	baseRetrier            internal.Retrier
+}
+
+func newMessageSettler(links internal.AMQPLinks, baseRetrier internal.Retrier) settler {
+	return &messageSettler{
+		links:       links,
+		baseRetrier: baseRetrier,
+	}
 }
 
 func (s *messageSettler) useManagementLink(m *ReceivedMessage, linkRevision uint64) bool {
@@ -24,70 +39,78 @@ func (s *messageSettler) useManagementLink(m *ReceivedMessage, linkRevision uint
 		m.linkRevision != linkRevision
 }
 
-// CompleteMessage completes a message, deleting it from the queue or subscription.
-func (s *messageSettler) CompleteMessage(ctx context.Context, message *ReceivedMessage) error {
+func (s *messageSettler) settleWithRetries(ctx context.Context, message *ReceivedMessage, settleFn func(mgmt internal.MgmtClient, linkRevision uint64) error) error {
 	if s == nil {
 		return errReceiveAndDeleteReceiver
 	}
 
-	_, _, mgmt, linkRevision, err := s.links.Get(ctx)
+	retrier := s.baseRetrier.Copy()
+	var lastErr error
 
-	if err != nil {
-		return err
+	for retrier.Try(ctx) {
+		var mgmt internal.MgmtClient
+		var linkRevision uint64
+
+		_, _, mgmt, linkRevision, lastErr = s.links.Get(ctx)
+
+		if lastErr != nil {
+			_ = s.links.RecoverIfNeeded(ctx, lastErr)
+			continue
+		}
+
+		lastErr := settleFn(mgmt, linkRevision)
+
+		if lastErr != nil {
+			_ = s.links.RecoverIfNeeded(ctx, lastErr)
+			continue
+		}
+
+		break
 	}
 
-	if s.useManagementLink(message, linkRevision) {
-		return mgmt.SendDisposition(ctx, bytesToAMQPUUID(message.LockToken), internal.Disposition{Status: internal.CompletedDisposition})
-	}
+	return lastErr
+}
 
-	return message.RawAMQPMessage.Accept(ctx)
+// CompleteMessage completes a message, deleting it from the queue or subscription.
+func (s *messageSettler) CompleteMessage(ctx context.Context, message *ReceivedMessage) error {
+	return s.settleWithRetries(ctx, message, func(mgmt internal.MgmtClient, linkRevision uint64) error {
+		if s.useManagementLink(message, linkRevision) {
+			return mgmt.SendDisposition(ctx, bytesToAMQPUUID(message.LockToken), internal.Disposition{Status: internal.CompletedDisposition})
+		} else {
+			return message.RawAMQPMessage.Accept(ctx)
+		}
+	})
 }
 
 // AbandonMessage will cause a message to be returned to the queue or subscription.
 // This will increment its delivery count, and potentially cause it to be dead lettered
 // depending on your queue or subscription's configuration.
 func (s *messageSettler) AbandonMessage(ctx context.Context, message *ReceivedMessage) error {
-	if s == nil {
-		return errReceiveAndDeleteReceiver
-	}
-
-	_, _, mgmt, linkRevision, err := s.links.Get(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	if s.useManagementLink(message, linkRevision) {
-		d := internal.Disposition{
-			Status: internal.AbandonedDisposition,
+	return s.settleWithRetries(ctx, message, func(mgmt internal.MgmtClient, linkRevision uint64) error {
+		if s.useManagementLink(message, linkRevision) {
+			d := internal.Disposition{
+				Status: internal.AbandonedDisposition,
+			}
+			return mgmt.SendDisposition(ctx, bytesToAMQPUUID(message.LockToken), d)
 		}
-		return mgmt.SendDisposition(ctx, bytesToAMQPUUID(message.LockToken), d)
-	}
 
-	return message.RawAMQPMessage.Modify(ctx, false, false, nil)
+		return message.RawAMQPMessage.Modify(ctx, false, false, nil)
+	})
 }
 
 // DeferMessage will cause a message to be deferred. Deferred messages
 // can be received using `Receiver.ReceiveDeferredMessages`.
 func (s *messageSettler) DeferMessage(ctx context.Context, message *ReceivedMessage) error {
-	if s == nil {
-		return errReceiveAndDeleteReceiver
-	}
-
-	_, _, mgmt, linkRevision, err := s.links.Get(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	if s.useManagementLink(message, linkRevision) {
-		d := internal.Disposition{
-			Status: internal.DeferredDisposition,
+	return s.settleWithRetries(ctx, message, func(mgmt internal.MgmtClient, linkRevision uint64) error {
+		if s.useManagementLink(message, linkRevision) {
+			d := internal.Disposition{
+				Status: internal.DeferredDisposition,
+			}
+			return mgmt.SendDisposition(ctx, bytesToAMQPUUID(message.LockToken), d)
 		}
-		return mgmt.SendDisposition(ctx, bytesToAMQPUUID(message.LockToken), d)
-	}
 
-	return message.RawAMQPMessage.Modify(ctx, false, true, nil)
+		return message.RawAMQPMessage.Modify(ctx, false, true, nil)
+	})
 }
 
 type DeadLetterOptions struct {
@@ -123,62 +146,54 @@ func DeadLetterWithPropertiesToModify(propertiesToModify map[string]interface{})
 // queue or subscription. To receive these messages create a receiver with `Client.NewReceiver()`
 // using the `ReceiverWithSubQueue()` option.
 func (s *messageSettler) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options ...DeadLetterOption) error {
-	if s == nil {
-		return errReceiveAndDeleteReceiver
-	}
+	return s.settleWithRetries(ctx, message, func(mgmt internal.MgmtClient, linkRevision uint64) error {
+		deadLetterOptions := &DeadLetterOptions{}
 
-	deadLetterOptions := &DeadLetterOptions{}
-
-	for _, opt := range options {
-		if err := opt(deadLetterOptions); err != nil {
-			return err
+		for _, opt := range options {
+			if err := opt(deadLetterOptions); err != nil {
+				return err
+			}
 		}
-	}
 
-	_, _, mgmt, linkRevision, err := s.links.Get(ctx)
+		reason := ""
 
-	if err != nil {
-		return err
-	}
-
-	reason := ""
-
-	if deadLetterOptions.reason != nil {
-		reason = *deadLetterOptions.reason
-	}
-
-	description := ""
-
-	if deadLetterOptions.errorDescription != nil {
-		description = *deadLetterOptions.errorDescription
-	}
-
-	if s.useManagementLink(message, linkRevision) {
-		d := internal.Disposition{
-			Status:                internal.SuspendedDisposition,
-			DeadLetterDescription: &description,
-			DeadLetterReason:      &reason,
+		if deadLetterOptions.reason != nil {
+			reason = *deadLetterOptions.reason
 		}
-		return mgmt.SendDisposition(ctx, bytesToAMQPUUID(message.LockToken), d)
-	}
 
-	info := map[string]interface{}{
-		"DeadLetterReason":           reason,
-		"DeadLetterErrorDescription": description,
-	}
+		description := ""
 
-	if deadLetterOptions.propertiesToModify != nil {
-		for key, val := range deadLetterOptions.propertiesToModify {
-			info[key] = val
+		if deadLetterOptions.errorDescription != nil {
+			description = *deadLetterOptions.errorDescription
 		}
-	}
 
-	amqpErr := amqp.Error{
-		Condition: "com.microsoft:dead-letter",
-		Info:      info,
-	}
+		if s.useManagementLink(message, linkRevision) {
+			d := internal.Disposition{
+				Status:                internal.SuspendedDisposition,
+				DeadLetterDescription: &description,
+				DeadLetterReason:      &reason,
+			}
+			return mgmt.SendDisposition(ctx, bytesToAMQPUUID(message.LockToken), d)
+		}
 
-	return message.RawAMQPMessage.Reject(ctx, &amqpErr)
+		info := map[string]interface{}{
+			"DeadLetterReason":           reason,
+			"DeadLetterErrorDescription": description,
+		}
+
+		if deadLetterOptions.propertiesToModify != nil {
+			for key, val := range deadLetterOptions.propertiesToModify {
+				info[key] = val
+			}
+		}
+
+		amqpErr := amqp.Error{
+			Condition: "com.microsoft:dead-letter",
+			Info:      info,
+		}
+
+		return message.RawAMQPMessage.Reject(ctx, &amqpErr)
+	})
 }
 
 func bytesToAMQPUUID(bytes [16]byte) *amqp.UUID {

--- a/sdk/messaging/azservicebus/processor.go
+++ b/sdk/messaging/azservicebus/processor.go
@@ -76,24 +76,6 @@ func ProcessorWithReceiveMode(receiveMode ReceiveMode) ProcessorOption {
 	}
 }
 
-// ProcessorWithQueue configures a processor to connect to a queue.
-func ProcessorWithQueue(queue string) ProcessorOption {
-	return func(processor *Processor) error {
-		processor.config.Entity.Queue = queue
-		return nil
-	}
-}
-
-// ProcessorWithSubscription configures a processor to connect to a subscription
-// associated with a topic.
-func ProcessorWithSubscription(topic string, subscription string) ProcessorOption {
-	return func(processor *Processor) error {
-		processor.config.Entity.Topic = topic
-		processor.config.Entity.Subscription = subscription
-		return nil
-	}
-}
-
 // ProcessorWithAutoComplete enables or disables auto-completion/abandon of messages
 // When this option is enabled the result of the `processMessage` handler determines whether
 // the message is abandoned (if an `error` is returned) or completed (if `nil` is returned).
@@ -357,4 +339,22 @@ func (p *Processor) processMessage(ctx context.Context, receiver internal.AMQPRe
 	}
 
 	return nil
+}
+
+// processorWithQueue configures a processor to connect to a queue.
+func processorWithQueue(queue string) ProcessorOption {
+	return func(processor *Processor) error {
+		processor.config.Entity.Queue = queue
+		return nil
+	}
+}
+
+// processorWithSubscription configures a processor to connect to a subscription
+// associated with a topic.
+func processorWithSubscription(topic string, subscription string) ProcessorOption {
+	return func(processor *Processor) error {
+		processor.config.Entity.Topic = topic
+		processor.config.Entity.Subscription = subscription
+		return nil
+	}
 }

--- a/sdk/messaging/azservicebus/processor_test.go
+++ b/sdk/messaging/azservicebus/processor_test.go
@@ -161,11 +161,11 @@ func TestProcessorUnitTests(t *testing.T) {
 	require.EqualValues(t, SubQueueTransfer, p.config.Entity.subqueue)
 
 	p = &Processor{}
-	require.NoError(t, ProcessorWithQueue("queue1")(p))
+	require.NoError(t, processorWithQueue("queue1")(p))
 	require.EqualValues(t, "queue1", p.config.Entity.Queue)
 
 	p = &Processor{}
-	require.NoError(t, ProcessorWithSubscription("topic1", "subscription1")(p))
+	require.NoError(t, processorWithSubscription("topic1", "subscription1")(p))
 	require.EqualValues(t, "topic1", p.config.Entity.Topic)
 	require.EqualValues(t, "subscription1", p.config.Entity.Subscription)
 

--- a/sdk/messaging/azservicebus/processor_test.go
+++ b/sdk/messaging/azservicebus/processor_test.go
@@ -116,7 +116,9 @@ func TestProcessorReceiveWith100MessagesWithMaxConcurrency(t *testing.T) {
 
 	require.NoError(t, err)
 
-	defer processor.Close(context.Background()) // multiple close is fine
+	defer func() {
+		require.NoError(t, processor.Close(context.Background())) // multiple close is fine
+	}()
 
 	var messages []string
 	mu := sync.Mutex{}

--- a/sdk/messaging/azservicebus/processor_test.go
+++ b/sdk/messaging/azservicebus/processor_test.go
@@ -102,9 +102,11 @@ func TestProcessorReceiveWith100MessagesWithMaxConcurrency(t *testing.T) {
 		// have been sent.
 		for i := 0; i < numMessages; i++ {
 			expectedBodies = append(expectedBodies, fmt.Sprintf("hello world %03d", i))
-			require.NoError(t, batch.Add(&Message{
+			added, err := batch.Add(&Message{
 				Body: []byte(expectedBodies[len(expectedBodies)-1]),
-			}))
+			})
+			require.NoError(t, err)
+			require.True(t, added)
 		}
 
 		require.NoError(t, sender.SendMessage(context.Background(), batch))

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -90,24 +90,6 @@ func ReceiverWithReceiveMode(receiveMode ReceiveMode) ReceiverOption {
 	}
 }
 
-// receiverWithQueue configures a receiver to connect to a queue.
-func receiverWithQueue(queue string) ReceiverOption {
-	return func(receiver *Receiver) error {
-		receiver.config.Entity.Queue = queue
-		return nil
-	}
-}
-
-// receiverWithSubscription configures a receiver to connect to a subscription
-// associated with a topic.
-func receiverWithSubscription(topic string, subscription string) ReceiverOption {
-	return func(receiver *Receiver) error {
-		receiver.config.Entity.Topic = topic
-		receiver.config.Entity.Subscription = subscription
-		return nil
-	}
-}
-
 func newReceiver(ns internal.NamespaceWithNewAMQPLinks, cleanupOnClose func(), options ...ReceiverOption) (*Receiver, error) {
 	receiver := &Receiver{
 		config: receiverConfig{
@@ -566,4 +548,22 @@ func createLinkOptions(mode ReceiveMode, entityPath string) []amqp.LinkOption {
 	}
 
 	return opts
+}
+
+// receiverWithQueue configures a receiver to connect to a queue.
+func receiverWithQueue(queue string) ReceiverOption {
+	return func(receiver *Receiver) error {
+		receiver.config.Entity.Queue = queue
+		return nil
+	}
+}
+
+// receiverWithSubscription configures a receiver to connect to a subscription
+// associated with a topic.
+func receiverWithSubscription(topic string, subscription string) ReceiverOption {
+	return func(receiver *Receiver) error {
+		receiver.config.Entity.Topic = topic
+		receiver.config.Entity.Subscription = subscription
+		return nil
+	}
 }

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
@@ -41,21 +42,24 @@ const (
 // Receiver receives messages using pull based functions (ReceiveMessages).
 // For push-based receiving via callbacks look at the `Processor` type.
 type Receiver struct {
-	settler *messageSettler
+	settler settler
 
-	config struct {
-		ReceiveMode    ReceiveMode
-		FullEntityPath string
-		Entity         entity
-
-		RetryOptions struct {
-			Times int
-			Delay time.Duration
-		}
-	}
+	config receiverConfig
 
 	lastPeekedSequenceNumber int64
 	amqpLinks                internal.AMQPLinks
+
+	mu        sync.Mutex
+	receiving bool
+}
+
+type receiverConfig struct {
+	ReceiveMode    ReceiveMode
+	FullEntityPath string
+	Entity         entity
+
+	baseRetrier    internal.Retrier
+	cleanupOnClose func()
 }
 
 const defaultLinkRxBuffer = 2048
@@ -63,7 +67,7 @@ const defaultLinkRxBuffer = 2048
 // ReceiverOption represents an option for a receiver.
 // Some examples:
 // - `ReceiverWithReceiveMode` to configure the receive mode,
-// - `ReceiverWithQueue` to target a queue.
+// - `ReceiverWithSubQueue` to connect to a subqueue, like a dead letter queue
 type ReceiverOption func(receiver *Receiver) error
 
 // ReceiverWithSubQueue allows you to open the sub queue (ie: dead letter queues, transfer dead letter queues)
@@ -86,17 +90,17 @@ func ReceiverWithReceiveMode(receiveMode ReceiveMode) ReceiverOption {
 	}
 }
 
-// ReceiverWithQueue configures a receiver to connect to a queue.
-func ReceiverWithQueue(queue string) ReceiverOption {
+// receiverWithQueue configures a receiver to connect to a queue.
+func receiverWithQueue(queue string) ReceiverOption {
 	return func(receiver *Receiver) error {
 		receiver.config.Entity.Queue = queue
 		return nil
 	}
 }
 
-// ReceiverWithSubscription configures a receiver to connect to a subscription
+// receiverWithSubscription configures a receiver to connect to a subscription
 // associated with a topic.
-func ReceiverWithSubscription(topic string, subscription string) ReceiverOption {
+func receiverWithSubscription(topic string, subscription string) ReceiverOption {
 	return func(receiver *Receiver) error {
 		receiver.config.Entity.Topic = topic
 		receiver.config.Entity.Subscription = subscription
@@ -104,18 +108,18 @@ func ReceiverWithSubscription(topic string, subscription string) ReceiverOption 
 	}
 }
 
-func newReceiver(ns internal.NamespaceWithNewAMQPLinks, options ...ReceiverOption) (*Receiver, error) {
+func newReceiver(ns internal.NamespaceWithNewAMQPLinks, cleanupOnClose func(), options ...ReceiverOption) (*Receiver, error) {
 	receiver := &Receiver{
-		config: struct {
-			ReceiveMode    ReceiveMode
-			FullEntityPath string
-			Entity         entity
-			RetryOptions   struct {
-				Times int
-				Delay time.Duration
-			}
-		}{
+		config: receiverConfig{
 			ReceiveMode: PeekLock,
+			// TODO: make this configurable
+			baseRetrier: internal.NewBackoffRetrier(internal.BackoffRetrierParams{
+				Factor:     2,
+				Min:        1,
+				Max:        time.Minute,
+				MaxRetries: 5,
+			}),
+			cleanupOnClose: cleanupOnClose,
 		},
 		lastPeekedSequenceNumber: 0,
 	}
@@ -139,7 +143,7 @@ func newReceiver(ns internal.NamespaceWithNewAMQPLinks, options ...ReceiverOptio
 
 	// 'nil' settler handles returning an error message for receiveAndDelete links.
 	if receiver.config.ReceiveMode == PeekLock {
-		receiver.settler = &messageSettler{links: receiver.amqpLinks}
+		receiver.settler = newMessageSettler(receiver.amqpLinks, receiver.config.baseRetrier)
 	}
 
 	return receiver, nil
@@ -182,6 +186,34 @@ func ReceiveWithMaxTimeAfterFirstMessage(max time.Duration) ReceiveOption {
 // 2. An implicit timeout (default: 1 second) that starts after the first
 //    message has been received. This time can be adjusted with `ReceiveWithMaxTimeAfterFirstMessage`
 func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options ...ReceiveOption) ([]*ReceivedMessage, error) {
+	r.mu.Lock()
+	isReceiving := r.receiving
+
+	if !isReceiving {
+		r.receiving = true
+
+		defer func() {
+			r.mu.Lock()
+			r.receiving = false
+			r.mu.Unlock()
+		}()
+	}
+	r.mu.Unlock()
+
+	if isReceiving {
+		return nil, errors.New("receiver is already receiving messages. ReceiveMessages() cannot be called concurrently.")
+	}
+
+	messages, err := r.receiveMessagesImpl(ctx, maxMessages, options...)
+
+	if err != nil {
+		_ = r.amqpLinks.RecoverIfNeeded(ctx, err)
+	}
+
+	return messages, err
+}
+
+func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, options ...ReceiveOption) ([]*ReceivedMessage, error) {
 	// There are three phases for this function:
 	// Phase 1. <receive, respecting user cancellation>
 	// Phase 2. <check error and exit if fatal>
@@ -203,61 +235,110 @@ func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options
 	_, receiver, _, _, err := r.amqpLinks.Get(ctx)
 
 	if err != nil {
+		if err := r.amqpLinks.RecoverIfNeeded(ctx, err); err != nil {
+			return nil, err
+		}
+
 		return nil, err
 	}
 
 	if err := receiver.IssueCredit(uint32(maxMessages)); err != nil {
+		_ = r.amqpLinks.RecoverIfNeeded(ctx, err)
 		return nil, err
 	}
 
-	var messages []*ReceivedMessage
+	messages, err := r.getMessages(ctx, receiver, maxMessages, ropts)
 
-	userCtx := ctx
-	ctx, cancel := context.WithTimeout(ctx, ropts.maxWaitTime)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(messages) == maxMessages {
+		// no drain needed, all messages arrived.
+		return messages, nil
+	}
+
+	return r.drainLink(receiver, messages)
+}
+
+// drainLink initiates a drainLink on the link. Service Bus will send whatever messages it might have still had and
+// set our link credit to 0.
+func (r *Receiver) drainLink(receiver internal.AMQPReceiver, messages []*ReceivedMessage) ([]*ReceivedMessage, error) {
+	receiveCtx, cancelReceive := context.WithCancel(context.Background())
+
+	// start the drain asynchronously. Note that we ignore the user's context at this point
+	// since draining makes sure we don't get messages when nobody is receiving.
+	go func() {
+		if err := receiver.DrainCredit(context.Background()); err != nil {
+			tab.For(receiveCtx).Debug(fmt.Sprintf("Draining of credit failed. link will be closed and will re-open on next receive: %s", err.Error()))
+
+			// if the drain fails we just close the link so it'll re-open at the next receive.
+			if err := r.amqpLinks.Close(context.Background(), false); err != nil {
+				tab.For(receiveCtx).Debug(fmt.Sprintf("Failed to close links on ReceiveMessages cleanup. Not fatal: %s", err.Error()))
+			}
+		}
+		cancelReceive()
+	}()
+
+	// Receive until the drain completes, at which point it'll cancel
+	// our context.
+	// NOTE: That's a gap here where we need to be able to drain _only_ the internally cached messages
+	// in the receiver. Filed as https://github.com/Azure/go-amqp/issues/71
+	for {
+		am, err := receiver.Receive(receiveCtx)
+
+		if internal.IsCancelError(err) {
+			break
+		} else if err != nil {
+			// something fatal happened, we will just
+			_ = r.amqpLinks.Close(context.TODO(), false)
+
+			if len(messages) > 0 {
+				return messages, nil
+			} else {
+				return nil, err
+			}
+		}
+
+		messages = append(messages, newReceivedMessage(receiveCtx, am))
+	}
+
+	return messages, nil
+}
+
+// getMessages receives messages until a link failure, timeout or the user
+// cancels their context.
+func (r *Receiver) getMessages(theirCtx context.Context, receiver internal.AMQPReceiver, maxMessages int, ropts *ReceiveOptions) ([]*ReceivedMessage, error) {
+	ctx, cancel := context.WithTimeout(theirCtx, ropts.maxWaitTime)
 	defer cancel()
 
-	// the last "interesting" error to occur in the sequence. Used only if we end up receiving zero
-	// messages (otherwise, the user won't even know to look at the return value).
-	var fatalError error
+	var messages []*ReceivedMessage
 
-	// Phase 1 - <receive, respecting user cancellation>
-	// receive until we get our first interruption:
-	// - context is cancelled because the user cancelled it
-	// - context is cancelled because one of our timeouts hit
-	// - we get all the messages we asked for
 	for {
+		var amqpMessage *amqp.Message
 		amqpMessage, err := receiver.Receive(ctx)
 
 		if err != nil {
-			fatalError = err
-
-			if !isCancelled(err) {
-				// link is dead. Close our local state so it can be recreated again on the next
-				// receiveMessage and return whatever we have (or this error if that's the best we can do)
-				if err := r.amqpLinks.Close(ctx, false); err != nil {
-					tab.For(ctx).Debug(fmt.Sprintf("failed when closing local links (not fatal): %s", err.Error()))
-				}
-
-				if len(messages) == 0 {
-					return nil, fatalError
-				} else {
-					// if they got _some_ messages we don't consider that fatal.
-					return messages, nil
-				}
+			if internal.IsCancelError(err) {
+				return messages, nil
 			}
-			break
+
+			// we'll close (instead of recovering) since we are holding onto messages
+			// and want to get them back to the user ASAP. (recovery will just happen
+			// on the next call to receive)
+			if err := r.amqpLinks.Close(context.Background(), false); err != nil {
+				tab.For(ctx).Debug(fmt.Sprintf("Failed to close links on ReceiveMessages cleanup. Not fatal: %s", err.Error()))
+			}
+			return nil, err
 		}
 
 		messages = append(messages, newReceivedMessage(ctx, amqpMessage))
 
 		if len(messages) == maxMessages {
-			break
+			return messages, nil
 		}
 
 		if len(messages) == 1 {
-			// once we receive a message we start a secondary
-			// timer - this one allows us to guarantee we don't hold
-			// onto messages too long.
 			go func() {
 				select {
 				case <-time.After(ropts.maxWaitTimeAfterFirstMessage):
@@ -267,83 +348,6 @@ func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options
 				}
 			}()
 		}
-	}
-
-	// Phase 2 - if the error is fatal (ie, link is dead) it's okay to just bail out since
-	// there's nothing to drain.
-	// For any other non-fatal errors we'll continue on to the drain phase, so we ensure
-	// no messages are sitting around without anyone to receive them.
-	if fatalError != nil {
-		if isCancelled(fatalError) {
-			select {
-			case <-userCtx.Done():
-				// user cancelled, finalError contains their cancellation error.
-				// if we end up getting no messages we'll end up returning it.
-				break
-			default:
-				// our normal timeout fired, no actual error
-				fatalError = nil
-			}
-		} else {
-			// link is dead. Close our local state so it can be recreated again on the next
-			// receiveMessage and return whatever we have (or this error if that's the best we can do)
-			if err := r.amqpLinks.Close(ctx, false); err != nil {
-				tab.For(ctx).Debug(fmt.Sprintf("failed when closing local links (not fatal): %s", err.Error()))
-			}
-
-			if len(messages) == 0 {
-				return nil, fatalError
-			} else {
-				// if they got _some_ messages we don't consider that fatal.
-				return messages, nil
-			}
-		}
-	}
-
-	// Phase 3. <drain the link and leave it in a good state>
-	// Check if there are any outstanding messsages/credits. If there are we want to drain
-	// so we can flush the link.
-	if len(messages) < maxMessages {
-		ctx, cancel = context.WithCancel(context.Background())
-
-		// this drain phase is pretty critical - we don't allow it to be interrupted otherwise the link is
-		// in an inconsistent state.
-		go func() {
-			if err := receiver.DrainCredit(ctx); err != nil {
-				tab.For(ctx).Debug(fmt.Sprintf("Draining of credit failed. link will be closed and will re-open on next receive: %s", err.Error()))
-
-				// if the drain fails we just close the link so it'll re-open at the next receive.
-				if err := r.amqpLinks.Close(ctx, false); err != nil {
-					tab.For(ctx).Debug(fmt.Sprintf("Failed to close links on ReceiveMessages cleanup. Not fatal: %s", err.Error()))
-				}
-			}
-			cancel()
-		}()
-
-		// now just read until drain completes
-		// That's a gap here where we need to be able to drain _only_ the internally cached messages
-		// in the receiver. Filed as https://github.com/Azure/go-amqp/issues/71
-		for {
-			am, err := receiver.Receive(ctx)
-
-			if isCancelled(err) {
-				fatalError = err
-				break
-			}
-
-			messages = append(messages, newReceivedMessage(ctx, am))
-		}
-	}
-
-	if len(messages) > 0 {
-		// if we were able to receive some messages then we're okay to just say this
-		// operation worked and basically 'erase' the error.
-		// This should be okay since messages can still be settled (they'll go against
-		// the management link) and the link has been recovered so the next receive should
-		// work as well.
-		return messages, nil
-	} else {
-		return nil, fatalError
 	}
 }
 
@@ -466,6 +470,7 @@ func (r *Receiver) receiveMessage(ctx context.Context, options ...ReceiveOption)
 
 // Close permanently closes the receiver.
 func (r *Receiver) Close(ctx context.Context) error {
+	r.config.cleanupOnClose()
 	return r.amqpLinks.Close(ctx, true)
 }
 
@@ -561,14 +566,4 @@ func createLinkOptions(mode ReceiveMode, entityPath string) []amqp.LinkOption {
 	}
 
 	return opts
-}
-
-func isCancelled(err error) bool {
-	if errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) ||
-		err.Error() == "context canceled" { // go-amqp is returning this when I cancel
-		return true
-	}
-
-	return false
 }

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -131,8 +131,8 @@ func newReceiver(ns internal.NamespaceWithNewAMQPLinks, cleanupOnClose func(), o
 	return receiver, nil
 }
 
-// ReceiveOptions are options for the ReceiveMessages function.
-type ReceiveOptions struct {
+// receiveOptions are options for the ReceiveMessages function.
+type receiveOptions struct {
 	maxWaitTime                  time.Duration
 	maxWaitTimeAfterFirstMessage time.Duration
 }
@@ -140,13 +140,13 @@ type ReceiveOptions struct {
 // ReceiveOption represents an option for a `ReceiveMessages`.
 // For example, `ReceiveWithMaxWaitTime` will let you configure the
 // maxmimum amount of time to wait for messages to arrive.
-type ReceiveOption func(options *ReceiveOptions) error
+type ReceiveOption func(options *receiveOptions) error
 
 // ReceiveWithMaxWaitTime configures how long to wait for the first
 // message in a set of messages to arrive.
 // Default: 60 seconds
 func ReceiveWithMaxWaitTime(max time.Duration) ReceiveOption {
-	return func(options *ReceiveOptions) error {
+	return func(options *receiveOptions) error {
 		options.maxWaitTime = max
 		return nil
 	}
@@ -156,7 +156,7 @@ func ReceiveWithMaxWaitTime(max time.Duration) ReceiveOption {
 // message arrives, to wait before returning.
 // Default: 1 second
 func ReceiveWithMaxTimeAfterFirstMessage(max time.Duration) ReceiveOption {
-	return func(options *ReceiveOptions) error {
+	return func(options *receiveOptions) error {
 		options.maxWaitTimeAfterFirstMessage = max
 		return nil
 	}
@@ -203,7 +203,7 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 	//    user isn't actually waiting for anymore. So we make sure that #3 runs if the
 	//    link is still valid.
 	// Phase 3. <drain the link and leave it in a good state>
-	ropts := &ReceiveOptions{
+	ropts := &receiveOptions{
 		maxWaitTime:                  time.Minute,
 		maxWaitTimeAfterFirstMessage: time.Second,
 	}
@@ -290,7 +290,7 @@ func (r *Receiver) drainLink(receiver internal.AMQPReceiver, messages []*Receive
 
 // getMessages receives messages until a link failure, timeout or the user
 // cancels their context.
-func (r *Receiver) getMessages(theirCtx context.Context, receiver internal.AMQPReceiver, maxMessages int, ropts *ReceiveOptions) ([]*ReceivedMessage, error) {
+func (r *Receiver) getMessages(theirCtx context.Context, receiver internal.AMQPReceiver, maxMessages int, ropts *receiveOptions) ([]*ReceivedMessage, error) {
 	ctx, cancel := context.WithTimeout(theirCtx, ropts.maxWaitTime)
 	defer cancel()
 

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -317,7 +317,7 @@ func (b badMgmtClient) ReceiveDeferred(ctx context.Context, mode ReceiveMode, se
 
 func TestReceiverDeferUnitTests(t *testing.T) {
 	r := &Receiver{
-		amqpLinks: internal.FakeAMQPLinks{
+		amqpLinks: &internal.FakeAMQPLinks{
 			Err: errors.New("links are dead"),
 		},
 	}
@@ -327,7 +327,7 @@ func TestReceiverDeferUnitTests(t *testing.T) {
 	require.Nil(t, messages)
 
 	r = &Receiver{
-		amqpLinks: internal.FakeAMQPLinks{
+		amqpLinks: &internal.FakeAMQPLinks{
 			Mgmt: &badMgmtClient{},
 		},
 	}

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -231,10 +231,12 @@ func TestReceiverPeek(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
-		err = batch.Add(&Message{
+		added, err := batch.Add(&Message{
 			Body: []byte(fmt.Sprintf("Message %d", i)),
 		})
+
 		require.NoError(t, err)
+		require.True(t, added)
 	}
 
 	err = sender.SendMessage(ctx, batch)

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestReceiverSendFiveReceiveFive(t *testing.T) {
-	serviceBusClient, cleanup, queueName := setupLiveTest(t)
+	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()
 
 	sender, err := serviceBusClient.NewSender(queueName)
@@ -31,7 +31,7 @@ func TestReceiverSendFiveReceiveFive(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	receiver, err := serviceBusClient.NewReceiver(ReceiverWithQueue(queueName))
+	receiver, err := serviceBusClient.NewReceiverForQueue(queueName)
 	require.NoError(t, err)
 
 	messages, err := receiver.ReceiveMessages(context.Background(), 5)
@@ -51,7 +51,7 @@ func TestReceiverSendFiveReceiveFive(t *testing.T) {
 }
 
 func TestReceiverForceTimeoutWithTooFewMessages(t *testing.T) {
-	serviceBusClient, cleanup, queueName := setupLiveTest(t)
+	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()
 
 	sender, err := serviceBusClient.NewSender(queueName)
@@ -63,7 +63,7 @@ func TestReceiverForceTimeoutWithTooFewMessages(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	receiver, err := serviceBusClient.NewReceiver(ReceiverWithQueue(queueName))
+	receiver, err := serviceBusClient.NewReceiverForQueue(queueName)
 	require.NoError(t, err)
 
 	// there's only one message, requesting more messages will time out.
@@ -78,7 +78,7 @@ func TestReceiverForceTimeoutWithTooFewMessages(t *testing.T) {
 }
 
 func TestReceiverAbandon(t *testing.T) {
-	serviceBusClient, cleanup, queueName := setupLiveTest(t)
+	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()
 
 	sender, err := serviceBusClient.NewSender(queueName)
@@ -90,7 +90,7 @@ func TestReceiverAbandon(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	receiver, err := serviceBusClient.NewReceiver(ReceiverWithQueue(queueName))
+	receiver, err := serviceBusClient.NewReceiverForQueue(queueName)
 	require.NoError(t, err)
 
 	messages, err := receiver.ReceiveMessages(context.Background(), 1)
@@ -110,7 +110,7 @@ func TestReceiverAbandon(t *testing.T) {
 // Receive has two timeouts - an explicit one (passed in via ReceiveWithMaxTimeout)
 // and an implicit one that kicks in as soon as we receive our first message.
 func TestReceiveWithEarlyFirstMessageTimeout(t *testing.T) {
-	serviceBusClient, cleanup, queueName := setupLiveTest(t)
+	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()
 
 	sender, err := serviceBusClient.NewSender(queueName)
@@ -122,7 +122,7 @@ func TestReceiveWithEarlyFirstMessageTimeout(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	receiver, err := serviceBusClient.NewReceiver(ReceiverWithQueue(queueName))
+	receiver, err := serviceBusClient.NewReceiverForQueue(queueName)
 	require.NoError(t, err)
 
 	startTime := time.Now()
@@ -138,7 +138,7 @@ func TestReceiveWithEarlyFirstMessageTimeout(t *testing.T) {
 }
 
 func TestReceiverSendAndReceiveManyTimes(t *testing.T) {
-	serviceBusClient, cleanup, queueName := setupLiveTest(t)
+	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()
 
 	sender, err := serviceBusClient.NewSender(queueName)
@@ -153,7 +153,7 @@ func TestReceiverSendAndReceiveManyTimes(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	receiver, err := serviceBusClient.NewReceiver(ReceiverWithQueue(queueName))
+	receiver, err := serviceBusClient.NewReceiverForQueue(queueName)
 	require.NoError(t, err)
 
 	var allMessages []*ReceivedMessage
@@ -174,7 +174,7 @@ func TestReceiverSendAndReceiveManyTimes(t *testing.T) {
 }
 
 func TestReceiverDeferAndReceiveDeferredMessages(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t)
+	client, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()
 
 	sender, err := client.NewSender(queueName)
@@ -189,7 +189,7 @@ func TestReceiverDeferAndReceiveDeferredMessages(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	receiver, err := client.NewReceiver(ReceiverWithQueue(queueName))
+	receiver, err := client.NewReceiverForQueue(queueName)
 	require.NoError(t, err)
 
 	messages, err := receiver.ReceiveMessages(ctx, 1)
@@ -217,7 +217,7 @@ func TestReceiverDeferAndReceiveDeferredMessages(t *testing.T) {
 }
 
 func TestReceiverPeek(t *testing.T) {
-	serviceBusClient, cleanup, queueName := setupLiveTest(t)
+	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()
 
 	sender, err := serviceBusClient.NewSender(queueName)
@@ -240,7 +240,7 @@ func TestReceiverPeek(t *testing.T) {
 	err = sender.SendMessage(ctx, batch)
 	require.NoError(t, err)
 
-	receiver, err := serviceBusClient.NewReceiver(ReceiverWithQueue(queueName))
+	receiver, err := serviceBusClient.NewReceiverForQueue(queueName)
 	require.NoError(t, err)
 
 	// wait for a message to show up
@@ -290,11 +290,11 @@ func TestReceiverOptions(t *testing.T) {
 	require.EqualValues(t, SubQueueTransfer, receiver.config.Entity.subqueue)
 
 	receiver = &Receiver{}
-	require.NoError(t, ReceiverWithQueue("queue1")(receiver))
+	require.NoError(t, receiverWithQueue("queue1")(receiver))
 	require.EqualValues(t, "queue1", receiver.config.Entity.Queue)
 
 	receiver = &Receiver{}
-	require.NoError(t, ReceiverWithSubscription("topic1", "subscription1")(receiver))
+	require.NoError(t, receiverWithSubscription("topic1", "subscription1")(receiver))
 	require.EqualValues(t, "topic1", receiver.config.Entity.Topic)
 	require.EqualValues(t, "subscription1", receiver.config.Entity.Subscription)
 

--- a/sdk/messaging/azservicebus/samples/processor/processor_sample.go
+++ b/sdk/messaging/azservicebus/samples/processor/processor_sample.go
@@ -54,11 +54,11 @@ func main() {
 	// receive the messages we've sent using the processor
 	//
 
-	processor, err := serviceBusClient.NewProcessor(
+	processor, err := serviceBusClient.NewProcessorForQueue(
+		queue,
 		// Will auto-complete or auto-abandon messages, based on the result from you callback
 		// (this is true, by default)
 		azservicebus.ProcessorWithAutoComplete(true),
-		azservicebus.ProcessorWithQueue(queue),
 		// or for a subscription
 		// azservicebus.ProcessorWithSubscription("topic", "subscription"),
 		azservicebus.ProcessorWithReceiveMode(azservicebus.PeekLock),
@@ -68,7 +68,7 @@ func main() {
 		log.Fatalf("Failed to create processor: %s", err.Error())
 	}
 
-	err = processor.Start(func(message *azservicebus.ReceivedMessage) error {
+	err = processor.Start(context.Background(), func(message *azservicebus.ReceivedMessage) error {
 		log.Printf("Received message %s", string(message.Body))
 
 		// with auto-complete on (which it is, by default):

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -114,7 +114,7 @@ func (sender *Sender) createSenderLink(ctx context.Context, session internal.AMQ
 	return amqpSender, nil, nil
 }
 
-func newSender(ns *internal.Namespace, queueOrTopic string, cleanupOnClose func()) (*Sender, error) {
+func newSender(ns internal.NamespaceWithNewAMQPLinks, queueOrTopic string, cleanupOnClose func()) (*Sender, error) {
 	sender := &Sender{
 		queueOrTopic:   queueOrTopic,
 		cleanupOnClose: cleanupOnClose,

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -27,15 +27,17 @@ func Test_Sender_SendBatchOfTwo(t *testing.T) {
 	batch, err := sender.NewMessageBatch(ctx)
 	require.NoError(t, err)
 
-	err = batch.Add(&Message{
+	added, err := batch.Add(&Message{
 		Body: []byte("[0] message in batch"),
 	})
 	require.NoError(t, err)
+	require.True(t, added)
 
-	err = batch.Add(&Message{
+	added, err = batch.Add(&Message{
 		Body: []byte("[1] message in batch"),
 	})
 	require.NoError(t, err)
+	require.True(t, added)
 
 	err = sender.SendMessage(ctx, batch)
 	require.NoError(t, err)
@@ -78,17 +80,19 @@ func Test_Sender_UsingPartitionedQueue(t *testing.T) {
 	batch, err := sender.NewMessageBatch(context.Background())
 	require.NoError(t, err)
 
-	err = batch.Add(&Message{
+	added, err := batch.Add(&Message{
 		Body:         []byte("2. Message in batch"),
 		PartitionKey: to.StringPtr("partitionKey1"),
 	})
 	require.NoError(t, err)
+	require.True(t, added)
 
-	err = batch.Add(&Message{
+	added, err = batch.Add(&Message{
 		Body:         []byte("3. Message in batch"),
 		PartitionKey: to.StringPtr("partitionKey1"),
 	})
 	require.NoError(t, err)
+	require.True(t, added)
 
 	err = sender.SendMessage(context.Background(), batch)
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -13,78 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSender(t *testing.T) {
-	cs := getConnectionString(t)
+func Test_Sender_SendBatchOfTwo(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, nil)
+	defer cleanup()
 
-	serviceBusClient, err := NewClientWithConnectionString(cs)
-	require.NoError(t, err)
+	ctx := context.Background()
 
-	t.Run("testSendBatchOfTwo", func(t *testing.T) {
-		queueName, cleanupQueue := createQueue(t, cs, nil)
-		defer cleanupQueue()
-		testSendBatchOfTwo(context.Background(), t, serviceBusClient, queueName)
-	})
-
-	t.Run("testUsingPartitionedQueue", func(t *testing.T) {
-		queueName, cleanupQueue := createQueue(t, cs, &internal.QueueDescription{
-			EnablePartitioning: to.BoolPtr(true),
-		})
-		defer cleanupQueue()
-
-		sender, err := serviceBusClient.NewSender(queueName)
-		require.NoError(t, err)
-		defer sender.Close(context.Background())
-
-		receiver, err := serviceBusClient.NewReceiver(
-			ReceiverWithQueue(queueName),
-			ReceiverWithReceiveMode(ReceiveAndDelete))
-		require.NoError(t, err)
-		defer receiver.Close(context.Background())
-
-		err = sender.SendMessage(context.Background(), &Message{
-			ID:           "message ID",
-			Body:         []byte("1. single partitioned message"),
-			PartitionKey: to.StringPtr("partitionKey1"),
-		})
-		require.NoError(t, err)
-
-		batch, err := sender.NewMessageBatch(context.Background())
-		require.NoError(t, err)
-
-		err = batch.Add(&Message{
-			Body:         []byte("2. Message in batch"),
-			PartitionKey: to.StringPtr("partitionKey1"),
-		})
-		require.NoError(t, err)
-
-		err = batch.Add(&Message{
-			Body:         []byte("3. Message in batch"),
-			PartitionKey: to.StringPtr("partitionKey1"),
-		})
-		require.NoError(t, err)
-
-		err = sender.SendMessage(context.Background(), batch)
-		require.NoError(t, err)
-
-		messages, err := receiver.ReceiveMessages(context.Background(), 1+2)
-		require.NoError(t, err)
-
-		sort.Sort(receivedMessages(messages))
-
-		require.EqualValues(t, 3, len(messages))
-
-		require.EqualValues(t, "partitionKey1", *messages[0].PartitionKey)
-		require.EqualValues(t, "partitionKey1", *messages[1].PartitionKey)
-		require.EqualValues(t, "partitionKey1", *messages[2].PartitionKey)
-	})
-}
-
-func TestSenderUnitTests(t *testing.T) {
-
-}
-
-func testSendBatchOfTwo(ctx context.Context, t *testing.T, serviceBusClient *Client, queueName string) {
-	sender, err := serviceBusClient.NewSender(queueName)
+	sender, err := client.NewSender(queueName)
 	require.NoError(t, err)
 
 	defer sender.Close(ctx)
@@ -105,8 +40,8 @@ func testSendBatchOfTwo(ctx context.Context, t *testing.T, serviceBusClient *Cli
 	err = sender.SendMessage(ctx, batch)
 	require.NoError(t, err)
 
-	receiver, err := serviceBusClient.NewReceiver(
-		ReceiverWithQueue(queueName),
+	receiver, err := client.NewReceiverForQueue(
+		queueName,
 		ReceiverWithReceiveMode(ReceiveAndDelete))
 	require.NoError(t, err)
 	defer receiver.Close(ctx)
@@ -117,20 +52,57 @@ func testSendBatchOfTwo(ctx context.Context, t *testing.T, serviceBusClient *Cli
 	require.EqualValues(t, []string{"[0] message in batch", "[1] message in batch"}, getSortedBodies(messages))
 }
 
-func getSortedBodiesFromChannel(ch chan *ReceivedMessage) []string {
-	var messages []*ReceivedMessage
+func Test_Sender_UsingPartitionedQueue(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, &internal.QueueDescription{
+		EnablePartitioning: to.BoolPtr(true),
+	})
+	defer cleanup()
 
-channelLoop:
-	for {
-		select {
-		case m := <-ch:
-			messages = append(messages, m)
-		default:
-			break channelLoop
-		}
-	}
+	sender, err := client.NewSender(queueName)
+	require.NoError(t, err)
+	defer sender.Close(context.Background())
 
-	return getSortedBodies(messages)
+	receiver, err := client.NewReceiverForQueue(
+		queueName,
+		ReceiverWithReceiveMode(ReceiveAndDelete))
+	require.NoError(t, err)
+	defer receiver.Close(context.Background())
+
+	err = sender.SendMessage(context.Background(), &Message{
+		ID:           "message ID",
+		Body:         []byte("1. single partitioned message"),
+		PartitionKey: to.StringPtr("partitionKey1"),
+	})
+	require.NoError(t, err)
+
+	batch, err := sender.NewMessageBatch(context.Background())
+	require.NoError(t, err)
+
+	err = batch.Add(&Message{
+		Body:         []byte("2. Message in batch"),
+		PartitionKey: to.StringPtr("partitionKey1"),
+	})
+	require.NoError(t, err)
+
+	err = batch.Add(&Message{
+		Body:         []byte("3. Message in batch"),
+		PartitionKey: to.StringPtr("partitionKey1"),
+	})
+	require.NoError(t, err)
+
+	err = sender.SendMessage(context.Background(), batch)
+	require.NoError(t, err)
+
+	messages, err := receiver.ReceiveMessages(context.Background(), 1+2)
+	require.NoError(t, err)
+
+	sort.Sort(receivedMessages(messages))
+
+	require.EqualValues(t, 3, len(messages))
+
+	require.EqualValues(t, "partitionKey1", *messages[0].PartitionKey)
+	require.EqualValues(t, "partitionKey1", *messages[1].PartitionKey)
+	require.EqualValues(t, "partitionKey1", *messages[2].PartitionKey)
 }
 
 func getSortedBodies(messages []*ReceivedMessage) []string {

--- a/sdk/messaging/azservicebus/stress/stress.go
+++ b/sdk/messaging/azservicebus/stress/stress.go
@@ -26,15 +26,15 @@ import (
 // | summarize Sum=sum(valueCount) by bin(timestamp, 30s), name
 // | render timechart
 
-type Stats struct {
+type stats struct {
 	Sent     int32
 	Received int32
 	Errors   int32
 }
 
-var processorStats Stats
-var receiverStats Stats
-var senderStats Stats
+var processorStats stats
+var receiverStats stats
+var senderStats stats
 
 func main() {
 	runBasicSendAndReceiveTest()
@@ -136,11 +136,11 @@ func runBasicSendAndReceiveTest() {
 		}
 	}()
 
-	go func() {
-		for {
-			runBatchReceiver(ctx, serviceBusClient, topicName, "batch", telemetryClient)
-		}
-	}()
+	// go func() {
+	// 	for {
+	// 		runBatchReceiver(ctx, serviceBusClient, topicName, "batch", telemetryClient)
+	// 	}
+	// }()
 
 	go func() {
 		for {
@@ -280,7 +280,7 @@ func createSubscriptions(telemetryClient appinsights.TelemetryClient, connection
 	}, nil
 }
 
-func trackException(stats *Stats, telemetryClient appinsights.TelemetryClient, message string, err error) {
+func trackException(stats *stats, telemetryClient appinsights.TelemetryClient, message string, err error) {
 	log.Printf("Exception: %s: %s", message, err.Error())
 
 	if stats != nil {

--- a/sdk/messaging/azservicebus/stress/stress.go
+++ b/sdk/messaging/azservicebus/stress/stress.go
@@ -130,17 +130,21 @@ func runBasicSendAndReceiveTest() {
 		},
 	})
 
-	go func() {
-		for {
-			runProcessor(ctx, serviceBusClient, topicName, "processor", telemetryClient)
-		}
-	}()
+	runProcessorTest := true
 
-	// go func() {
-	// 	for {
-	// 		runBatchReceiver(ctx, serviceBusClient, topicName, "batch", telemetryClient)
-	// 	}
-	// }()
+	if runProcessorTest {
+		go func() {
+			for {
+				runProcessor(ctx, serviceBusClient, topicName, "processor", telemetryClient)
+			}
+		}()
+	} else {
+		go func() {
+			for {
+				runBatchReceiver(ctx, serviceBusClient, topicName, "batch", telemetryClient)
+			}
+		}()
+	}
 
 	go func() {
 		for {


### PR DESCRIPTION
Adding in a _lot_ more error handling code and retries in areas that were shown to be weak during Service Bus stress testing.

The biggest issues were mostly:
- Some errors weren't accounted for at all (for instance, credentials expiring seemed to fall through)
- Some errors are getting stringized (or aren't proper types) so there's some string matching code in the errors.go. Shouldn't be permanent, but we can recognize things fairly well with what's in there now.
- Some spots didn't have retries but really needed them. For safety, there are also some bugs we're working around where some frames appear to be arriving out of order in go-amqp. Things like that just result in a connection reset, which should recover it.

Also, mopped up some other problems:
- Fixed the naming of the `NewReceiver/NewProcessor` functions so they have ForQueue/ForSubscription in them
- Moved over a version of the stderrTracer from event-hubs. It's not _great_, but it's functional enough to work with the stress.go. It could use some work though, it's a bit hacked together.