### PR TITLE
feat: add check release to auto trigger internal release job

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -4,67 +4,86 @@ parameters:
   ServiceDirectory: ''
 
 stages:
-  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - stage: Release
-      displayName: 'Release: ${{ parameters.ServiceDirectory }}'
-      dependsOn: ${{ parameters.DependsOn }}
-      condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-go-pr'))
-      jobs:
-        - deployment: TagRepository
-          displayName: "Create release tag"
-          condition: and(succeeded(), ne(variables['Skip.TagRepository'], 'true'))
-          environment: github
+  - stage: CheckRelease
+    displayName: 'Check Release: ${{ parameters.ServiceDirectory }}'
+    dependsOn: ${{ parameters.DependsOn }}
+    condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-go-pr'))
+    jobs:
+      - job: CheckReleaseJob
+        displayName: "Check whether need to release"
+        steps:
+          - task: PowerShell@2
+            name: Verify
+            inputs:
+              filePath: ./eng/scripts/Verify-NeedToRelease.ps1
+              arguments: >
+                -PackageName 'sdk/${{ parameters.ServiceDirectory }}'
+                -ServiceDirectory '${{ parameters.ServiceDirectory }}'
+                -repoId Azure/azure-sdk-for-go
+                -workingDirectory $(System.DefaultWorkingDirectory)
+              pwsh: true
+            env:
+              GH_TOKEN: $(azuresdk-github-pat)
+  - stage: Release
+    displayName: 'Release: ${{ parameters.ServiceDirectory }}'
+    dependsOn: CheckRelease
+    condition: and(succeeded(), eq(dependencies.CheckRelease.outputs['CheckReleaseJob.Verify.NeedToRelease'], 'true'))
+    jobs: 
+      - deployment: TagRepository
+        displayName: "Create release tag"
+        condition: and(succeeded(), eq(variables['NeedToRelease'], 'true'), ne(variables['Skip.TagRepository'], 'true'))
+        environment: github
 
-          pool:
-            name: azsdk-pool-mms-ubuntu-2004-general
-            vmImage: MMSUbuntu20.04
+        pool:
+          name: azsdk-pool-mms-ubuntu-2004-general
+          vmImage: MMSUbuntu20.04
 
-          strategy:
-            runOnce:
-              deploy:
-                steps:
-                  - checkout: self
-                  - template: /eng/common/pipelines/templates/steps/retain-run.yml
-                  - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
-                    parameters:
-                      PackageName: 'sdk/${{ parameters.ServiceDirectory }}'
-                      ForRelease: true
-                  - task: PowerShell@2
-                    displayName: 'Verify no replace directives in go.mod file'
-                    inputs:
-                      targetType: 'filePath'
-                      filePath: ./eng/scripts/validate_go_mod.ps1
-                      arguments: '${{ parameters.ServiceDirectory }}'
-                      pwsh: true
-                  - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-                    parameters:
-                      ArtifactLocation: $(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}
-                      ReleaseSha: $(Build.SourceVersion)
-                      RepoId: Azure/azure-sdk-for-go
-                      WorkingDirectory: $(System.DefaultWorkingDirectory)
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - template: /eng/common/pipelines/templates/steps/retain-run.yml
+                - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
+                  parameters:
+                    PackageName: 'sdk/${{ parameters.ServiceDirectory }}'
+                    ForRelease: true
+                - task: PowerShell@2
+                  displayName: 'Verify no replace directives in go.mod file'
+                  inputs:
+                    targetType: 'filePath'
+                    filePath: ./eng/scripts/validate_go_mod.ps1
+                    arguments: '${{ parameters.ServiceDirectory }}'
+                    pwsh: true
+                - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                  parameters:
+                    ArtifactLocation: $(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}
+                    ReleaseSha: $(Build.SourceVersion)
+                    RepoId: Azure/azure-sdk-for-go
+                    WorkingDirectory: $(System.DefaultWorkingDirectory)
 
-        - deployment: UpdatePackageVersion
-          displayName: "Update Package Version"
-          condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
-          environment: github
-          dependsOn: TagRepository
+      - deployment: UpdatePackageVersion
+        displayName: "Update Package Version"
+        condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
+        environment: github
+        dependsOn: TagRepository
 
-          pool:
-            name: azsdk-pool-mms-ubuntu-2004-general
-            vmImage: MMSUbuntu20.04
+        pool:
+          name: azsdk-pool-mms-ubuntu-2004-general
+          vmImage: MMSUbuntu20.04
 
-          strategy:
-            runOnce:
-              deploy:
-                steps:
-                  - checkout: self
-                  - pwsh: |
-                      eng/scripts/Update-ModuleVersion.ps1 -ModulePath 'sdk/${{parameters.ServiceDirectory}}'
-                    displayName: Increment package version
-                  - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-                    parameters:
-                      PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
-                      CommitMsg: "Increment package version after release of ${{ parameters.ServiceDirectory }}"
-                      PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
-                      PRLabels: "auto-merge"
-                      CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - pwsh: |
+                    eng/scripts/Update-ModuleVersion.ps1 -ModulePath 'sdk/${{parameters.ServiceDirectory}}'
+                  displayName: Increment package version
+                - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+                  parameters:
+                    PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
+                    CommitMsg: "Increment package version after release of ${{ parameters.ServiceDirectory }}"
+                    PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+                    PRLabels: "auto-merge"
+                    CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'

--- a/eng/scripts/Verify-NeedToRelease.ps1
+++ b/eng/scripts/Verify-NeedToRelease.ps1
@@ -1,0 +1,42 @@
+param (
+  $PackageName,
+  $ServiceDirectory,
+  $repoId
+)
+
+. (Join-Path $PSScriptRoot .. common scripts common.ps1)
+
+$apiUrl = "https://api.github.com/repos/$repoId"
+Write-Host "Using API URL $apiUrl"
+
+# VERIFY CHANGELOG
+$PackageProp = Get-PkgProperties -PackageName $PackageName -ServiceDirectory $ServiceDirectory
+$changeLogEntries = Get-ChangeLogEntries -ChangeLogLocation $PackageProp.ChangeLogPath
+$changeLogEntry = $changeLogEntries[$PackageProp.Version]
+
+if (!$changeLogEntry)
+{
+  Write-Host "Changelog not existed for package: $PackageName, version: $($PackageProp.Version)."
+  Write-Output "##vso[task.setvariable variable=NeedToRelease;isOutput=true]false"
+  return
+}
+
+if ([System.String]::IsNullOrEmpty($changeLogEntry.ReleaseStatus) -or $changeLogEntry.ReleaseStatus -eq $CHANGELOG_UNRELEASED_STATUS)
+{
+  Write-Host "Changelog not in release status for package: $PackageName, version: $($PackageProp.Version)."
+  Write-Output "##vso[task.setvariable variable=NeedToRelease;isOutput=true]false"
+  return
+}
+
+# VERIFY TAG
+$existingTags = GetExistingTags($apiUrl)
+if ($existingTags -contains "$($PackageProp.Name)/v$($PackageProp.Version)")
+{
+  Write-Host "Package: $PackageName, version: $($PackageProp.Version) already released."
+  Write-Output "##vso[task.setvariable variable=NeedToRelease;isOutput=true]false"
+}
+else
+{
+  Write-Host "Package: $PackageName, version: $($PackageProp.Version) need to release."
+  Write-Output "##vso[task.setvariable variable=NeedToRelease;isOutput=true]true"
+}

--- a/eng/scripts/Verify-NeedToRelease.ps1
+++ b/eng/scripts/Verify-NeedToRelease.ps1
@@ -16,14 +16,14 @@ $changeLogEntry = $changeLogEntries[$PackageProp.Version]
 
 if (!$changeLogEntry)
 {
-  Write-Host "Changelog not existed for package: $PackageName, version: $($PackageProp.Version)."
+  Write-Host "Changelog does not exist for package: $PackageName, version: $($PackageProp.Version)."
   Write-Output "##vso[task.setvariable variable=NeedToRelease;isOutput=true]false"
   return
 }
 
 if ([System.String]::IsNullOrEmpty($changeLogEntry.ReleaseStatus) -or $changeLogEntry.ReleaseStatus -eq $CHANGELOG_UNRELEASED_STATUS)
 {
-  Write-Host "Changelog not in release status for package: $PackageName, version: $($PackageProp.Version)."
+  Write-Host "Changelog is not in release status for package: $PackageName, version: $($PackageProp.Version)."
   Write-Output "##vso[task.setvariable variable=NeedToRelease;isOutput=true]false"
   return
 }
@@ -32,7 +32,7 @@ if ([System.String]::IsNullOrEmpty($changeLogEntry.ReleaseStatus) -or $changeLog
 $existingTags = GetExistingTags($apiUrl)
 if ($existingTags -contains "$($PackageProp.Name)/v$($PackageProp.Version)")
 {
-  Write-Host "Package: $PackageName, version: $($PackageProp.Version) already released."
+  Write-Host "Package: $PackageName, version: $($PackageProp.Version) has already released."
   Write-Output "##vso[task.setvariable variable=NeedToRelease;isOutput=true]false"
 }
 else


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md

As there are too many manual trigger works for SDK release, I added a release check stage before the release pipeline. The stage will check whether there is a new release and to trigger or skip release stage then.