### PR TITLE
[Performance] fixing ops/s prints, small cleanup

### DIFF
--- a/sdk/internal/perf/perf.go
+++ b/sdk/internal/perf/perf.go
@@ -12,6 +12,25 @@ import (
 	"runtime"
 )
 
+func init() {
+	// Start with adding all of our arguments
+	flag.IntVar(&duration, "d", 10, "Duration of test in seconds.")
+	flag.IntVar(&duration, "duration", 10, "Duration of test in seconds.")
+
+	flag.StringVar(&testProxyURLs, "test-proxies", "", "test proxy URLs to target. This can be a semi-colon separated list for multiple proxies.")
+	flag.StringVar(&testProxyURLs, "x", "", "test proxy URLs to target. This can be a semi-colon separated list for multiple proxies.")
+
+	flag.IntVar(&warmUpDuration, "warmup", 5, "Duration of warmup in seconds.")
+	flag.IntVar(&warmUpDuration, "w", 5, "Duration of warmup in seconds.")
+
+	flag.IntVar(&parallelInstances, "parallel", 1, "Degree of parallelism to run with.")
+	flag.IntVar(&parallelInstances, "p", 1, "Degree of parallelism to run with.")
+
+	flag.IntVar(&numProcesses, "maxprocs", runtime.NumCPU(), "Number of CPUs to use.")
+
+	flag.BoolVar(&debug, "debug", false, "Print debugging information")
+}
+
 // GlobalPerfTest methods execute once per process
 type GlobalPerfTest interface {
 	// NewPerfTest creates an instance of a PerfTest for each goroutine.
@@ -59,29 +78,6 @@ type PerfMethods struct {
 
 // Run runs an individual test, registers, and parses command line flags
 func Run(tests map[string]PerfMethods) {
-	// Start with adding all of our arguments
-	flag.IntVar(&duration, "d", 10, "Duration of test in seconds.")
-	flag.IntVar(&duration, "duration", 10, "Duration of test in seconds.")
-
-	flag.StringVar(&testProxyURLs, "test-proxies", "", "test proxy URLs to target. This can be a semi-colon separated list for multiple proxies.")
-	flag.StringVar(&testProxyURLs, "x", "", "test proxy URLs to target. This can be a semi-colon separated list for multiple proxies.")
-
-	flag.IntVar(&warmUpDuration, "warmup", 5, "Duration of warmup in seconds.")
-	flag.IntVar(&warmUpDuration, "w", 5, "Duration of warmup in seconds.")
-
-	flag.IntVar(&parallelInstances, "parallel", 1, "Degree of parallelism to run with.")
-	flag.IntVar(&parallelInstances, "p", 1, "Degree of parallelism to run with.")
-
-	flag.IntVar(&numProcesses, "maxprocs", runtime.NumCPU(), "Number of CPUs to use.")
-
-	flag.BoolVar(&debug, "debug", false, "Print debugging information")
-
-	if numProcesses > 0 {
-		val := runtime.GOMAXPROCS(numProcesses)
-		if debug {
-			fmt.Printf("Changed GOMAXPROCS from %d to %d\n", val, numProcesses)
-		}
-	}
 
 	if len(os.Args) < 2 {
 		// Error out and show available perf tests
@@ -113,12 +109,14 @@ func Run(tests map[string]PerfMethods) {
 	// We strip off the first argument because that is used in determining the test
 	os.Args = os.Args[1:]
 
-	fmt.Println(flag.Args(), os.Args[1:])
-	fmt.Println("Parsing: ", os.Args[1:])
 	flag.Parse()
-	fmt.Printf("Duration: %d\n", duration)
-	fmt.Printf("d: %d\n", duration)
-	fmt.Println("tail:", flag.Args())
+
+	if numProcesses > 0 {
+		val := runtime.GOMAXPROCS(numProcesses)
+		if debug {
+			fmt.Printf("Changed GOMAXPROCS from %d to %d\n", val, numProcesses)
+		}
+	}
 
 	fmt.Printf("\tRunning %s\n", testNameToRun)
 

--- a/sdk/internal/perf/perf.go
+++ b/sdk/internal/perf/perf.go
@@ -13,7 +13,6 @@ import (
 )
 
 func init() {
-	// Start with adding all of our arguments
 	flag.IntVar(&duration, "d", 10, "Duration of test in seconds.")
 	flag.IntVar(&duration, "duration", 10, "Duration of test in seconds.")
 

--- a/sdk/internal/perf/status.go
+++ b/sdk/internal/perf/status.go
@@ -164,10 +164,10 @@ func printFinalResults(elapsedTimes [][]float64, perSecondCount [][]int, warmup 
 	secondsPerOp := 1.0 / opsPerSecond
 	weightedAvgSec := float64(totalOperations) / opsPerSecond
 	fmt.Printf(
-		"Completed %s operations in a weighted-average of %.2fs (%s ops/s, %.3f s/op)\n",
+		"Completed %s operations in a weighted-average of %ss (%s ops/s, %s s/op)\n",
 		messagePrinter.Sprintf("%d", totalOperations),
-		weightedAvgSec,
-		messagePrinter.Sprintf("%d", int(opsPerSecond)),
-		secondsPerOp,
+		messagePrinter.Sprintf("%.2f", weightedAvgSec),
+		messagePrinter.Sprintf("%.2f", opsPerSecond),
+		messagePrinter.Sprintf("%.3f", secondsPerOp),
 	)
 }


### PR DESCRIPTION
Closes #17176 

* ops/s is printed as a float with 2 decimal points of precision
* Removed print statements from previous PR
* Put argsument parsing in an `init` function.
* moves the `runtime.GOMAXPROCS` function to after calling `flag.Parse`