### PR TITLE
Refactor IMDS discovery to remove probing, stop caching failures

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,10 @@
 ### Bugs Fixed
 
 ### Other Changes
+* `ManagedIdentityCredential` no longer probes IMDS before requesting a token
+  from it. Also, an error response from IMDS no longer disables a credential
+  instance. Following an error, a credential instance will continue to send
+  requests to IMDS as necessary.
 
 ## 0.12.0 (2021-11-02)
 ### Breaking Changes

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -54,11 +54,10 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		errMsg += err.Error()
 	}
 
-	msiCred, err := NewManagedIdentityCredential(
-		&ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions, imdsTimeout: time.Second},
-	)
+	msiCred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions})
 	if err == nil {
 		creds = append(creds, msiCred)
+		msiCred.client.imdsTimeout = time.Second
 	} else {
 		errMsg += err.Error()
 	}

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -6,6 +6,7 @@ package azidentity
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -53,7 +54,9 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		errMsg += err.Error()
 	}
 
-	msiCred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions})
+	msiCred, err := NewManagedIdentityCredential(
+		&ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions, imdsTimeout: time.Second},
+	)
 	if err == nil {
 		creds = append(creds, msiCred)
 	} else {

--- a/sdk/azidentity/logging.go
+++ b/sdk/azidentity/logging.go
@@ -5,7 +5,6 @@ package azidentity
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -19,30 +18,6 @@ import (
 // used when obtaining credentials and the type of credential used.
 const EventAuthentication log.Event = "Authentication"
 
-// log environment variables that can be used for credential types
-func logEnvVars() {
-	if !log.Should(EventAuthentication) {
-		return
-	}
-	// Log available environment variables
-	envVars := []string{}
-	if envCheck := os.Getenv("AZURE_TENANT_ID"); len(envCheck) > 0 {
-		envVars = append(envVars, "AZURE_TENANT_ID")
-	}
-	if envCheck := os.Getenv("AZURE_CLIENT_ID"); len(envCheck) > 0 {
-		envVars = append(envVars, "AZURE_CLIENT_ID")
-	}
-	if envCheck := os.Getenv("AZURE_CLIENT_SECRET"); len(envCheck) > 0 {
-		envVars = append(envVars, "AZURE_CLIENT_SECRET")
-	}
-	if envCheck := os.Getenv(azureAuthorityHost); len(envCheck) > 0 {
-		envVars = append(envVars, azureAuthorityHost)
-	}
-	if len(envVars) > 0 {
-		log.Writef(EventAuthentication, "Azure Identity => Found the following environment variables:\n\t%s", strings.Join(envVars, ", "))
-	}
-}
-
 func logGetTokenSuccess(cred azcore.TokenCredential, opts policy.TokenRequestOptions) {
 	if !log.Should(EventAuthentication) {
 		return
@@ -54,24 +29,6 @@ func logGetTokenSuccess(cred azcore.TokenCredential, opts policy.TokenRequestOpt
 
 func logCredentialError(credName string, err error) {
 	log.Writef(EventAuthentication, "Azure Identity => ERROR in %s: %s", credName, err.Error())
-}
-
-func logMSIEnv(msi msiType) {
-	if !log.Should(EventAuthentication) {
-		return
-	}
-	var msg string
-	switch msi {
-	case msiTypeIMDS:
-		msg = "Azure Identity => Managed Identity environment: IMDS"
-	case msiTypeAppServiceV20170901, msiTypeCloudShell, msiTypeAppServiceV20190801:
-		msg = "Azure Identity => Managed Identity environment: MSI_ENDPOINT"
-	case msiTypeUnavailable:
-		msg = "Azure Identity => Managed Identity environment: Unavailable"
-	default:
-		msg = "Azure Identity => Managed Identity environment: Unknown"
-	}
-	log.Write(EventAuthentication, msg)
 }
 
 func addGetTokenFailureLogs(credName string, err error, includeStack bool) {

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -114,7 +114,7 @@ func newManagedIdentityClient(options *ManagedIdentityCredentialOptions) (*manag
 		options = &ManagedIdentityCredentialOptions{}
 	}
 	cp := options.ClientOptions
-	c := managedIdentityClient{id: options.ID, endpoint: imdsEndpoint, msiType: msiTypeIMDS, imdsTimeout: options.imdsTimeout}
+	c := managedIdentityClient{id: options.ID, endpoint: imdsEndpoint, msiType: msiTypeIMDS}
 	env := "IMDS"
 	if endpoint, ok := os.LookupEnv(msiEndpoint); ok {
 		if _, ok := os.LookupEnv(msiSecret); ok {

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -117,31 +117,28 @@ func newManagedIdentityClient(options *ManagedIdentityCredentialOptions) (*manag
 	c := managedIdentityClient{id: options.ID, endpoint: imdsEndpoint, msiType: msiTypeIMDS, imdsTimeout: options.imdsTimeout}
 	env := "IMDS"
 	if endpoint, ok := os.LookupEnv(msiEndpoint); ok {
-		c.endpoint = endpoint
 		if _, ok := os.LookupEnv(msiSecret); ok {
-			c.msiType = msiTypeAppServiceV20170901
 			env = "App Service"
+			c.endpoint = endpoint
+			c.msiType = msiTypeAppServiceV20170901
 		} else {
-			c.msiType = msiTypeCloudShell
 			env = "Cloud Shell"
+			c.endpoint = endpoint
+			c.msiType = msiTypeCloudShell
 		}
 	} else if endpoint, ok := os.LookupEnv(identityEndpoint); ok {
-		c.endpoint = endpoint
 		if _, ok := os.LookupEnv(identityHeader); ok {
 			if _, ok := os.LookupEnv(identityServerThumbprint); ok {
-				c.msiType = msiTypeServiceFabric
 				env = "Service Fabric"
+				c.endpoint = endpoint
+				c.msiType = msiTypeServiceFabric
 			}
 		} else if _, ok := os.LookupEnv(arcIMDSEndpoint); ok {
-			c.msiType = msiTypeAzureArc
 			env = "Azure Arc"
-		} else {
-			// no known hosting environment sets only IDENTITY_ENDPOINT
-			return nil, newCredentialUnavailableError("Managed Identity Credential", "this environment is not supported")
+			c.endpoint = endpoint
+			c.msiType = msiTypeAzureArc
 		}
 	} else {
-		c.msiType = msiTypeIMDS
-		c.endpoint = imdsEndpoint
 		setIMDSRetryOptionDefaults(&cp.Retry)
 	}
 	c.pipeline = runtime.NewPipeline(component, version, runtime.PipelineOptions{}, &cp)

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -87,13 +87,8 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 // ctx: Context used to control the request lifetime.
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
-	if opts.Scopes == nil {
-		err := errors.New("must specify a resource in order to authenticate")
-		addGetTokenFailureLogs("Managed Identity Credential", err, true)
-		return nil, err
-	}
-	if len(opts.Scopes) != 1 {
-		err := errors.New("can only specify one resource to authenticate with ManagedIdentityCredential")
+	if opts.Scopes == nil || len(opts.Scopes) != 1 {
+		err := errors.New("ManagedIdentityCredential.GetToken() requires exactly one scope")
 		addGetTokenFailureLogs("Managed Identity Credential", err, true)
 		return nil, err
 	}

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -105,7 +105,6 @@ func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.To
 		return nil, err
 	}
 	logGetTokenSuccess(c, opts)
-	logMSIEnv(c.client.msiType)
 	return tk, err
 }
 

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -75,13 +75,11 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 	if options == nil {
 		options = &ManagedIdentityCredentialOptions{}
 	}
-	client := newManagedIdentityClient(options)
-	msiType, err := client.getMSIType()
+	client, err := newManagedIdentityClient(options)
 	if err != nil {
 		logCredentialError("Managed Identity Credential", err)
 		return nil, err
 	}
-	client.msiType = msiType
 	return &ManagedIdentityCredential{id: options.ID, client: client}, nil
 }
 

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -87,7 +87,7 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 // ctx: Context used to control the request lifetime.
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
-	if opts.Scopes == nil || len(opts.Scopes) != 1 {
+	if len(opts.Scopes) != 1 {
 		err := errors.New("ManagedIdentityCredential.GetToken() requires exactly one scope")
 		addGetTokenFailureLogs("Managed Identity Credential", err, true)
 		return nil, err

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -59,8 +58,6 @@ type ManagedIdentityCredentialOptions struct {
 	// instead of the hosting environment's default. The value may be the identity's client ID or resource ID, but note that
 	// some platforms don't accept resource IDs.
 	ID ManagedIDKind
-
-	imdsTimeout time.Duration // used by DefaultAzureCredential to set a short timeout on initial IMDS requests
 }
 
 // ManagedIdentityCredential authenticates with an Azure managed identity in any hosting environment which supports managed identities.

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -58,6 +59,8 @@ type ManagedIdentityCredentialOptions struct {
 	// instead of the hosting environment's default. The value may be the identity's client ID or resource ID, but note that
 	// some platforms don't accept resource IDs.
 	ID ManagedIDKind
+
+	imdsTimeout time.Duration // used by DefaultAzureCredential to set a short timeout on initial IMDS requests
 }
 
 // ManagedIdentityCredential authenticates with an Azure managed identity in any hosting environment which supports managed identities.

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -23,16 +23,16 @@ import (
 )
 
 const (
-	msiScope                     = "https://storage.azure.com"
 	appServiceWindowsSuccessResp = `{"access_token": "new_token", "expires_on": "9/14/2017 00:00:00 PM +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 	appServiceLinuxSuccessResp   = `{"access_token": "new_token", "expires_on": "09/14/2017 00:00:00 +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 	expiresOnIntResp             = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": "1560974028", "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 	expiresOnNonStringIntResp    = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": 1560974028, "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 )
 
+// TODO: replace with 1.17's T.Setenv
 func clearEnvVars(envVars ...string) {
 	for _, ev := range envVars {
-		_ = os.Setenv(ev, "")
+		_ = os.Unsetenv(ev)
 	}
 }
 
@@ -53,6 +53,16 @@ func (m *mockIMDS) Do(req *http.Request) (*http.Response, error) {
 		return &resp, nil
 	}
 	panic("no more responses")
+}
+
+// delayPolicy adds a delay to pipeline requests. Used to test timeout behavior.
+type delayPolicy struct {
+	delay time.Duration
+}
+
+func (p delayPolicy) Do(req *policy.Request) (resp *http.Response, err error) {
+	time.Sleep(p.delay)
+	return req.Next()
 }
 
 func TestManagedIdentityCredential_AzureArc(t *testing.T) {
@@ -173,7 +183,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_windows(t *
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -196,7 +206,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_linux(t *te
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -209,6 +219,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_linux(t *te
 }
 
 func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_windows(t *testing.T) {
+	t.Skip("App Service 2019-08-01 isn't supported because it's unavailable in some Functions apps.")
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(appServiceWindowsSuccessResp)))
@@ -219,7 +230,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_windows(t *
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -232,6 +243,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_windows(t *
 }
 
 func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_linux(t *testing.T) {
+	t.Skip("App Service 2019-08-01 isn't supported because it's unavailable in some Functions apps.")
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(appServiceLinuxSuccessResp)))
@@ -242,7 +254,7 @@ func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_linux(t *te
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -266,7 +278,7 @@ func TestManagedIdentityCredential_GetTokenInAzureFunctions_linux(t *testing.T) 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -279,6 +291,7 @@ func TestManagedIdentityCredential_GetTokenInAzureFunctions_linux(t *testing.T) 
 }
 
 func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20190801(t *testing.T) {
+	t.Skip("App Service 2019-08-01 isn't supported because it's unavailable in some Functions apps.")
 	// setting a dummy value for MSI_ENDPOINT in order to be able to get a ManagedIdentityCredential type in order
 	// to test App Service authentication request creation.
 	setEnvironmentVariables(t, map[string]string{identityEndpoint: "somevalue", identityHeader: "header"})
@@ -287,7 +300,7 @@ func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20190801(t *testi
 		t.Fatalf("unexpected error: %v", err)
 	}
 	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createAuthRequest(context.Background(), ClientID(fakeClientID), []string{msiScope})
+	req, err := cred.client.createAuthRequest(context.Background(), ClientID(fakeClientID), []string{liveTestScope})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +314,7 @@ func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20190801(t *testi
 	if reqQueryParams["api-version"][0] != "2019-08-01" {
 		t.Fatalf("Unexpected App Service API version")
 	}
-	if reqQueryParams["resource"][0] != msiScope {
+	if reqQueryParams["resource"][0] != liveTestScope {
 		t.Fatalf("Unexpected resource in resource query param")
 	}
 	if reqQueryParams[qpClientID][0] != fakeClientID {
@@ -318,7 +331,7 @@ func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20170901(t *testi
 		t.Fatalf("unexpected error: %v", err)
 	}
 	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createAuthRequest(context.Background(), ClientID(fakeClientID), []string{msiScope})
+	req, err := cred.client.createAuthRequest(context.Background(), ClientID(fakeClientID), []string{liveTestScope})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +345,7 @@ func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20170901(t *testi
 	if reqQueryParams["api-version"][0] != "2017-09-01" {
 		t.Fatalf("Unexpected App Service API version")
 	}
-	if reqQueryParams["resource"][0] != msiScope {
+	if reqQueryParams["resource"][0] != liveTestScope {
 		t.Fatalf("Unexpected resource in resource query param")
 	}
 	if reqQueryParams["clientid"][0] != fakeClientID {
@@ -351,7 +364,7 @@ func TestManagedIdentityCredential_CreateAccessTokenExpiresOnStringInt(t *testin
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -368,32 +381,26 @@ func TestManagedIdentityCredential_GetTokenInAppServiceMockFail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
 }
 
 func TestManagedIdentityCredential_GetTokenIMDS400(t *testing.T) {
+	res := http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(bytes.NewBufferString(""))}
 	options := ManagedIdentityCredentialOptions{}
-	res1 := http.Response{
-		StatusCode: http.StatusBadRequest,
-		Header:     http.Header{},
-		Body:       io.NopCloser(bytes.NewBufferString("")),
-	}
-	res2 := res1
-	options.Transport = newMockImds(res1, res2)
+	options.Transport = newMockImds(res, res, res)
 	cred, err := NewManagedIdentityCredential(&options)
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatal(err)
 	}
-	// cred should return CredentialUnavailableError when IMDS responds 400 to a token request.
-	// Also, it shouldn't send another token request (mockIMDS will appropriately panic if it does).
+	// cred should return CredentialUnavailableError when IMDS responds 400 to a token request
 	var expected CredentialUnavailableError
 	for i := 0; i < 3; i++ {
-		_, err = cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+		_, err = cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 		if !errors.As(err, &expected) {
-			t.Fatalf("Expected %T, got %T", expected, err)
+			t.Fatalf(`expected CredentialUnavailableError, got %T: "%s"`, err, err.Error())
 		}
 	}
 }
@@ -426,7 +433,7 @@ func TestManagedIdentityCredential_GetTokenUnexpectedJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err == nil {
 		t.Fatalf("Expected a JSON marshal error but received nil")
 	}
@@ -441,7 +448,7 @@ func TestManagedIdentityCredential_CreateIMDSAuthRequest(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createIMDSAuthRequest(context.Background(), ClientID(fakeClientID), []string{msiScope})
+	req, err := cred.client.createIMDSAuthRequest(context.Background(), ClientID(fakeClientID), []string{liveTestScope})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +462,7 @@ func TestManagedIdentityCredential_CreateIMDSAuthRequest(t *testing.T) {
 	if reqQueryParams["api-version"][0] != imdsAPIVersion {
 		t.Fatalf("Unexpected IMDS API version")
 	}
-	if reqQueryParams["resource"][0] != msiScope {
+	if reqQueryParams["resource"][0] != liveTestScope {
 		t.Fatalf("Unexpected resource in resource query param")
 	}
 	if reqQueryParams["client_id"][0] != fakeClientID {
@@ -469,43 +476,24 @@ func TestManagedIdentityCredential_CreateIMDSAuthRequest(t *testing.T) {
 	}
 }
 
-func TestManagedIdentityCredential_GetTokenEnvVar(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	setEnvironmentVariables(t, map[string]string{"AZURE_CLIENT_ID": "test_client_id", msiEndpoint: srv.URL(), msiSecret: "secret"})
-	options := ManagedIdentityCredentialOptions{}
-	options.Transport = srv
-	msiCred, err := NewManagedIdentityCredential(&options)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	at, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
-	if err != nil {
-		t.Fatalf("Received an error when attempting to retrieve a token")
-	}
-	if at.Token != "new_token" {
-		t.Fatalf("Did not receive the correct access token")
-	}
-}
-
-func TestManagedIdentityCredential_GetTokenNilResource(t *testing.T) {
+func TestManagedIdentityCredential_GetTokenScopes(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL()})
 	options := ManagedIdentityCredentialOptions{}
 	options.Transport = srv
 	msiCred, err := NewManagedIdentityCredential(&options)
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatal(err)
 	}
-	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: nil})
-	if err == nil {
-		t.Fatalf("Expected an error but did not receive one")
-	}
-	if err.Error() != "must specify a resource in order to authenticate" {
-		t.Fatalf("unexpected error: %v", err)
+	for _, scopes := range [][]string{nil, {}, {"a", "b"}} {
+		_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: scopes})
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if !strings.Contains(err.Error(), "scope") {
+			t.Fatalf(`unexpected error "%s"`, err.Error())
+		}
 	}
 }
 
@@ -530,26 +518,6 @@ func TestManagedIdentityCredential_ScopesImmutable(t *testing.T) {
 	}
 }
 
-func TestManagedIdentityCredential_GetTokenMultipleResources(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL()})
-	options := ManagedIdentityCredentialOptions{}
-	options.Transport = srv
-	msiCred, err := NewManagedIdentityCredential(&options)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{"resource1", "resource2"}})
-	if err == nil {
-		t.Fatalf("Expected an error but did not receive one")
-	}
-	if err.Error() != "can only specify one resource to authenticate with ManagedIdentityCredential" {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
 func TestManagedIdentityCredential_UseResourceID(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
@@ -562,7 +530,7 @@ func TestManagedIdentityCredential_UseResourceID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -571,7 +539,8 @@ func TestManagedIdentityCredential_UseResourceID(t *testing.T) {
 	}
 }
 
-func TestManagedIdentityCredential_ResourceID_AppService(t *testing.T) {
+func TestManagedIdentityCredential_ResourceID_AppServiceV20190801(t *testing.T) {
+	t.Skip("App Service 2019-08-01 isn't supported because it's unavailable in some Functions apps.")
 	setEnvironmentVariables(t, map[string]string{identityEndpoint: "somevalue", identityHeader: "header"})
 	resID := "sample/resource/id"
 	cred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{ID: ResourceID(resID)})
@@ -579,7 +548,7 @@ func TestManagedIdentityCredential_ResourceID_AppService(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createAuthRequest(context.Background(), cred.id, []string{msiScope})
+	req, err := cred.client.createAuthRequest(context.Background(), cred.id, []string{liveTestScope})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +562,7 @@ func TestManagedIdentityCredential_ResourceID_AppService(t *testing.T) {
 	if reqQueryParams["api-version"][0] != "2019-08-01" {
 		t.Fatalf("Unexpected App Service API version")
 	}
-	if reqQueryParams["resource"][0] != msiScope {
+	if reqQueryParams["resource"][0] != liveTestScope {
 		t.Fatalf("Unexpected resource in resource query param")
 	}
 	if reqQueryParams[qpResID][0] != resID {
@@ -603,7 +572,7 @@ func TestManagedIdentityCredential_ResourceID_AppService(t *testing.T) {
 
 func TestManagedIdentityCredential_ResourceID_IMDS(t *testing.T) {
 	// setting a dummy value for MSI_ENDPOINT in order to avoid failure in the constructor
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: "http://foo.com"})
+	setEnvironmentVariables(t, map[string]string{msiEndpoint: "http://localhost"})
 	resID := "sample/resource/id"
 	cred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{ID: ResourceID(resID)})
 	if err != nil {
@@ -611,7 +580,7 @@ func TestManagedIdentityCredential_ResourceID_IMDS(t *testing.T) {
 	}
 	cred.client.msiType = msiTypeIMDS
 	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createAuthRequest(context.Background(), cred.id, []string{msiScope})
+	req, err := cred.client.createAuthRequest(context.Background(), cred.id, []string{liveTestScope})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -622,7 +591,7 @@ func TestManagedIdentityCredential_ResourceID_IMDS(t *testing.T) {
 	if reqQueryParams["api-version"][0] != "2018-02-01" {
 		t.Fatalf("Unexpected App Service API version")
 	}
-	if reqQueryParams["resource"][0] != msiScope {
+	if reqQueryParams["resource"][0] != liveTestScope {
 		t.Fatalf("Unexpected resource in resource query param")
 	}
 	if reqQueryParams[qpResID][0] != resID {
@@ -641,7 +610,7 @@ func TestManagedIdentityCredential_CreateAccessTokenExpiresOnInt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
 		t.Fatalf("Received an error when attempting to retrieve a token")
 	}
@@ -659,7 +628,7 @@ func TestManagedIdentityCredential_CreateAccessTokenExpiresOnFail(t *testing.T) 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{msiScope}})
+	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err == nil {
 		t.Fatalf("expected to receive an error but received none")
 	}
@@ -747,5 +716,51 @@ func TestManagedIdentityCredential_IMDSResourceIDLive(t *testing.T) {
 	}
 	if tk.ExpiresOn.Before(time.Now().UTC()) {
 		t.Fatal("GetToken returned an invalid expiration time")
+	}
+}
+
+func TestManagedIdentityCredential_IMDSTimeoutExceeded(t *testing.T) {
+	resetEnvironmentVarsForTest()
+	cred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{
+		ClientOptions: policy.ClientOptions{
+			PerCallPolicies: []policy.Policy{delayPolicy{delay: time.Microsecond}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cred.client.imdsTimeout = time.Nanosecond
+	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
+	var expected CredentialUnavailableError
+	if !errors.As(err, &expected) {
+		t.Fatalf(`expected CredentialUnavailableError, got %T: "%v"`, err, err)
+	}
+	if tk != nil {
+		t.Fatal("GetToken returned a token and an error")
+	}
+}
+
+func TestManagedIdentityCredential_IMDSTimeoutSuccess(t *testing.T) {
+	resetEnvironmentVarsForTest()
+	res := http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(accessTokenRespSuccess))}
+	options := ManagedIdentityCredentialOptions{}
+	options.Transport = newMockImds(res, res)
+	cred, err := NewManagedIdentityCredential(&options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cred.client.imdsTimeout = time.Minute
+	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Token != tokenValue {
+		t.Fatalf(`got unexpected token "%s"`, tk.Token)
+	}
+	if !tk.ExpiresOn.After(time.Now().UTC()) {
+		t.Fatal("GetToken returned an invalid expiration time")
+	}
+	if cred.client.imdsTimeout > 0 {
+		t.Fatal("credential didn't remove IMDS timeout after receiving a response")
 	}
 }

--- a/sdk/azidentity/testdata/recordings/TestManagedIdentityCredential_IMDSClientIDLive.json
+++ b/sdk/azidentity/testdata/recordings/TestManagedIdentityCredential_IMDSClientIDLive.json
@@ -1,30 +1,6 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/metadata/identity/oauth2/token?api-version=2018-02-01",
-        ":scheme": "https",
-        "Accept-Encoding": "gzip",
-        "User-Agent": "azsdk-go-azidentity/v0.12.1 azsdk-go-azcore/v0.20.0 (go1.17.3; linux)"
-      },
-      "RequestBody": null,
-      "StatusCode": 400,
-      "ResponseHeaders": {
-        "Content-Length": "88",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 16 Nov 2021 17:37:54 GMT",
-        "Server": "IMDS/150.870.65.523"
-      },
-      "ResponseBody": {
-        "error": "invalid_request",
-        "error_description": "Required metadata header not specified"
-      }
-    },
-    {
       "RequestUri": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01\u0026client_id=fake-client-id\u0026resource=https%3A%2F%2Fmanagement.core.windows.net%2F",
       "RequestMethod": "GET",
       "RequestHeaders": {
@@ -34,23 +10,23 @@
         ":scheme": "https",
         "Accept-Encoding": "gzip",
         "metadata": "true",
-        "User-Agent": "azsdk-go-azidentity/v0.12.1 azsdk-go-azcore/v0.20.0 (go1.17.3; linux)"
+        "User-Agent": "azsdk-go-azidentity/v0.12.1 azsdk-go-azcore/v0.21.0 (go1.17.3; linux)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "248",
+        "Content-Length": "226",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 16 Nov 2021 17:37:54 GMT",
+        "Date": "Fri, 10 Dec 2021 23:57:32 GMT",
         "Server": "IMDS/150.870.65.523"
       },
       "ResponseBody": {
         "access_token": "redacted",
-        "client_id": "b48ae5dc-70d0-488a-8ef5-f30d905cd5ec",
-        "expires_in": "86329",
-        "expires_on": "1637170604",
+        "client_id": "fake-client-id",
+        "expires_in": "84474",
+        "expires_on": "1639265126",
         "ext_expires_in": "86399",
-        "not_before": "1637083904",
+        "not_before": "1639178426",
         "resource": "https://management.core.windows.net/",
         "token_type": "Bearer"
       }

--- a/sdk/azidentity/testdata/recordings/TestManagedIdentityCredential_IMDSLive.json
+++ b/sdk/azidentity/testdata/recordings/TestManagedIdentityCredential_IMDSLive.json
@@ -1,30 +1,6 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/metadata/identity/oauth2/token?api-version=2018-02-01",
-        ":scheme": "https",
-        "Accept-Encoding": "gzip",
-        "User-Agent": "azsdk-go-azidentity/v0.12.1 azsdk-go-azcore/v0.20.0 (go1.17.3; linux)"
-      },
-      "RequestBody": null,
-      "StatusCode": 400,
-      "ResponseHeaders": {
-        "Content-Length": "88",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 16 Nov 2021 17:37:54 GMT",
-        "Server": "IMDS/150.870.65.523"
-      },
-      "ResponseBody": {
-        "error": "invalid_request",
-        "error_description": "Required metadata header not specified"
-      }
-    },
-    {
       "RequestUri": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01\u0026resource=https%3A%2F%2Fmanagement.core.windows.net%2F",
       "RequestMethod": "GET",
       "RequestHeaders": {
@@ -34,23 +10,23 @@
         ":scheme": "https",
         "Accept-Encoding": "gzip",
         "metadata": "true",
-        "User-Agent": "azsdk-go-azidentity/v0.12.1 azsdk-go-azcore/v0.20.0 (go1.17.3; linux)"
+        "User-Agent": "azsdk-go-azidentity/v0.12.1 azsdk-go-azcore/v0.21.0 (go1.17.3; linux)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "248",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 16 Nov 2021 17:37:54 GMT",
+        "Date": "Fri, 10 Dec 2021 23:57:31 GMT",
         "Server": "IMDS/150.870.65.523"
       },
       "ResponseBody": {
         "access_token": "redacted",
         "client_id": "615e6319-bf4f-4279-937c-b9eb198e511f",
-        "expires_in": "84513",
-        "expires_on": "1637168788",
+        "expires_in": "84473",
+        "expires_on": "1639265125",
         "ext_expires_in": "86399",
-        "not_before": "1637082088",
+        "not_before": "1639178425",
         "resource": "https://management.core.windows.net/",
         "token_type": "Bearer"
       }

--- a/sdk/azidentity/testdata/recordings/TestManagedIdentityCredential_IMDSResourceIDLive.json
+++ b/sdk/azidentity/testdata/recordings/TestManagedIdentityCredential_IMDSResourceIDLive.json
@@ -1,30 +1,6 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/metadata/identity/oauth2/token?api-version=2018-02-01",
-        ":scheme": "https",
-        "Accept-Encoding": "gzip",
-        "User-Agent": "azsdk-go-azidentity/v0.12.1 azsdk-go-azcore/v0.20.0 (go1.17.3; linux)"
-      },
-      "RequestBody": null,
-      "StatusCode": 400,
-      "ResponseHeaders": {
-        "Content-Length": "88",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 16 Nov 2021 17:37:54 GMT",
-        "Server": "IMDS/150.870.65.523"
-      },
-      "ResponseBody": {
-        "error": "invalid_request",
-        "error_description": "Required metadata header not specified"
-      }
-    },
-    {
       "RequestUri": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01\u0026mi_res_id=%2Ffake%2Fresource%2FID\u0026resource=https%3A%2F%2Fmanagement.core.windows.net%2F",
       "RequestMethod": "GET",
       "RequestHeaders": {
@@ -34,23 +10,23 @@
         ":scheme": "https",
         "Accept-Encoding": "gzip",
         "metadata": "true",
-        "User-Agent": "azsdk-go-azidentity/v0.12.1 azsdk-go-azcore/v0.20.0 (go1.17.3; linux)"
+        "User-Agent": "azsdk-go-azidentity/v0.12.1 azsdk-go-azcore/v0.21.0 (go1.17.3; linux)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "248",
+        "Content-Length": "226",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 16 Nov 2021 17:37:54 GMT",
+        "Date": "Fri, 10 Dec 2021 23:57:32 GMT",
         "Server": "IMDS/150.870.65.523"
       },
       "ResponseBody": {
         "access_token": "redacted",
-        "client_id": "b48ae5dc-70d0-488a-8ef5-f30d905cd5ec",
-        "expires_in": "86329",
-        "expires_on": "1637170604",
+        "client_id": "fake-client-id",
+        "expires_in": "84474",
+        "expires_on": "1639265126",
         "ext_expires_in": "86399",
-        "not_before": "1637083904",
+        "not_before": "1639178426",
         "resource": "https://management.core.windows.net/",
         "token_type": "Bearer"
       }


### PR DESCRIPTION
Here's a few changes to behavior around IMDS managed identity to bring azidentity into alignment with the .NET SDK:
- A failed IMDS token request no longer stops a credential from requesting tokens in the future. All auth failures are now retriable without constructing new credentials or clients.
- ManagedIdentityCredential no longer probes IMDS to determine whether it's available before requesting a token from it. Transient latency spikes and connection failures don't disable the credential anymore.
  - To minimize the impact of timeouts when IMDS really isn't available, initial requests from DefaultAzureCredential have a 1 second timeout. This timeout is removed when IMDS responds, and the credential uses its default configuration thereafter.

Closes #15396, closes #16116