### PR TITLE
Prevent ChainedTokenCredential data race

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 * Prevented a data race in `DefaultAzureCredential` and `ChainedTokenCredential`
+  ([#17144](https://github.com/Azure/azure-sdk-for-go/issues/17144))
 
 ### Other Changes
 * Upgraded App Service managed identity version from 2017-09-01 to 2019-08-01

--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Release History
 
-## 0.13.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.13.2 (2022-03-08)
 
 ### Bugs Fixed
 * Prevented a data race in `DefaultAzureCredential` and `ChainedTokenCredential`
@@ -12,6 +8,7 @@
 
 ### Other Changes
 * Upgraded App Service managed identity version from 2017-09-01 to 2019-08-01
+  ([#17086](https://github.com/Azure/azure-sdk-for-go/pull/17086))
 
 ## 0.13.1 (2022-02-08)
 

--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Prevented a data race in `DefaultAzureCredential` and `ChainedTokenCredential`
 
 ### Other Changes
 * Upgraded App Service managed identity version from 2017-09-01 to 2019-08-01

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -75,6 +75,8 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.Token
 			}
 			if !c.iterating {
 				c.iterating = true
+				// allow other goroutines to wait while this one iterates
+				c.cond.L.Unlock()
 				break
 			}
 			c.cond.Wait()
@@ -99,6 +101,7 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.Token
 		}
 	}
 	if c.iterating {
+		c.cond.L.Lock()
 		c.iterating = false
 		c.cond.L.Unlock()
 		c.cond.Broadcast()

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -91,7 +91,9 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.Token
 		if err == nil {
 			log.Writef(EventAuthentication, "%s authenticated with %s", c.name, extractCredentialName(cred))
 			if c.iterating {
+				c.cond.L.Lock()
 				c.successfulCredential = cred
+				c.cond.L.Unlock()
 			}
 			break
 		}

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -28,12 +28,12 @@ type ChainedTokenCredentialOptions struct {
 // By default, this credential will assume that the first successful credential should be the only credential used on future requests.
 // If the `RetrySources` option is set to true, it will always try to get a token using all of the originally provided credentials.
 type ChainedTokenCredential struct {
-	sources              []azcore.TokenCredential
-	successfulCredential azcore.TokenCredential
-	retrySources         bool
-	name                 string
 	cond                 *sync.Cond
 	iterating            bool
+	name                 string
+	retrySources         bool
+	sources              []azcore.TokenCredential
+	successfulCredential azcore.TokenCredential
 }
 
 // NewChainedTokenCredential creates a ChainedTokenCredential.
@@ -55,9 +55,9 @@ func NewChainedTokenCredential(sources []azcore.TokenCredential, options *Chaine
 	}
 	return &ChainedTokenCredential{
 		cond:         sync.NewCond(&sync.Mutex{}),
-		sources:      cp,
 		name:         "ChainedTokenCredential",
 		retrySources: options.RetrySources,
+		sources:      cp,
 	}, nil
 }
 

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -292,9 +292,9 @@ func TestChainedTokenCredential_Race(t *testing.T) {
 			)
 			for i := 0; i < 5; i++ {
 				go func() {
-					success.GetToken(context.Background(), tro)
-					failure.GetToken(context.Background(), tro)
-					unavailable.GetToken(context.Background(), tro)
+					_, _ = success.GetToken(context.Background(), tro)
+					_, _ = failure.GetToken(context.Background(), tro)
+					_, _ = unavailable.GetToken(context.Background(), tro)
 				}()
 			}
 		})

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -14,22 +14,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
 
-func initEnvironmentVarsForTest() error {
-	err := os.Setenv("AZURE_TENANT_ID", fakeTenantID)
-	if err != nil {
-		return err
-	}
-	err = os.Setenv("AZURE_CLIENT_ID", fakeClientID)
-	if err != nil {
-		return err
-	}
-	err = os.Setenv("AZURE_CLIENT_SECRET", secret)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func resetEnvironmentVarsForTest() {
 	clearEnvVars("AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_CLIENT_CERTIFICATE_PATH", "AZURE_USERNAME", "AZURE_PASSWORD")
 }


### PR DESCRIPTION
Fixes #17144 by adding synchronization around `ChainedTokenCredential.successfulCredential`. The field is assigned at most once, so I used a read lock to minimize performance impact on subsequent calls.