### PR TITLE
Remove AzureGermany Endpoint

### DIFF
--- a/sdk/azcore/arm/client_options.go
+++ b/sdk/azcore/arm/client_options.go
@@ -14,8 +14,6 @@ type Endpoint string
 const (
 	// AzureChina is the Azure Resource Manager China cloud endpoint.
 	AzureChina Endpoint = "https://management.chinacloudapi.cn/"
-	// AzureGermany is the Azure Resource Manager Germany cloud endpoint.
-	AzureGermany Endpoint = "https://management.microsoftazure.de/"
 	// AzureGovernment is the Azure Resource Manager US government cloud endpoint.
 	AzureGovernment Endpoint = "https://management.usgovcloudapi.net/"
 	// AzurePublicCloud is the Azure Resource Manager public cloud endpoint.

--- a/sdk/azcore/internal/shared/shared_test.go
+++ b/sdk/azcore/internal/shared/shared_test.go
@@ -124,9 +124,6 @@ func TestHasStatusCode(t *testing.T) {
 }
 
 func TestEndpointToScope(t *testing.T) {
-	if s := EndpointToScope("https://management.microsoftazure.de/"); s != "https://management.microsoftazure.de//.default" {
-		t.Fatalf("unexpected scope %s", s)
-	}
 	if s := EndpointToScope("https://management.usgovcloudapi.net"); s != "https://management.usgovcloudapi.net//.default" {
 		t.Fatalf("unexpected scope %s", s)
 	}


### PR DESCRIPTION
Azure Germany closed (all subscriptions disabled) on 10/29: https://www.microsoft.com/en-us/cloud-platform/germany-cloud-regions