### PR TITLE
Upgrade App Service managed identity version

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+* Upgraded App Service managed identity version from 2017-09-01 to 2019-08-01
 
 ## 0.13.1 (2022-02-08)
 

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -31,7 +31,6 @@ const (
 	headerMetadata           = "Metadata"
 	imdsEndpoint             = "http://169.254.169.254/metadata/identity/oauth2/token"
 	msiEndpoint              = "MSI_ENDPOINT"
-	msiSecret                = "MSI_SECRET"
 	imdsAPIVersion           = "2018-02-01"
 	azureArcAPIVersion       = "2019-08-15"
 	serviceFabricAPIVersion  = "2019-07-01-preview"
@@ -43,8 +42,7 @@ const (
 type msiType int
 
 const (
-	msiTypeAppServiceV20170901 msiType = iota
-	msiTypeAppServiceV20190801
+	msiTypeAppService msiType = iota
 	msiTypeAzureArc
 	msiTypeCloudShell
 	msiTypeIMDS
@@ -116,28 +114,26 @@ func newManagedIdentityClient(options *ManagedIdentityCredentialOptions) (*manag
 	cp := options.ClientOptions
 	c := managedIdentityClient{id: options.ID, endpoint: imdsEndpoint, msiType: msiTypeIMDS}
 	env := "IMDS"
-	if endpoint, ok := os.LookupEnv(msiEndpoint); ok {
-		if _, ok := os.LookupEnv(msiSecret); ok {
-			env = "App Service"
-			c.endpoint = endpoint
-			c.msiType = msiTypeAppServiceV20170901
-		} else {
-			env = "Cloud Shell"
-			c.endpoint = endpoint
-			c.msiType = msiTypeCloudShell
-		}
-	} else if endpoint, ok := os.LookupEnv(identityEndpoint); ok {
+	if endpoint, ok := os.LookupEnv(identityEndpoint); ok {
 		if _, ok := os.LookupEnv(identityHeader); ok {
 			if _, ok := os.LookupEnv(identityServerThumbprint); ok {
 				env = "Service Fabric"
 				c.endpoint = endpoint
 				c.msiType = msiTypeServiceFabric
+			} else {
+				env = "App Service"
+				c.endpoint = endpoint
+				c.msiType = msiTypeAppService
 			}
 		} else if _, ok := os.LookupEnv(arcIMDSEndpoint); ok {
 			env = "Azure Arc"
 			c.endpoint = endpoint
 			c.msiType = msiTypeAzureArc
 		}
+	} else if endpoint, ok := os.LookupEnv(msiEndpoint); ok {
+		env = "Cloud Shell"
+		c.endpoint = endpoint
+		c.msiType = msiTypeCloudShell
 	} else {
 		setIMDSRetryOptionDefaults(&cp.Retry)
 	}
@@ -216,17 +212,7 @@ func (c *managedIdentityClient) createAccessToken(res *http.Response) (*azcore.A
 		if expiresOn, err := strconv.Atoi(v); err == nil {
 			return &azcore.AccessToken{Token: value.Token, ExpiresOn: time.Unix(int64(expiresOn), 0).UTC()}, nil
 		}
-		// this is the case when expires_on is a time string
-		// this is the format of the string coming from the service
-		if expiresOn, err := time.Parse("1/2/2006 15:04:05 PM +00:00", v); err == nil { // the date string specified is for Windows OS
-			eo := expiresOn.UTC()
-			return &azcore.AccessToken{Token: value.Token, ExpiresOn: eo}, nil
-		} else if expiresOn, err := time.Parse("1/2/2006 15:04:05 +00:00", v); err == nil { // the date string specified is for Linux OS
-			eo := expiresOn.UTC()
-			return &azcore.AccessToken{Token: value.Token, ExpiresOn: eo}, nil
-		} else {
-			return nil, err
-		}
+		return nil, newAuthenticationFailedError(credNameManagedIdentity, "unexpected expires_on value: "+v, res)
 	default:
 		msg := fmt.Sprintf("unsupported type received in expires_on: %T, %v", v, v)
 		return nil, newAuthenticationFailedError(credNameManagedIdentity, msg, res)
@@ -237,7 +223,7 @@ func (c *managedIdentityClient) createAuthRequest(ctx context.Context, id Manage
 	switch c.msiType {
 	case msiTypeIMDS:
 		return c.createIMDSAuthRequest(ctx, id, scopes)
-	case msiTypeAppServiceV20170901, msiTypeAppServiceV20190801:
+	case msiTypeAppService:
 		return c.createAppServiceAuthRequest(ctx, id, scopes)
 	case msiTypeAzureArc:
 		// need to perform preliminary request to retreive the secret key challenge provided by the HIMDS service
@@ -281,32 +267,17 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	request.Raw().Header.Set("X-IDENTITY-HEADER", os.Getenv(identityHeader))
 	q := request.Raw().URL.Query()
-	if c.msiType == msiTypeAppServiceV20170901 {
-		request.Raw().Header.Set("secret", os.Getenv(msiSecret))
-		q.Add("api-version", "2017-09-01")
-		q.Add("resource", strings.Join(scopes, " "))
-		if id != nil {
-			if id.idKind() == miResourceID {
-				q.Add(qpResID, id.String())
-			} else {
-				// the legacy 2017 API version specifically specifies "clientid" and not "client_id" as a query param
-				q.Add("clientid", id.String())
-			}
-		}
-	} else if c.msiType == msiTypeAppServiceV20190801 {
-		request.Raw().Header.Set("X-IDENTITY-HEADER", os.Getenv(identityHeader))
-		q.Add("api-version", "2019-08-01")
-		q.Add("resource", scopes[0])
-		if id != nil {
-			if id.idKind() == miResourceID {
-				q.Add(qpResID, id.String())
-			} else {
-				q.Add(qpClientID, id.String())
-			}
+	q.Add("api-version", "2019-08-01")
+	q.Add("resource", scopes[0])
+	if id != nil {
+		if id.idKind() == miResourceID {
+			q.Add(qpResID, id.String())
+		} else {
+			q.Add(qpClientID, id.String())
 		}
 	}
-
 	request.Raw().URL.RawQuery = q.Encode()
 	return request, nil
 }

--- a/sdk/azidentity/managed_identity_client_test.go
+++ b/sdk/azidentity/managed_identity_client_test.go
@@ -42,7 +42,7 @@ func TestManagedIdentityClient_UserAgent(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: "..."})
+	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL()})
 	options := ManagedIdentityCredentialOptions{
 		ClientOptions: azcore.ClientOptions{
 			Transport: srv, PerCallPolicies: []policy.Policy{userAgentValidatingPolicy{t: t}},
@@ -65,7 +65,7 @@ func TestManagedIdentityClient_ApplicationID(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: "..."})
+	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL()})
 	appID := "customvalue"
 	options := ManagedIdentityCredentialOptions{
 		ClientOptions: azcore.ClientOptions{

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -175,11 +175,11 @@ func TestManagedIdentityCredential_AppService(t *testing.T) {
 				t.Fatalf(`unexpected resource "%s"`, v)
 			}
 			if id == nil {
-				if q.Has(qpClientID) || q.Has(qpResID) {
+				if q.Get(qpClientID) != "" || q.Get(qpResID) != "" {
 					t.Fatal("request shouldn't include a user-assigned ID")
 				}
 			} else {
-				if q.Has(qpClientID) && q.Has(qpResID) {
+				if q.Get(qpClientID) != "" && q.Get(qpResID) != "" {
 					t.Fatal("request includes two IDs")
 				}
 				var v string

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -23,10 +24,9 @@ import (
 )
 
 const (
-	appServiceWindowsSuccessResp = `{"access_token": "new_token", "expires_on": "9/14/2017 00:00:00 PM +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
-	appServiceLinuxSuccessResp   = `{"access_token": "new_token", "expires_on": "09/14/2017 00:00:00 +00:00", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
-	expiresOnIntResp             = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": "1560974028", "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
-	expiresOnNonStringIntResp    = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": 1560974028, "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
+	appServiceSuccessResp     = `{"access_token": "` + tokenValue + `", "expires_on": "1560974028", "resource": "https://vault.azure.net", "token_type": "Bearer", "client_id": "some-guid"}`
+	expiresOnIntResp          = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": "1560974028", "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
+	expiresOnNonStringIntResp = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": 1560974028, "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 )
 
 // TODO: replace with 1.17's T.Setenv
@@ -180,217 +180,70 @@ func TestManagedIdentityCredential_CloudShellUserAssigned(t *testing.T) {
 	}
 }
 
-func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_windows(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	expectedSecret := "expected-secret"
-	pred := func(req *http.Request) bool {
-		if secret := req.Header.Get("Secret"); secret != expectedSecret {
-			t.Fatalf(`unexpected Secret header "%s"`, secret)
+func TestManagedIdentityCredential_AppService(t *testing.T) {
+	expectedID := "expected-ID"
+	expectedHeader := "header"
+	for _, id := range []ManagedIDKind{ClientID(expectedID), ResourceID(expectedID), nil} {
+		validateReq := func(req *http.Request) bool {
+			if h := req.Header.Get("X-IDENTITY-HEADER"); h != expectedHeader {
+				t.Fatalf("unexpected X-IDENTITY-HEADER: %s", h)
+			}
+			q := req.URL.Query()
+			if v := q.Get("api-version"); v != "2019-08-01" {
+				t.Fatalf(`unexpected api-version "%s"`, v)
+			}
+			if v := q.Get("resource"); v != strings.TrimSuffix(liveTestScope, "/.default") {
+				t.Fatalf(`unexpected resource "%s"`, v)
+			}
+			if id == nil {
+				if q.Has(qpClientID) || q.Has(qpResID) {
+					t.Fatal("request shouldn't include a user-assigned ID")
+				}
+			} else {
+				if q.Has(qpClientID) && q.Has(qpResID) {
+					t.Fatal("request includes two IDs")
+				}
+				var v string
+				if _, ok := id.(ClientID); ok {
+					v = q.Get(qpClientID)
+				} else if _, ok := id.(ResourceID); ok {
+					v = q.Get(qpResID)
+				}
+				if v != id.String() {
+					t.Fatalf(`unexpected id "%s"`, v)
+				}
+			}
+			return true
 		}
-		return true
-	}
-	srv.AppendResponse(mock.WithPredicate(pred), mock.WithBody([]byte(appServiceWindowsSuccessResp)))
-	srv.AppendResponse()
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: expectedSecret})
-	options := ManagedIdentityCredentialOptions{}
-	options.Transport = srv
-	msiCred, err := NewManagedIdentityCredential(&options)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
-	if err != nil {
-		t.Fatalf("Received an error when attempting to retrieve a token")
-	}
-	if tk.Token != "new_token" {
-		t.Fatalf("Did not receive the correct token. Expected \"new_token\", Received: %s", tk.Token)
-	}
-	if msiCred.client.msiType != msiTypeAppServiceV20170901 {
-		t.Fatalf("Failed to detect the correct MSI Environment. Expected: %d, Received: %d", msiTypeAppServiceV20170901, msiCred.client.msiType)
+
+		t.Run(fmt.Sprintf("%T", id), func(t *testing.T) {
+			srv, close := mock.NewServer()
+			defer close()
+			srv.AppendResponse(mock.WithPredicate(validateReq), mock.WithBody([]byte(appServiceSuccessResp)))
+			srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
+			setEnvironmentVariables(t, map[string]string{identityEndpoint: srv.URL(), identityHeader: expectedHeader})
+			options := ManagedIdentityCredentialOptions{ID: id}
+			options.Transport = srv
+			cred, err := NewManagedIdentityCredential(&options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tk.Token != tokenValue {
+				t.Fatalf(`unexpected token "%s"`, tk.Token)
+			}
+		})
 	}
 }
 
-func TestManagedIdentityCredential_GetTokenInAppServiceV20170901Mock_linux(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(appServiceLinuxSuccessResp)))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: "secret"})
-	options := ManagedIdentityCredentialOptions{}
-	options.Transport = srv
-	msiCred, err := NewManagedIdentityCredential(&options)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
-	if err != nil {
-		t.Fatalf("Received an error when attempting to retrieve a token")
-	}
-	if tk.Token != "new_token" {
-		t.Fatalf("Did not receive the correct token. Expected \"new_token\", Received: %s", tk.Token)
-	}
-	if msiCred.client.msiType != msiTypeAppServiceV20170901 {
-		t.Fatalf("Failed to detect the correct MSI Environment. Expected: %d, Received: %d", msiTypeAppServiceV20170901, msiCred.client.msiType)
-	}
-}
-
-func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_windows(t *testing.T) {
-	t.Skip("App Service 2019-08-01 isn't supported because it's unavailable in some Functions apps.")
-	srv, close := mock.NewServer()
-	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(appServiceWindowsSuccessResp)))
-	setEnvironmentVariables(t, map[string]string{identityEndpoint: srv.URL(), identityHeader: "header"})
-	options := ManagedIdentityCredentialOptions{}
-	options.Transport = srv
-	msiCred, err := NewManagedIdentityCredential(&options)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
-	if err != nil {
-		t.Fatalf("Received an error when attempting to retrieve a token")
-	}
-	if tk.Token != "new_token" {
-		t.Fatalf("Did not receive the correct token. Expected \"new_token\", Received: %s", tk.Token)
-	}
-	if msiCred.client.msiType != msiTypeAppServiceV20190801 {
-		t.Fatalf("Failed to detect the correct MSI Environment. Expected: %d, Received: %d", msiTypeAppServiceV20190801, msiCred.client.msiType)
-	}
-}
-
-func TestManagedIdentityCredential_GetTokenInAppServiceV20190801Mock_linux(t *testing.T) {
-	t.Skip("App Service 2019-08-01 isn't supported because it's unavailable in some Functions apps.")
-	srv, close := mock.NewServer()
-	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(appServiceLinuxSuccessResp)))
-	setEnvironmentVariables(t, map[string]string{identityEndpoint: srv.URL(), identityHeader: "header"})
-	options := ManagedIdentityCredentialOptions{}
-	options.Transport = srv
-	msiCred, err := NewManagedIdentityCredential(&options)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
-	if err != nil {
-		t.Fatalf("Received an error when attempting to retrieve a token")
-	}
-	if tk.Token != "new_token" {
-		t.Fatalf("Did not receive the correct token. Expected \"new_token\", Received: %s", tk.Token)
-	}
-	if msiCred.client.msiType != msiTypeAppServiceV20190801 {
-		t.Fatalf("Failed to detect the correct MSI Environment. Expected: %d, Received: %d", msiTypeAppServiceV20190801, msiCred.client.msiType)
-	}
-}
-
-// Azure Functions on linux environments currently doesn't properly support the identity header,
-// therefore, preference must be given to the legacy MSI_ENDPOINT variable.
-func TestManagedIdentityCredential_GetTokenInAzureFunctions_linux(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(appServiceWindowsSuccessResp)))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: "secret"})
-	setEnvironmentVariables(t, map[string]string{identityEndpoint: srv.URL(), identityHeader: "header"})
-	msiCred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{ClientOptions: azcore.ClientOptions{Transport: srv}})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	tk, err := msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
-	if err != nil {
-		t.Fatalf("Received an error when attempting to retrieve a token")
-	}
-	if tk.Token != "new_token" {
-		t.Fatalf("Did not receive the correct token. Expected \"new_token\", Received: %s", tk.Token)
-	}
-	if msiCred.client.msiType != msiTypeAppServiceV20170901 {
-		t.Fatalf("Failed to detect the correct MSI Environment. Expected: %d, Received: %d", msiTypeAppServiceV20170901, msiCred.client.msiType)
-	}
-}
-
-func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20190801(t *testing.T) {
-	t.Skip("App Service 2019-08-01 isn't supported because it's unavailable in some Functions apps.")
-	// setting a dummy value for MSI_ENDPOINT in order to be able to get a ManagedIdentityCredential type in order
-	// to test App Service authentication request creation.
-	setEnvironmentVariables(t, map[string]string{identityEndpoint: "somevalue", identityHeader: "header"})
-	cred, err := NewManagedIdentityCredential(nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createAuthRequest(context.Background(), ClientID(fakeClientID), []string{liveTestScope})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req.Raw().Header.Get("X-IDENTITY-HEADER") != "header" {
-		t.Fatalf("Unexpected value for secret header")
-	}
-	reqQueryParams, err := url.ParseQuery(req.Raw().URL.RawQuery)
-	if err != nil {
-		t.Fatalf("Unable to parse App Service request query params: %v", err)
-	}
-	if reqQueryParams["api-version"][0] != "2019-08-01" {
-		t.Fatalf("Unexpected App Service API version")
-	}
-	if reqQueryParams["resource"][0] != liveTestScope {
-		t.Fatalf("Unexpected resource in resource query param")
-	}
-	if reqQueryParams[qpClientID][0] != fakeClientID {
-		t.Fatalf("Unexpected client ID in resource query param")
-	}
-}
-
-func TestManagedIdentityCredential_CreateAppServiceAuthRequestV20170901(t *testing.T) {
-	// setting a dummy value for MSI_ENDPOINT in order to be able to get a ManagedIdentityCredential type in order
-	// to test App Service authentication request creation.
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: "somevalue", msiSecret: "secret"})
-	cred, err := NewManagedIdentityCredential(nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createAuthRequest(context.Background(), ClientID(fakeClientID), []string{liveTestScope})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req.Raw().Header.Get("secret") != "secret" {
-		t.Fatalf("Unexpected value for secret header")
-	}
-	reqQueryParams, err := url.ParseQuery(req.Raw().URL.RawQuery)
-	if err != nil {
-		t.Fatalf("Unable to parse App Service request query params: %v", err)
-	}
-	if reqQueryParams["api-version"][0] != "2017-09-01" {
-		t.Fatalf("Unexpected App Service API version")
-	}
-	if reqQueryParams["resource"][0] != liveTestScope {
-		t.Fatalf("Unexpected resource in resource query param")
-	}
-	if reqQueryParams["clientid"][0] != fakeClientID {
-		t.Fatalf("Unexpected client ID in resource query param")
-	}
-}
-
-func TestManagedIdentityCredential_CreateAccessTokenExpiresOnStringInt(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(expiresOnIntResp)))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: "secret"})
-	options := ManagedIdentityCredentialOptions{}
-	options.Transport = srv
-	msiCred, err := NewManagedIdentityCredential(&options)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
-	if err != nil {
-		t.Fatalf("Received an error when attempting to retrieve a token")
-	}
-}
-
-func TestManagedIdentityCredential_GetTokenInAppServiceMockFail(t *testing.T) {
+func TestManagedIdentityCredential_AppServiceError(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusUnauthorized))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: "secret"})
+	setEnvironmentVariables(t, map[string]string{identityEndpoint: srv.URL(), identityHeader: "secret"})
 	options := ManagedIdentityCredentialOptions{}
 	options.Transport = srv
 	msiCred, err := NewManagedIdentityCredential(&options)
@@ -456,9 +309,6 @@ func TestManagedIdentityCredential_GetTokenUnexpectedJSON(t *testing.T) {
 }
 
 func TestManagedIdentityCredential_CreateIMDSAuthRequest(t *testing.T) {
-	// setting a dummy value for MSI_ENDPOINT in order to be able to get a ManagedIdentityCredential type in order
-	// to test IMDS authentication request creation.
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: "somevalue", msiSecret: "secret"})
 	cred, err := NewManagedIdentityCredential(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -534,58 +384,6 @@ func TestManagedIdentityCredential_ScopesImmutable(t *testing.T) {
 	}
 }
 
-func TestManagedIdentityCredential_UseResourceID(t *testing.T) {
-	srv, close := mock.NewServer()
-	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(appServiceWindowsSuccessResp)))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: "secret"})
-	options := ManagedIdentityCredentialOptions{}
-	options.Transport = srv
-	options.ID = ResourceID("sample/resource/id")
-	cred, err := NewManagedIdentityCredential(&options)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if tk.Token != "new_token" {
-		t.Fatalf("unexpected token returned. Expected: %s, Received: %s", "new_token", tk.Token)
-	}
-}
-
-func TestManagedIdentityCredential_ResourceID_AppServiceV20190801(t *testing.T) {
-	t.Skip("App Service 2019-08-01 isn't supported because it's unavailable in some Functions apps.")
-	setEnvironmentVariables(t, map[string]string{identityEndpoint: "somevalue", identityHeader: "header"})
-	resID := "sample/resource/id"
-	cred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{ID: ResourceID(resID)})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	cred.client.endpoint = imdsEndpoint
-	req, err := cred.client.createAuthRequest(context.Background(), cred.id, []string{liveTestScope})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req.Raw().Header.Get("X-IDENTITY-HEADER") != "header" {
-		t.Fatalf("Unexpected value for secret header")
-	}
-	reqQueryParams, err := url.ParseQuery(req.Raw().URL.RawQuery)
-	if err != nil {
-		t.Fatalf("Unable to parse App Service request query params: %v", err)
-	}
-	if reqQueryParams["api-version"][0] != "2019-08-01" {
-		t.Fatalf("Unexpected App Service API version")
-	}
-	if reqQueryParams["resource"][0] != liveTestScope {
-		t.Fatalf("Unexpected resource in resource query param")
-	}
-	if reqQueryParams[qpResID][0] != resID {
-		t.Fatalf("Unexpected resource ID in resource query param")
-	}
-}
-
 func TestManagedIdentityCredential_ResourceID_IMDS(t *testing.T) {
 	// setting a dummy value for MSI_ENDPOINT in order to avoid failure in the constructor
 	setEnvironmentVariables(t, map[string]string{msiEndpoint: "http://localhost"})
@@ -619,7 +417,7 @@ func TestManagedIdentityCredential_CreateAccessTokenExpiresOnInt(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(expiresOnNonStringIntResp)))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: "secret"})
+	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL()})
 	options := ManagedIdentityCredentialOptions{}
 	options.Transport = srv
 	msiCred, err := NewManagedIdentityCredential(&options)
@@ -628,7 +426,7 @@ func TestManagedIdentityCredential_CreateAccessTokenExpiresOnInt(t *testing.T) {
 	}
 	_, err = msiCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
-		t.Fatalf("Received an error when attempting to retrieve a token")
+		t.Fatal(err)
 	}
 }
 
@@ -637,7 +435,7 @@ func TestManagedIdentityCredential_CreateAccessTokenExpiresOnFail(t *testing.T) 
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(`{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": "15609740s28", "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`)))
-	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL(), msiSecret: "secret"})
+	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL()})
 	options := ManagedIdentityCredentialOptions{}
 	options.Transport = srv
 	msiCred, err := NewManagedIdentityCredential(&options)


### PR DESCRIPTION
Upgrading from 2017-09-01 to 2019-08-01 because the service team told us the newer version is available everywhere now. I tested this live in addition to updating the offline tests.