### PR TITLE
[KeyVault] Fix issue with PATCH method

### DIFF
--- a/sdk/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/keyvault/azsecrets/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Release History
 
-## 0.4.1 (Unreleased)
+## 0.5.0 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixes a bug where `UpdateSecretProperties` will delete properties that are not explicitly set each time.
 
 ### Other Changes
 

--- a/sdk/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/keyvault/azsecrets/CHANGELOG.md
@@ -5,9 +5,9 @@
 ### Features Added
 
 ### Breaking Changes
+* Fixes a bug where `UpdateSecretProperties` will delete properties that are not explicitly set each time. This is only a breaking change at runtime, where the request body will change.
 
 ### Bugs Fixed
-* Fixes a bug where `UpdateSecretProperties` will delete properties that are not explicitly set each time.
 
 ### Other Changes
 

--- a/sdk/keyvault/azsecrets/client.go
+++ b/sdk/keyvault/azsecrets/client.go
@@ -439,14 +439,10 @@ type Properties struct {
 
 // convert the publicly exposed version to the generated version
 func (s Properties) toGenerated() internal.SecretUpdateParameters {
-	var secAttribs *internal.SecretAttributes
-	if s.SecretAttributes != nil {
-		secAttribs = s.SecretAttributes.toGenerated()
-	}
 	return internal.SecretUpdateParameters{
 		ContentType:      s.ContentType,
 		Tags:             createPtrMap(s.Tags),
-		SecretAttributes: secAttribs,
+		SecretAttributes: s.SecretAttributes.toGenerated(),
 	}
 }
 

--- a/sdk/keyvault/azsecrets/client_test.go
+++ b/sdk/keyvault/azsecrets/client_test.go
@@ -74,6 +74,53 @@ func TestSetGetSecret(t *testing.T) {
 	require.Equal(t, *getResp.Value, value)
 }
 
+func TestSecretTags(t *testing.T) {
+	stop := startTest(t)
+	defer stop()
+
+	client, err := createClient(t)
+	require.NoError(t, err)
+
+	secret, err := createRandomName(t, "secret")
+	require.NoError(t, err)
+	value, err := createRandomName(t, "value")
+	require.NoError(t, err)
+
+	defer cleanUpSecret(t, client, secret)
+
+	resp, err := client.SetSecret(context.Background(), secret, value, &SetSecretOptions{
+		Tags: map[string]string{
+			"Tag1": "Val1",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(resp.Tags))
+	require.Equal(t, "Val1", resp.Tags["Tag1"])
+
+	getResp, err := client.GetSecret(context.Background(), secret, nil)
+	require.NoError(t, err)
+	require.Equal(t, *getResp.Value, value)
+	require.Equal(t, 1, len(getResp.Tags))
+	require.Equal(t, "Val1", getResp.Tags["Tag1"])
+
+	updateResp, err := client.UpdateSecretProperties(context.Background(), secret, Properties{
+		SecretAttributes: &Attributes{
+			Expires: to.TimePtr(time.Now().Add(24 * time.Hour)),
+		},
+	}, &UpdateSecretPropertiesOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(updateResp.Tags))
+	require.Equal(t, "Val1", updateResp.Tags["Tag1"])
+
+	// Delete the tags
+	updateResp, err = client.UpdateSecretProperties(context.Background(), secret, Properties{
+		Tags: make(map[string]string),
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(updateResp.Tags))
+	require.NotEqual(t, "Val1", updateResp.Tags["Tag1"])
+}
+
 func TestListSecretVersions(t *testing.T) {
 	stop := startTest(t)
 	defer stop()

--- a/sdk/keyvault/azsecrets/client_test.go
+++ b/sdk/keyvault/azsecrets/client_test.go
@@ -105,7 +105,7 @@ func TestSecretTags(t *testing.T) {
 
 	updateResp, err := client.UpdateSecretProperties(context.Background(), secret, Properties{
 		SecretAttributes: &Attributes{
-			Expires: to.TimePtr(time.Now().Add(24 * time.Hour)),
+			Expires: to.TimePtr(time.Date(2040, time.April, 1, 1, 1, 1, 1, time.UTC)),
 		},
 	}, &UpdateSecretPropertiesOptions{})
 	require.NoError(t, err)

--- a/sdk/keyvault/azsecrets/internal/constants.go
+++ b/sdk/keyvault/azsecrets/internal/constants.go
@@ -10,7 +10,7 @@ package internal
 
 const (
 	moduleName    = "internal"
-	moduleVersion = "v0.4.1"
+	moduleVersion = "v0.5.0"
 )
 
 // DataAction - Supported permissions for data actions.

--- a/sdk/keyvault/azsecrets/models.go
+++ b/sdk/keyvault/azsecrets/models.go
@@ -87,7 +87,10 @@ type Attributes struct {
 	RecoveryLevel *DeletionRecoveryLevel `json:"recoveryLevel,omitempty" azure:"ro"`
 }
 
-func (s Attributes) toGenerated() *internal.SecretAttributes {
+func (s *Attributes) toGenerated() *internal.SecretAttributes {
+	if s == nil {
+		return nil
+	}
 	return &internal.SecretAttributes{
 		RecoverableDays: s.RecoverableDays,
 		RecoveryLevel:   s.RecoveryLevel.toGenerated(),
@@ -187,8 +190,11 @@ type BackupSecretResult struct {
 }
 
 func convertPtrMap(m map[string]*string) map[string]string {
-	ret := map[string]string{}
+	if m == nil {
+		return nil
+	}
 
+	ret := map[string]string{}
 	for key, val := range m {
 		ret[key] = *val
 	}
@@ -197,8 +203,11 @@ func convertPtrMap(m map[string]*string) map[string]string {
 }
 
 func createPtrMap(m map[string]string) map[string]*string {
-	ret := map[string]*string{}
+	if m == nil {
+		return nil
+	}
 
+	ret := map[string]*string{}
 	for key, val := range m {
 		ret[key] = &val
 	}

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestBackupSecret.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestBackupSecret.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:38 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -27,8 +27,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "6833c973-94f1-41f2-9b78-3a4c026646c5",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "7f3e99f5-c174-4022-8aaa-22f4d0522be9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -49,42 +49,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "43",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value1973943927"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "277",
+        "Content-Length": "267",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:39 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "76789a14-f617-4685-abff-a978dc8ffad1",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "bdcab79a-cdb5-4e90-b69d-4231aec49852",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value1973943927",
-        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/d3be2d16a0904261bbc13beaabcddaec",
+        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/f9f5358f1cba4794b0728f2625b2dd03",
         "attributes": {
           "enabled": true,
-          "created": 1642005039,
-          "updated": 1642005039,
+          "created": 1642625954,
+          "updated": 1642625954,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -99,7 +97,7 @@
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -107,19 +105,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4956",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:39 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "421dda37-de0c-48ea-bc33-317048f9d95b",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "89cf992c-f8f8-4146-a3de-9233881e976e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUl5WVdabU5tRmhNUzAzTm1Ka0xUUTBZVGN0WVRjek5DMDJaalZoWkRCaU5XRTRPVGdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQzB5TlRZaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuUG42bXVldy1xT3BYb01Celh2c1BTWHIxbnlDQm9DTWF1YXpfYUJSUU5zVFRKLWh1MDc5Vy1ZZEtpRENFTkE0dnVYMHZ0QS1qYUthTk5IRGtNaUhWN0VmN3UxYWMxYWxWaVcxU0FlTC1aalZiNmFFZTR1YXFTZFd4cXdvNG4zVTdGOWpRZ2dTc2IyVHFFdkFKVGJEeDI0OE5ncGJQOFB0NzhqZmtEMTc2b3pGQ3BhbUFKSzNFeTh1TXZkRFN3c2Mzc21MQVJ2V3hPLUhQQU9YOHhiU0NfTWllWWlmVGVMQ2JQZ1NWYVBKV2lwT3o4bVNqTFVJdS03MFZzdGZyT2FqaUJfeXEweVhOOGJpbG5JaFhmSTlUUnZqXzFkTkNRSWNmQ3hsZm5SWS1FaTFvc0Q1bnJOWHJEX0tmNFF4am9RRXB4emc4eVNuSVpob3RmTHZQSlVfVlRBLjJBeGI5SW9xdzFIaTJucjd0d1FMZUEuaC1KZUJUS05zWE82WGtJVVA2SWd5RWlTR2VXeHRwdlBJSU94U0pGM0V3MWRPM1d6bXplYkxrRWFhemN4WU1uOXlsQklrTncxV2JVMGVNWGtreFJ4YWU5N3dCTm5kZ2FKMURDVDJiNWxldVVjd0p6TTB6azBJNm1wYWtEelZ5UUwtMF9IMW9PVUY5RXFKdk9tQVlad01zbzJtOEp2cVE0R21tVm92MHJKRnlLRF9QSmpYVmRxN3UzQ3RNUXF1N2o5RGNyRF9FZ1RGUVJmRGpoWWphOVNzUVd1Z1pEZTNBbUZ1S0dNcUZzQUx4V0JrdndxeklJNEdTSExMOU02bWtVd1hLelJwWkVPVmt5Nmd2ZW9IVTUtTUJZQUEyeGV5dmpvUkUxUTFrUk4tQU9FT04xdUF6UnlPbUw1VnFtRTB4c095RmkwYV9fQ0s5bzZMYXlDVU91bnEwRl9xcGJEUkpRcFB3RW1zMU10NU5BQkpPbDNXMnBrQWJnYzNlSHpEN25PbW1HWktoMkRoRXZRd2p0SnE0dE1VWF9zek0wRnY2R1Frd3Rib3kxRW5OZ2FLU1RFUGJaZExCZEJqNVNFMmRQT1lVLWpOT3pBQW9zTWZuUzJkUDJQSWUtZWhsRnQxZmR6VWZ2SDk0eHFRSkw2c0YySFFsUENPeXJWT292TVhzMDVwWGxhOWptMGlFQjJmVFh1WUwtVVNzcFZ2aGhoeVFXekR1cUNtU0dJZ1JlbkY5ZERvT3dqc3ptbDA0WHF5QWhNT25ES2ZHdWZLdzBYNi1XcnFTSGt4enFDQXlqcXh5NlNpTkJVY0V5bDRWZ01aTElRb2NvdHN4bWdqeFRsMXRJUGpvTmR1bXRxSXBnODg3MFBfQ3ZYcG5jLUpRaURudVhaUFZWRl90RnBkS3NiUEh5UWFXbVZqTVFOdXVkNEpXUUNsbDQwYjRxVGhGZ2ZOdVdqbzZ2M3J4bE95R2d4c0Z1NzEta3lJblktY00yZXlNdHVxVHZnbGxqcl9tbl9GSWI3ZEdSTlBDM3JabDB6VXA0VEl3NE5SWDI0Ynd2MmdmY0ljdm1UdnhWV2tNbUdlXy1uOFhyeW9COFFLNU1FT0pOV2J5TU5HQVZYVmh0S2hWTy1KNWxpYklIZ3Njb1czNW9zTnJqVzFjTTVDY2M4eENsQ3hsc0RCTEVXbHFRQnFvcmVLNnZPaDhlRDc0ZUdCZlBic2tZYWc0UFV6ZXAxNzdCaDJlV2lJUlpUVWhuemJiOFQwbURyUEVJRTVya3ZxYldZU3NfTl9ZRVBXTFNWbTNjeHFVcmIwQkJUSXE0VXJWMGdVM0IyYTF4Tk5YcUNhckNlTXBYN3A0UF9OQ2J6cHVHSkpzZTk1ZmxIVThITWZnSkhNUXMzSGpLQkU0dGRIUnFrdGpuQVVvb0phaUwyb0pzLXNVeTIwTVNkUHVYcTRnclhOMWpIdzU5X085aWdaaExEYzd2SHYtaC1rRHNEOXpXRnFCRklrQXpZOXdrc1VZQTZNaEQzOEFVV0ZoNEk5NjNxM0dxYXRfNWc1YmFKRTZsaDE4MHh5aHdfS2FZd3RTUDlMZWp4V05sT1gtXzZpaTR3eXFjblVzQjV2eWlQRU9Gd3RDbWxIQnA3YVI1b0NDenZsWkp4cHQ1eU4tWTh2dWhSSW9WMFVvZ1AzRzVhdTRaRDZnSzlWQ2hhZTNJT3hnejl3M1g0ZkRSZlVpNjZaSmNndlBUby1QYzVZYUx1eUxDSlhVdktxVFE2WHdjb3d3UER4TXo5SmVrS2oyTFZlZXZ3WEhiVlExdVZrVFl0WGRBQS1CWFNhcDl2MXdCV3ZDT3VsWDNUeWstSEJSTkp3d1ZaRnQtTkRIVlZKZEFlZDRuTzl6b0V5cjJTdFpCSVJSMkdDUzBKcUR0UWx3eE4tVkJ5RXpPMEJ5WEdFSWZZWDlVSl9OSnprc0k3UFZFVGFDY3RPbmM2OEdjeDVwSjlEWWkwWVQtN3RfR3Njb2tJQWJHejBNYmRlQ1VhcTc1VmlZS29nX1N4MWdSTzFnU1RqMXNoVXJUSHE1cVV5SEtueGNrNjJ6UWpfVDlDZnlPMngxaWcyS2NyWVptVElyTTJCT1AtREQyeGFjRWFDM3BCeWpsT29tajk3YlNqN2xENGFRdkFjcGpGTnpVaWx3N3paVnhyZlhGQXhIc21ySWRERmtWWU5TREZfb051NXdKLXBIcEptMERuckRPNnBxTU5WVTJHMmRvNjJjb3RRbVUxV041RjBUMnNGeDhkVmxoOEtPNXRyeGQ1blBJS1ZDUzFYb1NBalhfczJ3LXFQWkRHc09vTHdpRDk4NTFSQ1prclJHOGh0ZTB2SnlibXpTc2dTMlg3M1pXRXdPU01RRjdBbUc3Q1BSUGQ3VGp2cnNNMFFvTmVleGxpZUdsU0dGUy1xNTZiaUZublB1ckMzWHU1MzJDWVhDNjBMZEl6bVh1TGE0VGk2NGZ4QU4wdTVHSGdneDNTNmJVM0E1UE1SaE0wWU45ekR3eThuYTZrYjBWZTZKb09WSnhZeWFDaWZsTzlWTGxxeHpRU2t1NUkxdHBBOEdiMTVJaU1sUEZKV3hXY0pDbUlldDBqTzktZ3U2QXNMc19hV0QwWENGMnJ6bVd3LTVrTDRDY0dKTURvOEVLZHFrLVdKZF9YMzVRQkhIWVZyOFNxYnBrN0syN21uTlNwZENBS1FWdHEwMDl1ZG1ncU04SHJvLU4yYm5nTnhsQXBYOUdvLWFVSVJZdUJLM2tVTEQxV3l4VGhUa3ZwblNUalBCdXI5S1gxbGZQYWJXZHN3aWRTLTlYcFplNXBtV3RVa3NqXzBCSGhUYVVaN3JhdWxyRFlhSHFZZ3RlQnVqdzJOV194NFNNeWZKdEdlTVhjcEVtUzlvVTNxRUNqVUJqX2VSYjhZVF9fSWpwOGZUS1haa3B4MHpFRHdWamlYU2NiMGU4Q3RxNmYxSHB0ZEkxWHZKbmRLTGlyWW50MjlFb0VoVE1RWHRoZGZaOTc3RU9QMFZIRnc5YzNueWtLaFE0dnh2bUcyQURfWkx5S0E0SFhFeVhHT3VBT2k5c3FhcVphSTdfSWZacE13SlNlYTVUUlQwVzhTMWxQQTQxbGxBUW56YmllbGxSVTNvaWM3cmIxUmxGdUNOWUtYVGYzd0Fzb0VPRmFBWk9jX3dYWi1kVEd0QmtjR1JvRy0tLXpzWFcyQTl0QjZ4RDlTTHcxNDhQSUFPYzJ1SkVvbjVzbGdGTlpBT1ZzSGl0YXFva24xVHYzTEEwX2dBRE5pZnRYLURTdm5JdUtIYjBKSy1xSnRnOTRObWZCSWV2Vms5Z1Rsbmp5SE1GeE9BX0RpM2RIM0ZFSUdvRWdtZ0RuWlJWVnZoQmZ6YVlCMWlPb1llb2ZWemItTnZfUzUyWnNxOGlrY296aFpDcnFCN0hpSW9vRE9UV0VXWENUZjF2ak9wMG5nMDVxb081ek1XNGFwLVk1M01FMmZCN2p4TXU4eTRaWGduNGJ2dUlTS01nOGs5YW1wMHdfbE8xOVRkbWtVVERXakdiQTAxTVlwaWpDTXFZQnluM2YzV2NraEYwLWVTdEV0YVBETGdmczQ2TWlTenRKRzlKZG9NWjdUVlU0QS0ycEx3cnBFcnY5N0I4NjRBTGxNTXpTVWxmdExKN2FCbHlnR3M5cTJxdjF3UVV6a0oydXpSTnc4NDRxdTgxXy1ZR2ZERHoxY0xFMkpPbE9RRzMzeXFXUHZSODJaMFJTVHpNMV9aakRSV1FpXzFDdWdBblByWVQ5RGtIUUJHb1dzS012OEh3c292MjZ4QXJTZDRpSTkxU3VUdWlyeG4zemZsa1FuWkZieldLd2V1RnRvWGhsc3FsbHRsUFhSSkRERUtHTlNpNXZVYkpTcXR4ZmF4SWdlZ3hibWtRNWdVZHRSVXZjangwbUFJR2dhQ2dKUS1LV2Z6dllaSHJrUDRVQTZNZmQ1blNIV2cyNUpNNEVBMGhlZ25GaDlTRWZqUEd3YUlBTXVOb2VFRUlkS1YxeXlvZ1AtYXZsemVRUC1ER1BHd1pILWp2b1NUX3UzT3pObnlUaXFGRUw5c2djU2NNWVIyQzdHWFdUVHVYWnB6eGlXUEtoV0lZOGs0MFRyVjFpX3pSYUc3bzhZbkl4N1pqbGdoVnpmSU4ybnN3US5tdnVkbDZFT0p3SkdudWhTYndiSFo3blpmb2VoRHpJRmg3M2Q0X3UwMW13"
+        "value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUl5WVdabU5tRmhNUzAzTm1Ka0xUUTBZVGN0WVRjek5DMDJaalZoWkRCaU5XRTRPVGdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQzB5TlRZaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuZHRrTEl0ZkRLMDAybmRmUDJPTnd0TS1ZYTVER0tHTmlYQ2lNNy1iVHZiLUxSVTRYV09RWlVzOVg0V3pvVzJTU0NHR0FFREFVcXUybm5zMVBEQXZGUnpHS3RKNVNOeU11SnMybWpROFhiMDhiOXlnelhLcWUwNGZvYk1XQ24tU1R3YUNSNVZJYXhYbTU2Z1NaRzJCVWttREprbk1IYjJSS0FMQ0pTMjYtYXpxd3ZQMDFOeFJjYUx5OUV6SHI5bnlhcndZUG51Sk8zblU3RUVxR0ctZ0x2dS1QWDVXQUN2cnFJajEyRWJ6NmdIMEZqeFFweFZBdi1Qc1p6LWNseUZmTmI4VC1LYi1LeS1Gd3F4dHV5cHRTTzlIOW5lZHFrYmJrUmhUMVFKbjJFczZSLUdoOFlmTjQ3d0ZRZ2ktS3FYZWQtbnRncmZHQWwwbXlpLUNJazRrQjRnLmZoUzkzQ25zTWxyV2VDbnA5ZFZWYmcubkNOcDdMRzJxLXhXS3pJajZJZDBmcUx0clZpbW5fdUJ2TEdpSkhxeG1rdFJzY0M3T3QtRVA4N0RIUGZmZ25yVDM0R1F3OUk2a3ZpMjBHdW5hSkJiZGVoYktPNkllWENCUG9Ob1NWWldTaU02UGxDN2lzVS1LSnB5YWhIeWJHXzEzUlREaXhPNjV4Um0tZFhtNmtTWG9lUVJWVUw2U0hnTjhGRmVoMlRQMXhNeWdsUHlia29FMWxsQXMtQUJFb0tZbTdUZ0pxLVYyelRXRmk5WnVfUklwdlF4eTZFczZUVFotZHRPdi1fNEhPRGlwbnh0QUF1WTMtNTdObEJSNmdQZU5vcDBWdjR2M1NhelVIVlFkMkNIMzk5eVdINEVuQ044bURRZ2pnRnAxR0ZOQ3pCUktRaVNVNnRlbU40ajQ2bElwWjFST1N5UGNHR3pnc0YyMVB1bUQ0RVJQMWxJT1NrQThlb0dZazNyRHFiZm9DSG1fV0pValBNUm9zc3ludWtDam1wQkoxaUIweUd2SV9iZDlSdGM3NEs5enFycG5DOG9DLVZkUWtnQTNUeElqdFdteFpWaHJFTFE1NXlSSUM5ZDlhSlBuWmdzTU4zZkVtTC1OZTZQTlhDd2paT25KX3dTTUhqY0JnNklEeUtoSXk4SVhHX2VTOGwweXFLald3dU5aUEhtZV9vZ0dlR3hpdHdlVG5tSlFUTkpHNXhOVlFxVEFMQkZ2RXBDNDBpeEo3Y3pNQzJRdF9qV2YxVEZuYXJraWF4UVdPTm9QXzlmeXZDaTBDbS1OZ0w2dmw1WDVMZ1VxM2dfcHM0SFpUN0tLMWsyeDk3WDRtd1VBTzMzWWptNUF1WGF4bVRmRVcwWnNURDFESUp3VGtTbU1hRS1CTWVyN2VkT2Ryd0poenlPUnJPemR4OGl1bzhCRmRYb1dqY1B3ZWlCdmhFU1F5X1lYTy0wUlBscmJmdWpFTTJTblJHSUpHOTZXTjUyVlM1eWtuNnhNeFVmVEhUQzFwa1RHUm4xd1lYdHNsVlQzNmdHbUJOUXJkanMxVEVQM0NVcDVvcDFqd0lIZDdObU1vVFEySmlieUd3S0xTdFd1Y1d1RHpLZVNVWk4xeW1lSkI2aVBySmpZU3VpaFJNSUlKb1h5WWs0SWJLalBSSGZkeVBtSDlhbXgyVFUzMm1tWTJ6QnVOcnM3b1B5cVA5a3A1S1JrQ2p1UU11bDdNaWVfQW5ORmRFbnVxc2pmUVVrTVprUkFXSVhqbm1mcktSSmlYdDRZVnJWT2dUWXVsQnRxb3BjbVl3SUlmeGl5d1Axejkwb2JxNE51OHlsMUJLMzNDcVpGSmdVVU56ZkR0RVB0dlAyemd5ZXdGUC1kUEtCQVBzYnhNcW5CblB0bVZ6blNwalJnSmhLcGFPd2RCZGNYNTVOMk05MkpSUjBtWE1EQTNvNGNaenRWWkVmRU1FM3hMRDZDbWtZTWZOTFpWZ1YwanFBX1JScmpRZTJ1Q2QzZ0VhS2NDTnlocENUUXNGLThmQ0pFRnozTEtCV2JMYXZITFdYQXZ5RTBQZE5nbVBvZmQzWUF3M2NOUHBQMXNHbkZoRWVUUVFweUZvd2FCR2dyYWVuY2QxMDVJY2VFNnFWWjZGYmFvX0RXQllpSUJuNDI1NTJvc0piREx2WEl5OWhVd0ZpeEg2SGRPZVJfMkpSUVE2Q2tTM0t4cTJnQVVaYW56Rnp1RzdUNVNDM2paNGl2WXI2eEV1Y21wOHRRRU1zaXljbmhwa1R2Mkh3anRsZjcxa0U5LWlfaDBRUElXTTRBdUhSbnZ0MmE3VEh0allnalRtMk5OWlFwZFJPTnBWUkhzZVhZZG9IVTJvc0ZWS0xiYXVRaEhrOGZWcWFMRzZWVjdfMDR5ZmU2dGZxYmZtU3JkYndteHdtLTNNYzUyb0QzSFdEM1hwc1VSOW91cmNHYTdacGxlNWZtcDJQWUhZQlRpcmRKTTNCMTY5T1phWVFIY0x6RFlmYzFHNXo0NmFHQUdJdU5xTDdhVm80QThhQ2pfc1gyVE9VaDEwYVd4eXExYXV0U1JTRGdiMEU3VHExZW15eUhqdEdOWVZ6eGN4UnNqZm9hT2NmVDZ3YW9COEtNY1c4Y0xkWHhxbzNrZy1qZ1NFZkxIVkc3YXcyY3lnNVBtZDBfN0JCSldFdExWUnlFUklkQXUzcWZEX3hISlctRC1Sb1VUTnJaV2dCcnFMV2RiUmc1TlRHZE1KRDA4ZkFaNEFzMUo4LUJGUFdwV2lxM2QzUGMxbFlyV3F3SVZOUUtrRzB6RWlCSnh2TXZDR3doTnJ2dGVEaGxWS1picHBLaHotZElBOU5zSF94ZkFBNk1vWnBaLUJlZlRZZ3pidzZ1aW5heFR3N2pCR0NzeGVYU2ltYXBWeFR0SGFoWkJwUlc4VTBmZE1MZmdpTVVKY1h3ek5WWjFhOHdzS3h4akYyejlVSTA0OHMwc3lIZlJ0SXlSTko5SmVnal81T0ZXZzd0QURvSF8xQWhYSDUwRWNKX1RvbXBBWmtFV05QRlNfTXExSmFJSVgzRC1TMW1hUllDQjdVTmlfNFpzTzA3cEhYVktxeHV3UFpfdnlCNS00SThNTWVkbV9hNkJXZmRsMHlXeEtLLVM3WktIN2RSUjZYdXcyczQ2MThnUTY5eS11V0RKQzBkeW1EV0FhVFBGSm1aZFFXTlFnSGlycDh5eUlFS29oWFdqRFkwa19yd2k0cTkydmk3bDFqVnptRDM4Mm9ySUpvWER5VFJTRGZ3XzlZZExpakNjb2N2enFRMFVDTGZpODhCR1FvTHFheGZBazBZVERodGU3djdUNUt5MXpuX2VmTC1WMmVoVzlyeGo4VTctaEY5cHd5cEZuZ3pGMzFXS1k4WTc3ODhKbjViR1pjc0s1dlNKVlBjQlVzMnpPODlRdFFqRmM3Y0pMOFRaRnFDR2J0MmhONC1keGZxU243VUFucHdBM21TWHJtTDkzcnJDNS1pejdoRGxsc1JreHhWMnp3VURtaEhpV3pkVDdNWExvc05acXhDdjFTenl0RzE0NmxSY1VhTjh5d2h1Y3ZmUHBVLWVwQWRJb3NoSmhwd01NNEVjeldQLUVnX3hlTFY0bGdOTXcxTlFhbHJWVzNNdS1xMThPMnRKRWhzZGJ5V3Uxa0dIb3FpX0twY1dJckRabjQ2TVFPZkFQU0NIc09rYkh5TjRvSUNRTTBsS21MRnpudmszZmlJM1AxZi1NVFJXUGYxa0dBWmMxTTVXa2ZwbXJ3N09hbTRKQ000TmR4d3I0LVVoN1dxaGZfUlJsX1NxaXdiaTF3ek5RN01wTGRadGVnMkpfUGhCN1Z3VEJveDFFNTBxemhJR2t6czB0STFuMGppaHFCdXM1WERMT0xvUEYyMVgxSGZNaTYtWE1FY3lkN2d6V1NETUt1VW9xTzRfV2J3S0daRGJmUW13ZnpZMVAyZVFaZXIxRjlYVXZBWnpWUzhFeFVHeEtsRERKbEhKaHdGUTg4Y1Uzd3NnZDNYNFVlX3VSTUt5WDNJbzVfM1J1cXA3cUd1UV9xSUFlZk1OMHNzenU5b1pMdmR1SnF1a3FQN05PVVNKVG5XTVQ0TmM4Qkp1dXZiVXRfX3o1a0FJYmRqN2piWmhseDJwM2VKNFJEeEZoQlZGZGMwSnJRQmdVZGtiM0t2eXE2cFVPdURaVXVNSWRobVB0NnFKa2JQV190aHJCd1dISHMycG9RQlZoRXloWEdCX3NXdklrSnVRSEM3dTdrejR6MjEwaTk3RWdjeUxLSTZ1M1JtelIyczRqSDVwai16Q3lveUNoRzZTNEVILTN2N1MxLWlzMUFlbFZsVTh1cmpwMkNubTh6RndxYTYxY2dvZzc5MUJ0c3VLMGhoaFZvY0ZYaUFWd21kUGo4cEZ6eHR5V2ZCb1FaY3Y2X3RTMGRiSWltSnM1NmtZbTRmOC11N09MWDRNNUZLWV9MblNuY2NoWmtfQ2d0NEkxMkFHeWZ3SFpObzhmR1d4WXdZbWxDSTVRNzA5dnE1blNlU0Z6b2N2b3hLdHlGOU9BZzR4QV95YWYxUUFtVmRza3RrbVY4bEFiS0FyeVVwaDhqVXEzU3VFRzR0QTl0ekRPaFU4UnNoTnVncWFaYTFNRXdwR3ZfQ0ludEFmWng2WnFZZk5pZS5DenBoUWhxQkdEWHk3UVBNQXE2T3NzOVB5UXJFZmcyd0NVLUhlcWRackRB"
       }
     },
     {
@@ -133,38 +131,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:39 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "bd0a2b09-6197-494b-9a35-f9c3c89a33f0",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "00b5aed2-77e8-4927-aae2-d9914ed34b27",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secrets1973943927",
-        "deletedDate": 1642005039,
-        "scheduledPurgeDate": 1642609839,
-        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/d3be2d16a0904261bbc13beaabcddaec",
+        "deletedDate": 1642625954,
+        "scheduledPurgeDate": 1643230754,
+        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/f9f5358f1cba4794b0728f2625b2dd03",
         "attributes": {
           "enabled": true,
-          "created": 1642005039,
-          "updated": 1642005039,
+          "created": 1642625954,
+          "updated": 1642625954,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -178,7 +175,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -186,15 +183,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:39 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "843e90e5-2dd1-4070-b410-8b1c46739f91",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "ed5e6bde-9843-49a8-8f86-274dc5693ee2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -215,7 +212,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -223,15 +220,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:39 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "90f573a5-fd12-411a-81e5-7a4fc29d069b",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b69a10d9-1602-49f4-bdda-3a8759db1355",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -252,7 +249,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -260,15 +257,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:39 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "81f441c5-e7d2-448b-9deb-4bc7bc24ec76",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "5e788e11-bdec-405c-92de-ab9ee986ebc6",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -289,7 +286,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -297,15 +294,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:40 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "ba467cda-608d-4e4a-99aa-18ae045c718e",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "af76ee06-5a1b-4b73-91a6-c40c7717c970",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -326,7 +323,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -334,15 +331,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:40 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "6d030bc8-df7a-4b6a-a9db-9e627d788e5a",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "34dea2c7-3c68-4ccb-a8eb-7c43280d264f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -363,7 +360,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -371,15 +368,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:40 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "672185e3-1e6d-4018-8efc-2215de9391f5",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "89264e93-b81e-4710-8930-d1b0c067074c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -400,7 +397,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -408,15 +405,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:41 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "0eed24c5-3591-4287-ac47-ed27d61517e9",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "bce1519d-0366-437e-a5db-0029ba1669ae",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -437,149 +434,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "91",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:41 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "01ad5b47-5024-43ff-9fd0-ea0d1587f0ba",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "SecretNotFound",
-          "message": "Deleted Secret not found: secrets1973943927"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secrets1973943927?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/deletedsecrets/secrets1973943927?api-version=7.2",
-        ":scheme": "https",
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "91",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:41 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "4ced0496-1fce-4211-8a22-3e1cfb913c85",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "SecretNotFound",
-          "message": "Deleted Secret not found: secrets1973943927"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secrets1973943927?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/deletedsecrets/secrets1973943927?api-version=7.2",
-        ":scheme": "https",
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "91",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:42 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "d2a6ff61-9186-4bef-a780-b595f12e010b",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "SecretNotFound",
-          "message": "Deleted Secret not found: secrets1973943927"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secrets1973943927?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/deletedsecrets/secrets1973943927?api-version=7.2",
-        ":scheme": "https",
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:42 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "0c2a0dd4-d4df-4488-b536-53f59ad7149c",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "a986dc89-925c-467a-922b-3e01a12be66e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secrets1973943927",
-        "deletedDate": 1642005039,
-        "scheduledPurgeDate": 1642609839,
-        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/d3be2d16a0904261bbc13beaabcddaec",
+        "deletedDate": 1642625954,
+        "scheduledPurgeDate": 1643230754,
+        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/f9f5358f1cba4794b0728f2625b2dd03",
         "attributes": {
           "enabled": true,
-          "created": 1642005039,
-          "updated": 1642005039,
+          "created": 1642625954,
+          "updated": 1642625954,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -593,21 +478,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:42 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "ca8518d4-2aab-4adc-a5f4-8605bd75510d",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "5df21857-5442-4754-8bbb-0b99ee61f0ac",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null
@@ -623,7 +508,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -631,15 +516,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "314",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:42 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "f6d9ebcb-9e27-4e9b-b451-6567d397eacc",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4f49c1b8-21da-4e93-9d6d-3637ec9d3699",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -660,7 +545,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -668,15 +553,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:42 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "7a3e6419-7efd-4208-9d0f-1a38bc528310",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "680403a1-42ed-4f7e-9c57-4538f35f289e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -699,37 +584,36 @@
         "Authorization": "Sanitized",
         "Content-Length": "4956",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
-        "value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUl5WVdabU5tRmhNUzAzTm1Ka0xUUTBZVGN0WVRjek5DMDJaalZoWkRCaU5XRTRPVGdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQzB5TlRZaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuUG42bXVldy1xT3BYb01Celh2c1BTWHIxbnlDQm9DTWF1YXpfYUJSUU5zVFRKLWh1MDc5Vy1ZZEtpRENFTkE0dnVYMHZ0QS1qYUthTk5IRGtNaUhWN0VmN3UxYWMxYWxWaVcxU0FlTC1aalZiNmFFZTR1YXFTZFd4cXdvNG4zVTdGOWpRZ2dTc2IyVHFFdkFKVGJEeDI0OE5ncGJQOFB0NzhqZmtEMTc2b3pGQ3BhbUFKSzNFeTh1TXZkRFN3c2Mzc21MQVJ2V3hPLUhQQU9YOHhiU0NfTWllWWlmVGVMQ2JQZ1NWYVBKV2lwT3o4bVNqTFVJdS03MFZzdGZyT2FqaUJfeXEweVhOOGJpbG5JaFhmSTlUUnZqXzFkTkNRSWNmQ3hsZm5SWS1FaTFvc0Q1bnJOWHJEX0tmNFF4am9RRXB4emc4eVNuSVpob3RmTHZQSlVfVlRBLjJBeGI5SW9xdzFIaTJucjd0d1FMZUEuaC1KZUJUS05zWE82WGtJVVA2SWd5RWlTR2VXeHRwdlBJSU94U0pGM0V3MWRPM1d6bXplYkxrRWFhemN4WU1uOXlsQklrTncxV2JVMGVNWGtreFJ4YWU5N3dCTm5kZ2FKMURDVDJiNWxldVVjd0p6TTB6azBJNm1wYWtEelZ5UUwtMF9IMW9PVUY5RXFKdk9tQVlad01zbzJtOEp2cVE0R21tVm92MHJKRnlLRF9QSmpYVmRxN3UzQ3RNUXF1N2o5RGNyRF9FZ1RGUVJmRGpoWWphOVNzUVd1Z1pEZTNBbUZ1S0dNcUZzQUx4V0JrdndxeklJNEdTSExMOU02bWtVd1hLelJwWkVPVmt5Nmd2ZW9IVTUtTUJZQUEyeGV5dmpvUkUxUTFrUk4tQU9FT04xdUF6UnlPbUw1VnFtRTB4c095RmkwYV9fQ0s5bzZMYXlDVU91bnEwRl9xcGJEUkpRcFB3RW1zMU10NU5BQkpPbDNXMnBrQWJnYzNlSHpEN25PbW1HWktoMkRoRXZRd2p0SnE0dE1VWF9zek0wRnY2R1Frd3Rib3kxRW5OZ2FLU1RFUGJaZExCZEJqNVNFMmRQT1lVLWpOT3pBQW9zTWZuUzJkUDJQSWUtZWhsRnQxZmR6VWZ2SDk0eHFRSkw2c0YySFFsUENPeXJWT292TVhzMDVwWGxhOWptMGlFQjJmVFh1WUwtVVNzcFZ2aGhoeVFXekR1cUNtU0dJZ1JlbkY5ZERvT3dqc3ptbDA0WHF5QWhNT25ES2ZHdWZLdzBYNi1XcnFTSGt4enFDQXlqcXh5NlNpTkJVY0V5bDRWZ01aTElRb2NvdHN4bWdqeFRsMXRJUGpvTmR1bXRxSXBnODg3MFBfQ3ZYcG5jLUpRaURudVhaUFZWRl90RnBkS3NiUEh5UWFXbVZqTVFOdXVkNEpXUUNsbDQwYjRxVGhGZ2ZOdVdqbzZ2M3J4bE95R2d4c0Z1NzEta3lJblktY00yZXlNdHVxVHZnbGxqcl9tbl9GSWI3ZEdSTlBDM3JabDB6VXA0VEl3NE5SWDI0Ynd2MmdmY0ljdm1UdnhWV2tNbUdlXy1uOFhyeW9COFFLNU1FT0pOV2J5TU5HQVZYVmh0S2hWTy1KNWxpYklIZ3Njb1czNW9zTnJqVzFjTTVDY2M4eENsQ3hsc0RCTEVXbHFRQnFvcmVLNnZPaDhlRDc0ZUdCZlBic2tZYWc0UFV6ZXAxNzdCaDJlV2lJUlpUVWhuemJiOFQwbURyUEVJRTVya3ZxYldZU3NfTl9ZRVBXTFNWbTNjeHFVcmIwQkJUSXE0VXJWMGdVM0IyYTF4Tk5YcUNhckNlTXBYN3A0UF9OQ2J6cHVHSkpzZTk1ZmxIVThITWZnSkhNUXMzSGpLQkU0dGRIUnFrdGpuQVVvb0phaUwyb0pzLXNVeTIwTVNkUHVYcTRnclhOMWpIdzU5X085aWdaaExEYzd2SHYtaC1rRHNEOXpXRnFCRklrQXpZOXdrc1VZQTZNaEQzOEFVV0ZoNEk5NjNxM0dxYXRfNWc1YmFKRTZsaDE4MHh5aHdfS2FZd3RTUDlMZWp4V05sT1gtXzZpaTR3eXFjblVzQjV2eWlQRU9Gd3RDbWxIQnA3YVI1b0NDenZsWkp4cHQ1eU4tWTh2dWhSSW9WMFVvZ1AzRzVhdTRaRDZnSzlWQ2hhZTNJT3hnejl3M1g0ZkRSZlVpNjZaSmNndlBUby1QYzVZYUx1eUxDSlhVdktxVFE2WHdjb3d3UER4TXo5SmVrS2oyTFZlZXZ3WEhiVlExdVZrVFl0WGRBQS1CWFNhcDl2MXdCV3ZDT3VsWDNUeWstSEJSTkp3d1ZaRnQtTkRIVlZKZEFlZDRuTzl6b0V5cjJTdFpCSVJSMkdDUzBKcUR0UWx3eE4tVkJ5RXpPMEJ5WEdFSWZZWDlVSl9OSnprc0k3UFZFVGFDY3RPbmM2OEdjeDVwSjlEWWkwWVQtN3RfR3Njb2tJQWJHejBNYmRlQ1VhcTc1VmlZS29nX1N4MWdSTzFnU1RqMXNoVXJUSHE1cVV5SEtueGNrNjJ6UWpfVDlDZnlPMngxaWcyS2NyWVptVElyTTJCT1AtREQyeGFjRWFDM3BCeWpsT29tajk3YlNqN2xENGFRdkFjcGpGTnpVaWx3N3paVnhyZlhGQXhIc21ySWRERmtWWU5TREZfb051NXdKLXBIcEptMERuckRPNnBxTU5WVTJHMmRvNjJjb3RRbVUxV041RjBUMnNGeDhkVmxoOEtPNXRyeGQ1blBJS1ZDUzFYb1NBalhfczJ3LXFQWkRHc09vTHdpRDk4NTFSQ1prclJHOGh0ZTB2SnlibXpTc2dTMlg3M1pXRXdPU01RRjdBbUc3Q1BSUGQ3VGp2cnNNMFFvTmVleGxpZUdsU0dGUy1xNTZiaUZublB1ckMzWHU1MzJDWVhDNjBMZEl6bVh1TGE0VGk2NGZ4QU4wdTVHSGdneDNTNmJVM0E1UE1SaE0wWU45ekR3eThuYTZrYjBWZTZKb09WSnhZeWFDaWZsTzlWTGxxeHpRU2t1NUkxdHBBOEdiMTVJaU1sUEZKV3hXY0pDbUlldDBqTzktZ3U2QXNMc19hV0QwWENGMnJ6bVd3LTVrTDRDY0dKTURvOEVLZHFrLVdKZF9YMzVRQkhIWVZyOFNxYnBrN0syN21uTlNwZENBS1FWdHEwMDl1ZG1ncU04SHJvLU4yYm5nTnhsQXBYOUdvLWFVSVJZdUJLM2tVTEQxV3l4VGhUa3ZwblNUalBCdXI5S1gxbGZQYWJXZHN3aWRTLTlYcFplNXBtV3RVa3NqXzBCSGhUYVVaN3JhdWxyRFlhSHFZZ3RlQnVqdzJOV194NFNNeWZKdEdlTVhjcEVtUzlvVTNxRUNqVUJqX2VSYjhZVF9fSWpwOGZUS1haa3B4MHpFRHdWamlYU2NiMGU4Q3RxNmYxSHB0ZEkxWHZKbmRLTGlyWW50MjlFb0VoVE1RWHRoZGZaOTc3RU9QMFZIRnc5YzNueWtLaFE0dnh2bUcyQURfWkx5S0E0SFhFeVhHT3VBT2k5c3FhcVphSTdfSWZacE13SlNlYTVUUlQwVzhTMWxQQTQxbGxBUW56YmllbGxSVTNvaWM3cmIxUmxGdUNOWUtYVGYzd0Fzb0VPRmFBWk9jX3dYWi1kVEd0QmtjR1JvRy0tLXpzWFcyQTl0QjZ4RDlTTHcxNDhQSUFPYzJ1SkVvbjVzbGdGTlpBT1ZzSGl0YXFva24xVHYzTEEwX2dBRE5pZnRYLURTdm5JdUtIYjBKSy1xSnRnOTRObWZCSWV2Vms5Z1Rsbmp5SE1GeE9BX0RpM2RIM0ZFSUdvRWdtZ0RuWlJWVnZoQmZ6YVlCMWlPb1llb2ZWemItTnZfUzUyWnNxOGlrY296aFpDcnFCN0hpSW9vRE9UV0VXWENUZjF2ak9wMG5nMDVxb081ek1XNGFwLVk1M01FMmZCN2p4TXU4eTRaWGduNGJ2dUlTS01nOGs5YW1wMHdfbE8xOVRkbWtVVERXakdiQTAxTVlwaWpDTXFZQnluM2YzV2NraEYwLWVTdEV0YVBETGdmczQ2TWlTenRKRzlKZG9NWjdUVlU0QS0ycEx3cnBFcnY5N0I4NjRBTGxNTXpTVWxmdExKN2FCbHlnR3M5cTJxdjF3UVV6a0oydXpSTnc4NDRxdTgxXy1ZR2ZERHoxY0xFMkpPbE9RRzMzeXFXUHZSODJaMFJTVHpNMV9aakRSV1FpXzFDdWdBblByWVQ5RGtIUUJHb1dzS012OEh3c292MjZ4QXJTZDRpSTkxU3VUdWlyeG4zemZsa1FuWkZieldLd2V1RnRvWGhsc3FsbHRsUFhSSkRERUtHTlNpNXZVYkpTcXR4ZmF4SWdlZ3hibWtRNWdVZHRSVXZjangwbUFJR2dhQ2dKUS1LV2Z6dllaSHJrUDRVQTZNZmQ1blNIV2cyNUpNNEVBMGhlZ25GaDlTRWZqUEd3YUlBTXVOb2VFRUlkS1YxeXlvZ1AtYXZsemVRUC1ER1BHd1pILWp2b1NUX3UzT3pObnlUaXFGRUw5c2djU2NNWVIyQzdHWFdUVHVYWnB6eGlXUEtoV0lZOGs0MFRyVjFpX3pSYUc3bzhZbkl4N1pqbGdoVnpmSU4ybnN3US5tdnVkbDZFT0p3SkdudWhTYndiSFo3blpmb2VoRHpJRmg3M2Q0X3UwMW13"
+        "value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUl5WVdabU5tRmhNUzAzTm1Ka0xUUTBZVGN0WVRjek5DMDJaalZoWkRCaU5XRTRPVGdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQzB5TlRZaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuZHRrTEl0ZkRLMDAybmRmUDJPTnd0TS1ZYTVER0tHTmlYQ2lNNy1iVHZiLUxSVTRYV09RWlVzOVg0V3pvVzJTU0NHR0FFREFVcXUybm5zMVBEQXZGUnpHS3RKNVNOeU11SnMybWpROFhiMDhiOXlnelhLcWUwNGZvYk1XQ24tU1R3YUNSNVZJYXhYbTU2Z1NaRzJCVWttREprbk1IYjJSS0FMQ0pTMjYtYXpxd3ZQMDFOeFJjYUx5OUV6SHI5bnlhcndZUG51Sk8zblU3RUVxR0ctZ0x2dS1QWDVXQUN2cnFJajEyRWJ6NmdIMEZqeFFweFZBdi1Qc1p6LWNseUZmTmI4VC1LYi1LeS1Gd3F4dHV5cHRTTzlIOW5lZHFrYmJrUmhUMVFKbjJFczZSLUdoOFlmTjQ3d0ZRZ2ktS3FYZWQtbnRncmZHQWwwbXlpLUNJazRrQjRnLmZoUzkzQ25zTWxyV2VDbnA5ZFZWYmcubkNOcDdMRzJxLXhXS3pJajZJZDBmcUx0clZpbW5fdUJ2TEdpSkhxeG1rdFJzY0M3T3QtRVA4N0RIUGZmZ25yVDM0R1F3OUk2a3ZpMjBHdW5hSkJiZGVoYktPNkllWENCUG9Ob1NWWldTaU02UGxDN2lzVS1LSnB5YWhIeWJHXzEzUlREaXhPNjV4Um0tZFhtNmtTWG9lUVJWVUw2U0hnTjhGRmVoMlRQMXhNeWdsUHlia29FMWxsQXMtQUJFb0tZbTdUZ0pxLVYyelRXRmk5WnVfUklwdlF4eTZFczZUVFotZHRPdi1fNEhPRGlwbnh0QUF1WTMtNTdObEJSNmdQZU5vcDBWdjR2M1NhelVIVlFkMkNIMzk5eVdINEVuQ044bURRZ2pnRnAxR0ZOQ3pCUktRaVNVNnRlbU40ajQ2bElwWjFST1N5UGNHR3pnc0YyMVB1bUQ0RVJQMWxJT1NrQThlb0dZazNyRHFiZm9DSG1fV0pValBNUm9zc3ludWtDam1wQkoxaUIweUd2SV9iZDlSdGM3NEs5enFycG5DOG9DLVZkUWtnQTNUeElqdFdteFpWaHJFTFE1NXlSSUM5ZDlhSlBuWmdzTU4zZkVtTC1OZTZQTlhDd2paT25KX3dTTUhqY0JnNklEeUtoSXk4SVhHX2VTOGwweXFLald3dU5aUEhtZV9vZ0dlR3hpdHdlVG5tSlFUTkpHNXhOVlFxVEFMQkZ2RXBDNDBpeEo3Y3pNQzJRdF9qV2YxVEZuYXJraWF4UVdPTm9QXzlmeXZDaTBDbS1OZ0w2dmw1WDVMZ1VxM2dfcHM0SFpUN0tLMWsyeDk3WDRtd1VBTzMzWWptNUF1WGF4bVRmRVcwWnNURDFESUp3VGtTbU1hRS1CTWVyN2VkT2Ryd0poenlPUnJPemR4OGl1bzhCRmRYb1dqY1B3ZWlCdmhFU1F5X1lYTy0wUlBscmJmdWpFTTJTblJHSUpHOTZXTjUyVlM1eWtuNnhNeFVmVEhUQzFwa1RHUm4xd1lYdHNsVlQzNmdHbUJOUXJkanMxVEVQM0NVcDVvcDFqd0lIZDdObU1vVFEySmlieUd3S0xTdFd1Y1d1RHpLZVNVWk4xeW1lSkI2aVBySmpZU3VpaFJNSUlKb1h5WWs0SWJLalBSSGZkeVBtSDlhbXgyVFUzMm1tWTJ6QnVOcnM3b1B5cVA5a3A1S1JrQ2p1UU11bDdNaWVfQW5ORmRFbnVxc2pmUVVrTVprUkFXSVhqbm1mcktSSmlYdDRZVnJWT2dUWXVsQnRxb3BjbVl3SUlmeGl5d1Axejkwb2JxNE51OHlsMUJLMzNDcVpGSmdVVU56ZkR0RVB0dlAyemd5ZXdGUC1kUEtCQVBzYnhNcW5CblB0bVZ6blNwalJnSmhLcGFPd2RCZGNYNTVOMk05MkpSUjBtWE1EQTNvNGNaenRWWkVmRU1FM3hMRDZDbWtZTWZOTFpWZ1YwanFBX1JScmpRZTJ1Q2QzZ0VhS2NDTnlocENUUXNGLThmQ0pFRnozTEtCV2JMYXZITFdYQXZ5RTBQZE5nbVBvZmQzWUF3M2NOUHBQMXNHbkZoRWVUUVFweUZvd2FCR2dyYWVuY2QxMDVJY2VFNnFWWjZGYmFvX0RXQllpSUJuNDI1NTJvc0piREx2WEl5OWhVd0ZpeEg2SGRPZVJfMkpSUVE2Q2tTM0t4cTJnQVVaYW56Rnp1RzdUNVNDM2paNGl2WXI2eEV1Y21wOHRRRU1zaXljbmhwa1R2Mkh3anRsZjcxa0U5LWlfaDBRUElXTTRBdUhSbnZ0MmE3VEh0allnalRtMk5OWlFwZFJPTnBWUkhzZVhZZG9IVTJvc0ZWS0xiYXVRaEhrOGZWcWFMRzZWVjdfMDR5ZmU2dGZxYmZtU3JkYndteHdtLTNNYzUyb0QzSFdEM1hwc1VSOW91cmNHYTdacGxlNWZtcDJQWUhZQlRpcmRKTTNCMTY5T1phWVFIY0x6RFlmYzFHNXo0NmFHQUdJdU5xTDdhVm80QThhQ2pfc1gyVE9VaDEwYVd4eXExYXV0U1JTRGdiMEU3VHExZW15eUhqdEdOWVZ6eGN4UnNqZm9hT2NmVDZ3YW9COEtNY1c4Y0xkWHhxbzNrZy1qZ1NFZkxIVkc3YXcyY3lnNVBtZDBfN0JCSldFdExWUnlFUklkQXUzcWZEX3hISlctRC1Sb1VUTnJaV2dCcnFMV2RiUmc1TlRHZE1KRDA4ZkFaNEFzMUo4LUJGUFdwV2lxM2QzUGMxbFlyV3F3SVZOUUtrRzB6RWlCSnh2TXZDR3doTnJ2dGVEaGxWS1picHBLaHotZElBOU5zSF94ZkFBNk1vWnBaLUJlZlRZZ3pidzZ1aW5heFR3N2pCR0NzeGVYU2ltYXBWeFR0SGFoWkJwUlc4VTBmZE1MZmdpTVVKY1h3ek5WWjFhOHdzS3h4akYyejlVSTA0OHMwc3lIZlJ0SXlSTko5SmVnal81T0ZXZzd0QURvSF8xQWhYSDUwRWNKX1RvbXBBWmtFV05QRlNfTXExSmFJSVgzRC1TMW1hUllDQjdVTmlfNFpzTzA3cEhYVktxeHV3UFpfdnlCNS00SThNTWVkbV9hNkJXZmRsMHlXeEtLLVM3WktIN2RSUjZYdXcyczQ2MThnUTY5eS11V0RKQzBkeW1EV0FhVFBGSm1aZFFXTlFnSGlycDh5eUlFS29oWFdqRFkwa19yd2k0cTkydmk3bDFqVnptRDM4Mm9ySUpvWER5VFJTRGZ3XzlZZExpakNjb2N2enFRMFVDTGZpODhCR1FvTHFheGZBazBZVERodGU3djdUNUt5MXpuX2VmTC1WMmVoVzlyeGo4VTctaEY5cHd5cEZuZ3pGMzFXS1k4WTc3ODhKbjViR1pjc0s1dlNKVlBjQlVzMnpPODlRdFFqRmM3Y0pMOFRaRnFDR2J0MmhONC1keGZxU243VUFucHdBM21TWHJtTDkzcnJDNS1pejdoRGxsc1JreHhWMnp3VURtaEhpV3pkVDdNWExvc05acXhDdjFTenl0RzE0NmxSY1VhTjh5d2h1Y3ZmUHBVLWVwQWRJb3NoSmhwd01NNEVjeldQLUVnX3hlTFY0bGdOTXcxTlFhbHJWVzNNdS1xMThPMnRKRWhzZGJ5V3Uxa0dIb3FpX0twY1dJckRabjQ2TVFPZkFQU0NIc09rYkh5TjRvSUNRTTBsS21MRnpudmszZmlJM1AxZi1NVFJXUGYxa0dBWmMxTTVXa2ZwbXJ3N09hbTRKQ000TmR4d3I0LVVoN1dxaGZfUlJsX1NxaXdiaTF3ek5RN01wTGRadGVnMkpfUGhCN1Z3VEJveDFFNTBxemhJR2t6czB0STFuMGppaHFCdXM1WERMT0xvUEYyMVgxSGZNaTYtWE1FY3lkN2d6V1NETUt1VW9xTzRfV2J3S0daRGJmUW13ZnpZMVAyZVFaZXIxRjlYVXZBWnpWUzhFeFVHeEtsRERKbEhKaHdGUTg4Y1Uzd3NnZDNYNFVlX3VSTUt5WDNJbzVfM1J1cXA3cUd1UV9xSUFlZk1OMHNzenU5b1pMdmR1SnF1a3FQN05PVVNKVG5XTVQ0TmM4Qkp1dXZiVXRfX3o1a0FJYmRqN2piWmhseDJwM2VKNFJEeEZoQlZGZGMwSnJRQmdVZGtiM0t2eXE2cFVPdURaVXVNSWRobVB0NnFKa2JQV190aHJCd1dISHMycG9RQlZoRXloWEdCX3NXdklrSnVRSEM3dTdrejR6MjEwaTk3RWdjeUxLSTZ1M1JtelIyczRqSDVwai16Q3lveUNoRzZTNEVILTN2N1MxLWlzMUFlbFZsVTh1cmpwMkNubTh6RndxYTYxY2dvZzc5MUJ0c3VLMGhoaFZvY0ZYaUFWd21kUGo4cEZ6eHR5V2ZCb1FaY3Y2X3RTMGRiSWltSnM1NmtZbTRmOC11N09MWDRNNUZLWV9MblNuY2NoWmtfQ2d0NEkxMkFHeWZ3SFpObzhmR1d4WXdZbWxDSTVRNzA5dnE1blNlU0Z6b2N2b3hLdHlGOU9BZzR4QV95YWYxUUFtVmRza3RrbVY4bEFiS0FyeVVwaDhqVXEzU3VFRzR0QTl0ekRPaFU4UnNoTnVncWFaYTFNRXdwR3ZfQ0ludEFmWng2WnFZZk5pZS5DenBoUWhxQkdEWHk3UVBNQXE2T3NzOVB5UXJFZmcyd0NVLUhlcWRackRB"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "251",
+        "Content-Length": "241",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:47 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "d5e3694d-8334-4964-898f-84022cb146ea",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "6125ec42-87e5-484c-98c2-469180c162c0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/d3be2d16a0904261bbc13beaabcddaec",
+        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/f9f5358f1cba4794b0728f2625b2dd03",
         "attributes": {
           "enabled": true,
-          "created": 1642005039,
-          "updated": 1642005039,
+          "created": 1642625954,
+          "updated": 1642625954,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -743,36 +627,35 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "277",
+        "Content-Length": "267",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:48 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "9a3b9f37-31e4-4ab3-a111-bfc02f27f80d",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "eafb2eaf-9472-478d-8084-a084c6220538",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value1973943927",
-        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/d3be2d16a0904261bbc13beaabcddaec",
+        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/f9f5358f1cba4794b0728f2625b2dd03",
         "attributes": {
           "enabled": true,
-          "created": 1642005039,
-          "updated": 1642005039,
+          "created": 1642625954,
+          "updated": 1642625954,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -786,38 +669,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:48 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "594d96f2-3f79-4b61-a6f9-8a93b280de6f",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "e2bd7b14-7972-4073-a225-708d76a45151",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secrets1973943927",
-        "deletedDate": 1642005048,
-        "scheduledPurgeDate": 1642609848,
-        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/d3be2d16a0904261bbc13beaabcddaec",
+        "deletedDate": 1642625963,
+        "scheduledPurgeDate": 1643230763,
+        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/f9f5358f1cba4794b0728f2625b2dd03",
         "attributes": {
           "enabled": true,
-          "created": 1642005039,
-          "updated": 1642005039,
+          "created": 1642625954,
+          "updated": 1642625954,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -831,7 +713,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -839,15 +721,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:48 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "f126e63b-d2a4-429c-97aa-b6700fa4fee6",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2c02c1aa-3bb3-4f06-8a21-72fbdf765461",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -868,7 +750,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -876,15 +758,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:48 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "5973d0bc-a8b8-4938-bdc0-8fa34cd55d43",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9a8294d6-64ab-4340-aabc-4b6843e57665",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -905,7 +787,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -913,15 +795,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:48 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:23 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "703a785d-94a4-4f0f-9268-79f9565d8934",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "3258fd3f-5ff9-41fa-8227-5c1c177e5ae0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -942,38 +824,111 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:23 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "6320c5b4-04d7-4d8c-a799-74c97380965b",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secrets1973943927"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secrets1973943927?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secrets1973943927?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:23 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "dd8a9f6c-4b10-4353-817b-f29fe498dd4e",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secrets1973943927"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secrets1973943927?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secrets1973943927?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:49 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "ab0b4732-0e93-4867-a899-b56419ce0f56",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "8068f9a8-c422-4498-990f-a47c53343f44",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secrets1973943927",
-        "deletedDate": 1642005048,
-        "scheduledPurgeDate": 1642609848,
-        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/d3be2d16a0904261bbc13beaabcddaec",
+        "deletedDate": 1642625963,
+        "scheduledPurgeDate": 1643230763,
+        "id": "https://rosebud.vault.azure.net/secrets/secrets1973943927/f9f5358f1cba4794b0728f2625b2dd03",
         "attributes": {
           "enabled": true,
-          "created": 1642005039,
-          "updated": 1642005039,
+          "created": 1642625954,
+          "updated": 1642625954,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -987,21 +942,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:49 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "51f8907d-95eb-4867-9f9d-2cae57416cf0",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "a2ecc624-d927-4a57-8598-67b50ec3bbe6",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestBeginRecoverDeletedSecret.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestBeginRecoverDeletedSecret.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:31 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -27,8 +27,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "6e74f8bc-4176-408b-bcfc-2803dbac10f8",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c9f8b7d4-1717-4a7f-85b0-699c1c1b4b8a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -49,42 +49,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "43",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value3547619827"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "276",
+        "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:31 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c7477d52-c698-424a-be20-251784145976",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2219bdaf-4f0f-4408-aa3f-59252602fe83",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value3547619827",
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/9cafe1b4014644d781ff62f4c0252a91",
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/f52d4dcbabca47d5a5597e11a74b8cae",
         "attributes": {
           "enabled": true,
-          "created": 1642005032,
-          "updated": 1642005032,
+          "created": 1642625946,
+          "updated": 1642625946,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -98,38 +96,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:31 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "37ac4f8e-2d40-47bc-8751-f19d2304da64",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "06d06627-c1ab-4d63-9fb6-067b9e034356",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret3547619827",
-        "deletedDate": 1642005032,
-        "scheduledPurgeDate": 1642609832,
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/9cafe1b4014644d781ff62f4c0252a91",
+        "deletedDate": 1642625946,
+        "scheduledPurgeDate": 1643230746,
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/f52d4dcbabca47d5a5597e11a74b8cae",
         "attributes": {
           "enabled": true,
-          "created": 1642005032,
-          "updated": 1642005032,
+          "created": 1642625946,
+          "updated": 1642625946,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -143,7 +140,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -151,15 +148,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:32 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:06 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "1afb0088-0256-412d-baca-98a03deba633",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "05d07a20-55ee-48c2-85f4-4a9b68ad0201",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -180,7 +177,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -188,15 +185,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:32 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:06 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "bb791737-4468-423b-91c7-bb9662daef59",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "8a95f7f8-22dd-449c-aad4-3c6fc967d506",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -217,7 +214,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -225,15 +222,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:32 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:06 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "396417fd-4eae-449a-8140-0fe1d7ab6b2f",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "66952612-b38c-4f8b-9252-bd9e0d955bd4",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -254,38 +251,148 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:06 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "fa8d18df-7bad-4171-abc0-5de66825f630",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3547619827"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3547619827?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3547619827?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:07 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "7caec51f-bfc6-47b5-b8b1-b975b82567b8",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3547619827"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3547619827?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3547619827?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:07 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "ba0c64a3-a064-4f28-bca6-28169992f6c0",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3547619827"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3547619827?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3547619827?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:32 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "f8be460e-21c1-4521-843a-a6245937038c",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "45cc29b1-9c38-4435-aabf-560fa771c6da",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret3547619827",
-        "deletedDate": 1642005032,
-        "scheduledPurgeDate": 1642609832,
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/9cafe1b4014644d781ff62f4c0252a91",
+        "deletedDate": 1642625946,
+        "scheduledPurgeDate": 1643230746,
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/f52d4dcbabca47d5a5597e11a74b8cae",
         "attributes": {
           "enabled": true,
-          "created": 1642005032,
-          "updated": 1642005032,
+          "created": 1642625946,
+          "updated": 1642625946,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -300,35 +407,34 @@
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "250",
+        "Content-Length": "240",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:33 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "5007b8c1-918a-43cf-ad05-90835790e7d5",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "efa0b965-f959-4c32-92c1-025ef897a72d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/9cafe1b4014644d781ff62f4c0252a91",
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/f52d4dcbabca47d5a5597e11a74b8cae",
         "attributes": {
           "enabled": true,
-          "created": 1642005032,
-          "updated": 1642005032,
+          "created": 1642625946,
+          "updated": 1642625946,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -342,7 +448,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -350,15 +456,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "313",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:33 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c83f3f4a-1c61-4742-9d74-244dcd462c2a",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "8f66e715-2f73-4fe2-b607-722c389cd8d2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -379,7 +485,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -387,15 +493,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "313",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:33 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "4825e638-3ca1-45b6-940a-abe6ac75719d",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2870c4c9-c74c-4284-84bf-160054597b5b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -416,7 +522,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -424,15 +530,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "313",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:33 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "135deef5-7434-40ba-93be-a32c0325209f",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2fb93ed0-fc33-4cc2-aa49-9f74598c0f0d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -453,7 +559,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -461,15 +567,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "313",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:33 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "b2900c67-82d7-416c-b221-d0f0bb9d6c01",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "df5757cf-fe66-4dc9-bba5-e9b4bb2906b4",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -490,36 +596,183 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "313",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:10 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b5ae1335-14ad-4854-b317-acf3f209a78c",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "A secret with (name/id) secret3547619827 was not found in this key vault. If you recently deleted this secret you may be able to recover it using the correct recovery command. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret3547619827/?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/secrets/secret3547619827/?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "313",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:10 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4e2c6980-e810-4c46-b515-66dfd2ab0346",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "A secret with (name/id) secret3547619827 was not found in this key vault. If you recently deleted this secret you may be able to recover it using the correct recovery command. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret3547619827/?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/secrets/secret3547619827/?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "313",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:10 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4bafca72-7a19-488d-a6ed-10f37386b977",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "A secret with (name/id) secret3547619827 was not found in this key vault. If you recently deleted this secret you may be able to recover it using the correct recovery command. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret3547619827/?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/secrets/secret3547619827/?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "313",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:11 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "74151c83-f92f-4e4f-96d8-7236c9dc3655",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "A secret with (name/id) secret3547619827 was not found in this key vault. If you recently deleted this secret you may be able to recover it using the correct recovery command. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret3547619827/?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/secrets/secret3547619827/?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "276",
+        "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:35 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "cd7d25ed-2fa0-4bb5-a147-ecfa06168b9c",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "e3f14034-3691-487d-9053-392cb493cc3f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value3547619827",
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/9cafe1b4014644d781ff62f4c0252a91",
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/f52d4dcbabca47d5a5597e11a74b8cae",
         "attributes": {
           "enabled": true,
-          "created": 1642005032,
-          "updated": 1642005032,
+          "created": 1642625946,
+          "updated": 1642625946,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -533,36 +786,35 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "276",
+        "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:35 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c4c62a78-ae8e-4d68-8ae9-38a342ce6b2d",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9ad7f2db-b9ee-48ce-89ff-30ed40fbd6df",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value3547619827",
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/9cafe1b4014644d781ff62f4c0252a91",
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/f52d4dcbabca47d5a5597e11a74b8cae",
         "attributes": {
           "enabled": true,
-          "created": 1642005032,
-          "updated": 1642005032,
+          "created": 1642625946,
+          "updated": 1642625946,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -576,42 +828,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "43",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value3547619827"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "276",
+        "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:35 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "e54bcf10-509c-4125-bc04-f51f205fde48",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "e06364d8-5abd-4246-a63a-6fd76ffdcbec",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value3547619827",
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/5cbfbfca896147aa87188d81d7e18424",
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/733584f02ea24389aa2a248b64cd7a2a",
         "attributes": {
           "enabled": true,
-          "created": 1642005035,
-          "updated": 1642005035,
+          "created": 1642625952,
+          "updated": 1642625952,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -625,36 +875,35 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "276",
+        "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:35 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "7bb3bab8-0e08-429d-8b3a-e8942df48eba",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "dc04fe90-c89f-4db8-92f6-dc53db01e08c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value3547619827",
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/5cbfbfca896147aa87188d81d7e18424",
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/733584f02ea24389aa2a248b64cd7a2a",
         "attributes": {
           "enabled": true,
-          "created": 1642005035,
-          "updated": 1642005035,
+          "created": 1642625952,
+          "updated": 1642625952,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -668,38 +917,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:36 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "f8c37dd3-a1e1-4474-a275-c2a71dfed59b",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b992d670-806f-4acf-badc-19192b2abc82",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret3547619827",
-        "deletedDate": 1642005035,
-        "scheduledPurgeDate": 1642609835,
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/5cbfbfca896147aa87188d81d7e18424",
+        "deletedDate": 1642625952,
+        "scheduledPurgeDate": 1643230752,
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/733584f02ea24389aa2a248b64cd7a2a",
         "attributes": {
           "enabled": true,
-          "created": 1642005035,
-          "updated": 1642005035,
+          "created": 1642625952,
+          "updated": 1642625952,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -713,7 +961,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -721,15 +969,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:36 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "2976cfdd-b565-4601-96f6-836482dbe504",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9b5d1848-6a39-4182-b0dc-9b0eaf13366e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -750,7 +998,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -758,15 +1006,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:36 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "19babda0-233f-429d-b535-95b7e2dd74e0",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "14ce95f0-1d55-4daf-9c0b-347bf604ec19",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -787,7 +1035,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -795,15 +1043,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:36 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "8fee3196-93dc-4d2f-8f84-4ba9c5e70c58",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "18724f98-69d4-4e05-96ef-c358b3d79b69",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -824,7 +1072,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -832,15 +1080,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:36 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "561d4784-4fd4-45d5-8cc6-a9489c3e5446",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "e9265eca-ca5a-412f-b476-d957fc6350e5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -861,149 +1109,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "90",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:37 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "169c21e6-f172-4f34-a5ed-bc3f96b5cb58",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "SecretNotFound",
-          "message": "Deleted Secret not found: secret3547619827"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3547619827?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/deletedsecrets/secret3547619827?api-version=7.2",
-        ":scheme": "https",
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "90",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:37 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "64c9bca4-6c2e-484c-b870-671b7d374cdf",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "SecretNotFound",
-          "message": "Deleted Secret not found: secret3547619827"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3547619827?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/deletedsecrets/secret3547619827?api-version=7.2",
-        ":scheme": "https",
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "90",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:37 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "622a9d76-187a-4ac9-bb72-bb8a9592ea91",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "SecretNotFound",
-          "message": "Deleted Secret not found: secret3547619827"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3547619827?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/deletedsecrets/secret3547619827?api-version=7.2",
-        ":scheme": "https",
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:38 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "5266e272-26e6-4317-a17e-f0b1e2e80fe1",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c4c239a0-9290-41e9-8170-a3bfe116ad71",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret3547619827",
-        "deletedDate": 1642005035,
-        "scheduledPurgeDate": 1642609835,
-        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/5cbfbfca896147aa87188d81d7e18424",
+        "deletedDate": 1642625952,
+        "scheduledPurgeDate": 1643230752,
+        "id": "https://rosebud.vault.azure.net/secrets/secret3547619827/733584f02ea24389aa2a248b64cd7a2a",
         "attributes": {
           "enabled": true,
-          "created": 1642005035,
-          "updated": 1642005035,
+          "created": 1642625952,
+          "updated": 1642625952,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -1017,21 +1153,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:38 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "64a9f323-6fce-404c-9acb-626e4e84b4cc",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "1a936f9f-bd79-45e0-be28-0501f10ba385",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestDeleteSecret.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestDeleteSecret.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:23 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -27,8 +27,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "205b907b-24e8-438f-8d58-26fa6d4bf79c",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "344ee149-9f74-4cfc-82d7-625dd66ddf49",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -49,42 +49,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "43",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value1641844154"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "276",
+        "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:24 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "d6b82111-e0d1-4e8b-b8eb-9490db015236",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "63c8448e-5e23-4e82-be10-eb5a648aaf20",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value1641844154",
-        "id": "https://rosebud.vault.azure.net/secrets/secret1641844154/195edc68515e4e5aba977ae2a9cfe917",
+        "id": "https://rosebud.vault.azure.net/secrets/secret1641844154/824bdc23b571424f93527e0d22914c88",
         "attributes": {
           "enabled": true,
-          "created": 1642005024,
-          "updated": 1642005024,
+          "created": 1642625938,
+          "updated": 1642625938,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -98,38 +96,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:24 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "8b2b817f-2f3f-4d45-8e31-5c693fabc6ad",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "bb472022-0b53-4d7f-9182-01057efcd7b5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret1641844154",
-        "deletedDate": 1642005024,
-        "scheduledPurgeDate": 1642609824,
-        "id": "https://rosebud.vault.azure.net/secrets/secret1641844154/195edc68515e4e5aba977ae2a9cfe917",
+        "deletedDate": 1642625938,
+        "scheduledPurgeDate": 1643230738,
+        "id": "https://rosebud.vault.azure.net/secrets/secret1641844154/824bdc23b571424f93527e0d22914c88",
         "attributes": {
           "enabled": true,
-          "created": 1642005024,
-          "updated": 1642005024,
+          "created": 1642625938,
+          "updated": 1642625938,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -143,7 +140,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -151,15 +148,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:24 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "58a3f3c2-5ca7-450f-8c21-ee384e9d278c",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4699febc-5347-4ccd-b300-9c88392d6a46",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -180,7 +177,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -188,15 +185,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:24 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "b32f3fc9-ba0c-4998-b740-9fb62a45f029",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "dd0894b7-7f50-4ae2-8a3a-cdb2b7527d5e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -217,7 +214,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -225,15 +222,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:24 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "e333a06d-2c90-4106-bc86-56410c74eefe",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "3df0aa6c-775f-4430-96ae-d302d49c4f04",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -254,7 +251,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -262,15 +259,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:25 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "9a822a96-0e4c-4396-bd5a-d517e5ce27fe",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "f876fd9e-467a-49b0-9fca-3b3459c9ab54",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -291,7 +288,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -299,15 +296,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:25 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "350d4c39-1441-4c6f-9cd2-d206fe026578",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "8e69509a-22d4-4438-8dbb-693d9c931e04",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -328,38 +325,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:25 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "2b0eca98-9c03-466d-b30b-0d09534fe854",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "66dfb11d-232e-40d6-a201-6851310b5737",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret1641844154",
-        "deletedDate": 1642005024,
-        "scheduledPurgeDate": 1642609824,
-        "id": "https://rosebud.vault.azure.net/secrets/secret1641844154/195edc68515e4e5aba977ae2a9cfe917",
+        "deletedDate": 1642625938,
+        "scheduledPurgeDate": 1643230738,
+        "id": "https://rosebud.vault.azure.net/secrets/secret1641844154/824bdc23b571424f93527e0d22914c88",
         "attributes": {
           "enabled": true,
-          "created": 1642005024,
-          "updated": 1642005024,
+          "created": 1642625938,
+          "updated": 1642625938,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -373,38 +369,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:25 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c4a41c6d-479b-4835-b920-dfc00704fa8e",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "0329c94b-a9f9-4233-a111-747517448c89",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret1641844154",
-        "deletedDate": 1642005024,
-        "scheduledPurgeDate": 1642609824,
-        "id": "https://rosebud.vault.azure.net/secrets/secret1641844154/195edc68515e4e5aba977ae2a9cfe917",
+        "deletedDate": 1642625938,
+        "scheduledPurgeDate": 1643230738,
+        "id": "https://rosebud.vault.azure.net/secrets/secret1641844154/824bdc23b571424f93527e0d22914c88",
         "attributes": {
           "enabled": true,
-          "created": 1642005024,
-          "updated": 1642005024,
+          "created": 1642625938,
+          "updated": 1642625938,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -418,21 +413,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:26 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c7bc98f9-df0c-4399-a0e9-05a336d7c740",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b54a5d24-6861-4674-81d4-da3e534daefd",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null
@@ -448,7 +443,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -456,15 +451,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "313",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:26 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "d2c89b67-636b-4c48-8409-b9bc6d842add",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "141d90ca-9ae7-47c5-84e9-815289da9d5e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestListDeletedSecrets.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestListDeletedSecrets.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:17 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -27,8 +27,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "b90b29f3-5a19-40b5-81b3-a1fe6a7c45fa",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "d22f3b10-1414-424d-ab2f-434bd57ffe63",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -49,42 +49,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "54",
+        "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value13245351623"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "278",
+        "Content-Length": "268",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:18 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "06e9c798-d236-4fa6-875b-325ec24688a1",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "31bcb898-ed5e-4d9d-b4a0-cdb9af41a592",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value13245351623",
-        "id": "https://rosebud.vault.azure.net/secrets/secret13245351623/0674104e1e634317af54759a977ea624",
+        "id": "https://rosebud.vault.azure.net/secrets/secret13245351623/9acbdb574c4448748a035fcfa0dfca77",
         "attributes": {
           "enabled": true,
-          "created": 1642005018,
-          "updated": 1642005018,
+          "created": 1642625929,
+          "updated": 1642625929,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -98,42 +96,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "54",
+        "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value23245351623"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "278",
+        "Content-Length": "268",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:18 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "41a8bf59-7dc2-4f17-92ff-0fe4fb72614f",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "d85f107b-920b-4f10-9987-e9026f765207",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value23245351623",
-        "id": "https://rosebud.vault.azure.net/secrets/secret23245351623/609baa700bde487c938c40321a4a1b5e",
+        "id": "https://rosebud.vault.azure.net/secrets/secret23245351623/47ee68797eef46b68a05579af24f03c7",
         "attributes": {
           "enabled": true,
-          "created": 1642005019,
-          "updated": 1642005019,
+          "created": 1642625929,
+          "updated": 1642625929,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -147,38 +143,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:18 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "f1a15936-6f35-4742-833c-63b3bf6e1017",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "f0be2a50-c7f0-436a-98f6-e7c52ccb5159",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret13245351623",
-        "deletedDate": 1642005019,
-        "scheduledPurgeDate": 1642609819,
-        "id": "https://rosebud.vault.azure.net/secrets/secret13245351623/0674104e1e634317af54759a977ea624",
+        "deletedDate": 1642625929,
+        "scheduledPurgeDate": 1643230729,
+        "id": "https://rosebud.vault.azure.net/secrets/secret13245351623/9acbdb574c4448748a035fcfa0dfca77",
         "attributes": {
           "enabled": true,
-          "created": 1642005018,
-          "updated": 1642005018,
+          "created": 1642625929,
+          "updated": 1642625929,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -192,7 +187,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -200,15 +195,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:19 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "f40b3414-aa38-4c56-8d89-9099b32c33e1",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "5a0c81cc-8ec7-4488-8c78-6fe69c2dc858",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -229,7 +224,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -237,15 +232,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:19 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "2742da37-5867-4cd8-bbba-195b3226e583",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "3bb62831-cbe5-48f1-8b4f-c9dc7785ff08",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -266,7 +261,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -274,15 +269,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:19 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:50 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c9131d9d-d233-4dd5-a3bb-0e9ee7ecb38a",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9e445ef4-aef5-4798-966a-84c02771accf",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -303,38 +298,370 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:50 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "40c14017-b2d3-4343-b779-9f10910c1ae0",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret13245351623"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret13245351623?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret13245351623?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:51 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "599507b0-f913-48c3-9293-8fa03ff66a87",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret13245351623"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret13245351623?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret13245351623?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:51 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "24ceda3e-84d4-4116-9a05-773597e20140",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret13245351623"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret13245351623?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret13245351623?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:51 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "d622af8e-4eed-400c-a89b-b0562d86dcda",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret13245351623"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret13245351623?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret13245351623?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:52 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "d2982e00-075c-450a-8466-fc66d519286b",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret13245351623"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret13245351623?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret13245351623?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:52 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b2e888e4-70af-4d28-9f5a-e8625df8ed6a",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret13245351623"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret13245351623?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret13245351623?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:53 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9f3c5589-aa42-47bf-91ec-efa92029cb2b",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret13245351623"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret13245351623?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret13245351623?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:53 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "fc2b51da-caf5-44ce-933c-66f82a015c47",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret13245351623"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret13245351623?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret13245351623?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:53 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "ddf166b6-4c7a-4ce8-8fc1-5fd5fc04b6bd",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret13245351623"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret13245351623?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret13245351623?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:19 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "4fbaffa1-70eb-419e-a4e8-ed10f6568b0d",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "e29c96fd-bc87-4da3-bb46-2757f14f97f5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret13245351623",
-        "deletedDate": 1642005019,
-        "scheduledPurgeDate": 1642609819,
-        "id": "https://rosebud.vault.azure.net/secrets/secret13245351623/0674104e1e634317af54759a977ea624",
+        "deletedDate": 1642625929,
+        "scheduledPurgeDate": 1643230729,
+        "id": "https://rosebud.vault.azure.net/secrets/secret13245351623/9acbdb574c4448748a035fcfa0dfca77",
         "attributes": {
           "enabled": true,
-          "created": 1642005018,
-          "updated": 1642005018,
+          "created": 1642625929,
+          "updated": 1642625929,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -348,38 +675,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:19 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "03ab0175-a55f-463a-a704-a66aaf258389",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "09f343ce-8fcd-48ec-b943-4e0efbd15818",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret23245351623",
-        "deletedDate": 1642005020,
-        "scheduledPurgeDate": 1642609820,
-        "id": "https://rosebud.vault.azure.net/secrets/secret23245351623/609baa700bde487c938c40321a4a1b5e",
+        "deletedDate": 1642625934,
+        "scheduledPurgeDate": 1643230734,
+        "id": "https://rosebud.vault.azure.net/secrets/secret23245351623/47ee68797eef46b68a05579af24f03c7",
         "attributes": {
           "enabled": true,
-          "created": 1642005019,
-          "updated": 1642005019,
+          "created": 1642625929,
+          "updated": 1642625929,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -393,7 +719,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -401,15 +727,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:20 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "9371f3ad-d2ea-4c3d-8294-8896135efa07",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "220a7d74-ac75-4928-8287-3a822da0d10d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -430,7 +756,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -438,15 +764,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:20 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "33eeaca2-f8f7-41b4-adb0-04d9ad091125",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "ab3db531-a2e1-4b33-91f0-d77791633b51",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -467,7 +793,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -475,15 +801,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:20 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "2a6f4ee7-0ee6-4090-a396-8f4cfb263459",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9a4bc50f-69eb-4961-b20e-e9e918537e72",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -504,7 +830,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -512,15 +838,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:20 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c865416f-080e-4512-98e9-ca0c65e70755",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "83074f14-c2f2-4f74-ac61-2dcebd8259d2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -541,7 +867,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -549,15 +875,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:21 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "bb672e35-dd7a-4286-a10f-e341cf0934ae",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "0ead9cf2-538c-45fb-82d1-06ebdeb5ef48",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -578,7 +904,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -586,15 +912,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:21 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "5f21370b-39db-481c-8428-6e2b8ceb70cf",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9fead637-8206-4887-bbfb-724f2a586961",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -615,7 +941,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -623,15 +949,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:21 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:56 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "043d8a0f-439e-4d30-a770-43dac52cc6c8",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "dab7fb0f-c33e-42ad-9c51-7019d7eab7fa",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -652,7 +978,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -660,15 +986,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:22 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:56 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "4bf28087-7993-4ec5-a886-3e72e37004ea",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "43988bcf-6975-4438-9701-433c8d6b60df",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -689,7 +1015,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -697,15 +1023,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:22 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:56 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "363b02a4-885e-47b0-aa5e-8d182f96ad5a",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4b810118-48be-4974-a3ff-6f90b6074677",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -726,38 +1052,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:22 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "a986b23b-9df8-4fe6-b779-61bc93c62da9",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "ccaca9a3-e362-46ca-a3e7-078762f9d775",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret23245351623",
-        "deletedDate": 1642005020,
-        "scheduledPurgeDate": 1642609820,
-        "id": "https://rosebud.vault.azure.net/secrets/secret23245351623/609baa700bde487c938c40321a4a1b5e",
+        "deletedDate": 1642625934,
+        "scheduledPurgeDate": 1643230734,
+        "id": "https://rosebud.vault.azure.net/secrets/secret23245351623/47ee68797eef46b68a05579af24f03c7",
         "attributes": {
           "enabled": true,
-          "created": 1642005019,
-          "updated": 1642005019,
+          "created": 1642625929,
+          "updated": 1642625929,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -771,54 +1096,52 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "739",
+        "Content-Length": "719",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:22 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "e2e582d2-c5a6-46db-979f-b0300c6d65f5",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "3f96f12e-d683-46aa-9442-5882a243cd6a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": [
           {
             "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret13245351623",
-            "deletedDate": 1642005019,
-            "scheduledPurgeDate": 1642609819,
+            "deletedDate": 1642625929,
+            "scheduledPurgeDate": 1643230729,
             "id": "https://rosebud.vault.azure.net/secrets/secret13245351623",
             "attributes": {
               "enabled": true,
-              "created": 1642005018,
-              "updated": 1642005018,
+              "created": 1642625929,
+              "updated": 1642625929,
               "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
               "recoverableDays": 7
-            },
-            "tags": {}
+            }
           },
           {
             "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret23245351623",
-            "deletedDate": 1642005020,
-            "scheduledPurgeDate": 1642609820,
+            "deletedDate": 1642625934,
+            "scheduledPurgeDate": 1643230734,
             "id": "https://rosebud.vault.azure.net/secrets/secret23245351623",
             "attributes": {
               "enabled": true,
-              "created": 1642005019,
-              "updated": 1642005019,
+              "created": 1642625929,
+              "updated": 1642625929,
               "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
               "recoverableDays": 7
-            },
-            "tags": {}
+            }
           }
         ],
         "nextLink": null
@@ -835,21 +1158,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:23 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c6956520-8766-4988-855c-0a0d4bebd5e5",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4e0a0e2b-f00a-444e-82c3-57e184fc709f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null
@@ -865,21 +1188,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:23 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c402f336-8e00-452a-8c9e-deb2bd8a4d9b",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4b95b319-b339-4588-8903-e09840f9bad0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestListSecretVersions.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestListSecretVersions.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:03 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:18 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -27,8 +27,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "a7c81bed-c373-4bec-b78b-741b07e14272",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "360b7fb9-5c36-45d2-858c-36d1376b7d0a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -49,42 +49,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "43",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value2628844972"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "276",
+        "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:03 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:18 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "8b1b18e4-daa9-4539-ab3c-c3211a21bb34",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c7dbf958-e432-4c0c-ae5b-70dcbfc100ea",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value2628844972",
-        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/a22c8cd41dc0407493a305832cb38559",
+        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/449dea31db0b4793a46afce5a32d6915",
         "attributes": {
           "enabled": true,
-          "created": 1642005004,
-          "updated": 1642005004,
+          "created": 1642625898,
+          "updated": 1642625898,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -98,42 +96,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "54",
+        "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value26288449721"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "277",
+        "Content-Length": "267",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:03 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:18 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "d56b2b55-32a5-4b52-8c05-c31c631074ef",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "ee63fef3-0ed1-4855-a092-140253344843",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value26288449721",
-        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/cca9fdecd4a24a3eb8001d96087b4517",
+        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/63cbcd25301d429ba5290077c6978f0c",
         "attributes": {
           "enabled": true,
-          "created": 1642005004,
-          "updated": 1642005004,
+          "created": 1642625899,
+          "updated": 1642625899,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -147,42 +143,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "54",
+        "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value26288449722"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "277",
+        "Content-Length": "267",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:04 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "487a4259-c663-4193-934e-c7a261ec54e2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "3e0f93ae-d02b-44f3-b93f-bcce94f9c138",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value26288449722",
-        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/078450a9056442b3b4e560504bab42f0",
+        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/81707064389446b08884b40a5d0ce8fb",
         "attributes": {
           "enabled": true,
-          "created": 1642005004,
-          "updated": 1642005004,
+          "created": 1642625899,
+          "updated": 1642625899,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -196,59 +190,56 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "780",
+        "Content-Length": "750",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:04 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "5c81be11-6d98-4cd0-99a5-dc7b8498bd8d",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "8591ae0f-9981-4a19-ae81-a918726c86be",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/078450a9056442b3b4e560504bab42f0",
+            "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/449dea31db0b4793a46afce5a32d6915",
             "attributes": {
               "enabled": true,
-              "created": 1642005004,
-              "updated": 1642005004,
+              "created": 1642625898,
+              "updated": 1642625898,
               "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
               "recoverableDays": 7
-            },
-            "tags": {}
+            }
           },
           {
-            "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/a22c8cd41dc0407493a305832cb38559",
+            "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/63cbcd25301d429ba5290077c6978f0c",
             "attributes": {
               "enabled": true,
-              "created": 1642005004,
-              "updated": 1642005004,
+              "created": 1642625899,
+              "updated": 1642625899,
               "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
               "recoverableDays": 7
-            },
-            "tags": {}
+            }
           },
           {
-            "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/cca9fdecd4a24a3eb8001d96087b4517",
+            "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/81707064389446b08884b40a5d0ce8fb",
             "attributes": {
               "enabled": true,
-              "created": 1642005004,
-              "updated": 1642005004,
+              "created": 1642625899,
+              "updated": 1642625899,
               "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
               "recoverableDays": 7
-            },
-            "tags": {}
+            }
           }
         ],
         "nextLink": null
@@ -265,38 +256,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:04 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "9e918746-650a-4611-8422-1c4ac2f1214a",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "0b741ec4-0f38-4adb-84ef-d8cb1d509a1e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret2628844972",
-        "deletedDate": 1642005004,
-        "scheduledPurgeDate": 1642609804,
-        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/078450a9056442b3b4e560504bab42f0",
+        "deletedDate": 1642625899,
+        "scheduledPurgeDate": 1643230699,
+        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/81707064389446b08884b40a5d0ce8fb",
         "attributes": {
           "enabled": true,
-          "created": 1642005004,
-          "updated": 1642005004,
+          "created": 1642625899,
+          "updated": 1642625899,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -310,7 +300,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -318,15 +308,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:04 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "e2e98c9a-e9ae-4e54-be90-9361d536486c",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "17c7a94a-b173-4a3b-a2eb-f59781088b1a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -347,7 +337,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -355,15 +345,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:04 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "f9180ba5-0233-4444-9505-ab9d6be446ff",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "6015f8c8-888e-4c4c-b356-3e3e6c591849",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -384,7 +374,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -392,15 +382,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:04 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "d5735b44-fb83-4a89-9fa9-ba5d1944de68",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "256767b4-e620-4e9a-963e-b995366e22dc",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -421,7 +411,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -429,15 +419,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:05 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "82fc31ba-2d66-47b6-9b6e-381d4c212d1d",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2e516669-5367-4fcb-96a4-4b60990e8911",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -458,7 +448,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -466,15 +456,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:05 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "b0f8bea5-7bda-434f-90c9-74482ffed7ec",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "ef2ed4af-b94f-4eb4-b999-559763cc23ba",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -495,7 +485,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -503,15 +493,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:05 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "77e49d4b-cedf-451a-b6a4-91086d134ba1",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "0370d41e-f1e6-499b-ab58-475943a801f9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -532,7 +522,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -540,15 +530,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:06 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "1cb075b3-2513-4e15-9b46-6deb5fa9371f",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "3ac57b91-addf-4e21-b762-b9ae38bc6a9f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -569,7 +559,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -577,15 +567,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:06 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "8cd54d42-e96b-432e-b7ec-cf2efd4c1513",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "87a67f23-81e3-4956-9d3e-e0dbf6995e0f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -606,7 +596,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -614,15 +604,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:07 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "41572703-380e-41e3-b7de-c1e6cab0b229",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4d2b8f23-8c15-4ad2-88cf-6274ed1682c4",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -643,7 +633,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -651,15 +641,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:07 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "79441f7b-37ab-42ea-97dd-49d0dba13b39",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "3c63b204-71ab-4229-b667-0a4c62a11728",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -680,38 +670,148 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:22 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "1f2679ce-9626-44f9-b87c-0aeef7829a93",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2628844972"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2628844972?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2628844972?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:23 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "72ec9790-39ed-49bf-be51-ee87fd3a4240",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2628844972"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2628844972?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2628844972?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:23 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c16dc74a-98ce-4d9e-be8b-ebbdd13d50d0",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2628844972"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2628844972?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2628844972?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:07 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "44ab22f0-3958-463b-8fa6-738c0bf7aa3e",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c16af7c0-919c-41e4-8821-b83f35a38b1d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret2628844972",
-        "deletedDate": 1642005004,
-        "scheduledPurgeDate": 1642609804,
-        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/078450a9056442b3b4e560504bab42f0",
+        "deletedDate": 1642625899,
+        "scheduledPurgeDate": 1643230699,
+        "id": "https://rosebud.vault.azure.net/secrets/secret2628844972/81707064389446b08884b40a5d0ce8fb",
         "attributes": {
           "enabled": true,
-          "created": 1642005004,
-          "updated": 1642005004,
+          "created": 1642625899,
+          "updated": 1642625899,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -725,21 +825,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:07 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "26f41400-d5a0-4cee-aa20-24ac0b815c45",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "62647906-8b83-4266-95ab-a8812882a3a1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestListSecrets.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestListSecrets.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:08 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -27,8 +27,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "a496af83-705b-47b5-ba4b-e4a842ea752d",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "e1861550-ba2e-493d-add5-495ced674b28",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -49,42 +49,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "43",
+        "Content-Length": "33",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "257",
+        "Content-Length": "247",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:08 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "b69c106a-9bfa-4ad5-8524-e8980644a5de",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "bd9fa1d9-d1a5-47b5-a07f-177da1eba174",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value",
-        "id": "https://rosebud.vault.azure.net/secrets/secret1/c0327873036844388d1fc2ec68bf4683",
+        "id": "https://rosebud.vault.azure.net/secrets/secret1/a414146b68fc44edb49a8c5ef24b2bb2",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -98,42 +96,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "43",
+        "Content-Length": "33",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "257",
+        "Content-Length": "247",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:08 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "92c95058-6d34-4b27-ab45-b0f8d83a46cc",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "44cc37af-2d2e-4182-a8c4-bd21865788b3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value",
-        "id": "https://rosebud.vault.azure.net/secrets/secret2/45b86e335e42427091d682a5149fa505",
+        "id": "https://rosebud.vault.azure.net/secrets/secret2/010757a9663a4a629df1445ba232869b",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -147,42 +143,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "43",
+        "Content-Length": "33",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "257",
+        "Content-Length": "247",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:08 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "8431fca6-5e7a-4e3b-a4af-b6c0ff89f0c7",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "95a478f2-ba2d-43ee-b717-877306dc9e3a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value",
-        "id": "https://rosebud.vault.azure.net/secrets/secret3/2347eb12db5a4a679f6905d1f9630edb",
+        "id": "https://rosebud.vault.azure.net/secrets/secret3/4da350f6713e4099a5c787df4798d44d",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -196,42 +190,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "43",
+        "Content-Length": "33",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "257",
+        "Content-Length": "247",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:08 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "54f66eb3-e133-4bc7-9417-f448b68b1d10",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c47c916d-4904-45c1-b92e-ab4f9bfd14aa",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value",
-        "id": "https://rosebud.vault.azure.net/secrets/secret4/97dd42df6c664a33b8d048c79346a5cf",
+        "id": "https://rosebud.vault.azure.net/secrets/secret4/8036738d0da54b8db2e79504d6af8bc5",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -245,23 +237,23 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "863",
+        "Content-Length": "823",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:09 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "fce80af2-37e9-4e55-a8b0-84c1327ae1fd",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "eec9c2bb-67b9-4315-860f-30c44c82bbae",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -270,45 +262,41 @@
             "id": "https://rosebud.vault.azure.net/secrets/secret1",
             "attributes": {
               "enabled": true,
-              "created": 1642005009,
-              "updated": 1642005009,
+              "created": 1642625905,
+              "updated": 1642625905,
               "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
               "recoverableDays": 7
-            },
-            "tags": {}
+            }
           },
           {
             "id": "https://rosebud.vault.azure.net/secrets/secret2",
             "attributes": {
               "enabled": true,
-              "created": 1642005009,
-              "updated": 1642005009,
+              "created": 1642625905,
+              "updated": 1642625905,
               "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
               "recoverableDays": 7
-            },
-            "tags": {}
+            }
           },
           {
             "id": "https://rosebud.vault.azure.net/secrets/secret3",
             "attributes": {
               "enabled": true,
-              "created": 1642005009,
-              "updated": 1642005009,
+              "created": 1642625905,
+              "updated": 1642625905,
               "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
               "recoverableDays": 7
-            },
-            "tags": {}
+            }
           },
           {
             "id": "https://rosebud.vault.azure.net/secrets/secret4",
             "attributes": {
               "enabled": true,
-              "created": 1642005009,
-              "updated": 1642005009,
+              "created": 1642625905,
+              "updated": 1642625905,
               "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
               "recoverableDays": 7
-            },
-            "tags": {}
+            }
           }
         ],
         "nextLink": null
@@ -325,38 +313,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "368",
+        "Content-Length": "358",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:09 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "e66a4db1-5225-46db-aadf-4d6ac88d5f28",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "a739c209-9dbd-4b83-b524-fa07f4d56945",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret4",
-        "deletedDate": 1642005009,
-        "scheduledPurgeDate": 1642609809,
-        "id": "https://rosebud.vault.azure.net/secrets/secret4/97dd42df6c664a33b8d048c79346a5cf",
+        "deletedDate": 1642625906,
+        "scheduledPurgeDate": 1643230706,
+        "id": "https://rosebud.vault.azure.net/secrets/secret4/8036738d0da54b8db2e79504d6af8bc5",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -370,7 +357,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -378,15 +365,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:09 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "f0f69249-f1e1-40aa-a95c-5c85384a1166",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "91e98b4f-8752-4a36-9c8e-f0a103764726",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -407,7 +394,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -415,15 +402,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:09 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "8e7f4479-00c0-4320-b635-67a5fa516cfe",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "1b76c8eb-d9ab-487e-8387-a8e438e84fde",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -444,7 +431,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -452,15 +439,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:09 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:26 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "e2fe3eda-6ce0-4cf6-8539-1e66ad850610",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "cc28c050-18e2-44eb-80da-e1cc5e703c10",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -481,7 +468,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -489,15 +476,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:10 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:26 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "cce2ccad-27ce-41dd-9421-258efead4ebb",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "26b1866f-bb60-4f36-aa6e-740a5dd30840",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -518,7 +505,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -526,15 +513,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:10 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:27 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "721df1fb-060d-4777-ab7d-08abf54e9ea6",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "e3822925-ab84-4a18-b545-ab88466c25a2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -555,38 +542,296 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:27 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2c574a95-c4f5-4267-9787-fea1e0e1e7b4",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret4"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret4?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret4?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:27 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2bc2ab1f-6d94-4a9a-84a4-3aeaa04cbfb2",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret4"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret4?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret4?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:28 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c3b22837-1155-42a6-a402-069e00208537",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret4"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret4?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret4?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:28 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2ceadaba-dfe8-4b1a-9904-dd57da909090",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret4"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret4?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret4?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:28 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "cdf70481-2715-4a54-9f91-12f70e7d7d12",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret4"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret4?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret4?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:29 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "965af9cc-8c86-4f24-bacd-c80152bdeb73",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret4"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret4?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret4?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:29 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "ffa9340e-c942-423c-90c0-8abc42822975",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret4"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret4?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret4?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "368",
+        "Content-Length": "358",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:11 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c91b000c-7719-4d34-8b9d-88f873000333",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "f2af5f29-5660-44c6-ae39-4f839acf0a9c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret4",
-        "deletedDate": 1642005009,
-        "scheduledPurgeDate": 1642609809,
-        "id": "https://rosebud.vault.azure.net/secrets/secret4/97dd42df6c664a33b8d048c79346a5cf",
+        "deletedDate": 1642625906,
+        "scheduledPurgeDate": 1643230706,
+        "id": "https://rosebud.vault.azure.net/secrets/secret4/8036738d0da54b8db2e79504d6af8bc5",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -600,21 +845,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:11 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "295278cc-b4d5-4066-aafa-5c57ea3ed341",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "71a70944-fc37-4780-8bdb-c621744bc7d0",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null
@@ -630,38 +875,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "368",
+        "Content-Length": "358",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:11 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "7ef5bd41-8bb5-4d2d-81d7-c85d8a13da50",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "d6e13b80-04f1-4a69-aa9d-ffae280c1649",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret3",
-        "deletedDate": 1642005012,
-        "scheduledPurgeDate": 1642609812,
-        "id": "https://rosebud.vault.azure.net/secrets/secret3/2347eb12db5a4a679f6905d1f9630edb",
+        "deletedDate": 1642625910,
+        "scheduledPurgeDate": 1643230710,
+        "id": "https://rosebud.vault.azure.net/secrets/secret3/4da350f6713e4099a5c787df4798d44d",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -675,7 +919,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -683,15 +927,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:11 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "db19566d-a6e8-466f-b40b-d0a7946c38c2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "101f2ffd-a638-4708-8192-d3ef2e8f0f89",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -712,7 +956,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -720,15 +964,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:11 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "07a88ae3-7837-4d52-96ee-455becdb6ce3",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "be7f5c98-8735-4c79-a4f6-439a16e56160",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -749,7 +993,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -757,15 +1001,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:12 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "dc68e487-9e40-43a2-ae8a-8e80a4366164",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9ab6fb9a-03e9-432f-8cf1-c76020edb94c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -786,38 +1030,444 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:31 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9f99e37c-e0a6-467d-b3f0-747112257526",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:31 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "1d95c285-9a43-421b-95a0-95c17fba875c",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:31 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2f297301-675f-4138-aa64-ec4e1f3d73db",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:32 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "dd53f7f8-4bb3-4ff0-bc93-bffaa0f29e37",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:32 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "18b15652-8d7a-4cf3-a414-756347e20d96",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:32 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4e174abc-c8cc-4654-896b-7d500c2ab841",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:33 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "40f0e6c7-dfaa-48cf-b414-6be22c7b2342",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:33 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "0dd0ecd2-7e95-443f-9602-ab4a3836578f",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:33 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "dacdeee6-22c4-416f-be76-039176ff9c82",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:34 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "3c4c5f1e-76ba-407e-8cc4-5a3aca24a8b4",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:34 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "d4e3f926-ef4b-49f3-ad44-6019fa6f4cd8",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "368",
+        "Content-Length": "358",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:12 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:34 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "2baabe27-0d35-4d94-a7b0-73031aa26996",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "8c0da330-6bae-40af-8b45-700d4a30aac8",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret3",
-        "deletedDate": 1642005012,
-        "scheduledPurgeDate": 1642609812,
-        "id": "https://rosebud.vault.azure.net/secrets/secret3/2347eb12db5a4a679f6905d1f9630edb",
+        "deletedDate": 1642625910,
+        "scheduledPurgeDate": 1643230710,
+        "id": "https://rosebud.vault.azure.net/secrets/secret3/4da350f6713e4099a5c787df4798d44d",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -831,21 +1481,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:12 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "3e850236-c5b3-48f2-b76f-67e47a67df56",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2c89bd71-fea6-4323-81c5-a34dbff6d41e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null
@@ -861,38 +1511,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "368",
+        "Content-Length": "358",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:12 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "f7830210-b8e3-4e6b-bbaa-0f90b07b17d8",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "fd23faf6-1cd9-48f0-8ee3-5d1d7d5d8b9b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret2",
-        "deletedDate": 1642005013,
-        "scheduledPurgeDate": 1642609813,
-        "id": "https://rosebud.vault.azure.net/secrets/secret2/45b86e335e42427091d682a5149fa505",
+        "deletedDate": 1642625915,
+        "scheduledPurgeDate": 1643230715,
+        "id": "https://rosebud.vault.azure.net/secrets/secret2/010757a9663a4a629df1445ba232869b",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -906,7 +1555,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -914,15 +1563,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:12 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "3c035760-0fee-4a2a-b49c-3704f0fb7593",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b41f25db-6eb5-4aa8-8ba8-e1a113cd4dd2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -943,7 +1592,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -951,15 +1600,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:12 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "848e30fe-1b43-445c-b493-cfcc1ea7e0b1",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4a369e53-4c2b-42ba-960b-95821c6cf98e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -980,7 +1629,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -988,15 +1637,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:14 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "cc11f92b-a1fe-4919-8142-b13e6bddb007",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "86b2fbdb-d70b-4c96-a460-e308b352b58d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -1017,7 +1666,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -1025,15 +1674,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:14 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:36 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "7f0bb765-cd0f-4e18-a461-f72333fb9ef1",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "3218d39d-be50-47af-b115-aad4ae0e2480",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -1054,38 +1703,444 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:36 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "62dfc420-143e-4594-ada5-acb5805b4402",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:36 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "92bf849c-e68d-47a4-945f-15de0bd986f3",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:37 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "76ace0e8-30c8-48f3-861a-3ffe28f9cb11",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:37 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "93ae3a1c-9b4f-402b-aaf1-a330d6c996f5",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:37 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "7285a5da-7c4e-4b33-abba-2e43ee0dcdd2",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:38 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "7b9f294b-697b-4222-9796-3755e4adbbbd",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:38 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c9512809-e6d1-43bd-9931-47d0537158d2",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:39 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c31aa69b-29fd-496c-ad87-8ffa61e90e8d",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:39 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "1b13f6d2-0998-418f-be4c-08ef5a6d002a",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:40 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "6246b463-26aa-4d68-b794-50af97c1f766",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:40 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "6fc88996-3796-49f8-9148-602f839e115d",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret2"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret2?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret2?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "368",
+        "Content-Length": "358",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:14 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "774a0aa0-2324-4671-86ad-6660a3dfad5e",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "d089492f-4017-4b96-8357-9fa8ce5ff133",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret2",
-        "deletedDate": 1642005013,
-        "scheduledPurgeDate": 1642609813,
-        "id": "https://rosebud.vault.azure.net/secrets/secret2/45b86e335e42427091d682a5149fa505",
+        "deletedDate": 1642625915,
+        "scheduledPurgeDate": 1643230715,
+        "id": "https://rosebud.vault.azure.net/secrets/secret2/010757a9663a4a629df1445ba232869b",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -1099,21 +2154,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:14 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "32852901-9003-4df9-9473-51a65deba646",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "a5507837-2d48-4a19-bad7-c59d7b953570",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null
@@ -1129,38 +2184,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "368",
+        "Content-Length": "358",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:15 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c4152069-1bf2-43de-9852-5cd3384924b2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b93b2b7e-6846-4939-a02d-3094110be2c5",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret1",
-        "deletedDate": 1642005015,
-        "scheduledPurgeDate": 1642609815,
-        "id": "https://rosebud.vault.azure.net/secrets/secret1/c0327873036844388d1fc2ec68bf4683",
+        "deletedDate": 1642625921,
+        "scheduledPurgeDate": 1643230721,
+        "id": "https://rosebud.vault.azure.net/secrets/secret1/a414146b68fc44edb49a8c5ef24b2bb2",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -1174,7 +2228,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -1182,15 +2236,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:15 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "a4f083b8-1b73-4170-a5a9-20b86644bf2c",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "56cee86a-eceb-4d8c-b367-a7983d006ac2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -1211,7 +2265,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -1219,15 +2273,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:15 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c0963aac-48ae-425f-9323-6b0d7efa0c39",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "19fe6ba5-5f2f-437c-b931-74b97bc32c45",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -1248,7 +2302,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -1256,15 +2310,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:15 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "4d14c791-6335-421c-98ac-f2eee7958a86",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "cb02ce3e-1d55-4d65-aec7-2a413d9c6a60",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -1285,7 +2339,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -1293,15 +2347,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:15 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "5c79de32-3f46-4f8c-8870-a3dcf98a90e8",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2ff1034f-4d40-470c-bcae-19670700192d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -1322,7 +2376,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -1330,15 +2384,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:16 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "07cf588f-fb38-45ef-9b43-5d5a424f4528",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "8ac2f3ad-afb5-4810-b8a7-ea6292acc989",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -1359,7 +2413,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -1367,15 +2421,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:16 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "7a18037d-ae02-4d69-b747-09a3baaeacc6",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "a04fc267-fe46-4f35-81a8-a903deb593a6",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -1396,7 +2450,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -1404,15 +2458,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:16 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "858967d3-8f77-427e-b32e-6e22a4bbddcd",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "e70f3707-d428-44e1-afaf-88d62d874937",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -1433,38 +2487,444 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "9d624b36-bfc3-459e-b86b-1d20aad10040",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "560b2347-a16e-4e9d-9c21-0a85dcfbcf93",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:44 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "5d4127e0-72ca-422c-9867-2bec10fd4b15",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:44 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "a8def7f6-51bc-461a-b4a9-d39f4a207afc",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "7bed5e4a-4578-4d0c-810e-2c243985d150",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "247aa7bc-4d6c-4b72-8ed3-6d5b9e0cb4da",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "72aca237-49d3-4f77-86a9-1f4797b256d8",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:47 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "5b4457bc-d513-4212-aefe-a36a6e885758",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:47 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "276bf463-a373-4591-a7d9-e0d3e6043cba",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:47 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "1d7d9748-cd13-402c-8ef2-41e7197aff94",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "81",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:48 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "779abf94-4944-459a-a388-b17e666679f2",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "368",
+        "Content-Length": "358",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:17 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "2f6fbedc-0b7c-46e9-ba09-66974199ac2a",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "0d295564-644d-46c3-a63c-024fa51850e3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret1",
-        "deletedDate": 1642005015,
-        "scheduledPurgeDate": 1642609815,
-        "id": "https://rosebud.vault.azure.net/secrets/secret1/c0327873036844388d1fc2ec68bf4683",
+        "deletedDate": 1642625921,
+        "scheduledPurgeDate": 1643230721,
+        "id": "https://rosebud.vault.azure.net/secrets/secret1/a414146b68fc44edb49a8c5ef24b2bb2",
         "attributes": {
           "enabled": true,
-          "created": 1642005009,
-          "updated": 1642005009,
+          "created": 1642625905,
+          "updated": 1642625905,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -1478,21 +2938,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:17 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "6dec9b07-f7f9-406e-a0c2-62759c1a29de",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "54fe2476-b4e2-4408-93f3-46b79a531a03",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestPurgeDeletedSecret.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestPurgeDeletedSecret.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:26 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -27,8 +27,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "493b1e3f-671e-4781-a8c5-534098540a61",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "fca980b6-d126-4afa-b1c1-ead28b167c33",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -49,42 +49,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "54",
+        "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value14039052661"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "278",
+        "Content-Length": "268",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:26 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "c471ea41-7fb2-42cb-ae66-b028ad4997be",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "381d1052-588c-4de0-8173-4782a64e61e3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value14039052661",
-        "id": "https://rosebud.vault.azure.net/secrets/secret14039052661/06ed52bd40d84136bfedc6a272a4bc41",
+        "id": "https://rosebud.vault.azure.net/secrets/secret14039052661/f4bf89d376e1422cb99579462af447ca",
         "attributes": {
           "enabled": true,
-          "created": 1642005027,
-          "updated": 1642005027,
+          "created": 1642625941,
+          "updated": 1642625941,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -98,38 +96,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:26 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "2fea4a61-1bae-4550-b6c2-8e8c46dce93f",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b3f42dc8-0b85-4004-a565-bff6b669d416",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret14039052661",
-        "deletedDate": 1642005027,
-        "scheduledPurgeDate": 1642609827,
-        "id": "https://rosebud.vault.azure.net/secrets/secret14039052661/06ed52bd40d84136bfedc6a272a4bc41",
+        "deletedDate": 1642625941,
+        "scheduledPurgeDate": 1643230741,
+        "id": "https://rosebud.vault.azure.net/secrets/secret14039052661/f4bf89d376e1422cb99579462af447ca",
         "attributes": {
           "enabled": true,
-          "created": 1642005027,
-          "updated": 1642005027,
+          "created": 1642625941,
+          "updated": 1642625941,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -143,7 +140,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -151,15 +148,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:26 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "833f8563-75b6-46c3-b9c9-ecadefbe6126",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "707825f3-609b-42b8-8707-ff814079462c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -180,7 +177,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -188,15 +185,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:27 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "aad8390f-a429-4d38-9d58-0b3b1cad11ba",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c51ca431-3db7-4282-a2c1-ec71b44776bc",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -217,7 +214,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -225,15 +222,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:27 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "dd3dbf0e-8136-489e-ba8a-4ae4276cedfe",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "d41446f6-38d7-42f8-b093-c4132806c128",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -254,7 +251,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -262,15 +259,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:27 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "b5508dcd-a900-43e9-89f5-fa0aa77be3e8",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b03219ab-f957-42a0-83fe-e66a6cc571e9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -291,38 +288,74 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "91",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:59:02 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "50199a45-0189-4aac-8968-0977e312ac03",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret14039052661"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret14039052661?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret14039052661?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "388",
+        "Content-Length": "378",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:28 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "e5f898dd-eeb4-4e8e-bf78-3329300db087",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "f0a58163-4677-451f-b00e-bf2e30861d6d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret14039052661",
-        "deletedDate": 1642005027,
-        "scheduledPurgeDate": 1642609827,
-        "id": "https://rosebud.vault.azure.net/secrets/secret14039052661/06ed52bd40d84136bfedc6a272a4bc41",
+        "deletedDate": 1642625941,
+        "scheduledPurgeDate": 1643230741,
+        "id": "https://rosebud.vault.azure.net/secrets/secret14039052661/f4bf89d376e1422cb99579462af447ca",
         "attributes": {
           "enabled": true,
-          "created": 1642005027,
-          "updated": 1642005027,
+          "created": 1642625941,
+          "updated": 1642625941,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -336,21 +369,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:28 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "1e677ed3-927e-407c-ab1b-0dc872e94a82",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "395df3d7-aeae-4ff9-9e74-1e18e6ebf3d1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null
@@ -366,7 +399,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -374,15 +407,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "28",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:28 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "3d62a956-60fd-4bf1-bee6-42ddb5da18dc",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "dde35fb8-eec1-4efc-93b8-914b0f568fc3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestSecretTags.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestSecretTags.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:42 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -28,7 +28,7 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "bb23b53e-3205-4f0e-92bf-dbe5a62f451d",
+        "x-ms-request-id": "91e496f5-20fe-455c-ad20-3bdb0ef1840f",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -51,7 +51,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "66",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
@@ -65,7 +65,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "289",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:39 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -73,16 +73,16 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "bbeddf6a-9b6d-47dd-9288-28143c4dd7ac",
+        "x-ms-request-id": "6776e971-e617-486f-b9e3-ec2a524a8bba",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value1390897724",
-        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/6e685901ed624d8da6c24d2460bb0a78",
         "attributes": {
           "enabled": true,
-          "created": 1642625264,
-          "updated": 1642625264,
+          "created": 1642626220,
+          "updated": 1642626220,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -102,7 +102,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -110,7 +110,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "289",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:39 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -118,16 +118,16 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "2163e2c7-fc11-4bf7-9c39-83c51265f1f7",
+        "x-ms-request-id": "0d3ec55d-36fe-4618-b998-9bdf4ff6a193",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value1390897724",
-        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/6e685901ed624d8da6c24d2460bb0a78",
         "attributes": {
           "enabled": true,
-          "created": 1642625264,
-          "updated": 1642625264,
+          "created": 1642626220,
+          "updated": 1642626220,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -149,11 +149,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "33",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {
-          "exp": 1642711663
+          "exp": 2216854861
         }
       },
       "StatusCode": 200,
@@ -161,7 +161,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -169,16 +169,16 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "0b73e96b-2bed-41b2-99c1-d824192c8791",
+        "x-ms-request-id": "7b9191b8-24cc-4b37-a651-fd7f817ddc93",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/6e685901ed624d8da6c24d2460bb0a78",
         "attributes": {
           "enabled": true,
-          "exp": 1642711663,
-          "created": 1642625264,
-          "updated": 1642625264,
+          "exp": 2216854861,
+          "created": 1642626220,
+          "updated": 1642626220,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -200,7 +200,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "11",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "tags": {}
@@ -210,7 +210,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "267",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -218,16 +218,16 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "f6492bb0-df73-4a9e-b1db-dce9b5e21803",
+        "x-ms-request-id": "a4c7d0f4-b48e-4aca-9ca0-36def916a30d",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
-        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/6e685901ed624d8da6c24d2460bb0a78",
         "attributes": {
           "enabled": true,
-          "exp": 1642711663,
-          "created": 1642625264,
-          "updated": 1642625264,
+          "exp": 2216854861,
+          "created": 1642626220,
+          "updated": 1642626220,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -245,7 +245,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -253,7 +253,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -261,19 +261,19 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "a757c248-7c14-42b3-b241-34ef8e7fa5f9",
+        "x-ms-request-id": "ee216491-6018-42f6-a734-253ee173f511",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret1390897724",
-        "deletedDate": 1642625264,
-        "scheduledPurgeDate": 1643230064,
-        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "deletedDate": 1642626221,
+        "scheduledPurgeDate": 1643231021,
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/6e685901ed624d8da6c24d2460bb0a78",
         "attributes": {
           "enabled": true,
-          "exp": 1642711663,
-          "created": 1642625264,
-          "updated": 1642625264,
+          "exp": 2216854861,
+          "created": 1642626220,
+          "updated": 1642626220,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -291,7 +291,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -299,7 +299,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -307,7 +307,7 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "54c3a4de-bd34-4c3f-8d65-c5ef9969601a",
+        "x-ms-request-id": "2f180c27-9d62-4ee4-923e-594890d93ee1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -328,7 +328,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -336,7 +336,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -344,7 +344,7 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "f2018d95-7f48-4547-8ed6-525ca003ae72",
+        "x-ms-request-id": "b5378378-a724-4b2d-9b04-458b25b03a09",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -365,7 +365,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -373,7 +373,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:44 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -381,7 +381,7 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "2d2afc0a-cb86-4659-9fb6-04ff1b624793",
+        "x-ms-request-id": "09c2fe04-8da2-4c76-818c-d8e500a7cdb1",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -402,7 +402,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -410,7 +410,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:44 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -418,7 +418,7 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "a2f262f5-a5e5-4d8b-9dfe-c2c70ac0043a",
+        "x-ms-request-id": "c43d29ba-bc32-4f64-a3c0-f233014ab705",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -439,7 +439,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -447,7 +447,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:46 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -455,7 +455,7 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "30858722-8025-4018-b0a8-503084d890f5",
+        "x-ms-request-id": "7b65f173-a5d2-4ab5-98c5-f40c00dd8f2a",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -476,7 +476,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -484,7 +484,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Jan 2022 20:47:46 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -492,19 +492,19 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "fde5aa8f-ea2f-412d-87a5-7c06189d1c05",
+        "x-ms-request-id": "6ca6ba95-fd44-4170-b18c-f8468aa472eb",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret1390897724",
-        "deletedDate": 1642625264,
-        "scheduledPurgeDate": 1643230064,
-        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "deletedDate": 1642626221,
+        "scheduledPurgeDate": 1643231021,
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/6e685901ed624d8da6c24d2460bb0a78",
         "attributes": {
           "enabled": true,
-          "exp": 1642711663,
-          "created": 1642625264,
-          "updated": 1642625264,
+          "exp": 2216854861,
+          "created": 1642626220,
+          "updated": 1642626220,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -522,13 +522,13 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 19 Jan 2022 20:47:46 GMT",
+        "Date": "Wed, 19 Jan 2022 21:03:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -536,7 +536,7 @@
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.264.1",
-        "x-ms-request-id": "23d3d171-6a6c-4fe1-8714-986afb4e9efd",
+        "x-ms-request-id": "fdb90c26-c49d-4fe3-8b0f-bc22a68dc43c",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestSecretTags.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestSecretTags.json
@@ -1,0 +1,546 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "PUT",
+        ":path": "/secrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:42 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "bb23b53e-3205-4f0e-92bf-dbe5a62f451d",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "PUT",
+        ":path": "/secrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "Content-Length": "66",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": {
+        "attributes": {},
+        "tags": {
+          "Tag1": "Val1"
+        },
+        "value": "value1390897724"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "289",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "bbeddf6a-9b6d-47dd-9288-28143c4dd7ac",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "value": "value1390897724",
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "attributes": {
+          "enabled": true,
+          "created": 1642625264,
+          "updated": 1642625264,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7
+        },
+        "tags": {
+          "Tag1": "Val1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret1390897724/?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/secrets/secret1390897724/?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "289",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2163e2c7-fc11-4bf7-9c39-83c51265f1f7",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "value": "value1390897724",
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "attributes": {
+          "enabled": true,
+          "created": 1642625264,
+          "updated": 1642625264,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7
+        },
+        "tags": {
+          "Tag1": "Val1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret1390897724/?api-version=7.2",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "PATCH",
+        ":path": "/secrets/secret1390897724/?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "Content-Length": "33",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": {
+        "attributes": {
+          "exp": 1642711663
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "0b73e96b-2bed-41b2-99c1-d824192c8791",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "attributes": {
+          "enabled": true,
+          "exp": 1642711663,
+          "created": 1642625264,
+          "updated": 1642625264,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7
+        },
+        "tags": {
+          "Tag1": "Val1"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret1390897724/?api-version=7.2",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "PATCH",
+        ":path": "/secrets/secret1390897724/?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "Content-Length": "11",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": {
+        "tags": {}
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "267",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "f6492bb0-df73-4a9e-b1db-dce9b5e21803",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "attributes": {
+          "enabled": true,
+          "exp": 1642711663,
+          "created": 1642625264,
+          "updated": 1642625264,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7
+        },
+        "tags": {}
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/secrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "DELETE",
+        ":path": "/secrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "403",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "a757c248-7c14-42b3-b241-34ef8e7fa5f9",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret1390897724",
+        "deletedDate": 1642625264,
+        "scheduledPurgeDate": 1643230064,
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "attributes": {
+          "enabled": true,
+          "exp": 1642711663,
+          "created": 1642625264,
+          "updated": 1642625264,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7
+        },
+        "tags": {}
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "54c3a4de-bd34-4c3f-8d65-c5ef9969601a",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1390897724"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "f2018d95-7f48-4547-8ed6-525ca003ae72",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1390897724"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:44 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "2d2afc0a-cb86-4659-9fb6-04ff1b624793",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1390897724"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:44 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "a2f262f5-a5e5-4d8b-9dfe-c2c70ac0043a",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1390897724"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:46 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "30858722-8025-4018-b0a8-503084d890f5",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret1390897724"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "403",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:47:46 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "fde5aa8f-ea2f-412d-87a5-7c06189d1c05",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret1390897724",
+        "deletedDate": 1642625264,
+        "scheduledPurgeDate": 1643230064,
+        "id": "https://rosebud.vault.azure.net/secrets/secret1390897724/b84b10132d934e6e9854e8143a453208",
+        "attributes": {
+          "enabled": true,
+          "exp": 1642711663,
+          "created": 1642625264,
+          "updated": 1642625264,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7
+        },
+        "tags": {}
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret1390897724?api-version=7.2",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "DELETE",
+        ":path": "/deletedsecrets/secret1390897724?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.4.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Wed, 19 Jan 2022 20:47:46 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "23d3d171-6a6c-4fe1-8714-986afb4e9efd",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestSetGetSecret.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestSetGetSecret.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:00 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -27,8 +27,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "35c97668-f054-432a-9b44-deb98ec76dd9",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "6bc88d91-c3a5-4073-822f-4c507243abb9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -49,42 +49,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "43",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value3379360089"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "276",
+        "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:01 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "340827d0-43b0-4309-b713-df472f5a449b",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "76ac372b-354b-4d38-bf81-2d84e815e71e",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value3379360089",
-        "id": "https://rosebud.vault.azure.net/secrets/secret3379360089/c66bc717b2a8440abe181ef319b5ddbb",
+        "id": "https://rosebud.vault.azure.net/secrets/secret3379360089/7a79d4e3524443d0ad85b31e81073f14",
         "attributes": {
           "enabled": true,
-          "created": 1642005001,
-          "updated": 1642005001,
+          "created": 1642625890,
+          "updated": 1642625890,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -98,36 +96,35 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "276",
+        "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:01 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "7e9d83eb-313d-4958-a94b-ffc039c8c1c4",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "6c912fa1-f8a8-4572-95bf-9da49b308538",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value3379360089",
-        "id": "https://rosebud.vault.azure.net/secrets/secret3379360089/c66bc717b2a8440abe181ef319b5ddbb",
+        "id": "https://rosebud.vault.azure.net/secrets/secret3379360089/7a79d4e3524443d0ad85b31e81073f14",
         "attributes": {
           "enabled": true,
-          "created": 1642005001,
-          "updated": 1642005001,
+          "created": 1642625890,
+          "updated": 1642625890,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -141,38 +138,37 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:01 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "1f32b345-0f9f-4e3e-bc54-45ec13c90806",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "f16f94eb-bf41-421a-a3e6-4810eb984d06",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret3379360089",
-        "deletedDate": 1642005001,
-        "scheduledPurgeDate": 1642609801,
-        "id": "https://rosebud.vault.azure.net/secrets/secret3379360089/c66bc717b2a8440abe181ef319b5ddbb",
+        "deletedDate": 1642625891,
+        "scheduledPurgeDate": 1643230691,
+        "id": "https://rosebud.vault.azure.net/secrets/secret3379360089/7a79d4e3524443d0ad85b31e81073f14",
         "attributes": {
           "enabled": true,
-          "created": 1642005001,
-          "updated": 1642005001,
+          "created": 1642625890,
+          "updated": 1642625890,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -186,7 +182,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -194,15 +190,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:01 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "fd3ff47b-bd4f-4ac0-96d9-f50c3de7af18",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "46cbc638-5089-4ac5-9e12-95b0029c0bc3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -223,7 +219,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -231,15 +227,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:01 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "48d9165d-e02b-4ce9-9845-f9f0e62f35cb",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "e9f6aa3e-bfb6-4805-93da-d7a1977638e3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -260,7 +256,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -268,15 +264,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:02 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "dbe5fae2-a326-47f6-b8b2-1443f2dc9657",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "5a8cb011-6a5c-4df0-be7f-d890096433b2",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -297,7 +293,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -305,15 +301,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "90",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:02 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "3eca9690-3d50-4ce1-ad66-8dd7867339a1",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "8d423b29-9f3d-494e-85f1-70e6be287271",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -334,38 +330,185 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:12 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "4518f0f1-948d-4c52-9769-78fa3053d05e",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3379360089"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3379360089?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3379360089?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:12 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "1b92c137-6e3a-44a3-9475-92042122dd44",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3379360089"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3379360089?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3379360089?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:13 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "fba88c22-7062-4175-bb09-4fdd787c6541",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3379360089"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3379360089?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3379360089?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "90",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 19 Jan 2022 20:58:13 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "b9733616-0f94-4411-be98-f4972d7469c6",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "SecretNotFound",
+          "message": "Deleted Secret not found: secret3379360089"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret3379360089?api-version=7.2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":authority": "localhost:5001",
+        ":method": "GET",
+        ":path": "/deletedsecrets/secret3379360089?api-version=7.2",
+        ":scheme": "https",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "386",
+        "Content-Length": "376",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:02 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "ea7de47c-c37b-48b7-9503-bb1b2748ff17",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "fbda0b04-db92-4ea7-946a-7be68ec76eee",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret3379360089",
-        "deletedDate": 1642005001,
-        "scheduledPurgeDate": 1642609801,
-        "id": "https://rosebud.vault.azure.net/secrets/secret3379360089/c66bc717b2a8440abe181ef319b5ddbb",
+        "deletedDate": 1642625891,
+        "scheduledPurgeDate": 1643230691,
+        "id": "https://rosebud.vault.azure.net/secrets/secret3379360089/7a79d4e3524443d0ad85b31e81073f14",
         "attributes": {
           "enabled": true,
-          "created": 1642005001,
-          "updated": 1642005001,
+          "created": 1642625890,
+          "updated": 1642625890,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -379,21 +522,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:02 GMT",
+        "Date": "Wed, 19 Jan 2022 20:58:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "cbe3dff5-35cc-454e-9f5d-aab8a94f76a2",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "ff4314da-1f4a-48ad-832e-8d08f5cc7598",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null

--- a/sdk/keyvault/azsecrets/testdata/recordings/TestUpdateSecretProperties.json
+++ b/sdk/keyvault/azsecrets/testdata/recordings/TestUpdateSecretProperties.json
@@ -11,7 +11,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -19,7 +19,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:28 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -27,8 +27,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "63e0fe4c-160e-4501-8935-6b6118fa8767",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c640ae69-7311-4129-8763-8441c6ce6f4b",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -49,42 +49,40 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "53",
+        "Content-Length": "43",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {},
-        "tags": {},
         "value": "value2319658013"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "277",
+        "Content-Length": "267",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:29 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "14df8412-f54e-4dee-a42b-03175ca1283f",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "71e0a516-6912-4a63-96f8-a785ef5f6b68",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value2319658013",
-        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/cee42e02363244d993deb6a11e56af54",
+        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/92965824659841d2a1451cbb27297f22",
         "attributes": {
           "enabled": true,
-          "created": 1642005029,
-          "updated": 1642005029,
+          "created": 1642625944,
+          "updated": 1642625944,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -98,36 +96,35 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "277",
+        "Content-Length": "267",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:29 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "137496bf-4f2a-43af-bd6e-0f546807d20e",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c26ed2cd-67c0-4f9f-9b3c-5c2836f30e12",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value2319658013",
-        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/cee42e02363244d993deb6a11e56af54",
+        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/92965824659841d2a1451cbb27297f22",
         "attributes": {
           "enabled": true,
-          "created": 1642005029,
-          "updated": 1642005029,
+          "created": 1642625944,
+          "updated": 1642625944,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
-        },
-        "tags": {}
+        }
       }
     },
     {
@@ -143,13 +140,13 @@
         "Authorization": "Sanitized",
         "Content-Length": "116",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": {
         "attributes": {
           "enabled": true,
-          "exp": 1642177830,
-          "nbf": 1641918630
+          "exp": 1642798744,
+          "nbf": 1642539544
         },
         "contentType": "password",
         "tags": {
@@ -161,26 +158,26 @@
         "Cache-Control": "no-cache",
         "Content-Length": "326",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:29 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "6877125c-3e15-4900-9eb8-c0980701bec0",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "440592bf-b1f8-4884-8bca-0b2639f20fe6",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "contentType": "password",
-        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/cee42e02363244d993deb6a11e56af54",
+        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/92965824659841d2a1451cbb27297f22",
         "attributes": {
           "enabled": true,
-          "nbf": 1641918630,
-          "exp": 1642177830,
-          "created": 1642005029,
-          "updated": 1642005030,
+          "nbf": 1642539544,
+          "exp": 1642798744,
+          "created": 1642625944,
+          "updated": 1642625944,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -200,7 +197,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -208,27 +205,27 @@
         "Cache-Control": "no-cache",
         "Content-Length": "352",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:29 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "6458fe8e-06fc-4f9d-addb-4b14acf89b6f",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "1f57dc48-63a9-40a0-bede-ebf4fa6825ff",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "value": "value2319658013",
         "contentType": "password",
-        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/cee42e02363244d993deb6a11e56af54",
+        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/92965824659841d2a1451cbb27297f22",
         "attributes": {
           "enabled": true,
-          "nbf": 1641918630,
-          "exp": 1642177830,
-          "created": 1642005029,
-          "updated": 1642005030,
+          "nbf": 1642539544,
+          "exp": 1642798744,
+          "created": 1642625944,
+          "updated": 1642625944,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -248,7 +245,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -256,29 +253,29 @@
         "Cache-Control": "no-cache",
         "Content-Length": "463",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:29 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "2d290173-57bd-4ca6-983c-6c1ba72bb0e7",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "8ae745a8-f4c9-4baf-8df6-d1ecd458c0f9",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret22319658013",
-        "deletedDate": 1642005030,
-        "scheduledPurgeDate": 1642609830,
+        "deletedDate": 1642625944,
+        "scheduledPurgeDate": 1643230744,
         "contentType": "password",
-        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/cee42e02363244d993deb6a11e56af54",
+        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/92965824659841d2a1451cbb27297f22",
         "attributes": {
           "enabled": true,
-          "nbf": 1641918630,
-          "exp": 1642177830,
-          "created": 1642005029,
-          "updated": 1642005030,
+          "nbf": 1642539544,
+          "exp": 1642798744,
+          "created": 1642625944,
+          "updated": 1642625944,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -298,7 +295,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -306,15 +303,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:29 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "ee3ce931-219d-4a9f-a58f-e0ffe50798f9",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "6c3706a6-aced-4b2c-bd9b-3a656db317af",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -335,7 +332,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -343,15 +340,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:29 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "3bec5b4b-217c-41de-8f63-cb0fb2cad9ce",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "c3a2a069-a839-420b-8b4b-bc54507ecfb3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -372,7 +369,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 404,
@@ -380,15 +377,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:30 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "0937a925-62da-45be-8626-227f77879d10",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "aadcb2a2-2969-480d-bb21-03109ddd7913",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
@@ -409,44 +406,7 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "91",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "a757adf6-e3a5-4e5a-93ce-15d1f97f5118",
-        "X-Powered-By": "ASP.NET"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "SecretNotFound",
-          "message": "Deleted Secret not found: secret22319658013"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakekvurl.vault.azure.net/deletedsecrets/secret22319658013?api-version=7.2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        ":authority": "localhost:5001",
-        ":method": "GET",
-        ":path": "/deletedsecrets/secret22319658013?api-version=7.2",
-        ":scheme": "https",
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -454,29 +414,29 @@
         "Cache-Control": "no-cache",
         "Content-Length": "463",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 12 Jan 2022 16:30:30 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "e0806c57-ec4f-4a4e-87d8-2860d9320cb8",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "eec1af1c-f35c-4779-8ff4-bbd835879fc3",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": {
         "recoveryId": "https://rosebud.vault.azure.net/deletedsecrets/secret22319658013",
-        "deletedDate": 1642005030,
-        "scheduledPurgeDate": 1642609830,
+        "deletedDate": 1642625944,
+        "scheduledPurgeDate": 1643230744,
         "contentType": "password",
-        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/cee42e02363244d993deb6a11e56af54",
+        "id": "https://rosebud.vault.azure.net/secrets/secret22319658013/92965824659841d2a1451cbb27297f22",
         "attributes": {
           "enabled": true,
-          "nbf": 1641918630,
-          "exp": 1642177830,
-          "created": 1642005029,
-          "updated": 1642005030,
+          "nbf": 1642539544,
+          "exp": 1642798744,
+          "created": 1642625944,
+          "updated": 1642625944,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -496,21 +456,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.4.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
+        "User-Agent": "azsdk-go-internal/v0.5.0 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Wed, 12 Jan 2022 16:30:31 GMT",
+        "Date": "Wed, 19 Jan 2022 20:59:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=72.49.29.93;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.226.1",
-        "x-ms-request-id": "d638308c-b92e-43f8-bce6-28330344e379",
+        "x-ms-keyvault-service-version": "1.9.264.1",
+        "x-ms-request-id": "1f77fd25-9de7-424b-8d92-1766508f78a4",
         "X-Powered-By": "ASP.NET"
       },
       "ResponseBody": null


### PR DESCRIPTION
I noticed this issue while fixing #16858 , on PATCH methods, properties would be erased if they are not explicitly set. This fixes that by setting generated values as `nil` if they are not explicitly specified.