### PR TITLE
[azservicebus] Add support for using connection strings with embedded SharedAccessSignature

### DIFF
--- a/sdk/messaging/internal/conn/conn_test.go
+++ b/sdk/messaging/internal/conn/conn_test.go
@@ -26,17 +26,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
-	namespace    = "mynamespace"
-	keyName      = "keyName"
-	secret       = "superSecret="
-	hubName      = "myhub"
-	happyConnStr = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";EntityPath=" + hubName
-	noEntityPath = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret
-	lowerCase    = "endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccesskeyName=" + keyName + ";sharedAccessKey=" + secret + ";Entitypath=" + hubName
-	noEndpoint   = "NoEndpoint=Blah"
+	namespace       = "mynamespace"
+	keyName         = "keyName"
+	secret          = "superSecret="
+	hubName         = "myhub"
+	happyConnStr    = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";EntityPath=" + hubName
+	noEntityPath    = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret
+	lowerCase       = "endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccesskeyName=" + keyName + ";sharedAccessKey=" + secret + ";Entitypath=" + hubName
+	withEmbeddedSAS = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessSignature=SharedAccessSignature sr=" + namespace + ".servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"
+	noEndpoint      = "NoEndpoint=Blah"
 )
 
 func TestParsedConnectionFromStr(t *testing.T) {
@@ -67,6 +69,17 @@ func TestParsedConnectionFromStrWithoutEntityPath(t *testing.T) {
 		assert.Equal(t, secret, parsed.Key)
 		assert.Equal(t, "", parsed.HubName)
 	}
+}
+
+func TestParsedConnectionFromStrWithEmbeddedSAS(t *testing.T) {
+	parsed, err := ParsedConnectionFromStr(withEmbeddedSAS)
+	require.NoError(t, err)
+
+	require.Equal(t, &ParsedConn{
+		Namespace: namespace + ".servicebus.windows.net",
+		SAS:       "SharedAccessSignature sr=" + namespace + ".servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>",
+	}, parsed)
+
 }
 
 func TestFailedParsedConnectionFromStrWithoutEndpoint(t *testing.T) {

--- a/sdk/messaging/internal/sas/sas_test.go
+++ b/sdk/messaging/internal/sas/sas_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/internal/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +44,20 @@ func TestNewSigner(t *testing.T) {
 	assert.Equal(t, keyName, sig.skn)
 	assert.Equal(t, expiry, sig.se)
 	assert.NotNil(t, sig.sig)
+}
+
+func TestTokenProviderWithSAS(t *testing.T) {
+	tp, err := NewTokenProvider(TokenProviderWithSAS("hello"))
+	require.NoError(t, err)
+
+	token, err := tp.GetToken("audience")
+	require.NoError(t, err)
+
+	require.Equal(t, &auth.Token{
+		TokenType: auth.CBSTokenTypeSAS,
+		Expiry:    "0",
+		Token:     "hello",
+	}, token)
 }
 
 func parseSig(sigStr string) (*sig, error) {


### PR DESCRIPTION
Enable using connection strings with an embedded SharedAccessSignature.

First part of the fix for #16641