### PR TITLE
Return topic name in subscription properties item

### DIFF
--- a/sdk/messaging/azservicebus/admin/admin_client_subscription.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_subscription.go
@@ -261,6 +261,7 @@ func (p *SubscriptionPager) getNext(ctx context.Context) (*ListSubscriptionsResp
 		}
 
 		all = append(all, &SubscriptionPropertiesItem{
+			TopicName:              p.topicName,
 			SubscriptionName:       env.Title,
 			SubscriptionProperties: *props,
 		})

--- a/sdk/messaging/azservicebus/admin/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_test.go
@@ -655,6 +655,7 @@ func TestAdminClient_ListSubscriptions(t *testing.T) {
 	for i, expectedTopic := range expectedSubscriptions {
 		props, exists := all[expectedTopic]
 		require.True(t, exists)
+		require.Equal(t, topicName, props.TopicName)
 		require.EqualValues(t, time.Duration(i+1)*time.Minute, *props.DefaultMessageTimeToLive)
 	}
 }


### PR DESCRIPTION
Return topic name in subscription properties item when paging over subscriptions. Fixes #17058