### PR TITLE
[azservicebus] Adding tests for multi-link and multi-entity

### DIFF
--- a/sdk/messaging/azservicebus/liveTestHelpers_test.go
+++ b/sdk/messaging/azservicebus/liveTestHelpers_test.go
@@ -27,15 +27,12 @@ func setupLiveTest(t *testing.T, props *admin.QueueProperties) (*Client, func(),
 	testCleanup := func() {
 		require.NoError(t, serviceBusClient.Close(context.Background()))
 		cleanupQueue()
-		require.NoError(t, serviceBusClient.Close(context.Background()))
 	}
 
 	return serviceBusClient, testCleanup, queueName
 }
 
-// createQueue creates a queue using a subset of entries in 'queueDescription':
-// - EnablePartitioning
-// - RequiresSession
+// createQueue creates a queue, automatically setting it to delete on idle in 5 minutes.
 func createQueue(t *testing.T, connectionString string, queueProperties *admin.QueueProperties) (string, func()) {
 	nanoSeconds := time.Now().UnixNano()
 	queueName := fmt.Sprintf("queue-%X", nanoSeconds)


### PR DESCRIPTION
AMQP lets you create multiple links on a single connection. As a simple sanity check I'm actually using that - sending and receiving to separate queues using the same connection and also just creating multiple sender/receiver links and sending/receiving to the same queue.