### PR TITLE
Remove view= syntax from link

### DIFF
--- a/documentation/previous-versions-quickstart.md
+++ b/documentation/previous-versions-quickstart.md
@@ -165,7 +165,7 @@ below.
 
 > Note: If you need to create a new service principal, run `az ad sp create-for-rbac -n "<app_name>" --role Contributor` in the
 > [azure-cli](https://github.com/Azure/azure-cli). See [these
-> docs](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest)
+> docs](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli)
 > for more info. Copy the new principal's ID, secret, and tenant ID for use in
 > your app, or consider the `--sdk-auth` parameter for serialized output.
 


### PR DESCRIPTION
Removing `view=` syntax from link per User Story: https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1907185

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
