### PR TITLE
fix: wrong specRoot folder calculation for multi packages

### DIFF
--- a/eng/tools/generator/cmd/v2/automation/automationCmd.go
+++ b/eng/tools/generator/cmd/v2/automation/automationCmd.go
@@ -109,7 +109,7 @@ func (ctx *automationContext) generate(input *pipeline.GenerateInput) (*pipeline
 			if sepStr == "resource-manager" {
 				readme = strings.Join(sepStrs[i-1:], "/")
 				if i > 1 {
-					ctx.specRoot = ctx.specRoot + "/" + strings.Join(sepStrs[:i-1], "/")
+					ctx.specRoot = input.SpecFolder + "/" + strings.Join(sepStrs[:i-1], "/")
 				}
 				break
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
