### PR TITLE
Add sharedkey when initializing blob client using the container client

### DIFF
--- a/sdk/storage/azblob/zc_container_client.go
+++ b/sdk/storage/azblob/zc_container_client.go
@@ -66,7 +66,8 @@ func (c ContainerClient) NewBlobClient(blobName string) BlobClient {
 	newCon := &connection{u: blobURL, p: c.client.con.p}
 
 	return BlobClient{
-		client: &blobClient{newCon, nil},
+		sharedKey: c.sharedKey,
+		client:    &blobClient{newCon, nil},
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md

There is a bug when initializing the BlobClient we don't pass the sharedkey value and it gives the following error when I try to generate SAS token for the blobpath:
`credential is not a SharedKeyCredential. SAS can only be signed with a SharedKeyCredential`