### PR TITLE
[azservicebus] Adding in support for embedded SharedAccessSignatures in connection strings

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Support for using a SharedAccessSignature in a connection string. Ex: `Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>` (#TBD)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/messaging/azservicebus/admin/admin_client.go
+++ b/sdk/messaging/azservicebus/admin/admin_client.go
@@ -32,6 +32,11 @@ type ClientOptions struct {
 }
 
 // NewClientFromConnectionString creates a Client authenticating using a connection string.
+// connectionString can be a Service Bus connection string for the namespace or for an entity, which contains a
+// SharedAccessKeyName and SharedAccessKey properties (for instance, from the Azure Portal):
+//   Endpoint=sb://<sb>.servicebus.windows.net/;SharedAccessKeyName=<key name>;SharedAccessKey=<key value>
+// Or it can be a connection string with a SharedAccessSignature:
+//   Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>
 func NewClientFromConnectionString(connectionString string, options *ClientOptions) (*Client, error) {
 	em, err := atom.NewEntityManagerWithConnectionString(connectionString, internal.Version)
 

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -86,7 +86,11 @@ func NewClient(fullyQualifiedNamespace string, credential azcore.TokenCredential
 
 // NewClientFromConnectionString creates a new Client for a Service Bus namespace using a connection string.
 // A Client allows you create receivers (for queues or subscriptions) and senders (for queues and topics).
-// connectionString is a Service Bus connection string for the namespace or for an entity.
+// connectionString can be a Service Bus connection string for the namespace or for an entity, which contains a
+// SharedAccessKeyName and SharedAccessKey properties (for instance, from the Azure Portal):
+//   Endpoint=sb://<sb>.servicebus.windows.net/;SharedAccessKeyName=<key name>;SharedAccessKey=<key value>
+// Or it can be a connection string with a SharedAccessSignature:
+//   Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>
 func NewClientFromConnectionString(connectionString string, options *ClientOptions) (*Client, error) {
 	if connectionString == "" {
 		return nil, errors.New("connectionString must not be empty")

--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3
-	github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.0.0-20211208010914-2b10e91d237e
+	github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.0.0-20220314210312-9302dcfe9a45
 	github.com/Azure/go-amqp v0.17.4
 	github.com/devigned/tab v0.1.1
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/sdk/messaging/azservicebus/go.sum
+++ b/sdk/messaging/azservicebus/go.sum
@@ -7,8 +7,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0/go.mod h1:TmXReXZ9yPp5D
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.2/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
-github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.0.0-20211208010914-2b10e91d237e h1:9n9b/dngBY5hfevx1jmEMbGvZGCcx1zAUaeYF8dk9Co=
-github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.0.0-20211208010914-2b10e91d237e/go.mod h1:7hMUlcqiMXDUJtU1EWQlhhkC4BfIr6pEsiyuRYq4xLQ=
+github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.0.0-20220314210312-9302dcfe9a45 h1:2iK++BgVHH5TR4I3zeVmikeiAxE/C/gisBNxMlv1UBw=
+github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.0.0-20220314210312-9302dcfe9a45/go.mod h1:7hMUlcqiMXDUJtU1EWQlhhkC4BfIr6pEsiyuRYq4xLQ=
 github.com/Azure/go-amqp v0.17.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/Azure/go-amqp v0.17.4 h1:6t9wEiwA4uXMRoUj3Cd3K2gmH8cW8ylizmBnSeF0bzM=
 github.com/Azure/go-amqp v0.17.4/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -163,7 +163,7 @@ func NewEntityManagerWithConnectionString(connectionString string, version strin
 		return nil, err
 	}
 
-	provider, err := sbauth.NewTokenProviderWithConnectionString(parsed.KeyName, parsed.Key)
+	provider, err := sbauth.NewTokenProviderWithConnectionString(parsed)
 
 	if err != nil {
 		return nil, err

--- a/sdk/messaging/azservicebus/internal/sbauth/token_provider.go
+++ b/sdk/messaging/azservicebus/internal/sbauth/token_provider.go
@@ -11,30 +11,42 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/internal/auth"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/internal/conn"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/internal/sas"
 )
 
 // TokenProvider handles access tokens and expiration calculation for SAS
 // keys (via connection strings) or TokenCredentials from Azure Identity.
 type TokenProvider struct {
-	core azcore.TokenCredential
-	sas  *sas.TokenProvider
+	tokenCred        azcore.TokenCredential
+	sasTokenProvider *sas.TokenProvider
 }
 
 // NewTokenProvider creates a tokenProvider from azcore.TokenCredential.
 func NewTokenProvider(tokenCredential azcore.TokenCredential) *TokenProvider {
-	return &TokenProvider{core: tokenCredential}
+	return &TokenProvider{tokenCred: tokenCredential}
 }
 
 // NewTokenProviderWithConnectionString creates a tokenProvider from a connection string.
-func NewTokenProviderWithConnectionString(keyName string, key string) (*TokenProvider, error) {
-	provider, err := sas.NewTokenProvider(sas.TokenProviderWithKey(keyName, key))
+func NewTokenProviderWithConnectionString(parsed *conn.ParsedConn) (*TokenProvider, error) {
+	// NOTE: this is the value we've been using since forever. AFAIK, it's arbitrary.
+	const defaultTokenExpiry = 2 * time.Hour
+
+	var authOption sas.TokenProviderOption
+
+	if parsed.SAS == "" {
+		authOption = sas.TokenProviderWithKey(parsed.KeyName, parsed.Key, defaultTokenExpiry)
+	} else {
+		authOption = sas.TokenProviderWithSAS(parsed.SAS)
+	}
+
+	provider, err := sas.NewTokenProvider(authOption)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &TokenProvider{sas: provider}, nil
+	return &TokenProvider{sasTokenProvider: provider}, nil
 }
 
 // singleUseTokenProvider allows you to wrap an *auth.Token so it can be used
@@ -68,7 +80,7 @@ func (tp *TokenProvider) GetTokenAsTokenProvider(uri string) (*singleUseTokenPro
 }
 
 func (tp *TokenProvider) getTokenImpl(uri string) (*auth.Token, time.Time, error) {
-	if tp.sas != nil {
+	if tp.sasTokenProvider != nil {
 		return tp.getSASToken(uri)
 	} else {
 		return tp.getAZCoreToken()
@@ -77,7 +89,7 @@ func (tp *TokenProvider) getTokenImpl(uri string) (*auth.Token, time.Time, error
 
 func (tpa *TokenProvider) getAZCoreToken() (*auth.Token, time.Time, error) {
 	// not sure if URI plays in here.
-	accessToken, err := tpa.core.GetToken(context.TODO(), policy.TokenRequestOptions{
+	accessToken, err := tpa.tokenCred.GetToken(context.TODO(), policy.TokenRequestOptions{
 		Scopes: []string{
 			"https://servicebus.azure.net//.default",
 		},
@@ -99,7 +111,7 @@ func (tpa *TokenProvider) getAZCoreToken() (*auth.Token, time.Time, error) {
 }
 
 func (tpa *TokenProvider) getSASToken(uri string) (*auth.Token, time.Time, error) {
-	authToken, err := tpa.sas.GetToken(uri)
+	authToken, err := tpa.sasTokenProvider.GetToken(uri)
 
 	if err != nil {
 		return nil, time.Time{}, err

--- a/sdk/messaging/azservicebus/internal/stress/tools/generate_sas.go
+++ b/sdk/messaging/azservicebus/internal/stress/tools/generate_sas.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tools
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/stress/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/internal/sas"
+)
+
+func GenerateSas(remainingArgs []string) int {
+	fs := flag.NewFlagSet("generatesas", flag.ExitOnError)
+
+	csVarName := fs.String("varname", "SERVICEBUS_CONNECTION_STRING", "The environment variable with a Service Bus connection string")
+	durationStr := fs.String("duration", "1h", "Duration that the SAS key will be valid for")
+
+	_ = shared.LoadEnvironment()
+
+	// parse the connection string.
+	connectionString := os.Getenv(*csVarName)
+
+	if connectionString == "" {
+		fmt.Printf("No connection string found in environment variable '%s'", *csVarName)
+		fs.PrintDefaults()
+		return 1
+	}
+
+	duration, err := time.ParseDuration(*durationStr)
+
+	if err != nil {
+		fmt.Printf("Duration '%s' was invalid: %s", *durationStr, err.Error())
+		fs.PrintDefaults()
+		return 1
+	}
+
+	cs, err := sas.CreateConnectionStringWithSAS(connectionString, duration)
+
+	if err != nil {
+		fmt.Printf("Failed to generate a connection with string with SAS: %s", err.Error())
+		return 1
+	}
+
+	fmt.Println(cs)
+	return 0
+}

--- a/sdk/messaging/azservicebus/internal/stress/tools/tools.go
+++ b/sdk/messaging/azservicebus/internal/stress/tools/tools.go
@@ -13,7 +13,7 @@ import (
 func Run(remainingArgs []string) {
 	onBadCommand := func() {
 		fmt.Printf("ERROR: missing tool name\n")
-		fmt.Printf("Usage: stress tools (delete)\n")
+		fmt.Printf("Usage: stress tools (delete|constantupdate|tempqueue|generatesas)\n")
 		os.Exit(1)
 	}
 
@@ -30,6 +30,8 @@ func Run(remainingArgs []string) {
 		ec = ConstantlyUpdateQueue(remainingArgs[1:])
 	case "tempqueue":
 		ec = CreateTempQueue(remainingArgs[1:])
+	case "generatesas":
+		ec = GenerateSas(remainingArgs[1:])
 	default:
 		onBadCommand()
 	}


### PR DESCRIPTION
Adding support for parity with other Service Bus libraries allow you pass a connection string with a SharedAccessSignature, rather than an embedded SharedKey.

Fixes #16641