### PR TITLE
Add generic poller implementation

### DIFF
--- a/sdk/azcore/arm/runtime/poller.go
+++ b/sdk/azcore/arm/runtime/poller.go
@@ -7,10 +7,12 @@
 package runtime
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/internal/pollers/async"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/internal/pollers/body"
@@ -22,7 +24,7 @@ import (
 
 // NewPoller creates a Poller based on the provided initial response.
 // pollerID - a unique identifier for an LRO.  it's usually the client.Method string.
-func NewPoller(pollerID string, finalState string, resp *http.Response, pl pipeline.Pipeline) (*pollers.Poller, error) {
+func NewPoller[T any](pollerID string, finalState string, resp *http.Response, pl pipeline.Pipeline, rt *T) (*Poller[T], error) {
 	defer resp.Body.Close()
 	// this is a back-stop in case the swagger is incorrect (i.e. missing one or more status codes for success).
 	// ideally the codegen should return an error if the initial response failed and not even create a poller.
@@ -50,12 +52,15 @@ func NewPoller(pollerID string, finalState string, resp *http.Response, pl pipel
 	if err != nil {
 		return nil, err
 	}
-	return pollers.NewPoller(lro, resp, pl), nil
+	return &Poller[T]{
+		pt: pollers.NewPoller(lro, resp, pl),
+		rt: rt,
+	}, nil
 }
 
 // NewPollerFromResumeToken creates a Poller from a resume token string.
 // pollerID - a unique identifier for an LRO.  it's usually the client.Method string.
-func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipeline) (*pollers.Poller, error) {
+func NewPollerFromResumeToken[T any](pollerID string, token string, pl pipeline.Pipeline, rt *T) (*Poller[T], error) {
 	kind, err := pollers.KindFromToken(pollerID, token)
 	if err != nil {
 		return nil, err
@@ -78,5 +83,61 @@ func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipelin
 	if err = json.Unmarshal([]byte(token), lro); err != nil {
 		return nil, err
 	}
-	return pollers.NewPoller(lro, nil, pl), nil
+	return &Poller[T]{
+		pt: pollers.NewPoller(lro, nil, pl),
+		rt: rt,
+	}, nil
+}
+
+// Poller encapsulates a long-running operation, providing polling facilities until the operation reaches a terminal state.
+type Poller[T any] struct {
+	pt *pollers.Poller
+	rt *T
+}
+
+// PollUntilDone will poll the service endpoint until a terminal state is reached, an error is received, or the context expires.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *Poller[T]) PollUntilDone(ctx context.Context, freq time.Duration) (T, error) {
+	var resp T
+	if p.rt != nil {
+		resp = *p.rt
+	}
+	_, err := p.pt.PollUntilDone(ctx, freq, &resp)
+	return resp, err
+}
+
+// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
+// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// response is returned.
+// If the LRO has completed with failure or was cancelled, the poller's state is
+// updated and the error is returned.
+// If the LRO has not reached a terminal state, the poller's state is updated and
+// the latest HTTP response is returned.
+// If Poll fails, the poller's state is unmodified and the error is returned.
+// Calling Poll on an LRO that has reached a terminal state will return the final
+// HTTP response or error.
+func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Done returns true if the LRO has reached a terminal state.
+func (p *Poller[T]) Done() bool {
+	return p.pt.Done()
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Calling this on an LRO in a non-terminal state will return an error.
+func (p *Poller[T]) Result(ctx context.Context) (T, error) {
+	var resp T
+	if p.rt != nil {
+		resp = *p.rt
+	}
+	_, err := p.pt.FinalResponse(ctx, &resp)
+	return resp, err
+}
+
+// ResumeToken returns a value representing the poller that can be used to resume
+// the LRO at a later time. ResumeTokens are unique per service operation.
+func (p *Poller[T]) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
 }

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -9,7 +9,6 @@ package azcore
 import (
 	"reflect"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
@@ -72,6 +71,3 @@ func IsNullValue[T any](v T) bool {
 
 // ClientOptions contains configuration settings for a client's pipeline.
 type ClientOptions = policy.ClientOptions
-
-// Poller encapsulates state and logic for polling on long-running operations.
-type Poller = pollers.Poller

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -7,10 +7,12 @@
 package runtime
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pipeline"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers"
@@ -21,7 +23,7 @@ import (
 
 // NewPoller creates a Poller based on the provided initial response.
 // pollerID - a unique identifier for an LRO, it's usually the client.Method string.
-func NewPoller(pollerID string, resp *http.Response, pl pipeline.Pipeline) (*pollers.Poller, error) {
+func NewPoller[T any](pollerID string, resp *http.Response, pl pipeline.Pipeline, rt *T) (*Poller[T], error) {
 	defer resp.Body.Close()
 	// this is a back-stop in case the swagger is incorrect (i.e. missing one or more status codes for success).
 	// ideally the codegen should return an error if the initial response failed and not even create a poller.
@@ -42,12 +44,15 @@ func NewPoller(pollerID string, resp *http.Response, pl pipeline.Pipeline) (*pol
 	if err != nil {
 		return nil, err
 	}
-	return pollers.NewPoller(lro, resp, pl), nil
+	return &Poller[T]{
+		pt: pollers.NewPoller(lro, resp, pl),
+		rt: rt,
+	}, nil
 }
 
 // NewPollerFromResumeToken creates a Poller from a resume token string.
 // pollerID - a unique identifier for an LRO, it's usually the client.Method string.
-func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipeline) (*pollers.Poller, error) {
+func NewPollerFromResumeToken[T any](pollerID string, token string, pl pipeline.Pipeline, rt *T) (*Poller[T], error) {
 	kind, err := pollers.KindFromToken(pollerID, token)
 	if err != nil {
 		return nil, err
@@ -67,5 +72,61 @@ func NewPollerFromResumeToken(pollerID string, token string, pl pipeline.Pipelin
 	if err = json.Unmarshal([]byte(token), lro); err != nil {
 		return nil, err
 	}
-	return pollers.NewPoller(lro, nil, pl), nil
+	return &Poller[T]{
+		pt: pollers.NewPoller(lro, nil, pl),
+		rt: rt,
+	}, nil
+}
+
+// Poller encapsulates a long-running operation, providing polling facilities until the operation reaches a terminal state.
+type Poller[T any] struct {
+	pt *pollers.Poller
+	rt *T
+}
+
+// PollUntilDone will poll the service endpoint until a terminal state is reached, an error is received, or the context expires.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *Poller[T]) PollUntilDone(ctx context.Context, freq time.Duration) (T, error) {
+	var resp T
+	if p.rt != nil {
+		resp = *p.rt
+	}
+	_, err := p.pt.PollUntilDone(ctx, freq, &resp)
+	return resp, err
+}
+
+// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
+// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// response is returned.
+// If the LRO has completed with failure or was cancelled, the poller's state is
+// updated and the error is returned.
+// If the LRO has not reached a terminal state, the poller's state is updated and
+// the latest HTTP response is returned.
+// If Poll fails, the poller's state is unmodified and the error is returned.
+// Calling Poll on an LRO that has reached a terminal state will return the final
+// HTTP response or error.
+func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Done returns true if the LRO has reached a terminal state.
+func (p *Poller[T]) Done() bool {
+	return p.pt.Done()
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Calling this on an LRO in a non-terminal state will return an error.
+func (p *Poller[T]) Result(ctx context.Context) (T, error) {
+	var resp T
+	if p.rt != nil {
+		resp = *p.rt
+	}
+	_, err := p.pt.FinalResponse(ctx, &resp)
+	return resp, err
+}
+
+// ResumeToken returns a value representing the poller that can be used to resume
+// the LRO at a later time. ResumeTokens are unique per service operation.
+func (p *Poller[T]) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
 }


### PR DESCRIPTION
Due to lack of support for type aliasing a generic type, we have
duplicate definitions for ARM and data-plane.  We can consolidate the
definitions when type aliasing support is added in the future.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
