### PR TITLE
[azservicebus] Fixing a few errors related to either cleanup or closing

### DIFF
--- a/sdk/messaging/azservicebus/admin/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_test.go
@@ -506,7 +506,7 @@ func TestAdminClient_ListTopics(t *testing.T) {
 
 		go func(i int) {
 			defer wg.Done()
-			_, err = adminClient.CreateTopic(context.Background(), topicName, &TopicProperties{
+			_, err := adminClient.CreateTopic(context.Background(), topicName, &TopicProperties{
 				DefaultMessageTimeToLive: toDurationPtr(time.Duration(i+1) * time.Minute),
 			}, nil)
 			require.NoError(t, err)

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -308,8 +307,6 @@ func (client *Client) AcceptNextSessionForSubscription(ctx context.Context, topi
 // Close closes the current connection Service Bus as well as any Senders or Receivers created
 // using this client.
 func (client *Client) Close(ctx context.Context) error {
-	var lastError error
-
 	var links []internal.Closeable
 
 	client.linksMu.Lock()
@@ -322,15 +319,11 @@ func (client *Client) Close(ctx context.Context) error {
 
 	for _, link := range links {
 		if err := link.Close(ctx); err != nil {
-			log.Writef(internal.EventConn, "Failed to close links (error might be cached): %s", err.Error())
-			lastError = err
+			log.Writef(internal.EventConn, "Failed to close link (error might be cached): %s", err.Error())
 		}
 	}
 
-	if lastError != nil {
-		return fmt.Errorf("errors while closing links: %w", lastError)
-	}
-	return nil
+	return client.namespace.Close(ctx, true)
 }
 
 func (client *Client) addCloseable(id uint64, closeable internal.Closeable) {

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -93,8 +93,8 @@ type AMQPLinksImpl struct {
 	// Recover() does not affect this value.
 	closedPermanently bool
 
-	cancelAuthRefreshLink     func() <-chan struct{}
-	cancelAuthRefreshMgmtLink func() <-chan struct{}
+	cancelAuthRefreshLink     func()
+	cancelAuthRefreshMgmtLink func()
 
 	ns NamespaceForAMQPLinks
 }
@@ -379,7 +379,7 @@ func (l *AMQPLinksImpl) CloseIfNeeded(ctx context.Context, err error) recoveryKi
 		_ = l.closeWithoutLocking(ctx, false)
 		return rk
 	case RecoveryKindConn:
-		_ = l.ns.Close(ctx)
+		_ = l.ns.Close(ctx, false)
 		_ = l.closeWithoutLocking(ctx, false)
 		return rk
 	case RecoveryKindFatal:
@@ -399,7 +399,7 @@ func (l *AMQPLinksImpl) initWithoutLocking(ctx context.Context) error {
 	_ = l.closeWithoutLocking(ctx, false)
 
 	var err error
-	l.cancelAuthRefreshLink, err = l.ns.NegotiateClaim(ctx, l.entityPath)
+	l.cancelAuthRefreshLink, _, err = l.ns.NegotiateClaim(ctx, l.entityPath)
 
 	if err != nil {
 		if err := l.closeWithoutLocking(ctx, false); err != nil {
@@ -408,7 +408,7 @@ func (l *AMQPLinksImpl) initWithoutLocking(ctx context.Context) error {
 		return err
 	}
 
-	l.cancelAuthRefreshMgmtLink, err = l.ns.NegotiateClaim(ctx, l.managementPath)
+	l.cancelAuthRefreshMgmtLink, _, err = l.ns.NegotiateClaim(ctx, l.managementPath)
 
 	if err != nil {
 		if err := l.closeWithoutLocking(ctx, false); err != nil {

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -93,7 +93,7 @@ func TestAMQPLinksLive(t *testing.T) {
 	ns, err := NewNamespace(NamespaceWithConnectionString(cs))
 	require.NoError(t, err)
 
-	defer func() { _ = ns.Close(context.Background()) }()
+	defer func() { _ = ns.Close(context.Background(), false) }()
 
 	createLinksCalled := 0
 
@@ -148,7 +148,7 @@ func TestAMQPLinksLive(t *testing.T) {
 }
 
 func TestAMQPLinksLiveRecoverLink(t *testing.T) {
-	// we're not going to use this client for tehse tests.
+	// we're not going to use this client for these tests.
 	entityPath, cleanup := test.CreateExpiringQueue(t, nil)
 	defer cleanup()
 
@@ -156,7 +156,7 @@ func TestAMQPLinksLiveRecoverLink(t *testing.T) {
 	ns, err := NewNamespace(NamespaceWithConnectionString(cs))
 	require.NoError(t, err)
 
-	defer func() { _ = ns.Close(context.Background()) }()
+	defer func() { _ = ns.Close(context.Background(), false) }()
 
 	createLinksCalled := 0
 
@@ -184,7 +184,7 @@ func TestAMQPLinksLiveRace(t *testing.T) {
 	ns, err := NewNamespace(NamespaceWithConnectionString(cs))
 	require.NoError(t, err)
 
-	defer func() { _ = ns.Close(context.Background()) }()
+	defer func() { _ = ns.Close(context.Background(), false) }()
 
 	createLinksCalled := 0
 
@@ -218,7 +218,7 @@ func TestAMQPLinksLiveRaceLink(t *testing.T) {
 	ns, err := NewNamespace(NamespaceWithConnectionString(cs))
 	require.NoError(t, err)
 
-	defer func() { _ = ns.Close(context.Background()) }()
+	defer func() { _ = ns.Close(context.Background(), false) }()
 
 	createLinksCalled := 0
 
@@ -254,7 +254,7 @@ func TestAMQPLinksRetry(t *testing.T) {
 	ns, err := NewNamespace(NamespaceWithConnectionString(cs))
 	require.NoError(t, err)
 
-	defer func() { _ = ns.Close(context.Background()) }()
+	defer func() { _ = ns.Close(context.Background(), false) }()
 
 	createLinksCalled := 0
 
@@ -286,7 +286,7 @@ func TestAMQPLinksMultipleWithSameConnection(t *testing.T) {
 	ns, err := NewNamespace(NamespaceWithConnectionString(cs))
 	require.NoError(t, err)
 
-	defer func() { _ = ns.Close(context.Background()) }()
+	defer func() { _ = ns.Close(context.Background(), false) }()
 
 	createLinksCalled := 0
 
@@ -327,7 +327,7 @@ func TestAMQPLinksMultipleWithSameConnection(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		err = links2.RecoverIfNeeded(context.Background(), lwr2.ID, &amqp.DetachError{})
+		err := links2.RecoverIfNeeded(context.Background(), lwr2.ID, &amqp.DetachError{})
 		require.NoError(t, err)
 	}()
 

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -187,15 +187,13 @@ func (s *FakeAMQPSession) Close(ctx context.Context) error {
 	return nil
 }
 
-func (ns *FakeNS) NegotiateClaim(ctx context.Context, entityPath string) (func() <-chan struct{}, error) {
+func (ns *FakeNS) NegotiateClaim(ctx context.Context, entityPath string) (context.CancelFunc, <-chan struct{}, error) {
 	ch := make(chan struct{})
 	close(ch)
 
 	ns.claimNegotiated++
 
-	return func() <-chan struct{} {
-		return ch
-	}, nil
+	return func() {}, ch, nil
 }
 
 func (ns *FakeNS) GetEntityAudience(entityPath string) string {
@@ -216,8 +214,12 @@ func (ns *FakeNS) Recover(ctx context.Context, clientRevision uint64) (bool, err
 	return true, nil
 }
 
-func (ns *FakeNS) Close(ctx context.Context) error {
+func (ns *FakeNS) Close(ctx context.Context, permanently bool) error {
 	ns.CloseCalled++
+	return nil
+}
+
+func (ns *FakeNS) Check() error {
 	return nil
 }
 

--- a/sdk/messaging/azservicebus/internal/namespace_test.go
+++ b/sdk/messaging/azservicebus/internal/namespace_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/sbauth"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/test"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/internal/auth"
 	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/require"
@@ -51,7 +52,7 @@ func TestNamespaceNegotiateClaim(t *testing.T) {
 	}
 
 	// fire off a basic negotiate claim. The renewal duration is so long that it won't run - that's a separate test.
-	cancel, err := ns.startNegotiateClaimRenewer(
+	cancel, _, err := ns.startNegotiateClaimRenewer(
 		context.Background(),
 		"my entity path",
 		cbsNegotiateClaim,
@@ -107,7 +108,7 @@ func TestNamespaceNegotiateClaimRenewal(t *testing.T) {
 	nextRefreshDurationChecks := 0
 
 	// fire off a basic negotiate claim. The renewal duration is so long that it won't run - that's a separate test.
-	cancel, err := ns.startNegotiateClaimRenewer(
+	cancel, _, err := ns.startNegotiateClaimRenewer(
 		context.Background(),
 		"my entity path",
 		cbsNegotiateClaim, getAMQPClient, func(expirationTimeParam, currentTime time.Time) time.Duration {
@@ -137,7 +138,7 @@ func TestNamespaceNegotiateClaimFailsToGetClient(t *testing.T) {
 		TokenProvider: sbauth.NewTokenProvider(&fakeTokenCredential{expires: time.Now()}),
 	}
 
-	cancel, err := ns.startNegotiateClaimRenewer(
+	cancel, _, err := ns.startNegotiateClaimRenewer(
 		context.Background(),
 		"entity path",
 		func(ctx context.Context, audience string, conn *amqp.Client, provider auth.TokenProvider) error {
@@ -170,22 +171,19 @@ func TestNamespaceNegotiateClaimNonRenewableToken(t *testing.T) {
 	}
 
 	// since the token is non-renewable we will just do the single cbsNegotiateClaim call and never renew.
-	cancel, err := ns.startNegotiateClaimRenewer(
+	_, done, err := ns.startNegotiateClaimRenewer(
 		context.Background(),
 		"my entity path",
 		cbsNegotiateClaim, func(ctx context.Context) (*amqp.Client, uint64, error) { return &amqp.Client{}, 0, nil },
 		func(expirationTimeParam, currentTime time.Time) time.Duration {
 			panic("Won't be called, no refreshing of claims will be done")
 		})
-	defer cancel()
-
-	time.Sleep(3 * time.Second) // make sure, even given additional time, that we never attempted to renew the token
 
 	require.NoError(t, err)
 	require.Equal(t, 1, cbsNegotiateClaimCalled)
 
 	select {
-	case <-cancel():
+	case <-done:
 	default:
 		require.Fail(t, "cancel() returns a channel that is already Done()")
 	}
@@ -196,7 +194,7 @@ func TestNamespaceNegotiateClaimFails(t *testing.T) {
 		TokenProvider: sbauth.NewTokenProvider(&fakeTokenCredential{expires: time.Now()}),
 	}
 
-	cancel, err := ns.startNegotiateClaimRenewer(
+	cancel, _, err := ns.startNegotiateClaimRenewer(
 		context.Background(),
 		"entity path",
 		func(ctx context.Context, audience string, conn *amqp.Client, provider auth.TokenProvider) error {
@@ -210,6 +208,50 @@ func TestNamespaceNegotiateClaimFails(t *testing.T) {
 
 	require.EqualError(t, err, "NegotiateClaim amqp.Client failed")
 	require.Nil(t, cancel)
+}
+
+func TestNamespaceNegotiateClaimFatalErrors(t *testing.T) {
+	ns := &Namespace{
+		TokenProvider: sbauth.NewTokenProvider(&fakeTokenCredential{expires: time.Now()}),
+	}
+
+	cbsNegotiateClaimCalled := 0
+
+	cbsNegotiateClaim := func(ctx context.Context, audience string, conn *amqp.Client, provider auth.TokenProvider) error {
+		cbsNegotiateClaimCalled++
+
+		// work the first time, fail on renewals.
+		if cbsNegotiateClaimCalled > 1 {
+			return errNonRetriable{Message: "non retriable error message"}
+		}
+
+		return nil
+	}
+
+	var logs []string
+	cleanupLoggers := test.CaptureLogsForTest(&logs)
+	defer cleanupLoggers()
+
+	_, done, err := ns.startNegotiateClaimRenewer(
+		context.Background(),
+		"entity path",
+		cbsNegotiateClaim, func(ctx context.Context) (*amqp.Client, uint64, error) {
+			return &amqp.Client{}, 0, nil
+		}, func(expirationTime, currentTime time.Time) time.Duration {
+			// instant renewals.
+			return 0
+		})
+
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+		// check the log messages - we should have one telling us why we stopped the claims loop
+		require.Contains(t, logs, "[azsb.Auth] [entity path] fatal error, stopping token refresh loop: non retriable error message")
+	case <-time.After(3 * time.Second):
+		// was locked! Should have been closed.
+		require.Fail(t, "claim renewal was automatically cancelled because of a non-retriable error")
+	}
 }
 
 func TestNamespaceNextClaimRefreshDuration(t *testing.T) {

--- a/sdk/messaging/azservicebus/internal/namespace_test.go
+++ b/sdk/messaging/azservicebus/internal/namespace_test.go
@@ -228,9 +228,8 @@ func TestNamespaceNegotiateClaimFatalErrors(t *testing.T) {
 		return nil
 	}
 
-	var logs []string
-	cleanupLoggers := test.CaptureLogsForTest(&logs)
-	defer cleanupLoggers()
+	endCapture := test.CaptureLogsForTest()
+	defer endCapture()
 
 	_, done, err := ns.startNegotiateClaimRenewer(
 		context.Background(),
@@ -246,6 +245,7 @@ func TestNamespaceNegotiateClaimFatalErrors(t *testing.T) {
 
 	select {
 	case <-done:
+		logs := endCapture()
 		// check the log messages - we should have one telling us why we stopped the claims loop
 		require.Contains(t, logs, "[azsb.Auth] [entity path] fatal error, stopping token refresh loop: non retriable error message")
 	case <-time.After(3 * time.Second):

--- a/sdk/messaging/azservicebus/internal/test/test_helpers.go
+++ b/sdk/messaging/azservicebus/internal/test/test_helpers.go
@@ -84,14 +84,44 @@ func CreateExpiringQueue(t *testing.T, qd *atom.QueueDescription) (string, func(
 	}
 }
 
-// CaptureLogsForTest adds a listener that appends to your `logMessages`
-// slice.
-// Returns a function that should be called to unregister our listener.
-func CaptureLogsForTest(logMessages *[]string) func() {
+// CaptureLogsForTest adds a logging listener which captures messages to an
+// internal channel.
+// Returns a function that ends log capturing and returns any captured messages.
+// It's safe to call endCapture() multiple times, so a simple call pattern is:
+//
+//   endCapture := CaptureLogsForTest()
+//   defer endCapture()				// ensure cleanup in case of test assert failures
+//
+//   /* some test code */
+//
+//   messages := endCapture()
+//   /* do inspection of log messages */
+//
+func CaptureLogsForTest() func() []string {
+	messagesCh := make(chan string, 10000)
+
 	setAzLogListener(func(e azlog.Event, s string) {
-		*logMessages = append(*logMessages, fmt.Sprintf("[%s] %s", e, s))
+		messagesCh <- fmt.Sprintf("[%s] %s", e, s)
 	})
-	return func() { setAzLogListener(nil) }
+
+	return func() []string {
+		if messagesCh == nil {
+			// already been closed, probably manually.
+			return nil
+		}
+
+		setAzLogListener(nil)
+		close(messagesCh)
+
+		var messages []string
+
+		for msg := range messagesCh {
+			messages = append(messages, msg)
+		}
+
+		messagesCh = nil
+		return messages
+	}
 }
 
 // EnableStdoutLogging turns on logging to stdout for diagnostics.

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -122,6 +122,10 @@ type newReceiverArgs struct {
 }
 
 func newReceiver(args newReceiverArgs, options *ReceiverOptions) (*Receiver, error) {
+	if err := args.ns.Check(); err != nil {
+		return nil, err
+	}
+
 	receiver := &Receiver{
 		lastPeekedSequenceNumber: 0,
 		cleanupOnClose:           args.cleanupOnClose,

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -445,9 +445,7 @@ func TestReceiverDetachWithPeekLock(t *testing.T) {
 
 func TestReceiverDetachWithReceiveAndDelete(t *testing.T) {
 	// NOTE: uncomment this to see some of the background reconnects
-	// azlog.SetListener(func(e azlog.Event, s string) {
-	// 	log.Printf("%s %s", e, s)
-	// })
+	// test.EnableStdoutLogging
 
 	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -147,6 +147,10 @@ type newSenderArgs struct {
 }
 
 func newSender(args newSenderArgs, retryOptions RetryOptions) (*Sender, error) {
+	if err := args.ns.Check(); err != nil {
+		return nil, err
+	}
+	
 	sender := &Sender{
 		queueOrTopic:   args.queueOrTopic,
 		cleanupOnClose: args.cleanupOnClose,

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -150,7 +150,7 @@ func newSender(args newSenderArgs, retryOptions RetryOptions) (*Sender, error) {
 	if err := args.ns.Check(); err != nil {
 		return nil, err
 	}
-	
+
 	sender := &Sender{
 		queueOrTopic:   args.queueOrTopic,
 		cleanupOnClose: args.cleanupOnClose,

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -286,9 +286,7 @@ func Test_Sender_ScheduleMessages(t *testing.T) {
 
 func TestSender_SendMessagesDetach(t *testing.T) {
 	// NOTE: uncomment this to see some of the background reconnects
-	// azlog.SetListener(func(e azlog.Event, s string) {
-	// 	log.Printf("%s %s", e, s)
-	// })
+	// test.EnableStdoutLogging
 
 	sbc, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()


### PR DESCRIPTION
Fixing a few errors related to either cleanup or closing:
- negotiateClaim() would cycle infinitely if there was a fatal error, rather than exiting
- the func() returned from negotiateClaim would return before the claim loop had completely exited. Not fatal, but the intention was that there was no further claim activity after the cancel func was called. Fixed.
 - Connection was not being by client.Close(). Also, added in a "permanent close" error that gets returned from all the normal spots.
- Fixing some race conditions that were in the _test_ code

Fixes #17183