### PR TITLE
Set floor of one second for polling delay

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Added string typdef `arm.Endpoint` to provide a hint toward expected ARM client endpoints
 * `azcore.ClientOptions` contains common pipeline configuration settings
 * Added support for multi-tenant authorization in `arm/runtime`
+* Require one second minimum when calling `PollUntilDone()`
 
 ### Bug Fixes
 * Fixed a potential panic when creating the default Transporter.

--- a/sdk/azcore/arm/runtime/poller_test.go
+++ b/sdk/azcore/arm/runtime/poller_test.go
@@ -111,7 +111,7 @@ func TestNewPollerAsync(t *testing.T) {
 		t.Fatal(err)
 	}
 	var result mockType
-	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
+	_, err = poller.PollUntilDone(context.Background(), time.Second, &result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +147,7 @@ func TestNewPollerBody(t *testing.T) {
 		t.Fatal(err)
 	}
 	var result mockType
-	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
+	_, err = poller.PollUntilDone(context.Background(), time.Second, &result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func TestNewPollerLoc(t *testing.T) {
 		t.Fatal(err)
 	}
 	var result mockType
-	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
+	_, err = poller.PollUntilDone(context.Background(), time.Second, &result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestNewPollerInitialRetryAfter(t *testing.T) {
 		t.Fatalf("unexpected poller type %s", pt.String())
 	}
 	var result mockType
-	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
+	_, err = poller.PollUntilDone(context.Background(), time.Second, &result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +273,7 @@ func TestNewPollerFailedWithError(t *testing.T) {
 		t.Fatalf("unexpected poller type %s", pt.String())
 	}
 	var result mockType
-	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
+	_, err = poller.PollUntilDone(context.Background(), time.Second, &result)
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func TestNewPollerSuccessNoContent(t *testing.T) {
 		t.Fatal(err)
 	}
 	var result mockType
-	_, err = poller.PollUntilDone(context.Background(), 10*time.Millisecond, &result)
+	_, err = poller.PollUntilDone(context.Background(), time.Second, &result)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azcore/internal/pollers/poller.go
+++ b/sdk/azcore/internal/pollers/poller.go
@@ -169,9 +169,11 @@ func (l *Poller) FinalResponse(ctx context.Context, respType interface{}) (*http
 // PollUntilDone will handle the entire span of the polling operation until a terminal state is reached,
 // then return the final HTTP response for the polling operation and unmarshal the content of the payload
 // into the respType interface that is provided.
-// freq - the time to wait between polling intervals if the endpoint doesn't send a Retry-After header.
-//        A good starting value is 30 seconds.  Note that some resources might benefit from a different value.
+// freq - the time to wait between intervals in absence of a Retry-After header.  Minimum is one second.
 func (l *Poller) PollUntilDone(ctx context.Context, freq time.Duration, respType interface{}) (*http.Response, error) {
+	if freq < time.Second {
+		return nil, errors.New("polling frequency minimum is one second")
+	}
 	start := time.Now()
 	logPollUntilDoneExit := func(v interface{}) {
 		log.Writef(log.EventLRO, "END PollUntilDone() for %T: %v, total time: %s", l.lro, v, time.Since(start))

--- a/sdk/azcore/internal/pollers/poller_test.go
+++ b/sdk/azcore/internal/pollers/poller_test.go
@@ -132,6 +132,13 @@ func TestNewPoller(t *testing.T) {
 		t.Fatal("unexpected empty resume token")
 	}
 	resp, err = p.PollUntilDone(context.Background(), 1*time.Millisecond, nil)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response")
+	}
+	resp, err = p.PollUntilDone(context.Background(), time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +174,7 @@ func TestNewPollerWithFinalGET(t *testing.T) {
 		Shape string `json:"shape"`
 	}
 	var w widget
-	resp, err := p.PollUntilDone(context.Background(), 1*time.Millisecond, &w)
+	resp, err := p.PollUntilDone(context.Background(), time.Second, &w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +205,7 @@ func TestNewPollerFail1(t *testing.T) {
 	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl, func(*http.Response) error {
 		return errors.New("failed")
 	})
-	resp, err := p.PollUntilDone(context.Background(), 1*time.Millisecond, nil)
+	resp, err := p.PollUntilDone(context.Background(), time.Second, nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	} else if s := err.Error(); s != "failed" {
@@ -221,7 +228,7 @@ func TestNewPollerFail2(t *testing.T) {
 	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl, func(*http.Response) error {
 		return errors.New("failed")
 	})
-	resp, err := p.PollUntilDone(context.Background(), 1*time.Millisecond, nil)
+	resp, err := p.PollUntilDone(context.Background(), time.Second, nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	} else if s := err.Error(); s != "failed" {
@@ -244,7 +251,7 @@ func TestNewPollerError(t *testing.T) {
 	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl, func(*http.Response) error {
 		return errors.New("failed")
 	})
-	resp, err := p.PollUntilDone(context.Background(), 1*time.Millisecond, nil)
+	resp, err := p.PollUntilDone(context.Background(), time.Second, nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	} else if s := err.Error(); s != "fatal" {

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -41,6 +41,7 @@ func setDefaults(o *policy.RetryOptions) {
 	if o.StatusCodes == nil {
 		o.StatusCodes = []int{
 			http.StatusRequestTimeout,      // 408
+			http.StatusTooManyRequests,     // 429
 			http.StatusInternalServerError, // 500
 			http.StatusBadGateway,          // 502
 			http.StatusServiceUnavailable,  // 503

--- a/sdk/azcore/runtime/poller_test.go
+++ b/sdk/azcore/runtime/poller_test.go
@@ -107,7 +107,7 @@ func TestLocPollerSimple(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	resp, err := lro.PollUntilDone(context.Background(), time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestLocPollerWithWidget(t *testing.T) {
 		t.Fatal("initial response body wasn't closed")
 	}
 	var w widget
-	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	resp, err := lro.PollUntilDone(context.Background(), time.Second, &w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +178,7 @@ func TestLocPollerCancelled(t *testing.T) {
 		t.Fatal("initial response body wasn't closed")
 	}
 	var w widget
-	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	resp, err := lro.PollUntilDone(context.Background(), time.Second, &w)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -218,7 +218,7 @@ func TestLocPollerWithError(t *testing.T) {
 		t.Fatal("initial response body wasn't closed")
 	}
 	var w widget
-	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	resp, err := lro.PollUntilDone(context.Background(), time.Second, &w)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -282,7 +282,7 @@ func TestLocPollerWithResumeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	resp, err = lro.PollUntilDone(context.Background(), time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,7 +295,7 @@ func TestLocPollerWithTimeout(t *testing.T) {
 	srv, close := mock.NewServer()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
-	srv.AppendResponse(mock.WithSlowResponse(2 * time.Second))
+	srv.AppendResponse(mock.WithSlowResponse(5 * time.Second))
 	defer close()
 
 	firstResp := &http.Response{
@@ -314,8 +314,8 @@ func TestLocPollerWithTimeout(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	resp, err := lro.PollUntilDone(ctx, 5*time.Millisecond, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	resp, err := lro.PollUntilDone(ctx, time.Second, nil)
 	cancel()
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -357,7 +357,7 @@ func TestOpPollerSimple(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	resp, err := lro.PollUntilDone(context.Background(), time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +401,7 @@ func TestOpPollerWithWidgetPUT(t *testing.T) {
 		t.Fatal("initial response body wasn't closed")
 	}
 	var w widget
-	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	resp, err := lro.PollUntilDone(context.Background(), time.Second, &w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -449,7 +449,7 @@ func TestOpPollerWithWidgetPOSTLocation(t *testing.T) {
 		t.Fatal("initial response body wasn't closed")
 	}
 	var w widget
-	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	resp, err := lro.PollUntilDone(context.Background(), time.Second, &w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -495,7 +495,7 @@ func TestOpPollerWithWidgetPOST(t *testing.T) {
 		t.Fatal("initial response body wasn't closed")
 	}
 	var w widget
-	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	resp, err := lro.PollUntilDone(context.Background(), time.Second, &w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -544,7 +544,7 @@ func TestOpPollerWithWidgetResourceLocation(t *testing.T) {
 		t.Fatal("initial response body wasn't closed")
 	}
 	var w widget
-	resp, err := lro.PollUntilDone(context.Background(), 5*time.Millisecond, &w)
+	resp, err := lro.PollUntilDone(context.Background(), time.Second, &w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,7 +613,7 @@ func TestOpPollerWithResumeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	resp, err = lro.PollUntilDone(context.Background(), time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -656,7 +656,7 @@ func TestNopPoller(t *testing.T) {
 	if resp != firstResp {
 		t.Fatal("unexpected response")
 	}
-	resp, err = lro.PollUntilDone(context.Background(), 5*time.Millisecond, nil)
+	resp, err = lro.PollUntilDone(context.Background(), time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
To avoid excessive polling.
Add 429 to list of retriable HTTP status codes.
