### PR TITLE
Add allow-lists for headers and query parameters

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.20.1 (Unreleased)
 
 ### Features Added
+* Added `AllowedHeaders` and `AllowedQueryParams` to `policy.LogOptions` to control which headers and query parameters are written to the logger.
 
 ### Breaking Changes
 

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -59,6 +59,7 @@ type LogOptions struct {
 
 	// AllowedHeaders is the slice of headers to log with their values intact.
 	// All headers not in the slice will have their values REDACTED.
+	// Applies to request and response headers.
 	AllowedHeaders []string
 
 	// AllowedQueryParams is the slice of query parameters to log with their values intact.

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -56,6 +56,14 @@ type LogOptions struct {
 	// The default value is false.
 	// NOTE: enabling this can lead to disclosure of sensitive information, use with care.
 	IncludeBody bool
+
+	// AllowedHeaders is the slice of headers to log with their values intact.
+	// All headers not in the slice will have their values REDACTED.
+	AllowedHeaders []string
+
+	// AllowedQueryParams is the slice of query parameters to log with their values intact.
+	// All query parameters not in the slice will have their values REDACTED.
+	AllowedQueryParams []string
 }
 
 // RetryOptions configures the retry policy's behavior.

--- a/sdk/azcore/runtime/policy_logging.go
+++ b/sdk/azcore/runtime/policy_logging.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -21,7 +22,9 @@ import (
 )
 
 type logPolicy struct {
-	options policy.LogOptions
+	includeBody    bool
+	allowedHeaders map[string]struct{}
+	allowedQP      map[string]struct{}
 }
 
 // NewLogPolicy creates a request/response logging policy object configured using the specified options.
@@ -30,7 +33,49 @@ func NewLogPolicy(o *policy.LogOptions) policy.Policy {
 	if o == nil {
 		o = &policy.LogOptions{}
 	}
-	return &logPolicy{options: *o}
+	// construct default hash set of allowed headers
+	allowedHeaders := map[string]struct{}{
+		"accept":                        {},
+		"cache-control":                 {},
+		"connection":                    {},
+		"content-length":                {},
+		"content-type":                  {},
+		"date":                          {},
+		"etag":                          {},
+		"expires":                       {},
+		"if-match":                      {},
+		"if-modified-since":             {},
+		"if-none-match":                 {},
+		"if-unmodified-since":           {},
+		"last-modified":                 {},
+		"ms-cv":                         {},
+		"pragma":                        {},
+		"request-id":                    {},
+		"retry-after":                   {},
+		"server":                        {},
+		"traceparent":                   {},
+		"transfer-encoding":             {},
+		"user-agent":                    {},
+		"x-ms-request-id":               {},
+		"x-ms-client-request-id":        {},
+		"x-ms-return-client-request-id": {},
+	}
+	// add any caller-specified allowed headers to the set
+	for _, ah := range o.AllowedHeaders {
+		allowedHeaders[strings.ToLower(ah)] = struct{}{}
+	}
+	// now do the same thing for query params
+	allowedQP := map[string]struct{}{
+		"api-version": {},
+	}
+	for _, qp := range o.AllowedQueryParams {
+		allowedQP[strings.ToLower(qp)] = struct{}{}
+	}
+	return &logPolicy{
+		includeBody:    o.IncludeBody,
+		allowedHeaders: allowedHeaders,
+		allowedQP:      allowedQP,
+	}
 }
 
 // logPolicyOpValues is the struct containing the per-operation values
@@ -52,9 +97,9 @@ func (p *logPolicy) Do(req *policy.Request) (*http.Response, error) {
 	if log.Should(log.EventRequest) {
 		b := &bytes.Buffer{}
 		fmt.Fprintf(b, "==> OUTGOING REQUEST (Try=%d)\n", opValues.try)
-		writeRequestWithResponse(b, req, nil, nil)
+		p.writeRequestWithResponse(b, req, nil, nil)
 		var err error
-		if p.options.IncludeBody {
+		if p.includeBody {
 			err = writeReqBody(req, b)
 		}
 		log.Write(log.EventRequest, b.String())
@@ -80,16 +125,66 @@ func (p *logPolicy) Do(req *policy.Request) (*http.Response, error) {
 			fmt.Fprint(b, "RESPONSE RECEIVED\n")
 		}
 
-		writeRequestWithResponse(b, req, response, err)
+		p.writeRequestWithResponse(b, req, response, err)
 		if err != nil {
 			// skip frames runtime.Callers() and runtime.StackTrace()
 			b.WriteString(diag.StackTrace(2, 32))
-		} else if p.options.IncludeBody {
+		} else if p.includeBody {
 			err = writeRespBody(response, b)
 		}
 		log.Write(log.EventResponse, b.String())
 	}
 	return response, err
+}
+
+const redactedValue = "REDACTED"
+
+// writeRequestWithResponse appends a formatted HTTP request into a Buffer. If request and/or err are
+// not nil, then these are also written into the Buffer.
+func (p *logPolicy) writeRequestWithResponse(b *bytes.Buffer, req *policy.Request, resp *http.Response, err error) {
+	// redact applicable query params
+	cpURL := *req.Raw().URL
+	qp := cpURL.Query()
+	for k := range qp {
+		if _, ok := p.allowedQP[strings.ToLower(k)]; !ok {
+			qp.Set(k, redactedValue)
+		}
+	}
+	cpURL.RawQuery = qp.Encode()
+	// Write the request into the buffer.
+	fmt.Fprint(b, "   "+req.Raw().Method+" "+cpURL.String()+"\n")
+	p.writeHeader(b, req.Raw().Header)
+	if resp != nil {
+		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
+		fmt.Fprint(b, "   RESPONSE Status: "+resp.Status+"\n")
+		p.writeHeader(b, resp.Header)
+	}
+	if err != nil {
+		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
+		fmt.Fprint(b, "   ERROR:\n"+err.Error()+"\n")
+	}
+}
+
+// formatHeaders appends an HTTP request's or response's header into a Buffer.
+func (p *logPolicy) writeHeader(b *bytes.Buffer, header http.Header) {
+	if len(header) == 0 {
+		b.WriteString("   (no headers)\n")
+		return
+	}
+	keys := make([]string, 0, len(header))
+	// Alphabetize the headers
+	for k := range header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		value := header.Get(k)
+		// redact all header values not in the allow-list
+		if _, ok := p.allowedHeaders[strings.ToLower(k)]; !ok {
+			value = redactedValue
+		}
+		fmt.Fprintf(b, "   %s: %+v\n", k, value)
+	}
 }
 
 // returns true if the request/response body should be logged.

--- a/sdk/azcore/runtime/policy_logging_test.go
+++ b/sdk/azcore/runtime/policy_logging_test.go
@@ -33,8 +33,8 @@ func TestPolicyLoggingSuccess(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	qp := req.Raw().URL.Query()
-	qp.Set("one", "fish")
-	qp.Set("sig", "redact")
+	qp.Set("api-version", "12345")
+	qp.Set("sig", "redact_me")
 	req.Raw().URL.RawQuery = qp.Encode()
 	resp, err := pl.Do(req)
 	if err != nil {
@@ -49,6 +49,12 @@ func TestPolicyLoggingSuccess(t *testing.T) {
 		// 	(no headers)
 		if !strings.Contains(logReq, "(no headers)") {
 			t.Fatal("missing (no headers)")
+		}
+		if !strings.Contains(logReq, "api-version=12345") {
+			t.Fatal("didn't find api-version query param")
+		}
+		if strings.Contains(logReq, "sig=redact_me") {
+			t.Fatal("sig query param wasn't redacted")
 		}
 	} else {
 		t.Fatal("missing LogRequest")

--- a/sdk/azcore/runtime/response.go
+++ b/sdk/azcore/runtime/response.go
@@ -15,11 +15,8 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"sort"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 // Payload reads and returns the response body or an error.
@@ -144,44 +141,5 @@ func DecodeByteArray(s string, v *[]byte, format Base64Encoding) error {
 		return err
 	default:
 		return fmt.Errorf("unrecognized byte array format: %d", format)
-	}
-}
-
-// writeRequestWithResponse appends a formatted HTTP request into a Buffer. If request and/or err are
-// not nil, then these are also written into the Buffer.
-func writeRequestWithResponse(b *bytes.Buffer, req *policy.Request, resp *http.Response, err error) {
-	// Write the request into the buffer.
-	fmt.Fprint(b, "   "+req.Raw().Method+" "+req.Raw().URL.String()+"\n")
-	writeHeader(b, req.Raw().Header)
-	if resp != nil {
-		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
-		fmt.Fprint(b, "   RESPONSE Status: "+resp.Status+"\n")
-		writeHeader(b, resp.Header)
-	}
-	if err != nil {
-		fmt.Fprintln(b, "   --------------------------------------------------------------------------------")
-		fmt.Fprint(b, "   ERROR:\n"+err.Error()+"\n")
-	}
-}
-
-// formatHeaders appends an HTTP request's or response's header into a Buffer.
-func writeHeader(b *bytes.Buffer, header http.Header) {
-	if len(header) == 0 {
-		b.WriteString("   (no headers)\n")
-		return
-	}
-	keys := make([]string, 0, len(header))
-	// Alphabetize the headers
-	for k := range header {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		// Redact the value of any Authorization header to prevent security information from persisting in logs
-		value := interface{}("REDACTED")
-		if !strings.EqualFold(k, "Authorization") {
-			value = header[k]
-		}
-		fmt.Fprintf(b, "   %s: %+v\n", k, value)
 	}
 }


### PR DESCRIPTION
LogOptions now contains allow-lists for headers and query parameters.
Any header and/or query parameter not in the allow lists, combined with
the default set, will have its value written as REDACTED to the log.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
