### PR TITLE
[Tables] Improving documentation on client methods

### DIFF
--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -45,6 +45,7 @@ func NewClient(serviceURL string, cred azcore.TokenCredential, options *ClientOp
 
 // NewClientWithNoCredential creates a Client struct in the context of the table specified in the serviceURL.
 // The serviceURL param is expected to have the name of the table in a format similar to: "https://myAccountName.core.windows.net/<myTableName>?<SAS token>".
+// Pass in nil for options to construct the client with the default ClientOptions.
 func NewClientWithNoCredential(serviceURL string, options *ClientOptions) (*Client, error) {
 	if options == nil {
 		options = &ClientOptions{}
@@ -62,6 +63,7 @@ func NewClientWithNoCredential(serviceURL string, options *ClientOptions) (*Clie
 
 // NewClientWithSharedKey creates a Client struct in the context of the table specified in the serviceURL, authorizing requests with a shared key.
 // The serviceURL param is expected to have the name of the table in a format similar to: "https://myAccountName.core.windows.net/<myTableName>".
+// Pass in nil for options to construct the client with the default ClientOptions.
 func NewClientWithSharedKey(serviceURL string, cred *SharedKeyCredential, options *ClientOptions) (*Client, error) {
 	if options == nil {
 		options = &ClientOptions{}

--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -114,7 +114,8 @@ func createTableResponseFromGen(g *generated.TableClientCreateResponse) CreateTa
 	}
 }
 
-// Create creates the table with the tableName specified when NewClient was called.
+// Create creates the table with the tableName specified when NewClient was called. If the service returns a non-successful
+// HTTP status code, the function returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) Create(ctx context.Context, options *CreateTableOptions) (CreateTableResponse, error) {
 	if options == nil {
 		options = &CreateTableOptions{}
@@ -123,7 +124,8 @@ func (t *Client) Create(ctx context.Context, options *CreateTableOptions) (Creat
 	return createTableResponseFromGen(&resp), err
 }
 
-// Delete deletes the table with the tableName specified when NewClient was called.
+// Delete deletes the table with the tableName specified when NewClient was called. If the service returns a non-successful HTTP status
+// code, the function returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) Delete(ctx context.Context, options *DeleteTableOptions) (DeleteTableResponse, error) {
 	return t.service.DeleteTable(ctx, t.name, options)
 }
@@ -282,7 +284,7 @@ func (p *tableEntityQueryResponsePager) Err() error {
 }
 
 // List queries the entities using the specified ListEntitiesOptions.
-// listOptions can specify the following properties to affect the query results returned:
+// ListEntitiesOptions can specify the following properties to affect the query results returned:
 //
 // Filter: An OData filter expression that limits results to those entities that satisfy the filter expression.
 // For example, the following expression would return only entities with a PartitionKey of 'foo': "PartitionKey eq 'foo'"
@@ -293,7 +295,7 @@ func (p *tableEntityQueryResponsePager) Err() error {
 // Top: The maximum number of entities that will be returned per page of results.
 // Note: This value does not limit the total number of results if NextPage is called on the returned Pager until it returns false.
 //
-// List returns a Pager, which allows iteration through each page of results.
+// List returns a Pager, which allows iteration through each page of results. Use nil for listOptions if you want to use the default options.
 func (t *Client) List(listOptions *ListEntitiesOptions) ListEntitiesPager {
 	if listOptions == nil {
 		listOptions = &ListEntitiesOptions{}
@@ -346,7 +348,9 @@ func newGetEntityResponse(g generated.TableClientQueryEntityWithPartitionAndRowK
 	}, nil
 }
 
-// GetEntity retrieves a specific entity from the service using the specified partitionKey and rowKey values. If no entity is available it returns an error
+// GetEntity retrieves a specific entity from the service using the specified partitionKey and rowKey values. If
+// no entity is available it returns an error. If the service returns a non-successful HTTP status code, the function
+// returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) GetEntity(ctx context.Context, partitionKey string, rowKey string, options *GetEntityOptions) (GetEntityResponse, error) {
 	if options == nil {
 		options = &GetEntityOptions{}
@@ -388,7 +392,8 @@ func addEntityResponseFromGenerated(g *generated.TableClientInsertEntityResponse
 
 // AddEntity adds an entity (described by a byte slice) to the table. This method returns an error if an entity with
 // the same PartitionKey and RowKey already exists in the table. If the supplied entity does not contain both a PartitionKey
-// and a RowKey an error will be returned.
+// and a RowKey an error will be returned. If the service returns a non-successful HTTP status code, the function returns
+// an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) AddEntity(ctx context.Context, entity []byte, options *AddEntityOptions) (AddEntityResponse, error) {
 	var mapEntity map[string]interface{}
 	err := json.Unmarshal(entity, &mapEntity)
@@ -424,7 +429,8 @@ func deleteEntityResponseFromGenerated(g *generated.TableClientDeleteEntityRespo
 	}
 }
 
-// DeleteEntity deletes the entity with the specified partitionKey and rowKey from the table.
+// DeleteEntity deletes the entity with the specified partitionKey and rowKey from the table. If the service returns a non-successful HTTP
+// status code, the function returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) DeleteEntity(ctx context.Context, partitionKey string, rowKey string, options *DeleteEntityOptions) (DeleteEntityResponse, error) {
 	if options == nil {
 		options = &DeleteEntityOptions{}
@@ -502,6 +508,7 @@ func updateEntityResponseFromUpdateGenerated(g *generated.TableClientUpdateEntit
 // If updateMode is Merge, the property values present in the specified entity will be merged with the existing entity. Properties not specified in the merge will be unaffected.
 // The specified etag value will be used for optimistic concurrency. If the etag does not match the value of the entity in the table, the operation will fail.
 // The response type will be TableEntityMergeResponse if updateMode is Merge and TableEntityUpdateResponse if updateMode is Replace.
+// If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) UpdateEntity(ctx context.Context, entity []byte, options *UpdateEntityOptions) (UpdateEntityResponse, error) {
 	if options == nil {
 		options = &UpdateEntityOptions{
@@ -600,6 +607,8 @@ func insertEntityFromGeneratedUpdate(g *generated.TableClientUpdateEntityRespons
 // replaced or merged as specified the updateMode parameter. If the entity exists and updateMode is Merge, the property
 // values present in the specified entity will be merged with the existing entity rather than replaced.
 // The response type will be TableEntityMergeResponse if updateMode is Merge and TableEntityUpdateResponse if updateMode is Replace.
+// If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
+// Specify nil for options if you want to use the default options.
 func (t *Client) InsertEntity(ctx context.Context, entity []byte, options *InsertEntityOptions) (InsertEntityResponse, error) {
 	if options == nil {
 		options = &InsertEntityOptions{
@@ -675,7 +684,9 @@ func getAccessPolicyResponseFromGenerated(g *generated.TableClientGetAccessPolic
 	}
 }
 
-// GetAccessPolicy retrieves details about any stored access policies specified on the table that may be used with the Shared Access Signature
+// GetAccessPolicy retrieves details about any stored access policies specified on the table that may be used with the Shared Access Signature.
+// If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
+// Specify nil for options if you want to use the default options.
 func (t *Client) GetAccessPolicy(ctx context.Context, options *GetAccessPolicyOptions) (GetAccessPolicyResponse, error) {
 	resp, err := t.client.GetAccessPolicy(ctx, t.name, generated.Enum4ACL, options.toGenerated())
 	return getAccessPolicyResponseFromGenerated(&resp), err
@@ -707,7 +718,9 @@ func (s *SetAccessPolicyOptions) toGenerated() *generated.TableClientSetAccessPo
 	}
 }
 
-// SetAccessPolicy sets stored access policies for the table that may be used with SharedAccessSignature
+// SetAccessPolicy sets stored access policies for the table that may be used with SharedAccessSignature.
+// If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
+// Specify nil for options if you want to use the default options.
 func (t *Client) SetAccessPolicy(ctx context.Context, options *SetAccessPolicyOptions) (SetAccessPolicyResponse, error) {
 	response, err := t.client.SetAccessPolicy(ctx, t.name, generated.Enum4ACL, options.toGenerated())
 	if len(options.TableACL) > 5 {

--- a/sdk/data/aztables/connection_string.go
+++ b/sdk/data/aztables/connection_string.go
@@ -10,6 +10,7 @@ import (
 
 // NewServiceClientFromConnectionString creates a new ServiceClient struct from a connection string. The connection
 // string must contain either an account name and account key or an account name and a shared access signature.
+// Pass in nil for options to construct the client with the default ClientOptions.
 func NewServiceClientFromConnectionString(connectionString string, options *ClientOptions) (*ServiceClient, error) {
 	endpoint, credential, err := parseConnectionString(connectionString)
 	if err != nil {

--- a/sdk/data/aztables/service_client.go
+++ b/sdk/data/aztables/service_client.go
@@ -92,7 +92,8 @@ func (c *CreateTableOptions) toGenerated() *generated.TableClientCreateOptions {
 	return &generated.TableClientCreateOptions{}
 }
 
-// Create creates a table with the specified name.
+// Create creates a table with the specified name. If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
+// Specify nil for options if you want to use the default options.
 func (t *ServiceClient) CreateTable(ctx context.Context, name string, options *CreateTableOptions) (*Client, error) {
 	if options == nil {
 		options = &CreateTableOptions{}
@@ -123,7 +124,8 @@ func deleteTableResponseFromGen(g *generated.TableClientDeleteResponse) DeleteTa
 	}
 }
 
-// Delete deletes a table by name.
+// Delete deletes a table by name. If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
+// Specify nil for options if you want to use the default options.
 func (t *ServiceClient) DeleteTable(ctx context.Context, name string, options *DeleteTableOptions) (DeleteTableResponse, error) {
 	if options == nil {
 		options = &DeleteTableOptions{}
@@ -276,7 +278,7 @@ func (p *tableQueryResponsePager) Err() error {
 // Top: The maximum number of tables that will be returned per page of results.
 // Note: This value does not limit the total number of results if NextPage is called on the returned Pager until it returns false.
 //
-// List returns a Pager, which allows iteration through each page of results.
+// List returns a Pager, which allows iteration through each page of results. Specify nil for listOptions if you want to use the default options.
 func (t *ServiceClient) ListTables(listOptions *ListTablesOptions) ListTablesPager {
 	return &tableQueryResponsePager{
 		client:            t.client,
@@ -305,7 +307,8 @@ func (g *GetStatisticsOptions) toGenerated() *generated.ServiceClientGetStatisti
 	return &generated.ServiceClientGetStatisticsOptions{}
 }
 
-// GetStatistics retrieves all the statistics for an account with Geo-redundancy established.
+// GetStatistics retrieves all the statistics for an account with Geo-redundancy established. If the service returns a non-successful
+// HTTP status code, the function returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *ServiceClient) GetStatistics(ctx context.Context, options *GetStatisticsOptions) (GetStatisticsResponse, error) {
 	if options == nil {
 		options = &GetStatisticsOptions{}
@@ -351,6 +354,8 @@ func getPropertiesResponseFromGenerated(g *generated.ServiceClientGetPropertiesR
 }
 
 // GetProperties retrieves the properties for an account including the metrics, logging, and cors rules established.
+// If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
+// Specify nil for options if you want to use the default options.
 func (t *ServiceClient) GetProperties(ctx context.Context, options *GetPropertiesOptions) (GetPropertiesResponse, error) {
 	if options == nil {
 		options = &GetPropertiesOptions{}
@@ -375,7 +380,7 @@ func setPropertiesResponseFromGenerated(g *generated.ServiceClientSetPropertiesR
 	}
 }
 
-// SetProperties allows the user to set cors , metrics, and logging rules for the account.
+// SetProperties allows the user to set cors, metrics, and logging rules for the account.
 //
 // Cors: A slice of CorsRules.
 //
@@ -383,7 +388,9 @@ func setPropertiesResponseFromGenerated(g *generated.ServiceClientSetPropertiesR
 //
 // HoursMetrics: A summary of request statistics grouped in minute aggregates for tables
 //
-// Logging: Azure Analytics logging settings
+// Logging: Azure Analytics logging settings. If the service returns a non-successful HTTP
+// status code, the function returns an *azcore.ResponseError type.
+// Specify nil for options if you want to use the default options.
 func (t *ServiceClient) SetProperties(ctx context.Context, properties ServiceProperties, options *SetPropertiesOptions) (SetPropertiesResponse, error) {
 	if options == nil {
 		options = &SetPropertiesOptions{}

--- a/sdk/data/aztables/service_client.go
+++ b/sdk/data/aztables/service_client.go
@@ -25,6 +25,7 @@ type ServiceClient struct {
 }
 
 // NewServiceClient creates a ServiceClient struct using the specified serviceURL, credential, and options.
+// Pass in nil for options to construct the client with the default ClientOptions.
 func NewServiceClient(serviceURL string, cred azcore.TokenCredential, options *ClientOptions) (*ServiceClient, error) {
 	conOptions := getConnectionOptions(serviceURL, options)
 	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, runtime.NewBearerTokenPolicy(cred, []string{"https://storage.azure.com/.default"}, nil))
@@ -38,6 +39,7 @@ func NewServiceClient(serviceURL string, cred azcore.TokenCredential, options *C
 
 // NewServiceClientWithNoCredential creates a ServiceClient struct using the specified serviceURL and options.
 // Call this method when serviceURL contains a SAS token.
+// Pass in nil for options to construct the client with the default ClientOptions.
 func NewServiceClientWithNoCredential(serviceURL string, options *ClientOptions) (*ServiceClient, error) {
 	conOptions := getConnectionOptions(serviceURL, options)
 	con := generated.NewConnection(serviceURL, conOptions)
@@ -49,6 +51,7 @@ func NewServiceClientWithNoCredential(serviceURL string, options *ClientOptions)
 }
 
 // NewServiceClientWithSharedKey creates a ServiceClient struct using the specified serviceURL, credential, and options.
+// Pass in nil for options to construct the client with the default ClientOptions.
 func NewServiceClientWithSharedKey(serviceURL string, cred *SharedKeyCredential, options *ClientOptions) (*ServiceClient, error) {
 	conOptions := getConnectionOptions(serviceURL, options)
 	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, newSharedKeyCredPolicy(cred))


### PR DESCRIPTION
Closes #17139 

* Adds a doc comment that non-successful HTTP responses return an error
* pass in nil for options to use default options.