### PR TITLE
Retract azartifacts early preview release

### DIFF
--- a/sdk/synapse/azartifacts/CHANGELOG.md
+++ b/sdk/synapse/azartifacts/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 0.1.1 (2021-11-02)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+* Retract released versions.
+
 ## 0.1.0 (2021-05-21)
 
 Generated from https://github.com/Azure/azure-rest-api-specs/tree/e0624d2b17a8dcee07acfb08f39508a773a8dc21

--- a/sdk/synapse/azartifacts/LICENSE.txt
+++ b/sdk/synapse/azartifacts/LICENSE.txt
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2021 Microsoft
+Copyright (c) Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -18,4 +18,4 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+SOFTWARE

--- a/sdk/synapse/azartifacts/go.mod
+++ b/sdk/synapse/azartifacts/go.mod
@@ -1,8 +1,13 @@
 module github.com/Azure/azure-sdk-for-go/sdk/synapse/azartifacts
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go v54.3.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.1
+)
+
+retract (
+	v0.1.0 // https://github.com/Azure/azure-sdk-for-go/issues/16058
+	v0.1.1 // contains retractions
 )

--- a/sdk/synapse/azartifacts/zz_generated_connection.go
+++ b/sdk/synapse/azartifacts/zz_generated_connection.go
@@ -15,7 +15,7 @@ import (
 )
 
 const scope = "https://dev.azuresynapse.net/.default"
-const telemetryInfo = "azsdk-go-azartifacts/v0.1.0"
+const telemetryInfo = "azsdk-go-azartifacts/v0.1.1"
 
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.


### PR DESCRIPTION
Bump Go version to 1.16.

Reference https://golang.org/ref/mod#go-mod-file-retract