### PR TITLE
fix: version param name change in tools

### DIFF
--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -33,7 +33,7 @@ var (
 	v2BeginRegex             = regexp.MustCompile("^```\\s*yaml\\s*\\$\\(go\\)\\s*&&\\s*\\$\\((track2|v2)\\)")
 	v2EndRegex               = regexp.MustCompile("^\\s*```\\s*$")
 	newClientMethodNameRegex = regexp.MustCompile("^New.+Client$")
-	versionLineRegex         = regexp.MustCompile(`version\s*=\s*\".*v\d+\.\d+\.\d+\"`)
+	versionLineRegex         = regexp.MustCompile(`moduleVersion\s*=\s*\".*v\d+\.\d+\.\d+\"`)
 	changelogVersionRegex    = regexp.MustCompile(`##\s*(?P<version>\d+\.\d+\.\d+)\s*\((\d{4}-\d{2}-\d{2}|Unreleased)\)`)
 	packageConfigRegex       = regexp.MustCompile(`\$\((package-.+)\)`)
 )
@@ -233,7 +233,7 @@ func ReplaceVersion(packageRootPath string, newVersion string) error {
 	if b, err = ioutil.ReadFile(path); err != nil {
 		return err
 	}
-	contents := versionLineRegex.ReplaceAllString(string(b), "version = \"v"+newVersion+"\"")
+	contents := versionLineRegex.ReplaceAllString(string(b), "moduleVersion = \"v"+newVersion+"\"")
 
 	return ioutil.WriteFile(path, []byte(contents), 0644)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
