### PR TITLE
Refactor error responses

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Features Added
 * Added `AllowedHeaders` and `AllowedQueryParams` to `policy.LogOptions` to control which headers and query parameters are written to the logger.
+* Added `azcore.ResponseError` type which is returned from APIs when a non-success HTTP status code is received.
 
 ### Breaking Changes
 * Moved `[]policy.Policy` parameters of `arm/runtime.NewPipeline` and `runtime.NewPipeline` into a new struct, `runtime.PipelineOptions`
 * Renamed `arm/ClientOptions.Host` to `.Endpoint`
 * Moved `Request.SkipBodyDownload` method to function `runtime.SkipBodyDownload`
+* Removed `azcore.HTTPResponse` interface type
+* `arm.NewPoller()` and `runtime.NewPoller()` no longer require an `eu` parameter
+* `runtime.NewResponseError()` no longer requires an `error` parameter
 
 ### Bugs Fixed
 

--- a/sdk/azcore/arm/runtime/policy_register_rp.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -246,7 +245,7 @@ func (client *providersOperations) getCreateRequest(ctx context.Context, resourc
 // getHandleResponse handles the Get response.
 func (client *providersOperations) getHandleResponse(resp *http.Response) (*ProviderResponse, error) {
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return nil, client.getHandleError(resp)
+		return nil, shared.NewResponseError(resp)
 	}
 	result := ProviderResponse{RawResponse: resp}
 	err := runtime.UnmarshalAsJSON(resp, &result.Provider)
@@ -254,18 +253,6 @@ func (client *providersOperations) getHandleResponse(resp *http.Response) (*Prov
 		return nil, err
 	}
 	return &result, err
-}
-
-// getHandleError handles the Get error response.
-func (client *providersOperations) getHandleError(resp *http.Response) error {
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return shared.NewResponseError(err, resp)
-	}
-	if len(body) == 0 {
-		return shared.NewResponseError(errors.New(resp.Status), resp)
-	}
-	return shared.NewResponseError(errors.New(string(body)), resp)
 }
 
 // Register - Registers a subscription with a resource provider.
@@ -303,7 +290,7 @@ func (client *providersOperations) registerCreateRequest(ctx context.Context, re
 // registerHandleResponse handles the Register response.
 func (client *providersOperations) registerHandleResponse(resp *http.Response) (*ProviderResponse, error) {
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return nil, client.registerHandleError(resp)
+		return nil, shared.NewResponseError(resp)
 	}
 	result := ProviderResponse{RawResponse: resp}
 	err := runtime.UnmarshalAsJSON(resp, &result.Provider)
@@ -311,18 +298,6 @@ func (client *providersOperations) registerHandleResponse(resp *http.Response) (
 		return nil, err
 	}
 	return &result, err
-}
-
-// registerHandleError handles the Register error response.
-func (client *providersOperations) registerHandleError(resp *http.Response) error {
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return shared.NewResponseError(err, resp)
-	}
-	if len(body) == 0 {
-		return shared.NewResponseError(errors.New(resp.Status), resp)
-	}
-	return shared.NewResponseError(errors.New(string(body)), resp)
 }
 
 // ProviderResponse is the response envelope for operations that return a Provider type.

--- a/sdk/azcore/arm/runtime/poller.go
+++ b/sdk/azcore/arm/runtime/poller.go
@@ -22,7 +22,7 @@ import (
 
 // NewPoller creates a Poller based on the provided initial response.
 // pollerID - a unique identifier for an LRO.  it's usually the client.Method string.
-func NewPoller(pollerID string, finalState string, resp *http.Response, pl pipeline.Pipeline, eu func(*http.Response) error) (*pollers.Poller, error) {
+func NewPoller(pollerID string, finalState string, resp *http.Response, pl pipeline.Pipeline) (*pollers.Poller, error) {
 	defer resp.Body.Close()
 	// this is a back-stop in case the swagger is incorrect (i.e. missing one or more status codes for success).
 	// ideally the codegen should return an error if the initial response failed and not even create a poller.
@@ -50,12 +50,12 @@ func NewPoller(pollerID string, finalState string, resp *http.Response, pl pipel
 	if err != nil {
 		return nil, err
 	}
-	return pollers.NewPoller(lro, resp, pl, eu), nil
+	return pollers.NewPoller(lro, resp, pl), nil
 }
 
 // NewPollerFromResumeToken creates a Poller from a resume token string.
 // pollerID - a unique identifier for an LRO.  it's usually the client.Method string.
-func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipeline, eu func(*http.Response) error) (*pollers.Poller, error) {
+func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipeline) (*pollers.Poller, error) {
 	kind, err := pollers.KindFromToken(pollerID, token)
 	if err != nil {
 		return nil, err
@@ -78,5 +78,5 @@ func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipelin
 	if err = json.Unmarshal([]byte(token), lro); err != nil {
 		return nil, err
 	}
-	return pollers.NewPoller(lro, nil, pl, eu), nil
+	return pollers.NewPoller(lro, nil, pl), nil
 }

--- a/sdk/azcore/errors.go
+++ b/sdk/azcore/errors.go
@@ -8,12 +8,9 @@ package azcore
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 )
 
 // ResponseError is returned when a request is made to a service and
 // the service returns a non-success HTTP status code.
 // Use errors.As() to access this type in the error chain.
 type ResponseError = shared.ResponseError
-
-var _ errorinfo.NonRetriable = (*ResponseError)(nil)

--- a/sdk/azcore/errors.go
+++ b/sdk/azcore/errors.go
@@ -7,20 +7,13 @@
 package azcore
 
 import (
-	"net/http"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 )
 
-// HTTPResponse provides access to an HTTP response when available.
-// Errors returned from failed API calls will implement this interface.
-// Use errors.As() to access this interface in the error chain.
-// If there was no HTTP response then this interface will be omitted
-// from any error in the chain.
-type HTTPResponse interface {
-	RawResponse() *http.Response
-}
+// ResponseError is returned when a request is made to a service and
+// the service returns a non-success HTTP status code.
+// Use errors.As() to access this type in the error chain.
+type ResponseError = shared.ResponseError
 
-var _ HTTPResponse = (*shared.ResponseError)(nil)
-var _ errorinfo.NonRetriable = (*shared.ResponseError)(nil)
+var _ errorinfo.NonRetriable = (*ResponseError)(nil)

--- a/sdk/azcore/example_test.go
+++ b/sdk/azcore/example_test.go
@@ -64,20 +64,20 @@ func ExampleNullValue() {
 	// {"count":null}
 }
 
-func ExampleHTTPResponse() {
+func ExampleResponseError() {
 	pipeline := runtime.NewPipeline("module", "version", runtime.PipelineOptions{}, nil)
 	req, err := runtime.NewRequest(context.Background(), "POST", "https://fakecontainerregisty.azurecr.io/acr/v1/nonexisteng/_tags")
 	if err != nil {
 		panic(err)
 	}
 	resp, err := pipeline.Do(req)
-	var httpErr azcore.HTTPResponse
-	if errors.As(err, &httpErr) {
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
 		// Handle Error
-		if httpErr.RawResponse().StatusCode == http.StatusNotFound {
-			fmt.Printf("Repository could not be found: %v", httpErr.RawResponse())
-		} else if httpErr.RawResponse().StatusCode == http.StatusForbidden {
-			fmt.Printf("You do not have permission to access this repository: %v", httpErr.RawResponse())
+		if respErr.StatusCode == http.StatusNotFound {
+			fmt.Printf("Repository could not be found: %v", respErr)
+		} else if respErr.StatusCode == http.StatusForbidden {
+			fmt.Printf("You do not have permission to access this repository: %v", respErr)
 		} else {
 			// ...
 		}

--- a/sdk/azcore/internal/pollers/poller_test.go
+++ b/sdk/azcore/internal/pollers/poller_test.go
@@ -111,9 +111,7 @@ func TestNewPoller(t *testing.T) {
 		Header:     http.Header{},
 	}
 	firstResp.Header.Set(shared.HeaderRetryAfter, "1")
-	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl, func(*http.Response) error {
-		return errors.New("failed")
-	})
+	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl)
 	if p.Done() {
 		t.Fatal("unexpected done")
 	}
@@ -164,9 +162,7 @@ func TestNewPollerWithFinalGET(t *testing.T) {
 	firstResp := &http.Response{
 		StatusCode: http.StatusAccepted,
 	}
-	p := NewPoller(&fakePoller{Ep: srv.URL(), Fg: srv.URL()}, firstResp, pl, func(*http.Response) error {
-		return errors.New("failed")
-	})
+	p := NewPoller(&fakePoller{Ep: srv.URL(), Fg: srv.URL()}, firstResp, pl)
 	if p.Done() {
 		t.Fatal("unexpected done")
 	}
@@ -202,14 +198,14 @@ func TestNewPollerFail1(t *testing.T) {
 	firstResp := &http.Response{
 		StatusCode: http.StatusAccepted,
 	}
-	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl, func(*http.Response) error {
-		return errors.New("failed")
-	})
+	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl)
 	resp, err := p.PollUntilDone(context.Background(), time.Second, nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
-	} else if s := err.Error(); s != "failed" {
-		t.Fatalf("unexpected error %s", s)
+	var respErr *shared.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	if respErr.StatusCode != http.StatusConflict {
+		t.Fatalf("unexpected terminal status code %d", respErr.StatusCode)
 	}
 	if resp != nil {
 		t.Fatal("expected nil response")
@@ -225,14 +221,14 @@ func TestNewPollerFail2(t *testing.T) {
 	firstResp := &http.Response{
 		StatusCode: http.StatusAccepted,
 	}
-	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl, func(*http.Response) error {
-		return errors.New("failed")
-	})
+	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl)
 	resp, err := p.PollUntilDone(context.Background(), time.Second, nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
-	} else if s := err.Error(); s != "failed" {
-		t.Fatalf("unexpected error %s", s)
+	var respErr *shared.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	if respErr.StatusCode != http.StatusCreated {
+		t.Fatalf("unexpected terminal status code %d", respErr.StatusCode)
 	}
 	if resp != nil {
 		t.Fatal("expected nil response")
@@ -248,9 +244,7 @@ func TestNewPollerError(t *testing.T) {
 	firstResp := &http.Response{
 		StatusCode: http.StatusAccepted,
 	}
-	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl, func(*http.Response) error {
-		return errors.New("failed")
-	})
+	p := NewPoller(&fakePoller{Ep: srv.URL()}, firstResp, pl)
 	resp, err := p.PollUntilDone(context.Background(), time.Second, nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")

--- a/sdk/azcore/internal/shared/response_error.go
+++ b/sdk/azcore/internal/shared/response_error.go
@@ -128,11 +128,7 @@ type ResponseError struct {
 }
 
 // Error implements the error interface for type ResponseError.
+// Note that the message contents are not contractual and can change over time.
 func (e *ResponseError) Error() string {
 	return e.msg
-}
-
-// NonRetriable indicates this error is non-transient.
-func (e *ResponseError) NonRetriable() {
-	// marker method
 }

--- a/sdk/azcore/internal/shared/response_error.go
+++ b/sdk/azcore/internal/shared/response_error.go
@@ -1,0 +1,138 @@
+//go:build go1.16
+// +build go1.16
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package shared
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+)
+
+// NewResponseError creates a new *ResponseError from the provided HTTP response.
+func NewResponseError(resp *http.Response) error {
+	respErr := &ResponseError{
+		StatusCode:  resp.StatusCode,
+		RawResponse: resp,
+	}
+
+	// prefer the error code in the response header
+	if ec := resp.Header.Get("x-ms-error-code"); ec != "" {
+		respErr.ErrorCode = ec
+	}
+
+	// write the request method and URL with response status code
+	msg := &bytes.Buffer{}
+	fmt.Fprintf(msg, "%s %s://%s%s\n", resp.Request.Method, resp.Request.URL.Scheme, resp.Request.URL.Host, resp.Request.URL.Path)
+	fmt.Fprintln(msg, "--------------------------------------------------------------------------------")
+	fmt.Fprintf(msg, "RESPONSE %d: %s\n", resp.StatusCode, resp.Status)
+
+	body, err := Payload(resp)
+	if err != nil {
+		body = []byte(fmt.Sprintf("Error reading response body: %v", err))
+		goto Epilog
+	}
+
+	// if we didn't get x-ms-error-code, check in the response body
+	if respErr.ErrorCode == "" && len(body) > 0 {
+		if code := extractErrorCodeJSON(body); code != "" {
+			respErr.ErrorCode = code
+		} else if code := extractErrorCodeXML(body); code != "" {
+			respErr.ErrorCode = code
+		}
+	}
+
+Epilog:
+	if respErr.ErrorCode != "" {
+		fmt.Fprintf(msg, "ERROR CODE: %s\n", respErr.ErrorCode)
+	} else {
+		fmt.Fprintln(msg, "ERROR CODE UNAVAILABLE")
+	}
+
+	fmt.Fprintln(msg, "--------------------------------------------------------------------------------")
+	if len(body) > 0 {
+		if err := json.Indent(msg, body, "", "  "); err != nil {
+			// failed to pretty-print so just dump it verbatim
+			fmt.Fprint(msg, string(body))
+		}
+		// the standard library doesn't have a pretty-printer for XML
+		fmt.Fprintln(msg)
+	} else {
+		fmt.Fprintln(msg, "Response contained no body")
+	}
+	fmt.Fprintln(msg, "--------------------------------------------------------------------------------")
+
+	respErr.msg = msg.String()
+	return respErr
+}
+
+func extractErrorCodeJSON(body []byte) string {
+	var rawObj map[string]interface{}
+	if err := json.Unmarshal(body, &rawObj); err != nil {
+		// not a JSON object
+		return ""
+	}
+
+	// check if this is a wrapped error, i.e. { "error": { ... } }
+	// if so then unwrap it
+	if wrapped, ok := rawObj["error"]; ok {
+		unwrapped, ok := wrapped.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		rawObj = unwrapped
+	}
+
+	// now check for the error code
+	code, ok := rawObj["code"]
+	if !ok {
+		return ""
+	}
+	codeStr, ok := code.(string)
+	if !ok {
+		return ""
+	}
+	return codeStr
+}
+
+func extractErrorCodeXML(body []byte) string {
+	// regular expression is much easier than dealing with the XML parser
+	rx := regexp.MustCompile(`<[c|C]ode>\s*(\w+)\s*<\/[c|C]ode>`)
+	res := rx.FindStringSubmatch(string(body))
+	if len(res) != 2 {
+		return ""
+	}
+	// first submatch is the entire thing, second one is the captured error code
+	return res[1]
+}
+
+// ResponseError is returned when a request is made to a service and
+// the service returns a non-success HTTP status code.
+// Use errors.As() to access this type in the error chain.
+type ResponseError struct {
+	msg string
+
+	// ErrorCode is the error code returned by the resource provider if available.
+	ErrorCode string
+
+	// StatusCode is the HTTP status code.
+	StatusCode int
+
+	// RawResponse is the underlying HTTP response.
+	RawResponse *http.Response
+}
+
+// Error implements the error interface for type ResponseError.
+func (e *ResponseError) Error() string {
+	return e.msg
+}
+
+// NonRetriable indicates this error is non-transient.
+func (e *ResponseError) NonRetriable() {
+	// marker method
+}

--- a/sdk/azcore/internal/shared/response_error.go
+++ b/sdk/azcore/internal/shared/response_error.go
@@ -120,7 +120,7 @@ type ResponseError struct {
 	// ErrorCode is the error code returned by the resource provider if available.
 	ErrorCode string
 
-	// StatusCode is the HTTP status code.
+	// StatusCode is the HTTP status code as defined in https://pkg.go.dev/net/http#pkg-constants.
 	StatusCode int
 
 	// RawResponse is the underlying HTTP response.

--- a/sdk/azcore/internal/shared/response_error_test.go
+++ b/sdk/azcore/internal/shared/response_error_test.go
@@ -1,0 +1,405 @@
+//go:build go1.16
+// +build go1.16
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package shared
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestNewResponseErrorNoBodyNoErrorCode(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Body:       http.NoBody,
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if re.ErrorCode != "" {
+		t.Fatal("expected empty error code")
+	}
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE UNAVAILABLE
+--------------------------------------------------------------------------------
+Response contained no body
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestNewResponseErrorNoBody(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	respHeader := http.Header{}
+	const errorCode = "ErrorTooManyCheats"
+	respHeader.Set("x-ms-error-code", errorCode)
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Body:       http.NoBody,
+		Header:     respHeader,
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if ec := re.ErrorCode; ec != errorCode {
+		t.Fatalf("unexpected error code %s", ec)
+	}
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE: ErrorTooManyCheats
+--------------------------------------------------------------------------------
+Response contained no body
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestNewResponseErrorNoErrorCode(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader(`{ "code": "ErrorItsBroken", "message": "it's not working" }`)),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE: ErrorItsBroken
+--------------------------------------------------------------------------------
+{
+  "code": "ErrorItsBroken",
+  "message": "it's not working"
+}
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestNewResponseErrorPreferErrorCodeHeader(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	respHeader := http.Header{}
+	respHeader.Set("x-ms-error-code", "ErrorTooManyCheats")
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader(`{ "code": "ErrorItsBroken", "message": "it's not working" }`)),
+		Header:     respHeader,
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE: ErrorTooManyCheats
+--------------------------------------------------------------------------------
+{
+  "code": "ErrorItsBroken",
+  "message": "it's not working"
+}
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestNewResponseErrorNoErrorCodeWrappedError(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader(`{ "error": { "code": "ErrorItsBroken", "message": "it's not working" } }`)),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE: ErrorItsBroken
+--------------------------------------------------------------------------------
+{
+  "error": {
+    "code": "ErrorItsBroken",
+    "message": "it's not working"
+  }
+}
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestNewResponseErrorNoErrorCodeInvalidBody(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader("JSON error string")),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE UNAVAILABLE
+--------------------------------------------------------------------------------
+JSON error string
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+type readFailer struct{}
+
+func (r *readFailer) Close() error {
+	return nil
+}
+
+func (r *readFailer) Read(p []byte) (int, error) {
+	return 0, errors.New("mock read failure")
+}
+
+func TestNewResponseErrorNoErrorCodeCantReadBody(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Body:       &readFailer{},
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE UNAVAILABLE
+--------------------------------------------------------------------------------
+Error reading response body: mock read failure
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestNewResponseErrorNoErrorCodeXML(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Error><Code>ContainerAlreadyExists</Code><Message>The specified container already exists.\nRequestId:73b2473b-c1c8-4162-97bb-dc171bff61c9\nTime:2021-12-13T19:45:40.679Z</Message></Error>`)),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE: ContainerAlreadyExists
+--------------------------------------------------------------------------------
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Error><Code>ContainerAlreadyExists</Code><Message>The specified container already exists.\nRequestId:73b2473b-c1c8-4162-97bb-dc171bff61c9\nTime:2021-12-13T19:45:40.679Z</Message></Error>
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestNewResponseErrorErrorCodeHeaderXML(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	respHeader := http.Header{}
+	respHeader.Set("x-ms-error-code", "ContainerAlreadyExists")
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Header:     respHeader,
+		Body:       io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Error><Code>ContainerAlreadyExists</Code><Message>The specified container already exists.\nRequestId:73b2473b-c1c8-4162-97bb-dc171bff61c9\nTime:2021-12-13T19:45:40.679Z</Message></Error>`)),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE: ContainerAlreadyExists
+--------------------------------------------------------------------------------
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Error><Code>ContainerAlreadyExists</Code><Message>The specified container already exists.\nRequestId:73b2473b-c1c8-4162-97bb-dc171bff61c9\nTime:2021-12-13T19:45:40.679Z</Message></Error>
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestNewResponseErrorAllMissingXML(t *testing.T) {
+	fakeURL, err := url.Parse("https://fakeurl.com/the/path?qp=removed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	respHeader := http.Header{}
+	err = NewResponseError(&http.Response{
+		Status:     "the system is down",
+		StatusCode: http.StatusInternalServerError,
+		Header:     respHeader,
+		Body:       io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Error><Message>The specified container already exists.\nRequestId:73b2473b-c1c8-4162-97bb-dc171bff61c9\nTime:2021-12-13T19:45:40.679Z</Message></Error>`)),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    fakeURL,
+		},
+	})
+	re, ok := err.(*ResponseError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	re.NonRetriable() // nop
+	if c := re.StatusCode; c != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d", c)
+	}
+	const want = `GET https://fakeurl.com/the/path
+--------------------------------------------------------------------------------
+RESPONSE 500: the system is down
+ERROR CODE UNAVAILABLE
+--------------------------------------------------------------------------------
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Error><Message>The specified container already exists.\nRequestId:73b2473b-c1c8-4162-97bb-dc171bff61c9\nTime:2021-12-13T19:45:40.679Z</Message></Error>
+--------------------------------------------------------------------------------
+`
+	if got := re.Error(); got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}

--- a/sdk/azcore/internal/shared/response_error_test.go
+++ b/sdk/azcore/internal/shared/response_error_test.go
@@ -33,7 +33,6 @@ func TestNewResponseErrorNoBodyNoErrorCode(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if re.ErrorCode != "" {
 		t.Fatal("expected empty error code")
 	}
@@ -75,7 +74,6 @@ func TestNewResponseErrorNoBody(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if ec := re.ErrorCode; ec != errorCode {
 		t.Fatalf("unexpected error code %s", ec)
 	}
@@ -113,7 +111,6 @@ func TestNewResponseErrorNoErrorCode(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if c := re.StatusCode; c != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code %d", c)
 	}
@@ -154,7 +151,6 @@ func TestNewResponseErrorPreferErrorCodeHeader(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if c := re.StatusCode; c != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code %d", c)
 	}
@@ -192,7 +188,6 @@ func TestNewResponseErrorNoErrorCodeWrappedError(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if c := re.StatusCode; c != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code %d", c)
 	}
@@ -232,7 +227,6 @@ func TestNewResponseErrorNoErrorCodeInvalidBody(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if c := re.StatusCode; c != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code %d", c)
 	}
@@ -277,7 +271,6 @@ func TestNewResponseErrorNoErrorCodeCantReadBody(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if c := re.StatusCode; c != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code %d", c)
 	}
@@ -312,7 +305,6 @@ func TestNewResponseErrorNoErrorCodeXML(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if c := re.StatusCode; c != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code %d", c)
 	}
@@ -350,7 +342,6 @@ func TestNewResponseErrorErrorCodeHeaderXML(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if c := re.StatusCode; c != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code %d", c)
 	}
@@ -387,7 +378,6 @@ func TestNewResponseErrorAllMissingXML(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	re.NonRetriable() // nop
 	if c := re.StatusCode; c != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code %d", c)
 	}

--- a/sdk/azcore/internal/shared/response_error_test.go
+++ b/sdk/azcore/internal/shared/response_error_test.go
@@ -267,22 +267,12 @@ func TestNewResponseErrorNoErrorCodeCantReadBody(t *testing.T) {
 			URL:    fakeURL,
 		},
 	})
-	re, ok := err.(*ResponseError)
-	if !ok {
+	_, ok := err.(*ResponseError)
+	if ok {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	if c := re.StatusCode; c != http.StatusInternalServerError {
-		t.Fatalf("unexpected status code %d", c)
-	}
-	const want = `GET https://fakeurl.com/the/path
---------------------------------------------------------------------------------
-RESPONSE 500: the system is down
-ERROR CODE UNAVAILABLE
---------------------------------------------------------------------------------
-Error reading response body: mock read failure
---------------------------------------------------------------------------------
-`
-	if got := re.Error(); got != want {
+	const want = `mock read failure`
+	if got := err.Error(); got != want {
 		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
 	}
 }

--- a/sdk/azcore/internal/shared/shared.go
+++ b/sdk/azcore/internal/shared/shared.go
@@ -37,35 +37,6 @@ func NopCloser(rs io.ReadSeeker) io.ReadSeekCloser {
 	return nopCloser{rs}
 }
 
-func NewResponseError(inner error, resp *http.Response) error {
-	return &ResponseError{inner: inner, resp: resp}
-}
-
-type ResponseError struct {
-	inner error
-	resp  *http.Response
-}
-
-// Error implements the error interface for type ResponseError.
-func (e *ResponseError) Error() string {
-	return e.inner.Error()
-}
-
-// Unwrap returns the inner error.
-func (e *ResponseError) Unwrap() error {
-	return e.inner
-}
-
-// RawResponse returns the HTTP response associated with this error.
-func (e *ResponseError) RawResponse() *http.Response {
-	return e.resp
-}
-
-// NonRetriable indicates this error is non-transient.
-func (e *ResponseError) NonRetriable() {
-	// marker method
-}
-
 // Delay waits for the duration to elapse or the context to be cancelled.
 func Delay(ctx context.Context, delay time.Duration) error {
 	select {
@@ -130,6 +101,81 @@ func HasStatusCode(resp *http.Response, statusCodes ...int) bool {
 		}
 	}
 	return false
+}
+
+// Payload reads and returns the response body or an error.
+// On a successful read, the response body is cached.
+// Subsequent reads will access the cached value.
+func Payload(resp *http.Response) ([]byte, error) {
+	// r.Body won't be a nopClosingBytesReader if downloading was skipped
+	if buf, ok := resp.Body.(*NopClosingBytesReader); ok {
+		return buf.Bytes(), nil
+	}
+	bytesBody, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = &NopClosingBytesReader{s: bytesBody, i: 0}
+	return bytesBody, nil
+}
+
+// NopClosingBytesReader is an io.ReadSeekCloser around a byte slice.
+// It also provides direct access to the byte slice to avoid rereading.
+type NopClosingBytesReader struct {
+	s []byte
+	i int64
+}
+
+// NewNopClosingBytesReader creates a new NopClosingBytesReader around the specified byte slice.
+func NewNopClosingBytesReader(data []byte) *NopClosingBytesReader {
+	return &NopClosingBytesReader{s: data}
+}
+
+// Bytes returns the underlying byte slice.
+func (r *NopClosingBytesReader) Bytes() []byte {
+	return r.s
+}
+
+// Close implements the io.Closer interface.
+func (*NopClosingBytesReader) Close() error {
+	return nil
+}
+
+// Read implements the io.Reader interface.
+func (r *NopClosingBytesReader) Read(b []byte) (n int, err error) {
+	if r.i >= int64(len(r.s)) {
+		return 0, io.EOF
+	}
+	n = copy(b, r.s[r.i:])
+	r.i += int64(n)
+	return
+}
+
+// Set replaces the existing byte slice with the specified byte slice and resets the reader.
+func (r *NopClosingBytesReader) Set(b []byte) {
+	r.s = b
+	r.i = 0
+}
+
+// Seek implements the io.Seeker interface.
+func (r *NopClosingBytesReader) Seek(offset int64, whence int) (int64, error) {
+	var i int64
+	switch whence {
+	case io.SeekStart:
+		i = offset
+	case io.SeekCurrent:
+		i = r.i + offset
+	case io.SeekEnd:
+		i = int64(len(r.s)) + offset
+	default:
+		return 0, errors.New("nopClosingBytesReader: invalid whence")
+	}
+	if i < 0 {
+		return 0, errors.New("nopClosingBytesReader: negative position")
+	}
+	r.i = i
+	return i, nil
 }
 
 const defaultScope = "/.default"

--- a/sdk/azcore/internal/shared/shared_test.go
+++ b/sdk/azcore/internal/shared/shared_test.go
@@ -9,6 +9,7 @@ package shared
 import (
 	"context"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -20,33 +21,6 @@ func TestNopCloser(t *testing.T) {
 	nc := NopCloser(strings.NewReader("foo"))
 	if err := nc.Close(); err != nil {
 		t.Fatal(err)
-	}
-}
-
-type testError struct {
-	m string
-}
-
-func (t testError) Error() string {
-	return t.m
-}
-
-func TestNewResponseError(t *testing.T) {
-	err := NewResponseError(testError{m: "crash"}, &http.Response{StatusCode: http.StatusInternalServerError})
-	if s := err.Error(); s != "crash" {
-		t.Fatalf("unexpected error %s", s)
-	}
-	re, ok := err.(*ResponseError)
-	if !ok {
-		t.Fatalf("unexpected error type %T", err)
-	}
-	re.NonRetriable() // nop
-	if c := re.RawResponse().StatusCode; c != http.StatusInternalServerError {
-		t.Fatalf("unexpected status code %d", c)
-	}
-	var te testError
-	if !errors.As(err, &te) {
-		t.Fatal("unwrap failed")
 	}
 }
 
@@ -126,5 +100,85 @@ func TestHasStatusCode(t *testing.T) {
 func TestEndpointToScope(t *testing.T) {
 	if s := EndpointToScope("https://management.usgovcloudapi.net"); s != "https://management.usgovcloudapi.net//.default" {
 		t.Fatalf("unexpected scope %s", s)
+	}
+}
+
+func TestPayload(t *testing.T) {
+	const val = "payload"
+	resp := &http.Response{
+		Body: io.NopCloser(strings.NewReader(val)),
+	}
+	b, err := Payload(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != val {
+		t.Fatalf("got %s, want %s", string(b), val)
+	}
+	b, err = Payload(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != val {
+		t.Fatalf("got %s, want %s", string(b), val)
+	}
+}
+
+func TestNopClosingBytesReader(t *testing.T) {
+	const val1 = "the data"
+	ncbr := NewNopClosingBytesReader([]byte(val1))
+	b, err := io.ReadAll(ncbr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != val1 {
+		t.Fatalf("got %s, want %s", string(b), val1)
+	}
+	const val2 = "something else"
+	ncbr.Set([]byte(val2))
+	b, err = io.ReadAll(ncbr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != val2 {
+		t.Fatalf("got %s, want %s", string(b), val2)
+	}
+	if err = ncbr.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// seek to beginning and read again
+	i, err := ncbr.Seek(0, io.SeekStart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if i != 0 {
+		t.Fatalf("got %d, want %d", i, 0)
+	}
+	b, err = io.ReadAll(ncbr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != val2 {
+		t.Fatalf("got %s, want %s", string(b), val2)
+	}
+	// seek to middle from the end
+	i, err = ncbr.Seek(-4, io.SeekEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l := int64(len(val2)) - 4; i != l {
+		t.Fatalf("got %d, want %d", l, i)
+	}
+	b, err = io.ReadAll(ncbr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "else" {
+		t.Fatalf("got %s, want %s", string(b), "else")
+	}
+	// underflow
+	_, err = ncbr.Seek(-int64(len(val2)+1), io.SeekCurrent)
+	if err == nil {
+		t.Fatal("unexpected nil error")
 	}
 }

--- a/sdk/azcore/runtime/errors.go
+++ b/sdk/azcore/runtime/errors.go
@@ -12,10 +12,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 )
 
-// NewResponseError wraps the specified error with an error that provides access to an HTTP response.
-// If an HTTP request returns a non-successful status code, wrap the response and the associated error
-// in this error type so that callers can access the underlying *http.Response as required.
-// DO NOT wrap failed HTTP requests that returned an error and no response with this type.
-func NewResponseError(inner error, resp *http.Response) error {
-	return shared.NewResponseError(inner, resp)
+// NewResponseError creates an *azcore.ResponseError from the provided HTTP response.
+// Call this when a service request returns a non-successful status code.
+func NewResponseError(resp *http.Response) error {
+	return shared.NewResponseError(resp)
 }

--- a/sdk/azcore/runtime/policy_body_download_test.go
+++ b/sdk/azcore/runtime/policy_body_download_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
@@ -307,7 +308,7 @@ func TestReadBodyAfterSeek(t *testing.T) {
 	if string(payload) != message {
 		t.Fatal("incorrect payload")
 	}
-	nb, ok := resp.Body.(*nopClosingBytesReader)
+	nb, ok := resp.Body.(*shared.NopClosingBytesReader)
 	if !ok {
 		t.Fatalf("unexpected body type: %t", resp.Body)
 	}

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -21,7 +21,7 @@ import (
 
 // NewPoller creates a Poller based on the provided initial response.
 // pollerID - a unique identifier for an LRO, it's usually the client.Method string.
-func NewPoller(pollerID string, resp *http.Response, pl pipeline.Pipeline, eu func(*http.Response) error) (*pollers.Poller, error) {
+func NewPoller(pollerID string, resp *http.Response, pl pipeline.Pipeline) (*pollers.Poller, error) {
 	defer resp.Body.Close()
 	// this is a back-stop in case the swagger is incorrect (i.e. missing one or more status codes for success).
 	// ideally the codegen should return an error if the initial response failed and not even create a poller.
@@ -42,12 +42,12 @@ func NewPoller(pollerID string, resp *http.Response, pl pipeline.Pipeline, eu fu
 	if err != nil {
 		return nil, err
 	}
-	return pollers.NewPoller(lro, resp, pl, eu), nil
+	return pollers.NewPoller(lro, resp, pl), nil
 }
 
 // NewPollerFromResumeToken creates a Poller from a resume token string.
 // pollerID - a unique identifier for an LRO, it's usually the client.Method string.
-func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipeline, eu func(*http.Response) error) (*pollers.Poller, error) {
+func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipeline) (*pollers.Poller, error) {
 	kind, err := pollers.KindFromToken(pollerID, token)
 	if err != nil {
 		return nil, err
@@ -67,5 +67,5 @@ func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipelin
 	if err = json.Unmarshal([]byte(token), lro); err != nil {
 		return nil, err
 	}
-	return pollers.NewPoller(lro, nil, pl, eu), nil
+	return pollers.NewPoller(lro, nil, pl), nil
 }

--- a/sdk/azcore/runtime/response.go
+++ b/sdk/azcore/runtime/response.go
@@ -21,18 +21,9 @@ import (
 
 // Payload reads and returns the response body or an error.
 // On a successful read, the response body is cached.
+// Subsequent reads will access the cached value.
 func Payload(resp *http.Response) ([]byte, error) {
-	// r.Body won't be a nopClosingBytesReader if downloading was skipped
-	if buf, ok := resp.Body.(*nopClosingBytesReader); ok {
-		return buf.Bytes(), nil
-	}
-	bytesBody, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-	resp.Body = &nopClosingBytesReader{s: bytesBody, i: 0}
-	return bytesBody, nil
+	return shared.Payload(resp)
 }
 
 // HasStatusCode returns true if the Response's status code is one of the specified values.
@@ -108,7 +99,7 @@ func removeBOM(resp *http.Response) error {
 	// UTF8
 	trimmed := bytes.TrimPrefix(payload, []byte("\xef\xbb\xbf"))
 	if len(trimmed) < len(payload) {
-		resp.Body.(*nopClosingBytesReader).Set(trimmed)
+		resp.Body.(*shared.NopClosingBytesReader).Set(trimmed)
 	}
 	return nil
 }


### PR DESCRIPTION
SDK APIs will now return an *azcore.ResponseError when a request is made
to the service and the service returns a non-success HTTP status code.
ResponseError provides the HTTP status code, error code when available,
and the raw *http.Response.
The Error() method provides pretty-printing of the error, see the tests
for example output.
Since user-defined errors are no longer returned, the LRO pollers no
longer need a callback to create them so this has been removed.
Payload() and NopClosingBytesReader have been moved to the internal,
shared package so ResponseError can use them.
Removed some unnecessary error unmarshallers in the register RP policy.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
