### PR TITLE
Revise azidentity error messages

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -1,19 +1,23 @@
 # Release History
 
-## 0.13.1 (Unreleased)
+## 0.13.1 (2022-02-08)
 
 ### Features Added
+* `EnvironmentCredential` supports certificate SNI authentication when
+  `AZURE_CLIENT_SEND_CERTIFICATE_CHAIN` is "true".
+  ([#16851](https://github.com/Azure/azure-sdk-for-go/pull/16851))
 
 ### Breaking Changes
 
 ### Bugs Fixed
 * `ManagedIdentityCredential.GetToken()` now returns an error when configured for
    a user assigned identity in Azure Cloud Shell (which doesn't support such identities)
+   ([#16946](https://github.com/Azure/azure-sdk-for-go/pull/16946))
 
 ### Other Changes
-
-* Improved the diagnosability of the `DefaultAzureCredential` by logging failures by credentials when at least one credential succeeded at initialization.
-* Improved the diagnosability of the `DefaultAzureCredential` and `ChainedTokenCredential` aggregating all the errors that might have occurred on the credential chain during `GetToken` calls into a single message provided via logs and errors if the chain is finally unable to retrieve a token.
+* `NewDefaultAzureCredential()` logs non-fatal errors. These errors are also included in the
+  error returned by `DefaultAzureCredential.GetToken()` when it's unable to acquire a token
+  from any source. ([#15923](https://github.com/Azure/azure-sdk-for-go/issues/15923))
 
 ## 0.13.0 (2022-01-11)
 

--- a/sdk/azidentity/authorization_code_credential.go
+++ b/sdk/azidentity/authorization_code_credential.go
@@ -14,6 +14,8 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
+const credNameAuthCode = "AuthorizationCodeCredential"
+
 // AuthorizationCodeCredentialOptions contains optional parameters for AuthorizationCodeCredential.
 type AuthorizationCodeCredentialOptions struct {
 	azcore.ClientOptions
@@ -90,8 +92,8 @@ func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts policy.
 		}
 		ar, err = c.cca.AcquireTokenByAuthCode(ctx, c.authCode, c.redirectURI, opts.Scopes)
 		if err != nil {
-			addGetTokenFailureLogs("AuthorizationCodeCredential", err, true)
-			return nil, newAuthenticationFailedError(err, nil)
+			addGetTokenFailureLogs(credNameAuthCode, err, true)
+			return nil, newAuthenticationFailedError(credNameAuthCode, err, nil)
 		}
 		logGetTokenSuccess(c, opts)
 		c.account = ar.Account
@@ -105,8 +107,8 @@ func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts policy.
 	}
 	ar, err = c.pca.AcquireTokenByAuthCode(ctx, c.authCode, c.redirectURI, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("AuthorizationCodeCredential", err, true)
-		return nil, newAuthenticationFailedError(err, nil)
+		addGetTokenFailureLogs(credNameAuthCode, err, true)
+		return nil, newAuthenticationFailedError(credNameAuthCode, err, nil)
 	}
 	logGetTokenSuccess(c, opts)
 	c.account = ar.Account

--- a/sdk/azidentity/authorization_code_credential.go
+++ b/sdk/azidentity/authorization_code_credential.go
@@ -90,7 +90,7 @@ func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts policy.
 		}
 		ar, err = c.cca.AcquireTokenByAuthCode(ctx, c.authCode, c.redirectURI, opts.Scopes)
 		if err != nil {
-			addGetTokenFailureLogs("Authorization Code Credential", err, true)
+			addGetTokenFailureLogs("AuthorizationCodeCredential", err, true)
 			return nil, newAuthenticationFailedError(err, nil)
 		}
 		logGetTokenSuccess(c, opts)
@@ -105,7 +105,7 @@ func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts policy.
 	}
 	ar, err = c.pca.AcquireTokenByAuthCode(ctx, c.authCode, c.redirectURI, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Authorization Code Credential", err, true)
+		addGetTokenFailureLogs("AuthorizationCodeCredential", err, true)
 		return nil, newAuthenticationFailedError(err, nil)
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/authorization_code_credential.go
+++ b/sdk/azidentity/authorization_code_credential.go
@@ -93,7 +93,7 @@ func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts policy.
 		ar, err = c.cca.AcquireTokenByAuthCode(ctx, c.authCode, c.redirectURI, opts.Scopes)
 		if err != nil {
 			addGetTokenFailureLogs(credNameAuthCode, err, true)
-			return nil, newAuthenticationFailedError(credNameAuthCode, err, nil)
+			return nil, newAuthenticationFailedErrorFromMSALError(credNameAuthCode, err)
 		}
 		logGetTokenSuccess(c, opts)
 		c.account = ar.Account
@@ -108,7 +108,7 @@ func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts policy.
 	ar, err = c.pca.AcquireTokenByAuthCode(ctx, c.authCode, c.redirectURI, opts.Scopes)
 	if err != nil {
 		addGetTokenFailureLogs(credNameAuthCode, err, true)
-		return nil, newAuthenticationFailedError(credNameAuthCode, err, nil)
+		return nil, newAuthenticationFailedErrorFromMSALError(credNameAuthCode, err)
 	}
 	logGetTokenSuccess(c, opts)
 	c.account = ar.Account

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -71,7 +71,7 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequ
 	scope := strings.TrimSuffix(opts.Scopes[0], defaultSuffix)
 	at, err := c.authenticate(ctx, scope)
 	if err != nil {
-		addGetTokenFailureLogs("Azure CLI Credential", err, true)
+		addGetTokenFailureLogs("AzureCLICredential", err, true)
 		return nil, err
 	}
 	logGetTokenSuccess(c, opts)
@@ -132,7 +132,7 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 			if msg == "" {
 				msg = err.Error()
 			}
-			return nil, newCredentialUnavailableError("Azure CLI Credential", msg)
+			return nil, newCredentialUnavailableError("AzureCLICredential", msg)
 		}
 
 		return output, nil

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -67,7 +67,7 @@ func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredent
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *AzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	if len(opts.Scopes) != 1 {
-		return nil, errors.New("this credential requires exactly one scope per token request")
+		return nil, errors.New(credNameAzureCLI + ": GetToken() requires exactly one scope")
 	}
 	// CLI expects an AAD v1 resource, not a v2 scope
 	scope := strings.TrimSuffix(opts.Scopes[0], defaultSuffix)
@@ -98,7 +98,7 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 			return nil, err
 		}
 		if !match {
-			return nil, fmt.Errorf(`unexpected scope "%s". Only alphanumeric characters and ".", ";", "-", and "/" are allowed`, resource)
+			return nil, fmt.Errorf(`%s: unexpected scope "%s". Only alphanumeric characters and ".", ";", "-", and "/" are allowed`, credNameAzureCLI, resource)
 		}
 
 		ctx, cancel := context.WithTimeout(ctx, timeoutCLIRequest)
@@ -112,7 +112,7 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 		if runtime.GOOS == "windows" {
 			dir := os.Getenv("SYSTEMROOT")
 			if dir == "" {
-				return nil, errors.New("environment variable 'SYSTEMROOT' has no value")
+				return nil, newCredentialUnavailableError(credNameAzureCLI, "environment variable 'SYSTEMROOT' has no value")
 			}
 			cliCmd = exec.CommandContext(ctx, "cmd.exe", "/c", commandLine)
 			cliCmd.Dir = dir

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -125,8 +125,11 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 		output, err := cliCmd.Output()
 		if err != nil {
 			msg := stderr.String()
+			var exErr *exec.ExitError
+			if errors.As(err, &exErr); exErr.ExitCode() == 127 || strings.HasPrefix(msg, "'az' is not recognized") {
+				msg = "Azure CLI not found on path"
+			}
 			if msg == "" {
-				// if there's no output in stderr report the error message instead
 				msg = err.Error()
 			}
 			return nil, newCredentialUnavailableError("Azure CLI Credential", msg)

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -20,6 +20,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
+const credNameAzureCLI = "AzureCLICredential"
+
 // used by tests to fake invoking the CLI
 type azureCLITokenProvider func(ctx context.Context, resource string, tenantID string) ([]byte, error)
 
@@ -71,7 +73,7 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequ
 	scope := strings.TrimSuffix(opts.Scopes[0], defaultSuffix)
 	at, err := c.authenticate(ctx, scope)
 	if err != nil {
-		addGetTokenFailureLogs("AzureCLICredential", err, true)
+		addGetTokenFailureLogs(credNameAzureCLI, err, true)
 		return nil, err
 	}
 	logGetTokenSuccess(c, opts)
@@ -132,7 +134,7 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 			if msg == "" {
 				msg = err.Error()
 			}
-			return nil, newCredentialUnavailableError("AzureCLICredential", msg)
+			return nil, newCredentialUnavailableError(credNameAzureCLI, msg)
 		}
 
 		return output, nil

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -56,45 +56,39 @@ func NewChainedTokenCredential(sources []azcore.TokenCredential, options *Chaine
 // GetToken calls GetToken on the chained credentials in turn, stopping when one returns a token. This method is called automatically by Azure SDK clients.
 // ctx: Context controlling the request lifetime.
 // opts: Options for the token request, in particular the desired scope of the access token.
-func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (token *azcore.AccessToken, err error) {
+func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	if c.successfulCredential != nil && !c.retrySources {
 		return c.successfulCredential.GetToken(ctx, opts)
 	}
-	var errList []credentialUnavailableError
+
+	var errs []error
 	for _, cred := range c.sources {
-		token, err = cred.GetToken(ctx, opts)
-		var credErr credentialUnavailableError
-		if errors.As(err, &credErr) {
-			errList = append(errList, credErr)
-		} else if err != nil {
-			var authFailed AuthenticationFailedError
-			if errors.As(err, &authFailed) {
-				err = fmt.Errorf("%s: %s\n\t%s", c.name, createChainedErrorMessage(errList), err)
-				authErr := newAuthenticationFailedError(c.name, err, authFailed.RawResponse)
-				return nil, authErr
-			}
-			return nil, err
-		} else {
+		token, err := cred.GetToken(ctx, opts)
+		if err == nil {
 			log.Writef(EventAuthentication, "Azure Identity => %s authenticated with %s", c.name, extractCredentialName(cred))
 			c.successfulCredential = cred
 			return token, nil
 		}
+		errs = append(errs, err)
+		if _, ok := err.(credentialUnavailableError); !ok {
+			res := getResponseFromError(err)
+			msg := createChainedErrorMessage(errs)
+			return nil, newAuthenticationFailedError(c.name, msg, res)
+		}
 	}
-
-	// if we reach this point it means that all of the credentials in the chain returned CredentialUnavailableError
-	credErr := newCredentialUnavailableError(c.name, createChainedErrorMessage(errList))
-
-	log.Writef(EventAuthentication, "Azure Identity => ERROR in GetToken() call for %s", credErr.Error())
-
-	return nil, credErr
+	// if we get here, all credentials returned credentialUnavailableError
+	msg := createChainedErrorMessage(errs)
+	err := newCredentialUnavailableError(c.name, msg)
+	log.Write(EventAuthentication, "Azure Identity => ERROR: "+err.Error())
+	return nil, err
 }
 
-func createChainedErrorMessage(errList []credentialUnavailableError) string {
-	msg := "failed to acquire a token.\nAttempted credentials:\n"
-	for _, err := range errList {
-		msg += fmt.Sprintf("\t%s\n", err.Error())
+func createChainedErrorMessage(errs []error) string {
+	msg := "failed to acquire a token.\nAttempted credentials:"
+	for _, err := range errs {
+		msg += fmt.Sprintf("\n\t%s", err.Error())
 	}
-	return msg[0 : len(msg)-1]
+	return msg
 }
 
 func extractCredentialName(credential azcore.TokenCredential) string {

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -70,7 +70,7 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.Token
 			var authFailed AuthenticationFailedError
 			if errors.As(err, &authFailed) {
 				err = fmt.Errorf("%s: %s\n\t%s", c.name, createChainedErrorMessage(errList), err)
-				authErr := newAuthenticationFailedError(err, authFailed.RawResponse)
+				authErr := newAuthenticationFailedError(c.name, err, authFailed.RawResponse)
 				return nil, authErr
 			}
 			return nil, err

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -153,7 +153,7 @@ func TestChainedTokenCredential_MultipleCredentialsGetTokenAuthenticationFailed(
 		{err: newCredentialUnavailableError("unavailableCredential2", "Unavailable expected error")},
 	}}
 	credential3 := &TestCredential{responses: []testCredentialResponse{
-		{err: newAuthenticationFailedError("authenticationFailedCredential3", newCredentialUnavailableError("authenticationFailedCredential3", "Authentication failed expected error"), nil)},
+		{err: newAuthenticationFailedError("authenticationFailedCredential3", "Authentication failed expected error", nil)},
 	}}
 	cred, err := NewChainedTokenCredential([]azcore.TokenCredential{credential1, credential2, credential3}, nil)
 	if err != nil {

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -153,7 +153,7 @@ func TestChainedTokenCredential_MultipleCredentialsGetTokenAuthenticationFailed(
 		{err: newCredentialUnavailableError("unavailableCredential2", "Unavailable expected error")},
 	}}
 	credential3 := &TestCredential{responses: []testCredentialResponse{
-		{err: newAuthenticationFailedError(newCredentialUnavailableError("authenticationFailedCredential3", "Authentication failed expected error"), nil)},
+		{err: newAuthenticationFailedError("authenticationFailedCredential3", newCredentialUnavailableError("authenticationFailedCredential3", "Authentication failed expected error"), nil)},
 	}}
 	cred, err := NewChainedTokenCredential([]azcore.TokenCredential{credential1, credential2, credential3}, nil)
 	if err != nil {

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -21,6 +21,8 @@ import (
 	"golang.org/x/crypto/pkcs12"
 )
 
+const credNameCert = "ClientCertificateCredential"
+
 // ClientCertificateCredentialOptions contains optional parameters for ClientCertificateCredential.
 type ClientCertificateCredentialOptions struct {
 	azcore.ClientOptions
@@ -61,7 +63,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 	}
 	authorityHost, err := setAuthorityHost(options.AuthorityHost)
 	if err != nil {
-		logCredentialError("ClientCertificateCredential", err)
+		logCredentialError(credNameCert, err)
 		return nil, err
 	}
 	cert, err := newCertContents(certs, pk, options.SendCertificateChain)
@@ -98,8 +100,8 @@ func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts policy.
 
 	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("ClientCertificateCredential", err, true)
-		return nil, newAuthenticationFailedError(err, nil)
+		addGetTokenFailureLogs(credNameCert, err, true)
+		return nil, newAuthenticationFailedError(credNameCert, err, nil)
 	}
 	logGetTokenSuccess(c, opts)
 	return &azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -101,7 +101,7 @@ func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts policy.
 	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	if err != nil {
 		addGetTokenFailureLogs(credNameCert, err, true)
-		return nil, newAuthenticationFailedError(credNameCert, err, nil)
+		return nil, newAuthenticationFailedErrorFromMSALError(credNameCert, err)
 	}
 	logGetTokenSuccess(c, opts)
 	return &azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -61,7 +61,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 	}
 	authorityHost, err := setAuthorityHost(options.AuthorityHost)
 	if err != nil {
-		logCredentialError("Client Certificate Credential", err)
+		logCredentialError("ClientCertificateCredential", err)
 		return nil, err
 	}
 	cert, err := newCertContents(certs, pk, options.SendCertificateChain)
@@ -98,7 +98,7 @@ func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts policy.
 
 	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Client Certificate Credential", err, true)
+		addGetTokenFailureLogs("ClientCertificateCredential", err, true)
 		return nil, newAuthenticationFailedError(err, nil)
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -13,6 +13,8 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
 )
 
+const credNameSecret = "ClientSecretCredential"
+
 // ClientSecretCredentialOptions contains optional parameters for ClientSecretCredential.
 type ClientSecretCredentialOptions struct {
 	azcore.ClientOptions
@@ -69,8 +71,8 @@ func (c *ClientSecretCredential) GetToken(ctx context.Context, opts policy.Token
 
 	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("ClientSecretCredential", err, true)
-		return nil, newAuthenticationFailedError(err, nil)
+		addGetTokenFailureLogs(credNameSecret, err, true)
+		return nil, newAuthenticationFailedError(credNameSecret, err, nil)
 	}
 	logGetTokenSuccess(c, opts)
 	return &azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -72,7 +72,7 @@ func (c *ClientSecretCredential) GetToken(ctx context.Context, opts policy.Token
 	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	if err != nil {
 		addGetTokenFailureLogs(credNameSecret, err, true)
-		return nil, newAuthenticationFailedError(credNameSecret, err, nil)
+		return nil, newAuthenticationFailedErrorFromMSALError(credNameSecret, err)
 	}
 	logGetTokenSuccess(c, opts)
 	return &azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -69,7 +69,7 @@ func (c *ClientSecretCredential) GetToken(ctx context.Context, opts policy.Token
 
 	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Client Secret Credential", err, true)
+		addGetTokenFailureLogs("ClientSecretCredential", err, true)
 		return nil, newAuthenticationFailedError(err, nil)
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -6,7 +6,6 @@ package azidentity
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -54,7 +53,7 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 	if err == nil {
 		creds = append(creds, envCred)
 	} else {
-		errorMessages = append(errorMessages, fmt.Sprintf("EnvironmentCredential: %s", err.Error()))
+		errorMessages = append(errorMessages, "EnvironmentCredential: "+err.Error())
 		creds = append(creds, &defaultCredentialErrorReporter{credType: "EnvironmentCredential", err: err})
 	}
 
@@ -63,16 +62,16 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		creds = append(creds, msiCred)
 		msiCred.client.imdsTimeout = time.Second
 	} else {
-		errorMessages = append(errorMessages, fmt.Sprintf("ManagedIdentityCredential: %s", err.Error()))
-		creds = append(creds, &defaultCredentialErrorReporter{credType: "ManagedIdentityCredential", err: err})
+		errorMessages = append(errorMessages, credNameManagedIdentity+": "+err.Error())
+		creds = append(creds, &defaultCredentialErrorReporter{credType: credNameManagedIdentity, err: err})
 	}
 
 	cliCred, err := NewAzureCLICredential(&AzureCLICredentialOptions{TenantID: options.TenantID})
 	if err == nil {
 		creds = append(creds, cliCred)
 	} else {
-		errorMessages = append(errorMessages, fmt.Sprintf("AzureCLICredential: %s", err.Error()))
-		creds = append(creds, &defaultCredentialErrorReporter{credType: "AzureCLICredential", err: err})
+		errorMessages = append(errorMessages, credNameAzureCLI+": "+err.Error())
+		creds = append(creds, &defaultCredentialErrorReporter{credType: credNameAzureCLI, err: err})
 	}
 
 	err = defaultAzureCredentialConstructorErrorHandler(len(creds), errorMessages)
@@ -119,7 +118,7 @@ func defaultAzureCredentialConstructorErrorHandler(numberOfSuccessfulCredentials
 // in the error returned by ChainedTokenCredential.GetToken()
 type defaultCredentialErrorReporter struct {
 	credType string
-	err error
+	err      error
 }
 
 func (d *defaultCredentialErrorReporter) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (token *azcore.AccessToken, err error) {

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -109,7 +109,7 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 	dc, err := c.client.AcquireTokenByDeviceCode(ctx, opts.Scopes)
 	if err != nil {
 		addGetTokenFailureLogs(credNameDeviceCode, err, true)
-		return nil, newAuthenticationFailedError(credNameDeviceCode, err, nil)
+		return nil, newAuthenticationFailedErrorFromMSALError(credNameDeviceCode, err)
 	}
 	err = c.userPrompt(ctx, DeviceCodeMessage{
 		UserCode:        dc.Result.UserCode,
@@ -122,7 +122,7 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 	ar, err = dc.AuthenticationResult(ctx)
 	if err != nil {
 		addGetTokenFailureLogs(credNameDeviceCode, err, true)
-		return nil, newAuthenticationFailedError(credNameDeviceCode, err, nil)
+		return nil, newAuthenticationFailedErrorFromMSALError(credNameDeviceCode, err)
 	}
 	c.account = ar.Account
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -14,6 +14,8 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
+const credNameDeviceCode = "DeviceCodeCredential"
+
 // DeviceCodeCredentialOptions contains optional parameters for DeviceCodeCredential.
 type DeviceCodeCredentialOptions struct {
 	azcore.ClientOptions
@@ -106,8 +108,8 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 	}
 	dc, err := c.client.AcquireTokenByDeviceCode(ctx, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("DeviceCodeCredential", err, true)
-		return nil, newAuthenticationFailedError(err, nil)
+		addGetTokenFailureLogs(credNameDeviceCode, err, true)
+		return nil, newAuthenticationFailedError(credNameDeviceCode, err, nil)
 	}
 	err = c.userPrompt(ctx, DeviceCodeMessage{
 		UserCode:        dc.Result.UserCode,
@@ -119,8 +121,8 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 	}
 	ar, err = dc.AuthenticationResult(ctx)
 	if err != nil {
-		addGetTokenFailureLogs("DeviceCodeCredential", err, true)
-		return nil, newAuthenticationFailedError(err, nil)
+		addGetTokenFailureLogs(credNameDeviceCode, err, true)
+		return nil, newAuthenticationFailedError(credNameDeviceCode, err, nil)
 	}
 	c.account = ar.Account
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -106,7 +106,7 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 	}
 	dc, err := c.client.AcquireTokenByDeviceCode(ctx, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Device Code Credential", err, true)
+		addGetTokenFailureLogs("DeviceCodeCredential", err, true)
 		return nil, newAuthenticationFailedError(err, nil)
 	}
 	err = c.userPrompt(ctx, DeviceCodeMessage{
@@ -119,7 +119,7 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 	}
 	ar, err = dc.AuthenticationResult(ctx)
 	if err != nil {
-		addGetTokenFailureLogs("Device Code Credential", err, true)
+		addGetTokenFailureLogs("DeviceCodeCredential", err, true)
 		return nil, newAuthenticationFailedError(err, nil)
 	}
 	c.account = ar.Account

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -65,7 +65,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 		return nil, errors.New("missing environment variable AZURE_CLIENT_ID")
 	}
 	if clientSecret := os.Getenv("AZURE_CLIENT_SECRET"); clientSecret != "" {
-		log.Write(EventAuthentication, "Azure Identity => NewEnvironmentCredential() invoking ClientSecretCredential")
+		log.Write(EventAuthentication, "Azure Identity => EnvironmentCredential will authenticate with ClientSecretCredential")
 		o := &ClientSecretCredentialOptions{AuthorityHost: options.AuthorityHost, ClientOptions: options.ClientOptions}
 		cred, err := NewClientSecretCredential(tenantID, clientID, clientSecret, o)
 		if err != nil {
@@ -74,7 +74,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 		return &EnvironmentCredential{cred: cred}, nil
 	}
 	if certPath := os.Getenv("AZURE_CLIENT_CERTIFICATE_PATH"); certPath != "" {
-		log.Write(EventAuthentication, "Azure Identity => NewEnvironmentCredential() invoking ClientCertificateCredential")
+		log.Write(EventAuthentication, "Azure Identity => EnvironmentCredential will authenticate with ClientCertificateCredential")
 		certData, err := os.ReadFile(certPath)
 		if err != nil {
 			return nil, fmt.Errorf(`failed to read certificate file "%s": %v`, certPath, err)
@@ -95,7 +95,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 	}
 	if username := os.Getenv("AZURE_USERNAME"); username != "" {
 		if password := os.Getenv("AZURE_PASSWORD"); password != "" {
-			log.Write(EventAuthentication, "Azure Identity => NewEnvironmentCredential() invoking UsernamePasswordCredential")
+			log.Write(EventAuthentication, "Azure Identity => EnvironmentCredential will authenticate with UsernamePasswordCredential")
 			o := &UsernamePasswordCredentialOptions{AuthorityHost: options.AuthorityHost, ClientOptions: options.ClientOptions}
 			cred, err := NewUsernamePasswordCredential(tenantID, clientID, username, password, o)
 			if err != nil {
@@ -103,8 +103,9 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 			}
 			return &EnvironmentCredential{cred: cred}, nil
 		}
+		return nil, errors.New("no value for AZURE_PASSWORD")
 	}
-	return nil, errors.New("missing environment variable AZURE_CLIENT_SECRET or AZURE_CLIENT_CERTIFICATE_PATH or AZURE_USERNAME and AZURE_PASSWORD")
+	return nil, errors.New("incomplete environment variable configuration. Only AZURE_TENANT_ID and AZURE_CLIENT_ID are set")
 }
 
 // GetToken obtains a token from Azure Active Directory. This method is called automatically by Azure SDK clients.

--- a/sdk/azidentity/errors.go
+++ b/sdk/azidentity/errors.go
@@ -17,20 +17,21 @@ import (
 
 // AuthenticationFailedError indicates an authentication request has failed.
 type AuthenticationFailedError struct {
-	err error
+	credType string
+	err      error
 
 	// RawResponse is the HTTP response motivating the error, if available.
 	RawResponse *http.Response
 }
 
-func newAuthenticationFailedError(err error, resp *http.Response) AuthenticationFailedError {
+func newAuthenticationFailedError(credType string, err error, resp *http.Response) AuthenticationFailedError {
 	if resp == nil {
 		var e msal.CallErr
 		if errors.As(err, &e) {
 			return AuthenticationFailedError{err: e, RawResponse: e.Resp}
 		}
 	}
-	return AuthenticationFailedError{err: err, RawResponse: resp}
+	return AuthenticationFailedError{credType: credType, err: err, RawResponse: resp}
 }
 
 // Error implements the error interface for type ResponseError.

--- a/sdk/azidentity/errors.go
+++ b/sdk/azidentity/errors.go
@@ -28,7 +28,7 @@ func newAuthenticationFailedError(credType string, err error, resp *http.Respons
 	if resp == nil {
 		var e msal.CallErr
 		if errors.As(err, &e) {
-			return AuthenticationFailedError{err: e, RawResponse: e.Resp}
+			return AuthenticationFailedError{credType: credType, err: e, RawResponse: e.Resp}
 		}
 	}
 	return AuthenticationFailedError{credType: credType, err: err, RawResponse: resp}
@@ -38,9 +38,10 @@ func newAuthenticationFailedError(credType string, err error, resp *http.Respons
 // Note that the message contents are not contractual and can change over time.
 func (e AuthenticationFailedError) Error() string {
 	if e.RawResponse == nil {
-		return e.err.Error()
+		return e.credType + " authentication failed: " + e.err.Error()
 	}
 	msg := &bytes.Buffer{}
+	fmt.Fprintf(msg, e.credType+" authentication failed\n")
 	fmt.Fprintf(msg, "%s %s://%s%s\n", e.RawResponse.Request.Method, e.RawResponse.Request.URL.Scheme, e.RawResponse.Request.URL.Host, e.RawResponse.Request.URL.Path)
 	fmt.Fprintln(msg, "--------------------------------------------------------------------------------")
 	fmt.Fprintf(msg, "RESPONSE %s\n", e.RawResponse.Status)

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -91,7 +91,7 @@ func (c *InteractiveBrowserCredential) GetToken(ctx context.Context, opts policy
 	ar, err = c.client.AcquireTokenInteractive(ctx, opts.Scopes, o...)
 	if err != nil {
 		addGetTokenFailureLogs(credNameBrowser, err, true)
-		return nil, newAuthenticationFailedError(credNameBrowser, err, nil)
+		return nil, newAuthenticationFailedErrorFromMSALError(credNameBrowser, err)
 	}
 	c.account = ar.Account
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -13,6 +13,8 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
+const credNameBrowser = "InteractiveBrowserCredentiall"
+
 // InteractiveBrowserCredentialOptions contains optional parameters for InteractiveBrowserCredential.
 type InteractiveBrowserCredentialOptions struct {
 	azcore.ClientOptions
@@ -88,8 +90,8 @@ func (c *InteractiveBrowserCredential) GetToken(ctx context.Context, opts policy
 	}
 	ar, err = c.client.AcquireTokenInteractive(ctx, opts.Scopes, o...)
 	if err != nil {
-		addGetTokenFailureLogs("InteractiveBrowserCredential", err, true)
-		return nil, newAuthenticationFailedError(err, nil)
+		addGetTokenFailureLogs(credNameBrowser, err, true)
+		return nil, newAuthenticationFailedError(credNameBrowser, err, nil)
 	}
 	c.account = ar.Account
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -88,7 +88,7 @@ func (c *InteractiveBrowserCredential) GetToken(ctx context.Context, opts policy
 	}
 	ar, err = c.client.AcquireTokenInteractive(ctx, opts.Scopes, o...)
 	if err != nil {
-		addGetTokenFailureLogs("Interactive Browser Credential", err, true)
+		addGetTokenFailureLogs("InteractiveBrowserCredential", err, true)
 		return nil, newAuthenticationFailedError(err, nil)
 	}
 	c.account = ar.Account

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -171,7 +171,7 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
 		if cancel != nil && errors.Is(err, context.DeadlineExceeded) {
 			return nil, newCredentialUnavailableError(credNameManagedIdentity, "IMDS token request timed out")
 		}
-		return nil, newAuthenticationFailedError(credNameManagedIdentity, err, nil)
+		return nil, newAuthenticationFailedError(credNameManagedIdentity, err.Error(), nil)
 	}
 
 	// got a response, remove the IMDS timeout so future requests use the transport's configuration
@@ -183,12 +183,12 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
 
 	if c.msiType == msiTypeIMDS && resp.StatusCode == 400 {
 		if id != nil {
-			return nil, newAuthenticationFailedError(credNameManagedIdentity, errors.New("the requested identity isn't assigned to this resource"), resp)
+			return nil, newAuthenticationFailedError(credNameManagedIdentity, "the requested identity isn't assigned to this resource", resp)
 		}
 		return nil, newCredentialUnavailableError(credNameManagedIdentity, "no default identity is assigned to this resource")
 	}
 
-	return nil, newAuthenticationFailedError(credNameManagedIdentity, errors.New("authentication failed"), resp)
+	return nil, newAuthenticationFailedError(credNameManagedIdentity, "authentication failed", resp)
 }
 
 func (c *managedIdentityClient) createAccessToken(res *http.Response) (*azcore.AccessToken, error) {
@@ -228,8 +228,8 @@ func (c *managedIdentityClient) createAccessToken(res *http.Response) (*azcore.A
 			return nil, err
 		}
 	default:
-		err := fmt.Errorf("unsupported type received in expires_on: %T, %v", v, v)
-		return nil, newAuthenticationFailedError(credNameManagedIdentity, err, res)
+		msg := fmt.Sprintf("unsupported type received in expires_on: %T, %v", v, v)
+		return nil, newAuthenticationFailedError(credNameManagedIdentity, msg, res)
 	}
 }
 
@@ -243,7 +243,7 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, id Manage
 		// need to perform preliminary request to retreive the secret key challenge provided by the HIMDS service
 		key, err := c.getAzureArcSecretKey(ctx, scopes)
 		if err != nil {
-			msg := fmt.Errorf("failed to retreive secret key from the identity endpoint: %v", err)
+			msg := fmt.Sprintf("failed to retreive secret key from the identity endpoint: %v", err)
 			return nil, newAuthenticationFailedError(credNameManagedIdentity, msg, nil)
 		}
 		return c.createAzureArcAuthRequest(ctx, key, scopes)
@@ -347,8 +347,8 @@ func (c *managedIdentityClient) getAzureArcSecretKey(ctx context.Context, resour
 	// the endpoint is expected to return a 401 with the WWW-Authenticate header set to the location
 	// of the secret key file. Any other status code indicates an error in the request.
 	if response.StatusCode != 401 {
-		err := fmt.Errorf("expected a 401 response, received %d", response.StatusCode)
-		return "", newAuthenticationFailedError(credNameManagedIdentity, err, response)
+		msg := fmt.Sprintf("expected a 401 response, received %d", response.StatusCode)
+		return "", newAuthenticationFailedError(credNameManagedIdentity, msg, response)
 	}
 	header := response.Header.Get("WWW-Authenticate")
 	if len(header) == 0 {
@@ -383,7 +383,7 @@ func (c *managedIdentityClient) createAzureArcAuthRequest(ctx context.Context, k
 func (c *managedIdentityClient) createCloudShellAuthRequest(ctx context.Context, id ManagedIDKind, scopes []string) (*policy.Request, error) {
 	if id != nil {
 		msg := "Cloud Shell doesn't support user assigned managed identities. To authenticate the signed in user, omit ManagedIdentityCredentialOptions.ID"
-		return nil, newAuthenticationFailedError(credNameManagedIdentity, errors.New(msg), nil) //lint:ignore ST1005 Cloud Shell is a proper noun
+		return nil, newAuthenticationFailedError(credNameManagedIdentity, msg, nil)
 	}
 	request, err := runtime.NewRequest(ctx, http.MethodPost, c.endpoint)
 	if err != nil {

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -169,7 +169,7 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
 	resp, err := c.pipeline.Do(msg)
 	if err != nil {
 		if cancel != nil && errors.Is(err, context.DeadlineExceeded) {
-			return nil, newCredentialUnavailableError("Managed Identity Credential", "IMDS token request timed out")
+			return nil, newCredentialUnavailableError("ManagedIdentityCredential", "IMDS token request timed out")
 		}
 		return nil, newAuthenticationFailedError(err, nil)
 	}
@@ -185,7 +185,7 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
 		if id != nil {
 			return nil, newAuthenticationFailedError(errors.New("the requested identity isn't assigned to this resource"), resp)
 		}
-		return nil, newCredentialUnavailableError("Managed Identity Credential", "no default identity is assigned to this resource")
+		return nil, newCredentialUnavailableError("ManagedIdentityCredential", "no default identity is assigned to this resource")
 	}
 
 	return nil, newAuthenticationFailedError(errors.New("authentication failed"), resp)
@@ -252,7 +252,7 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, id Manage
 	case msiTypeCloudShell:
 		return c.createCloudShellAuthRequest(ctx, id, scopes)
 	default:
-		return nil, newCredentialUnavailableError("Managed Identity Credential", "managed identity isn't supported in this environment")
+		return nil, newCredentialUnavailableError("ManagedIdentityCredential", "managed identity isn't supported in this environment")
 	}
 }
 

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
+const credNameManagedIdentity = "ManagedIdentityCredential"
+
 type managedIdentityIDKind int
 
 const (
@@ -77,7 +79,7 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 	}
 	client, err := newManagedIdentityClient(options)
 	if err != nil {
-		logCredentialError("ManagedIdentityCredential", err)
+		logCredentialError(credNameManagedIdentity, err)
 		return nil, err
 	}
 	return &ManagedIdentityCredential{id: options.ID, client: client}, nil
@@ -89,14 +91,14 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	if len(opts.Scopes) != 1 {
 		err := errors.New("ManagedIdentityCredential.GetToken() requires exactly one scope")
-		addGetTokenFailureLogs("ManagedIdentityCredential", err, true)
+		addGetTokenFailureLogs(credNameManagedIdentity, err, true)
 		return nil, err
 	}
 	// managed identity endpoints require an AADv1 resource (i.e. token audience), not a v2 scope, so we remove "/.default" here
 	scopes := []string{strings.TrimSuffix(opts.Scopes[0], defaultSuffix)}
 	tk, err := c.client.authenticate(ctx, c.id, scopes)
 	if err != nil {
-		addGetTokenFailureLogs("ManagedIdentityCredential", err, true)
+		addGetTokenFailureLogs(credNameManagedIdentity, err, true)
 		return nil, err
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -77,7 +77,7 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 	}
 	client, err := newManagedIdentityClient(options)
 	if err != nil {
-		logCredentialError("Managed Identity Credential", err)
+		logCredentialError("ManagedIdentityCredential", err)
 		return nil, err
 	}
 	return &ManagedIdentityCredential{id: options.ID, client: client}, nil
@@ -89,14 +89,14 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	if len(opts.Scopes) != 1 {
 		err := errors.New("ManagedIdentityCredential.GetToken() requires exactly one scope")
-		addGetTokenFailureLogs("Managed Identity Credential", err, true)
+		addGetTokenFailureLogs("ManagedIdentityCredential", err, true)
 		return nil, err
 	}
 	// managed identity endpoints require an AADv1 resource (i.e. token audience), not a v2 scope, so we remove "/.default" here
 	scopes := []string{strings.TrimSuffix(opts.Scopes[0], defaultSuffix)}
 	tk, err := c.client.authenticate(ctx, c.id, scopes)
 	if err != nil {
-		addGetTokenFailureLogs("Managed Identity Credential", err, true)
+		addGetTokenFailureLogs("ManagedIdentityCredential", err, true)
 		return nil, err
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -90,7 +90,7 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	if len(opts.Scopes) != 1 {
-		err := errors.New("ManagedIdentityCredential.GetToken() requires exactly one scope")
+		err := errors.New(credNameManagedIdentity + ": GetToken() requires exactly one scope")
 		addGetTokenFailureLogs(credNameManagedIdentity, err, true)
 		return nil, err
 	}

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -74,7 +74,7 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.T
 	ar, err = c.client.AcquireTokenByUsernamePassword(ctx, opts.Scopes, c.username, c.password)
 	if err != nil {
 		addGetTokenFailureLogs(credNameUserPassword, err, true)
-		return nil, newAuthenticationFailedError(credNameUserPassword, err, nil)
+		return nil, newAuthenticationFailedErrorFromMSALError(credNameUserPassword, err)
 	}
 	c.account = ar.Account
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -13,6 +13,8 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
+const credNameUserPassword = "UsernamePasswordCredential"
+
 // UsernamePasswordCredentialOptions contains optional parameters for UsernamePasswordCredential.
 type UsernamePasswordCredentialOptions struct {
 	azcore.ClientOptions
@@ -71,8 +73,8 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.T
 	}
 	ar, err = c.client.AcquireTokenByUsernamePassword(ctx, opts.Scopes, c.username, c.password)
 	if err != nil {
-		addGetTokenFailureLogs("UsernamePasswordCredential", err, true)
-		return nil, newAuthenticationFailedError(err, nil)
+		addGetTokenFailureLogs(credNameUserPassword, err, true)
+		return nil, newAuthenticationFailedError(credNameUserPassword, err, nil)
 	}
 	c.account = ar.Account
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -71,7 +71,7 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.T
 	}
 	ar, err = c.client.AcquireTokenByUsernamePassword(ctx, opts.Scopes, c.username, c.password)
 	if err != nil {
-		addGetTokenFailureLogs("Username Password Credential", err, true)
+		addGetTokenFailureLogs("UsernamePasswordCredential", err, true)
 		return nil, newAuthenticationFailedError(err, nil)
 	}
 	c.account = ar.Account


### PR DESCRIPTION
This makes error messages in general more consistent and improves them in some key scenarios. For example, when no inner credential can provide a token, DefaultAzureCredential.GetToken() now includes messages from those credentials' constructors (fixes #15923). There are a couple functional changes I doubt will have any impact:
- ChainedTokenCredential returns credentialUnavailableError if and only if all its sources return that type of error
- AzureCLICredential returns credentialUnavailableError on Windows when it can't identify a safe working directory