### PR TITLE
Docker Failure Investigation

### DIFF
--- a/eng/common/testproxy/docker-start-proxy.ps1
+++ b/eng/common/testproxy/docker-start-proxy.ps1
@@ -25,7 +25,7 @@ catch {
     Write-Error "Please check your docker invocation and try running the script again."
 }
 
-$SELECTED_IMAGE_TAG = "1084681"
+$SELECTED_IMAGE_TAG = "1108695"
 $CONTAINER_NAME = "ambitious_azsdk_test_proxy"
 $LINUX_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-lin:${SELECTED_IMAGE_TAG}"
 $WINDOWS_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-win:${SELECTED_IMAGE_TAG}"

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -72,6 +72,7 @@ steps:
       env:
         GO111MODULE: 'on'
         PROXY_CERT: $(Build.SourcesDirectory)/eng/common/testproxy/dotnet-devcert.crt
+        AZURE_RECORD_MODE: 'playback'
         ${{ insert }}: ${{ parameters.EnvVars }}
 
     - pwsh: |

--- a/sdk/data/aztables/ci.yml
+++ b/sdk/data/aztables/ci.yml
@@ -27,3 +27,4 @@ stages:
     ServiceDirectory: 'data/aztables'
     RunTests: true
     RunLiveTests: true
+


### PR DESCRIPTION
Really don't know what's going on here. 

Locally both `go116` and `go117` BOTH check out against the container, even with ALL dev certs removed from local machine. The errors in the docker logs don't strike me as accurate.

After this, my next attempt will be build a specific version of the image that maintains the `dotnet devcerts https --import` (but not the trust).

I'm at a complete loss to explain why this refuses to repro locally.