### PR TITLE
Distinguish client ID when multiple identities assigned with DefaultCredential

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.14.1 (Unreleased)
 
 ### Features Added
+* `DefaultAzureCredential` reads environment variable `AZURE_CLIENT_ID` for the
+  client ID of a user-assigned managed identity
+  ([#17293](https://github.com/Azure/azure-sdk-for-go/pull/17293))
 
 ### Breaking Changes
 

--- a/sdk/azidentity/README.md
+++ b/sdk/azidentity/README.md
@@ -76,6 +76,7 @@ in any hosting environment which supports managed identities, such as (this list
 
 - [Authenticate with DefaultAzureCredential](#authenticate-with-defaultazurecredential "Authenticate with DefaultAzureCredential")
 - [Define a custom authentication flow with ChainedTokenCredential](#define-a-custom-authentication-flow-with-chainedtokencredential "Define a custom authentication flow with ChainedTokenCredential")
+- [Specify a user-assigned managed identity for DefaultAzureCredential](#specify-a-user-assigned-managed-identity-for-defaultazurecredential)
 
 ### Authenticate with DefaultAzureCredential
 
@@ -90,6 +91,9 @@ if err != nil {
 client := armresources.NewResourceGroupsClient("subscription ID", cred, nil)
 ```
 
+### Specify a user-assigned managed identity for DefaultAzureCredential
+
+To configure `DefaultAzureCredential` to authenticate a user-assigned managed identity, set the environment variable `AZURE_CLIENT_ID` to the identity's client ID.
 
 ### Define a custom authentication flow with `ChainedTokenCredential`
 

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -23,13 +23,14 @@ import (
 )
 
 const (
+	azureAuthorityHost = "AZURE_AUTHORITY_HOST"
+	azureClientID      = "AZURE_CLIENT_ID"
+
 	organizationsTenantID   = "organizations"
 	developerSignOnClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 	defaultSuffix           = "/.default"
 	tenantIDValidationErr   = "invalid tenantID. You can locate your tenantID by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names"
 )
-
-const azureAuthorityHost = "AZURE_AUTHORITY_HOST"
 
 // setAuthorityHost initializes the authority host for credentials. Precedence is:
 // 1. cloud.Configuration.LoginEndpoint value set by user

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -53,14 +53,11 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		creds = append(creds, &defaultCredentialErrorReporter{credType: "EnvironmentCredential", err: err})
 	}
 
-	var managedClientID ClientID
-	if s := os.Getenv("AZURE_CLIENT_ID"); s != "" {
-		managedClientID = ClientID(s)
+	o := &ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions}
+	if ID, ok := os.LookupEnv("AZURE_CLIENT_ID"); ok {
+		o.ID = ClientID(ID)
 	}
-	msiCred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{
-		ClientOptions: options.ClientOptions,
-		ID:            managedClientID,
-	})
+	msiCred, err := NewManagedIdentityCredential(o)
 	if err == nil {
 		creds = append(creds, msiCred)
 		msiCred.client.imdsTimeout = time.Second

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -6,6 +6,7 @@ package azidentity
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"time"
 
@@ -52,7 +53,14 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		creds = append(creds, &defaultCredentialErrorReporter{credType: "EnvironmentCredential", err: err})
 	}
 
-	msiCred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions})
+	var managedClientID ClientID
+	if s := os.Getenv("AZURE_CLIENT_ID"); s != "" {
+		managedClientID = ClientID(s)
+	}
+	msiCred, err := NewManagedIdentityCredential(&ManagedIdentityCredentialOptions{
+		ClientOptions: options.ClientOptions,
+		ID:            managedClientID,
+	})
 	if err == nil {
 		creds = append(creds, msiCred)
 		msiCred.client.imdsTimeout = time.Second

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -54,7 +54,7 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 	}
 
 	o := &ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions}
-	if ID, ok := os.LookupEnv("AZURE_CLIENT_ID"); ok {
+	if ID, ok := os.LookupEnv(azureClientID); ok {
 		o.ID = ClientID(ID)
 	}
 	msiCred, err := NewManagedIdentityCredential(o)

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDefaultAzureCredential_GetTokenSuccess(t *testing.T) {
-	env := map[string]string{"AZURE_TENANT_ID": fakeTenantID, "AZURE_CLIENT_ID": fakeClientID, "AZURE_CLIENT_SECRET": secret}
+	env := map[string]string{"AZURE_TENANT_ID": fakeTenantID, azureClientID: fakeClientID, "AZURE_CLIENT_SECRET": secret}
 	setEnvironmentVariables(t, env)
 	cred, err := NewDefaultAzureCredential(nil)
 	if err != nil {

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -5,6 +5,7 @@ package azidentity
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -60,5 +61,28 @@ func TestDefaultAzureCredential_ConstructorErrorHandler(t *testing.T) {
 	}
 	if logMessages[0] != expectedLogs {
 		t.Fatalf("Did not receive the expected logs.\n\nReceived:\n%s\n\nExpected:\n%s", logMessages[0], expectedLogs)
+	}
+}
+
+func TestDefaultAzureCredential_UserAssignedIdentity(t *testing.T) {
+	for _, ID := range []ManagedIDKind{nil, ClientID("client-id")} {
+		t.Run(fmt.Sprintf("%v", ID), func(t *testing.T) {
+			if ID != nil {
+				t.Setenv(azureClientID, ID.String())
+			}
+			cred, err := NewDefaultAzureCredential(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, c := range cred.chain.sources {
+				if mic, ok := c.(*ManagedIdentityCredential); ok {
+					if mic.id != ID {
+						t.Fatalf(`expected %v, got "%v"`, ID, mic.id)
+					}
+					return
+				}
+			}
+			t.Fatal("default chain should include ManagedIdentityCredential")
+		})
 	}
 }

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -56,9 +56,9 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 	if tenantID == "" {
 		return nil, errors.New("missing environment variable AZURE_TENANT_ID")
 	}
-	clientID := os.Getenv("AZURE_CLIENT_ID")
+	clientID := os.Getenv(azureClientID)
 	if clientID == "" {
-		return nil, errors.New("missing environment variable AZURE_CLIENT_ID")
+		return nil, errors.New("missing environment variable " + azureClientID)
 	}
 	if clientSecret := os.Getenv("AZURE_CLIENT_SECRET"); clientSecret != "" {
 		log.Write(EventAuthentication, "EnvironmentCredential will authenticate with ClientSecretCredential")

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -15,12 +15,12 @@ import (
 )
 
 func resetEnvironmentVarsForTest() {
-	clearEnvVars("AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_CLIENT_CERTIFICATE_PATH", "AZURE_USERNAME", "AZURE_PASSWORD")
+	clearEnvVars("AZURE_TENANT_ID", azureClientID, "AZURE_CLIENT_SECRET", "AZURE_CLIENT_CERTIFICATE_PATH", "AZURE_USERNAME", "AZURE_PASSWORD")
 }
 
 func TestEnvironmentCredential_TenantIDNotSet(t *testing.T) {
 	resetEnvironmentVarsForTest()
-	err := os.Setenv("AZURE_CLIENT_ID", fakeClientID)
+	err := os.Setenv(azureClientID, fakeClientID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestEnvironmentCredential_ClientSecretNotSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_CLIENT_ID", fakeClientID)
+	err = os.Setenv(azureClientID, fakeClientID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestEnvironmentCredential_ClientSecretSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_CLIENT_ID", fakeClientID)
+	err = os.Setenv(azureClientID, fakeClientID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestEnvironmentCredential_ClientCertificatePathSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_CLIENT_ID", fakeClientID)
+	err = os.Setenv(azureClientID, fakeClientID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestEnvironmentCredential_UsernameOnlySet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_CLIENT_ID", fakeClientID)
+	err = os.Setenv(azureClientID, fakeClientID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestEnvironmentCredential_UsernamePasswordSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_CLIENT_ID", fakeClientID)
+	err = os.Setenv(azureClientID, fakeClientID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestEnvironmentCredential_SendCertificateChain(t *testing.T) {
 	srv.AppendResponse()
 
 	vars := map[string]string{
-		"AZURE_CLIENT_ID":               liveSP.clientID,
+		azureClientID:                   liveSP.clientID,
 		"AZURE_CLIENT_CERTIFICATE_PATH": liveSP.pfxPath,
 		"AZURE_TENANT_ID":               liveSP.tenantID,
 		envVarSendCertChain:             "true",
@@ -190,7 +190,7 @@ func TestEnvironmentCredential_SendCertificateChain(t *testing.T) {
 
 func TestEnvironmentCredential_ClientSecretLive(t *testing.T) {
 	vars := map[string]string{
-		"AZURE_CLIENT_ID":     liveSP.clientID,
+		azureClientID:         liveSP.clientID,
 		"AZURE_CLIENT_SECRET": liveSP.secret,
 		"AZURE_TENANT_ID":     liveSP.tenantID,
 	}
@@ -206,7 +206,7 @@ func TestEnvironmentCredential_ClientSecretLive(t *testing.T) {
 
 func TestEnvironmentCredential_InvalidClientSecretLive(t *testing.T) {
 	vars := map[string]string{
-		"AZURE_CLIENT_ID":     liveSP.clientID,
+		azureClientID:         liveSP.clientID,
 		"AZURE_CLIENT_SECRET": "invalid secret",
 		"AZURE_TENANT_ID":     liveSP.tenantID,
 	}
@@ -232,7 +232,7 @@ func TestEnvironmentCredential_InvalidClientSecretLive(t *testing.T) {
 
 func TestEnvironmentCredential_UserPasswordLive(t *testing.T) {
 	vars := map[string]string{
-		"AZURE_CLIENT_ID": developerSignOnClientID,
+		azureClientID:     developerSignOnClientID,
 		"AZURE_TENANT_ID": liveUser.tenantID,
 		"AZURE_USERNAME":  liveUser.username,
 		"AZURE_PASSWORD":  liveUser.password,
@@ -249,7 +249,7 @@ func TestEnvironmentCredential_UserPasswordLive(t *testing.T) {
 
 func TestEnvironmentCredential_InvalidPasswordLive(t *testing.T) {
 	vars := map[string]string{
-		"AZURE_CLIENT_ID": developerSignOnClientID,
+		azureClientID:     developerSignOnClientID,
 		"AZURE_TENANT_ID": liveUser.tenantID,
 		"AZURE_USERNAME":  liveUser.username,
 		"AZURE_PASSWORD":  "invalid password",


### PR DESCRIPTION
DefaultCredential may not work when there are multiple managed
identities assigned on a VM/VMSS node. It's not possible to
distinguish the client ID to use in this case. The PR addresses
the issue by using the value set for AZURE_CLIENT_ID environment
variables.

Signed-off-by: Zhongcheng Lao <Zhongcheng.Lao@microsoft.com>

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
