### PR TITLE
[azservicebus] Session API work (session state support, removing RenewMessageLock), etc...

### DIFF
--- a/sdk/messaging/azservicebus/example_receiver_test.go
+++ b/sdk/messaging/azservicebus/example_receiver_test.go
@@ -16,7 +16,7 @@ func ExampleClient_NewReceiverForSubscription() {
 		"exampleTopic",
 		"exampleSubscription",
 		&azservicebus.ReceiverOptions{
-			ReceiveMode: azservicebus.PeekLock,
+			ReceiveMode: azservicebus.ReceiveModePeekLock,
 		},
 	)
 	exitOnError("Failed to create Receiver", err)
@@ -26,7 +26,7 @@ func ExampleClient_NewReceiverForQueue() {
 	receiver, err = client.NewReceiverForQueue(
 		"exampleQueue",
 		&azservicebus.ReceiverOptions{
-			ReceiveMode: azservicebus.PeekLock,
+			ReceiveMode: azservicebus.ReceiveModePeekLock,
 		},
 	)
 	exitOnError("Failed to create Receiver", err)
@@ -36,7 +36,7 @@ func ExampleClient_NewReceiverForQueue_deadLetterQueue() {
 	receiver, err = client.NewReceiverForQueue(
 		"exampleQueue",
 		&azservicebus.ReceiverOptions{
-			ReceiveMode: azservicebus.PeekLock,
+			ReceiveMode: azservicebus.ReceiveModePeekLock,
 			SubQueue:    azservicebus.SubQueueDeadLetter,
 		},
 	)
@@ -48,7 +48,7 @@ func ExampleClient_NewReceiverForSubscription_deadLetterQueue() {
 		"exampleTopic",
 		"exampleSubscription",
 		&azservicebus.ReceiverOptions{
-			ReceiveMode: azservicebus.PeekLock,
+			ReceiveMode: azservicebus.ReceiveModePeekLock,
 			SubQueue:    azservicebus.SubQueueDeadLetter,
 		},
 	)

--- a/sdk/messaging/azservicebus/processor.go
+++ b/sdk/messaging/azservicebus/processor.go
@@ -83,7 +83,7 @@ type processor struct {
 func applyProcessorOptions(p *processor, entity *entity, options *processorOptions) error {
 	if options == nil {
 		p.maxConcurrentCalls = 1
-		p.receiveMode = PeekLock
+		p.receiveMode = ReceiveModePeekLock
 		p.autoComplete = true
 
 		return nil
@@ -372,7 +372,7 @@ func (p *processor) processMessage(ctx context.Context, receiver internal.AMQPRe
 }
 
 func checkReceiverMode(receiveMode ReceiveMode) error {
-	if receiveMode == PeekLock || receiveMode == ReceiveAndDelete {
+	if receiveMode == ReceiveModePeekLock || receiveMode == ReceiveModeReceiveAndDelete {
 		return nil
 	} else {
 		return fmt.Errorf("Invalid receive mode %d, must be either azservicebus.PeekLock or azservicebus.ReceiveAndDelete", receiveMode)

--- a/sdk/messaging/azservicebus/processor_test.go
+++ b/sdk/messaging/azservicebus/processor_test.go
@@ -165,7 +165,7 @@ func TestProcessorUnitTests(t *testing.T) {
 	require.NoError(t, applyProcessorOptions(p, e, nil))
 	require.True(t, p.autoComplete)
 	require.EqualValues(t, 1, p.maxConcurrentCalls)
-	require.EqualValues(t, PeekLock, p.receiveMode)
+	require.EqualValues(t, ReceiveModePeekLock, p.receiveMode)
 
 	p = &processor{}
 	e = &entity{
@@ -173,7 +173,7 @@ func TestProcessorUnitTests(t *testing.T) {
 	}
 
 	require.NoError(t, applyProcessorOptions(p, e, &processorOptions{
-		ReceiveMode:         ReceiveAndDelete,
+		ReceiveMode:         ReceiveModeReceiveAndDelete,
 		SubQueue:            SubQueueDeadLetter,
 		DisableAutoComplete: true,
 		MaxConcurrentCalls:  101,
@@ -181,7 +181,7 @@ func TestProcessorUnitTests(t *testing.T) {
 
 	require.False(t, p.autoComplete)
 	require.EqualValues(t, 101, p.maxConcurrentCalls)
-	require.EqualValues(t, ReceiveAndDelete, p.receiveMode)
+	require.EqualValues(t, ReceiveModeReceiveAndDelete, p.receiveMode)
 	fullEntityPath, err := e.String()
 	require.NoError(t, err)
 	require.EqualValues(t, "queue/$DeadLetterQueue", fullEntityPath)

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -20,12 +20,12 @@ import (
 type ReceiveMode = internal.ReceiveMode
 
 const (
-	// PeekLock will lock messages as they are received and can be settled
+	// ReceiveModePeekLock will lock messages as they are received and can be settled
 	// using the Receiver's (Complete|Abandon|DeadLetter|Defer)Message
 	// functions.
-	PeekLock ReceiveMode = internal.PeekLock
-	// ReceiveAndDelete will delete messages as they are received.
-	ReceiveAndDelete ReceiveMode = internal.ReceiveAndDelete
+	ReceiveModePeekLock ReceiveMode = internal.PeekLock
+	// ReceiveModeReceiveAndDelete will delete messages as they are received.
+	ReceiveModeReceiveAndDelete ReceiveMode = internal.ReceiveAndDelete
 )
 
 // SubQueue allows you to target a subqueue of a queue or subscription.
@@ -82,7 +82,7 @@ const defaultLinkRxBuffer = 2048
 
 func applyReceiverOptions(receiver *Receiver, entity *entity, options *ReceiverOptions) error {
 	if options == nil {
-		receiver.receiveMode = PeekLock
+		receiver.receiveMode = ReceiveModePeekLock
 		return nil
 	}
 
@@ -133,7 +133,7 @@ func newReceiver(ns internal.NamespaceWithNewAMQPLinks, entity *entity, cleanupO
 	receiver.amqpLinks = ns.NewAMQPLinks(entityPath, newLinksFn)
 
 	// 'nil' settler handles returning an error message for receiveAndDelete links.
-	if receiver.receiveMode == PeekLock {
+	if receiver.receiveMode == ReceiveModePeekLock {
 		receiver.settler = newMessageSettler(receiver.amqpLinks, receiver.baseRetrier)
 	}
 
@@ -506,7 +506,7 @@ func createReceiverLink(ctx context.Context, session internal.AMQPSession, linkO
 func createLinkOptions(mode ReceiveMode, entityPath string) []amqp.LinkOption {
 	receiveMode := amqp.ModeSecond
 
-	if mode == ReceiveAndDelete {
+	if mode == ReceiveModeReceiveAndDelete {
 		receiveMode = amqp.ModeFirst
 	}
 
@@ -517,7 +517,7 @@ func createLinkOptions(mode ReceiveMode, entityPath string) []amqp.LinkOption {
 		amqp.LinkCredit(defaultLinkRxBuffer),
 	}
 
-	if mode == ReceiveAndDelete {
+	if mode == ReceiveModeReceiveAndDelete {
 		opts = append(opts, amqp.LinkSenderSettle(amqp.ModeSettled))
 	}
 

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -198,9 +198,9 @@ func (r *Receiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers 
 	return receivedMessages, nil
 }
 
-// PeekOptions contains options for the `Receiver.PeekMessages`
+// PeekMessagesOptions contains options for the `Receiver.PeekMessages`
 // function.
-type PeekOptions struct {
+type PeekMessagesOptions struct {
 	// FromSequenceNumber is the sequence number to start with when peeking messages.
 	FromSequenceNumber *int64
 }
@@ -209,7 +209,7 @@ type PeekOptions struct {
 // Messages that are peeked do not have lock tokens, so settlement methods
 // like CompleteMessage, AbandonMessage, DeferMessage or DeadLetterMessage
 // will not work with them.
-func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekOptions) ([]*ReceivedMessage, error) {
+func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekMessagesOptions) ([]*ReceivedMessage, error) {
 	_, _, mgmt, _, err := r.amqpLinks.Get(ctx)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -172,6 +172,159 @@ func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options
 	return r.receiveMessagesImpl(ctx, maxMessages, options)
 }
 
+// ReceiveDeferredMessages receives messages that were deferred using `Receiver.DeferMessage`.
+func (r *Receiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers []int64) ([]*ReceivedMessage, error) {
+	_, _, mgmt, _, err := r.amqpLinks.Get(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	amqpMessages, err := mgmt.ReceiveDeferred(ctx, r.receiveMode, sequenceNumbers)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var receivedMessages []*ReceivedMessage
+
+	for _, amqpMsg := range amqpMessages {
+		receivedMsg := newReceivedMessage(ctx, amqpMsg)
+		receivedMsg.deferred = true
+
+		receivedMessages = append(receivedMessages, receivedMsg)
+	}
+
+	return receivedMessages, nil
+}
+
+// PeekOptions contains options for the `Receiver.PeekMessages`
+// function.
+type PeekOptions struct {
+	// FromSequenceNumber is the sequence number to start with when peeking messages.
+	FromSequenceNumber *int64
+}
+
+// PeekMessages will peek messages without locking or deleting messages.
+// Messages that are peeked do not have lock tokens, so settlement methods
+// like CompleteMessage, AbandonMessage, DeferMessage or DeadLetterMessage
+// will not work with them.
+func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekOptions) ([]*ReceivedMessage, error) {
+	_, _, mgmt, _, err := r.amqpLinks.Get(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var sequenceNumber = r.lastPeekedSequenceNumber + 1
+	updateInternalSequenceNumber := true
+
+	if options != nil && options.FromSequenceNumber != nil {
+		sequenceNumber = *options.FromSequenceNumber
+		updateInternalSequenceNumber = false
+	}
+
+	messages, err := mgmt.PeekMessages(ctx, sequenceNumber, int32(maxMessageCount))
+
+	if err != nil {
+		return nil, err
+	}
+
+	receivedMessages := make([]*ReceivedMessage, len(messages))
+
+	for i := 0; i < len(messages); i++ {
+		receivedMessages[i] = newReceivedMessage(ctx, messages[i])
+	}
+
+	if len(receivedMessages) > 0 && updateInternalSequenceNumber {
+		// only update this if they're doing the implicit iteration as part of the receiver.
+		r.lastPeekedSequenceNumber = *receivedMessages[len(receivedMessages)-1].SequenceNumber
+	}
+
+	return receivedMessages, nil
+}
+
+// RenewLock renews the lock on a message, updating the `LockedUntil` field on `msg`.
+func (r *Receiver) RenewMessageLock(ctx context.Context, msg *ReceivedMessage) error {
+	_, _, mgmt, _, err := r.amqpLinks.Get(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	newExpirationTime, err := mgmt.RenewLocks(ctx, msg.rawAMQPMessage.LinkName(), []amqp.UUID{
+		(amqp.UUID)(msg.LockToken),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	msg.LockedUntil = &newExpirationTime[0]
+	return nil
+}
+
+// Close permanently closes the receiver.
+func (r *Receiver) Close(ctx context.Context) error {
+	r.cleanupOnClose()
+	return r.amqpLinks.Close(ctx, true)
+}
+
+// CompleteMessage completes a message, deleting it from the queue or subscription.
+func (r *Receiver) CompleteMessage(ctx context.Context, message *ReceivedMessage) error {
+	return r.settler.CompleteMessage(ctx, message)
+}
+
+// AbandonMessage will cause a message to be returned to the queue or subscription.
+// This will increment its delivery count, and potentially cause it to be dead lettered
+// depending on your queue or subscription's configuration.
+func (r *Receiver) AbandonMessage(ctx context.Context, message *ReceivedMessage) error {
+	return r.settler.AbandonMessage(ctx, message)
+}
+
+// DeferMessage will cause a message to be deferred. Deferred messages
+// can be received using `Receiver.ReceiveDeferredMessages`.
+func (r *Receiver) DeferMessage(ctx context.Context, message *ReceivedMessage) error {
+	return r.settler.DeferMessage(ctx, message)
+}
+
+// DeadLetterMessage settles a message by moving it to the dead letter queue for a
+// queue or subscription. To receive these messages create a receiver with `Client.NewReceiverForQueue()`
+// or `Client.NewReceiverForSubscription()` using the `ReceiverOptions.SubQueue` option.
+func (r *Receiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
+	return r.settler.DeadLetterMessage(ctx, message, options)
+}
+
+// receiveDeferredMessage receives a single message that was deferred using `Receiver.DeferMessage`.
+func (r *Receiver) receiveDeferredMessage(ctx context.Context, sequenceNumber int64) (*ReceivedMessage, error) {
+	messages, err := r.ReceiveDeferredMessages(ctx, []int64{sequenceNumber})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(messages) == 0 {
+		return nil, nil
+	}
+
+	return messages[0], nil
+}
+
+// receiveMessage receives a single message, waiting up to `ReceiveOptions.MaxWaitTime` (default: 60 seconds)
+func (r *Receiver) receiveMessage(ctx context.Context, options *ReceiveOptions) (*ReceivedMessage, error) {
+	messages, err := r.ReceiveMessages(ctx, 1, options)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(messages) == 0 {
+		return nil, nil
+	}
+
+	return messages[0], nil
+}
+
 func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, options *ReceiveOptions) ([]*ReceivedMessage, error) {
 	// There are three phases for this function:
 	// Phase 1. <receive, respecting user cancellation>
@@ -299,159 +452,6 @@ func (r *Receiver) getMessages(ctx context.Context, receiver internal.AMQPReceiv
 			defer cancel()
 		}
 	}
-}
-
-// ReceiveDeferredMessages receives messages that were deferred using `Receiver.DeferMessage`.
-func (r *Receiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers []int64) ([]*ReceivedMessage, error) {
-	_, _, mgmt, _, err := r.amqpLinks.Get(ctx)
-
-	if err != nil {
-		return nil, err
-	}
-
-	amqpMessages, err := mgmt.ReceiveDeferred(ctx, r.receiveMode, sequenceNumbers)
-
-	if err != nil {
-		return nil, err
-	}
-
-	var receivedMessages []*ReceivedMessage
-
-	for _, amqpMsg := range amqpMessages {
-		receivedMsg := newReceivedMessage(ctx, amqpMsg)
-		receivedMsg.deferred = true
-
-		receivedMessages = append(receivedMessages, receivedMsg)
-	}
-
-	return receivedMessages, nil
-}
-
-// PeekOptions contains options for the `Receiver.PeekMessages`
-// function.
-type PeekOptions struct {
-	// FromSequenceNumber is the sequence number to start with when peeking messages.
-	FromSequenceNumber *int64
-}
-
-// PeekMessages will peek messages without locking or deleting messages.
-// Messages that are peeked do not have lock tokens, so settlement methods
-// like CompleteMessage, AbandonMessage, DeferMessage or DeadLetterMessage
-// will not work with them.
-func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekOptions) ([]*ReceivedMessage, error) {
-	_, _, mgmt, _, err := r.amqpLinks.Get(ctx)
-
-	if err != nil {
-		return nil, err
-	}
-
-	var sequenceNumber = r.lastPeekedSequenceNumber + 1
-	updateInternalSequenceNumber := true
-
-	if options != nil && options.FromSequenceNumber != nil {
-		sequenceNumber = *options.FromSequenceNumber
-		updateInternalSequenceNumber = false
-	}
-
-	messages, err := mgmt.PeekMessages(ctx, sequenceNumber, int32(maxMessageCount))
-
-	if err != nil {
-		return nil, err
-	}
-
-	receivedMessages := make([]*ReceivedMessage, len(messages))
-
-	for i := 0; i < len(messages); i++ {
-		receivedMessages[i] = newReceivedMessage(ctx, messages[i])
-	}
-
-	if len(receivedMessages) > 0 && updateInternalSequenceNumber {
-		// only update this if they're doing the implicit iteration as part of the receiver.
-		r.lastPeekedSequenceNumber = *receivedMessages[len(receivedMessages)-1].SequenceNumber
-	}
-
-	return receivedMessages, nil
-}
-
-// receiveDeferredMessage receives a single message that was deferred using `Receiver.DeferMessage`.
-func (r *Receiver) receiveDeferredMessage(ctx context.Context, sequenceNumber int64) (*ReceivedMessage, error) {
-	messages, err := r.ReceiveDeferredMessages(ctx, []int64{sequenceNumber})
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(messages) == 0 {
-		return nil, nil
-	}
-
-	return messages[0], nil
-}
-
-// receiveMessage receives a single message, waiting up to `ReceiveOptions.MaxWaitTime` (default: 60 seconds)
-func (r *Receiver) receiveMessage(ctx context.Context, options *ReceiveOptions) (*ReceivedMessage, error) {
-	messages, err := r.ReceiveMessages(ctx, 1, options)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(messages) == 0 {
-		return nil, nil
-	}
-
-	return messages[0], nil
-}
-
-// RenewLock renews the lock on a message, updating the `LockedUntil` field on `msg`.
-func (r *Receiver) RenewMessageLock(ctx context.Context, msg *ReceivedMessage) error {
-	_, _, mgmt, _, err := r.amqpLinks.Get(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	newExpirationTime, err := mgmt.RenewLocks(ctx, msg.rawAMQPMessage.LinkName(), []amqp.UUID{
-		(amqp.UUID)(msg.LockToken),
-	})
-
-	if err != nil {
-		return err
-	}
-
-	msg.LockedUntil = &newExpirationTime[0]
-	return nil
-}
-
-// Close permanently closes the receiver.
-func (r *Receiver) Close(ctx context.Context) error {
-	r.cleanupOnClose()
-	return r.amqpLinks.Close(ctx, true)
-}
-
-// CompleteMessage completes a message, deleting it from the queue or subscription.
-func (r *Receiver) CompleteMessage(ctx context.Context, message *ReceivedMessage) error {
-	return r.settler.CompleteMessage(ctx, message)
-}
-
-// AbandonMessage will cause a message to be returned to the queue or subscription.
-// This will increment its delivery count, and potentially cause it to be dead lettered
-// depending on your queue or subscription's configuration.
-func (r *Receiver) AbandonMessage(ctx context.Context, message *ReceivedMessage) error {
-	return r.settler.AbandonMessage(ctx, message)
-}
-
-// DeferMessage will cause a message to be deferred. Deferred messages
-// can be received using `Receiver.ReceiveDeferredMessages`.
-func (r *Receiver) DeferMessage(ctx context.Context, message *ReceivedMessage) error {
-	return r.settler.DeferMessage(ctx, message)
-}
-
-// DeadLetterMessage settles a message by moving it to the dead letter queue for a
-// queue or subscription. To receive these messages create a receiver with `Client.NewReceiverForQueue()`
-// or `Client.NewReceiverForSubscription()` using the `ReceiverOptions.SubQueue` option.
-func (r *Receiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
-	return r.settler.DeadLetterMessage(ctx, message, options)
 }
 
 type entity struct {

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -340,7 +340,7 @@ func TestReceiverOptions(t *testing.T) {
 
 	require.NoError(t, applyReceiverOptions(receiver, e, nil))
 
-	require.EqualValues(t, PeekLock, receiver.receiveMode)
+	require.EqualValues(t, ReceiveModePeekLock, receiver.receiveMode)
 	path, err := e.String()
 	require.NoError(t, err)
 	require.EqualValues(t, "topic/Subscriptions/subscription", path)
@@ -350,11 +350,11 @@ func TestReceiverOptions(t *testing.T) {
 	e = &entity{Topic: "topic", Subscription: "subscription"}
 
 	require.NoError(t, applyReceiverOptions(receiver, e, &ReceiverOptions{
-		ReceiveMode: ReceiveAndDelete,
+		ReceiveMode: ReceiveModeReceiveAndDelete,
 		SubQueue:    SubQueueTransfer,
 	}))
 
-	require.EqualValues(t, ReceiveAndDelete, receiver.receiveMode)
+	require.EqualValues(t, ReceiveModeReceiveAndDelete, receiver.receiveMode)
 	path, err = e.String()
 	require.NoError(t, err)
 	require.EqualValues(t, "topic/Subscriptions/subscription/$Transfer/$DeadLetterQueue", path)

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -278,7 +278,7 @@ func TestReceiverPeek(t *testing.T) {
 		"Message 0", "Message 1", "Message 2",
 	}, getSortedBodies(append(peekedMessages, peekedMessages2...)))
 
-	repeekedMessages, err := receiver.PeekMessages(ctx, 1, &PeekOptions{
+	repeekedMessages, err := receiver.PeekMessages(ctx, 1, &PeekMessagesOptions{
 		FromSequenceNumber: peekedMessages2[0].SequenceNumber,
 	})
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -43,7 +43,7 @@ func Test_Sender_SendBatchOfTwo(t *testing.T) {
 	require.NoError(t, err)
 
 	receiver, err := client.NewReceiverForQueue(
-		queueName, &ReceiverOptions{ReceiveMode: ReceiveAndDelete})
+		queueName, &ReceiverOptions{ReceiveMode: ReceiveModeReceiveAndDelete})
 	require.NoError(t, err)
 	defer receiver.Close(ctx)
 
@@ -64,7 +64,7 @@ func Test_Sender_UsingPartitionedQueue(t *testing.T) {
 	defer sender.Close(context.Background())
 
 	receiver, err := client.NewReceiverForQueue(
-		queueName, &ReceiverOptions{ReceiveMode: ReceiveAndDelete})
+		queueName, &ReceiverOptions{ReceiveMode: ReceiveModeReceiveAndDelete})
 	require.NoError(t, err)
 	defer receiver.Close(context.Background())
 
@@ -116,7 +116,7 @@ func Test_Sender_SendMessages(t *testing.T) {
 	defer cleanup()
 
 	receiver, err := client.NewReceiverForQueue(
-		queueName, &ReceiverOptions{ReceiveMode: ReceiveAndDelete})
+		queueName, &ReceiverOptions{ReceiveMode: ReceiveModeReceiveAndDelete})
 	require.NoError(t, err)
 	defer receiver.Close(context.Background())
 
@@ -151,12 +151,12 @@ func Test_Sender_SendMessages_resend(t *testing.T) {
 	require.NoError(t, err)
 
 	peekLockReceiver, err := client.NewReceiverForQueue(queueName, &ReceiverOptions{
-		ReceiveMode: PeekLock,
+		ReceiveMode: ReceiveModePeekLock,
 	})
 	require.NoError(t, err)
 
 	deletingReceiver, err := client.NewReceiverForQueue(queueName, &ReceiverOptions{
-		ReceiveMode: ReceiveAndDelete,
+		ReceiveMode: ReceiveModeReceiveAndDelete,
 	})
 	require.NoError(t, err)
 
@@ -205,7 +205,7 @@ func Test_Sender_ScheduleMessages(t *testing.T) {
 	defer cleanup()
 
 	receiver, err := client.NewReceiverForQueue(
-		queueName, &ReceiverOptions{ReceiveMode: ReceiveAndDelete})
+		queueName, &ReceiverOptions{ReceiveMode: ReceiveModeReceiveAndDelete})
 	require.NoError(t, err)
 	defer receiver.Close(context.Background())
 

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -118,7 +118,7 @@ func (r *SessionReceiver) ReceiveDeferredMessages(ctx context.Context, sequenceN
 // Messages that are peeked do not have lock tokens, so settlement methods
 // like CompleteMessage, AbandonMessage, DeferMessage or DeadLetterMessage
 // will not work with them.
-func (r *SessionReceiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekOptions) ([]*ReceivedMessage, error) {
+func (r *SessionReceiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekMessagesOptions) ([]*ReceivedMessage, error) {
 	return r.inner.PeekMessages(ctx, maxMessageCount, options)
 }
 

--- a/sdk/messaging/azservicebus/session_receiver_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_test.go
@@ -224,8 +224,8 @@ func Test_toReceiverOptions(t *testing.T) {
 	require.Nil(t, toReceiverOptions(nil))
 
 	require.EqualValues(t, &ReceiverOptions{
-		ReceiveMode: ReceiveAndDelete,
+		ReceiveMode: ReceiveModeReceiveAndDelete,
 	}, toReceiverOptions(&SessionReceiverOptions{
-		ReceiveMode: ReceiveAndDelete,
+		ReceiveMode: ReceiveModeReceiveAndDelete,
 	}))
 }

--- a/sdk/messaging/azservicebus/session_receiver_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_test.go
@@ -35,7 +35,7 @@ func TestSessionReceiver_acceptSession(t *testing.T) {
 	receiver, err := client.AcceptSessionForQueue(ctx, queueName, "session-1", nil)
 	require.NoError(t, err)
 
-	msg, err := receiver.receiveMessage(ctx, nil)
+	msg, err := receiver.inner.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 
 	require.EqualValues(t, "session-based message", msg.Body)
@@ -43,6 +43,15 @@ func TestSessionReceiver_acceptSession(t *testing.T) {
 	require.NoError(t, receiver.CompleteMessage(ctx, msg))
 
 	require.EqualValues(t, "session-1", receiver.SessionID())
+
+	sessionState, err := receiver.GetSessionState(ctx)
+	require.NoError(t, err)
+	require.Nil(t, sessionState)
+
+	require.NoError(t, receiver.SetSessionState(ctx, []byte("hello")))
+	sessionState, err = receiver.GetSessionState(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, "hello", string(sessionState))
 }
 
 func TestSessionReceiver_blankSessionIDs(t *testing.T) {
@@ -69,7 +78,7 @@ func TestSessionReceiver_blankSessionIDs(t *testing.T) {
 	receiver, err := client.AcceptSessionForQueue(ctx, queueName, "", nil)
 	require.NoError(t, err)
 
-	msg, err := receiver.receiveMessage(ctx, nil)
+	msg, err := receiver.inner.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 
 	require.EqualValues(t, "session-based message", msg.Body)
@@ -120,7 +129,7 @@ func TestSessionReceiver_acceptNextSession(t *testing.T) {
 	receiver, err := client.AcceptNextSessionForQueue(ctx, queueName, nil)
 	require.NoError(t, err)
 
-	msg, err := receiver.receiveMessage(ctx, nil)
+	msg, err := receiver.inner.receiveMessage(ctx, nil)
 	require.NoError(t, err)
 
 	require.EqualValues(t, "session-based message", msg.Body)
@@ -128,6 +137,15 @@ func TestSessionReceiver_acceptNextSession(t *testing.T) {
 	require.NoError(t, receiver.CompleteMessage(ctx, msg))
 
 	require.EqualValues(t, "acceptnextsession-test", receiver.SessionID())
+
+	sessionState, err := receiver.GetSessionState(ctx)
+	require.NoError(t, err)
+	require.Nil(t, sessionState)
+
+	require.NoError(t, receiver.SetSessionState(ctx, []byte("hello")))
+	sessionState, err = receiver.GetSessionState(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, "hello", string(sessionState))
 }
 
 func TestSessionReceiver_noSessionsAvailable(t *testing.T) {


### PR DESCRIPTION
- Adding in ability to save/restore session state (just an arbitrary bunch of bytes)
- Prefix the ReceiveMode constants with `ReceiveMode`
- Removing the unneeded RenewMessageLock() function from the session receiver.

Fixes #15773, #15925