### PR TITLE
Fix performance test build task

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -62,7 +62,7 @@ steps:
       ${{ insert }}: ${{ parameters.EnvVars }}
 
   - task: PowerShell@2
-    display: 'Build Performance Tests'
+    displayName: 'Build Performance Tests'
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/Build_Perf.ps1


### PR DESCRIPTION
Fixes invalid yaml syntax introduced in #17306 (related to #17364 as well).

The template pipeline triggers against `eng/` changes to catch potential issues. If there are syntactic errors in the yaml then the pipeline "fails to run" which isn't a valid criteria/event to get posted back to the check runs.

For example: [failing pipeline](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1456127&view=results)

Currently, the only way to verify eng pipeline yaml changes are valid would be to manually invoke the pipeline like `/azp run go - aztemplate` and make sure it was successfully run. I'm not sure if it's going to be possible to get the check runs to detect pipeline initialization failures.
