### PR TITLE
Fix pkg.go.dev link for certificates README

### DIFF
--- a/sdk/keyvault/azcertificates/README.md
+++ b/sdk/keyvault/azcertificates/README.md
@@ -123,7 +123,7 @@ func main() {
 		panic(err)
 	}
 
-	client, err = azcertificates.NewClient("https://my-key-vault.vault.azure.net/", credential, nil)
+	client, err := azcertificates.NewClient("https://my-key-vault.vault.azure.net/", credential, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -162,7 +162,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	client, err = azcertificates.NewClient("https://my-key-vault.vault.azure.net/", credential, nil)
+	client, err := azcertificates.NewClient("https://my-key-vault.vault.azure.net/", credential, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -450,7 +450,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [azure_sub]: https://azure.microsoft.com/free/
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [keyvault_docs]: https://docs.microsoft.com/azure/key-vault/
-[pkggodev_azcerts]: https://pypi.org/project/azure-keyvault-certificates/
+[pkggodev_azcerts]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/keyvault/azcertificates
 [certificate_client_docs]: https://aka.ms/azsdk/go/azcertificates
 [rbac_guide]: https://docs.microsoft.com/azure/key-vault/general/rbac-guide
 [reference_docs]: https://aka.ms/azsdk/go/azcertificates


### PR DESCRIPTION
The link right now is going to the Python library. Also fixed a couple errors in the sample code.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
