### PR TITLE
[azservicebus] Invert the dependency for websockets so we don't directly depend on a 3rd party package

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Enabling websocket support via `ClientOptions.NewWebSocketConn`. For an example, see the `ExampleNewClient_usingWebsockets` function in `example_client_test.go`.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -20,7 +20,7 @@ import (
 // Client provides methods to create Sender and Receiver
 // instances to send and receive messages from Service Bus.
 type Client struct {
-	config    clientCreds
+	creds     clientCreds
 	namespace interface {
 		// used internally by `Client`
 		internal.NamespaceWithNewAMQPLinks
@@ -91,22 +91,22 @@ type clientCreds struct {
 	credential              azcore.TokenCredential
 }
 
-func newClientImpl(config clientCreds, options *ClientOptions) (*Client, error) {
+func newClientImpl(creds clientCreds, options *ClientOptions) (*Client, error) {
 	client := &Client{
 		linksMu: &sync.Mutex{},
-		config:  config,
+		creds:   creds,
 		links:   map[uint64]internal.Closeable{},
 	}
 
 	var err error
 	var nsOptions []internal.NamespaceOption
 
-	if client.config.connectionString != "" {
-		nsOptions = append(nsOptions, internal.NamespaceWithConnectionString(client.config.connectionString))
-	} else if client.config.credential != nil {
+	if client.creds.connectionString != "" {
+		nsOptions = append(nsOptions, internal.NamespaceWithConnectionString(client.creds.connectionString))
+	} else if client.creds.credential != nil {
 		option := internal.NamespacesWithTokenCredential(
-			client.config.fullyQualifiedNamespace,
-			client.config.credential)
+			client.creds.fullyQualifiedNamespace,
+			client.creds.credential)
 
 		nsOptions = append(nsOptions, option)
 	}

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -20,7 +20,7 @@ import (
 // Client provides methods to create Sender and Receiver
 // instances to send and receive messages from Service Bus.
 type Client struct {
-	config    clientConfig
+	config    clientCreds
 	namespace interface {
 		// used internally by `Client`
 		internal.NamespaceWithNewAMQPLinks
@@ -57,7 +57,7 @@ func NewClient(fullyQualifiedNamespace string, credential azcore.TokenCredential
 		return nil, errors.New("credential was nil")
 	}
 
-	return newClientImpl(clientConfig{
+	return newClientImpl(clientCreds{
 		credential:              credential,
 		fullyQualifiedNamespace: fullyQualifiedNamespace,
 	}, options)
@@ -71,7 +71,7 @@ func NewClientFromConnectionString(connectionString string, options *ClientOptio
 		return nil, errors.New("connectionString must not be empty")
 	}
 
-	return newClientImpl(clientConfig{
+	return newClientImpl(clientCreds{
 		connectionString: connectionString,
 	}, options)
 }
@@ -80,7 +80,7 @@ func NewClientFromConnectionString(connectionString string, options *ClientOptio
 // func NewClientWithNamedKeyCredential(fullyQualifiedNamespace string, credential azcore.TokenCredential, options *ClientOptions) (*Client, error) {
 // }
 
-type clientConfig struct {
+type clientCreds struct {
 	connectionString string
 
 	// the Service Bus namespace name (ex: myservicebus.servicebus.windows.net)
@@ -88,7 +88,7 @@ type clientConfig struct {
 	credential              azcore.TokenCredential
 }
 
-func newClientImpl(config clientConfig, options *ClientOptions) (*Client, error) {
+func newClientImpl(config clientCreds, options *ClientOptions) (*Client, error) {
 	client := &Client{
 		linksMu: &sync.Mutex{},
 		config:  config,

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -41,8 +41,11 @@ type ClientOptions struct {
 
 	// NewWebSocketConn is a function that can create a net.Conn for use with websockets.
 	// For an example, see ExampleNewClient_usingWebsockets() function in example_client_test.go.
-	NewWebSocketConn func(ctx context.Context, wssHost string) (net.Conn, error)
+	NewWebSocketConn func(ctx context.Context, args NewWebSocketConnArgs) (net.Conn, error)
 }
+
+// NewWebSocketConnArgs are passed to your web socket creation function (ClientOptions.NewWebSocketConn)
+type NewWebSocketConnArgs = internal.NewWebSocketConnArgs
 
 // NewClient creates a new Client for a Service Bus namespace, using a TokenCredential.
 // A Client allows you create receivers (for queues or subscriptions) and senders (for queues and topics).

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -65,10 +65,10 @@ func TestNewClientWithWebsockets(t *testing.T) {
 	webSocketCreateCalled := false
 
 	client, err := NewClientFromConnectionString(connectionString, &ClientOptions{
-		NewWebSocketConn: func(ctx context.Context, wssHost string) (net.Conn, error) {
+		NewWebSocketConn: func(ctx context.Context, args NewWebSocketConnArgs) (net.Conn, error) {
 			webSocketCreateCalled = true
 			opts := &websocket.DialOptions{Subprotocols: []string{"amqp"}}
-			wssConn, _, err := websocket.Dial(ctx, wssHost, opts)
+			wssConn, _, err := websocket.Dial(ctx, args.Host, opts)
 
 			if err != nil {
 				return nil, err

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -111,13 +111,13 @@ func TestNewClientUnitTests(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, err)
-		require.EqualValues(t, fakeTokenCredential, client.config.credential)
-		require.EqualValues(t, "fake.something", client.config.fullyQualifiedNamespace)
+		require.EqualValues(t, fakeTokenCredential, client.creds.credential)
+		require.EqualValues(t, "fake.something", client.creds.fullyQualifiedNamespace)
 
 		client, err = NewClient("mysb.windows.servicebus.net", fakeTokenCredential, nil)
 		require.NoError(t, err)
-		require.EqualValues(t, fakeTokenCredential, client.config.credential)
-		require.EqualValues(t, "mysb.windows.servicebus.net", client.config.fullyQualifiedNamespace)
+		require.EqualValues(t, fakeTokenCredential, client.creds.credential)
+		require.EqualValues(t, "mysb.windows.servicebus.net", client.creds.fullyQualifiedNamespace)
 
 		_, err = NewClientFromConnectionString("", nil)
 		require.EqualError(t, err, "connectionString must not be empty")

--- a/sdk/messaging/azservicebus/example_client_test.go
+++ b/sdk/messaging/azservicebus/example_client_test.go
@@ -4,8 +4,12 @@
 package azservicebus_test
 
 import (
+	"context"
+	"net"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"nhooyr.io/websocket"
 )
 
 func ExampleNewClient() {
@@ -32,6 +36,27 @@ func ExampleNewClientFromConnectionString() {
 	// the `NewClient` function instead.
 
 	client, err = azservicebus.NewClientFromConnectionString(connectionString, nil)
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ExampleNewClient_usingWebsockets() {
+	// NOTE: If you'd like to authenticate via Azure Active Directory look at
+	// the `NewClient` function instead.
+	client, err = azservicebus.NewClientFromConnectionString(connectionString, &azservicebus.ClientOptions{
+		NewWebSocketConn: func(ctx context.Context, wssHost string) (net.Conn, error) {
+			opts := &websocket.DialOptions{Subprotocols: []string{"amqp"}}
+			wssConn, _, err := websocket.Dial(ctx, wssHost, opts)
+
+			if err != nil {
+				return nil, err
+			}
+
+			return websocket.NetConn(context.Background(), wssConn, websocket.MessageBinary), nil
+		},
+	})
 
 	if err != nil {
 		panic(err)

--- a/sdk/messaging/azservicebus/example_client_test.go
+++ b/sdk/messaging/azservicebus/example_client_test.go
@@ -46,9 +46,9 @@ func ExampleNewClient_usingWebsockets() {
 	// NOTE: If you'd like to authenticate via Azure Active Directory look at
 	// the `NewClient` function instead.
 	client, err = azservicebus.NewClientFromConnectionString(connectionString, &azservicebus.ClientOptions{
-		NewWebSocketConn: func(ctx context.Context, wssHost string) (net.Conn, error) {
+		NewWebSocketConn: func(ctx context.Context, args azservicebus.NewWebSocketConnArgs) (net.Conn, error) {
 			opts := &websocket.DialOptions{Subprotocols: []string{"amqp"}}
-			wssConn, _, err := websocket.Dial(ctx, wssHost, opts)
+			wssConn, _, err := websocket.Dial(ctx, args.Host, opts)
 
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
We were previously depending on a 3rd party package for websockets, but our interaction with it was pretty minimal. I've reduced this down to just a single function call and allow a customer to pass in that function so we can invert the dependency and not directly require a specific version of the websockets library, provided it understands how to create a net.Conn.

I've moved the code we used to have in the library into an example instead, so it's still a simple operation for a customer to join it up with a package of their choice.

Fixes #16201