### PR TITLE
fix: maunal set autorest core version for track2 build to prevent str…

### DIFF
--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -9,6 +9,7 @@ param(
     [switch]$format,
     [switch]$tidy,
     [string]$config = "autorest.md",
+    [string]$autorestVersion = "3.7.3",
     [string]$goExtension = "@autorest/go@4.0.0-preview.36",
     [string]$outputFolder
 )
@@ -40,7 +41,7 @@ function Process-Sdk ()
         {
             $outputFolder = $currentDirectory
         }
-        autorest --use=$goExtension --go --track2 --output-folder=$outputFolder --file-prefix="zz_generated_" --clear-output-folder=false --go.clear-output-folder=false $autorestPath
+        autorest --version=$autorestVersion --use=$goExtension --go --track2 --output-folder=$outputFolder --file-prefix="zz_generated_" --clear-output-folder=false --go.clear-output-folder=false $autorestPath
         if ($LASTEXITCODE)
         {
             Write-Host "##[error]Error running autorest.go"


### PR DESCRIPTION
…ange core version default fetch

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
