### PR TITLE
[azservicebus] Add testing for primitive data types.

### DIFF
--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/test"
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/utils"
 	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/require"
 )
@@ -545,35 +544,89 @@ func TestReceiver_RenewMessageLock(t *testing.T) {
 		"error message from SB comes through")
 }
 
-func TestReceiverOptions(t *testing.T) {
-	// defaults
-	receiver := &Receiver{}
-	e := &entity{Topic: "topic", Subscription: "subscription"}
+// TestReceiverAMQPDataTypes checks that we can send and receive all the AMQP primitive types that are supported
+// in ApplicationProperties.
+// http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties
+//
+// > The keys of this map are restricted to be of type string (which excludes the possibility of a null key) and the values
+// > are restricted to be of simple types only, that is, excluding map, list, and array types.
+func TestReceiverAMQPDataTypes(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, nil)
+	defer cleanup()
 
-	require.NoError(t, applyReceiverOptions(receiver, e, nil))
-
-	require.EqualValues(t, ReceiveModePeekLock, receiver.receiveMode)
-	path, err := e.String()
+	sender, err := client.NewSender(queueName, nil)
 	require.NoError(t, err)
-	require.EqualValues(t, "topic/Subscriptions/subscription", path)
 
-	// using options
-	receiver = &Receiver{}
-	e = &entity{Topic: "topic", Subscription: "subscription"}
-
-	require.NoError(t, applyReceiverOptions(receiver, e, &ReceiverOptions{
+	receiver, err := client.NewReceiverForQueue(queueName, &ReceiverOptions{
 		ReceiveMode: ReceiveModeReceiveAndDelete,
-		SubQueue:    SubQueueTransfer,
-		retryOptions: utils.RetryOptions{
-			MaxRetries: 101,
+	})
+	require.NoError(t, err)
+
+	expectedTime, err := time.Parse(time.RFC3339, "2000-01-01T01:02:03Z")
+	require.NoError(t, err)
+
+	require.NoError(t, sender.SendMessage(context.Background(), &Message{
+		Body: []byte("hello, this is the body"),
+		ApplicationProperties: map[string]interface{}{
+			// Some primitive types are missing - it's a bit unclear what the right representation of this would be in Go:
+			// - TypeCodeDecimal32
+			// - TypeCodeDecimal64
+			// - TypeCodeDecimal128
+			// - TypeCodeChar  (although note below that a 'char' does work, although it's not a TypecodeChar value)
+			// https://github.com/Azure/go-amqp/blob/e0c6c63fb01e6642686ee4f8e7412da042bf35dd/internal/encoding/decode.go#L568
+			"timestamp": expectedTime,
+
+			"byte":   byte(128),
+			"uint8":  int8(101),
+			"uint32": int32(400),
+			"uint64": int64(400),
+
+			"int":   400,
+			"int8":  int8(-101),
+			"int32": int32(-400),
+			"int64": int64(-400),
+
+			"float":   400.1,
+			"float64": float64(400.1),
+
+			"string": "hello world",
+			// these aren't "true" chars in the amqp sense - they end up being in32's.
+			"char":  'g',
+			"char2": '❤',
+
+			"bool": true,
+			"uuid": amqp.UUID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}),
 		},
 	}))
 
-	require.EqualValues(t, ReceiveModeReceiveAndDelete, receiver.receiveMode)
-	path, err = e.String()
+	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
-	require.EqualValues(t, "topic/Subscriptions/subscription/$Transfer/$DeadLetterQueue", path)
-	require.EqualValues(t, 101, receiver.retryOptions.MaxRetries)
+
+	actualProps := messages[0].ApplicationProperties
+
+	require.Equal(t, map[string]interface{}{
+		"timestamp": expectedTime,
+
+		"byte":   byte(128),
+		"uint8":  int8(101),
+		"uint32": int32(400),
+		"uint64": int64(400),
+
+		"int":   int64(400),
+		"int8":  int8(-101),
+		"int32": int32(-400),
+		"int64": int64(-400),
+
+		"float":   float64(400.1),
+		"float64": float64(400.1),
+
+		"string": "hello world",
+		"char":   'g',
+		"char2":  '❤',
+
+		"bool": true,
+		"uuid": amqp.UUID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}),
+	}, actualProps)
 }
 
 type badRPCLink struct {

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -572,7 +572,7 @@ func TestReceiverAMQPDataTypes(t *testing.T) {
 			// - TypeCodeDecimal32
 			// - TypeCodeDecimal64
 			// - TypeCodeDecimal128
-			// - TypeCodeChar  (although note below that a 'char' does work, although it's not a TypecodeChar value)
+			// - TypeCodeChar  (although note below that a 'character' does work, although it's not a TypecodeChar value)
 			// https://github.com/Azure/go-amqp/blob/e0c6c63fb01e6642686ee4f8e7412da042bf35dd/internal/encoding/decode.go#L568
 			"timestamp": expectedTime,
 
@@ -590,7 +590,7 @@ func TestReceiverAMQPDataTypes(t *testing.T) {
 			"float64": float64(400.1),
 
 			"string": "hello world",
-			// these aren't "true" chars in the amqp sense - they end up being in32's.
+			// these aren't "true" chars in the amqp sense - they end up being int32's
 			"char":  'g',
 			"char2": '❤',
 


### PR DESCRIPTION
This adds in some tests for #17047, where we were concerned about which primitives can be both sent and deserialized properly.

go-amqp currently lacks support for decoding/encoding the AMQP primitives for TypeCodeDecimal and TypeCodeChar. These don't necessarily have a proper analog where we'd properly round-trip them so we'd need to think about how to implement this in Go, if needed.

Fixes #17047