### PR TITLE
Remove ServiceBus from the list of other packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Azure provides several other packages for using services from Go, listed below. 
 | Storage - Blobs      | [github.com/Azure/azure-storage-blob-go](https://github.com/Azure/azure-storage-blob-go)           |
 | Storage - Files      | [github.com/Azure/azure-storage-file-go](https://github.com/Azure/azure-storage-file-go)           |
 | Storage - Queues     | [github.com/Azure/azure-storage-queue-go](https://github.com/Azure/azure-storage-queue-go)         |
-| Service Bus          | [github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/messaging/azservicebus)             |
 | Event Hubs           | [github.com/Azure/azure-event-hubs-go](https://github.com/Azure/azure-event-hubs-go)               |
 | Application Insights | [github.com/Microsoft/ApplicationInsights-go](https://github.com/Microsoft/ApplicationInsights-go) |
 


### PR DESCRIPTION
ServiceBus follows the New Release guidelines.  It does not fit within this table.
