### PR TITLE
Disable publishing test results for now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,7 @@ jobs:
       failOnStderr: true
       condition: succeededOrFailed()
 
-    - script: gofmt -s -l -d $(find . -path ./vendor -prune -o -name '*.go' -print) >&2
+    - script: gofmt -s -l -d $(find . $(go.test.filter) -name '*.go' -print) >&2
       workingDirectory: '$(sdkPath)'
       displayName: 'Format Check'
       failOnStderr: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,11 @@ jobs:
       failOnStderr: true
       condition: succeededOrFailed()
 
-    - script: gofmt -s -l -d $(find . $(go.test.filter) -name '*.go' -print) >&2
+    - script: |
+        for dd in $(go.list.filter); do
+          cd $(sdkPath)/$dd
+          gofmt -s -l -d $(find . -name '*.go' -print) >&2
+        done
       workingDirectory: '$(sdkPath)'
       displayName: 'Format Check'
       failOnStderr: true

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -11,6 +11,8 @@ go test -run "^Test" -v -coverprofile coverage.txt ./... | Tee-Object -FilePath 
 if ($LASTEXITCODE) {
     exit $LASTEXITCODE
 }
+exit 0
+
 Get-Content outfile.txt | go-junit-report > report.xml
 
 # if no tests were actually run (e.g. examples) delete the coverage file so it's omitted from the coverage report

--- a/sdk/azcore/etag_test.go
+++ b/sdk/azcore/etag_test.go
@@ -24,7 +24,7 @@ func TestETagEquals(t *testing.T) {
 	require.Equal(t, string(e2), "\"tag\"")
 
 	e3 := createETag("W/\"weakETag\"")
-	require.Equal(t, string(e3), "W/\"weakETag\"")
+	require.Equal(t, string(e3), "W/\"weak1ETag\"")
 	require.Truef(t, e3.IsWeak(), "ETag is expected to be weak")
 
 	strongETag := createETag("\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\"")

--- a/sdk/azcore/etag_test.go
+++ b/sdk/azcore/etag_test.go
@@ -24,7 +24,7 @@ func TestETagEquals(t *testing.T) {
 	require.Equal(t, string(e2), "\"tag\"")
 
 	e3 := createETag("W/\"weakETag\"")
-	require.Equal(t, string(e3), "W/\"weak1ETag\"")
+	require.Equal(t, string(e3), "W/\"weakETag\"")
 	require.Truef(t, e3.IsWeak(), "ETag is expected to be weak")
 
 	strongETag := createETag("\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\"")


### PR DESCRIPTION
It's broken due to lack of generics support.  Test failures will still
block CI though.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
