### PR TITLE
Handling amqp.DetachError as retryable error

### DIFF
--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -158,6 +158,13 @@ func isRetryableAMQPError(ctxForLogging context.Context, err error) bool {
 		return ok
 	}
 
+	var amqpDetachErr *amqp.DetachError
+	var isAMQPDetachError = errors.As(err, &amqpDetachErr)
+
+	if isAMQPDetachError {
+		return isRetryableAMQPError(ctxForLogging, amqpDetachErr.RemoteError)
+	}
+
 	// TODO: there is a bug somewhere that seems to be errorString'ing errors. Need to track that down.
 	// In the meantime, try string matching instead
 	for condition := range retryableAMQPConditions {

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -113,6 +113,11 @@ func Test_isRetryableAMQPError(t *testing.T) {
 		require.True(t, isRetryableAMQPError(ctx, &amqp.Error{
 			Condition: amqp.ErrorCondition(code),
 		}))
+		require.True(t, isRetryableAMQPError(ctx, &amqp.DetachError{
+			RemoteError: &amqp.Error{
+				Condition: amqp.ErrorCondition(code),
+			},
+		}))
 
 		// it works equally well if the error is just in the String().
 		// Need to narrow this down some more to see where the errors


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
