### PR TITLE
[EngSys] Optionally extend test runtime

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
@@ -1,5 +1,10 @@
 parameters:
-  ServiceDirectory: ''
+  - name: ServiceDirectory
+    type: string
+    default: ''
+  - name: TestRunTime
+    type: string
+    default: '600s'
 
 stages:
   - stage: Build
@@ -46,6 +51,7 @@ stages:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           Image: $(vm.image)
           GoVersion: $(go.version)
+          TestRunTime: ${{ parameters.TestRunTime }}
 
     - job: Analyze
       displayName: Analyze

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -65,6 +65,9 @@ parameters:
   - name: MatrixReplace
     type: object
     default: []
+  - name: TestRunTime
+    type: string
+    default: '600s'
 
 
 stages:
@@ -113,7 +116,7 @@ stages:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           Image: $(vm.image)
           GoVersion: $(go.version)
-          TestProxy: true # Do we need this conditional if it's always true? @benbp
+          TestProxy: true
           EnvVars:
             AZURE_RECORD_MODE: 'playback'
 

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -28,6 +28,9 @@ parameters:
   - name: UsePlatformContainer
     type: boolean
     default: false
+  - name: TestRunTime
+    type: string
+    default: '600s'
 
 jobs:
   - job:
@@ -84,6 +87,7 @@ jobs:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           Image: $(OSVmImage)
           GoVersion: $(GoVersion)
+          TestRunTime: ${{ parameters.TestRunTime }}
           EnvVars:
             AZURE_RECORD_MODE: 'live'
             ${{ insert }}: ${{ parameters.EnvVars }}

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -14,6 +14,9 @@ parameters:
   - name: EnvVars
     type: object
     default: {}
+  - name: TestRunTime
+    type: string
+    default: '600s'
 
 steps:
   - task: Powershell@2
@@ -51,7 +54,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/run_tests.ps1
-      arguments: '${{ parameters.ServiceDirectory }}'
+      arguments: '${{ parameters.ServiceDirectory }} ${{ parameters.TestRunTime }}'
       pwsh: true
     env:
       GO111MODULE: 'on'

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -6,9 +6,9 @@ Param(
 )
 
 Push-Location sdk/$serviceDirectory
-Write-Host "##[command] Executing 'go test -timeout $runTime s -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
+Write-Host "##[command] Executing 'go test -timeout $runTime -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
 
-go test -timeout $runTime s -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
+go test -timeout $runTime -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
 if ($LASTEXITCODE) {
     exit $LASTEXITCODE
 }

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -2,13 +2,13 @@
 
 Param(
     [string] $serviceDirectory,
-    [string] $runTime
+    [string] $testTimeout
 )
 
 Push-Location sdk/$serviceDirectory
-Write-Host "##[command] Executing 'go test -timeout $runTime -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
+Write-Host "##[command] Executing 'go test -timeout $testTimeout -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
 
-go test -timeout $runTime -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
+go test -timeout $testTimeout -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
 if ($LASTEXITCODE) {
     exit $LASTEXITCODE
 }

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -1,13 +1,14 @@
 #Requires -Version 7.0
 
 Param(
-    [string] $serviceDirectory
+    [string] $serviceDirectory,
+    [string] $runTime
 )
 
 Push-Location sdk/$serviceDirectory
-Write-Host "##[command] Executing 'go test -run "^Test" -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
+Write-Host "##[command] Executing 'go test -timeout $runTime s -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
 
-go test -run "^Test" -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
+go test -timeout $runTime s -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
 if ($LASTEXITCODE) {
     exit $LASTEXITCODE
 }

--- a/sdk/keyvault/azcertificates/ci.yml
+++ b/sdk/keyvault/azcertificates/ci.yml
@@ -27,3 +27,4 @@ stages:
   parameters:
     ServiceDirectory: 'keyvault/azcertificates'
     RunLiveTests: true
+    TestRunTime: '720s'


### PR DESCRIPTION
It happens sporadically, but `azcertificates` (full of LROs) live tests will fail because the tests do not complete in >600s (the default in Go). This change provides a way to specify in the `ci.yml` for larger test suites.