### PR TITLE
feat: add generator cmd to generate or update readme.go.md file for track2 sdk param

### DIFF
--- a/eng/tools/generator/cmd/root.go
+++ b/eng/tools/generator/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/eng/tools/generator/cmd/release"
 	"github.com/Azure/azure-sdk-for-go/eng/tools/generator/cmd/template"
 	automation_v2 "github.com/Azure/azure-sdk-for-go/eng/tools/generator/cmd/v2/automation"
+	"github.com/Azure/azure-sdk-for-go/eng/tools/generator/cmd/v2/readme"
 	refresh_v2 "github.com/Azure/azure-sdk-for-go/eng/tools/generator/cmd/v2/refresh"
 	release_v2 "github.com/Azure/azure-sdk-for-go/eng/tools/generator/cmd/v2/release"
 	"github.com/Azure/azure-sdk-for-go/eng/tools/generator/common"
@@ -49,6 +50,7 @@ func Command() *cobra.Command {
 		automation_v2.Command(),
 		release_v2.Command(),
 		refresh_v2.Command(),
+		readme.Command(),
 	)
 
 	return rootCmd

--- a/eng/tools/generator/cmd/v2/readme/readmeCmd.go
+++ b/eng/tools/generator/cmd/v2/readme/readmeCmd.go
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package readme
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Command returns the generate-go-readme command.
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generate-go-readme <rp readme filepath>",
+		Short: "Generate a go readme file or add go track2 part to go readme file according to base swagger readme file",
+		Args:  cobra.ExactArgs(1),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			log.SetFlags(0) // remove the time stamp prefix
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := execute(args[0]); err != nil {
+				logError(err)
+				return err
+			}
+			return nil
+		},
+		SilenceUsage: true, // this command is used for a pipeline, the usage should never show
+	}
+
+	return cmd
+}
+
+func execute(rpReadmeFilepath string) error {
+	if _, err := os.Stat(rpReadmeFilepath); errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	basePath := filepath.Dir(rpReadmeFilepath)
+	rpName := filepath.Base(filepath.Dir(basePath))
+
+	readmeGoFile := filepath.Join(basePath, "readme.go.md")
+	content := ""
+	if _, err := os.Stat(readmeGoFile); err == nil {
+		b, err := ioutil.ReadFile(readmeGoFile)
+		if err != nil {
+			return err
+		}
+		content = string(b)
+	}
+
+	if !strings.Contains(content, "$(go) && $(track2)") {
+		content += fmt.Sprintf("\n\n``` yaml $(go) && $(track2)\nlicense-header: MICROSOFT_MIT_NO_VERSION\nmodule-name: sdk/resourcemanager/%s/arm%s\nmodule: github.com/Azure/azure-sdk-for-go/$(module-name)\noutput-folder: $(go-sdk-folder)/$(module-name)\nazure-arm: true\n```\n", rpName, rpName)
+		if err := ioutil.WriteFile(readmeGoFile, []byte(content), 0644); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("Succeed to generate readme.go.me file from '%s'...", rpReadmeFilepath)
+
+	return nil
+}
+
+func logError(err error) {
+	for _, line := range strings.Split(err.Error(), "\n") {
+		if l := strings.TrimSpace(line); l != "" {
+			log.Printf("[ERROR] %s", l)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
