### PR TITLE
[Core] bumping internal to 0.8.2

### DIFF
--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -1,7 +1,7 @@
 module github.com/Azure/azure-sdk-for-go/sdk/azcore
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.2
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b
 )

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1 h1:BUYIbDf/mMZ8945v3QkG3OuqGVyS4Iek0AOLwdRAYoc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.2 h1:rImM7Yjz9yUgpdxp3A4cZLm1JZuo4XbtIp2LrUZnwYw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.2/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=


### PR DESCRIPTION
Bumps version of internal for latest changes. This allows all our client/mgmt plane packages to use the latest versions of internal as well.