### PR TITLE
Cloud Shell doesn't support user assigned identities

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* `ManagedIdentityCredential.GetToken()` now returns an error when configured for
+   a user assigned identity in Azure Cloud Shell (which doesn't support such identities)
 
 ### Other Changes
 

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -164,6 +164,22 @@ func TestManagedIdentityCredential_CloudShell(t *testing.T) {
 	}
 }
 
+func TestManagedIdentityCredential_CloudShellUserAssigned(t *testing.T) {
+	setEnvironmentVariables(t, map[string]string{msiEndpoint: "http://localhost"})
+	for _, id := range []ManagedIDKind{ClientID("client-id"), ResourceID("/resource/id")} {
+		options := ManagedIdentityCredentialOptions{ID: id}
+		msiCred, err := NewManagedIdentityCredential(&options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
+		var authErr AuthenticationFailedError
+		if !errors.As(err, &authErr) {
+			t.Fatal("expected AuthenticationFailedError")
+		}
+	}
+}
+
 func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_windows(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()


### PR DESCRIPTION
Cloud Shell's token endpoint ignores unexpected parameters and always authenticates the signed in user. This means that when ManagedIdentityCredential requests a token for a user assigned identity, Cloud Shell returns a token for the signed in user instead. The credential should therefore return an authentication failed error when asked to get a token for a user assigned identity in Cloud Shell.