### PR TITLE
Add options struct for NewPipeline

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Added `AllowedHeaders` and `AllowedQueryParams` to `policy.LogOptions` to control which headers and query parameters are written to the logger.
 
 ### Breaking Changes
-* Moved `[]policy.Policy` parameters of `arm/runtime.NewPipeline` and `runtime.NewPipeline` into a new struct, `runtime.SDKOptions`
+* Moved `[]policy.Policy` parameters of `arm/runtime.NewPipeline` and `runtime.NewPipeline` into a new struct, `runtime.PipelineOptions`
 
 ### Bugs Fixed
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `AllowedHeaders` and `AllowedQueryParams` to `policy.LogOptions` to control which headers and query parameters are written to the logger.
 
 ### Breaking Changes
+* Moved `[]policy.Policy` parameters of `arm/runtime.NewPipeline` and `runtime.NewPipeline` into a new struct, `runtime.SDKOptions`
 
 ### Bugs Fixed
 

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -12,13 +12,12 @@ import (
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pipeline"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
-	azpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
 // NewPipeline creates a pipeline from connection options.
 // The telemetry policy, when enabled, will use the specified module and version info.
-func NewPipeline(module, version string, cred azcore.TokenCredential, options *arm.ClientOptions) pipeline.Pipeline {
+func NewPipeline(module, version string, cred azcore.TokenCredential, sdkOpts azruntime.SDKOptions, options *arm.ClientOptions) pipeline.Pipeline {
 	if options == nil {
 		options = &arm.ClientOptions{}
 	}
@@ -26,16 +25,15 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, options *a
 	if len(ep) == 0 {
 		ep = arm.AzurePublicCloud
 	}
-	perCallPolicies := []azpolicy.Policy{}
+	authPolicy := NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{
+		Scopes:           []string{shared.EndpointToScope(string(ep))},
+		AuxiliaryTenants: options.AuxiliaryTenants,
+	})
+	o := sdkOpts
+	o.PerRetry = append(o.PerRetry, authPolicy)
 	if !options.DisableRPRegistration {
 		regRPOpts := armpolicy.RegistrationOptions{ClientOptions: options.ClientOptions}
-		perCallPolicies = append(perCallPolicies, NewRPRegistrationPolicy(string(ep), cred, &regRPOpts))
+		o.PerCall = append(o.PerCall, NewRPRegistrationPolicy(string(ep), cred, &regRPOpts))
 	}
-	perRetryPolicies := []azpolicy.Policy{
-		NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{
-			Scopes:           []string{shared.EndpointToScope(string(ep))},
-			AuxiliaryTenants: options.AuxiliaryTenants,
-		}),
-	}
-	return azruntime.NewPipeline(module, version, perCallPolicies, perRetryPolicies, &options.ClientOptions)
+	return azruntime.NewPipeline(module, version, o, &options.ClientOptions)
 }

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -17,7 +17,7 @@ import (
 
 // NewPipeline creates a pipeline from connection options.
 // The telemetry policy, when enabled, will use the specified module and version info.
-func NewPipeline(module, version string, cred azcore.TokenCredential, sdkOpts azruntime.SDKOptions, options *arm.ClientOptions) pipeline.Pipeline {
+func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azruntime.PipelineOptions, options *arm.ClientOptions) pipeline.Pipeline {
 	if options == nil {
 		options = &arm.ClientOptions{}
 	}
@@ -29,7 +29,7 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, sdkOpts az
 		Scopes:           []string{shared.EndpointToScope(string(ep))},
 		AuxiliaryTenants: options.AuxiliaryTenants,
 	})
-	o := sdkOpts
+	o := plOpts
 	o.PerRetry = append(o.PerRetry, authPolicy)
 	if !options.DisableRPRegistration {
 		regRPOpts := armpolicy.RegistrationOptions{ClientOptions: options.ClientOptions}

--- a/sdk/azcore/arm/runtime/pipeline_test.go
+++ b/sdk/azcore/arm/runtime/pipeline_test.go
@@ -31,7 +31,7 @@ func TestNewPipelineWithOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	resp, err := NewPipeline("armtest", "v1.2.3", mockTokenCred{}, &opt).Do(req)
+	resp, err := NewPipeline("armtest", "v1.2.3", mockTokenCred{}, azruntime.PipelineOptions{}, &opt).Do(req)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestNewPipelineWithCustomTelemetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	resp, err := NewPipeline("armtest", "v1.2.3", mockTokenCred{}, &opt).Do(req)
+	resp, err := NewPipeline("armtest", "v1.2.3", mockTokenCred{}, azruntime.PipelineOptions{}, &opt).Do(req)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestDisableAutoRPRegistration(t *testing.T) {
 	log.SetListener(func(cls log.Event, msg string) {
 		logEntries++
 	})
-	resp, err := NewPipeline("armtest", "v1.2.3", mockTokenCred{}, opts).Do(req)
+	resp, err := NewPipeline("armtest", "v1.2.3", mockTokenCred{}, azruntime.PipelineOptions{}, opts).Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestPipelineWithCustomPolicies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := NewPipeline("armtest", "v1.2.3", mockTokenCred{}, opts).Do(req)
+	resp, err := NewPipeline("armtest", "v1.2.3", mockTokenCred{}, azruntime.PipelineOptions{}, opts).Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -49,7 +49,7 @@ func (mc mockCredential) Do(req *azpolicy.Request) (*http.Response, error) {
 }
 
 func newTestPipeline(opts *azpolicy.ClientOptions) pipeline.Pipeline {
-	return runtime.NewPipeline("testmodule", "v0.1.0", nil, nil, opts)
+	return runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, opts)
 }
 
 func defaultTestPipeline(srv azpolicy.Transporter, scope string) pipeline.Pipeline {
@@ -61,6 +61,7 @@ func defaultTestPipeline(srv azpolicy.Transporter, scope string) pipeline.Pipeli
 		"testmodule",
 		"v0.1.0",
 		mockCredential{},
+		runtime.PipelineOptions{},
 		&arm.ClientOptions{
 			ClientOptions: azcore.ClientOptions{
 				Retry:     retryOpts,

--- a/sdk/azcore/arm/runtime/policy_register_rp.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp.go
@@ -59,7 +59,7 @@ func NewRPRegistrationPolicy(endpoint string, cred azcore.TokenCredential, o *ar
 	authPolicy := NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{Scopes: []string{shared.EndpointToScope(endpoint)}})
 	p := &rpRegistrationPolicy{
 		endpoint: endpoint,
-		pipeline: runtime.NewPipeline(shared.Module, shared.Version, nil, []pipeline.Policy{authPolicy}, &o.ClientOptions),
+		pipeline: runtime.NewPipeline(shared.Module, shared.Version, runtime.PipelineOptions{PerRetry: []pipeline.Policy{authPolicy}}, &o.ClientOptions),
 		options:  *o,
 	}
 	// init the copy

--- a/sdk/azcore/arm/runtime/policy_register_rp_test.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp_test.go
@@ -58,7 +58,7 @@ const requestEndpoint = "/subscriptions/00000000-0000-0000-0000-000000000000/res
 func newTestRPRegistrationPipeline(srv *mock.Server) pipeline.Pipeline {
 	opts := azcore.ClientOptions{Transport: srv}
 	rp := NewRPRegistrationPolicy(srv.URL(), mockTokenCred{}, testRPRegistrationOptions(srv))
-	return runtime.NewPipeline("test", "v0.1.0", []azpolicy.Policy{rp}, nil, &opts)
+	return runtime.NewPipeline("test", "v0.1.0", runtime.PipelineOptions{PerCall: []azpolicy.Policy{rp}}, &opts)
 }
 
 func testRPRegistrationOptions(t azpolicy.Transporter) *armpolicy.RegistrationOptions {
@@ -350,7 +350,7 @@ func TestRPRegistrationPolicyDisabled(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
 	ops := testRPRegistrationOptions(srv)
 	ops.MaxAttempts = -1
-	pl := runtime.NewPipeline("test", "v0.1.0", []pipeline.Policy{NewRPRegistrationPolicy(srv.URL(), mockTokenCred{}, ops)}, nil, nil)
+	pl := runtime.NewPipeline("test", "v0.1.0", runtime.PipelineOptions{PerCall: []pipeline.Policy{NewRPRegistrationPolicy(srv.URL(), mockTokenCred{}, ops)}}, nil)
 	req, err := runtime.NewRequest(context.Background(), http.MethodGet, runtime.JoinPaths(srv.URL(), requestEndpoint))
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azcore/arm/runtime/poller_test.go
+++ b/sdk/azcore/arm/runtime/poller_test.go
@@ -54,8 +54,7 @@ func getPipeline(srv *mock.Server) pipeline.Pipeline {
 	return runtime.NewPipeline(
 		"test",
 		"v0.1.0",
-		nil,
-		[]pipeline.Policy{runtime.NewLogPolicy(nil)},
+		runtime.PipelineOptions{PerRetry: []pipeline.Policy{runtime.NewLogPolicy(nil)}},
 		&policy.ClientOptions{Transport: srv},
 	)
 }

--- a/sdk/azcore/example_test.go
+++ b/sdk/azcore/example_test.go
@@ -65,7 +65,7 @@ func ExampleNullValue() {
 }
 
 func ExampleHTTPResponse() {
-	pipeline := runtime.NewPipeline("module", "version", nil, nil, nil)
+	pipeline := runtime.NewPipeline("module", "version", runtime.SDKOptions{}, nil)
 	req, err := runtime.NewRequest(context.Background(), "POST", "https://fakecontainerregisty.azurecr.io/acr/v1/nonexisteng/_tags")
 	if err != nil {
 		panic(err)

--- a/sdk/azcore/example_test.go
+++ b/sdk/azcore/example_test.go
@@ -65,7 +65,7 @@ func ExampleNullValue() {
 }
 
 func ExampleHTTPResponse() {
-	pipeline := runtime.NewPipeline("module", "version", runtime.SDKOptions{}, nil)
+	pipeline := runtime.NewPipeline("module", "version", runtime.PipelineOptions{}, nil)
 	req, err := runtime.NewRequest(context.Background(), "POST", "https://fakecontainerregisty.azurecr.io/acr/v1/nonexisteng/_tags")
 	if err != nil {
 		panic(err)

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -11,8 +11,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-// SDKOptions contains Pipeline options for SDK developers
-type SDKOptions struct {
+// PipelineOptions contains Pipeline options for SDK developers
+type PipelineOptions struct {
 	AllowedHeaders, AllowedQueryParameters []string
 	PerCall, PerRetry                      []policy.Policy
 }
@@ -21,21 +21,21 @@ type SDKOptions struct {
 // module, version: used by the telemetry policy, when enabled
 // perCall: additional policies to invoke once per request
 // perRetry: additional policies to invoke once per request and once per retry of that request
-func NewPipeline(module, version string, sdkOpts SDKOptions, options *policy.ClientOptions) Pipeline {
+func NewPipeline(module, version string, plOpts PipelineOptions, options *policy.ClientOptions) Pipeline {
 	cp := policy.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
-	cp.Logging.AllowedHeaders = append(cp.Logging.AllowedHeaders, sdkOpts.AllowedHeaders...)
+	cp.Logging.AllowedHeaders = append(cp.Logging.AllowedHeaders, plOpts.AllowedHeaders...)
 	policies := []policy.Policy{}
 	if !options.Telemetry.Disabled {
 		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))
 	}
 	policies = append(policies, cp.PerCallPolicies...)
-	policies = append(policies, sdkOpts.PerCall...)
+	policies = append(policies, plOpts.PerCall...)
 	policies = append(policies, NewRetryPolicy(&cp.Retry))
 	policies = append(policies, cp.PerRetryPolicies...)
-	policies = append(policies, sdkOpts.PerRetry...)
+	policies = append(policies, plOpts.PerRetry...)
 	policies = append(policies, NewLogPolicy(&cp.Logging))
 	policies = append(policies, pipeline.PolicyFunc(httpHeaderPolicy), pipeline.PolicyFunc(bodyDownloadPolicy))
 	transport := cp.Transport

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -28,7 +28,7 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 	}
 	cp.Logging.AllowedHeaders = append(cp.Logging.AllowedHeaders, plOpts.AllowedHeaders...)
 	policies := []policy.Policy{}
-	if !options.Telemetry.Disabled {
+	if !cp.Telemetry.Disabled {
 		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))
 	}
 	policies = append(policies, cp.PerCallPolicies...)

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -26,7 +26,12 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 	if options != nil {
 		cp = *options
 	}
-	cp.Logging.AllowedHeaders = append(cp.Logging.AllowedHeaders, plOpts.AllowedHeaders...)
+	if len(plOpts.AllowedHeaders) > 0 {
+		headers := make([]string, 0, len(plOpts.AllowedHeaders)+len(cp.Logging.AllowedHeaders))
+		copy(headers, plOpts.AllowedHeaders)
+		headers = append(headers, cp.Logging.AllowedHeaders...)
+		cp.Logging.AllowedHeaders = headers
+	}
 	policies := []policy.Policy{}
 	if !cp.Telemetry.Disabled {
 		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -32,6 +32,12 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 		headers = append(headers, cp.Logging.AllowedHeaders...)
 		cp.Logging.AllowedHeaders = headers
 	}
+	if len(plOpts.AllowedQueryParameters) > 0 {
+		qp := make([]string, 0, len(plOpts.AllowedQueryParameters)+len(cp.Logging.AllowedQueryParams))
+		copy(qp, plOpts.AllowedQueryParameters)
+		qp = append(qp, cp.Logging.AllowedQueryParams...)
+		cp.Logging.AllowedQueryParams = qp
+	}
 	policies := []policy.Policy{}
 	if !cp.Telemetry.Disabled {
 		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))

--- a/sdk/azcore/runtime/pipeline_test.go
+++ b/sdk/azcore/runtime/pipeline_test.go
@@ -47,7 +47,7 @@ func TestNewPipelineTelemetry(t *testing.T) {
 			}
 			module := "test"
 			version := "v1.2.3"
-			resp, err := NewPipeline(module, version, nil, nil, &opt).Do(req)
+			resp, err := NewPipeline(module, version, PipelineOptions{}, &opt).Do(req)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -72,7 +72,7 @@ func TestNewPipelineCustomTelemetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	resp, err := NewPipeline("armtest", "v1.2.3", nil, nil, &opts).Do(req)
+	resp, err := NewPipeline("armtest", "v1.2.3", PipelineOptions{}, &opts).Do(req)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -96,7 +96,12 @@ func TestNewPipelineCustomPolicies(t *testing.T) {
 	}
 	perCallPolicy := &countingPolicy{}
 	perRetryPolicy := &countingPolicy{}
-	_, err = NewPipeline("", "", []pipeline.Policy{perCallPolicy}, []pipeline.Policy{perRetryPolicy}, &opts).Do(req)
+	pl := NewPipeline("",
+		"",
+		PipelineOptions{PerCall: []pipeline.Policy{perCallPolicy}, PerRetry: []pipeline.Policy{perRetryPolicy}},
+		&opts,
+	)
+	_, err = pl.Do(req)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/sdk/azcore/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/runtime/policy_bearer_token_test.go
@@ -53,8 +53,7 @@ func defaultTestPipeline(srv policy.Transporter, scope string) Pipeline {
 	return NewPipeline(
 		"testmodule",
 		"v0.1.0",
-		nil,
-		[]policy.Policy{b},
+		PipelineOptions{PerRetry: []policy.Policy{b}},
 		&azcore.ClientOptions{Retry: retryOpts, Transport: srv},
 	)
 }

--- a/sdk/azcore/runtime/policy_http_header_test.go
+++ b/sdk/azcore/runtime/policy_http_header_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func newTestPipeline(opts *policy.ClientOptions) Pipeline {
-	return NewPipeline("testmodule", "v0.1.0", nil, nil, opts)
+	return NewPipeline("testmodule", "v0.1.0", PipelineOptions{}, opts)
 }
 
 func TestAddCustomHTTPHeaderSuccess(t *testing.T) {


### PR DESCRIPTION
Following from https://github.com/Azure/azure-sdk-for-go/pull/16076#pullrequestreview-798084846, this adds a new struct for pipeline and policy options intended for use by SDK developers. Pipeline constructors merge these options with the application's `azcore.ClientOptions` without mutating the latter.