### PR TITLE
Fix NullValue for maps and slices

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 * Restore response body after reading in `Poller.FinalResponse()`
+* Fixed bug in `NullValue` that could lead to incorrect comparisons for empty maps/slices
 
 ### Other Changes
 * `BearerTokenPolicy` is more resilient to transient authentication failures

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -34,9 +34,13 @@ func NullValue(v interface{}) interface{} {
 	v, found := nullables[t]
 	if !found {
 		var o reflect.Value
-		if k := t.Kind(); k == reflect.Slice || k == reflect.Map {
-			o = reflect.New(t) // *[]type / *map[]
-			o = o.Elem()       // []type / map[]
+		if k := t.Kind(); k == reflect.Map {
+			o = reflect.MakeMap(t)
+		} else if k == reflect.Slice {
+			// empty slices appear to all point to the same data block
+			// which causes comparisons to become ambiguous.  so we create
+			// a slice with len/cap of one which ensures a unique address.
+			o = reflect.MakeSlice(t, 1, 1)
 		} else {
 			o = reflect.New(t.Elem())
 		}

--- a/sdk/azcore/core_test.go
+++ b/sdk/azcore/core_test.go
@@ -91,4 +91,35 @@ func TestIsNullValueMapSlice(t *testing.T) {
 	if !IsNullValue(m) {
 		t.Fatal("expected null value for s")
 	}
+
+	type nullFields struct {
+		Map   map[string]int
+		Slice []string
+	}
+
+	nf := nullFields{}
+	if IsNullValue(nf.Map) {
+		t.Fatal("unexpected null map")
+	}
+	if IsNullValue(nf.Slice) {
+		t.Fatal("unexpected null slice")
+	}
+
+	nf.Map = map[string]int{}
+	nf.Slice = []string{}
+	if IsNullValue(nf.Map) {
+		t.Fatal("unexpected null map")
+	}
+	if IsNullValue(nf.Slice) {
+		t.Fatal("unexpected null slice")
+	}
+
+	nf.Map = NullValue(map[string]int{}).(map[string]int)
+	nf.Slice = NullValue([]string{}).([]string)
+	if !IsNullValue(nf.Map) {
+		t.Fatal("expected null map")
+	}
+	if !IsNullValue(nf.Slice) {
+		t.Fatal("expected null slice")
+	}
 }


### PR DESCRIPTION
Using reflect.New created a pointer to a zero-value underlying type.
For maps and slices this meant nil which lead to incorrect comparisons.
Instead, create an empty map which ensures a unique address.
For slices, create a slice with a length of one to avoid an apparent
optimization with zero-length slices.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
