### PR TITLE
Remove SkipBodyDownload from Request

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Breaking Changes
 * Moved `[]policy.Policy` parameters of `arm/runtime.NewPipeline` and `runtime.NewPipeline` into a new struct, `runtime.PipelineOptions`
 * Renamed `arm/ClientOptions.Host` to `.Endpoint`
+* Moved `Request.SkipBodyDownload` method to function `runtime.SkipBodyDownload`
 
 ### Bugs Fixed
 

--- a/sdk/azcore/internal/pipeline/request.go
+++ b/sdk/azcore/internal/pipeline/request.go
@@ -136,11 +136,6 @@ func (req *Request) SetBody(body io.ReadSeekCloser, contentType string) error {
 	return nil
 }
 
-// SkipBodyDownload will disable automatic downloading of the response body.
-func (req *Request) SkipBodyDownload() {
-	req.SetOperationValue(shared.BodyDownloadPolicyOpValues{Skip: true})
-}
-
 // RewindBody seeks the request's Body stream back to the beginning so it can be resent when retrying an operation.
 func (req *Request) RewindBody() error {
 	if req.body != nil {

--- a/sdk/azcore/internal/pipeline/request_test.go
+++ b/sdk/azcore/internal/pipeline/request_test.go
@@ -74,7 +74,6 @@ func TestRequestBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.SkipBodyDownload()
 	if err := req.RewindBody(); err != nil {
 		t.Fatal(err)
 	}
@@ -97,16 +96,20 @@ func TestRequestClone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.SkipBodyDownload()
 	if err := req.SetBody(shared.NopCloser(strings.NewReader("test")), "application/text"); err != nil {
 		t.Fatal(err)
 	}
+	type ensureCloned struct {
+		Count int
+	}
+	source := ensureCloned{Count: 12345}
+	req.SetOperationValue(source)
 	clone := req.Clone(context.Background())
-	var skip shared.BodyDownloadPolicyOpValues
-	if !clone.OperationValue(&skip) {
+	var cloned ensureCloned
+	if !clone.OperationValue(&cloned) {
 		t.Fatal("missing operation value")
 	}
-	if !skip.Skip {
+	if cloned.Count != source.Count {
 		t.Fatal("wrong operation value")
 	}
 	if clone.body == nil {

--- a/sdk/azcore/internal/shared/shared.go
+++ b/sdk/azcore/internal/shared/shared.go
@@ -37,11 +37,6 @@ func NopCloser(rs io.ReadSeeker) io.ReadSeekCloser {
 	return nopCloser{rs}
 }
 
-// BodyDownloadPolicyOpValues is the struct containing the per-operation values
-type BodyDownloadPolicyOpValues struct {
-	Skip bool
-}
-
 func NewResponseError(inner error, resp *http.Response) error {
 	return &ResponseError{inner: inner, resp: resp}
 }

--- a/sdk/azcore/runtime/policy_body_download.go
+++ b/sdk/azcore/runtime/policy_body_download.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 )
@@ -25,7 +24,7 @@ func bodyDownloadPolicy(req *policy.Request) (*http.Response, error) {
 	if err != nil {
 		return resp, err
 	}
-	var opValues shared.BodyDownloadPolicyOpValues
+	var opValues bodyDownloadPolicyOpValues
 	// don't skip downloading error response bodies
 	if req.OperationValue(&opValues); opValues.Skip && resp.StatusCode < 400 {
 		return resp, err
@@ -39,6 +38,11 @@ func bodyDownloadPolicy(req *policy.Request) (*http.Response, error) {
 	}
 	resp.Body = &nopClosingBytesReader{s: b}
 	return resp, err
+}
+
+// bodyDownloadPolicyOpValues is the struct containing the per-operation values
+type bodyDownloadPolicyOpValues struct {
+	Skip bool
 }
 
 type bodyDownloadError struct {

--- a/sdk/azcore/runtime/policy_body_download_test.go
+++ b/sdk/azcore/runtime/policy_body_download_test.go
@@ -55,7 +55,7 @@ func TestSkipBodyDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	req.SkipBodyDownload()
+	SkipBodyDownload(req)
 	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -267,7 +267,7 @@ func TestSkipBodyDownloadWith400(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	req.SkipBodyDownload()
+	SkipBodyDownload(req)
 	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -433,7 +433,7 @@ func TestRetryPolicyFailOnErrorNoDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	req.SkipBodyDownload()
+	SkipBodyDownload(req)
 	resp, err := pl.Do(req)
 	if !errors.Is(err, fakeErr) {
 		t.Fatalf("unexpected error: %v", err)
@@ -455,7 +455,7 @@ func TestRetryPolicySuccessNoDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	req.SkipBodyDownload()
+	SkipBodyDownload(req)
 	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -475,7 +475,7 @@ func TestRetryPolicySuccessNoDownloadNoBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	req.SkipBodyDownload()
+	SkipBodyDownload(req)
 	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -143,6 +143,11 @@ func SetMultipartFormData(req *policy.Request, formData map[string]interface{}) 
 	return req.SetBody(shared.NopCloser(bytes.NewReader(body.Bytes())), writer.FormDataContentType())
 }
 
+// SkipBodyDownload will disable automatic downloading of the response body.
+func SkipBodyDownload(req *policy.Request) {
+	req.SetOperationValue(bodyDownloadPolicyOpValues{Skip: true})
+}
+
 // returns a clone of the object graph pointed to by v, omitting values of all read-only
 // fields. if there are no read-only fields in the object graph, no clone is created.
 func cloneWithoutReadOnlyFields(v interface{}) interface{} {

--- a/sdk/azcore/runtime/response_test.go
+++ b/sdk/azcore/runtime/response_test.go
@@ -93,7 +93,7 @@ func TestResponseUnmarshalJSONskipDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	req.SkipBodyDownload()
+	SkipBodyDownload(req)
 	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/sdk/azcore/streaming/progress_test.go
+++ b/sdk/azcore/streaming/progress_test.go
@@ -35,7 +35,7 @@ func TestProgressReporting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	req.SkipBodyDownload()
+	runtime.SkipBodyDownload(req)
 	var bytesSent int64
 	reqRpt := NewRequestProgress(NopCloser(body), func(bytesTransferred int64) {
 		bytesSent = bytesTransferred
@@ -84,7 +84,7 @@ func TestProgressReportingSeek(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	req.SkipBodyDownload()
+	runtime.SkipBodyDownload(req)
 	var bytesSent int64
 	reqRpt := NewRequestProgress(NopCloser(body), func(bytesTransferred int64) {
 		bytesSent = bytesTransferred


### PR DESCRIPTION
It's not part of the Request, it's part of the body download policy.
Moved to a stand-alone function in runtime to decouple it.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
