### PR TITLE
[azservicebus/stress] Make sure you pull the image always

### DIFF
--- a/sdk/messaging/azservicebus/internal/stress/templates/deploy-job.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/templates/deploy-job.yaml
@@ -9,6 +9,7 @@ spec:
       # az acr list -g rg-stress-cluster-test --subscription "Azure SDK Developer Playground" --query "[0].loginServer"
       image:  {{ .Values.image }}
       command: ['/app/stress']
+      imagePullPolicy: Always
       args: 
       - "tests"
       # (this is injected automatically. The full list of scenarios is in `../values.yaml`)


### PR DESCRIPTION
Make sure we always pull the stress test image.

Without this you'll end up in a situation where, if you're repeatedly testing, you end up running the last cached image, which is probably not what you want.