### PR TITLE
Handle error response XML with whitespace

### DIFF
--- a/sdk/storage/azblob/zc_storage_error.go
+++ b/sdk/storage/azblob/zc_storage_error.go
@@ -8,10 +8,11 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"net/http"
 	"sort"
 	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 // InternalError is an internal error type that all errors get wrapped in.
@@ -193,8 +194,12 @@ func (e *StorageError) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (err
 		switch tt := t.(type) {
 		case xml.StartElement:
 			tokName = tt.Name.Local
+		case xml.EndElement:
+			tokName = ""
 		case xml.CharData:
 			switch tokName {
+			case "":
+				continue
 			case "Message":
 				e.description = string(tt)
 			default:

--- a/sdk/storage/azblob/zc_storage_error_test.go
+++ b/sdk/storage/azblob/zc_storage_error_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azblob
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (s *azblobUnrecordedTestSuite) TestErrorResponseUnmarshal() {
+	t := s.T()
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"singleline", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Error><Code>ContainerAlreadyExists</Code><Message>The specified container already exists.\nRequestId:73b2473b-c1c8-4162-97bb-dc171bff61c9\nTime:2021-12-13T19:45:40.679Z</Message></Error>"},
+		{"multiline", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<Error>\n  <Code>ContainerAlreadyExists</Code>\n  <Message>The specified container already exists.\nRequestId:73b2473b-c1c8-4162-97bb-dc171bff61c9\nTime:2021-12-13T19:45:40.679Z</Message>\n</Error>"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_assert := assert.New(t)
+			se := StorageError{}
+			_assert.Nil(xml.Unmarshal([]byte(c.input), &se))
+
+			_assert.Contains(se.details, "Code")
+			_assert.Equal("ContainerAlreadyExists", se.details["Code"])
+
+			_assert.Equal("The specified container already exists.\nRequestId:73b2473b-c1c8-4162-97bb-dc171bff61c9\nTime:2021-12-13T19:45:40.679Z", se.description)
+		})
+	}
+}


### PR DESCRIPTION
Addresses #16542. Azurite returns error response bodies with newlines, and the SDK does not expect this. 

The fix is simply ignoring `CharData` nodes outside of XML elements. 

Kudos to @Leavrth for the detailed bug report (which included the fix!)

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
