### PR TITLE
Revise azidentity logging

### DIFF
--- a/sdk/azidentity/authorization_code_credential.go
+++ b/sdk/azidentity/authorization_code_credential.go
@@ -92,7 +92,6 @@ func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts policy.
 		}
 		ar, err = c.cca.AcquireTokenByAuthCode(ctx, c.authCode, c.redirectURI, opts.Scopes)
 		if err != nil {
-			addGetTokenFailureLogs(credNameAuthCode, err, true)
 			return nil, newAuthenticationFailedErrorFromMSALError(credNameAuthCode, err)
 		}
 		logGetTokenSuccess(c, opts)
@@ -107,7 +106,6 @@ func (c *AuthorizationCodeCredential) GetToken(ctx context.Context, opts policy.
 	}
 	ar, err = c.pca.AcquireTokenByAuthCode(ctx, c.authCode, c.redirectURI, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs(credNameAuthCode, err, true)
 		return nil, newAuthenticationFailedErrorFromMSALError(credNameAuthCode, err)
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -73,7 +73,6 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequ
 	scope := strings.TrimSuffix(opts.Scopes[0], defaultSuffix)
 	at, err := c.authenticate(ctx, scope)
 	if err != nil {
-		addGetTokenFailureLogs(credNameAzureCLI, err, true)
 		return nil, err
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -78,9 +78,7 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.Token
 	}
 	// if we get here, all credentials returned credentialUnavailableError
 	msg := createChainedErrorMessage(errs)
-	err := newCredentialUnavailableError(c.name, msg)
-	log.Write(EventAuthentication, "Azure Identity => ERROR: "+err.Error())
-	return nil, err
+	return nil, newCredentialUnavailableError(c.name, msg)
 }
 
 func createChainedErrorMessage(errs []error) string {

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -65,7 +65,7 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.Token
 	for _, cred := range c.sources {
 		token, err := cred.GetToken(ctx, opts)
 		if err == nil {
-			log.Writef(EventAuthentication, "Azure Identity => %s authenticated with %s", c.name, extractCredentialName(cred))
+			log.Writef(EventAuthentication, "%s authenticated with %s", c.name, extractCredentialName(cred))
 			c.successfulCredential = cred
 			return token, nil
 		}

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -63,7 +63,6 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 	}
 	authorityHost, err := setAuthorityHost(options.AuthorityHost)
 	if err != nil {
-		logCredentialError(credNameCert, err)
 		return nil, err
 	}
 	cert, err := newCertContents(certs, pk, options.SendCertificateChain)
@@ -100,7 +99,6 @@ func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts policy.
 
 	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs(credNameCert, err, true)
 		return nil, newAuthenticationFailedErrorFromMSALError(credNameCert, err)
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -71,7 +71,6 @@ func (c *ClientSecretCredential) GetToken(ctx context.Context, opts policy.Token
 
 	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs(credNameSecret, err, true)
 		return nil, newAuthenticationFailedErrorFromMSALError(credNameSecret, err)
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -104,7 +104,7 @@ func defaultAzureCredentialConstructorErrorHandler(numberOfSuccessfulCredentials
 	}
 
 	if len(errorMessages) != 0 {
-		log.Writef(EventAuthentication, "Azure Identity => Failed to initialize some credentials on the Default Azure Credential:\n\t%s", errorMessage)
+		log.Writef(EventAuthentication, "NewDefaultAzureCredential failed to initialize some credentials:\n\t%s", errorMessage)
 	}
 
 	return nil

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -100,9 +100,7 @@ func defaultAzureCredentialConstructorErrorHandler(numberOfSuccessfulCredentials
 	errorMessage := strings.Join(errorMessages, "\n\t")
 
 	if numberOfSuccessfulCredentials == 0 {
-		err := errors.New(errorMessage)
-		log.Writef(EventAuthentication, "Azure Identity => Failed to initialize the Default Azure Credential:\n\t%s", err.Error())
-		return err
+		return errors.New(errorMessage)
 	}
 
 	if len(errorMessages) != 0 {

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -108,7 +108,6 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 	}
 	dc, err := c.client.AcquireTokenByDeviceCode(ctx, opts.Scopes)
 	if err != nil {
-		addGetTokenFailureLogs(credNameDeviceCode, err, true)
 		return nil, newAuthenticationFailedErrorFromMSALError(credNameDeviceCode, err)
 	}
 	err = c.userPrompt(ctx, DeviceCodeMessage{
@@ -121,7 +120,6 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 	}
 	ar, err = dc.AuthenticationResult(ctx)
 	if err != nil {
-		addGetTokenFailureLogs(credNameDeviceCode, err, true)
 		return nil, newAuthenticationFailedErrorFromMSALError(credNameDeviceCode, err)
 	}
 	c.account = ar.Account

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -65,7 +65,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 		return nil, errors.New("missing environment variable AZURE_CLIENT_ID")
 	}
 	if clientSecret := os.Getenv("AZURE_CLIENT_SECRET"); clientSecret != "" {
-		log.Write(EventAuthentication, "Azure Identity => EnvironmentCredential will authenticate with ClientSecretCredential")
+		log.Write(EventAuthentication, "EnvironmentCredential will authenticate with ClientSecretCredential")
 		o := &ClientSecretCredentialOptions{AuthorityHost: options.AuthorityHost, ClientOptions: options.ClientOptions}
 		cred, err := NewClientSecretCredential(tenantID, clientID, clientSecret, o)
 		if err != nil {
@@ -74,7 +74,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 		return &EnvironmentCredential{cred: cred}, nil
 	}
 	if certPath := os.Getenv("AZURE_CLIENT_CERTIFICATE_PATH"); certPath != "" {
-		log.Write(EventAuthentication, "Azure Identity => EnvironmentCredential will authenticate with ClientCertificateCredential")
+		log.Write(EventAuthentication, "EnvironmentCredential will authenticate with ClientCertificateCredential")
 		certData, err := os.ReadFile(certPath)
 		if err != nil {
 			return nil, fmt.Errorf(`failed to read certificate file "%s": %v`, certPath, err)
@@ -95,7 +95,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 	}
 	if username := os.Getenv("AZURE_USERNAME"); username != "" {
 		if password := os.Getenv("AZURE_PASSWORD"); password != "" {
-			log.Write(EventAuthentication, "Azure Identity => EnvironmentCredential will authenticate with UsernamePasswordCredential")
+			log.Write(EventAuthentication, "EnvironmentCredential will authenticate with UsernamePasswordCredential")
 			o := &UsernamePasswordCredentialOptions{AuthorityHost: options.AuthorityHost, ClientOptions: options.ClientOptions}
 			cred, err := NewUsernamePasswordCredential(tenantID, clientID, username, password, o)
 			if err != nil {

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -90,7 +90,6 @@ func (c *InteractiveBrowserCredential) GetToken(ctx context.Context, opts policy
 	}
 	ar, err = c.client.AcquireTokenInteractive(ctx, opts.Scopes, o...)
 	if err != nil {
-		addGetTokenFailureLogs(credNameBrowser, err, true)
 		return nil, newAuthenticationFailedErrorFromMSALError(credNameBrowser, err)
 	}
 	c.account = ar.Account

--- a/sdk/azidentity/logging.go
+++ b/sdk/azidentity/logging.go
@@ -21,7 +21,7 @@ func logGetTokenSuccess(cred azcore.TokenCredential, opts policy.TokenRequestOpt
 	if !log.Should(EventAuthentication) {
 		return
 	}
-	msg := fmt.Sprintf("Azure Identity => GetToken() result for %T: SUCCESS\n", cred)
-	msg += fmt.Sprintf("\tCredential Scopes: [%s]", strings.Join(opts.Scopes, ", "))
+	scope := strings.Join(opts.Scopes, ", ")
+	msg := fmt.Sprintf("%s.GetToken() acquired a token for scope %s\n", cred, scope)
 	log.Write(EventAuthentication, msg)
 }

--- a/sdk/azidentity/logging.go
+++ b/sdk/azidentity/logging.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/diag"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
@@ -25,20 +24,4 @@ func logGetTokenSuccess(cred azcore.TokenCredential, opts policy.TokenRequestOpt
 	msg := fmt.Sprintf("Azure Identity => GetToken() result for %T: SUCCESS\n", cred)
 	msg += fmt.Sprintf("\tCredential Scopes: [%s]", strings.Join(opts.Scopes, ", "))
 	log.Write(EventAuthentication, msg)
-}
-
-func logCredentialError(credName string, err error) {
-	log.Writef(EventAuthentication, "Azure Identity => ERROR in %s: %s", credName, err.Error())
-}
-
-func addGetTokenFailureLogs(credName string, err error, includeStack bool) {
-	if !log.Should(EventAuthentication) {
-		return
-	}
-	stack := ""
-	if includeStack {
-		// skip the stack trace frames and ourself
-		stack = "\n" + diag.StackTrace(3, 32)
-	}
-	log.Writef(EventAuthentication, "Azure Identity => ERROR in GetToken() call for %s: %s%s", credName, err.Error(), stack)
 }

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -144,7 +144,7 @@ func newManagedIdentityClient(options *ManagedIdentityCredentialOptions) (*manag
 	c.pipeline = runtime.NewPipeline(component, version, runtime.PipelineOptions{}, &cp)
 
 	if log.Should(EventAuthentication) {
-		log.Writef(EventAuthentication, "Azure Identity => Managed Identity Credential will use %s managed identity", env)
+		log.Writef(EventAuthentication, "Managed Identity Credential will use %s managed identity", env)
 	}
 
 	return &c, nil

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -79,7 +79,6 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 	}
 	client, err := newManagedIdentityClient(options)
 	if err != nil {
-		logCredentialError(credNameManagedIdentity, err)
 		return nil, err
 	}
 	return &ManagedIdentityCredential{id: options.ID, client: client}, nil
@@ -91,14 +90,12 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
 	if len(opts.Scopes) != 1 {
 		err := errors.New(credNameManagedIdentity + ": GetToken() requires exactly one scope")
-		addGetTokenFailureLogs(credNameManagedIdentity, err, true)
 		return nil, err
 	}
 	// managed identity endpoints require an AADv1 resource (i.e. token audience), not a v2 scope, so we remove "/.default" here
 	scopes := []string{strings.TrimSuffix(opts.Scopes[0], defaultSuffix)}
 	tk, err := c.client.authenticate(ctx, c.id, scopes)
 	if err != nil {
-		addGetTokenFailureLogs(credNameManagedIdentity, err, true)
 		return nil, err
 	}
 	logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -73,7 +73,6 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.T
 	}
 	ar, err = c.client.AcquireTokenByUsernamePassword(ctx, opts.Scopes, c.username, c.password)
 	if err != nil {
-		addGetTokenFailureLogs(credNameUserPassword, err, true)
 		return nil, newAuthenticationFailedErrorFromMSALError(credNameUserPassword, err)
 	}
 	c.account = ar.Account


### PR DESCRIPTION
A couple small changes I hope will make authentication logs less noisy and more useful:
- Stop logging errors returned from `GetToken()` because the application gets the error and is compelled to handle it
- Remove "Azure Identity => " prefix because listeners don't need it for filtering or formatting