### PR TITLE
Add live tests to azidentity pipeline

### DIFF
--- a/sdk/azidentity/aad_identity_client_test.go
+++ b/sdk/azidentity/aad_identity_client_test.go
@@ -29,13 +29,6 @@ func TestAzureChinaParse(t *testing.T) {
 	}
 }
 
-func TestAzureGermanyParse(t *testing.T) {
-	_, err := url.Parse(string(AzureGermany))
-	if err != nil {
-		t.Fatalf("Failed to parse AzureGermany authority host: %v", err)
-	}
-}
-
 func TestAzureGovernmentParse(t *testing.T) {
 	_, err := url.Parse(string(AzureGovernment))
 	if err != nil {

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -22,8 +22,6 @@ type AuthorityHost string
 const (
 	// AzureChina is a global constant to use in order to access the Azure China cloud.
 	AzureChina AuthorityHost = "https://login.chinacloudapi.cn/"
-	// AzureGermany is a global constant to use in order to access the Azure Germany cloud.
-	AzureGermany AuthorityHost = "https://login.microsoftonline.de/"
 	// AzureGovernment is a global constant to use in order to access the Azure Government cloud.
 	AzureGovernment AuthorityHost = "https://login.microsoftonline.us/"
 	// AzurePublicCloud is a global constant to use in order to access the Azure public cloud.

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
+const azureAuthorityHost = "AZURE_AUTHORITY_HOST"
+
 // AuthorityHost is the base URL for Azure Active Directory
 type AuthorityHost string
 
@@ -25,7 +27,7 @@ const (
 	// AzureGovernment is a global constant to use in order to access the Azure Government cloud.
 	AzureGovernment AuthorityHost = "https://login.microsoftonline.us/"
 	// AzurePublicCloud is a global constant to use in order to access the Azure public cloud.
-	AzurePublicCloud AuthorityHost = "https://login.microsoftonline.com"
+	AzurePublicCloud AuthorityHost = "https://login.microsoftonline.com/"
 )
 
 // defaultSuffix is the default AADv2 scope
@@ -57,7 +59,7 @@ func setAuthorityHost(authorityHost AuthorityHost) (string, error) {
 	host := string(authorityHost)
 	if host == "" {
 		host = string(AzurePublicCloud)
-		if envAuthorityHost := os.Getenv("AZURE_AUTHORITY_HOST"); envAuthorityHost != "" {
+		if envAuthorityHost := os.Getenv(azureAuthorityHost); envAuthorityHost != "" {
 			host = envAuthorityHost
 		}
 	}

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -45,8 +45,6 @@ func init() {
 	switch host {
 	case AzureChina:
 		liveTestScope = "https://management.core.chinacloudapi.cn//.default"
-	case AzureGermany:
-		liveTestScope = "https://management.core.cloudapi.de//.default"
 	case AzureGovernment:
 		liveTestScope = "https://management.core.usgovcloudapi.net//.default"
 	}

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -21,6 +21,37 @@ const (
 	tokenValue               = "new_token"
 )
 
+// configuration for live tests
+var liveSP = struct {
+	tenantID string
+	clientID string
+	secret   string
+	pemPath  string
+	pfxPath  string
+	sniPath  string
+}{
+	tenantID: os.Getenv("IDENTITY_SP_TENANT_ID"),
+	clientID: os.Getenv("IDENTITY_SP_CLIENT_ID"),
+	secret:   os.Getenv("IDENTITY_SP_CLIENT_SECRET"),
+	pemPath:  os.Getenv("IDENTITY_SP_CERT_PEM"),
+	pfxPath:  os.Getenv("IDENTITY_SP_CERT_PFX"),
+	sniPath:  os.Getenv("IDENTITY_SP_CERT_SNI"),
+}
+
+var liveTestScope = "https://management.core.windows.net//.default"
+
+func init() {
+	host := AuthorityHost(os.Getenv("AZURE_AUTHORITY_HOST"))
+	switch host {
+	case AzureChina:
+		liveTestScope = "https://management.core.chinacloudapi.cn//.default"
+	case AzureGermany:
+		liveTestScope = "https://management.core.cloudapi.de//.default"
+	case AzureGovernment:
+		liveTestScope = "https://management.core.usgovcloudapi.net//.default"
+	}
+}
+
 func defaultTestPipeline(srv policy.Transporter, cred azcore.TokenCredential, scope string) runtime.Pipeline {
 	retryOpts := policy.RetryOptions{
 		MaxRetryDelay: 500 * time.Millisecond,

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -41,7 +41,7 @@ var liveSP = struct {
 var liveTestScope = "https://management.core.windows.net//.default"
 
 func init() {
-	host := AuthorityHost(os.Getenv("AZURE_AUTHORITY_HOST"))
+	host := AuthorityHost(os.Getenv(azureAuthorityHost))
 	switch host {
 	case AzureChina:
 		liveTestScope = "https://management.core.chinacloudapi.cn//.default"
@@ -90,7 +90,7 @@ func setEnvironmentVariables(t *testing.T, vars map[string]string) {
 }
 
 func Test_SetEnvAuthorityHost(t *testing.T) {
-	setEnvironmentVariables(t, map[string]string{"AZURE_AUTHORITY_HOST": envHostString})
+	setEnvironmentVariables(t, map[string]string{azureAuthorityHost: envHostString})
 	authorityHost, err := setAuthorityHost("")
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +101,7 @@ func Test_SetEnvAuthorityHost(t *testing.T) {
 }
 
 func Test_CustomAuthorityHost(t *testing.T) {
-	setEnvironmentVariables(t, map[string]string{"AZURE_AUTHORITY_HOST": envHostString})
+	setEnvironmentVariables(t, map[string]string{azureAuthorityHost: envHostString})
 	authorityHost, err := setAuthorityHost(customHostString)
 	if err != nil {
 		t.Fatal(err)
@@ -113,7 +113,7 @@ func Test_CustomAuthorityHost(t *testing.T) {
 }
 
 func Test_DefaultAuthorityHost(t *testing.T) {
-	setEnvironmentVariables(t, map[string]string{"AZURE_AUTHORITY_HOST": ""})
+	setEnvironmentVariables(t, map[string]string{azureAuthorityHost: ""})
 	authorityHost, err := setAuthorityHost("")
 	if err != nil {
 		t.Fatal(err)
@@ -124,7 +124,7 @@ func Test_DefaultAuthorityHost(t *testing.T) {
 }
 
 func Test_NonHTTPSAuthorityHost(t *testing.T) {
-	setEnvironmentVariables(t, map[string]string{"AZURE_AUTHORITY_HOST": ""})
+	setEnvironmentVariables(t, map[string]string{azureAuthorityHost: ""})
 	authorityHost, err := setAuthorityHost("http://foo.com")
 	if err == nil {
 		t.Fatal("Expected an error but did not receive one.")

--- a/sdk/azidentity/ci.yml
+++ b/sdk/azidentity/ci.yml
@@ -21,7 +21,30 @@ pr:
     include:
     - sdk/azidentity/
 
+variables:
+  - group: 'Test Secrets for Go Identity Live Tests'
+
 stages:
 - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
+    RunLiveTests: true
     ServiceDirectory: 'azidentity'
+    PreSteps:
+      - pwsh: |
+          [System.Convert]::FromBase64String($env:PFX_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/test.pfx -AsByteStream
+          Set-Content -Path $(Agent.TempDirectory)/test.pem -Value $env:PEM_CONTENTS
+          [System.Convert]::FromBase64String($env:SNI_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/testsni.pfx -AsByteStream
+        env:
+          PFX_CONTENTS: $(net-identity-spcert-pfx)
+          PEM_CONTENTS: $(net-identity-spcert-pem)
+          SNI_CONTENTS: $(net-identity-spcert-sni)
+    EnvVars:
+      AZURE_IDENTITY_TEST_TENANTID: $(net-identity-tenantid)
+      AZURE_IDENTITY_TEST_USERNAME: $(net-identity-username)
+      AZURE_IDENTITY_TEST_PASSWORD: $(net-identity-password)
+      IDENTITY_SP_TENANT_ID: $(net-identity-sp-tenantid)
+      IDENTITY_SP_CLIENT_ID: $(net-identity-sp-clientid)
+      IDENTITY_SP_CLIENT_SECRET: $(net-identity-sp-clientsecret)
+      IDENTITY_SP_CERT_PEM: $(Agent.TempDirectory)/test.pem
+      IDENTITY_SP_CERT_PFX: $(Agent.TempDirectory)/test.pfx
+      IDENTITY_SP_CERT_SNI: $(Agent.TempDirectory)/testsni.pfx

--- a/sdk/azidentity/ci.yml
+++ b/sdk/azidentity/ci.yml
@@ -21,9 +21,6 @@ pr:
     include:
     - sdk/azidentity/
 
-variables:
-  - group: 'Test Secrets for Go Identity Live Tests'
-
 stages:
 - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -4,8 +4,12 @@
 package azidentity
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 func initEnvironmentVarsForTest() error {
@@ -166,5 +170,62 @@ func TestEnvironmentCredential_UsernamePasswordSet(t *testing.T) {
 	}
 	if _, ok := cred.cred.(*UsernamePasswordCredential); !ok {
 		t.Fatalf("Did not receive the right credential type. Expected *azidentity.UsernamePasswordCredential, Received: %t", cred)
+	}
+}
+
+func TestEnvironmentCredential_ClientSecretLive(t *testing.T) {
+	vars := map[string]string{
+		"AZURE_CLIENT_ID":     liveSP.clientID,
+		"AZURE_CLIENT_SECRET": liveSP.secret,
+		"AZURE_TENANT_ID":     liveSP.tenantID,
+	}
+	for _, v := range vars {
+		if v == "" {
+			t.Skip("missing live service principal configuration")
+		}
+	}
+	setEnvironmentVariables(t, vars)
+	cred, err := NewEnvironmentCredential(nil)
+	if err != nil {
+		t.Fatalf("failed to construct credential: %v", err)
+	}
+	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
+	if err != nil {
+		t.Fatalf("GetToken failed: %v", err)
+	}
+	if tk.Token == "" {
+		t.Fatalf("GetToken returned an invalid token")
+	}
+	if !tk.ExpiresOn.After(time.Now().UTC()) {
+		t.Fatalf("GetToken returned an invalid expiration time")
+	}
+}
+
+func TestEnvironmentCredential_UserPasswordLive(t *testing.T) {
+	vars := map[string]string{
+		"AZURE_CLIENT_ID": developerSignOnClientID,
+		"AZURE_TENANT_ID": os.Getenv("AZURE_IDENTITY_TEST_TENANTID"),
+		"AZURE_USERNAME":  os.Getenv("AZURE_IDENTITY_TEST_USERNAME"),
+		"AZURE_PASSWORD":  os.Getenv("AZURE_IDENTITY_TEST_PASSWORD"),
+	}
+	for _, v := range vars {
+		if v == "" {
+			t.Skip("missing live user configuration")
+		}
+	}
+	setEnvironmentVariables(t, vars)
+	cred, err := NewEnvironmentCredential(nil)
+	if err != nil {
+		t.Fatalf("failed to construct credential: %v", err)
+	}
+	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
+	if err != nil {
+		t.Fatalf("GetToken failed: %v", err)
+	}
+	if tk.Token == "" {
+		t.Fatalf("GetToken returned an invalid token")
+	}
+	if !tk.ExpiresOn.After(time.Now().UTC()) {
+		t.Fatalf("GetToken returned an invalid expiration time")
 	}
 }

--- a/sdk/azidentity/logging.go
+++ b/sdk/azidentity/logging.go
@@ -35,8 +35,8 @@ func logEnvVars() {
 	if envCheck := os.Getenv("AZURE_CLIENT_SECRET"); len(envCheck) > 0 {
 		envVars = append(envVars, "AZURE_CLIENT_SECRET")
 	}
-	if envCheck := os.Getenv("AZURE_AUTHORITY_HOST"); len(envCheck) > 0 {
-		envVars = append(envVars, "AZURE_AUTHORITY_HOST")
+	if envCheck := os.Getenv(azureAuthorityHost); len(envCheck) > 0 {
+		envVars = append(envVars, azureAuthorityHost)
 	}
 	if len(envVars) > 0 {
 		log.Writef(EventCredential, "Azure Identity => Found the following environment variables:\n\t%s", strings.Join(envVars, ", "))


### PR DESCRIPTION
Adds live tests for service principal and user password authentication and the CI configuration necessary to run them. #15973 tracks recording these.

Closes #15403, closes #15876