### PR TITLE
Add WWW-Authenticate header to default allow-list

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.21.2 (Unreleased)
 
 ### Features Added
+* Added header `WWW-Authenticate` to the default allow-list of headers for logging.
 
 ### Breaking Changes
 

--- a/sdk/azcore/runtime/policy_logging.go
+++ b/sdk/azcore/runtime/policy_logging.go
@@ -56,6 +56,7 @@ func NewLogPolicy(o *policy.LogOptions) policy.Policy {
 		"traceparent":                   {},
 		"transfer-encoding":             {},
 		"user-agent":                    {},
+		"www-authenticate":              {},
 		"x-ms-request-id":               {},
 		"x-ms-client-request-id":        {},
 		"x-ms-return-client-request-id": {},


### PR DESCRIPTION
Customer request and it's been deemed by privacy to be safe to log.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
