### PR TITLE
[azservicebus] Docs fixes

### DIFF
--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -230,7 +230,7 @@ To see some example code for receiving messages using the Receiver see the ["Rec
 
 ### Logging
 
-This module uses the classification-based logging implementation in `azcore`. To enable console logging for all SDK modules, set `AZURE_SDK_GO_LOGGING` to `all`. 
+This module uses the classification-based logging implementation in `azcore`. To enable console logging for all SDK modules, set the environment variable `AZURE_SDK_GO_LOGGING` to `all`. 
 
 Use the `azcore/log` package to control log event output or to enable logs for `azservicebus` only. For example:
 

--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -56,7 +56,7 @@ func main() {
   // The service principal specified by the credential needs to be added to the appropriate Service Bus roles for your
   // resource. More information about Service Bus roles can be found here:
   // https://docs.microsoft.com/azure/service-bus-messaging/service-bus-managed-service-identity#azure-built-in-roles-for-azure-service-bus
-  client, err = azservicebus.NewClient("<ex: myservicebus.servicebus.windows.net>", credential, nil)
+  client, err := azservicebus.NewClient("<ex: myservicebus.servicebus.windows.net>", credential, nil)
 
   if err != nil {
     panic(err)
@@ -74,7 +74,7 @@ import (
 func main() {
   // See here for instructions on how to get a Service Bus connection string:
   // https://docs.microsoft.com/azure/service-bus-messaging/service-bus-quickstart-portal#get-the-connection-string
-  client, err = azservicebus.NewClientFromConnectionString(connectionString, nil)
+  client, err := azservicebus.NewClientFromConnectionString(connectionString, nil)
 
   if err != nil {
     panic(err)
@@ -131,14 +131,14 @@ You can also send messages in batches, which can be more efficient than sending 
 ```go
 // Create a message batch. It will automatically be sized for the Service Bus
 // Namespace's maximum message size.
-messageBatch, err := sender.NewMessageBatch(context.TODO())
+messageBatch, err := sender.NewMessageBatch(context.TODO(), nil)
 
 if err != nil {
   panic(err)
 }
 
 // Add a message to our message batch. This can be called multiple times.
-err := messageBatch.Add(&azservicebus.Message{
+err = messageBatch.AddMessage(&azservicebus.Message{
     Body: []byte(fmt.Sprintf("hello world")),
 })
 
@@ -147,6 +147,10 @@ if err == azservicebus.ErrMessageTooLarge {
 
   // send what we have since the batch is full
   err := sender.SendMessageBatch(context.TODO(), messageBatch)
+
+  if err != nil {
+    panic(err)
+  }
   
   // Create a new batch, add this message and start again.
 } else if err != nil {
@@ -173,7 +177,7 @@ receiver, err := client.NewReceiverForQueue(
 ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
 defer cancel()
 
-messages, err = receiver.ReceiveMessages(ctx,
+messages, err := receiver.ReceiveMessages(ctx,
   // The number of messages to receive. Note this is merely an upper
   // bound. It is possible to get fewer message (or zero), depending
   // on the contents of the remote queue or subscription and network

--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -142,7 +142,7 @@ err = messageBatch.AddMessage(&azservicebus.Message{
     Body: []byte(fmt.Sprintf("hello world")),
 })
 
-if err == azservicebus.ErrMessageTooLarge {
+if errors.Is(err, azservicebus.ErrMessageTooLarge) {
   fmt.Printf("Message batch is full. We should send it and create a new one.\n")
 
   // send what we have since the batch is full

--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -222,6 +222,41 @@ deadLetterReceiver, err := client.NewReceiverForQueue("<queue>",
 
 To see some example code for receiving messages using the Receiver see the ["Receive messages"](#receive-messages) sample.
 
+## Troubleshooting
+
+### Logging
+
+This module uses the classification-based logging implementation in `azcore`. To enable console logging for all SDK modules, set `AZURE_SDK_GO_LOGGING` to `all`. 
+
+Use the `azcore/log` package to control log event output or to enable logs for `azservicebus` only. For example:
+
+```go
+import (
+  "fmt"
+  azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
+)
+
+// print log output to stdout
+azlog.SetListener(func(event azlog.Event, s string) {
+    fmt.Printf("[%s] %s\n", event, s)
+})
+
+// pick the set of events to log
+azlog.SetEvents(
+  // connection/reconnect related events)
+  "azsb.Conn",
+  // authentication events
+  "azsb.Auth",
+  // receiver specific events
+  "azsb.Receiver",
+  // management link related events
+  "azsb.Mgmt",
+  // retry related events
+  "azsb.Retry",
+)
+```
+
+
 ## Next steps
 
 Please take a look at the [samples][godoc_examples] for detailed examples on how to use this library to send and receive messages to/from [Service Bus Queues, Topics and Subscriptions](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview).

--- a/sdk/messaging/azservicebus/migrationguide.md
+++ b/sdk/messaging/azservicebus/migrationguide.md
@@ -42,7 +42,7 @@ New (using `azservicebus`):
 ```go
 // new code
 
-client, err = azservicebus.NewClientFromConnectionString(connectionString, nil)
+client, err := azservicebus.NewClientFromConnectionString(connectionString, nil)
 ```
 
 ### Sending messages
@@ -64,29 +64,33 @@ Sending messages in batches is similar, except that the focus has been moved mor
 towards giving the user full control using the `MessageBatch` type.
 
 ```go
-batch, err := sender.NewMessageBatch(context.TODO(), nil)
-
-// can be called multiple times
-err := batch.AddMessage(&azservicebus.Message{
-  Body: []byte("hello world"),
-})
+// Create a message batch. It will automatically be sized for the Service Bus
+// Namespace's maximum message size.
+messageBatch, err := sender.NewMessageBatch(context.TODO(), nil)
 
 if err != nil {
-  switch err {
-  case azservicebus.ErrMessageTooLarge:
-    // At this point you can do a few things:
-    // 1. Ignore this message
-    // 2. Send this batch (it's full) and create a new batch.
-    //
-    // The batch can still be used after this error if you have
-    // smaller messages you'd still like to add in.
-    fmt.Printf("Failed to add message to batch\n")
-  default:
-    exitOnError("Error while trying to add message to batch", err)
-  }
+  panic(err)
 }
 
-sender.SendMessageBatch(context.TODO(), batch)
+// Add a message to our message batch. This can be called multiple times.
+err = messageBatch.AddMessage(&azservicebus.Message{
+    Body: []byte(fmt.Sprintf("hello world")),
+})
+
+if err == azservicebus.ErrMessageTooLarge {
+  fmt.Printf("Message batch is full. We should send it and create a new one.\n")
+
+  // send what we have since the batch is full
+  err := sender.SendMessageBatch(context.TODO(), messageBatch)
+
+  if err != nil {
+    panic(err)
+  }
+  
+  // Create a new batch, add this message and start again.
+} else if err != nil {
+  panic(err)
+}
 ```
 
 ### Processing and receiving messages
@@ -105,8 +109,7 @@ receiver, err := client.NewReceiverForQueue(queue, nil)
 receiver, err := client.NewReceiverForSubscription(topicName, subscriptionName, nil)
 
 // receiving multiple messages at a time. 
-var messages []*azservicebus.ReceivedMessage
-messages, err = receiver.ReceiveMessages(context.TODO(), numMessages, nil)
+messages, err := receiver.ReceiveMessages(context.TODO(), numMessages, nil)
 ```
 
 ### Using dead letter queues
@@ -134,7 +137,7 @@ Now, in `azservicebus`:
 ```go
 // new code
 
-receiver, err = client.NewReceiverForQueue(
+receiver, err := client.NewReceiverForQueue(
 	queueName,
 	&azservicebus.ReceiverOptions{
 		ReceiveMode: azservicebus.ReceiveModePeekLock,
@@ -143,7 +146,7 @@ receiver, err = client.NewReceiverForQueue(
 
 //or
 
-receiver, err = client.NewReceiverForSubscription(
+receiver, err := client.NewReceiverForSubscription(
   topicName,
   subscriptionName,
   &azservicebus.ReceiverOptions{
@@ -178,7 +181,7 @@ Now, using `azservicebus`:
 // with a Receiver
 messages, err := receiver.ReceiveMessages(ctx, 10, nil)
 
-for _, m := range messages {
+for _, message := range messages {
   err = receiver.CompleteMessage(ctx, message)
 }
 ```
@@ -191,7 +194,7 @@ In `azservicebus`:
 
 ```go
 credential, err := azidentity.NewDefaultAzureCredential(nil)
-client, err = azservicebus.NewClient("<ex: myservicebus.servicebus.windows.net>", credential, nil)
+client, err := azservicebus.NewClient("<ex: myservicebus.servicebus.windows.net>", credential, nil)
 ```
 
 # Entity management using admin.Client
@@ -199,6 +202,7 @@ client, err = azservicebus.NewClient("<ex: myservicebus.servicebus.windows.net>"
 Administration features, like creating queues, topics and subscriptions, has been moved into a dedicated client (admin.Client).
 
 ```go
+// note: import "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
 adminClient, err := admin.NewClientFromConnectionString(connectionString, nil)
 
 // create a queue with default properties
@@ -223,8 +227,8 @@ sessionReceiver, err := client.AcceptNextSessionForQueue(context.TODO(), "queue"
 
 // managing session state
 sessionData, err := sessionReceiver.GetSessionState(context.TODO())
-err := sessionReceiver.SetSessionState(context.TODO(), []byte("data"))
+err = sessionReceiver.SetSessionState(context.TODO(), []byte("data"))
 
 // renewing the lock associated with the session
-err := sessionReceiver.RenewSessionLock(context.TODO())
+err = sessionReceiver.RenewSessionLock(context.TODO())
 ```

--- a/sdk/messaging/azservicebus/migrationguide.md
+++ b/sdk/messaging/azservicebus/migrationguide.md
@@ -77,7 +77,7 @@ err = messageBatch.AddMessage(&azservicebus.Message{
     Body: []byte(fmt.Sprintf("hello world")),
 })
 
-if err == azservicebus.ErrMessageTooLarge {
+if errors.Is(err, azservicebus.ErrMessageTooLarge) {
   fmt.Printf("Message batch is full. We should send it and create a new one.\n")
 
   // send what we have since the batch is full


### PR DESCRIPTION
Fixing docs issues in azservicebus

- Syntax errors in some of the samples for both the readme and the migrationguide.
- Adding in a section to describe how to enable the azcore logging specific things in azservicebus

Fixes the 'azservicebus' part of #16521