### PR TITLE
Changed ThroughputOptions to use azcore Etag

### DIFF
--- a/sdk/data/azcosmos/example_test.go
+++ b/sdk/data/azcosmos/example_test.go
@@ -144,7 +144,7 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	var itemResponseBody map[string]interface{}
+	var itemResponseBody map[string]string
 	err = json.Unmarshal(itemResponse.Value, &itemResponseBody)
 	if err != nil {
 		log.Fatal(err)
@@ -189,7 +189,7 @@ func Example() {
 			log.Fatal(err)
 		}
 
-		var itemResponseBody map[string]interface{}
+		var itemResponseBody map[string]string
 		err = json.Unmarshal(itemResponse.Value, &itemResponseBody)
 		if err != nil {
 			log.Fatal(err)

--- a/sdk/data/azcosmos/throughput_request_options.go
+++ b/sdk/data/azcosmos/throughput_request_options.go
@@ -3,23 +3,27 @@
 
 package azcosmos
 
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
 // ThroughputOptions includes options for throughput operations.
 type ThroughputOptions struct {
-	IfMatchEtag     string
-	IfNoneMatchEtag string
+	IfMatchEtag     *azcore.ETag
+	IfNoneMatchEtag *azcore.ETag
 }
 
 func (options *ThroughputOptions) toHeaders() *map[string]string {
-	if options.IfMatchEtag == "" && options.IfNoneMatchEtag == "" {
+	if options.IfMatchEtag == nil && options.IfNoneMatchEtag == nil {
 		return nil
 	}
 
 	headers := make(map[string]string)
-	if options.IfMatchEtag != "" {
-		headers[headerIfMatch] = options.IfMatchEtag
+	if options.IfMatchEtag != nil {
+		headers[headerIfMatch] = string(*options.IfMatchEtag)
 	}
-	if options.IfNoneMatchEtag != "" {
-		headers[headerIfNoneMatch] = options.IfNoneMatchEtag
+	if options.IfNoneMatchEtag != nil {
+		headers[headerIfNoneMatch] = string(*options.IfNoneMatchEtag)
 	}
 	return &headers
 }

--- a/sdk/data/azcosmos/throughput_request_options_test.go
+++ b/sdk/data/azcosmos/throughput_request_options_test.go
@@ -5,6 +5,8 @@ package azcosmos
 
 import (
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 func TestThroughputRequestOptionsToHeaders(t *testing.T) {
@@ -13,18 +15,21 @@ func TestThroughputRequestOptionsToHeaders(t *testing.T) {
 		t.Error("toHeaders should return nil")
 	}
 
-	options.IfMatchEtag = "etag"
-	options.IfNoneMatchEtag = "noneetag"
+	etag := azcore.ETag("etag")
+	noneetag := azcore.ETag("noneetag")
+	options.IfMatchEtag = &etag
+	options.IfNoneMatchEtag = &noneetag
+
 	header := options.toHeaders()
-	if header == nil {
+	if *header == nil {
 		t.Error("toHeaders should return non-nil")
 	}
 
 	headers := *header
-	if headers[headerIfMatch] != options.IfMatchEtag {
+	if headers[headerIfMatch] != string(*options.IfMatchEtag) {
 		t.Errorf("IfMatchEtag not set matching expected %v got %v", options.IfMatchEtag, headers[headerIfMatch])
 	}
-	if headers[headerIfNoneMatch] != options.IfNoneMatchEtag {
+	if headers[headerIfNoneMatch] != string(*options.IfNoneMatchEtag) {
 		t.Errorf("IfNoneMatchEtag not set matching expected %v got %v", options.IfNoneMatchEtag, headers[headerIfNoneMatch])
 	}
 }


### PR DESCRIPTION


<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
