### PR TITLE
[azservicebus] Fixing messages received in ReceiveModeReceiveAndDelete settlement mode causing a panic

### DIFF
--- a/sdk/messaging/azservicebus/main_test.go
+++ b/sdk/messaging/azservicebus/main_test.go
@@ -15,7 +15,7 @@ func TestMain(m *testing.M) {
 	err := godotenv.Load()
 
 	if err != nil {
-		log.Printf("Failed to load env file, no live tests will run: %s", err.Error())
+		log.Printf("Failed to load env file, NO LIVE TESTS WILL RUN: %s", err.Error())
 	}
 
 	// call flag.Parse() here if TestMain uses flags

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/go-amqp"
 )
 
-var errReceiveAndDeleteReceiver = errors.New("messages that are received in receiveAndDelete mode are not settlable")
+var errReceiveAndDeleteReceiver = errors.New("messages that are received in `ReceiveModeReceiveAndDelete` mode are not settleable")
 
 type settler interface {
 	CompleteMessage(ctx context.Context, message *ReceivedMessage) error

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -133,6 +133,8 @@ func newReceiver(ns internal.NamespaceWithNewAMQPLinks, entity *entity, cleanupO
 	// 'nil' settler handles returning an error message for receiveAndDelete links.
 	if receiver.receiveMode == ReceiveModePeekLock {
 		receiver.settler = newMessageSettler(receiver.amqpLinks, receiver.baseRetrier)
+	} else {
+		receiver.settler = (*messageSettler)(nil)
 	}
 
 	return receiver, nil


### PR DESCRIPTION
Messages received in ReceiveModeReceiveAndDelete mode were panicking when settled. We had a check for this but it broke when I moved it to an interface, rather than an actual direct pointer type.