### PR TITLE
[azservicebus] Recategorize recovery for errors

### DIFF
--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -91,17 +91,18 @@ var amqpConditionsToRecoveryKind = map[amqp.ErrorCondition]recoveryKind{
 	amqp.ErrorCondition("com.microsoft:operation-cancelled"): RecoveryKindNone,
 
 	// Link recovery needed
-	amqp.ErrorDetachForced: RecoveryKindLink, // "amqp:link:detach-forced"
+	amqp.ErrorDetachForced:          RecoveryKindLink, // "amqp:link:detach-forced"
+	amqp.ErrorTransferLimitExceeded: RecoveryKindLink,
 
 	// Connection recovery needed
 	amqp.ErrorConnectionForced: RecoveryKindConn, // "amqp:connection:forced"
+	amqp.ErrorInternalError:    RecoveryKindConn, // "amqp:internal-error"
 
 	// No recovery possible - this operation is non retriable.
 	amqp.ErrorMessageSizeExceeded:                                 RecoveryKindFatal,
 	amqp.ErrorUnauthorizedAccess:                                  RecoveryKindFatal, // creds are bad
 	amqp.ErrorNotFound:                                            RecoveryKindFatal,
 	amqp.ErrorNotAllowed:                                          RecoveryKindFatal,
-	amqp.ErrorInternalError:                                       RecoveryKindFatal, // "amqp:internal-error"
 	amqp.ErrorCondition("com.microsoft:entity-disabled"):          RecoveryKindFatal, // entity is disabled in the portal
 	amqp.ErrorCondition("com.microsoft:session-cannot-be-locked"): RecoveryKindFatal,
 	amqp.ErrorCondition("com.microsoft:message-lock-lost"):        RecoveryKindFatal,
@@ -121,7 +122,7 @@ func GetRecoveryKind(err error) recoveryKind {
 		return RecoveryKindConn
 	}
 
-	var errNonRetriable *ErrNonRetriable
+	var errNonRetriable ErrNonRetriable
 
 	if errors.As(err, &errNonRetriable) {
 		return RecoveryKindFatal
@@ -130,13 +131,14 @@ func GetRecoveryKind(err error) recoveryKind {
 	var de *amqp.DetachError
 
 	// check the "special" AMQP errors that aren't condition-based.
-	if errors.Is(err, amqp.ErrSessionClosed) ||
-		errors.Is(err, amqp.ErrLinkClosed) ||
+	if errors.Is(err, amqp.ErrLinkClosed) ||
 		errors.As(err, &de) {
 		return RecoveryKindLink
 	}
 
-	if errors.Is(err, amqp.ErrConnClosed) {
+	if errors.Is(err, amqp.ErrConnClosed) ||
+		// session closures appear to leak through when the connection itself is going down.
+		errors.Is(err, amqp.ErrSessionClosed) {
 		return RecoveryKindConn
 	}
 
@@ -183,8 +185,8 @@ func GetRecoveryKind(err error) recoveryKind {
 		}
 	}
 
-	// this is some error type we've never seen.
-	return RecoveryKindFatal
+	// this is some error type we've never seen - recover the entire connection.
+	return RecoveryKindConn
 }
 
 type (

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -92,17 +92,17 @@ var amqpConditionsToRecoveryKind = map[amqp.ErrorCondition]recoveryKind{
 
 	// Link recovery needed
 	amqp.ErrorDetachForced:          RecoveryKindLink, // "amqp:link:detach-forced"
-	amqp.ErrorTransferLimitExceeded: RecoveryKindLink,
+	amqp.ErrorTransferLimitExceeded: RecoveryKindLink, // "amqp:link:transfer-limit-exceeded"
 
 	// Connection recovery needed
 	amqp.ErrorConnectionForced: RecoveryKindConn, // "amqp:connection:forced"
 	amqp.ErrorInternalError:    RecoveryKindConn, // "amqp:internal-error"
 
 	// No recovery possible - this operation is non retriable.
-	amqp.ErrorMessageSizeExceeded:                                 RecoveryKindFatal,
+	amqp.ErrorMessageSizeExceeded:                                 RecoveryKindFatal, // "amqp:link:message-size-exceeded"
 	amqp.ErrorUnauthorizedAccess:                                  RecoveryKindFatal, // creds are bad
-	amqp.ErrorNotFound:                                            RecoveryKindFatal,
-	amqp.ErrorNotAllowed:                                          RecoveryKindFatal,
+	amqp.ErrorNotFound:                                            RecoveryKindFatal, // "amqp:not-found"
+	amqp.ErrorNotAllowed:                                          RecoveryKindFatal, // "amqp:not-allowed"
 	amqp.ErrorCondition("com.microsoft:entity-disabled"):          RecoveryKindFatal, // entity is disabled in the portal
 	amqp.ErrorCondition("com.microsoft:session-cannot-be-locked"): RecoveryKindFatal,
 	amqp.ErrorCondition("com.microsoft:message-lock-lost"):        RecoveryKindFatal,

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -90,18 +90,19 @@ func Test_recoveryKind(t *testing.T) {
 			})
 		}
 
-		t.Run("sentintel errors", func(t *testing.T) {
+		t.Run("sentinel errors", func(t *testing.T) {
 			sbe := GetSBErrInfo(amqp.ErrLinkClosed)
 			require.EqualValues(t, RecoveryKindLink, sbe.RecoveryKind)
 
 			sbe = GetSBErrInfo(amqp.ErrSessionClosed)
-			require.EqualValues(t, RecoveryKindLink, sbe.RecoveryKind)
+			require.EqualValues(t, RecoveryKindConn, sbe.RecoveryKind)
 		})
 	})
 
 	t.Run("connection", func(t *testing.T) {
 		codes := []string{
 			string(amqp.ErrorConnectionForced),
+			string(amqp.ErrorInternalError),
 		}
 
 		for _, code := range codes {
@@ -119,8 +120,6 @@ func Test_recoveryKind(t *testing.T) {
 
 	t.Run("nonretriable", func(t *testing.T) {
 		codes := []string{
-			string(amqp.ErrorTransferLimitExceeded),
-			string(amqp.ErrorInternalError),
 			string(amqp.ErrorUnauthorizedAccess),
 			string(amqp.ErrorNotFound),
 			string(amqp.ErrorMessageSizeExceeded),
@@ -170,6 +169,7 @@ func Test_ServiceBusError_NoRecoveryNeeded(t *testing.T) {
 		&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:server-busy")},
 		&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:timeout")},
 		&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:operation-cancelled")},
+		&amqp.Error{Condition: amqp.ErrorTransferLimitExceeded},
 		errors.New("link is currently draining"), // not yet exposed from go-amqp
 		// simple timeouts from the mgmt link
 		mgmtError{Resp: &RPCResponse{Code: 408}},
@@ -186,7 +186,9 @@ func Test_ServiceBusError_NoRecoveryNeeded(t *testing.T) {
 func Test_ServiceBusError_ConnectionRecoveryNeeded(t *testing.T) {
 	var connErrors = []error{
 		&amqp.Error{Condition: amqp.ErrorConnectionForced},
+		&amqp.Error{Condition: amqp.ErrorInternalError},
 		amqp.ErrConnClosed,
+		amqp.ErrSessionClosed,
 		io.EOF,
 		fakeNetError{temp: true},
 		fakeNetError{timeout: true},
@@ -197,11 +199,14 @@ func Test_ServiceBusError_ConnectionRecoveryNeeded(t *testing.T) {
 		rk := GetSBErrInfo(err).RecoveryKind
 		require.EqualValues(t, RecoveryKindConn, rk, fmt.Sprintf("[%d] %v", i, err))
 	}
+
+	// unknown errors will just result in a connection recovery
+	rk := GetSBErrInfo(errors.New("Some unknown error")).RecoveryKind
+	require.EqualValues(t, RecoveryKindConn, rk, "some unknown error")
 }
 
 func Test_ServiceBusError_LinkRecoveryNeeded(t *testing.T) {
 	var linkErrors = []error{
-		amqp.ErrSessionClosed,
 		amqp.ErrLinkClosed,
 		&amqp.DetachError{},
 		&amqp.Error{Condition: amqp.ErrorDetachForced},
@@ -224,7 +229,6 @@ func Test_ServiceBusError_Fatal(t *testing.T) {
 		amqp.ErrorUnauthorizedAccess,
 		amqp.ErrorNotFound,
 		amqp.ErrorNotAllowed,
-		amqp.ErrorInternalError,
 		amqp.ErrorCondition("com.microsoft:entity-disabled"),
 		amqp.ErrorCondition("com.microsoft:session-cannot-be-locked"),
 		amqp.ErrorCondition("com.microsoft:message-lock-lost"),
@@ -234,8 +238,4 @@ func Test_ServiceBusError_Fatal(t *testing.T) {
 		rk := GetSBErrInfo(&amqp.Error{Condition: cond}).RecoveryKind
 		require.EqualValues(t, RecoveryKindFatal, rk, fmt.Sprintf("[%d] %s", i, cond))
 	}
-
-	// unknown errors are also considered fatal
-	rk := GetSBErrInfo(errors.New("Some unknown error")).RecoveryKind
-	require.EqualValues(t, RecoveryKindFatal, rk, "some unknown error")
 }

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -169,7 +169,6 @@ func Test_ServiceBusError_NoRecoveryNeeded(t *testing.T) {
 		&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:server-busy")},
 		&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:timeout")},
 		&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:operation-cancelled")},
-		&amqp.Error{Condition: amqp.ErrorTransferLimitExceeded},
 		errors.New("link is currently draining"), // not yet exposed from go-amqp
 		// simple timeouts from the mgmt link
 		mgmtError{Resp: &RPCResponse{Code: 408}},
@@ -210,6 +209,7 @@ func Test_ServiceBusError_LinkRecoveryNeeded(t *testing.T) {
 		amqp.ErrLinkClosed,
 		&amqp.DetachError{},
 		&amqp.Error{Condition: amqp.ErrorDetachForced},
+		&amqp.Error{Condition: amqp.ErrorTransferLimitExceeded},
 		// we lost the session lock, attempt link recovery
 		mgmtError{Resp: &RPCResponse{Code: 410}},
 		// this can happen when we're recovering the link - the client gets closed and the old link is still being


### PR DESCRIPTION
Recategorize recovery for errors:
- amqp.ErrorInternalError and amqp.ErrSessionClosed are now categorized as connection level recovery.
- ErrorTransferLimitExceeded is a link recovery event. From what I can see it signals a mismatch between wanting to send and not having credit available. A link reset should cause a reset on both sides.
- Default to connection recovery except for specific fatal errors.