### PR TITLE
Make azblob.BlobClient.downloadBlobToWriterAt public

### DIFF
--- a/sdk/storage/azblob/highlevel.go
+++ b/sdk/storage/azblob/highlevel.go
@@ -230,8 +230,9 @@ func (o *HighLevelDownloadFromBlobOptions) getDownloadBlobOptions(offSet, count 
 	}
 }
 
-// downloadBlobToWriterAt downloads an Azure blob to a buffer with parallel.
-func (b BlobClient) downloadBlobToWriterAt(ctx context.Context, offset int64, count int64, writer io.WriterAt, o HighLevelDownloadFromBlobOptions) error {
+// DownloadBlobToWriterAt downloads an Azure blob to a WriterAt with parallel.
+// Offset and count are optional, pass 0 for both to download the entire blob.
+func (b BlobClient) DownloadBlobToWriterAt(ctx context.Context, offset int64, count int64, writer io.WriterAt, o HighLevelDownloadFromBlobOptions) error {
 	if o.BlockSize == 0 {
 		o.BlockSize = BlobDefaultDownloadBlockSize
 	}
@@ -298,7 +299,7 @@ func (b BlobClient) downloadBlobToWriterAt(ctx context.Context, offset int64, co
 // DownloadBlobToBuffer downloads an Azure blob to a buffer with parallel.
 // Offset and count are optional, pass 0 for both to download the entire blob.
 func (b BlobClient) DownloadBlobToBuffer(ctx context.Context, offset int64, count int64, _bytes []byte, o HighLevelDownloadFromBlobOptions) error {
-	return b.downloadBlobToWriterAt(ctx, offset, count, newBytesWriter(_bytes), o)
+	return b.DownloadBlobToWriterAt(ctx, offset, count, newBytesWriter(_bytes), o)
 }
 
 // DownloadBlobToFile downloads an Azure blob to a local file.
@@ -332,7 +333,7 @@ func (b BlobClient) DownloadBlobToFile(ctx context.Context, offset int64, count 
 	}
 
 	if size > 0 {
-		return b.downloadBlobToWriterAt(ctx, offset, size, file, o)
+		return b.DownloadBlobToWriterAt(ctx, offset, size, file, o)
 	} else { // if the blob's size is 0, there is no need in downloading it
 		return nil
 	}


### PR DESCRIPTION
Make `azblob.BlobClient.downloadBlobToWriterAt` public, so that it is possible to download blobs through custom implementations of `io.WriterAt`.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
- [x] N/A: Tests are included and/or updated for code changes.
- [x] N/A: Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
