### PR TITLE
Refine HTTP response captuing APIs

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -5,8 +5,7 @@
 ### Features Added
 * Added header `WWW-Authenticate` to the default allow-list of headers for logging.
 * Added a pipeline policy that enables the retrieval of HTTP responses from API calls.
-  * Added `runtime.IncludeResponse` to enable the policy at the API level (off by default).
-  * Added `runtime.ResponseFromContext` to retreive the HTTP response from the context when enabled.
+  * Added `runtime.WithCaptureResponse` to enable the policy at the API level (off by default).
 
 ### Breaking Changes
 * Moved `WithHTTPHeader` and `WithRetryOptions` from the `policy` package to the `runtime` package.

--- a/sdk/azcore/runtime/examples_test.go
+++ b/sdk/azcore/runtime/examples_test.go
@@ -1,0 +1,17 @@
+//go:build go1.16
+// +build go1.16
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+)
+
+func ExampleWithCaptureResponse() {
+	var respFromCtx *http.Response
+	WithCaptureResponse(context.Background(), &respFromCtx)
+}

--- a/sdk/azcore/runtime/policy_include_response.go
+++ b/sdk/azcore/runtime/policy_include_response.go
@@ -27,19 +27,13 @@ func includeResponsePolicy(req *policy.Request) (*http.Response, error) {
 	return resp, err
 }
 
-// IncludeResponse applies the HTTP response retrieval annotation to the parent context.
-// Call runtime.ResponseFromContext() to retrieve the HTTP response from the context.
-func IncludeResponse(parent context.Context) context.Context {
-	var rawResp *http.Response
-	return context.WithValue(parent, shared.CtxIncludeResponseKey{}, &rawResp)
-}
-
-// ResponseFromContext retrieves the raw HTTP response from the specified context.
-// Disabled by default.  Use policy.IncludeResponse() to enable on the calling context.
-func ResponseFromContext(ctx context.Context) *http.Response {
-	if httpOutRaw := ctx.Value(shared.CtxIncludeResponseKey{}); httpOutRaw != nil {
-		httpOut := httpOutRaw.(**http.Response)
-		return *httpOut
+// WithCaptureResponse applies the HTTP response retrieval annotation to the parent context.
+// Call the returned function to retrieve the HTTP response after the request has completed.
+// The created context is NOT safe to use across multiple goroutines.
+func WithCaptureResponse(parent context.Context) (context.Context, func() *http.Response) {
+	var resp *http.Response
+	return context.WithValue(parent, shared.CtxIncludeResponseKey{}, &resp), func() *http.Response {
+		cap := &resp
+		return *cap
 	}
-	return nil
 }

--- a/sdk/azcore/runtime/policy_include_response.go
+++ b/sdk/azcore/runtime/policy_include_response.go
@@ -28,12 +28,7 @@ func includeResponsePolicy(req *policy.Request) (*http.Response, error) {
 }
 
 // WithCaptureResponse applies the HTTP response retrieval annotation to the parent context.
-// Call the returned function to retrieve the HTTP response after the request has completed.
-// The created context is NOT safe to use across multiple goroutines.
-func WithCaptureResponse(parent context.Context) (context.Context, func() *http.Response) {
-	var resp *http.Response
-	return context.WithValue(parent, shared.CtxIncludeResponseKey{}, &resp), func() *http.Response {
-		cap := &resp
-		return *cap
-	}
+// The resp parameter will contain the HTTP response after the request has completed.
+func WithCaptureResponse(parent context.Context, resp **http.Response) context.Context {
+	return context.WithValue(parent, shared.CtxIncludeResponseKey{}, resp)
 }

--- a/sdk/azcore/runtime/policy_include_response_test.go
+++ b/sdk/azcore/runtime/policy_include_response_test.go
@@ -18,12 +18,13 @@ import (
 )
 
 func TestIncludeResponse(t *testing.T) {
-	ctx, respFn := WithCaptureResponse(context.Background())
+	var respFromCtx *http.Response
+	ctx := WithCaptureResponse(context.Background(), &respFromCtx)
 	require.NotNil(t, ctx)
 	raw := ctx.Value(shared.CtxIncludeResponseKey{})
 	_, ok := raw.(**http.Response)
 	require.Truef(t, ok, "unexpected type %T", raw)
-	require.Nil(t, respFn())
+	require.Nil(t, respFromCtx)
 }
 
 func TestIncludeResponsePolicy(t *testing.T) {
@@ -33,12 +34,12 @@ func TestIncludeResponsePolicy(t *testing.T) {
 	srv.SetResponse()
 	// include response policy is automatically added during pipeline construction
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	ctxWithResp, respFn := WithCaptureResponse(context.Background())
+	var respFromCtx *http.Response
+	ctxWithResp := WithCaptureResponse(context.Background(), &respFromCtx)
 	req, err := NewRequest(ctxWithResp, http.MethodGet, srv.URL())
 	require.NoError(t, err)
 	resp, err := pl.Do(req)
 	require.NoError(t, err)
-	rawResp := respFn()
-	require.NotNil(t, rawResp)
-	require.Equal(t, rawResp, resp)
+	require.NotNil(t, respFromCtx)
+	require.Equal(t, respFromCtx, resp)
 }

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -297,7 +297,8 @@ func TestRetryPolicySuccessWithRetryComplex(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
 	pl := pipeline.NewPipeline(srv, pipeline.PolicyFunc(includeResponsePolicy), NewRetryPolicy(testRetryOptions()))
-	ctxWithResp, respFn := WithCaptureResponse(context.Background())
+	var respFromCtx *http.Response
+	ctxWithResp := WithCaptureResponse(context.Background(), &respFromCtx)
 	req, err := NewRequest(ctxWithResp, http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -310,7 +311,6 @@ func TestRetryPolicySuccessWithRetryComplex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	respFromCtx := respFn()
 	if respFromCtx != resp {
 		t.Fatal("response from context doesn't match returned response")
 	}

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -297,7 +297,7 @@ func TestRetryPolicySuccessWithRetryComplex(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
 	pl := pipeline.NewPipeline(srv, pipeline.PolicyFunc(includeResponsePolicy), NewRetryPolicy(testRetryOptions()))
-	ctxWithResp := IncludeResponse(context.Background())
+	ctxWithResp, respFn := WithCaptureResponse(context.Background())
 	req, err := NewRequest(ctxWithResp, http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -310,7 +310,7 @@ func TestRetryPolicySuccessWithRetryComplex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	respFromCtx := ResponseFromContext(ctxWithResp)
+	respFromCtx := respFn()
 	if respFromCtx != resp {
 		t.Fatal("response from context doesn't match returned response")
 	}

--- a/sdk/azcore/runtime/poller_test.go
+++ b/sdk/azcore/runtime/poller_test.go
@@ -92,7 +92,7 @@ func TestLocPollerSimple(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	ctxWithResp := IncludeResponse(context.Background())
+	ctxWithResp, respFn := WithCaptureResponse(context.Background())
 	resp, err := lro.PollUntilDone(ctxWithResp, time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func TestLocPollerSimple(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code %d", resp.StatusCode)
 	}
-	respFromCtx := ResponseFromContext(ctxWithResp)
+	respFromCtx := respFn()
 	if respFromCtx != resp {
 		t.Fatal("response from context doesn't match returned response")
 	}

--- a/sdk/azcore/runtime/poller_test.go
+++ b/sdk/azcore/runtime/poller_test.go
@@ -92,7 +92,8 @@ func TestLocPollerSimple(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	ctxWithResp, respFn := WithCaptureResponse(context.Background())
+	var respFromCtx *http.Response
+	ctxWithResp := WithCaptureResponse(context.Background(), &respFromCtx)
 	resp, err := lro.PollUntilDone(ctxWithResp, time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +101,6 @@ func TestLocPollerSimple(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code %d", resp.StatusCode)
 	}
-	respFromCtx := respFn()
 	if respFromCtx != resp {
 		t.Fatal("response from context doesn't match returned response")
 	}


### PR DESCRIPTION
Renamed IncludeResponse to WithCaptureResponse and changed its return
values to return a func used to retrieve the response.  This clarifies
the contract of the API and how to use it.
Removed ResponseFromContext as it's no longer required.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
