### PR TITLE
disable track 1 breaking change detection

### DIFF
--- a/eng/tools/generator/cmd/automation/automationCmd.go
+++ b/eng/tools/generator/cmd/automation/automationCmd.go
@@ -218,7 +218,8 @@ func (ctx *automationContext) generate(input *pipeline.GenerateInput) (*pipeline
 		for _, p := range packageResults {
 			log.Printf("Getting package result for package '%s'", p.Package.PackageName)
 			content := p.Package.Changelog.ToCompactMarkdown() + "\n" + p.Package.Changelog.GetChangeSummary()
-			breaking := p.Package.Changelog.HasBreakingChanges()
+			// explicitly disable the breaking change detection in SDK automation track 1 since we already have quite a coverage of track 2 packages, we will leverage the breaking change detection on track 2 modules
+			breaking := false
 			breakingChangeItems := p.Package.Changelog.GetBreakingChangeItems()
 			set.add(pipeline.PackageResult{
 				Version:     ctx.sdkVersion,


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
