### PR TITLE
[EngSys] adding ci checks for performance

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -65,7 +65,7 @@ steps:
     display: 'Build Performance Tests'
     inputs:
       targetType: 'filePath'
-      filePath: ./eng/scripts/run_tests.ps1
+      filePath: ./eng/scripts/Build_Perf.ps1
       arguments: '${{ parameters.ServiceDirectory }}'
       pwsh: true
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -61,6 +61,14 @@ steps:
       PROXY_CERT: $(Build.SourcesDirectory)/eng/common/testproxy/dotnet-devcert.crt
       ${{ insert }}: ${{ parameters.EnvVars }}
 
+  - tast: PowerShell@2
+    display: 'Build Performance Tests'
+    inputs:
+      targetType: 'filePath'
+      filePath: ./eng/scripts/run_tests.ps1
+      arguments: '${{ parameters.ServiceDirectory }}'
+      pwsh: true
+
   - ${{ if eq(parameters.TestProxy, true) }}:
     - pwsh: |
         # $(Build.SourcesDirectory)/test-proxy.log is the hardcoded output log location for the test-proxy-tool.yml

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -7,11 +7,13 @@ Param(
 Push-Location sdk/$serviceDirectory
 
 if (Test-Path -Path testdata/perf) {
+    Push-Location testdata/perf
     Write-Host "##[command] Building and vetting performance tests in sdk/$serviceDirectory/testdata/perf"
 
     Write-Host "##[command] Executing 'go build .' in sdk/$serviceDirectory/testdata/perf"
     go build .
     if ($LASTEXITCODE) {
+        Pop-Location
         Pop-Location
         exit $LASTEXITCODE
     }
@@ -20,8 +22,10 @@ if (Test-Path -Path testdata/perf) {
     go vet .
     if ($LASTEXITCODE) {
         Pop-Location
+        Pop-Location
         exit $LASTEXITCODE
     }
+    Pop-Location
 } else {
     Write-Host "##[command] Did not find performance tests in sdk/$serviceDirectory/testdata/perf"
 }

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -23,7 +23,7 @@ foreach ($perfDir in $perfDirectories) {
         Push-Location perf
         Write-Host "##[command] Building and vetting performance tests in $perfDir/perf"
 
-        Write-Host "##[command] Executing 'go build .' in $perfDir/testdata/perf"
+        Write-Host "##[command] Executing 'go build .' in $perfDir/perf"
         go build .
         if ($LASTEXITCODE) {
             $failed = $true

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -29,7 +29,7 @@ foreach ($perfDir in $perfDirectories) {
             $failed = $true
         }
 
-        Write-Host "##[command] Executing 'go vet .' in $perfDir/testdata/perf"
+        Write-Host "##[command] Executing 'go vet .' in $perfDir/perf"
         go vet .
         if ($LASTEXITCODE) {
             $failed = $true

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -21,7 +21,7 @@ foreach ($perfDir in $perfDirectories) {
 
     if (Test-Path -Path perf) {
         Push-Location perf
-        Write-Host "##[command] Building and vetting performance tests in $perfDir/testdata/perf"
+        Write-Host "##[command] Building and vetting performance tests in $perfDir/perf"
 
         Write-Host "##[command] Executing 'go build .' in $perfDir/testdata/perf"
         go build .

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 7.0
 
 Param(
-    [string] $serviceDirectory,
+    [string] $serviceDirectory
 )
 
 Push-Location sdk/$serviceDirectory
@@ -12,12 +12,14 @@ if (Test-Path -Path testdata/perf) {
     Write-Host "##[command] Executing 'go build .' in sdk/$serviceDirectory/testdata/perf"
     go build .
     if ($LASTEXITCODE) {
+        Pop-Location
         exit $LASTEXITCODE
     }
 
     Write-Host "##[command] Executing 'go vet .' in sdk/$serviceDirectory/testdata/perf"
     go vet .
     if ($LASTEXITCODE) {
+        Pop-Location
         exit $LASTEXITCODE
     }
 } else {

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -1,0 +1,27 @@
+#Requires -Version 7.0
+
+Param(
+    [string] $serviceDirectory,
+)
+
+Push-Location sdk/$serviceDirectory
+
+if (Test-Path -Path testdata/perf) {
+    Write-Host "##[command] Building and vetting performance tests in sdk/$serviceDirectory/testdata/perf"
+
+    Write-Host "##[command] Executing 'go build .' in sdk/$serviceDirectory/testdata/perf"
+    go build .
+    if ($LASTEXITCODE) {
+        exit $LASTEXITCODE
+    }
+
+    Write-Host "##[command] Executing 'go vet .' in sdk/$serviceDirectory/testdata/perf"
+    go vet .
+    if ($LASTEXITCODE) {
+        exit $LASTEXITCODE
+    }
+} else {
+    Write-Host "##[command] Did not find performance tests in sdk/$serviceDirectory/testdata/perf"
+}
+
+Pop-Location


### PR DESCRIPTION
* Runs `go build` and `go vet` on the testdata/perf directory if it exists