### PR TITLE
Migrate to latest two versions of Go

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,12 +18,12 @@ jobs:
   - job: Build_Test
     strategy:
       matrix:
-        Linux_Go116:
-          pool.name: azsdk-pool-mms-ubuntu-2004-general
-          go.version: '1.16.7'
         Linux_Go117:
           pool.name: azsdk-pool-mms-ubuntu-2004-general
-          go.version: '1.17'
+          go.version: '1.17.8'
+        Linux_Go118:
+          pool.name: azsdk-pool-mms-ubuntu-2004-general
+          go.version: '1.18'
 
     pool:
       name: $(pool.name)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
@@ -15,22 +15,22 @@ stages:
         - template: ../variables/globals.yml
       strategy:
         matrix:
+          Linux_Go118:
+            pool.name: azsdk-pool-mms-ubuntu-2004-general
+            image.name: MMSUbuntu20.04
+            go.version: '1.18'
+          Windows_Go118:
+            pool.name: azsdk-pool-mms-win-2019-general
+            image.name: MMS2019
+            go.version: '1.18'
           Linux_Go117:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.17'
+            go.version: '1.17.8'
           Windows_Go117:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
-            go.version: '1.17'
-          Linux_Go116:
-            pool.name: azsdk-pool-mms-ubuntu-2004-general
-            image.name: MMSUbuntu20.04
-            go.version: '1.16.7'
-          Windows_Go116:
-            pool.name: azsdk-pool-mms-win-2019-general
-            image.name: MMS2019
-            go.version: '1.16.7'
+            go.version: '1.17.8'
       pool:
         name: $(pool.name)
         vmImage: $(image.name)
@@ -63,7 +63,7 @@ stages:
       steps:
       - task: GoTool@0
         inputs:
-          version: '1.17'
+          version: '1.18'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -79,23 +79,23 @@ stages:
         - template: ../variables/globals.yml
       strategy:
         matrix:
+          Linux_Go118:
+            pool.name: azsdk-pool-mms-ubuntu-2004-general
+            image.name: MMSUbuntu20.04
+            go.version: '1.18'
+          Windows_Go118:
+            pool.name: azsdk-pool-mms-win-2019-general
+            image.name: MMS2019
+            go.version: '1.18'
+            generate.bom: true
           Linux_Go117:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.17'
+            go.version: '1.17.8'
           Windows_Go117:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
-            go.version: '1.17'
-            generate.bom: true
-          Linux_Go116:
-            pool.name: azsdk-pool-mms-ubuntu-2004-general
-            image.name: MMSUbuntu20.04
-            go.version: '1.16.7'
-          Windows_Go116:
-            pool.name: azsdk-pool-mms-win-2019-general
-            image.name: MMS2019
-            go.version: '1.16.7'
+            go.version: '1.17.8'
       pool:
         name: $(pool.name)
         vmImage: $(image.name)
@@ -137,7 +137,7 @@ stages:
 
       - task: GoTool@0
         inputs:
-          version: '1.17'
+          version: '1.18'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/mgmt-mock-test.yml
+++ b/eng/pipelines/templates/jobs/mgmt-mock-test.yml
@@ -14,7 +14,7 @@ jobs:
       displayName: 'Install autorest'
     - task: GoTool@0
       inputs:
-        version: '1.17'
+        version: '1.18'
       displayName: "Select Go Version"
 
     - template: /eng/pipelines/templates/steps/create-go-workspace.yml

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,3 +1,3 @@
 variables:
-  GoLintCLIVersion: 'v1.23.6'
+  GoLintCLIVersion: 'v1.45.0'
   Package.EnableSBOMSigning: true

--- a/eng/tools/smoketests/cmd/root.go
+++ b/eng/tools/smoketests/cmd/root.go
@@ -60,7 +60,7 @@ func getVersion() string {
 	}
 
 	// Default, go is not from a tag
-	return "go 1.17"
+	return "go 1.18"
 }
 
 func inIgnoredDirectories(path string) bool {

--- a/sdk/azcore/internal/pipeline/request.go
+++ b/sdk/azcore/internal/pipeline/request.go
@@ -157,8 +157,7 @@ func (req *Request) Close() error {
 
 // Clone returns a deep copy of the request with its context changed to ctx.
 func (req *Request) Clone(ctx context.Context) *Request {
-	r2 := Request{}
-	r2 = *req
+	r2 := *req
 	r2.req = req.req.Clone(ctx)
 	return &r2
 }


### PR DESCRIPTION
Make 1.18 the default.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
