### PR TITLE
[service-bus] Remove variadic config

### DIFF
--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -32,8 +32,8 @@ type Client struct {
 	links       map[uint64]internal.Closeable
 }
 
-// ClientOptions can be used to configure options in the client
-// beyond authentication.
+// ClientOptions contains options for the `NewClient` and `NewClientWithConnectionString`
+// functions.
 type ClientOptions struct {
 	// TLSConfig configures a client with a custom *tls.Config.
 	TLSConfig *tls.Config

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -119,11 +119,10 @@ func newClientImpl(config clientConfig, options ...ClientOption) (*Client, error
 }
 
 // NewProcessor creates a Processor for a queue.
-func (client *Client) NewProcessorForQueue(queue string, options ...ProcessorOption) (*Processor, error) {
-	options = append(options, processorWithQueue(queue))
+func (client *Client) NewProcessorForQueue(queue string, options *ProcessorOptions) (*Processor, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 
-	processor, err := newProcessor(client.namespace, cleanupOnClose, options...)
+	processor, err := newProcessor(client.namespace, &entity{Queue: queue}, cleanupOnClose, options)
 
 	if err != nil {
 		return nil, err
@@ -134,11 +133,10 @@ func (client *Client) NewProcessorForQueue(queue string, options ...ProcessorOpt
 }
 
 // NewProcessor creates a Processor for a subscription.
-func (client *Client) NewProcessorForSubscription(topic string, subscription string, options ...ProcessorOption) (*Processor, error) {
-	options = append(options, processorWithSubscription(topic, subscription))
+func (client *Client) NewProcessorForSubscription(topic string, subscription string, options *ProcessorOptions) (*Processor, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 
-	processor, err := newProcessor(client.namespace, cleanupOnClose, options...)
+	processor, err := newProcessor(client.namespace, &entity{Topic: topic, Subscription: subscription}, cleanupOnClose, options)
 
 	if err != nil {
 		return nil, err
@@ -149,11 +147,9 @@ func (client *Client) NewProcessorForSubscription(topic string, subscription str
 }
 
 // NewReceiver creates a Receiver for a queue. A receiver allows you to receive messages.
-func (client *Client) NewReceiverForQueue(queue string, options ...ReceiverOption) (*Receiver, error) {
+func (client *Client) NewReceiverForQueue(queue string, options *ReceiverOptions) (*Receiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
-	options = append(options, receiverWithQueue(queue))
-
-	receiver, err := newReceiver(client.namespace, cleanupOnClose, options...)
+	receiver, err := newReceiver(client.namespace, &entity{Queue: queue}, cleanupOnClose, options)
 
 	if err != nil {
 		return nil, err
@@ -164,11 +160,9 @@ func (client *Client) NewReceiverForQueue(queue string, options ...ReceiverOptio
 }
 
 // NewReceiver creates a Receiver for a subscription. A receiver allows you to receive messages.
-func (client *Client) NewReceiverForSubscription(topic string, subscription string, options ...ReceiverOption) (*Receiver, error) {
+func (client *Client) NewReceiverForSubscription(topic string, subscription string, options *ReceiverOptions) (*Receiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
-	options = append(options, receiverWithSubscription(topic, subscription))
-
-	receiver, err := newReceiver(client.namespace, cleanupOnClose, options...)
+	receiver, err := newReceiver(client.namespace, &entity{Topic: topic, Subscription: subscription}, cleanupOnClose, options)
 
 	if err != nil {
 		return nil, err

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -26,7 +26,7 @@ func TestNewClientWithAzureIdentity(t *testing.T) {
 		t.Skip("Azure Identity compatible credentials not configured")
 	}
 
-	client, err := NewClient(ns, dac)
+	client, err := NewClient(ns, dac, nil)
 	require.NoError(t, err)
 
 	sender, err := client.NewSender(queue)
@@ -57,28 +57,28 @@ func TestNewClientUnitTests(t *testing.T) {
 	t.Run("WithTokenCredential", func(t *testing.T) {
 		fakeTokenCredential := struct{ azcore.TokenCredential }{}
 
-		client, err := NewClient("fake.something", fakeTokenCredential)
+		client, err := NewClient("fake.something", fakeTokenCredential, nil)
 		require.NoError(t, err)
 
 		require.NoError(t, err)
 		require.EqualValues(t, fakeTokenCredential, client.config.credential)
 		require.EqualValues(t, "fake.something", client.config.fullyQualifiedNamespace)
 
-		client, err = NewClient("mysb.windows.servicebus.net", fakeTokenCredential)
+		client, err = NewClient("mysb.windows.servicebus.net", fakeTokenCredential, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, fakeTokenCredential, client.config.credential)
 		require.EqualValues(t, "mysb.windows.servicebus.net", client.config.fullyQualifiedNamespace)
 
-		_, err = NewClientWithConnectionString("")
+		_, err = NewClientWithConnectionString("", nil)
 		require.EqualError(t, err, "connectionString must not be empty")
 
-		_, err = NewClient("", fakeTokenCredential)
+		_, err = NewClient("", fakeTokenCredential, nil)
 		require.EqualError(t, err, "fullyQualifiedNamespace must not be empty")
 
-		_, err = NewClient("mysb", fakeTokenCredential)
+		_, err = NewClient("mysb", fakeTokenCredential, nil)
 		require.EqualError(t, err, "fullyQualifiedNamespace is not properly formed. Should be similar to 'myservicebus.servicebus.windows.net'")
 
-		_, err = NewClient("fake.something", nil)
+		_, err = NewClient("fake.something", nil, nil)
 		require.EqualError(t, err, "credential was nil")
 
 		// (really all part of the same functionality)
@@ -95,7 +95,7 @@ func TestNewClientUnitTests(t *testing.T) {
 
 	t.Run("CloseAndLinkTracking", func(t *testing.T) {
 		setupClient := func() (*Client, *internal.FakeNS) {
-			client, err := NewClient("fake.something", struct{ azcore.TokenCredential }{})
+			client, err := NewClient("fake.something", struct{ azcore.TokenCredential }{}, nil)
 			require.NoError(t, err)
 
 			ns := &internal.FakeNS{

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -35,12 +35,12 @@ func TestNewClientWithAzureIdentity(t *testing.T) {
 	err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")})
 	require.NoError(t, err)
 
-	receiver, err := client.NewReceiverForQueue(queue)
+	receiver, err := client.NewReceiverForQueue(queue, nil)
 	require.NoError(t, err)
 	actualSettler, _ := receiver.settler.(*messageSettler)
 	actualSettler.onlyDoBackupSettlement = true // this'll also exercise the management link
 
-	messages, err := receiver.ReceiveMessages(context.TODO(), 1)
+	messages, err := receiver.ReceiveMessages(context.TODO(), 1, nil)
 	require.NoError(t, err)
 
 	require.EqualValues(t, []string{"hello - authenticating with a TokenCredential"}, getSortedBodies(messages))
@@ -119,7 +119,7 @@ func TestNewClientUnitTests(t *testing.T) {
 		require.True(t, ns.AMQPLinks.ClosedPermanently())
 
 		client, ns = setupClient()
-		_, err = client.NewReceiverForQueue("hello")
+		_, err = client.NewReceiverForQueue("hello", nil)
 
 		require.NoError(t, err)
 		require.EqualValues(t, 1, len(client.links))
@@ -129,7 +129,7 @@ func TestNewClientUnitTests(t *testing.T) {
 		require.True(t, ns.AMQPLinks.ClosedPermanently())
 
 		client, ns = setupClient()
-		_, err = client.NewReceiverForSubscription("hello", "world")
+		_, err = client.NewReceiverForSubscription("hello", "world", nil)
 
 		require.NoError(t, err)
 		require.EqualValues(t, 1, len(client.links))
@@ -139,7 +139,7 @@ func TestNewClientUnitTests(t *testing.T) {
 		require.EqualValues(t, 1, ns.AMQPLinks.Closed)
 
 		client, ns = setupClient()
-		_, err = client.NewProcessorForQueue("hello")
+		_, err = client.NewProcessorForQueue("hello", nil)
 
 		require.NoError(t, err)
 		require.EqualValues(t, 1, len(client.links))
@@ -149,7 +149,7 @@ func TestNewClientUnitTests(t *testing.T) {
 		require.EqualValues(t, 1, ns.AMQPLinks.Closed)
 
 		client, ns = setupClient()
-		_, err = client.NewProcessorForSubscription("hello", "world")
+		_, err = client.NewProcessorForSubscription("hello", "world", nil)
 
 		require.NoError(t, err)
 		require.EqualValues(t, 1, len(client.links))

--- a/sdk/messaging/azservicebus/example_sending_message_batch_test.go
+++ b/sdk/messaging/azservicebus/example_sending_message_batch_test.go
@@ -38,7 +38,7 @@ func ExampleSender_NewMessageBatch() {
 	sender, err := client.NewSender(queueName)
 	panicOnError("Failed to create sender", err)
 
-	batch, err := sender.NewMessageBatch(context.TODO())
+	batch, err := sender.NewMessageBatch(context.TODO(), nil)
 	panicOnError("Failed to create message batch", err)
 
 	messagesToSend := []*azservicebus.Message{

--- a/sdk/messaging/azservicebus/example_sending_message_batch_test.go
+++ b/sdk/messaging/azservicebus/example_sending_message_batch_test.go
@@ -32,7 +32,7 @@ func ExampleSender_NewMessageBatch() {
 		return
 	}
 
-	client, err := azservicebus.NewClientWithConnectionString(connectionString)
+	client, err := azservicebus.NewClientWithConnectionString(connectionString, nil)
 	panicOnError("Failed to create client", err)
 
 	sender, err := client.NewSender(queueName)

--- a/sdk/messaging/azservicebus/liveTestHelpers_test.go
+++ b/sdk/messaging/azservicebus/liveTestHelpers_test.go
@@ -17,7 +17,7 @@ import (
 func setupLiveTest(t *testing.T, qd *internal.QueueDescription) (*Client, func(), string) {
 	cs := getConnectionString(t)
 
-	serviceBusClient, err := NewClientWithConnectionString(cs)
+	serviceBusClient, err := NewClientWithConnectionString(cs, nil)
 	require.NoError(t, err)
 
 	queueName, cleanupQueue := createQueue(t, cs, qd)

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -114,9 +114,16 @@ func (s *messageSettler) DeferMessage(ctx context.Context, message *ReceivedMess
 	})
 }
 
+// DeadLetterOptions describe the reason and error description for dead lettering
+// a message using the `Receiver.DeadLetterMessage()`
 type DeadLetterOptions struct {
-	ErrorDescription   *string
-	Reason             *string
+	// ErrorDescription that caused the dead lettering of the message.
+	ErrorDescription *string
+
+	// Reason for dead lettering the message.
+	Reason *string
+
+	// PropertiesToModify specifies properties to modify in the message when it is dead lettered.
 	PropertiesToModify map[string]interface{}
 }
 

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -17,7 +17,7 @@ type settler interface {
 	CompleteMessage(ctx context.Context, message *ReceivedMessage) error
 	AbandonMessage(ctx context.Context, message *ReceivedMessage) error
 	DeferMessage(ctx context.Context, message *ReceivedMessage) error
-	DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options ...DeadLetterOption) error
+	DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error
 }
 
 type messageSettler struct {

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -126,15 +126,16 @@ type DeadLetterOptions struct {
 func (s *messageSettler) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
 	return s.settleWithRetries(ctx, message, func(receiver internal.AMQPReceiver, mgmt internal.MgmtClient, linkRevision uint64) error {
 		reason := ""
-
-		if options.Reason != nil {
-			reason = *options.Reason
-		}
-
 		description := ""
 
-		if options.ErrorDescription != nil {
-			description = *options.ErrorDescription
+		if options != nil {
+			if options.Reason != nil {
+				reason = *options.Reason
+			}
+
+			if options.ErrorDescription != nil {
+				description = *options.ErrorDescription
+			}
 		}
 
 		if s.useManagementLink(message, linkRevision) {
@@ -151,7 +152,7 @@ func (s *messageSettler) DeadLetterMessage(ctx context.Context, message *Receive
 			"DeadLetterErrorDescription": description,
 		}
 
-		if options.PropertiesToModify != nil {
+		if options != nil && options.PropertiesToModify != nil {
 			for key, val := range options.PropertiesToModify {
 				info[key] = val
 			}

--- a/sdk/messaging/azservicebus/messageSettler_test.go
+++ b/sdk/messaging/azservicebus/messageSettler_test.go
@@ -22,7 +22,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg *ReceivedMessage
-	msg, err = receiver.receiveMessage(ctx)
+	msg, err = receiver.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, msg.DeliveryCount)
 
@@ -30,7 +30,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 	err = receiver.AbandonMessage(context.Background(), msg)
 	require.NoError(t, err)
 
-	msg, err = receiver.receiveMessage(ctx)
+	msg, err = receiver.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
@@ -38,7 +38,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 	err = receiver.DeadLetterMessage(ctx, msg)
 	require.NoError(t, err)
 
-	msg, err = deadLetterReceiver.receiveMessage(ctx)
+	msg, err = deadLetterReceiver.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
@@ -54,7 +54,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 	err = deadLetterReceiver.AbandonMessage(ctx, msg)
 	require.NoError(t, err)
 
-	msg, err = deadLetterReceiver.receiveMessage(ctx)
+	msg, err = deadLetterReceiver.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
@@ -77,7 +77,7 @@ func TestDeferredMessages(t *testing.T) {
 		require.NoError(t, err)
 
 		var msg *ReceivedMessage
-		msg, err = receiver.receiveMessage(ctx)
+		msg, err = receiver.receiveMessage(ctx, nil)
 		require.NoError(t, err)
 		require.NotNil(t, msg)
 
@@ -105,7 +105,7 @@ func TestDeferredMessages(t *testing.T) {
 		// BUG: we're timing out here, even though our abandon should have put the message
 		// back into the queue. It appears that settlement methods don't work on messages
 		// that have been received as deferred.
-		msg, err = receiver.receiveMessage(ctx)
+		msg, err = receiver.receiveMessage(ctx, nil)
 		require.NoError(t, err)
 		require.NotNil(t, msg)
 	})
@@ -117,7 +117,7 @@ func TestDeferredMessages(t *testing.T) {
 		require.NoError(t, err)
 
 		// check that the message made it to the dead letter queue
-		msg, err = deadLetterReceiver.receiveMessage(ctx)
+		msg, err = deadLetterReceiver.receiveMessage(ctx, nil)
 		require.NoError(t, err)
 
 		// remove it from the DLQ
@@ -176,21 +176,21 @@ func TestMessageSettlementUsingOnlyBackupSettlement(t *testing.T) {
 	actualSettler.onlyDoBackupSettlement = true
 
 	var msg *ReceivedMessage
-	msg, err = receiver.receiveMessage(ctx)
+	msg, err = receiver.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, msg.DeliveryCount)
 
 	err = receiver.AbandonMessage(context.Background(), msg)
 	require.NoError(t, err)
 
-	msg, err = receiver.receiveMessage(ctx)
+	msg, err = receiver.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
 	err = receiver.DeadLetterMessage(ctx, msg)
 	require.NoError(t, err)
 
-	msg, err = deadLetterReceiver.receiveMessage(ctx)
+	msg, err = deadLetterReceiver.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
@@ -235,15 +235,14 @@ func newTestStuff(t *testing.T) *testStuff {
 	}
 
 	var err error
-	testStuff.Receiver, err = client.NewReceiverForQueue(queueName)
+	testStuff.Receiver, err = client.NewReceiverForQueue(queueName, nil)
 	require.NoError(t, err)
 
 	testStuff.Sender, err = client.NewSender(queueName)
 	require.NoError(t, err)
 
 	testStuff.DeadLetterReceiver, err = client.NewReceiverForQueue(
-		queueName,
-		ReceiverWithSubQueue(SubQueueDeadLetter))
+		queueName, &ReceiverOptions{SubQueue: SubQueueDeadLetter})
 	require.NoError(t, err)
 
 	return testStuff

--- a/sdk/messaging/azservicebus/messageSettler_test.go
+++ b/sdk/messaging/azservicebus/messageSettler_test.go
@@ -35,7 +35,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
 	// message from queue -> DeadLetter -> to the dead letter queue
-	err = receiver.DeadLetterMessage(ctx, msg)
+	err = receiver.DeadLetterMessage(ctx, msg, nil)
 	require.NoError(t, err)
 
 	msg, err = deadLetterReceiver.receiveMessage(ctx, nil)
@@ -113,7 +113,7 @@ func TestDeferredMessages(t *testing.T) {
 	t.Run("DeadLetter", func(t *testing.T) {
 		msg := deferMessage()
 
-		err := receiver.DeadLetterMessage(ctx, msg)
+		err := receiver.DeadLetterMessage(ctx, msg, nil)
 		require.NoError(t, err)
 
 		// check that the message made it to the dead letter queue
@@ -187,7 +187,7 @@ func TestMessageSettlementUsingOnlyBackupSettlement(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
-	err = receiver.DeadLetterMessage(ctx, msg)
+	err = receiver.DeadLetterMessage(ctx, msg, nil)
 	require.NoError(t, err)
 
 	msg, err = deadLetterReceiver.receiveMessage(ctx, nil)

--- a/sdk/messaging/azservicebus/messageSettler_test.go
+++ b/sdk/messaging/azservicebus/messageSettler_test.go
@@ -249,7 +249,7 @@ func newTestStuff(t *testing.T) *testStuff {
 }
 
 func assertEntityEmpty(t *testing.T, receiver *Receiver) {
-	messages, err := receiver.PeekMessages(context.TODO(), 1)
+	messages, err := receiver.PeekMessages(context.TODO(), 1, nil)
 	require.NoError(t, err)
 	require.Empty(t, messages)
 }

--- a/sdk/messaging/azservicebus/messageSettler_test.go
+++ b/sdk/messaging/azservicebus/messageSettler_test.go
@@ -22,7 +22,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg *ReceivedMessage
-	msg, err = receiver.receiveMessage(ctx, nil)
+	msg, err = receiver.ReceiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, msg.DeliveryCount)
 
@@ -30,7 +30,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 	err = receiver.AbandonMessage(context.Background(), msg)
 	require.NoError(t, err)
 
-	msg, err = receiver.receiveMessage(ctx, nil)
+	msg, err = receiver.ReceiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
@@ -38,7 +38,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 	err = receiver.DeadLetterMessage(ctx, msg, nil)
 	require.NoError(t, err)
 
-	msg, err = deadLetterReceiver.receiveMessage(ctx, nil)
+	msg, err = deadLetterReceiver.ReceiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
@@ -54,7 +54,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 	err = deadLetterReceiver.AbandonMessage(ctx, msg)
 	require.NoError(t, err)
 
-	msg, err = deadLetterReceiver.receiveMessage(ctx, nil)
+	msg, err = deadLetterReceiver.ReceiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
@@ -77,7 +77,7 @@ func TestDeferredMessages(t *testing.T) {
 		require.NoError(t, err)
 
 		var msg *ReceivedMessage
-		msg, err = receiver.receiveMessage(ctx, nil)
+		msg, err = receiver.ReceiveMessage(ctx, nil)
 		require.NoError(t, err)
 		require.NotNil(t, msg)
 
@@ -86,7 +86,7 @@ func TestDeferredMessages(t *testing.T) {
 		err = receiver.DeferMessage(ctx, msg)
 		require.NoError(t, err)
 
-		msg, err = receiver.receiveDeferredMessage(ctx, *msg.SequenceNumber)
+		msg, err = receiver.ReceiveDeferredMessage(ctx, *msg.SequenceNumber)
 		require.NoError(t, err)
 
 		return msg
@@ -105,7 +105,7 @@ func TestDeferredMessages(t *testing.T) {
 		// BUG: we're timing out here, even though our abandon should have put the message
 		// back into the queue. It appears that settlement methods don't work on messages
 		// that have been received as deferred.
-		msg, err = receiver.receiveMessage(ctx, nil)
+		msg, err = receiver.ReceiveMessage(ctx, nil)
 		require.NoError(t, err)
 		require.NotNil(t, msg)
 	})
@@ -117,7 +117,7 @@ func TestDeferredMessages(t *testing.T) {
 		require.NoError(t, err)
 
 		// check that the message made it to the dead letter queue
-		msg, err = deadLetterReceiver.receiveMessage(ctx, nil)
+		msg, err = deadLetterReceiver.ReceiveMessage(ctx, nil)
 		require.NoError(t, err)
 
 		// remove it from the DLQ
@@ -143,7 +143,7 @@ func TestDeferredMessages(t *testing.T) {
 		err := receiver.DeferMessage(ctx, msg)
 		require.NoError(t, err)
 
-		msg, err = receiver.receiveDeferredMessage(ctx, *msg.SequenceNumber)
+		msg, err = receiver.ReceiveDeferredMessage(ctx, *msg.SequenceNumber)
 		require.NoError(t, err)
 
 		err = receiver.CompleteMessage(ctx, msg)
@@ -176,21 +176,21 @@ func TestMessageSettlementUsingOnlyBackupSettlement(t *testing.T) {
 	actualSettler.onlyDoBackupSettlement = true
 
 	var msg *ReceivedMessage
-	msg, err = receiver.receiveMessage(ctx, nil)
+	msg, err = receiver.ReceiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, msg.DeliveryCount)
 
 	err = receiver.AbandonMessage(context.Background(), msg)
 	require.NoError(t, err)
 
-	msg, err = receiver.receiveMessage(ctx, nil)
+	msg, err = receiver.ReceiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 
 	err = receiver.DeadLetterMessage(ctx, msg, nil)
 	require.NoError(t, err)
 
-	msg, err = deadLetterReceiver.receiveMessage(ctx, nil)
+	msg, err = deadLetterReceiver.ReceiveMessage(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, msg.DeliveryCount)
 

--- a/sdk/messaging/azservicebus/processor.go
+++ b/sdk/messaging/azservicebus/processor.go
@@ -16,6 +16,8 @@ import (
 	"github.com/devigned/tab"
 )
 
+// ProcessorOptions contains options for the `Client.NewProcessorForQueue` or
+// `Client.NewProcessorForSubscription` functions.
 type ProcessorOptions struct {
 	// ReceiveMode controls when a message is deleted from Service Bus.
 	//

--- a/sdk/messaging/azservicebus/processor.go
+++ b/sdk/messaging/azservicebus/processor.go
@@ -46,7 +46,7 @@ type ProcessorOptions struct {
 	// This option is enabled, by default.
 	ManualComplete bool
 
-	// ProcessorWithMaxConcurrentCalls controls the maximum number of message processing
+	// MaxConcurrentCalls controls the maximum number of message processing
 	// goroutines that are active at any time.
 	// Default is 1.
 	MaxConcurrentCalls int
@@ -268,8 +268,8 @@ func (p *Processor) DeferMessage(ctx context.Context, message *ReceivedMessage) 
 }
 
 // DeadLetterMessage settles a message by moving it to the dead letter queue for a
-// queue or subscription. To receive these messages create a receiver with `Client.NewProcessor()`
-// using the `ProcessorWithSubQueue()` option.
+// queue or subscription. To receive these messages create a processor with `Client.NewProcessorForQueue()`
+// or `Client.NewProcessorForSubscription()` using the `ProcessorOptions.SubQueue` option.
 func (p *Processor) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
 	return p.settler.DeadLetterMessage(ctx, message, options)
 }

--- a/sdk/messaging/azservicebus/processor.go
+++ b/sdk/messaging/azservicebus/processor.go
@@ -16,23 +16,48 @@ import (
 	"github.com/devigned/tab"
 )
 
-type processorConfig struct {
+type ProcessorOptions struct {
+	// ReceiveMode controls when a message is deleted from Service Bus.
+	//
+	// `azservicebus.PeekLock` is the default. The message is locked, preventing multiple
+	// receivers from processing the message at once. You control the lock state of the message
+	// using one of the message settlement functions like processor.CompleteMessage(), which removes
+	// it from Service Bus, or processor.AbandonMessage(), which makes it available again.
+	//
+	// `azservicebus.ReceiveAndDelete` causes Service Bus to remove the message as soon
+	// as it's received.
+	//
+	// More information about receive modes:
+	// https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations
 	ReceiveMode ReceiveMode
 
-	Entity entity
+	// SubQueue should be set to connect to the sub queue (ex: dead letter queue)
+	// of the queue or subscription.
+	SubQueue SubQueue
 
-	// determines if auto completion or abandonment of messages
-	// happens based on the return value of user's processMessage handler.
-	ShouldAutoComplete bool
+	// ManualComplete controls whether messages must be settled explicitly via the
+	// settlement methods (ie, Complete, Abandon) or if the
+	// processor will automatically settle messages.
+	//
+	// If true, no automatic settlement is done.
+	// If false, the return value of your `handleMessage` function will control if the
+	// message is abandoned (non-nil error return) or completed (nil error return).
+	//
+	// This option is enabled, by default.
+	ManualComplete bool
+
+	// ProcessorWithMaxConcurrentCalls controls the maximum number of message processing
+	// goroutines that are active at any time.
+	// Default is 1.
 	MaxConcurrentCalls int
-
-	baseRetrier internal.Retrier
-
-	cleanupOnClose func()
 }
 
 // Processor is a push-based receiver for Service Bus.
 type Processor struct {
+	receiveMode        ReceiveMode
+	autoComplete       bool
+	maxConcurrentCalls int
+
 	settler   settler
 	amqpLinks internal.AMQPLinks
 
@@ -46,97 +71,70 @@ type Processor struct {
 
 	wg sync.WaitGroup
 
-	// configuration data that is read-only after the Processor has been created
-	config processorConfig
+	baseRetrier    internal.Retrier
+	cleanupOnClose func()
 }
 
-// ProcessorOption represents an option on the Processor.
-// Some examples:
-// - `ProcessorWithReceiveMode` to configure the receive mode,
-// - `ProcessorWithQueue` to target a queue.
-type ProcessorOption func(processor *Processor) error
+func applyProcessorOptions(processor *Processor, entity *entity, options *ProcessorOptions) error {
+	if options == nil {
+		processor.maxConcurrentCalls = 1
+		processor.receiveMode = PeekLock
+		processor.autoComplete = true
 
-// ProcessorWithSubQueue allows you to open the sub queue (ie: dead letter queues, transfer dead letter queues)
-// for a queue or subscription.
-func ProcessorWithSubQueue(subQueue SubQueue) ProcessorOption {
-	return func(p *Processor) error {
-		return p.config.Entity.SetSubQueue(subQueue)
-	}
-}
-
-// ProcessorWithReceiveMode controls the receive mode for the processor.
-func ProcessorWithReceiveMode(receiveMode ReceiveMode) ProcessorOption {
-	return func(processor *Processor) error {
-		if receiveMode != PeekLock && receiveMode != ReceiveAndDelete {
-			return fmt.Errorf("invalid receive mode specified %d", receiveMode)
-		}
-
-		processor.config.ReceiveMode = receiveMode
 		return nil
 	}
-}
 
-// ProcessorWithAutoComplete enables or disables auto-completion/abandon of messages
-// When this option is enabled the result of the `processMessage` handler determines whether
-// the message is abandoned (if an `error` is returned) or completed (if `nil` is returned).
-// This option is enabled, by default.
-func ProcessorWithAutoComplete(enableAutoCompleteMessages bool) ProcessorOption {
-	return func(processor *Processor) error {
-		processor.config.ShouldAutoComplete = enableAutoCompleteMessages
-		return nil
+	processor.autoComplete = !options.ManualComplete
+
+	if err := checkReceiverMode(options.ReceiveMode); err != nil {
+		return err
 	}
-}
 
-// ProcessorWithMaxConcurrentCalls controls the maximum number of message processing
-// goroutines that are active at any time.
-// Default is 1.
-func ProcessorWithMaxConcurrentCalls(maxConcurrentCalls int) ProcessorOption {
-	return func(processor *Processor) error {
-		processor.config.MaxConcurrentCalls = maxConcurrentCalls
-		return nil
+	processor.receiveMode = options.ReceiveMode
+
+	if err := entity.SetSubQueue(options.SubQueue); err != nil {
+		return err
 	}
+
+	if options.MaxConcurrentCalls > 0 {
+		processor.maxConcurrentCalls = options.MaxConcurrentCalls
+	}
+
+	return nil
 }
 
-func newProcessor(ns internal.NamespaceWithNewAMQPLinks, cleanupOnClose func(), options ...ProcessorOption) (*Processor, error) {
+func newProcessor(ns internal.NamespaceWithNewAMQPLinks, entity *entity, cleanupOnClose func(), options *ProcessorOptions) (*Processor, error) {
 	processor := &Processor{
-		config: processorConfig{
-			ReceiveMode:        PeekLock,
-			ShouldAutoComplete: true,
-			MaxConcurrentCalls: 1,
-			// TODO: make this configurable
-			baseRetrier: internal.NewBackoffRetrier(internal.BackoffRetrierParams{
-				Factor:     1.5,
-				Min:        time.Second,
-				Max:        time.Minute,
-				MaxRetries: 10,
-			}),
-			cleanupOnClose: cleanupOnClose,
-		},
-
-		mu: &sync.Mutex{},
+		// TODO: make this configurable
+		baseRetrier: internal.NewBackoffRetrier(internal.BackoffRetrierParams{
+			Factor:     1.5,
+			Min:        time.Second,
+			Max:        time.Minute,
+			MaxRetries: 10,
+		}),
+		cleanupOnClose: cleanupOnClose,
+		mu:             &sync.Mutex{},
 	}
 
-	for _, opt := range options {
-		if err := opt(processor); err != nil {
-			return nil, err
-		}
+	if err := applyProcessorOptions(processor, entity, options); err != nil {
+		return nil, err
 	}
 
-	entityPath, err := processor.config.Entity.String()
+	entityPath, err := entity.String()
 
 	if err != nil {
 		return nil, err
 	}
 
 	processor.amqpLinks = ns.NewAMQPLinks(entityPath, func(ctx context.Context, session internal.AMQPSession) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error) {
-		linkOptions := createLinkOptions(processor.config.ReceiveMode, entityPath)
+		linkOptions := createLinkOptions(processor.receiveMode, entityPath)
 		_, receiver, err := createReceiverLink(ctx, session, linkOptions)
 
 		if err != nil {
 			return nil, nil, err
 		}
 
-		if err := receiver.IssueCredit(uint32(processor.config.MaxConcurrentCalls)); err != nil {
+		if err := receiver.IssueCredit(uint32(processor.maxConcurrentCalls)); err != nil {
 			_ = receiver.Close(ctx)
 			return nil, nil, err
 		}
@@ -144,7 +142,7 @@ func newProcessor(ns internal.NamespaceWithNewAMQPLinks, cleanupOnClose func(), 
 		return nil, receiver, nil
 	})
 
-	processor.settler = newMessageSettler(processor.amqpLinks, processor.config.baseRetrier)
+	processor.settler = newMessageSettler(processor.amqpLinks, processor.baseRetrier)
 	processor.receiversCtx, processor.cancelReceivers = context.WithCancel(context.Background())
 
 	return processor, nil
@@ -186,7 +184,7 @@ func (p *Processor) Start(ctx context.Context, handleMessage func(message *Recei
 	}
 
 	for {
-		retrier := p.config.baseRetrier.Copy()
+		retrier := p.baseRetrier.Copy()
 
 		for retrier.Try(p.receiversCtx) {
 			if err := p.subscribe(); err != nil {
@@ -232,7 +230,7 @@ func (p *Processor) Close(ctx context.Context) error {
 		}
 	}()
 
-	p.config.cleanupOnClose()
+	p.cleanupOnClose()
 
 	_, receiver, _, _, err := p.amqpLinks.Get(ctx)
 
@@ -339,7 +337,7 @@ func (p *Processor) processMessage(ctx context.Context, receiver internal.AMQPRe
 		p.userErrorHandler(messageHandlerErr)
 	}
 
-	if p.config.ShouldAutoComplete {
+	if p.autoComplete {
 		var settleErr error
 
 		if messageHandlerErr != nil {
@@ -370,20 +368,10 @@ func (p *Processor) processMessage(ctx context.Context, receiver internal.AMQPRe
 	return nil
 }
 
-// processorWithQueue configures a processor to connect to a queue.
-func processorWithQueue(queue string) ProcessorOption {
-	return func(processor *Processor) error {
-		processor.config.Entity.Queue = queue
+func checkReceiverMode(receiveMode ReceiveMode) error {
+	if receiveMode == PeekLock || receiveMode == ReceiveAndDelete {
 		return nil
-	}
-}
-
-// processorWithSubscription configures a processor to connect to a subscription
-// associated with a topic.
-func processorWithSubscription(topic string, subscription string) ProcessorOption {
-	return func(processor *Processor) error {
-		processor.config.Entity.Topic = topic
-		processor.config.Entity.Subscription = subscription
-		return nil
+	} else {
+		return fmt.Errorf("Invalid receive mode %d, must be either azservicebus.PeekLock or azservicebus.ReceiveAndDelete", receiveMode)
 	}
 }

--- a/sdk/messaging/azservicebus/processor.go
+++ b/sdk/messaging/azservicebus/processor.go
@@ -270,8 +270,8 @@ func (p *Processor) DeferMessage(ctx context.Context, message *ReceivedMessage) 
 // DeadLetterMessage settles a message by moving it to the dead letter queue for a
 // queue or subscription. To receive these messages create a receiver with `Client.NewProcessor()`
 // using the `ProcessorWithSubQueue()` option.
-func (p *Processor) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options ...DeadLetterOption) error {
-	return p.settler.DeadLetterMessage(ctx, message, options...)
+func (p *Processor) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
+	return p.settler.DeadLetterMessage(ctx, message, options)
 }
 
 // subscribe continually receives messages from Service Bus, stopping

--- a/sdk/messaging/azservicebus/processor_test.go
+++ b/sdk/messaging/azservicebus/processor_test.go
@@ -95,7 +95,7 @@ func TestProcessorReceiveWith100MessagesWithMaxConcurrency(t *testing.T) {
 
 		defer sender.Close(context.Background())
 
-		batch, err := sender.NewMessageBatch(context.Background())
+		batch, err := sender.NewMessageBatch(context.Background(), nil)
 		require.NoError(t, err)
 
 		// it's perfectly fine to have the processor started before the messages

--- a/sdk/messaging/azservicebus/processor_test.go
+++ b/sdk/messaging/azservicebus/processor_test.go
@@ -37,7 +37,7 @@ func TestProcessorReceiveWithDefaults(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	processor, err := serviceBusClient.NewProcessorForQueue(queueName)
+	processor, err := serviceBusClient.NewProcessorForQueue(queueName, nil)
 	require.NoError(t, err)
 
 	defer processor.Close(context.Background()) // multiple close is fine
@@ -114,7 +114,9 @@ func TestProcessorReceiveWith100MessagesWithMaxConcurrency(t *testing.T) {
 
 	processor, err := serviceBusClient.NewProcessorForQueue(
 		queueName,
-		ProcessorWithMaxConcurrentCalls(20))
+		&ProcessorOptions{
+			MaxConcurrentCalls: 20,
+		})
 
 	require.NoError(t, err)
 
@@ -157,30 +159,31 @@ func TestProcessorReceiveWith100MessagesWithMaxConcurrency(t *testing.T) {
 
 func TestProcessorUnitTests(t *testing.T) {
 	p := &Processor{}
-	require.NoError(t, ProcessorWithSubQueue(SubQueueDeadLetter)(p))
-	require.EqualValues(t, SubQueueDeadLetter, p.config.Entity.subqueue)
+	e := &entity{}
+
+	require.NoError(t, applyProcessorOptions(p, e, nil))
+	require.True(t, p.autoComplete)
+	require.EqualValues(t, 1, p.maxConcurrentCalls)
+	require.EqualValues(t, PeekLock, p.receiveMode)
 
 	p = &Processor{}
-	require.NoError(t, ProcessorWithSubQueue(SubQueueTransfer)(p))
-	require.EqualValues(t, SubQueueTransfer, p.config.Entity.subqueue)
+	e = &entity{
+		Queue: "queue",
+	}
 
-	p = &Processor{}
-	require.NoError(t, processorWithQueue("queue1")(p))
-	require.EqualValues(t, "queue1", p.config.Entity.Queue)
+	require.NoError(t, applyProcessorOptions(p, e, &ProcessorOptions{
+		ReceiveMode:        ReceiveAndDelete,
+		SubQueue:           SubQueueDeadLetter,
+		ManualComplete:     true,
+		MaxConcurrentCalls: 101,
+	}))
 
-	p = &Processor{}
-	require.NoError(t, processorWithSubscription("topic1", "subscription1")(p))
-	require.EqualValues(t, "topic1", p.config.Entity.Topic)
-	require.EqualValues(t, "subscription1", p.config.Entity.Subscription)
-
-	p = &Processor{}
-	require.NoError(t, ProcessorWithReceiveMode(PeekLock)(p))
-	require.EqualValues(t, PeekLock, p.config.ReceiveMode)
-
-	p = &Processor{}
-	require.NoError(t, ProcessorWithReceiveMode(ReceiveAndDelete)(p))
-	require.EqualValues(t, ReceiveAndDelete, p.config.ReceiveMode)
-
+	require.False(t, p.autoComplete)
+	require.EqualValues(t, 101, p.maxConcurrentCalls)
+	require.EqualValues(t, ReceiveAndDelete, p.receiveMode)
+	fullEntityPath, err := e.String()
+	require.NoError(t, err)
+	require.EqualValues(t, "queue/$DeadLetterQueue", fullEntityPath)
 }
 
 // func TestProcessorUnitTests(t *testing.T) {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -454,8 +454,8 @@ func (r *Receiver) DeferMessage(ctx context.Context, message *ReceivedMessage) e
 }
 
 // DeadLetterMessage settles a message by moving it to the dead letter queue for a
-// queue or subscription. To receive these messages create a receiver with `Client.NewReceiver()`
-// using the `ReceiverWithSubQueue()` option.
+// queue or subscription. To receive these messages create a receiver with `Client.NewReceiverForQueue()`
+// or `Client.NewReceiverForSubscription()` using the `ReceiverOptions.SubQueue` option.
 func (r *Receiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
 	return r.settler.DeadLetterMessage(ctx, message, options)
 }

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -33,6 +33,8 @@ const (
 type SubQueue int
 
 const (
+	// SubQueueNone means no sub queue.
+	SubQueueNone SubQueue = 0
 	// SubQueueDeadLetter targets the dead letter queue for a queue or subscription.
 	SubQueueDeadLetter SubQueue = 1
 	// SubQueueTransfer targets the transfer dead letter queue for a queue or subscription.
@@ -42,9 +44,11 @@ const (
 // Receiver receives messages using pull based functions (ReceiveMessages).
 // For push-based receiving via callbacks look at the `Processor` type.
 type Receiver struct {
-	settler settler
+	receiveMode ReceiveMode
 
-	config receiverConfig
+	settler        settler
+	baseRetrier    internal.Retrier
+	cleanupOnClose func()
 
 	lastPeekedSequenceNumber int64
 	amqpLinks                internal.AMQPLinks
@@ -53,122 +57,100 @@ type Receiver struct {
 	receiving bool
 }
 
-type receiverConfig struct {
-	ReceiveMode    ReceiveMode
-	FullEntityPath string
-	Entity         entity
+type ReceiverOptions struct {
+	// ReceiveMode controls when a message is deleted from Service Bus.
+	//
+	// `azservicebus.PeekLock` is the default. The message is locked, preventing multiple
+	// receivers from processing the message at once. You control the lock state of the message
+	// using one of the message settlement functions like processor.CompleteMessage(), which removes
+	// it from Service Bus, or processor.AbandonMessage(), which makes it available again.
+	//
+	// `azservicebus.ReceiveAndDelete` causes Service Bus to remove the message as soon
+	// as it's received.
+	//
+	// More information about receive modes:
+	// https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations
+	ReceiveMode ReceiveMode
 
-	baseRetrier    internal.Retrier
-	cleanupOnClose func()
+	// SubQueue should be set to connect to the sub queue (ex: dead letter queue)
+	// of the queue or subscription.
+	SubQueue SubQueue
 }
 
 const defaultLinkRxBuffer = 2048
 
-// ReceiverOption represents an option for a receiver.
-// Some examples:
-// - `ReceiverWithReceiveMode` to configure the receive mode,
-// - `ReceiverWithSubQueue` to connect to a subqueue, like a dead letter queue
-type ReceiverOption func(receiver *Receiver) error
-
-// ReceiverWithSubQueue allows you to open the sub queue (ie: dead letter queues, transfer dead letter queues)
-// for a queue or subscription.
-func ReceiverWithSubQueue(subQueue SubQueue) ReceiverOption {
-	return func(r *Receiver) error {
-		return r.config.Entity.SetSubQueue(subQueue)
-	}
-}
-
-// ReceiverWithReceiveMode controls the receive mode for the receiver.
-func ReceiverWithReceiveMode(receiveMode ReceiveMode) ReceiverOption {
-	return func(receiver *Receiver) error {
-		if receiveMode != PeekLock && receiveMode != ReceiveAndDelete {
-			return fmt.Errorf("invalid receive mode specified %d", receiveMode)
-		}
-
-		receiver.config.ReceiveMode = receiveMode
+func applyReceiverOptions(receiver *Receiver, entity *entity, options *ReceiverOptions) error {
+	if options == nil {
+		receiver.receiveMode = PeekLock
 		return nil
 	}
+
+	if err := checkReceiverMode(options.ReceiveMode); err != nil {
+		return err
+	}
+
+	receiver.receiveMode = options.ReceiveMode
+
+	if err := entity.SetSubQueue(options.SubQueue); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func newReceiver(ns internal.NamespaceWithNewAMQPLinks, cleanupOnClose func(), options ...ReceiverOption) (*Receiver, error) {
+func newReceiver(ns internal.NamespaceWithNewAMQPLinks, entity *entity, cleanupOnClose func(), options *ReceiverOptions) (*Receiver, error) {
 	receiver := &Receiver{
-		config: receiverConfig{
-			ReceiveMode: PeekLock,
-			// TODO: make this configurable
-			baseRetrier: internal.NewBackoffRetrier(internal.BackoffRetrierParams{
-				Factor:     1.5,
-				Jitter:     true,
-				Min:        time.Second,
-				Max:        time.Minute,
-				MaxRetries: 10,
-			}),
-			cleanupOnClose: cleanupOnClose,
-		},
 		lastPeekedSequenceNumber: 0,
+		// TODO: make this configurable
+		baseRetrier: internal.NewBackoffRetrier(internal.BackoffRetrierParams{
+			Factor:     1.5,
+			Jitter:     true,
+			Min:        time.Second,
+			Max:        time.Minute,
+			MaxRetries: 10,
+		}),
+		cleanupOnClose: cleanupOnClose,
 	}
 
-	for _, opt := range options {
-		if err := opt(receiver); err != nil {
-			return nil, err
-		}
+	if err := applyReceiverOptions(receiver, entity, options); err != nil {
+		return nil, err
 	}
 
-	entityPath, err := receiver.config.Entity.String()
+	entityPath, err := entity.String()
 
 	if err != nil {
 		return nil, err
 	}
 
 	receiver.amqpLinks = ns.NewAMQPLinks(entityPath, func(ctx context.Context, session internal.AMQPSession) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error) {
-		linkOptions := createLinkOptions(receiver.config.ReceiveMode, entityPath)
+		linkOptions := createLinkOptions(receiver.receiveMode, entityPath)
 		return createReceiverLink(ctx, session, linkOptions)
 	})
 
 	// 'nil' settler handles returning an error message for receiveAndDelete links.
-	if receiver.config.ReceiveMode == PeekLock {
-		receiver.settler = newMessageSettler(receiver.amqpLinks, receiver.config.baseRetrier)
+	if receiver.receiveMode == PeekLock {
+		receiver.settler = newMessageSettler(receiver.amqpLinks, receiver.baseRetrier)
 	}
 
 	return receiver, nil
 }
 
-// receiveOptions are options for the ReceiveMessages function.
-type receiveOptions struct {
-	maxWaitTime                  time.Duration
+// ReceiveOptions are options for the ReceiveMessages function.
+type ReceiveOptions struct {
+	// MaxWaitTime configures how long to wait for the first
+	// message in a set of messages to arrive.
+	// Default: 60 seconds
+	MaxWaitTime time.Duration
+
 	maxWaitTimeAfterFirstMessage time.Duration
-}
-
-// ReceiveOption represents an option for a `ReceiveMessages`.
-// For example, `ReceiveWithMaxWaitTime` will let you configure the
-// maxmimum amount of time to wait for messages to arrive.
-type ReceiveOption func(options *receiveOptions) error
-
-// ReceiveWithMaxWaitTime configures how long to wait for the first
-// message in a set of messages to arrive.
-// Default: 60 seconds
-func ReceiveWithMaxWaitTime(max time.Duration) ReceiveOption {
-	return func(options *receiveOptions) error {
-		options.maxWaitTime = max
-		return nil
-	}
-}
-
-// ReceiveWithMaxTimeAfterFirstMessage confiures how long, after the first
-// message arrives, to wait before returning.
-// Default: 1 second
-func ReceiveWithMaxTimeAfterFirstMessage(max time.Duration) ReceiveOption {
-	return func(options *receiveOptions) error {
-		options.maxWaitTimeAfterFirstMessage = max
-		return nil
-	}
 }
 
 // ReceiveMessages receives a fixed number of messages, up to numMessages.
 // There are two timeouts involved in receiving messages:
 // 1. An explicit timeout set with `ReceiveWithMaxWaitTime` (default: 60 seconds)
 // 2. An implicit timeout (default: 1 second) that starts after the first
-//    message has been received. This time can be adjusted with `ReceiveWithMaxTimeAfterFirstMessage`
-func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options ...ReceiveOption) ([]*ReceivedMessage, error) {
+//    message has been received.
+func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options *ReceiveOptions) ([]*ReceivedMessage, error) {
 	r.mu.Lock()
 	isReceiving := r.receiving
 
@@ -187,10 +169,10 @@ func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options
 		return nil, errors.New("receiver is already receiving messages. ReceiveMessages() cannot be called concurrently.")
 	}
 
-	return r.receiveMessagesImpl(ctx, maxMessages, options...)
+	return r.receiveMessagesImpl(ctx, maxMessages, options)
 }
 
-func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, options ...ReceiveOption) ([]*ReceivedMessage, error) {
+func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, options *ReceiveOptions) ([]*ReceivedMessage, error) {
 	// There are three phases for this function:
 	// Phase 1. <receive, respecting user cancellation>
 	// Phase 2. <check error and exit if fatal>
@@ -198,14 +180,16 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 	//    user isn't actually waiting for anymore. So we make sure that #3 runs if the
 	//    link is still valid.
 	// Phase 3. <drain the link and leave it in a good state>
-	ropts := &receiveOptions{
-		maxWaitTime:                  time.Minute,
+	localOpts := &ReceiveOptions{
+		MaxWaitTime:                  time.Minute,
 		maxWaitTimeAfterFirstMessage: time.Second,
 	}
 
-	for _, opt := range options {
-		if err := opt(ropts); err != nil {
-			return nil, err
+	if options != nil {
+		localOpts.MaxWaitTime = options.MaxWaitTime
+
+		if options.maxWaitTimeAfterFirstMessage != 0 {
+			localOpts.maxWaitTimeAfterFirstMessage = options.maxWaitTimeAfterFirstMessage
 		}
 	}
 
@@ -224,7 +208,7 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 		return nil, err
 	}
 
-	messages, err := r.getMessages(ctx, receiver, maxMessages, ropts)
+	messages, err := r.getMessages(ctx, receiver, maxMessages, localOpts)
 
 	if err != nil {
 		return nil, err
@@ -285,8 +269,8 @@ func (r *Receiver) drainLink(receiver internal.AMQPReceiver, messages []*Receive
 
 // getMessages receives messages until a link failure, timeout or the user
 // cancels their context.
-func (r *Receiver) getMessages(theirCtx context.Context, receiver internal.AMQPReceiver, maxMessages int, ropts *receiveOptions) ([]*ReceivedMessage, error) {
-	ctx, cancel := context.WithTimeout(theirCtx, ropts.maxWaitTime)
+func (r *Receiver) getMessages(theirCtx context.Context, receiver internal.AMQPReceiver, maxMessages int, ropts *ReceiveOptions) ([]*ReceivedMessage, error) {
+	ctx, cancel := context.WithTimeout(theirCtx, ropts.MaxWaitTime)
 	defer cancel()
 
 	var messages []*ReceivedMessage
@@ -336,7 +320,7 @@ func (r *Receiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers 
 		return nil, err
 	}
 
-	amqpMessages, err := mgmt.ReceiveDeferred(ctx, r.config.ReceiveMode, sequenceNumbers)
+	amqpMessages, err := mgmt.ReceiveDeferred(ctx, r.receiveMode, sequenceNumbers)
 
 	if err != nil {
 		return nil, err
@@ -415,7 +399,7 @@ func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, option
 	return receivedMessages, nil
 }
 
-// receiveDeferredMessage receives a single message that was deferred using `Receiver.DeferMessage`.
+// ReceiveDeferredMessage receives a single message that was deferred using `Receiver.DeferMessage`.
 func (r *Receiver) receiveDeferredMessage(ctx context.Context, sequenceNumber int64) (*ReceivedMessage, error) {
 	messages, err := r.ReceiveDeferredMessages(ctx, []int64{sequenceNumber})
 
@@ -430,9 +414,9 @@ func (r *Receiver) receiveDeferredMessage(ctx context.Context, sequenceNumber in
 	return messages[0], nil
 }
 
-// receiveMessage receives a single message.
-func (r *Receiver) receiveMessage(ctx context.Context, options ...ReceiveOption) (*ReceivedMessage, error) {
-	messages, err := r.ReceiveMessages(ctx, 1, options...)
+// ReceiveMessage receives a single message.
+func (r *Receiver) receiveMessage(ctx context.Context, options *ReceiveOptions) (*ReceivedMessage, error) {
+	messages, err := r.ReceiveMessages(ctx, 1, options)
 
 	if err != nil {
 		return nil, err
@@ -447,7 +431,7 @@ func (r *Receiver) receiveMessage(ctx context.Context, options ...ReceiveOption)
 
 // Close permanently closes the receiver.
 func (r *Receiver) Close(ctx context.Context) error {
-	r.config.cleanupOnClose()
+	r.cleanupOnClose()
 	return r.amqpLinks.Close(ctx, true)
 }
 
@@ -504,13 +488,14 @@ func (e *entity) String() (string, error) {
 }
 
 func (e *entity) SetSubQueue(subQueue SubQueue) error {
-	if subQueue == SubQueueDeadLetter || subQueue == SubQueueTransfer {
+	if subQueue == SubQueueNone {
+		return nil
+	} else if subQueue == SubQueueDeadLetter || subQueue == SubQueueTransfer {
 		e.subqueue = subQueue
-	} else {
-		return fmt.Errorf("unknown SubQueue %d", subQueue)
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("unknown SubQueue %d", subQueue)
 }
 
 func createReceiverLink(ctx context.Context, session internal.AMQPSession, linkOptions []amqp.LinkOption) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error) {
@@ -543,22 +528,4 @@ func createLinkOptions(mode ReceiveMode, entityPath string) []amqp.LinkOption {
 	}
 
 	return opts
-}
-
-// receiverWithQueue configures a receiver to connect to a queue.
-func receiverWithQueue(queue string) ReceiverOption {
-	return func(receiver *Receiver) error {
-		receiver.config.Entity.Queue = queue
-		return nil
-	}
-}
-
-// receiverWithSubscription configures a receiver to connect to a subscription
-// associated with a topic.
-func receiverWithSubscription(topic string, subscription string) ReceiverOption {
-	return func(receiver *Receiver) error {
-		receiver.config.Entity.Topic = topic
-		receiver.config.Entity.Subscription = subscription
-		return nil
-	}
 }

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -400,7 +400,7 @@ func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, option
 }
 
 // ReceiveDeferredMessage receives a single message that was deferred using `Receiver.DeferMessage`.
-func (r *Receiver) receiveDeferredMessage(ctx context.Context, sequenceNumber int64) (*ReceivedMessage, error) {
+func (r *Receiver) ReceiveDeferredMessage(ctx context.Context, sequenceNumber int64) (*ReceivedMessage, error) {
 	messages, err := r.ReceiveDeferredMessages(ctx, []int64{sequenceNumber})
 
 	if err != nil {
@@ -415,7 +415,7 @@ func (r *Receiver) receiveDeferredMessage(ctx context.Context, sequenceNumber in
 }
 
 // ReceiveMessage receives a single message.
-func (r *Receiver) receiveMessage(ctx context.Context, options *ReceiveOptions) (*ReceivedMessage, error) {
+func (r *Receiver) ReceiveMessage(ctx context.Context, options *ReceiveOptions) (*ReceivedMessage, error) {
 	messages, err := r.ReceiveMessages(ctx, 1, options)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -147,7 +147,7 @@ type ReceiveOptions struct {
 
 // ReceiveMessages receives a fixed number of messages, up to numMessages.
 // There are two timeouts involved in receiving messages:
-// 1. An explicit timeout set with `ReceiveWithMaxWaitTime` (default: 60 seconds)
+// 1. An explicit timeout set with `ReceiveOptions.MaxWaitTime` (default: 60 seconds)
 // 2. An implicit timeout (default: 1 second) that starts after the first
 //    message has been received.
 func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options *ReceiveOptions) ([]*ReceivedMessage, error) {
@@ -414,7 +414,7 @@ func (r *Receiver) ReceiveDeferredMessage(ctx context.Context, sequenceNumber in
 	return messages[0], nil
 }
 
-// ReceiveMessage receives a single message.
+// ReceiveMessage receives a single message, waiting up to `ReceiveOptions.MaxWaitTime` (default: 60 seconds)
 func (r *Receiver) ReceiveMessage(ctx context.Context, options *ReceiveOptions) (*ReceivedMessage, error) {
 	messages, err := r.ReceiveMessages(ctx, 1, options)
 

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -456,8 +456,8 @@ func (r *Receiver) DeferMessage(ctx context.Context, message *ReceivedMessage) e
 // DeadLetterMessage settles a message by moving it to the dead letter queue for a
 // queue or subscription. To receive these messages create a receiver with `Client.NewReceiver()`
 // using the `ReceiverWithSubQueue()` option.
-func (r *Receiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options ...DeadLetterOption) error {
-	return r.settler.DeadLetterMessage(ctx, message, options...)
+func (r *Receiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
+	return r.settler.DeadLetterMessage(ctx, message, options)
 }
 
 type entity struct {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -57,6 +57,8 @@ type Receiver struct {
 	receiving bool
 }
 
+// ReceiverOptions contains options for the `Client.NewReceiverForQueue` or `Client.NewReceiverForSubscription`
+// functions.
 type ReceiverOptions struct {
 	// ReceiveMode controls when a message is deleted from Service Bus.
 	//

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -261,11 +261,11 @@ func TestReceiverPeek(t *testing.T) {
 		require.NoError(t, receiver.AbandonMessage(ctx, m))
 	}
 
-	peekedMessages, err := receiver.PeekMessages(ctx, 2)
+	peekedMessages, err := receiver.PeekMessages(ctx, 2, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, len(peekedMessages))
 
-	peekedMessages2, err := receiver.PeekMessages(ctx, 2)
+	peekedMessages2, err := receiver.PeekMessages(ctx, 2, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, len(peekedMessages2))
 
@@ -275,7 +275,9 @@ func TestReceiverPeek(t *testing.T) {
 		"Message 0", "Message 1", "Message 2",
 	}, getSortedBodies(append(peekedMessages, peekedMessages2...)))
 
-	repeekedMessages, err := receiver.PeekMessages(ctx, 1, PeekFromSequenceNumber(*peekedMessages2[0].SequenceNumber))
+	repeekedMessages, err := receiver.PeekMessages(ctx, 1, &PeekOptions{
+		FromSequenceNumber: peekedMessages2[0].SequenceNumber,
+	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, len(repeekedMessages))
 
@@ -284,7 +286,7 @@ func TestReceiverPeek(t *testing.T) {
 	}, getSortedBodies(repeekedMessages))
 
 	// and peek again (note it won't reset so there'll be "nothing")
-	noMessagesExpected, err := receiver.PeekMessages(ctx, 1)
+	noMessagesExpected, err := receiver.PeekMessages(ctx, 1, nil)
 	require.NoError(t, err)
 	require.Empty(t, noMessagesExpected)
 }

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -234,7 +234,7 @@ func TestReceiverPeek(t *testing.T) {
 
 	defer sender.Close(ctx)
 
-	batch, err := sender.NewMessageBatch(ctx)
+	batch, err := sender.NewMessageBatch(ctx, nil)
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -109,7 +109,7 @@ func TestReceiverAbandon(t *testing.T) {
 	require.NoError(t, receiver.CompleteMessage(context.Background(), abandonedMessages[0]))
 }
 
-// Receive has two timeouts - an explicit one (passed in via ReceiveWithMaxTimeout)
+// Receive has two timeouts - an explicit one (passed in via ReceiveOptions.MaxWaitTime)
 // and an implicit one that kicks in as soon as we receive our first message.
 func TestReceiveWithEarlyFirstMessageTimeout(t *testing.T) {
 	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)

--- a/sdk/messaging/azservicebus/samples/processor/processor_sample.go
+++ b/sdk/messaging/azservicebus/samples/processor/processor_sample.go
@@ -24,7 +24,7 @@ func main() {
 		log.Fatalf("SERVICEBUS_CONNECTION_STRING and QUEUE_NAME must be defined in the environment for this sample")
 	}
 
-	serviceBusClient, err := azservicebus.NewClientWithConnectionString(cs)
+	serviceBusClient, err := azservicebus.NewClientWithConnectionString(cs, nil)
 
 	if err != nil {
 		log.Fatalf("Failed to create service bus client: %s", err.Error())
@@ -55,13 +55,13 @@ func main() {
 	//
 
 	processor, err := serviceBusClient.NewProcessorForQueue(
+		// or: azservicebus.NewProcessorForSubscription
 		queue,
 		&azservicebus.ProcessorOptions{
 			// Will auto-complete or auto-abandon messages, based on the result from you callback
 			// (this is true, by default)
 			ManualComplete: false,
 			// or for a subscription
-			// azservicebus.ProcessorWithSubscription("topic", "subscription"),
 			ReceiveMode: azservicebus.PeekLock,
 		},
 	)

--- a/sdk/messaging/azservicebus/samples/processor/processor_sample.go
+++ b/sdk/messaging/azservicebus/samples/processor/processor_sample.go
@@ -56,12 +56,14 @@ func main() {
 
 	processor, err := serviceBusClient.NewProcessorForQueue(
 		queue,
-		// Will auto-complete or auto-abandon messages, based on the result from you callback
-		// (this is true, by default)
-		azservicebus.ProcessorWithAutoComplete(true),
-		// or for a subscription
-		// azservicebus.ProcessorWithSubscription("topic", "subscription"),
-		azservicebus.ProcessorWithReceiveMode(azservicebus.PeekLock),
+		&azservicebus.ProcessorOptions{
+			// Will auto-complete or auto-abandon messages, based on the result from you callback
+			// (this is true, by default)
+			ManualComplete: false,
+			// or for a subscription
+			// azservicebus.ProcessorWithSubscription("topic", "subscription"),
+			ReceiveMode: azservicebus.PeekLock,
+		},
 	)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -13,9 +13,6 @@ import (
 )
 
 type (
-	// SenderOption specifies an option that can configure a Sender.
-	SenderOption func(sender *Sender) error
-
 	// Sender is used to send messages as well as schedule them to be delivered at a later date.
 	Sender struct {
 		queueOrTopic   string
@@ -36,6 +33,7 @@ const (
 	spanNameSendMessageFmt string = "sb.sender.SendMessage.%s"
 )
 
+// MessageBatchOptions contains options for the `Sender.NewMessageBatch` function.
 type MessageBatchOptions struct {
 	// MaxSizeInBytes overrides the max size (in bytes) for a batch.
 	// By default NewMessageBatch will use the max message size provided by the service.

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -24,7 +24,7 @@ func Test_Sender_SendBatchOfTwo(t *testing.T) {
 
 	defer sender.Close(ctx)
 
-	batch, err := sender.NewMessageBatch(ctx)
+	batch, err := sender.NewMessageBatch(ctx, nil)
 	require.NoError(t, err)
 
 	added, err := batch.Add(&Message{
@@ -75,7 +75,7 @@ func Test_Sender_UsingPartitionedQueue(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	batch, err := sender.NewMessageBatch(context.Background())
+	batch, err := sender.NewMessageBatch(context.Background(), nil)
 	require.NoError(t, err)
 
 	added, err := batch.Add(&Message{

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -43,12 +43,11 @@ func Test_Sender_SendBatchOfTwo(t *testing.T) {
 	require.NoError(t, err)
 
 	receiver, err := client.NewReceiverForQueue(
-		queueName,
-		ReceiverWithReceiveMode(ReceiveAndDelete))
+		queueName, &ReceiverOptions{ReceiveMode: ReceiveAndDelete})
 	require.NoError(t, err)
 	defer receiver.Close(ctx)
 
-	messages, err := receiver.ReceiveMessages(ctx, 2)
+	messages, err := receiver.ReceiveMessages(ctx, 2, nil)
 	require.NoError(t, err)
 
 	require.EqualValues(t, []string{"[0] message in batch", "[1] message in batch"}, getSortedBodies(messages))
@@ -65,8 +64,7 @@ func Test_Sender_UsingPartitionedQueue(t *testing.T) {
 	defer sender.Close(context.Background())
 
 	receiver, err := client.NewReceiverForQueue(
-		queueName,
-		ReceiverWithReceiveMode(ReceiveAndDelete))
+		queueName, &ReceiverOptions{ReceiveMode: ReceiveAndDelete})
 	require.NoError(t, err)
 	defer receiver.Close(context.Background())
 
@@ -97,7 +95,7 @@ func Test_Sender_UsingPartitionedQueue(t *testing.T) {
 	err = sender.SendMessage(context.Background(), batch)
 	require.NoError(t, err)
 
-	messages, err := receiver.ReceiveMessages(context.Background(), 1+2)
+	messages, err := receiver.ReceiveMessages(context.Background(), 1+2, nil)
 	require.NoError(t, err)
 
 	sort.Sort(receivedMessages(messages))

--- a/sdk/messaging/azservicebus/stress/stress.go
+++ b/sdk/messaging/azservicebus/stress/stress.go
@@ -165,7 +165,7 @@ func runBatchReceiver(ctx context.Context, serviceBusClient *azservicebus.Client
 	}
 
 	for {
-		messages, err := receiver.ReceiveMessages(ctx, 20)
+		messages, err := receiver.ReceiveMessages(ctx, 20, nil)
 
 		if err != nil {
 			trackException(&receiverStats, telemetryClient, "receive batch failure", err)

--- a/sdk/messaging/azservicebus/stress/stress.go
+++ b/sdk/messaging/azservicebus/stress/stress.go
@@ -158,7 +158,7 @@ func runBasicSendAndReceiveTest() {
 }
 
 func runBatchReceiver(ctx context.Context, serviceBusClient *azservicebus.Client, topicName string, subscriptionName string, telemetryClient appinsights.TelemetryClient) {
-	receiver, err := serviceBusClient.NewReceiverForSubscription(topicName, subscriptionName)
+	receiver, err := serviceBusClient.NewReceiverForSubscription(topicName, subscriptionName, nil)
 
 	if err != nil {
 		log.Fatalf("Failed to create receiver: %s", err.Error())
@@ -187,7 +187,7 @@ func runProcessor(ctx context.Context, client *azservicebus.Client, topicName st
 	log.Printf("Starting processor...")
 	processor, err := client.NewProcessorForSubscription(
 		topicName, subscriptionName,
-		azservicebus.ProcessorWithMaxConcurrentCalls(10))
+		&azservicebus.ProcessorOptions{MaxConcurrentCalls: 10})
 
 	if err != nil {
 		trackException(&processorStats, telemetryClient, "Failed when creating processor", err)

--- a/sdk/messaging/azservicebus/stress/stress.go
+++ b/sdk/messaging/azservicebus/stress/stress.go
@@ -107,7 +107,7 @@ func runBasicSendAndReceiveTest() {
 	ctx, cancel := context.WithTimeout(context.Background(), 24*5*time.Hour)
 	defer cancel()
 
-	serviceBusClient, err := azservicebus.NewClientWithConnectionString(cs)
+	serviceBusClient, err := azservicebus.NewClientWithConnectionString(cs, nil)
 	if err != nil {
 		trackException(nil, telemetryClient, "Failed to create service bus client", err)
 		return


### PR DESCRIPTION
Just removing all the variadic config I had in Service Bus before beta release:
- Dead letter options
- Creating receivers (NewReceiverFor*)
- Creating processors (NewProcessorFor*)
- Creating a message batch

I also did one other change - I exported the ReceiveMessage and ReceiveDeferredMessage functions (that get only a single message).