### PR TITLE
Use Payload() for reading response bodies

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Restore response body after reading in `Poller.FinalResponse()`
 
 ### Other Changes
 * `BearerTokenPolicy` is more resilient to transient authentication failures

--- a/sdk/azcore/internal/pollers/poller.go
+++ b/sdk/azcore/internal/pollers/poller.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"time"
@@ -154,8 +153,7 @@ func (l *Poller) FinalResponse(ctx context.Context, respType interface{}) (*http
 		log.Write(log.EventLRO, "final response specifies a response type but no payload was received")
 		return l.resp, nil
 	}
-	body, err := ioutil.ReadAll(l.resp.Body)
-	l.resp.Body.Close()
+	body, err := shared.Payload(l.resp)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azcore/internal/shared/shared.go
+++ b/sdk/azcore/internal/shared/shared.go
@@ -7,7 +7,6 @@
 package shared
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -76,16 +75,13 @@ var ErrNoBody = errors.New("the response did not contain a body")
 // GetJSON reads the response body into a raw JSON object.
 // It returns ErrNoBody if there was no content.
 func GetJSON(resp *http.Response) (map[string]interface{}, error) {
-	body, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
+	body, err := Payload(resp)
 	if err != nil {
 		return nil, err
 	}
 	if len(body) == 0 {
 		return nil, ErrNoBody
 	}
-	// put the body back so it's available to others
-	resp.Body = ioutil.NopCloser(bytes.NewReader(body))
 	// unmarshall the body to get the value
 	var jsonBody map[string]interface{}
 	if err = json.Unmarshal(body, &jsonBody); err != nil {

--- a/sdk/azcore/runtime/policy_body_download.go
+++ b/sdk/azcore/runtime/policy_body_download.go
@@ -8,7 +8,6 @@ package runtime
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -30,12 +29,10 @@ func bodyDownloadPolicy(req *policy.Request) (*http.Response, error) {
 	}
 	// Either bodyDownloadPolicyOpValues was not specified (so skip is false)
 	// or it was specified and skip is false: don't skip downloading the body
-	b, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
+	_, err = shared.Payload(resp)
 	if err != nil {
 		return resp, newBodyDownloadError(err, req)
 	}
-	resp.Body = shared.NewNopClosingBytesReader(b)
 	return resp, err
 }
 


### PR DESCRIPTION
Poller.FinalResponse() wasn't restoring the response body after reading.
Removed duplicate definitions from GetJSON and bodyDownloadPolicy.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
