### PR TITLE
[messaging/internal] updating to latest go-amqp where amqp.ErrLinkDetached has been removed

### DIFF
--- a/sdk/messaging/internal/go.mod
+++ b/sdk/messaging/internal/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.2
-	github.com/Azure/go-amqp v0.16.0
+	github.com/Azure/go-amqp v0.17.0
 	github.com/Azure/go-autorest/autorest v0.11.22
 	github.com/Azure/go-autorest/autorest/adal v0.9.17
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/sdk/messaging/internal/go.sum
+++ b/sdk/messaging/internal/go.sum
@@ -1,7 +1,7 @@
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.2 h1:rImM7Yjz9yUgpdxp3A4cZLm1JZuo4XbtIp2LrUZnwYw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.2/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
-github.com/Azure/go-amqp v0.16.0 h1:6mhxUxaKLjMtHlGqzeih/LKqjUPLZxbM6zwfz5/C4NQ=
-github.com/Azure/go-amqp v0.16.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
+github.com/Azure/go-amqp v0.17.0 h1:HHXa3149nKrI0IZwyM7DRcRy5810t9ZICDutn4BYzj4=
+github.com/Azure/go-amqp v0.17.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.22 h1:bXiQwDjrRmBQOE67bwlvUKAC1EU1yZTPQ38c+bstZws=

--- a/sdk/messaging/internal/rpc/rpc.go
+++ b/sdk/messaging/internal/rpc/rpc.go
@@ -272,7 +272,7 @@ func (l *Link) RPC(ctx context.Context, msg *amqp.Message) (*Response, error) {
 	ctx, span := tracing.StartSpanFromContext(ctx, "az-amqp-common.rpc.RPC")
 	defer span.End()
 
-	msg.Properties.ReplyTo = l.clientAddress
+	msg.Properties.ReplyTo = &l.clientAddress
 
 	if msg.ApplicationProperties == nil {
 		msg.ApplicationProperties = make(map[string]interface{})
@@ -496,8 +496,10 @@ func addMessageID(message *amqp.Message, uuidNewV4 func() (uuid.UUID, error)) (*
 }
 
 func isClosedError(err error) bool {
+	var detachError *amqp.DetachError
+
 	return errors.Is(err, amqp.ErrLinkClosed) ||
-		errors.Is(err, amqp.ErrLinkDetached) ||
+		errors.As(err, &detachError) ||
 		errors.Is(err, amqp.ErrConnClosed) ||
 		errors.Is(err, amqp.ErrSessionClosed)
 }

--- a/sdk/messaging/internal/rpc/rpc_test.go
+++ b/sdk/messaging/internal/rpc/rpc_test.go
@@ -82,7 +82,7 @@ func TestResponseRouterBadCorrelationID(t *testing.T) {
 func TestResponseRouterFatalErrors(t *testing.T) {
 	fatalErrors := []error{
 		amqp.ErrLinkClosed,
-		amqp.ErrLinkDetached,
+		&amqp.DetachError{},
 		amqp.ErrConnClosed,
 		amqp.ErrSessionClosed,
 	}


### PR DESCRIPTION
ErrLinkDetached has been removed - we should be using the existing *amqp.DetachError instead.