### PR TITLE
Test-Proxy Runs using tool

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -116,11 +116,6 @@ stages:
           EnvVars:
             AZURE_RECORD_MODE: 'playback'
 
-      - pwsh: |
-          docker logs ambitious_azsdk_test_proxy
-        displayName: "Show Docker Logs"
-        condition: succeededOrFailed()
-
     - ${{ if startsWith(parameters.ServiceDirectory, 'resourcemanager') }}:
       - template: /eng/pipelines/templates/jobs/mgmt-mock-test.yml
         parameters:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -44,7 +44,7 @@ steps:
     displayName: "Install Coverage and Junit Dependencies"
 
   - ${{ if eq(parameters.TestProxy, true) }}:
-    - template: /eng/common/testproxy/test-proxy-docker.yml
+    - template: /eng/common/testproxy/test-proxy-tool.yml
 
   - task: PowerShell@2
     displayName: 'Run Tests'
@@ -60,9 +60,8 @@ steps:
 
   - ${{ if eq(parameters.TestProxy, true) }}:
     - pwsh: |
-        # ambitious_azsdk_test_proxy is the hardcoded container name used
-        # by the test proxy startup script
-        docker logs ambitious_azsdk_test_proxy
+        # $(Build.SourcesDirectory)/test-proxy.log is the hardcoded output log location for the test-proxy-tool.yml
+        cat $(Build.SourcesDirectory)/test-proxy.log
       displayName: 'Dump Test Proxy logs'
       condition: succeededOrFailed()
 


### PR DESCRIPTION
...rather than docker.

@seankane-msft 

I have no explanation (and can't get one short term) about why the test proxy refuses to properly start on our CI machines. I want to say that there is something wrong with the actual instances of the machines given the irregularity with which this appears.

