### PR TITLE
Installation capability is deprecated from go get. Need to use go install instead.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
         go version
         curl -sSL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
         dep ensure -v
-        go get -u golang.org/x/lint/golint
+        go install golang.org/x/lint/golint
       workingDirectory: '$(sdkPath)'
       displayName: 'Install Dependencies'
 

--- a/documentation/new-version-quickstart.md
+++ b/documentation/new-version-quickstart.md
@@ -80,14 +80,14 @@ This project uses Go modules for versioning and dependency management.
 As an example, to install the Azure Compute module, you would run :
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute
 ```
 
 We also recommend installing other packages for authentication and core functionalities :
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/azcore
-go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
+go install github.com/Azure/azure-sdk-for-go/sdk/azcore
+go install github.com/Azure/azure-sdk-for-go/sdk/azidentity
 ```
 
 Authentication

--- a/documentation/previous-versions-quickstart.md
+++ b/documentation/previous-versions-quickstart.md
@@ -32,7 +32,7 @@ to change, including breaking changes outside of a major semver bump.
 ## Install
 
 ```sh
-$ go get -u github.com/Azure/azure-sdk-for-go/...
+$ go install github.com/Azure/azure-sdk-for-go/...
 ```
 
 and you should also make sure to include the minimum version of [`go-autorest`](https://github.com/Azure/go-autorest) that is specified in `Gopkg.toml` file.

--- a/documentation/release.md
+++ b/documentation/release.md
@@ -22,4 +22,4 @@ After going through a minimal architects board review and preparing your package
 1. Complete all steps of the Release Checklist shown above
 2. Mark the package as 'in-release' by running the `./eng/common/scripts/Prepare-Release.ps1` script and following the prompts. The script may update the version and/or `CHANGELOG.md` of the package. If changes are made, these changes need to be committed and merged before continuing with the release process.
 3. Run the pipeline from the `internal` Azure Devops. This will require you to approve the release after both the live and recorded test pipelines pass.
-4. Validate the package was released properly by running `go get <your-package>@<your-version>` (ie. `go get github.com/Azure/azure-sdk-for-go/sdk/azcore@v0.20.0`) and validating that pkg.go.dev has updated with the latest version.
+4. Validate the package was released properly by running `go install <your-package>@<your-version>` (ie. `go install github.com/Azure/azure-sdk-for-go/sdk/azcore@v0.20.0`) and validating that pkg.go.dev has updated with the latest version.

--- a/eng/initScript.sh
+++ b/eng/initScript.sh
@@ -9,7 +9,7 @@ curl -sSL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 PATH=$PATH:$GOPATH/bin
 dep ensure
 export GO111MODULE=on
-go get github.com/Azure/azure-sdk-for-go/eng/tools/generator@latest
+go install github.com/Azure/azure-sdk-for-go/eng/tools/generator@latest
 cat > $2 << EOF
 {
   "envs": {

--- a/eng/tools/generator/cmd/v2/common/cmdProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/cmdProcessor.go
@@ -23,12 +23,12 @@ func ExecuteGoGenerate(path string) error {
 
 // execute `goimports` command and fetch result
 func ExecuteGoimports(path string) error {
-	cmd := exec.Command("go", "get", "golang.org/x/tools/cmd/goimports")
+	cmd := exec.Command("go", "install", "golang.org/x/tools/cmd/goimports")
 	cmd.Dir = path
 	output, err := cmd.CombinedOutput()
-	log.Printf("Result of `go get golang.org/x/tools/cmd/goimports` execution: \n%s", string(output))
+	log.Printf("Result of `go install golang.org/x/tools/cmd/goimports` execution: \n%s", string(output))
 	if err != nil {
-		return fmt.Errorf("failed to execute `go get golang.org/x/tools/cmd/goimports` '%s': %+v", string(output), err)
+		return fmt.Errorf("failed to execute `go install golang.org/x/tools/cmd/goimports` '%s': %+v", string(output), err)
 	}
 	cmd = exec.Command("goimports", "-w", ".")
 	cmd.Dir = path

--- a/eng/tools/generator/template/rpName/packageName/README.md.tpl
+++ b/eng/tools/generator/template/rpName/packageName/README.md.tpl
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure {{PackageTitle}} module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/{{rpName}}/{{packageName}}
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/{{rpName}}/{{packageName}}
 ```
 
 ## Authorization

--- a/eng/tools/profileBuilder/README.md
+++ b/eng/tools/profileBuilder/README.md
@@ -24,7 +24,7 @@ scattered throughout the consumer's code.
 The simplest version of installation is very easy but not stable, just run the following command:
 
 ``` bash
-go get -u github.com/Azure/azure-sdk-for-go/eng/tools/profileBuilder
+go install github.com/Azure/azure-sdk-for-go/eng/tools/profileBuilder
 ```
 
 If that causes you trouble, run the following commands:

--- a/sdk/azcore/README.md
+++ b/sdk/azcore/README.md
@@ -15,7 +15,7 @@ Typically, you will not need to explicitly install `azcore` as it will be instal
 To add the latest version to your `go.mod` file, execute the following command.
 
 ```bash
-go get github.com/Azure/azure-sdk-for-go/sdk/azcore
+go install github.com/Azure/azure-sdk-for-go/sdk/azcore
 ```
 
 General documentation and examples can be found on [pkg.go.dev](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore).

--- a/sdk/azidentity/README.md
+++ b/sdk/azidentity/README.md
@@ -15,7 +15,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Identity module:
 
 ```sh
-go get -u github.com/Azure/azure-sdk-for-go/sdk/azidentity
+go install github.com/Azure/azure-sdk-for-go/sdk/azidentity
 ```
 
 ## Prerequisites

--- a/sdk/data/azcosmos/README.md
+++ b/sdk/data/azcosmos/README.md
@@ -24,10 +24,10 @@ You can create an Azure Cosmos account using:
 
 #### Install the package
 
-* Install the Azure Cosmos DB SDK for Go with `go get`:
+* Install the Azure Cosmos DB SDK for Go with `go install`:
 
   ```bash
-  go get -u github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
+  go install github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
   ```
 
 #### Authenticate the client

--- a/sdk/data/aztables/README.md
+++ b/sdk/data/aztables/README.md
@@ -20,9 +20,9 @@ The Azure Tables SDK can access an Azure Storage or CosmosDB account.
 * To create a new Cosmos storage account, you can use the [Azure CLI][azure_cli_create_cosmos] or [Azure Portal][azure_portal_create_cosmos].
 
 ### Install the package
-Install the Azure Tables client library for Go with `go get`:
+Install the Azure Tables client library for Go with `go install`:
 ```bash
-go get github.com/Azure/azure-sdk-for-go/sdk/data/aztables
+go install github.com/Azure/azure-sdk-for-go/sdk/data/aztables
 ```
 
 #### Create the client

--- a/sdk/keyvault/azkeys/README.md
+++ b/sdk/keyvault/azkeys/README.md
@@ -7,10 +7,10 @@ access to the keys used to encrypt your data
 
 ## Getting started
 ### Install packages
-Install [azkeys][goget_azkeys] and [azidentity][goget_azidentity] with `go get`:
+Install [azkeys][goget_azkeys] and [azidentity][goget_azidentity] with `go install`:
 ```Bash
-go get github.com/Azure/azure-sdk-for-go/sdk/keys/azkeys
-go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
+go install github.com/Azure/azure-sdk-for-go/sdk/keys/azkeys
+go install github.com/Azure/azure-sdk-for-go/sdk/azidentity
 ```
 [azidentity][azure_identity] is used for Azure Active Directory authentication as demonstrated below.
 

--- a/sdk/keyvault/azsecrets/README.md
+++ b/sdk/keyvault/azsecrets/README.md
@@ -8,11 +8,11 @@ Azure Key Vault helps securely store and control access to tokens, passwords, ce
 ### Install packages
 Install `azsecrets` and [azure-identity][azidentity_goget]:
 ```
-go get -u github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets
+go install github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets
 ```
 [azure-identity][azure_identity] is used for Azure Active Directory authentication as demonstrated below.
 ```
-go get -u github.com/Azure/azure-sdk-for-go/sdk/azidentity
+go install github.com/Azure/azure-sdk-for-go/sdk/azidentity
 ```
 
 

--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -19,10 +19,10 @@ Key links:
 
 ### Install the package
 
-Install the Azure Service Bus client module for Go with `go get`:
+Install the Azure Service Bus client module for Go with `go install`:
 
 ```bash
-go get github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus
+go install github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus
 ```
 
 ### Prerequisites

--- a/sdk/resourcemanager/agrifood/armagrifood/README.md
+++ b/sdk/resourcemanager/agrifood/armagrifood/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure AgriFood module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/agrifood/armagrifood
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/agrifood/armagrifood
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/alertsmanagement/armalertsmanagement/README.md
+++ b/sdk/resourcemanager/alertsmanagement/armalertsmanagement/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Alerts Management module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/armalertsmanagement
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/armalertsmanagement
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/apimanagement/armapimanagement/README.md
+++ b/sdk/resourcemanager/apimanagement/armapimanagement/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure API Management module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/appplatform/armappplatform/README.md
+++ b/sdk/resourcemanager/appplatform/armappplatform/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure App Platform module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/authorization/armauthorization/README.md
+++ b/sdk/resourcemanager/authorization/armauthorization/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Authorization module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/automation/armautomation/README.md
+++ b/sdk/resourcemanager/automation/armautomation/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Automation module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automation/armautomation
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automation/armautomation
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/cdn/armcdn/README.md
+++ b/sdk/resourcemanager/cdn/armcdn/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Content Delivery Network module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/cognitiveservices/armcognitiveservices/README.md
+++ b/sdk/resourcemanager/cognitiveservices/armcognitiveservices/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Cognitive Services module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/compute/armcompute/README.md
+++ b/sdk/resourcemanager/compute/armcompute/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Compute module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/consumption/armconsumption/README.md
+++ b/sdk/resourcemanager/consumption/armconsumption/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Consumption module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/containerregistry/armcontainerregistry/README.md
+++ b/sdk/resourcemanager/containerregistry/armcontainerregistry/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Container Registry module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/containerservice/armcontainerservice/README.md
+++ b/sdk/resourcemanager/containerservice/armcontainerservice/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Container Service module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/cosmos/armcosmos/README.md
+++ b/sdk/resourcemanager/cosmos/armcosmos/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Cosmos DB module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/databricks/armdatabricks/README.md
+++ b/sdk/resourcemanager/databricks/armdatabricks/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Databricks module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/datalake-analytics/armdatalakeanalytics/README.md
+++ b/sdk/resourcemanager/datalake-analytics/armdatalakeanalytics/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Data Lake Analytics module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-analytics/armdatalakeanalytics
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-analytics/armdatalakeanalytics
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/datalake-store/armdatalakestore/README.md
+++ b/sdk/resourcemanager/datalake-store/armdatalakestore/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Data Lake Storage module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-store/armdatalakestore
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-store/armdatalakestore
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/eventgrid/armeventgrid/README.md
+++ b/sdk/resourcemanager/eventgrid/armeventgrid/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Event Grid module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/eventhub/armeventhub/README.md
+++ b/sdk/resourcemanager/eventhub/armeventhub/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Event Hubs module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/iothub/armiothub/README.md
+++ b/sdk/resourcemanager/iothub/armiothub/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure IoT Hub module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/keyvault/armkeyvault/README.md
+++ b/sdk/resourcemanager/keyvault/armkeyvault/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Key Vault module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/logic/armlogic/README.md
+++ b/sdk/resourcemanager/logic/armlogic/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Logic Apps module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/managementgroups/armmanagementgroups/README.md
+++ b/sdk/resourcemanager/managementgroups/armmanagementgroups/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Management Groups module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/mediaservices/armmediaservices/README.md
+++ b/sdk/resourcemanager/mediaservices/armmediaservices/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Media Services module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mediaservices/armmediaservices
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mediaservices/armmediaservices
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/monitor/armmonitor/README.md
+++ b/sdk/resourcemanager/monitor/armmonitor/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Monitor module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/msi/armmsi/README.md
+++ b/sdk/resourcemanager/msi/armmsi/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Managed Service Identity module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/mysql/armmysql/README.md
+++ b/sdk/resourcemanager/mysql/armmysql/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Database for MySQL module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/mysql/armmysqlflexibleservers/README.md
+++ b/sdk/resourcemanager/mysql/armmysqlflexibleservers/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Database for MySQL module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/network/armnetwork/README.md
+++ b/sdk/resourcemanager/network/armnetwork/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Network module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/notificationhubs/armnotificationhubs/README.md
+++ b/sdk/resourcemanager/notificationhubs/armnotificationhubs/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Notification Hubs module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/operationalinsights/armoperationalinsights/README.md
+++ b/sdk/resourcemanager/operationalinsights/armoperationalinsights/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Operational Insights module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/operationsmanagement/armoperationsmanagement/README.md
+++ b/sdk/resourcemanager/operationsmanagement/armoperationsmanagement/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Operations Management module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationsmanagement/armoperationsmanagement
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationsmanagement/armoperationsmanagement
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/postgresql/armpostgresql/README.md
+++ b/sdk/resourcemanager/postgresql/armpostgresql/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Database for PostgreSQL module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/README.md
+++ b/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Database for PostgreSQL module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/privatedns/armprivatedns/README.md
+++ b/sdk/resourcemanager/privatedns/armprivatedns/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Private DNS module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/recoveryservices/armrecoveryservices/README.md
+++ b/sdk/resourcemanager/recoveryservices/armrecoveryservices/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Recovery Services module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/redis/armredis/README.md
+++ b/sdk/resourcemanager/redis/armredis/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Cache for Redis module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/relay/armrelay/README.md
+++ b/sdk/resourcemanager/relay/armrelay/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Relay module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/README.md
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Resource Health module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/resources/armresources/README.md
+++ b/sdk/resourcemanager/resources/armresources/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Resources module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/scheduler/armscheduler/README.md
+++ b/sdk/resourcemanager/scheduler/armscheduler/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Scheduler module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/scheduler/armscheduler
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/scheduler/armscheduler
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/search/armsearch/README.md
+++ b/sdk/resourcemanager/search/armsearch/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Search module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/security/armsecurity/README.md
+++ b/sdk/resourcemanager/security/armsecurity/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Security module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/servicebus/armservicebus/README.md
+++ b/sdk/resourcemanager/servicebus/armservicebus/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Service Bus module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/servicefabric/armservicefabric/README.md
+++ b/sdk/resourcemanager/servicefabric/armservicefabric/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Service Fabric module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabric/armservicefabric
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabric/armservicefabric
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/sql/armsql/README.md
+++ b/sdk/resourcemanager/sql/armsql/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure SQL Database module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/storage/armstorage/README.md
+++ b/sdk/resourcemanager/storage/armstorage/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Storage module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/streamanalytics/armstreamanalytics/README.md
+++ b/sdk/resourcemanager/streamanalytics/armstreamanalytics/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Stream Analytics module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/streamanalytics/armstreamanalytics
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/streamanalytics/armstreamanalytics
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/web/armweb/README.md
+++ b/sdk/resourcemanager/web/armweb/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Web module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/web/armweb
+go install github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/web/armweb
 ```
 
 ## Authorization

--- a/sdk/storage/azblob/README.md
+++ b/sdk/storage/azblob/README.md
@@ -19,9 +19,9 @@ The Azure Blob SDK can access an Azure Storage account.
 * To create a new Storage account, you can use [Azure Portal][azure_portal_create_account], [Azure PowerShell][azure_powershell_create_account], or [Azure CLI][azure_cli_create_account].
 
 ### Install the package
-* Install the Azure blob storage for Go with `go get`:
+* Install the Azure blob storage for Go with `go install`:
   ```bash
-  go get github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
+  go install github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
   ```
   
 #### Create the client

--- a/sdk/synapse/azartifacts/README.md
+++ b/sdk/synapse/azartifacts/README.md
@@ -20,7 +20,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Synapse Artifacts module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/synapse/azartifacts
+go install github.com/Azure/azure-sdk-for-go/sdk/synapse/azartifacts
 ```
 
 ## Authorization


### PR DESCRIPTION
Installation capability is removed from go get. Need to use go install instead.

"Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead."
Source: https://golang.org/doc/go-get-install-deprecation

The -i flag for go install is also deprecated and go install is enough.

Tested with go1.13.13, go1.15.15 as well as go1.17.2.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
