### PR TITLE
Avoid retries on terminal failures in challenge policy

### DIFF
--- a/sdk/keyvault/azkeys/go.mod
+++ b/sdk/keyvault/azkeys/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.2.0
 	github.com/stretchr/testify v1.7.0
 )
+
+replace github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal => ../internal

--- a/sdk/keyvault/azkeys/go.sum
+++ b/sdk/keyvault/azkeys/go.sum
@@ -7,8 +7,6 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1/go.mod h1:KLF4gFr6DcKFZwSu
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0 h1:HMbyI+KfvL+XyuWekow/nWbRxsAhB6+DVzgQTIABecU=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.2.0 h1:gyGoG9FrTr5AQqpa7nPMMd2HewJGuVKdHFAe8x4tRAk=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.2.0/go.mod h1:qKJHexVLI0iqKFeV/2WnqbRBQtJTPOMeBdmHOxs+E88=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0 h1:WVsrXCnHlDDX8ls+tootqRE87/hL9S/g4ewig9RsD/c=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/sdk/keyvault/azsecrets/go.mod
+++ b/sdk/keyvault/azsecrets/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.2.0
 	github.com/stretchr/testify v1.7.0
 )
+
+replace github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal => ../internal

--- a/sdk/keyvault/azsecrets/go.sum
+++ b/sdk/keyvault/azsecrets/go.sum
@@ -7,8 +7,6 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1/go.mod h1:KLF4gFr6DcKFZwSu
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0 h1:HMbyI+KfvL+XyuWekow/nWbRxsAhB6+DVzgQTIABecU=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.2.0 h1:gyGoG9FrTr5AQqpa7nPMMd2HewJGuVKdHFAe8x4tRAk=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.2.0/go.mod h1:qKJHexVLI0iqKFeV/2WnqbRBQtJTPOMeBdmHOxs+E88=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0 h1:WVsrXCnHlDDX8ls+tootqRE87/hL9S/g4ewig9RsD/c=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/sdk/keyvault/internal/challenge_policy.go
+++ b/sdk/keyvault/internal/challenge_policy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 )
 
 const headerAuthorization = "Authorization"
@@ -57,6 +58,10 @@ func (k *KeyVaultChallengePolicy) Do(req *policy.Request) (*http.Response, error
 			return nil, err
 		}
 
+		if resp.StatusCode > 299 {
+			// the request failed, don't try any further
+			return resp, nil
+		}
 		err = k.findScopeAndTenant(resp)
 		if err != nil {
 			return nil, err
@@ -128,11 +133,29 @@ func parseTenant(url string) *string {
 	return &tenant
 }
 
+type challengePolicyError struct {
+	err error
+}
+
+func (c *challengePolicyError) Error() string {
+	return c.err.Error()
+}
+
+func (*challengePolicyError) NonRetriable() {
+	// marker method
+}
+
+func (c *challengePolicyError) Unwrap() error {
+	return c.err
+}
+
+var _ errorinfo.NonRetriable = (*challengePolicyError)(nil)
+
 // sets the k.scope and k.tenantID from the WWW-Authenticate header
 func (k *KeyVaultChallengePolicy) findScopeAndTenant(resp *http.Response) error {
 	authHeader := resp.Header.Get("WWW-Authenticate")
 	if authHeader == "" {
-		return errors.New("response has no WWW-Authenticate header for challenge authentication")
+		return &challengePolicyError{err: errors.New("response has no WWW-Authenticate header for challenge authentication")}
 	}
 
 	// Strip down to auth and resource
@@ -161,7 +184,7 @@ func (k *KeyVaultChallengePolicy) findScopeAndTenant(resp *http.Response) error 
 		}
 		k.scope = &resource
 	} else {
-		return errors.New("could not find a valid resource in the WWW-Authenticate header")
+		return &challengePolicyError{err: errors.New("could not find a valid resource in the WWW-Authenticate header")}
 	}
 
 	return nil
@@ -170,7 +193,7 @@ func (k *KeyVaultChallengePolicy) findScopeAndTenant(resp *http.Response) error 
 func (k KeyVaultChallengePolicy) getChallengeRequest(orig policy.Request) (*policy.Request, error) {
 	req, err := runtime.NewRequest(orig.Raw().Context(), orig.Raw().Method, orig.Raw().URL.String())
 	if err != nil {
-		return nil, err
+		return nil, &challengePolicyError{err: err}
 	}
 
 	req.Raw().Header = orig.Raw().Header
@@ -183,7 +206,7 @@ func (k KeyVaultChallengePolicy) getChallengeRequest(orig policy.Request) (*poli
 	copied.Raw().Header.Set("Content-Length", "0")
 	err = copied.SetBody(streaming.NopCloser(bytes.NewReader([]byte{})), "application/json")
 	if err != nil {
-		return nil, err
+		return nil, &challengePolicyError{err: err}
 	}
 	copied.Raw().Header.Del("Content-Type")
 

--- a/sdk/keyvault/internal/challenge_policy.go
+++ b/sdk/keyvault/internal/challenge_policy.go
@@ -58,7 +58,7 @@ func (k *KeyVaultChallengePolicy) Do(req *policy.Request) (*http.Response, error
 			return nil, err
 		}
 
-		if resp.StatusCode > 299 {
+		if resp.StatusCode > 399 {
 			// the request failed, don't try any further
 			return resp, nil
 		}

--- a/sdk/keyvault/internal/challenge_policy.go
+++ b/sdk/keyvault/internal/challenge_policy.go
@@ -58,8 +58,8 @@ func (k *KeyVaultChallengePolicy) Do(req *policy.Request) (*http.Response, error
 			return nil, err
 		}
 
-		if resp.StatusCode > 399 {
-			// the request failed, don't try any further
+		if resp.StatusCode > 399 && resp.StatusCode != http.StatusUnauthorized {
+			// the request failed for some other reason, don't try any further
 			return resp, nil
 		}
 		err = k.findScopeAndTenant(resp)

--- a/sdk/keyvault/internal/go.mod
+++ b/sdk/keyvault/internal/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1
 	github.com/stretchr/testify v1.7.0
 )


### PR DESCRIPTION
If the challenge request fails, return the response to the caller as it
won't contain an authentication header.
Make hard errors non retriable.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
