### PR TITLE
[service-bus] Separating code coverage changes out

### DIFF
--- a/eng/config.json
+++ b/eng/config.json
@@ -27,6 +27,10 @@
         {
             "Name": "azsecrets",
             "CoverageGoal": 0.76
+        },
+        {
+            "Name": "messaging",
+            "CoverageGoal": 0.10
         }
     ]
 }


### PR DESCRIPTION
Talking with Joel and Ben - the track 1 CI pipeline is triggering for the changes I've got in my main PR. 

This is unintentional, and I believe the only reason it's running at all is because the config.json file changed. Testing that theory now.