### PR TITLE
Support sovereign cloud testing on weekly schedule

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -150,7 +150,7 @@ stages:
   - ${{if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.RunLiveTests, 'true'))}}:
     - ${{ each cloud in parameters.CloudConfig }}:
       # Run all clouds by default for weekly test pipeline, except for clouds specifically unsupported by the calling pipeline
-      - ${{ if or(contains(parameters.Clouds, cloud.key), and(contains(variables['Build.DefinitionName'], 'tests-weekly'), contains(parameters.SupportedClouds, cloud.key))) }}:
+      - ${{ if or(contains(parameters.Clouds, cloud.key), and(contains(variables['Build.DefinitionName'], 'weekly'), contains(parameters.SupportedClouds, cloud.key))) }}:
         - ${{ if not(contains(parameters.UnsupportedClouds, cloud.key)) }}:
           - stage: ${{ cloud.key }}
             displayName: Live Test ${{ cloud.key }}
@@ -189,7 +189,7 @@ stages:
                   Cloud: ${{ cloud.key }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), not(contains(variables['Build.DefinitionName'], 'weekly')), eq(variables['System.TeamProject'], 'internal'))}}:
     - template: archetype-go-release.yml
       parameters:
         DependsOn:

--- a/sdk/messaging/azservicebus/ci.yml
+++ b/sdk/messaging/azservicebus/ci.yml
@@ -26,6 +26,7 @@ stages:
   parameters:
     ServiceDirectory: 'messaging/azservicebus'
     RunLiveTests: true
+    SupportedClouds: 'Public,UsGov,China'
     EnvVars:
       AZURE_CLIENT_ID: $(AZSERVICEBUS_CLIENT_ID)
       AZURE_TENANT_ID: $(AZSERVICEBUS_TENANT_ID)


### PR DESCRIPTION
This PR adds support for a weekly-scheduled sovereign cloud testing pipeline (ending in ` - weekly`).

Additionally it updates azservicebus to test against the UsGov and China clouds.
