### PR TITLE
[Tables] Batching response struct is now empty

### DIFF
--- a/sdk/data/aztables/CHANGELOG.md
+++ b/sdk/data/aztables/CHANGELOG.md
@@ -13,6 +13,7 @@
     * The `More` method checks whether there are more pages to retrieve.
     * The `NextPage(context.Context)` method gets the next page and returns a response and an `error`.
 * Removed `RawResponse` from all Response structs
+* `TransactionResponse` is an empty struct
 
 ## 0.5.0 (2022-01-12)
 

--- a/sdk/data/aztables/constants.go
+++ b/sdk/data/aztables/constants.go
@@ -15,7 +15,6 @@ const (
 	timestamp                     = "Timestamp"
 	partitionKey                  = "PartitionKey"
 	rowKey                        = "RowKey"
-	etag                          = "ETag"
 )
 
 // ResponseFormat determines what is returned from a service request

--- a/sdk/data/aztables/example_test.go
+++ b/sdk/data/aztables/example_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"time"
 
@@ -135,7 +134,7 @@ func ExampleClient_SubmitTransaction() {
 		})
 	}
 
-	resp, err := client.SubmitTransaction(context.TODO(), batch, nil)
+	_, err = client.SubmitTransaction(context.TODO(), batch, nil)
 	if err != nil {
 		var httpErr *azcore.ResponseError
 		if errors.As(err, &httpErr) {
@@ -146,16 +145,6 @@ func ExampleClient_SubmitTransaction() {
 			fmt.Println(string(body)) // Do some parsing of the body
 		} else {
 			panic(err)
-		}
-	} else {
-		for _, subResp := range resp.TransactionResponses {
-			if subResp.StatusCode != http.StatusAccepted {
-				body, err := ioutil.ReadAll(subResp.Body)
-				if err != nil {
-					panic(err)
-				}
-				fmt.Println(string(body))
-			}
 		}
 	}
 }

--- a/sdk/data/aztables/go.mod
+++ b/sdk/data/aztables/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/sdk/data/aztables/go.mod
+++ b/sdk/data/aztables/go.mod
@@ -2,8 +2,6 @@ module github.com/Azure/azure-sdk-for-go/sdk/data/aztables
 
 go 1.16
 
-replace github.com/Azure/azure-sdk-for-go/sdk/internal => ../../internal
-
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0

--- a/sdk/data/aztables/go.sum
+++ b/sdk/data/aztables/go.sum
@@ -3,8 +3,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0 h1:bLRntPH25SkY1uZ/YZW+dmxNky9r1fAHvDFrzluo+4Q=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0/go.mod h1:TmXReXZ9yPp5D5TBRMTAtyz+UyOl15Py4hL5E5p6igQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0 h1:HMbyI+KfvL+XyuWekow/nWbRxsAhB6+DVzgQTIABecU=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.1 h1:sLZ/Y+P/5RRtsXWylBjB5lkgixYfm0MQPiwrSX//JSo=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.1/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0 h1:WVsrXCnHlDDX8ls+tootqRE87/hL9S/g4ewig9RsD/c=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/sdk/data/aztables/go.sum
+++ b/sdk/data/aztables/go.sum
@@ -2,6 +2,9 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0 h1:bLRntPH25SkY1uZ/YZW+dmxNky9r1fAHvDFrzluo+4Q=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0/go.mod h1:TmXReXZ9yPp5D5TBRMTAtyz+UyOl15Py4hL5E5p6igQ=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0 h1:HMbyI+KfvL+XyuWekow/nWbRxsAhB6+DVzgQTIABecU=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0 h1:WVsrXCnHlDDX8ls+tootqRE87/hL9S/g4ewig9RsD/c=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,7 +24,6 @@ github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 h1:Qj1ukM4GlMWXNdMBuXc
 github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/sdk/data/aztables/transaction_batch_test.go
+++ b/sdk/data/aztables/transaction_batch_test.go
@@ -6,10 +6,8 @@ package aztables
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/stretchr/testify/require"
 )
@@ -33,13 +31,8 @@ func TestBatchAdd(t *testing.T) {
 				batch = append(batch, TransactionAction{ActionType: TransactionTypeAdd, Entity: marshalled})
 			}
 
-			resp, err := client.SubmitTransaction(ctx, batch, nil)
-
+			_, err = client.SubmitTransaction(ctx, batch, nil)
 			require.NoError(t, err)
-			for i := 0; i < len(resp.TransactionResponses); i++ {
-				r := (resp.TransactionResponses)[i]
-				require.Equal(t, r.StatusCode, http.StatusNoContent)
-			}
 
 			pager := client.List(nil)
 			count := 0
@@ -80,12 +73,8 @@ func TestBatchInsert(t *testing.T) {
 				)
 			}
 
-			resp, err := client.SubmitTransaction(ctx, batch, nil)
+			_, err = client.SubmitTransaction(ctx, batch, nil)
 			require.NoError(t, err)
-			for i := 1; i < len(resp.TransactionResponses); i++ {
-				r := (resp.TransactionResponses)[i]
-				require.Equal(t, r.StatusCode, http.StatusNoContent)
-			}
 
 			pager := client.List(nil)
 			count := 0
@@ -122,12 +111,8 @@ func TestBatchMixed(t *testing.T) {
 				})
 			}
 
-			resp, err := client.SubmitTransaction(ctx, batch, nil)
+			_, err = client.SubmitTransaction(ctx, batch, nil)
 			require.NoError(t, err)
-			for i := 0; i < len(resp.TransactionResponses); i++ {
-				r := (resp.TransactionResponses)[i]
-				require.Equal(t, http.StatusNoContent, r.StatusCode)
-			}
 
 			var qResp ListEntitiesPageResponse
 			filter := "RowKey eq '1'"
@@ -155,11 +140,9 @@ func TestBatchMixed(t *testing.T) {
 			}
 			marshalledMergeEntity, err := json.Marshal(mergeEntity)
 			require.NoError(t, err)
-			etag := azcore.ETag((resp.TransactionResponses)[0].Header.Get(etag))
 			batch2 = append(batch2, TransactionAction{
 				ActionType: TransactionTypeUpdateMerge,
 				Entity:     marshalledMergeEntity,
-				IfMatch:    &etag,
 			})
 
 			// create a delete action for the second added entity
@@ -186,14 +169,8 @@ func TestBatchMixed(t *testing.T) {
 			batch2 = append(batch2, TransactionAction{ActionType: TransactionTypeUpdateMerge, Entity: marshalled4thEntity})
 			batch2 = append(batch2, TransactionAction{ActionType: TransactionTypeInsertMerge, Entity: marshalled5thEntity})
 
-			resp, err = client.SubmitTransaction(ctx, batch2, nil)
+			_, err = client.SubmitTransaction(ctx, batch2, nil)
 			require.NoError(t, err)
-
-			for i := 0; i < len(resp.TransactionResponses); i++ {
-				r := (resp.TransactionResponses)[i]
-				require.Equal(t, http.StatusNoContent, r.StatusCode)
-
-			}
 
 			pager = client.List(list)
 			for pager.More() {
@@ -342,12 +319,8 @@ func TestBatchComplex(t *testing.T) {
 				Entity:     marshalled5,
 			})
 
-			resp, err := client.SubmitTransaction(ctx, batch, nil)
+			_, err = client.SubmitTransaction(ctx, batch, nil)
 			require.NoError(t, err)
-			for i := 0; i < len(resp.TransactionResponses); i++ {
-				r := (resp.TransactionResponses)[i]
-				require.Equal(t, http.StatusNoContent, r.StatusCode)
-			}
 
 			var batch2 []TransactionAction
 			edmEntity.Properties["Bool"] = false
@@ -374,12 +347,8 @@ func TestBatchComplex(t *testing.T) {
 				Entity:     marshalled3,
 			})
 
-			resp, err = client.SubmitTransaction(ctx, batch2, nil)
+			_, err = client.SubmitTransaction(ctx, batch2, nil)
 			require.NoError(t, err)
-			for i := 0; i < len(resp.TransactionResponses); i++ {
-				r := (resp.TransactionResponses)[i]
-				require.Equal(t, http.StatusNoContent, r.StatusCode)
-			}
 
 			received, err := client.GetEntity(ctx, edmEntity.PartitionKey, edmEntity.RowKey, nil)
 			require.NoError(t, err)


### PR DESCRIPTION
After discussion with Jeff, the `TransactionResponse` object is empty now and customers can parse the `azcore.ResponseError` to understand why the transaction failed.