### PR TITLE
Add `dockerd` Restart

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -56,7 +56,7 @@ steps:
 
     - pwsh: |
          Get-Service docker | Restart-Service
-      condition: and(eq(parameters['TestProxy'], true), eq(variables['Agent.OS'],'Windows_NT'))
+      condition: and(succeededOrFailed(), eq('${{ parameters.TestProxy }}', 'true'), eq(variables['Agent.OS'],'Windows_NT'))
 
     - ${{ if eq(parameters.TestProxy, true) }}:
       - template: /eng/common/testproxy/test-proxy-docker.yml


### PR DESCRIPTION
@seankane-msft I have reason to believe there is something going on with the service being in a bad state, or something along those lines.

The issue seems to be appearing every 5 or 10 builds, so I'll just queue up a ton of them against this PR.

11 builds later, it hasn't repro-ed, so my suspicion on the service not properly started seems...likely.

Instead of _always_ doing a restart, I need to check the status of the service next. That'll come in a follow-up PR. Closing for now.