### PR TITLE
Refactor azcosmos client constructor

### DIFF
--- a/sdk/data/azcosmos/README.md
+++ b/sdk/data/azcosmos/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This client library enables client applications to connect to Azure Cosmos via the SQL API. Azure Cosmos is a globally distributed, multi-model database service. 
+This client library enables client applications to connect to Azure Cosmos via the SQL API. Azure Cosmos is a globally distributed, multi-model database service.
 
 ## Getting Started
 
@@ -29,7 +29,7 @@ You can create an Azure Cosmos account using:
   ```bash
   go get -u github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
   ```
-  
+
 #### Authenticate the client
 
 In order to interact with the Azure CosmosDB service you'll need to create an instance of the Cosmos Client class. To make this possible you will need an URL and key of the Azure CosmosDB service.
@@ -46,12 +46,12 @@ The following section provides several code snippets covering some of the most c
 
 ```go
 const (
-    CosmosDbEndpoint = "someEndpoint"
-    CosmoDbKey = "someKey"
+    cosmosDbEndpoint = "someEndpoint"
+    cosmosDbKey = "someKey"
 )
 
-cred, _ := NewSharedKeyCredential(CosmosDbEndpoint)
-client, err := NewCosmosClient(CosmoDbKey, cred, &CosmosClientOptions{})
+cred, _ := azcosmos.NewSharedKeyCredential(cosmosDbKey)
+client, err := azcosmos.NewClientWithSharedKey(cosmosDbEndpoint, cred, nil)
 handle(err)
 ```
 
@@ -60,7 +60,7 @@ handle(err)
 Using the client created in previous example, you can create a database like this:
 
 ```go
-database := CosmosDatabaseProperties{Id: dbName}
+database := azcosmos.CosmosDatabaseProperties{Id: dbName}
 response, err := client.CreateDatabase(context, database, nil, nil)
 handle(err)
 ```
@@ -70,14 +70,14 @@ handle(err)
 Using the above created database for creating a container, like this:
 
 ```go
-properties := CosmosContainerProperties{
+properties := azcosmos.CosmosContainerProperties{
     Id: "aContainer",
-    PartitionKeyDefinition: PartitionKeyDefinition{
+    PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{
         Paths: []string{"/id"},
     },
 }
 
-throughput := NewManualThroughputProperties(400)
+throughput := azcosmos.NewManualThroughputProperties(400)
 response, err := database.CreateContainer(context, properties, throughput, nil)
 handle(err)
 container := resp.ContainerProperties.Container
@@ -93,7 +93,7 @@ item := map[string]string{
 
 // Create partition key
 container := client.GetCosmosContainer(dbName, containerName)
-pk, err := NewPartitionKey("1")
+pk, err := azcosmos.NewPartitionKey("1")
 handle(err)
 
 // Create an item
@@ -139,4 +139,6 @@ do this once across all repos using our CLA.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional 
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go/sdk/data/azcosmos/README.png)

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -6,8 +6,6 @@ package azcosmos
 import (
 	"context"
 	"errors"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 // A CosmosClient is used to interact with the Azure Cosmos DB database service.
@@ -19,20 +17,18 @@ type CosmosClient struct {
 	options    *CosmosClientOptions
 }
 
-// NewCosmosClient creates a new instance of CosmosClient with the specified values. It uses the default pipeline configuration.
+// NewClientWithSharedKey creates a new instance of CosmosClient with the specified values. It uses the default pipeline configuration.
 // endpoint - The cosmos service endpoint to use.
 // cred - The credential used to authenticate with the cosmos service.
 // options - Optional CosmosClient options.  Pass nil to accept default values.
-func NewCosmosClient(endpoint string, cred azcore.Credential, options *CosmosClientOptions) (*CosmosClient, error) {
+func NewClientWithSharedKey(endpoint string, cred *SharedKeyCredential, options *CosmosClientOptions) (*CosmosClient, error) {
 	if options == nil {
 		options = &CosmosClientOptions{}
 	}
 
 	connection := newCosmosClientConnection(endpoint, cred, options)
 
-	c, _ := cred.(*SharedKeyCredential)
-
-	return &CosmosClient{Endpoint: endpoint, connection: connection, cred: c, options: options}, nil
+	return &CosmosClient{Endpoint: endpoint, connection: connection, cred: cred, options: options}, nil
 }
 
 // GetCosmosDatabase returns a CosmosDatabase object.

--- a/sdk/data/azcosmos/cosmos_client_connection.go
+++ b/sdk/data/azcosmos/cosmos_client_connection.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
@@ -22,7 +21,7 @@ type cosmosClientConnection struct {
 
 // newConnection creates an instance of the connection type with the specified endpoint.
 // Pass nil to accept the default options; this is the same as passing a zero-value options.
-func newCosmosClientConnection(endpoint string, cred azcore.Credential, options *CosmosClientOptions) *cosmosClientConnection {
+func newCosmosClientConnection(endpoint string, cred *SharedKeyCredential, options *CosmosClientOptions) *cosmosClientConnection {
 	policies := []policy.Policy{
 		azruntime.NewTelemetryPolicy("azcosmos", serviceLibVersion, &options.Telemetry),
 	}
@@ -30,7 +29,7 @@ func newCosmosClientConnection(endpoint string, cred azcore.Credential, options 
 	policies = append(policies, azruntime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, options.getSDKInternalPolicies()...)
-	policies = append(policies, cred.NewAuthenticationPolicy(azruntime.AuthenticationOptions{}))
+	policies = append(policies, newSharedKeyCredPolicy(cred))
 	policies = append(policies, azruntime.NewLogPolicy(&options.Logging))
 	return &cosmosClientConnection{endpoint: endpoint, Pipeline: azruntime.NewPipeline(options.HTTPClient, policies...)}
 }

--- a/sdk/data/azcosmos/emulator_tests.go
+++ b/sdk/data/azcosmos/emulator_tests.go
@@ -28,7 +28,7 @@ func newEmulatorTests(t *testing.T) *emulatorTests {
 
 func (e *emulatorTests) getClient(t *testing.T) *CosmosClient {
 	cred, _ := NewSharedKeyCredential(e.key)
-	client, err := NewCosmosClient(e.host, cred, nil)
+	client, err := NewClientWithSharedKey(e.host, cred, nil)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/sdk/data/azcosmos/shared_key_credential.go
+++ b/sdk/data/azcosmos/shared_key_credential.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
@@ -92,16 +91,12 @@ type sharedKeyCredPolicy struct {
 	cred *SharedKeyCredential
 }
 
-func newSharedKeyCredPolicy(cred *SharedKeyCredential, opts runtime.AuthenticationOptions) *sharedKeyCredPolicy {
+func newSharedKeyCredPolicy(cred *SharedKeyCredential) *sharedKeyCredPolicy {
 	s := &sharedKeyCredPolicy{
 		cred: cred,
 	}
 
 	return s
-}
-
-func (c *SharedKeyCredential) NewAuthenticationPolicy(options runtime.AuthenticationOptions) policy.Policy {
-	return newSharedKeyCredPolicy(c, options)
 }
 
 func (s *sharedKeyCredPolicy) Do(req *policy.Request) (*http.Response, error) {


### PR DESCRIPTION
The next version of azcore doesn't contain `azcore.Credential`, so client constructors must be explicit about the credential types they accept. Pretty straightforward here because there's only one credential type. I renamed the constructor NewCosmosClient -> NewClientWithSharedKey to align with upcoming guidelines for the SDK (the "good" name, NewClient, would go to a constructor taking `azcore.TokenCredential`, i.e. an Azure AD credential).