### PR TITLE
[azservicebus] update to go-amqp@v0.16.4

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.3.1 (2021-11-16)
+
+### Bugs Fixed
+
+- Updating go-amqp to v0.16.4 to fix a race condition found when running `go test -race`.  Thanks to @peterzeller for reporting this issue. PR: #16168
+
 ## 0.3.0 (2021-11-12)
 
 ### Features Added

--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.12.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1
-	github.com/Azure/go-amqp v0.16.3
+	github.com/Azure/go-amqp v0.16.4
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/adal v0.9.13
 	github.com/Azure/go-autorest/autorest/date v0.3.0

--- a/sdk/messaging/azservicebus/go.sum
+++ b/sdk/messaging/azservicebus/go.sum
@@ -13,6 +13,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1/go.mod h1:KLF4gFr6DcKFZwSu
 github.com/Azure/go-amqp v0.16.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/Azure/go-amqp v0.16.3 h1:zH2aVLvIn6tqRnYyviP/eqiZkbfPYBnvRE7fSz10SLY=
 github.com/Azure/go-amqp v0.16.3/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
+github.com/Azure/go-amqp v0.16.4-0.20211115174555-09c30bbe18ec h1:OCqvhNVlUQoxGcXF9Bxe8VfB765ReaVhqfNDjT2Gdwo=
+github.com/Azure/go-amqp v0.16.4-0.20211115174555-09c30bbe18ec/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
+github.com/Azure/go-amqp v0.16.4 h1:/1oIXrq5zwXLHaoYDliJyiFjJSpJZMWGgtMX9e0/Z30=
+github.com/Azure/go-amqp v0.16.4/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.18 h1:90Y4srNYrwOtAgVo3ndrQkTYn6kf1Eg/AjTFJ8Is2aM=

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -19,4 +19,4 @@ const (
 // TODO: this should move into a proper file. Need to resolve some interdependency
 // issues between the public and internal packages first.
 // Version is the semantic version number
-const Version = "v0.3.0"
+const Version = "v0.3.1"


### PR DESCRIPTION
Prior version of go-amqp v0.16.3 had a race condition where a link error could potentially be set when the link is unwound that was not synchronized with reading the error.

Fixes #16092