### PR TITLE
[azservicebus] reset connection on network failures

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix connection recovery in situations where network errors bubble up from go-amqp (#17048)
+
 ### Other Changes
 
 ## 0.3.5 (2022-02-10)

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -114,13 +114,10 @@ func GetRecoveryKind(err error) recoveryKind {
 
 	var netErr net.Error
 
-	if errors.As(err, &netErr) {
-		// ie, just retry
-		return RecoveryKindNone
-	}
-
-	// this is a carryover from another library. I haven't seen this in the wild.
-	if errors.Is(err, io.EOF) {
+	// these are errors that can flow from the go-amqp connection to
+	// us. There's work underway to improve this but for now we can handle
+	// these as "catastrophic" errors and reset everything.
+	if errors.Is(err, io.EOF) || errors.As(err, &netErr) {
 		return RecoveryKindConn
 	}
 

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -171,9 +171,6 @@ func Test_ServiceBusError_NoRecoveryNeeded(t *testing.T) {
 		&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:timeout")},
 		&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:operation-cancelled")},
 		errors.New("link is currently draining"), // not yet exposed from go-amqp
-		fakeNetError{temp: true},
-		fakeNetError{timeout: true},
-		fakeNetError{temp: false, timeout: false},
 		// simple timeouts from the mgmt link
 		mgmtError{Resp: &RPCResponse{Code: 408}},
 		mgmtError{Resp: &RPCResponse{Code: 503}},
@@ -191,6 +188,9 @@ func Test_ServiceBusError_ConnectionRecoveryNeeded(t *testing.T) {
 		&amqp.Error{Condition: amqp.ErrorConnectionForced},
 		amqp.ErrConnClosed,
 		io.EOF,
+		fakeNetError{temp: true},
+		fakeNetError{timeout: true},
+		fakeNetError{temp: false, timeout: false},
 	}
 
 	for i, err := range connErrors {


### PR DESCRIPTION
There are some errors coming from go-amqp that indicate internal or fatal errors with the connection. At the moment go-amqp does not recover from these so our only course of action is to treat them as "connection recovery" events and close and recreate the connection.

We're (jhendrix-msft and I) are still planning on a better error handling strategy, but this mitigation will be correct even after that change and will handle things until then.

Fixes #17017