### PR TITLE
fix a few azkey links

### DIFF
--- a/sdk/keyvault/azkeys/README.md
+++ b/sdk/keyvault/azkeys/README.md
@@ -9,7 +9,7 @@ access to the keys used to encrypt your data
 ### Install packages
 Install [azkeys][goget_azkeys] and [azidentity][goget_azidentity] with `go get`:
 ```Bash
-go get github.com/Azure/azure-sdk-for-go/sdk/keys/azkeys
+go get github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys
 go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
 ```
 [azidentity][azure_identity] is used for Azure Active Directory authentication as demonstrated below.
@@ -431,8 +431,7 @@ contact opencode@microsoft.com with any additional questions or comments.
 [default_cred_ref]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#NewDefaultAzureCredential
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [keyvault_docs]: https://docs.microsoft.com/azure/key-vault/
-[goget_azkey]: https://aka.ms/azsdk/go/keyvault-keys
-<!-- [goget_azkeys]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys -->
+[goget_azkeys]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys
 [rbac_guide]: https://docs.microsoft.com/azure/key-vault/general/rbac-guide
 [reference_docs]: https://aka.ms/azsdk/go/keyvault-keys
 [key_client_docs]: https://aka.ms/azsdk/go/keyvault-keys#Client


### PR DESCRIPTION
* the link to go get github.com/.../azkeys was corrected.
* goget_azkey link never referenced in this README, so I removed it.
* goget_azkeys link was commented out, so none of the links referencing it were working. I uncommented it.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
