### PR TITLE
[Identity] Add references to the troubleshooting guide on the error messages

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated the errors on all of the provided credentials to point to the troubleshooting guide.
+
 ## 0.13.0 (2022-01-11)
 
 ### Breaking Changes

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -132,7 +132,7 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 				// if there's no output in stderr report the error message instead
 				msg = err.Error()
 			}
-			troubleshootMessage := fmt.Sprintf("%s%s", msg, azureCliTroubleshootMessage)
+			troubleshootMessage := fmt.Sprintf("%s%s", msg, azureCliCredentialTroubleshootMessage)
 			return nil, newCredentialUnavailableError("Azure CLI Credential", troubleshootMessage)
 		}
 

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -73,9 +73,8 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequ
 	scope := strings.TrimSuffix(opts.Scopes[0], defaultSuffix)
 	at, err := c.authenticate(ctx, scope)
 	if err != nil {
-		error := fmt.Errorf("%s%s", err.Error(), azureCliCredentialTroubleshootMessage)
-		addGetTokenFailureLogs("Azure CLI Credential", error, true)
-		return nil, error
+		addGetTokenFailureLogs("Azure CLI Credential", err, true)
+		return nil, err
 	}
 	logGetTokenSuccess(c, opts)
 	return at, nil

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/crypto/pkcs12"
 )
 
-var clientCertificateTroubleshootMessage string = "\nTo troubleshoot, visit https://aka.ms/azsdk/go/identity/serviceprincipalauthentication/troubleshoot"
+const clientCertificateCredentialTroubleshootMessage string = "\nTo troubleshoot, visit https://aka.ms/azsdk/go/identity/serviceprincipalauthentication/troubleshoot"
 
 // ClientCertificateCredentialOptions contains optional parameters for ClientCertificateCredential.
 type ClientCertificateCredentialOptions struct {
@@ -64,9 +64,9 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 	}
 	authorityHost, err := setAuthorityHost(options.AuthorityHost)
 	if err != nil {
-		error := fmt.Errorf("%s%s", err.Error(), clientCertificateTroubleshootMessage)
+		error := fmt.Errorf("%s%s", err.Error(), clientCertificateCredentialTroubleshootMessage)
 		logCredentialError("Client Certificate Credential", error)
-		return nil, err
+		return nil, error
 	}
 	cert, err := newCertContents(certs, pk, options.SendCertificateChain)
 	if err != nil {
@@ -102,9 +102,9 @@ func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts policy.
 
 	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	if err != nil {
-		error := fmt.Errorf("%s%s", err.Error(), clientCertificateTroubleshootMessage)
+		error := fmt.Errorf("%s%s", err.Error(), clientCertificateCredentialTroubleshootMessage)
 		addGetTokenFailureLogs("Client Certificate Credential", error, true)
-		return nil, newAuthenticationFailedError(err, nil)
+		return nil, newAuthenticationFailedError(error, nil)
 	}
 	logGetTokenSuccess(c, opts)
 	return &azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+	msal "github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors"
 	"golang.org/x/crypto/pkcs12"
 )
 
@@ -104,6 +105,10 @@ func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts policy.
 	if err != nil {
 		error := fmt.Errorf("%s%s", err.Error(), clientCertificateCredentialTroubleshootMessage)
 		addGetTokenFailureLogs("Client Certificate Credential", error, true)
+		var e msal.CallErr
+		if errors.As(err, &e) {
+			return nil, newAuthenticationFailedError(error, e.Resp)
+		}
 		return nil, newAuthenticationFailedError(error, nil)
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -65,9 +65,8 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 	}
 	authorityHost, err := setAuthorityHost(options.AuthorityHost)
 	if err != nil {
-		error := fmt.Errorf("%s%s", err.Error(), clientCertificateCredentialTroubleshootMessage)
-		logCredentialError("Client Certificate Credential", error)
-		return nil, error
+		logCredentialError("Client Certificate Credential", err)
+		return nil, err
 	}
 	cert, err := newCertContents(certs, pk, options.SendCertificateChain)
 	if err != nil {

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -160,7 +160,7 @@ func ParseCertificates(certData []byte, password []byte) ([]*x509.Certificate, c
 		return nil, nil, errors.New("found no certificate")
 	}
 	if pk == nil {
-		return nil, nil, errors.New("found no certificate")
+		return nil, nil, errors.New("found no private key")
 	}
 	return certs, pk, nil
 }

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -6,12 +6,15 @@ package azidentity
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
 )
+
+const clientSecretCredentialTroubleshootMessage string = "\nTo troubleshoot, visit https://aka.ms/azsdk/go/identity/serviceprincipalauthentication/troubleshoot"
 
 // ClientSecretCredentialOptions contains optional parameters for ClientSecretCredential.
 type ClientSecretCredentialOptions struct {
@@ -52,7 +55,9 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 		confidential.WithHTTPClient(newPipelineAdapter(&options.ClientOptions)),
 	)
 	if err != nil {
-		return nil, err
+		error := fmt.Errorf("%s%s", err.Error(), clientSecretCredentialTroubleshootMessage)
+		logCredentialError("Client Secret Credential", error)
+		return nil, error
 	}
 	return &ClientSecretCredential{client: c}, nil
 }

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -5,12 +5,14 @@ package azidentity
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
+
+const defaultAzureCredentialTroubleshootMessage string = "\nTo troubleshoot, visit https://aka.ms/azsdk/go/identity/defaultazurecredential/troubleshoot"
 
 // DefaultAzureCredentialOptions contains optional parameters for DefaultAzureCredential.
 // These options may not apply to all credentials in the chain.
@@ -70,7 +72,7 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 	}
 
 	if len(creds) == 0 {
-		err := errors.New(errMsg)
+		err := fmt.Errorf("%s%s", errMsg, defaultAzureCredentialTroubleshootMessage)
 		logCredentialError("Default Azure Credential", err)
 		return nil, err
 	}

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -16,6 +16,7 @@ import (
 )
 
 const envVarSendCertChain = "AZURE_CLIENT_SEND_CERTIFICATE_CHAIN"
+const environmentCredentialTroubleshootMessage string = "\nTo troubleshoot, visit https://aka.ms/azsdk/go/identity/environmentcredential/troubleshoot"
 
 // EnvironmentCredentialOptions contains optional parameters for EnvironmentCredential
 type EnvironmentCredentialOptions struct {
@@ -104,7 +105,9 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 			return &EnvironmentCredential{cred: cred}, nil
 		}
 	}
-	return nil, errors.New("missing environment variable AZURE_CLIENT_SECRET or AZURE_CLIENT_CERTIFICATE_PATH or AZURE_USERNAME and AZURE_PASSWORD")
+	errorMessage := "missing environment variable AZURE_CLIENT_SECRET or AZURE_CLIENT_CERTIFICATE_PATH or AZURE_USERNAME and AZURE_PASSWORD"
+	err := fmt.Errorf("%s%s", errorMessage, environmentCredentialTroubleshootMessage)
+	return nil, err
 }
 
 // GetToken obtains a token from Azure Active Directory. This method is called automatically by Azure SDK clients.

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -5,13 +5,14 @@ package azidentity
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
+
+const managedIdentityCredentialTroubleshootMessage string = "\nTo troubleshoot, visit https://aka.ms/azsdk/go/identity/managedidentitycredential/troubleshoot"
 
 type managedIdentityIDKind int
 
@@ -77,7 +78,8 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 	}
 	client, err := newManagedIdentityClient(options)
 	if err != nil {
-		logCredentialError("Managed Identity Credential", err)
+		error := fmt.Errorf("%s%s", err.Error(), managedIdentityCredentialTroubleshootMessage)
+		logCredentialError("Managed Identity Credential", error)
 		return nil, err
 	}
 	return &ManagedIdentityCredential{id: options.ID, client: client}, nil
@@ -88,7 +90,8 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	if len(opts.Scopes) != 1 {
-		err := errors.New("ManagedIdentityCredential.GetToken() requires exactly one scope")
+		errorMessage := "ManagedIdentityCredential.GetToken() requires exactly one scope"
+		err := fmt.Errorf("%s%s", errorMessage, managedIdentityCredentialTroubleshootMessage)
 		addGetTokenFailureLogs("Managed Identity Credential", err, true)
 		return nil, err
 	}
@@ -96,7 +99,8 @@ func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.To
 	scopes := []string{strings.TrimSuffix(opts.Scopes[0], defaultSuffix)}
 	tk, err := c.client.authenticate(ctx, c.id, scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Managed Identity Credential", err, true)
+		error := fmt.Errorf("%s%s", err.Error(), managedIdentityCredentialTroubleshootMessage)
+		addGetTokenFailureLogs("Managed Identity Credential", error, true)
 		return nil, err
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -5,6 +5,7 @@ package azidentity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -90,8 +91,7 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	if len(opts.Scopes) != 1 {
-		errorMessage := "ManagedIdentityCredential.GetToken() requires exactly one scope"
-		err := fmt.Errorf("%s%s", errorMessage, managedIdentityCredentialTroubleshootMessage)
+		err := errors.New("ManagedIdentityCredential.GetToken() requires exactly one scope")
 		addGetTokenFailureLogs("Managed Identity Credential", err, true)
 		return nil, err
 	}

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	msal "github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
@@ -76,6 +77,10 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.T
 	if err != nil {
 		error := fmt.Errorf("%s%s", err.Error(), usernamePasswordCredentialTroubleshootMessage)
 		addGetTokenFailureLogs("Username Password Credential", error, true)
+		var e msal.CallErr
+		if errors.As(err, &e) {
+			return nil, newAuthenticationFailedError(error, e.Resp)
+		}
 		return nil, newAuthenticationFailedError(error, nil)
 	}
 	c.account = ar.Account

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -78,8 +78,10 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.T
 		error := fmt.Errorf("%s%s", err.Error(), usernamePasswordCredentialTroubleshootMessage)
 		addGetTokenFailureLogs("Username Password Credential", error, true)
 		var e msal.CallErr
-		errors.As(err, &e)
-		return nil, newAuthenticationFailedError(error, e.Resp)
+		if errors.As(err, &e) {
+			return nil, newAuthenticationFailedError(error, e.Resp)
+		}
+		return nil, newAuthenticationFailedError(error, nil)
 	}
 	c.account = ar.Account
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -6,12 +6,15 @@ package azidentity
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
+
+const usernamePasswordCredentialTroubleshootMessage string = "\nTo troubleshoot, visit https://aka.ms/azsdk/go/identity/usernamepasswordcredential/troubleshoot"
 
 // UsernamePasswordCredentialOptions contains optional parameters for UsernamePasswordCredential.
 type UsernamePasswordCredentialOptions struct {
@@ -71,8 +74,9 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.T
 	}
 	ar, err = c.client.AcquireTokenByUsernamePassword(ctx, opts.Scopes, c.username, c.password)
 	if err != nil {
-		addGetTokenFailureLogs("Username Password Credential", err, true)
-		return nil, newAuthenticationFailedError(err, nil)
+		error := fmt.Errorf("%s%s", err.Error(), usernamePasswordCredentialTroubleshootMessage)
+		addGetTokenFailureLogs("Username Password Credential", error, true)
+		return nil, newAuthenticationFailedError(error, nil)
 	}
 	c.account = ar.Account
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -78,10 +78,8 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.T
 		error := fmt.Errorf("%s%s", err.Error(), usernamePasswordCredentialTroubleshootMessage)
 		addGetTokenFailureLogs("Username Password Credential", error, true)
 		var e msal.CallErr
-		if errors.As(err, &e) {
-			return nil, newAuthenticationFailedError(error, e.Resp)
-		}
-		return nil, newAuthenticationFailedError(error, nil)
+		errors.As(err, &e)
+		return nil, newAuthenticationFailedError(error, e.Resp)
 	}
 	c.account = ar.Account
 	logGetTokenSuccess(c, opts)


### PR DESCRIPTION
In this PR I’m trying to add references to the troubleshooting guide on the error messages of the Identity credentials.

How is it going? 🙂

Eventually:
Fixes #16843