### PR TITLE
Document that nil credential options get default settings

### DIFF
--- a/sdk/azidentity/authorization_code_credential.go
+++ b/sdk/azidentity/authorization_code_credential.go
@@ -44,7 +44,7 @@ type AuthorizationCodeCredential struct {
 // clientID: The application's client ID.
 // authCode: The authorization code received from the authorization code flow. Note that authorization codes are single-use.
 // redirectURL: The application's redirect URL. Must match the redirect URL used to request the authorization code.
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewAuthorizationCodeCredential(tenantID string, clientID string, authCode string, redirectURL string, options *AuthorizationCodeCredentialOptions) (*AuthorizationCodeCredential, error) {
 	if !validTenantID(tenantID) {
 		return nil, errors.New(tenantIDValidationErr)

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -48,7 +48,7 @@ type AzureCLICredential struct {
 }
 
 // NewAzureCLICredential constructs an AzureCLICredential.
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredential, error) {
 	cp := AzureCLICredentialOptions{}
 	if options != nil {

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -35,7 +35,7 @@ type ChainedTokenCredential struct {
 
 // NewChainedTokenCredential creates a ChainedTokenCredential.
 // sources: Credential instances to comprise the chain. GetToken() will invoke them in the given order.
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewChainedTokenCredential(sources []azcore.TokenCredential, options *ChainedTokenCredentialOptions) (*ChainedTokenCredential, error) {
 	if len(sources) == 0 {
 		return nil, errors.New("sources must contain at least one TokenCredential")

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -46,7 +46,7 @@ type ClientCertificateCredential struct {
 // clientID: The application's client ID.
 // certs: one or more certificates, for example as returned by ParseCertificates()
 // key: the signing certificate's private key, for example as returned by ParseCertificates()
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewClientCertificateCredential(tenantID string, clientID string, certs []*x509.Certificate, key crypto.PrivateKey, options *ClientCertificateCredentialOptions) (*ClientCertificateCredential, error) {
 	if len(certs) == 0 {
 		return nil, errors.New("at least one certificate is required")

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -33,7 +33,7 @@ type ClientSecretCredential struct {
 // tenantID: The application's Azure Active Directory tenant or directory ID.
 // clientID: The application's client ID.
 // clientSecret: One of the application's client secrets.
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewClientSecretCredential(tenantID string, clientID string, clientSecret string, options *ClientSecretCredentialOptions) (*ClientSecretCredential, error) {
 	if !validTenantID(tenantID) {
 		return nil, errors.New(tenantIDValidationErr)

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -73,7 +73,7 @@ type DeviceCodeCredential struct {
 }
 
 // NewDeviceCodeCredential creates a DeviceCodeCredential.
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeCredential, error) {
 	cp := DeviceCodeCredentialOptions{}
 	if options != nil {

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -51,7 +51,7 @@ type EnvironmentCredential struct {
 }
 
 // NewEnvironmentCredential creates an EnvironmentCredential.
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*EnvironmentCredential, error) {
 	if options == nil {
 		options = &EnvironmentCredentialOptions{}

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -50,7 +50,7 @@ type InteractiveBrowserCredential struct {
 }
 
 // NewInteractiveBrowserCredential constructs a new InteractiveBrowserCredential.
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOptions) (*InteractiveBrowserCredential, error) {
 	cp := InteractiveBrowserCredentialOptions{}
 	if options != nil {

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -72,7 +72,7 @@ type ManagedIdentityCredential struct {
 }
 
 // NewManagedIdentityCredential creates a ManagedIdentityCredential.
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*ManagedIdentityCredential, error) {
 	if options == nil {
 		options = &ManagedIdentityCredentialOptions{}

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -40,7 +40,7 @@ type UsernamePasswordCredential struct {
 // clientID: The ID of the application users will authenticate to.
 // username: A username (typically an email address).
 // password: That user's password.
-// options: Optional configuration.
+// options: Optional configuration. Pass nil to accept default settings.
 func NewUsernamePasswordCredential(tenantID string, clientID string, username string, password string, options *UsernamePasswordCredentialOptions) (*UsernamePasswordCredential, error) {
 	if !validTenantID(tenantID) {
 		return nil, errors.New(tenantIDValidationErr)


### PR DESCRIPTION
Pointing out there's no need to pass an empty struct.