### PR TITLE
Revise azidentity doc comments

### DIFF
--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -12,18 +12,19 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-// ChainedTokenCredentialOptions contains optional parameters for ChainedTokenCredential
+// ChainedTokenCredentialOptions contains optional parameters for ChainedTokenCredential.
 type ChainedTokenCredentialOptions struct {
 	// placeholder for future options
 }
 
-// ChainedTokenCredential provides a TokenCredential implementation that chains multiple TokenCredential sources to be tried in order
-// and returns the token from the first successful call to GetToken().
+// ChainedTokenCredential is a chain of credentials that enables fallback behavior when a credential can't authenticate.
 type ChainedTokenCredential struct {
 	sources []azcore.TokenCredential
 }
 
-// NewChainedTokenCredential creates an instance of ChainedTokenCredential with the specified TokenCredential sources.
+// NewChainedTokenCredential creates a ChainedTokenCredential.
+// sources: Credential instances to comprise the chain. GetToken() will invoke them in the given order.
+// options: Optional configuration.
 func NewChainedTokenCredential(sources []azcore.TokenCredential, options *ChainedTokenCredentialOptions) (*ChainedTokenCredential, error) {
 	if len(sources) == 0 {
 		return nil, errors.New("sources must contain at least one TokenCredential")
@@ -38,43 +39,36 @@ func NewChainedTokenCredential(sources []azcore.TokenCredential, options *Chaine
 	return &ChainedTokenCredential{sources: cp}, nil
 }
 
-// GetToken sequentially calls TokenCredential.GetToken on all the specified sources, returning the token from the first successful call to GetToken().
+// GetToken calls GetToken on the chained credentials in turn, stopping when one returns a token. This method is called automatically by Azure SDK clients.
+// ctx: Context controlling the request lifetime.
+// opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (token *azcore.AccessToken, err error) {
 	var errList []CredentialUnavailableError
-	// loop through all of the credentials provided in sources
 	for _, cred := range c.sources {
-		// make a GetToken request for the current credential in the loop
 		token, err = cred.GetToken(ctx, opts)
-		// check if we received a CredentialUnavailableError
 		var credErr CredentialUnavailableError
 		if errors.As(err, &credErr) {
-			// if we did receive a CredentialUnavailableError then we append it to our error slice and continue looping for a good credential
 			errList = append(errList, credErr)
 		} else if err != nil {
-			// if we receive some other type of error then we must stop looping and process the error accordingly
 			var authFailed AuthenticationFailedError
 			if errors.As(err, &authFailed) {
-				// if the error is an AuthenticationFailedError we return the error related to the invalid credential and append all of the other error messages received prior to this point
 				err = fmt.Errorf("Authentication failed:\n%s\n%s"+createChainedErrorMessage(errList), err)
 				authErr := newAuthenticationFailedError(err, authFailed.RawResponse())
 				return nil, authErr
 			}
-			// if we receive some other error type this is unexpected and we simple return the unexpected error
 			return nil, err
 		} else {
 			logGetTokenSuccess(c, opts)
-			// if we did not receive an error then we return the token
 			return token, nil
 		}
 	}
-	// if we reach this point it means that all of the credentials in the chain returned CredentialUnavailableErrors
+	// if we reach this point it means that all of the credentials in the chain returned CredentialUnavailableError
 	credErr := newCredentialUnavailableError("Chained Token Credential", createChainedErrorMessage(errList))
 	// skip adding the stack trace here as it was already logged by other calls to GetToken()
 	addGetTokenFailureLogs("Chained Token Credential", credErr, false)
 	return nil, credErr
 }
 
-// helper function used to chain the error messages of the CredentialUnavailableError slice
 func createChainedErrorMessage(errList []CredentialUnavailableError) string {
 	msg := ""
 	for _, err := range errList {

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -11,31 +11,28 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-// ClientSecretCredentialOptions configures the ClientSecretCredential with optional parameters.
-// All zero-value fields will be initialized with their default values.
+// ClientSecretCredentialOptions contains optional parameters for ClientSecretCredential.
 type ClientSecretCredentialOptions struct {
 	azcore.ClientOptions
 
-	// The host of the Azure Active Directory authority. The default is AzurePublicCloud.
-	// Leave empty to allow overriding the value from the AZURE_AUTHORITY_HOST environment variable.
+	// AuthorityHost is the base URL of an Azure Active Directory authority. Defaults
+	// to the value of environment variable AZURE_AUTHORITY_HOST, if set, or AzurePublicCloud.
 	AuthorityHost AuthorityHost
 }
 
-// ClientSecretCredential enables authentication to Azure Active Directory using a client secret that was generated for an App Registration.  More information on how
-// to configure a client secret can be found here:
-// https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis#add-credentials-to-your-web-application
+// ClientSecretCredential authenticates an application with a client secret.
 type ClientSecretCredential struct {
 	client       *aadIdentityClient
-	tenantID     string // Gets the Azure Active Directory tenant (directory) ID of the service principal
-	clientID     string // Gets the client (application) ID of the service principal
-	clientSecret string // Gets the client secret that was generated for the App Registration used to authenticate the client.
+	tenantID     string
+	clientID     string
+	clientSecret string
 }
 
-// NewClientSecretCredential constructs a new ClientSecretCredential with the details needed to authenticate against Azure Active Directory with a client secret.
-// tenantID: The Azure Active Directory tenant (directory) ID of the service principal.
-// clientID: The client (application) ID of the service principal.
-// clientSecret: A client secret that was generated for the App Registration used to authenticate the client.
-// options: allow to configure the management of the requests sent to Azure Active Directory.
+// NewClientSecretCredential constructs a ClientSecretCredential.
+// tenantID: The application's Azure Active Directory tenant or directory ID.
+// clientID: The application's client ID.
+// clientSecret: One of the application's client secrets.
+// options: Optional configuration.
 func NewClientSecretCredential(tenantID string, clientID string, clientSecret string, options *ClientSecretCredentialOptions) (*ClientSecretCredential, error) {
 	if !validTenantID(tenantID) {
 		return nil, errors.New(tenantIDValidationErr)
@@ -55,10 +52,9 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 	return &ClientSecretCredential{tenantID: tenantID, clientID: clientID, clientSecret: clientSecret, client: c}, nil
 }
 
-// GetToken obtains a token from Azure Active Directory, using the specified client secret to authenticate.
+// GetToken obtains a token from Azure Active Directory. This method is called automatically by Azure SDK clients.
 // ctx: Context used to control the request lifetime.
-// opts: TokenRequestOptions contains the list of scopes for which the token will have access.
-// Returns an AccessToken which can be used to authenticate service client calls.
+// opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ClientSecretCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	tk, err := c.client.authenticate(ctx, c.tenantID, c.clientID, c.clientSecret, opts.Scopes)
 	if err != nil {

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -16,22 +16,22 @@ const (
 	developerSignOnClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 )
 
-// DefaultAzureCredentialOptions contains options for configuring authentication. These options
-// may not apply to all credentials in the default chain.
+// DefaultAzureCredentialOptions contains optional parameters for DefaultAzureCredential.
+// These options may not apply to all credentials in the chain.
 type DefaultAzureCredentialOptions struct {
 	azcore.ClientOptions
 
-	// The host of the Azure Active Directory authority. The default is AzurePublicCloud.
-	// Leave empty to allow overriding the value from the AZURE_AUTHORITY_HOST environment variable.
+	// AuthorityHost is the base URL of an Azure Active Directory authority. Defaults
+	// to the value of environment variable AZURE_AUTHORITY_HOST, if set, or AzurePublicCloud.
 	AuthorityHost AuthorityHost
 	// TenantID identifies the tenant the Azure CLI should authenticate in.
 	// Defaults to the CLI's default tenant, which is typically the home tenant of the user logged in to the CLI.
 	TenantID string
 }
 
-// DefaultAzureCredential is a default credential chain for applications that will be deployed to Azure.
-// It combines credentials suitable for deployed applications with credentials suitable in local development.
-// It attempts to authenticate with each of these credential types, in the following order:
+// DefaultAzureCredential is a default credential chain for applications that will deploy to Azure.
+// It combines credentials suitable for deployment with credentials suitable for local development.
+// It attempts to authenticate with each of these credential types, in the following order, stopping when one provides a token:
 // - EnvironmentCredential
 // - ManagedIdentityCredential
 // - AzureCLICredential
@@ -40,7 +40,7 @@ type DefaultAzureCredential struct {
 	chain *ChainedTokenCredential
 }
 
-// NewDefaultAzureCredential creates a default credential chain for applications that will be deployed to Azure.
+// NewDefaultAzureCredential creates a DefaultAzureCredential.
 func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*DefaultAzureCredential, error) {
 	var creds []azcore.TokenCredential
 	errMsg := ""
@@ -85,7 +85,9 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 	return &DefaultAzureCredential{chain: chain}, nil
 }
 
-// GetToken attempts to acquire a token from each of the default chain's credentials, stopping when one provides a token.
+// GetToken obtains a token from Azure Active Directory. This method is called automatically by Azure SDK clients.
+// ctx: Context used to control the request lifetime.
+// opts: Options for the token request, in particular the desired scope of the access token.
 func (c *DefaultAzureCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (token *azcore.AccessToken, err error) {
 	return c.chain.GetToken(ctx, opts)
 }

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -18,31 +18,26 @@ const (
 	deviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
 )
 
-// DeviceCodeCredentialOptions provide options that can configure DeviceCodeCredential instead of using the default values.
-// All zero-value fields will be initialized with their default values. Please note, that both the TenantID or ClientID fields should
-// changed together if default values are not desired.
+// DeviceCodeCredentialOptions contains optional parameters for DeviceCodeCredential.
 type DeviceCodeCredentialOptions struct {
 	azcore.ClientOptions
 
-	// Gets the Azure Active Directory tenant (directory) ID of the service principal
-	// The default value is "organizations". If this value is changed, then also change ClientID to the corresponding value.
+	// TenantID is the Azure Active Directory tenant the credential authenticates in. Defaults to the
+	// "organizations" tenant, which can authenticate work and school accounts. Required for single-tenant
+	// applications.
 	TenantID string
-	// Gets the client (application) ID of the service principal
-	// The default value is the developer sign on ID for the corresponding "organizations" TenantID.
+	// ClientID is the ID of the application users will authenticate to.
+	// Defaults to the ID of an Azure development application.
 	ClientID string
-	// The callback function used to send the login message back to the user
-	// The default will print device code log in information to stdout.
+	// UserPrompt controls how the credential presents authentication instructions. The credential calls
+	// this function with authentication details when it receives a device code. By default, the credential
+	// prints these details to stdout.
 	UserPrompt func(context.Context, DeviceCodeMessage) error
-	// The host of the Azure Active Directory authority. The default is AzurePublicCloud.
-	// Leave empty to allow overriding the value from the AZURE_AUTHORITY_HOST environment variable.
+	// AuthorityHost is the base URL of an Azure Active Directory authority. Defaults
+	// to the value of environment variable AZURE_AUTHORITY_HOST, if set, or AzurePublicCloud.
 	AuthorityHost AuthorityHost
 }
 
-// init provides the default settings for DeviceCodeCredential.
-// It will set the following default values:
-// TenantID set to "organizations".
-// ClientID set to the default developer sign on client ID "04b07795-8ddb-461a-bbee-02f9e1bf7b46".
-// UserPrompt set to output login information for the user to stdout.
 func (o *DeviceCodeCredentialOptions) init() {
 	if o.TenantID == "" {
 		o.TenantID = organizationsTenantID
@@ -58,19 +53,21 @@ func (o *DeviceCodeCredentialOptions) init() {
 	}
 }
 
-// DeviceCodeMessage is used to store device code related information to help the user login and allow the device code flow to continue
-// to request a token to authenticate a user.
+// DeviceCodeMessage contains the information a user needs to complete authentication.
 type DeviceCodeMessage struct {
-	// User code returned by the service.
+	// UserCode is the user code returned by the service.
 	UserCode string `json:"user_code"`
-	// Verification URL where the user must navigate to authenticate using the device code and credentials.
+	// VerificationURL is the URL at which the user must authenticate.
 	VerificationURL string `json:"verification_uri"`
-	// User friendly text response that can be used for display purposes.
+	// Message is user instruction from Azure Active Directory.
 	Message string `json:"message"`
 }
 
-// DeviceCodeCredential authenticates a user using the device code flow, and provides access tokens for that user account.
-// For more information on the device code authentication flow see: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code.
+// DeviceCodeCredential acquires tokens for a user via the device code flow, which has the
+// user browse to an Azure Active Directory URL, enter a code, and authenticate. It's useful
+// for authenticating a user in an environment without a web browser, such as an SSH session.
+// If a web browser is available, InteractiveBrowserCredential is more convenient because it
+// automatically opens a browser to the login page.
 type DeviceCodeCredential struct {
 	client       *aadIdentityClient
 	tenantID     string
@@ -79,8 +76,8 @@ type DeviceCodeCredential struct {
 	refreshToken string
 }
 
-// NewDeviceCodeCredential constructs a new DeviceCodeCredential used to authenticate against Azure Active Directory with a device code.
-// options: Options used to configure the management of the requests sent to Azure Active Directory, please see DeviceCodeCredentialOptions for a description of each field.
+// NewDeviceCodeCredential creates a DeviceCodeCredential.
+// options: Optional configuration.
 func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeCredential, error) {
 	cp := DeviceCodeCredentialOptions{}
 	if options != nil {
@@ -101,18 +98,17 @@ func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeC
 	return &DeviceCodeCredential{tenantID: cp.TenantID, clientID: cp.ClientID, userPrompt: cp.UserPrompt, client: c}, nil
 }
 
-// GetToken obtains a token from Azure Active Directory, following the device code authentication
-// flow. This function first requests a device code and requests that the user login before continuing to authenticate the device.
-// This function will keep polling the service for a token until the user logs in.
-// scopes: The list of scopes for which the token will have access. The "offline_access" scope is checked for and automatically added in case it isn't present to allow for silent token refresh.
-// ctx: The context for controlling the request lifetime.
-// Returns an AccessToken which can be used to authenticate service client calls.
+// GetToken obtains a token from Azure Active Directory. It will begin the device code flow and poll until the user completes authentication.
+// This method is called automatically by Azure SDK clients.
+// ctx: Context used to control the request lifetime.
+// opts: Options for the token request, in particular the desired scope of the access token.
 func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
+	// ensure we request offline_access
 	for i, scope := range opts.Scopes {
-		if scope == "offline_access" { // if we find that the opts.Scopes slice contains "offline_access" then we don't need to do anything and exit
+		if scope == "offline_access" {
 			break
 		}
-		if i == len(opts.Scopes)-1 && scope != "offline_access" { // if we haven't found "offline_access" when reaching the last element in the slice then we append it
+		if i == len(opts.Scopes)-1 && scope != "offline_access" {
 			opts.Scopes = append(opts.Scopes, "offline_access")
 		}
 	}
@@ -122,14 +118,10 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 			addGetTokenFailureLogs("Device Code Credential", err, true)
 			return nil, err
 		}
-		// assign new refresh token to the credential for future use
 		c.refreshToken = tk.refreshToken
 		logGetTokenSuccess(c, opts)
-		// passing the access token and/or error back up
 		return tk.token, nil
 	}
-	// if there is no refreshToken, then begin the Device Code flow from the beginning
-	// make initial request to the device code endpoint for a device code and instructions for authentication
 	dc, err := c.client.requestNewDeviceCode(ctx, c.tenantID, c.clientID, opts.Scopes)
 	if err != nil {
 		authErr := newAuthenticationFailedError(err, nil)
@@ -137,7 +129,6 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 		return nil, authErr
 	}
 	// send authentication flow instructions back to the user to log in and authorize the device
-
 	err = c.userPrompt(ctx, DeviceCodeMessage{
 		UserCode:        dc.UserCode,
 		VerificationURL: dc.VerificationURL,
@@ -163,7 +154,6 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 			time.Sleep(time.Duration(dc.Interval) * time.Second)
 		} else {
 			addGetTokenFailureLogs("Device Code Credential", err, true)
-			// any other error should be returned
 			return nil, err
 		}
 	}

--- a/sdk/azidentity/doc.go
+++ b/sdk/azidentity/doc.go
@@ -1,87 +1,20 @@
-//go:build go1.13
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
-// Copyright 2017 Microsoft Corporation. All rights reserved.
-// Use of this source code is governed by an MIT
-// license that can be found in the LICENSE file.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 /*
-Package azidentity implements a set of credential types for use with
-Azure SDK clients that support Azure Active Directory (AAD) token authentication.
+azidentity provides Azure Active Directory token authentication for Azure SDK clients.
 
-The following credential types are included in this module:
-	- AuthorizationCodeCredential
-	- AzureCLICredential
-	- ChainedTokenCredential
-	- ClientCertificateCredential
-	- ClientSecretCredential
-	- DefaultAzureCredential
-	- DeviceCodeCredential
-	- EnvironmentCredential
-	- InteractiveBrowserCredential
-	- ManagedIdentityCredential
-	- UsernamePasswordCredential
+Azure SDK clients supporting token authentication can use any azidentity credential.
+For example, authenticating a resource group client with DefaultAzureCredential:
 
-By default, the recommendation is that users call NewDefaultAzureCredential() which will
-provide a default ChainedTokenCredential configuration composed of:
-	- EnvironmentCredential
-	- ManagedIdentityCredential
-	- AzureCLICredential
-Configuration options can be used to exclude any of the previous credentials from the
-DefaultAzureCredential implementation.
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	...
+	client := armresources.NewResourceGroupsClient("subscription ID", cred, nil)
 
-Example call to NewDefaultAzureCredential():
-	cred, err := NewDefaultAzureCredential(nil) // pass in nil to get default behavior for this credential
-	if err != nil {
-		// process error
-	}
-	// pass credential in to an Azure SDK client
-
-Example call to NewDefaultAzureCredential() with options set:
-	// these options will make sure the AzureCLICredential will not be added to the credential chain
-	cred, err := NewDefaultAzureCredential(&DefaultAzureCredentialOptions{ExcludeAzureCLICredential: true})
-	if err != nil {
-		// process error
-	}
-	// pass credential in to an Azure SDK client
-
-Additional configuration of each credential can be done through each credential's
-options type. These options can also be used to modify the default pipeline for each
-credential.
-
-Example pattern for modifying credential options:
-	cred, err := azidentity.NewClientCertificateCredential("<tenant ID>", "<client ID>", "<certificate path>", &ClientCertificateCredentialOptions{Password: "<certificate password>"})
-	if err != nil {
-		// process error
-	}
-
-CREDENTIAL AUTHORITY HOSTS
-
-The default authority host for all credentials, except for ManagedIdentityCredential, is the
-AzurePublicCloud host. This value can be changed through the credential options or by specifying
-a different value in an environment variable called AZURE_AUTHORITY_HOST.
-NOTE: An alternate value for authority host explicitly set through the code will take precedence over the
-AZURE_AUTHORITY_HOST environment variable.
-
-Example of setting an alternate Azure authority host through code:
-	cred, err := azidentity.NewClientSecretCredential("<tenant ID>", "<client ID>", "<client secret>", &ClientSecretCredentialOptions{AuthorityHost: azidentity.AzureChina})
-	if err != nil {
-		// process error
-	}
-	// pass credential in to an Azure SDK client
-
-Example of setting an alternate authority host value in the AZURE_AUTHORITY_HOST environment variable (in Powershell):
-	$env:AZURE_AUTHORITY_HOST="https://contoso.com/auth/"
-
-
-ERROR HANDLING
-
-The credential types in azidentity will return one of the following error types, unless there was some other unexpected failure:
-	- CredentialUnavailableError: 	This error signals that an essential component for using the credential is missing or that
-									the credential is being instantiated in an environment that is incompatible with its
-									functionality. These will generally be returned at credential creation after calling
-									the constructor.
-	- AuthenticationFailedError:	This error typically signals that a request has been made to the service and that
-									authentication failed at the service level.
+Different credential types implement different authentication flows. Each credential's
+documentation describes how it authenticates.
 */
 package azidentity

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -50,8 +50,7 @@ func (r ResourceID) String() string {
 	return string(r)
 }
 
-// ManagedIdentityCredentialOptions contains parameters that can be used to configure the pipeline used with Managed Identity Credential.
-// All zero-value fields will be initialized with their default values.
+// ManagedIdentityCredentialOptions contains optional parameters for ManagedIdentityCredential.
 type ManagedIdentityCredentialOptions struct {
 	azcore.ClientOptions
 
@@ -61,39 +60,35 @@ type ManagedIdentityCredentialOptions struct {
 	ID ManagedIDKind
 }
 
-// ManagedIdentityCredential attempts authentication using a managed identity that has been assigned to the deployment environment. This authentication type works in several
-// managed identity environments such as Azure VMs, App Service, Azure Functions, Azure CloudShell, among others. More information about configuring managed identities can be found here:
-// https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
+// ManagedIdentityCredential authenticates with an Azure managed identity in any hosting environment which supports managed identities.
+// This credential defaults to using a system-assigned identity. Use ManagedIdentityCredentialOptions.ID to specify a user-assigned identity.
+// See Azure Active Directory documentation for more information about managed identities:
+// https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
 type ManagedIdentityCredential struct {
 	id     ManagedIDKind
 	client *managedIdentityClient
 }
 
-// NewManagedIdentityCredential creates a credential instance capable of authenticating an Azure managed identity in any hosting environment
-// supporting managed identities. See https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview for more
-// information about Azure Managed Identity.
-// options: ManagedIdentityCredentialOptions that configure the pipeline for requests sent to Azure Active Directory.
+// NewManagedIdentityCredential creates a ManagedIdentityCredential.
+// options: Optional configuration.
 func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*ManagedIdentityCredential, error) {
-	// Create a new Managed Identity Client with default options
 	cp := ManagedIdentityCredentialOptions{}
 	if options != nil {
 		cp = *options
 	}
 	client := newManagedIdentityClient(&cp)
 	msiType, err := client.getMSIType()
-	// If there is an error that means that the code is not running in a Managed Identity environment
 	if err != nil {
 		logCredentialError("Managed Identity Credential", err)
 		return nil, err
 	}
-	// Assign the msiType discovered onto the client
 	client.msiType = msiType
 	return &ManagedIdentityCredential{id: cp.ID, client: client}, nil
 }
 
-// GetToken obtains an AccessToken from the Managed Identity service if available.
-// scopes: The list of scopes for which the token will have access.
-// Returns an AccessToken which can be used to authenticate service client calls.
+// GetToken obtains a token from Azure Active Directory. This method is called automatically by Azure SDK clients.
+// ctx: Context used to control the request lifetime.
+// opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	if opts.Scopes == nil {
 		err := errors.New("must specify a resource in order to authenticate")

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -11,35 +11,33 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-// UsernamePasswordCredentialOptions can be used to provide additional information to configure the UsernamePasswordCredential.
-// Use these options to modify the default pipeline behavior through the TokenCredentialcp.
-// All zero-value fields will be initialized with their default values.
+// UsernamePasswordCredentialOptions contains optional parameters for UsernamePasswordCredential.
 type UsernamePasswordCredentialOptions struct {
 	azcore.ClientOptions
 
-	// The host of the Azure Active Directory authority. The default is AzurePublicCloud.
-	// Leave empty to allow overriding the value from the AZURE_AUTHORITY_HOST environment variable.
+	// AuthorityHost is the base URL of an Azure Active Directory authority. Defaults
+	// to the value of environment variable AZURE_AUTHORITY_HOST, if set, or AzurePublicCloud.
 	AuthorityHost AuthorityHost
 }
 
-// UsernamePasswordCredential enables authentication to Azure Active Directory using a user's  username and password. If the user has MFA enabled this
-// credential will fail to get a token returning an AuthenticationFailureError. Also, this credential requires a high degree of trust and is not
-// recommended outside of prototyping when more secure credentials can be used.
+// UsernamePasswordCredential authenticates user with a password. Microsoft doesn't recommend this kind of authentication,
+// because it's less secure than other authentication flows. This credential is not interactive, so it isn't compatible
+// with any form of multi-factor authentication, and the application must already have user or admin consent.
+// This credential can only authenticate work and school accounts; it can't authenticate Microsoft accounts.
 type UsernamePasswordCredential struct {
 	client   *aadIdentityClient
-	tenantID string // Gets the Azure Active Directory tenant (directory) ID of the service principal
-	clientID string // Gets the client (application) ID of the service principal
-	username string // Gets the user account's user name
-	password string // Gets the user account's password
+	tenantID string
+	clientID string
+	username string
+	password string
 }
 
-// NewUsernamePasswordCredential constructs a new UsernamePasswordCredential with the details needed to authenticate against Azure Active Directory with
-// a simple username and password.
-// tenantID: The Azure Active Directory tenant (directory) ID of the service principal.
-// clientID: The client (application) ID of the service principal.
-// username: A user's account username
-// password: A user's account password
-// options: UsernamePasswordCredentialOptions used to configure the pipeline for the requests sent to Azure Active Directory.
+// NewUsernamePasswordCredential creates a UsernamePasswordCredential.
+// tenantID: The ID of the Azure Active Directory tenant the credential authenticates in.
+// clientID: The ID of the application users will authenticate to.
+// username: A username (typically an email address).
+// password: That user's password.
+// options: Optional configuration.
 func NewUsernamePasswordCredential(tenantID string, clientID string, username string, password string, options *UsernamePasswordCredentialOptions) (*UsernamePasswordCredential, error) {
 	if !validTenantID(tenantID) {
 		return nil, errors.New(tenantIDValidationErr)
@@ -59,10 +57,9 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 	return &UsernamePasswordCredential{tenantID: tenantID, clientID: clientID, username: username, password: password, client: c}, nil
 }
 
-// GetToken obtains a token from Azure Active Directory using the specified username and password.
-// scopes: The list of scopes for which the token will have access.
-// ctx: The context used to control the request lifetime.
-// Returns an AccessToken which can be used to authenticate service client calls.
+// GetToken obtains a token from Azure Active Directory. This method is called automatically by Azure SDK clients.
+// ctx: Context used to control the request lifetime.
+// opts: Options for the token request, in particular the desired scope of the access token.
 func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	tk, err := c.client.authenticateUsernamePassword(ctx, c.tenantID, c.clientID, c.username, c.password, opts.Scopes)
 	if err != nil {


### PR DESCRIPTION
Revised all the credential doc comments, updating content and improving consistency. I deleted most of doc.go because on pkg.go.dev it appears after the readme, which has the overview content I think would belong in doc.go.