### PR TITLE
[azservicebus] Handle 500 as a retryable code (no recovery needed)

### DIFF
--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -175,7 +175,10 @@ func GetRecoveryKind(err error) recoveryKind {
 		}
 
 		// simple timeouts
-		if me.Resp.Code == 408 || me.Resp.Code == 503 {
+		if me.Resp.Code == 408 || me.Resp.Code == 503 || 
+			// internal server errors are worth retrying (they will typically lead 
+			// to a more actionable error)
+			me.Resp.Code == 500 {
 			return RecoveryKindNone
 		}
 	}

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -175,9 +175,9 @@ func GetRecoveryKind(err error) recoveryKind {
 		}
 
 		// simple timeouts
-		if me.Resp.Code == 408 || me.Resp.Code == 503 || 
-			// internal server errors are worth retrying (they will typically lead 
-			// to a more actionable error). A simple example of this is when you're 
+		if me.Resp.Code == 408 || me.Resp.Code == 503 ||
+			// internal server errors are worth retrying (they will typically lead
+			// to a more actionable error). A simple example of this is when you're
 			// in the middle of an operation and the link is detached. Sometimes you'll get
 			// the detached event immediately, but sometimes you'll get an intermediate 500
 			// indicating your original operation was cancelled.

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -177,7 +177,10 @@ func GetRecoveryKind(err error) recoveryKind {
 		// simple timeouts
 		if me.Resp.Code == 408 || me.Resp.Code == 503 || 
 			// internal server errors are worth retrying (they will typically lead 
-			// to a more actionable error)
+			// to a more actionable error). A simple example of this is when you're 
+			// in the middle of an operation and the link is detached. Sometimes you'll get
+			// the detached event immediately, but sometimes you'll get an intermediate 500
+			// indicating your original operation was cancelled.
 			me.Resp.Code == 500 {
 			return RecoveryKindNone
 		}

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -177,6 +177,7 @@ func Test_ServiceBusError_NoRecoveryNeeded(t *testing.T) {
 		// simple timeouts from the mgmt link
 		mgmtError{Resp: &RPCResponse{Code: 408}},
 		mgmtError{Resp: &RPCResponse{Code: 503}},
+		mgmtError{Resp: &RPCResponse{Code: 500}},
 	}
 
 	for i, err := range tempErrors {
@@ -236,8 +237,5 @@ func Test_ServiceBusError_Fatal(t *testing.T) {
 
 	// unknown errors are also considered fatal
 	rk := GetSBErrInfo(errors.New("Some unknown error")).RecoveryKind
-	require.EqualValues(t, RecoveryKindFatal, rk, "some unknown error")
-
-	rk = GetSBErrInfo(mgmtError{Resp: &RPCResponse{Code: 500}}).RecoveryKind
 	require.EqualValues(t, RecoveryKindFatal, rk, "some unknown error")
 }

--- a/sdk/messaging/azservicebus/session_receiver_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_test.go
@@ -6,9 +6,11 @@ package azservicebus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
@@ -267,6 +269,10 @@ func TestSessionReceiver_Detach(t *testing.T) {
 		RequiresSession: to.BoolPtr(true),
 	})
 	defer cleanup()
+
+	azlog.SetListener(func(e azlog.Event, s string) {
+		fmt.Printf("%s %s\n", e, s)
+	})
 
 	adminClient, err := admin.NewClientFromConnectionString(test.GetConnectionString(t), nil)
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/session_receiver_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_test.go
@@ -274,6 +274,8 @@ func TestSessionReceiver_Detach(t *testing.T) {
 		fmt.Printf("%s %s\n", e, s)
 	})
 
+	defer azlog.SetListener(nil)
+
 	adminClient, err := admin.NewClientFromConnectionString(test.GetConnectionString(t), nil)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Handle 500 as a retryable code (no link/connection recovery needed)

This can happen if, for instance, your link gets detached in the middle of an operation. Typically you'll get the 500, and then subsequent retries will work or reveal the underlying cause (ie, link detached, etc..).