### PR TITLE
fix: empty breaking or additive items in changelog

### DIFF
--- a/eng/tools/generator/autorest/model/changelog.go
+++ b/eng/tools/generator/autorest/model/changelog.go
@@ -83,15 +83,21 @@ func writeChangelogForPackage(r *report.Package) string {
 	md := &markdown.Writer{}
 
 	// write breaking changes
-	md.WriteHeader("Breaking Changes")
-	for _, item := range getBreakingChanges(r.BreakingChanges) {
-		md.WriteListItem(item)
+	breakings := getBreakingChanges(r.BreakingChanges)
+	if len(breakings) > 0 {
+		md.WriteHeader("Breaking Changes")
+		for _, item := range breakings {
+			md.WriteListItem(item)
+		}
 	}
 
 	// write additional changes
-	md.WriteHeader("Features Added")
-	for _, item := range getNewContents(r.AdditiveChanges) {
-		md.WriteListItem(item)
+	additives := getNewContents(r.AdditiveChanges)
+	if len(additives) > 0 {
+		md.WriteHeader("Features Added")
+		for _, item := range additives {
+			md.WriteListItem(item)
+		}
 	}
 
 	return md.String()

--- a/sdk/resourcemanager/resources/armpolicy/CHANGELOG.md
+++ b/sdk/resourcemanager/resources/armpolicy/CHANGELOG.md
@@ -18,10 +18,6 @@
 - Struct `ErrorAdditionalInfo` has been removed
 - Struct `ErrorResponse` has been removed
 
-### Features Added
-
-
-
 ## 0.2.0 (2022-01-13)
 ### Breaking Changes
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
