### PR TITLE
[messaging] `internal` has to get staged in first for azservicebus to build prope…

### DIFF
--- a/sdk/messaging/internal/rpc/rpc_test.go
+++ b/sdk/messaging/internal/rpc/rpc_test.go
@@ -135,7 +135,7 @@ func TestResponseRouterNoResponse(t *testing.T) {
 }
 
 func TestAddMessageID(t *testing.T) {
-	message, id, err := addMessageID(&amqp.Message{}, uuid.NewV4)
+	message, id, err := addMessageID(&amqp.Message{}, uuid.New)
 	require.NoError(t, err)
 	require.NotEmpty(t, id)
 	require.EqualValues(t, message.Properties.MessageID, id)
@@ -146,7 +146,7 @@ func TestAddMessageID(t *testing.T) {
 			UserID:    []byte("my user ID"),
 			MessageID: "is that will not be copied"},
 	}
-	message, id, err = addMessageID(m, uuid.NewV4)
+	message, id, err = addMessageID(m, uuid.New)
 	require.NoError(t, err)
 	require.NotEmpty(t, id)
 	require.EqualValues(t, message.Properties.MessageID, id)
@@ -259,7 +259,7 @@ func TestRPCNilMessageMap(t *testing.T) {
 		// there.
 		responseMap:             nil,
 		startResponseRouterOnce: &sync.Once{},
-		uuidNewV4:               uuid.NewV4,
+		uuidNewV4:               uuid.New,
 	}
 
 	// sanity check - all the map/channel functions are returning nil

--- a/sdk/messaging/internal/sas/sas_test.go
+++ b/sdk/messaging/internal/sas/sas_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -30,6 +31,7 @@ func TestNewSigner(t *testing.T) {
 	before := time.Now().UTC().Add(-2 * time.Second)
 	sigStr, expiry := signer.SignWithDuration("http://microsoft.com", 1*time.Hour)
 	nixExpiry, err := strconv.ParseInt(expiry, 10, 64)
+	require.NoError(t, err)
 	assert.WithinDuration(t, before.Add(1*time.Hour), time.Unix(nixExpiry, 0), 10*time.Second, "signing expiry")
 
 	sig, err := parseSig(sigStr)


### PR DESCRIPTION
`internal` has to get staged in first for azservicebus to build properly. These are the minimal changes needed - basically removing any "suffix" special case handling.

Part of #15979