### PR TITLE
Added support for Client Assertion (Workload identity federation)

### DIFF
--- a/sdk/azidentity/client_assertion_credential.go
+++ b/sdk/azidentity/client_assertion_credential.go
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+)
+
+// ClientAssertionCredentialOptions contains optional parameters for ClientAssertionCredential.
+type ClientAssertionCredentialOptions struct {
+	azcore.ClientOptions
+
+	// AuthorityHost is the base URL of an Azure Active Directory authority. Defaults
+	// to the value of environment variable AZURE_AUTHORITY_HOST, if set, or AzurePublicCloud.
+	AuthorityHost AuthorityHost
+}
+
+// ClientAssertionCredential authenticates an application with a client assertion.
+type ClientAssertionCredential struct {
+	client confidentialClient
+}
+
+// NewClientAssertionCredential constructs a ClientAssertionCredential.
+// tenantID: The application's Azure Active Directory tenant or directory ID.
+// clientID: The application's client ID.
+// clientAssertion: Signed assertion.
+// options: Optional configuration.
+func NewClientAssertionCredential(tenantID string, clientID string, clientAssertion string, options *ClientAssertionCredentialOptions) (*ClientAssertionCredential, error) {
+	if !validTenantID(tenantID) {
+		return nil, errors.New(tenantIDValidationErr)
+	}
+	if options == nil {
+		options = &ClientAssertionCredentialOptions{}
+	}
+	authorityHost, err := setAuthorityHost(options.AuthorityHost)
+	if err != nil {
+		return nil, err
+	}
+	cred, err := confidential.NewCredFromAssertion(clientAssertion)
+	if err != nil {
+		return nil, err
+	}
+	c, err := confidential.New(clientID, cred,
+		confidential.WithAuthority(runtime.JoinPaths(authorityHost, tenantID)),
+		confidential.WithHTTPClient(newPipelineAdapter(&options.ClientOptions)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &ClientAssertionCredential{client: c}, nil
+}
+
+// GetToken obtains a token from Azure Active Directory. This method is called automatically by Azure SDK clients.
+// ctx: Context used to control the request lifetime.
+// opts: Options for the token request, in particular the desired scope of the access token.
+func (c *ClientAssertionCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
+	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes)
+	if err == nil {
+		logGetTokenSuccess(c, opts)
+		return &azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
+	}
+
+	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
+	if err != nil {
+		addGetTokenFailureLogs("Client Assertion Credential", err, true)
+		return nil, newAuthenticationFailedError(err, nil)
+	}
+	logGetTokenSuccess(c, opts)
+	return &azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
+}
+
+var _ azcore.TokenCredential = (*ClientAssertionCredential)(nil)

--- a/sdk/azidentity/client_assertion_credential_test.go
+++ b/sdk/azidentity/client_assertion_credential_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+const Assertion = "SomeJWTToken"
+
+func TestClientAssertionCredential_InvalidTenantID(t *testing.T) {
+	cred, err := NewClientAssertionCredential(badTenantID, fakeClientID, Assertion, nil)
+	if err == nil {
+		t.Fatal("Expected an error but received none")
+	}
+	if cred != nil {
+		t.Fatalf("Expected a nil credential value. Received: %v", cred)
+	}
+}
+
+func TestClientAssertionCredential_GetTokenSuccess(t *testing.T) {
+	cred, err := NewClientAssertionCredential(fakeTenantID, fakeClientID, Assertion, nil)
+	if err != nil {
+		t.Fatalf("Unable to create credential. Received: %v", err)
+	}
+	cred.client = fakeConfidentialClient{}
+	_, err = cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
+	if err != nil {
+		t.Fatalf("Expected an empty error but received: %v", err)
+	}
+}
+
+//
+// TODO - this test needs to configure Workload Identity Federated token on AzureAD against tests are run to
+//func TestClientAssertionCredential_Live(t *testing.T) {
+//	opts, stop := initRecording(t)
+//	defer stop()
+//	o := ClientAssertionCredentialOptions{ClientOptions: opts}
+//	cred, err := NewClientAssertionCredential(liveSP.tenantID, liveSP.clientID, liveSP.clientAssertion, &o)
+//	if err != nil {
+//		t.Fatalf("failed to construct credential: %v", err)
+//	}
+//	testGetTokenSuccess(t, cred)
+//}
+
+func TestClientAssertionCredential_InvalidAssertionLive(t *testing.T) {
+	opts, stop := initRecording(t)
+	defer stop()
+	o := ClientAssertionCredentialOptions{ClientOptions: opts}
+	cred, err := NewClientAssertionCredential(liveSP.tenantID, liveSP.clientID, "invalid Assertion", &o)
+	if err != nil {
+		t.Fatalf("failed to construct credential: %v", err)
+	}
+	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
+	if tk != nil {
+		t.Fatal("GetToken returned a token")
+	}
+	var e AuthenticationFailedError
+	if !errors.As(err, &e) {
+		t.Fatal("expected AuthenticationFailedError")
+	}
+	if e.RawResponse == nil {
+		t.Fatal("expected a non-nil RawResponse")
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

Add support for https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation JWT tokens in azidentity package. These tokens are called assertions in AzureAD REST API and MSAL for Go library, so same name used in this merge request.

I was not able to create test to correctly auth using Assertion as configuration to Live AzureAD needs to be done.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
