### PR TITLE
[azservicebus] Fixing batch algorithm to calculate accurately

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Features Added
 
-- Support for using a SharedAccessSignature in a connection string. Ex: `Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>` (#TBD)
+- Support for using a SharedAccessSignature in a connection string. Ex: `Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>` (#17314)
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- Fixed bug where message batch size calculation was inaccurate, resulting in batches that were too large to be sent. (#17318)
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/message_batch_test.go
+++ b/sdk/messaging/azservicebus/message_batch_test.go
@@ -7,23 +7,74 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/require"
 )
 
+func TestMessageBatchConstants(t *testing.T) {
+	smallBytes := [255]byte{0} // 'vbin8'
+	largeBytes := [256]byte{0} // 'vbin32'
+
+	require.Greater(t, calcActualSizeForPayload(largeBytes[:]), calcActualSizeForPayload(smallBytes[:]))
+
+	require.EqualValues(t, calcActualSizeForPayload(smallBytes[:]), mustEncode(t, &amqp.Message{Data: [][]byte{smallBytes[:]}}))
+	require.EqualValues(t, calcActualSizeForPayload(smallBytes[:])*2, mustEncode(t, &amqp.Message{Data: [][]byte{smallBytes[:], smallBytes[:]}}))
+
+	require.EqualValues(t, calcActualSizeForPayload(largeBytes[:]), mustEncode(t, &amqp.Message{Data: [][]byte{largeBytes[:]}}))
+	require.EqualValues(t, calcActualSizeForPayload(largeBytes[:])*2, mustEncode(t, &amqp.Message{Data: [][]byte{largeBytes[:], largeBytes[:]}}))
+
+	require.EqualValues(t, calcActualSizeForPayload(largeBytes[:])+calcActualSizeForPayload(smallBytes[:]), mustEncode(t, &amqp.Message{Data: [][]byte{smallBytes[:], largeBytes[:]}}))
+}
+
 func TestMessageBatchUnitTests(t *testing.T) {
-	t.Run("addMessages", func(t *testing.T) {
-		mb := newMessageBatch(1000)
+	as2k := [2048]byte{'A'}
+
+	t.Run("sizeCalculationsAreCorrectVBin8", func(t *testing.T) {
+		mb := newMessageBatch(8000)
 
 		err := mb.AddMessage(&Message{
-			Body: []byte("hello world"),
+			Body: []byte("small body"),
+			ApplicationProperties: map[string]interface{}{
+				"small": "value",
+			},
 		})
 
 		require.NoError(t, err)
 		require.EqualValues(t, 1, mb.NumMessages())
-		require.EqualValues(t, 183, mb.NumBytes())
+		require.EqualValues(t, 196, mb.NumBytes())
+
+		actualBytes, err := mb.toAMQPMessage().MarshalBinary()
+		require.NoError(t, err)
+
+		require.Equal(t, 196, len(actualBytes))
 	})
 
-	t.Run("addTooManyMessages", func(t *testing.T) {
+	t.Run("sizeCalculationsAreCorrectVBin32", func(t *testing.T) {
+		mb := newMessageBatch(8000)
+
+		err := mb.AddMessage(&Message{
+			Body: []byte("small body"),
+			ApplicationProperties: map[string]interface{}{
+				"hello":      "world",
+				"anInt":      100,
+				"aFLoat":     100.1,
+				"lotsOfData": string(as2k[:]),
+			},
+		})
+
+		require.NoError(t, err)
+		require.EqualValues(t, 1, mb.NumMessages())
+		require.EqualValues(t, 4381, mb.NumBytes())
+
+		actualBytes, err := mb.toAMQPMessage().MarshalBinary()
+		require.NoError(t, err)
+
+		require.Equal(t, 4381, len(actualBytes))
+	})
+
+	// the first message gets special treatment since it gets used as the actual
+	// batch message's envelope.
+	t.Run("firstMessageTooLarge", func(t *testing.T) {
 		mb := newMessageBatch(1)
 
 		err := mb.AddMessage(&Message{
@@ -31,6 +82,31 @@ func TestMessageBatchUnitTests(t *testing.T) {
 		})
 
 		require.EqualError(t, err, ErrMessageTooLarge.Error())
+
+		require.EqualValues(t, 0, mb.NumBytes())
+		require.EqualValues(t, 0, len(mb.marshaledMessages))
+	})
+
+	t.Run("addTooManyMessages", func(t *testing.T) {
+		mb := newMessageBatch(200)
+
+		require.EqualValues(t, 0, mb.currentSize)
+		err := mb.AddMessage(&Message{
+			Body: []byte("hello world"),
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 145, mb.currentSize)
+
+		sizeBefore := mb.NumBytes()
+		countBefore := mb.NumMessages()
+
+		err = mb.AddMessage(&Message{
+			Body: as2k[:],
+		})
+		require.EqualError(t, err, ErrMessageTooLarge.Error())
+
+		require.Equal(t, sizeBefore, mb.NumBytes(), "size is unchanged when a message fails to get added")
+		require.Equal(t, countBefore, mb.NumMessages(), "count is unchanged when a message fails to get added")
 	})
 
 	t.Run("addConcurrently", func(t *testing.T) {
@@ -54,4 +130,10 @@ func TestMessageBatchUnitTests(t *testing.T) {
 		wg.Wait()
 		require.EqualValues(t, 100, mb.NumMessages())
 	})
+}
+
+func mustEncode(t *testing.T, msg *amqp.Message) int {
+	bytes, err := msg.MarshalBinary()
+	require.NoError(t, err)
+	return len(bytes)
 }


### PR DESCRIPTION
Message batches were being calculated incorrectly, using an assumed fixed size overhead which wasn't accurate. We're now doing this dynamically. 

This also made it so I could fix a stress test that's been broken because of the batch size.

Fixes #16090
Fixes #15562