### PR TITLE
azblob: fix ListBlob to preserve prefix while paging

### DIFF
--- a/sdk/storage/azblob/zc_container_client.go
+++ b/sdk/storage/azblob/zc_container_client.go
@@ -187,9 +187,8 @@ func (c ContainerClient) ListBlobsFlat(listOptions *ContainerListBlobFlatSegment
 
 	// override the advancer
 	pager.advancer = func(ctx context.Context, response ContainerListBlobFlatSegmentResponse) (*policy.Request, error) {
-		return c.client.listBlobFlatSegmentCreateRequest(ctx, &ContainerListBlobFlatSegmentOptions{
-			Marker: response.NextMarker,
-		})
+		listOptions.Marker = response.NextMarker
+		return c.client.listBlobFlatSegmentCreateRequest(ctx, listOptions)
 	}
 
 	// TODO: Come Here
@@ -217,9 +216,8 @@ func (c ContainerClient) ListBlobsHierarchy(delimiter string, listOptions *Conta
 
 	// override the advancer
 	pager.advancer = func(ctx context.Context, response ContainerListBlobHierarchySegmentResponse) (*policy.Request, error) {
-		return c.client.listBlobHierarchySegmentCreateRequest(ctx, delimiter, &ContainerListBlobHierarchySegmentOptions{
-			Marker: response.NextMarker,
-		})
+		listOptions.Marker = response.NextMarker
+		return c.client.listBlobHierarchySegmentCreateRequest(ctx, delimiter, listOptions)
 	}
 
 	// todo: come here

--- a/sdk/storage/azblob/zc_service_client.go
+++ b/sdk/storage/azblob/zc_service_client.go
@@ -252,7 +252,7 @@ func (s ServiceClient) GetSASToken(resources AccountSASResourceTypes, permission
 // eg. "dog='germanshepherd' and penguin='emperorpenguin'"
 // To specify a container, eg. "@container=’containerName’ and Name = ‘C’"
 func (s ServiceClient) FindBlobsByTags(ctx context.Context, options ServiceFilterBlobsByTagsOptions) (ServiceFilterBlobsResponse, error) {
-	// TODO: Use pager here? Missing support from zz_generated_pagera.go
+	// TODO: Use pager here? Missing support from zz_generated_pagers.go
 	serviceFilterBlobsOptions := options.pointer()
 	return s.client.FilterBlobs(ctx, serviceFilterBlobsOptions)
 }


### PR DESCRIPTION
#16295 was not fixed by #16354 because _all_ options must be repeated in following requests, not just marker. ie prefix would be dropped when paging

This PR opts to modify the passed in options. It's probably preferable to clone the options to a variable within scope to avoid mutating caller's options