### PR TITLE
Fix deadlock when erroring writes are slow

### DIFF
--- a/sdk/storage/azblob/blockblob/chunkwriting_test.go
+++ b/sdk/storage/azblob/blockblob/chunkwriting_test.go
@@ -30,6 +30,7 @@ type fakeBlockWriter struct {
 	path       string
 	block      int32
 	errOnBlock int32
+	stageDelay time.Duration
 }
 
 func newFakeBlockWriter() *fakeBlockWriter {
@@ -49,7 +50,12 @@ func newFakeBlockWriter() *fakeBlockWriter {
 
 func (f *fakeBlockWriter) StageBlock(_ context.Context, blockID string, body io.ReadSeekCloser, _ *StageBlockOptions) (StageBlockResponse, error) {
 	n := atomic.AddInt32(&f.block, 1)
-	if n == f.errOnBlock {
+
+	if f.stageDelay > 0 {
+		time.Sleep(f.stageDelay)
+	}
+
+	if f.errOnBlock > -1 && n >= f.errOnBlock {
 		return StageBlockResponse{}, io.ErrNoProgress
 	}
 
@@ -189,6 +195,45 @@ func TestGetErr(t *testing.T) {
 		if test.want != got {
 			t.Errorf("TestGetErr(%s): got %v, want %v", test.desc, got, test.want)
 		}
+	}
+}
+
+func TestSlowDestCopyFrom(t *testing.T) {
+	p, err := createSrcFile(_1MiB + 500*1024) //This should cause 2 reads
+	if err != nil {
+		panic(err)
+	}
+	defer func(name string) {
+		_ = os.Remove(name)
+	}(p)
+
+	from, err := os.Open(p)
+	if err != nil {
+		panic(err)
+	}
+	defer from.Close()
+
+	br := newFakeBlockWriter()
+	defer br.cleanup()
+
+	br.stageDelay = 200 * time.Millisecond
+	br.errOnBlock = 0
+
+	errs := make(chan error, 1)
+	go func() {
+		_, err := copyFromReader(context.Background(), from, br, UploadStreamOptions{})
+		errs <- err
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		failMsg := "TestSlowDestCopyFrom(slow writes shouldn't cause deadlock) failed: Context expired, copy deadlocked"
+		t.Error(failMsg)
+	case <-errs:
+		return
 	}
 }
 


### PR DESCRIPTION
`c.getErr` can return before slow writes complete. If there is more than one write and those writes result in errors, the second write blocks on a full `errCh`. The result is a deadlocked `copyFromReader` call because the wait groups never clear.

The test included tests demonstrates the deadlock. 

This PR causes `close` to simultaneously drain the `errCh` while it waits for writes to complete. It combines any errors that are returned.

I looked at the CHANGELOG, but not sure this change fits. Let me know if I need to do something else.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included. 
- [x] MIT license headers are included in each file.

