### PR TITLE
Skip test proxy container steps in live test mode

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -111,6 +111,7 @@ stages:
           Image: $(vm.image)
           GoVersion: $(go.version)
           RunTests: ${{ parameters.RunTests }}
+          TestProxy: true
           EnvVars:
             AZURE_RECORD_MODE: 'playback'
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -11,6 +11,9 @@ parameters:
   - name:  GoVersion
     type: string
     default: ''
+  - name:  TestProxy
+    type: boolean
+    default: false
   - name:  RunTests
     type: boolean
     default: false
@@ -51,7 +54,8 @@ steps:
       displayName: "Install Coverage and Junit Dependencies"
       workingDirectory: '${{parameters.GoWorkspace}}'
 
-    - template: /eng/common/testproxy/test-proxy-docker.yml
+    - ${{ if eq(parameters.TestProxy, true) }}:
+      - template: /eng/common/testproxy/test-proxy-docker.yml
 
     - pwsh: |
         $testDirs = ./eng/scripts/get_test_dirs.ps1 '${{ parameters.ServiceDirectory }}'
@@ -74,10 +78,13 @@ steps:
         PROXY_CERT: $(Build.SourcesDirectory)/eng/common/testproxy/dotnet-devcert.crt
         ${{ insert }}: ${{ parameters.EnvVars }}
 
-    - pwsh: |
-        docker logs ambitious_azsdk_test_proxy
-      displayName: 'Dump Docker logs'
-      condition: succeededOrFailed()
+    - ${{ if eq(parameters.TestProxy, true) }}:
+      - pwsh: |
+          # ambitious_azsdk_test_proxy is the hardcoded container name used
+          # by the test proxy startup script
+          docker logs ambitious_azsdk_test_proxy
+        displayName: 'Dump Test Proxy logs'
+        condition: succeededOrFailed()
 
     - pwsh: ../eng/scripts/create_coverage.ps1 ${{parameters.ServiceDirectory}}
       displayName: 'Generate Coverage XML'


### PR DESCRIPTION
The test proxy steps add a few minutes of extra time on windows builds due to large image downloads. There's no need to run the proxy in live testing mode anyway, so skip it.

Depends on https://github.com/Azure/azure-sdk-for-go/pull/15546