### PR TITLE
Update Language-Settings for new moduleVersion

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -21,7 +21,7 @@ function Get-GoModuleVersionInfo($modPath)
 
     # finding where the version number are
     if ($content -match $VERSION_LINE_REGEX) {
-        return "$($matches["version"])", $versionFile
+        return "$($matches["moduleVersion"])", $versionFile
     }
 
     # This is an easy mistake to make (X.Y.Z instead of vX.Y.Z) so add a very clear error log to make debugging easier

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -6,7 +6,7 @@ $LanguageDisplayName = "go"
 function Get-GoModuleVersionInfo($modPath)
 {
   $NO_PREFIX_VERSION_LINE_REGEX = ".+\s*=\s*`"(?<bad_version>$([AzureEngSemanticVersion]::SEMVER_REGEX))`""
-  $VERSION_LINE_REGEX = ".+\s*=\s*`".*v(?<version>$([AzureEngSemanticVersion]::SEMVER_REGEX))`""
+  $VERSION_LINE_REGEX = ".+\s*=\s*`".*v(?<moduleVersion>$([AzureEngSemanticVersion]::SEMVER_REGEX))`""
 
   $versionFiles = Get-ChildItem -Recurse -Path $modPath -Filter *.go
 


### PR DESCRIPTION
autorest changed the variable name from `version` to `moduleVersion`

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
