### PR TITLE
[azservicebus] Return nil in adminClient functions for non-existent entities

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Breaking Changes
 
-- The following 'Get' APIs have been changed to return a nil result when an item is not found: (#TBD)
+- The following 'Get' APIs have been changed to return a nil result when an item is not found: (#17229)
   - GetQueue, GetQueueRuntimeProperties
   - GetTopic, GetTopicRuntimeProperties
   - GetSubscription, GetSubscriptionRuntimeProperties

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -8,6 +8,13 @@
 - Quicker reattach for idle links. (#17205)
 - Quick exit on receiver reconnects to avoid potentially returning duplicate messages. (#17157)
 
+### Breaking Changes
+
+- The following 'Get' APIs have been changed to return a nil result when an item is not found: (#TBD)
+  - GetQueue, GetQueueRuntimeProperties
+  - GetTopic, GetTopicRuntimeProperties
+  - GetSubscription, GetSubscriptionRuntimeProperties
+
 ### Other Changes
 
 ## 0.3.5 (2022-02-10)

--- a/sdk/messaging/azservicebus/admin/admin_client_queue.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_queue.go
@@ -185,11 +185,16 @@ type GetQueueOptions struct {
 }
 
 // GetQueue gets a queue by name.
+// If the entity does not exist this function will return a nil GetQueueResponse and a nil error.
 func (ac *Client) GetQueue(ctx context.Context, queueName string, options *GetQueueOptions) (*GetQueueResponse, error) {
 	var atomResp *atom.QueueEnvelope
 	resp, err := ac.em.Get(ctx, "/"+queueName, &atomResp)
 
 	if err != nil {
+		if atom.IsFeedEmptyError(err) {
+			return nil, nil
+		}
+
 		return nil, err
 	}
 
@@ -223,11 +228,16 @@ type GetQueueRuntimePropertiesOptions struct {
 }
 
 // GetQueueRuntimeProperties gets runtime properties of a queue, like the SizeInBytes, or ActiveMessageCount.
+// If the entity does not exist this function will return a nil GetQueueRuntimePropertiesResponse and a nil error.
 func (ac *Client) GetQueueRuntimeProperties(ctx context.Context, queueName string, options *GetQueueRuntimePropertiesOptions) (*GetQueueRuntimePropertiesResponse, error) {
 	var atomResp *atom.QueueEnvelope
 	resp, err := ac.em.Get(ctx, "/"+queueName, &atomResp)
 
 	if err != nil {
+		if atom.IsFeedEmptyError(err) {
+			return nil, nil
+		}
+
 		return nil, err
 	}
 

--- a/sdk/messaging/azservicebus/admin/admin_client_queue.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_queue.go
@@ -5,6 +5,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -191,7 +192,7 @@ func (ac *Client) GetQueue(ctx context.Context, queueName string, options *GetQu
 	resp, err := ac.em.Get(ctx, "/"+queueName, &atomResp)
 
 	if err != nil {
-		if atom.IsFeedEmptyError(err) {
+		if errors.Is(err, atom.ErrFeedEmpty) {
 			return nil, nil
 		}
 
@@ -234,7 +235,7 @@ func (ac *Client) GetQueueRuntimeProperties(ctx context.Context, queueName strin
 	resp, err := ac.em.Get(ctx, "/"+queueName, &atomResp)
 
 	if err != nil {
-		if atom.IsFeedEmptyError(err) {
+		if errors.Is(err, atom.ErrFeedEmpty) {
 			return nil, nil
 		}
 

--- a/sdk/messaging/azservicebus/admin/admin_client_subscription.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_subscription.go
@@ -5,10 +5,12 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/atom"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/utils"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/internal/auth"
@@ -138,11 +140,22 @@ type GetSubscriptionOptions struct {
 }
 
 // GetSubscription gets a subscription by name.
+// If the entity does not exist this function will return a nil GetSubscriptionResponse and a nil error.
 func (ac *Client) GetSubscription(ctx context.Context, topicName string, subscriptionName string, options *GetSubscriptionOptions) (*GetSubscriptionResponse, error) {
 	var atomResp *atom.SubscriptionEnvelope
 	resp, err := ac.em.Get(ctx, fmt.Sprintf("/%s/Subscriptions/%s", topicName, subscriptionName), &atomResp)
 
 	if err != nil {
+		if atom.IsFeedEmptyError(err) {
+			return nil, nil
+		}
+
+		var respError *azcore.ResponseError
+
+		if errors.As(err, &respError) && respError.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+
 		return nil, err
 	}
 
@@ -175,11 +188,22 @@ type GetSubscriptionRuntimePropertiesOptions struct {
 }
 
 // GetSubscriptionRuntimeProperties gets runtime properties of a subscription, like the SizeInBytes, or SubscriptionCount.
+// If the entity does not exist this function will return a nil GetSubscriptionRuntimePropertiesResponse and a nil error.
 func (ac *Client) GetSubscriptionRuntimeProperties(ctx context.Context, topicName string, subscriptionName string, options *GetSubscriptionRuntimePropertiesOptions) (*GetSubscriptionRuntimePropertiesResponse, error) {
 	var atomResp *atom.SubscriptionEnvelope
 	resp, err := ac.em.Get(ctx, fmt.Sprintf("/%s/Subscriptions/%s", topicName, subscriptionName), &atomResp)
 
 	if err != nil {
+		if atom.IsFeedEmptyError(err) {
+			return nil, nil
+		}
+
+		var respError *azcore.ResponseError
+
+		if errors.As(err, &respError) && respError.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+
 		return nil, err
 	}
 

--- a/sdk/messaging/azservicebus/admin/admin_client_subscription.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_subscription.go
@@ -146,7 +146,7 @@ func (ac *Client) GetSubscription(ctx context.Context, topicName string, subscri
 	resp, err := ac.em.Get(ctx, fmt.Sprintf("/%s/Subscriptions/%s", topicName, subscriptionName), &atomResp)
 
 	if err != nil {
-		if atom.IsFeedEmptyError(err) {
+		if errors.Is(err, atom.ErrFeedEmpty) {
 			return nil, nil
 		}
 
@@ -194,7 +194,7 @@ func (ac *Client) GetSubscriptionRuntimeProperties(ctx context.Context, topicNam
 	resp, err := ac.em.Get(ctx, fmt.Sprintf("/%s/Subscriptions/%s", topicName, subscriptionName), &atomResp)
 
 	if err != nil {
-		if atom.IsFeedEmptyError(err) {
+		if errors.Is(err, atom.ErrFeedEmpty) {
 			return nil, nil
 		}
 

--- a/sdk/messaging/azservicebus/admin/admin_client_topic.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_topic.go
@@ -5,6 +5,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -126,7 +127,7 @@ func (ac *Client) GetTopic(ctx context.Context, topicName string, options *GetTo
 	resp, err := ac.em.Get(ctx, "/"+topicName, &atomResp)
 
 	if err != nil {
-		if atom.IsFeedEmptyError(err) {
+		if errors.Is(err, atom.ErrFeedEmpty) {
 			return nil, nil
 		}
 
@@ -170,7 +171,7 @@ func (ac *Client) GetTopicRuntimeProperties(ctx context.Context, topicName strin
 	resp, err := ac.em.Get(ctx, "/"+topicName, &atomResp)
 
 	if err != nil {
-		if atom.IsFeedEmptyError(err) {
+		if errors.Is(err, atom.ErrFeedEmpty) {
 			return nil, nil
 		}
 

--- a/sdk/messaging/azservicebus/admin/admin_client_topic.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_topic.go
@@ -120,11 +120,16 @@ type GetTopicOptions struct {
 }
 
 // GetTopic gets a topic by name.
+// If the entity does not exist this function will return a nil GetTopicResponse and a nil error.
 func (ac *Client) GetTopic(ctx context.Context, topicName string, options *GetTopicOptions) (*GetTopicResponse, error) {
 	var atomResp *atom.TopicEnvelope
 	resp, err := ac.em.Get(ctx, "/"+topicName, &atomResp)
 
 	if err != nil {
+		if atom.IsFeedEmptyError(err) {
+			return nil, nil
+		}
+
 		return nil, err
 	}
 
@@ -159,11 +164,16 @@ type GetTopicRuntimePropertiesOptions struct {
 }
 
 // GetTopicRuntimeProperties gets runtime properties of a topic, like the SizeInBytes, or SubscriptionCount.
+// If the entity does not exist this function will return a nil GetTopicRuntimePropertiesResponse and a nil error.
 func (ac *Client) GetTopicRuntimeProperties(ctx context.Context, topicName string, options *GetTopicRuntimePropertiesOptions) (*GetTopicRuntimePropertiesResponse, error) {
 	var atomResp *atom.TopicEnvelope
 	resp, err := ac.em.Get(ctx, "/"+topicName, &atomResp)
 
 	if err != nil {
+		if atom.IsFeedEmptyError(err) {
+			return nil, nil
+		}
+
 		return nil, err
 	}
 

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -419,31 +419,15 @@ func TraceReqAndResponseMiddleware() MiddlewareFunc {
 	}
 }
 
-type feedEmptyError struct {
-	response *http.Response
-}
+type feedEmptyError struct{}
 
-func (e feedEmptyError) RawResponse() *http.Response {
-	return e.response
-}
 func (e feedEmptyError) Error() string {
 	return "entity does not exist"
 }
 
-func NotFound(err error) (bool, *http.Response) {
+func IsFeedEmptyError(err error) bool {
 	var feedEmptyError feedEmptyError
-
-	if errors.As(err, &feedEmptyError) {
-		return true, feedEmptyError.RawResponse()
-	}
-
-	return false, nil
-}
-
-func isEmptyFeed(b []byte) bool {
-	var emptyFeed QueueFeed
-	feedErr := xml.Unmarshal(b, &emptyFeed)
-	return feedErr == nil && emptyFeed.Title == "Publicly Listed Services"
+	return errors.As(err, &feedEmptyError)
 }
 
 // ptrString takes a string and returns a pointer to that string. For use in literal pointers,
@@ -452,6 +436,9 @@ func ptrString(toPtr string) *string {
 	return &toPtr
 }
 
+// deserializeBody deserializes the body of the response into the type specified by respObj
+// (similar to xml.Unmarshal, which this func is calling).
+// If an empty feed is found, it returns nil.
 func deserializeBody(resp *http.Response, respObj interface{}) (*http.Response, error) {
 	bytes, err := ioutil.ReadAll(resp.Body)
 
@@ -460,10 +447,18 @@ func deserializeBody(resp *http.Response, respObj interface{}) (*http.Response, 
 	}
 
 	if err := xml.Unmarshal(bytes, respObj); err != nil {
-		// ATOM does this interesting thing where, when something doesn't exist, it gives you back an empty feed
-		// check:
-		if isEmptyFeed(bytes) {
-			return nil, feedEmptyError{response: resp}
+		// In ATOM when you request a specific entity (queue, topic, sub) you typically get an
+		// <Entry>. However, if the entity is not found, instead of getting a 404 you actually
+		// get a <Feed> XML object that is empty and an HTTP status code of 200.
+		//
+		// So the combination of "can't deserialize object" and "it's an empty feed" are enough
+		// for us to note that we weren't expecting a feed (ie, GET /queue) and that the feed
+		// itself is the special "empty feed".
+		var emptyFeed QueueFeed
+		feedErr := xml.Unmarshal(bytes, &emptyFeed)
+
+		if feedErr == nil && emptyFeed.Title == "Publicly Listed Services" {
+			return resp, feedEmptyError{}
 		}
 
 		return resp, err

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -419,16 +419,7 @@ func TraceReqAndResponseMiddleware() MiddlewareFunc {
 	}
 }
 
-type feedEmptyError struct{}
-
-func (e feedEmptyError) Error() string {
-	return "entity does not exist"
-}
-
-func IsFeedEmptyError(err error) bool {
-	var feedEmptyError feedEmptyError
-	return errors.As(err, &feedEmptyError)
-}
+var ErrFeedEmpty = errors.New("entity does not exist")
 
 // ptrString takes a string and returns a pointer to that string. For use in literal pointers,
 // ptrString(fmt.Sprintf("..", foo)) -> *string
@@ -458,7 +449,7 @@ func deserializeBody(resp *http.Response, respObj interface{}) (*http.Response, 
 		feedErr := xml.Unmarshal(bytes, &emptyFeed)
 
 		if feedErr == nil && emptyFeed.Title == "Publicly Listed Services" {
-			return resp, feedEmptyError{}
+			return resp, ErrFeedEmpty
 		}
 
 		return resp, err


### PR DESCRIPTION
Making it so our adminClient returns a nil result when the underlying entity is not found.

This avoids having to fabricate a fake status code (and possibly inconsistent HTTP response), which was the worse alternative.
    
Fixes #17065