### PR TITLE
[azservicebus] Quicker reattach of mostly-idle links

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Release History
 
-## 0.3.6 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.3.6 (2022-03-08)
 
 ### Bugs Fixed
 
-- Fix connection recovery in situations where network errors bubble up from go-amqp (#17048)
+- Fix connection recovery in situations where network errors bubble up from go-amqp. (#17048)
+- Quicker reattach for idle links. (#17205)
+- Quick exit on receiver reconnects to avoid potentially returning duplicate messages. (#17157)
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -324,7 +324,7 @@ func (l *AMQPLinksImpl) Retry(ctx context.Context, name string, fn RetryWithLink
 				// Whereas normally you'd do (for non-detach errors):
 				//   0th attempt
 				//   (actual retries)
-				log.Writef(EventConn, "Link was previously detached. attempting quick reconnect to recover from error: %s", err.Error())
+				log.Writef(EventConn, "Link was previously detached. Attempting quick reconnect to recover from error: %s", err.Error())
 				didQuickRetry = true
 				args.ResetAttempts()
 			}

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -324,6 +324,7 @@ func (l *AMQPLinksImpl) Retry(ctx context.Context, name string, fn RetryWithLink
 				// Whereas normally you'd do (for non-detach errors):
 				//   0th attempt
 				//   (actual retries)
+				log.Writef(EventConn, "Link was previously detached (err: %s), attempting quick reconnect", err.Error())
 				didQuickRetry = true
 				args.ResetAttempts()
 			}

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -289,6 +289,8 @@ func (l *AMQPLinksImpl) Get(ctx context.Context) (*LinksWithID, error) {
 func (l *AMQPLinksImpl) Retry(ctx context.Context, name string, fn RetryWithLinksFn, o utils.RetryOptions) error {
 	var lastID LinkID
 
+	didQuickRetry := false
+
 	return utils.Retry(ctx, name, func(ctx context.Context, args *utils.RetryFnArgs) error {
 		if err := l.RecoverIfNeeded(ctx, lastID, args.LastErr); err != nil {
 			return err
@@ -301,7 +303,35 @@ func (l *AMQPLinksImpl) Retry(ctx context.Context, name string, fn RetryWithLink
 		}
 
 		lastID = linksWithVersion.ID
-		return fn(ctx, linksWithVersion, args)
+
+		if err := fn(ctx, linksWithVersion, args); err != nil {
+			if args.I == 0 && !didQuickRetry && IsDetachError(err) {
+				// go-amqp will asynchronously handle detaches. This means errors that you get
+				// back from Send(), for instance, can actually be from much earlier in time
+				// depending on the last time you called into Send().
+				//
+				// This means we'll sometimes do an unneeded sleep after a failed retry when
+				// it would have just immediately worked. To counteract that we'll do a one-time
+				// quick attempt to recreate link immediately if we see a detach error. This might
+				// waste a bit of time attempting to do the creation, but since it's just link creation
+				// it should be fairly fast.
+				//
+				// So when we've received a detach is:
+				//   0th attempt
+				//   extra immediate 0th attempt (if last error was detach)
+				//   (actual retries)
+				//
+				// Whereas normally you'd do (for non-detach errors):
+				//   0th attempt
+				//   (actual retries)
+				didQuickRetry = true
+				args.ResetAttempts()
+			}
+
+			return err
+		}
+
+		return nil
 	}, IsFatalSBError, o)
 }
 

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -324,7 +324,7 @@ func (l *AMQPLinksImpl) Retry(ctx context.Context, name string, fn RetryWithLink
 				// Whereas normally you'd do (for non-detach errors):
 				//   0th attempt
 				//   (actual retries)
-				log.Writef(EventConn, "Link was previously detached (err: %s), attempting quick reconnect", err.Error())
+				log.Writef(EventConn, "Link was previously detached. attempting quick reconnect to recover from error: %s", err.Error())
 				didQuickRetry = true
 				args.ResetAttempts()
 			}

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -506,7 +506,7 @@ func TestAMQPLinksRetriesUnit(t *testing.T) {
 			require.Equal(t, testData.Attempts, attempts)
 
 			if testData.ExpectReset {
-				require.Contains(t, logMessages, fmt.Sprintf("[azsb.Conn] Link was previously detached (err: %s), attempting quick reconnect", err.Error()))
+				require.Contains(t, logMessages, fmt.Sprintf("[azsb.Conn] Link was previously detached. attempting quick reconnect to recover from error: %s", err.Error()))
 			} else {
 				for _, msg := range logMessages {
 					require.NotContains(t, msg, "Link was previously detached")

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -506,7 +506,7 @@ func TestAMQPLinksRetriesUnit(t *testing.T) {
 			require.Equal(t, testData.Attempts, attempts)
 
 			if testData.ExpectReset {
-				require.Contains(t, logMessages, fmt.Sprintf("[azsb.Conn] Link was previously detached. attempting quick reconnect to recover from error: %s", err.Error()))
+				require.Contains(t, logMessages, fmt.Sprintf("[azsb.Conn] Link was previously detached. Attempting quick reconnect to recover from error: %s", err.Error()))
 			} else {
 				for _, msg := range logMessages {
 					require.NotContains(t, msg, "Link was previously detached")

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -67,6 +67,11 @@ func GetSBErrInfo(err error) *SBErrInfo {
 	return sbe
 }
 
+func IsDetachError(err error) bool {
+	var de *amqp.DetachError
+	return errors.As(err, &de)
+}
+
 func IsCancelError(err error) bool {
 	if err == nil {
 		return false
@@ -136,11 +141,9 @@ func GetRecoveryKind(err error) recoveryKind {
 		return RecoveryKindFatal
 	}
 
-	var de *amqp.DetachError
-
 	// check the "special" AMQP errors that aren't condition-based.
 	if errors.Is(err, amqp.ErrLinkClosed) ||
-		errors.As(err, &de) {
+		IsDetachError(err) {
 		return RecoveryKindLink
 	}
 

--- a/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package tests
 
 import (

--- a/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
@@ -1,0 +1,80 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/stress/shared"
+	"github.com/microsoft/ApplicationInsights-Go/appinsights"
+)
+
+func IdleFastReconnect(remainingArgs []string) {
+	sc := shared.MustCreateStressContext("IdleFastReconnect")
+
+	topicName := fmt.Sprintf("topic-%s", sc.Nano)
+
+	startEvent := appinsights.NewEventTelemetry("Start")
+	startEvent.Properties["Topic"] = topicName
+	sc.Track(startEvent)
+
+	defer sc.End()
+
+	ac, err := admin.NewClientFromConnectionString(sc.ConnectionString, nil)
+	sc.PanicOnError("Failed to create a topic manager", err)
+
+	_, err = ac.CreateTopic(context.Background(), topicName, nil, nil)
+	sc.PanicOnError("Failed to create topic", err)
+
+	defer func() { _, _ = ac.DeleteTopic(context.Background(), topicName, nil) }()
+
+	client, err := azservicebus.NewClientFromConnectionString(sc.ConnectionString, &azservicebus.ClientOptions{
+		RetryOptions: azservicebus.RetryOptions{
+			// NOTE: we'll _never_ use this timeout - the idle detach below
+			// should use the "quick" reconnect.
+			RetryDelay: time.Hour,
+		},
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	sender, err := client.NewSender(topicName, nil)
+
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("Sending first message to make sure connection is open")
+
+	err = sender.SendMessage(context.Background(), &azservicebus.Message{
+		Body: []byte("hello"),
+	})
+
+	if err != nil {
+		log.Printf("%#v", err)
+		panic(err)
+	}
+
+	// let the link idle out
+	log.Printf("Sleeping for 11 minutes to trigger the idle link detaching")
+	time.Sleep(11 * time.Minute)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = sender.SendMessage(ctx, &azservicebus.Message{
+		Body: []byte("hello"),
+	})
+
+	if err != nil {
+		log.Printf("%#v", err)
+		panic(err)
+	}
+
+	log.Printf("Quicker reconnect worked")
+}

--- a/sdk/messaging/azservicebus/internal/stress/tests/tests.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/tests.go
@@ -40,6 +40,7 @@ func Run(remainingArgs []string) {
 		"longRunningRenewLock":     LongRunningRenewLockTest,
 		"rapidOpenClose":           RapidOpenCloseTest,
 		"receiveCancellation":      ReceiveCancellation,
+		"idleFastReconnect":        IdleFastReconnect,
 	}
 
 	if len(remainingArgs) == 0 {
@@ -70,6 +71,6 @@ func printUsageAndQuit(allTests map[string]func(args []string)) {
 
 	sort.Strings(names)
 
-	fmt.Printf("Usage: stress test (%s)", strings.Join(names, " or "))
+	fmt.Printf("Usage: stress test <stress test name, listed below> \n  %s\n", strings.Join(names, "\n  "))
 	os.Exit(1)
 }

--- a/sdk/messaging/azservicebus/internal/stress/values.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/values.yaml
@@ -10,3 +10,5 @@ scenarios:
 - "longRunningRenewLock"
 - "rapidOpenClose"
 - "receiveCancellation"
+- "idleFastReconnect"
+

--- a/sdk/messaging/azservicebus/internal/utils/retrier.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier.go
@@ -16,6 +16,9 @@ import (
 const EventRetry = "azsb.Retry"
 
 type RetryFnArgs struct {
+	// I is the iteration of the retry "loop" and starts at 0.
+	// The 0th iteration is the first call, and doesn't count as a retry.
+	// The last try will equal RetryOptions.MaxRetries
 	I int32
 	// LastErr is the returned error from the previous loop.
 	// If you have potentially expensive
@@ -24,11 +27,8 @@ type RetryFnArgs struct {
 	resetAttempts bool
 }
 
-// ResetAttempts causes the current retry attempt number to be reset
-// in time for the next recovery (should we fail).
-// NOTE: Use of this should be pretty rare, it's really only needed when you have
-// a situation like Receiver.ReceiveMessages() that can recovery but intentionally
-// does not return.
+// ResetAttempts resets all Retry() attempts, starting back
+// at iteration 0.
 func (rf *RetryFnArgs) ResetAttempts() {
 	rf.resetAttempts = true
 }
@@ -60,7 +60,7 @@ func Retry(ctx context.Context, name string, fn func(ctx context.Context, args *
 
 		if args.resetAttempts {
 			log.Writef(EventRetry, "(%s) Resetting attempts", name)
-			i = int32(0)
+			i = int32(-1)
 		}
 
 		if err != nil {

--- a/sdk/messaging/azservicebus/internal/utils/retrier.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier.go
@@ -60,6 +60,12 @@ func Retry(ctx context.Context, name string, fn func(ctx context.Context, args *
 
 		if args.resetAttempts {
 			log.Writef(EventRetry, "(%s) Resetting attempts", name)
+
+			// it looks weird, but we're doing -1 here because the post-increment
+			// will set it back to 0, which is what we want - go back to the 0th
+			// iteration so we don't sleep before the attempt.
+			//
+			// You'll use this when you want to get another "fast" retry attempt.
 			i = int32(-1)
 		}
 

--- a/sdk/messaging/azservicebus/internal/utils/retrier_test.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier_test.go
@@ -114,23 +114,25 @@ func TestRetrier(t *testing.T) {
 
 		var actualAttempts []int32
 
+		maxRetries := int32(2)
+
 		err := Retry(context.Background(), "ResetAttempts", func(ctx context.Context, args *RetryFnArgs) error {
 			actualAttempts = append(actualAttempts, args.I)
 
-			if len(actualAttempts) == 3 {
+			if len(actualAttempts) == int(maxRetries+1) {
 				args.ResetAttempts()
 			}
 
 			return errors.New("whatever")
 		}, isFatalFn, RetryOptions{
-			MaxRetries:    2,
+			MaxRetries:    maxRetries,
 			RetryDelay:    time.Millisecond,
 			MaxRetryDelay: time.Millisecond,
 		})
 
 		expectedAttempts := []int32{
 			0, 1, 2, // we resetted attempts here.
-			1, 2, // and we start at the first retry attempt again.
+			0, 1, 2, // and we start at the first retry attempt again.
 		}
 
 		require.EqualValues(t, "whatever", err.Error())


### PR DESCRIPTION
Fixing the 'stale' sender by adding in some special double-iteration-0 logic in the 
amqpLinks.Retry().
    
This changes the semantics of how ResetAttempts() works but it wasn't used anywhere 
anymore and it makes more sense this way anyways.

Fixes #17182