### PR TITLE
[azservicebus] Handle 410 properly for session and non-session based links.

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - Support for using a SharedAccessSignature in a connection string. Ex: `Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>` (#17314)
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fixed bug where message batch size calculation was inaccurate, resulting in batches that were too large to be sent. (#17318)
-
-### Other Changes
+- Fixing an issue with an entity not being found leading to a longer timeout than needed. (#17279)
+- Fixed the RPCLink so it does better handling of connection/link failures. (#17389)
+- Fixed issue where a message lock expiring would cause unnecessary retries. These retries could cause message settlement calls (ex: Receiver.CompleteMessage) 
+  to appear to hang. (#17382)
 
 ## 0.3.6 (2022-03-08)
 

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -156,9 +156,10 @@ func newClientImpl(creds clientCreds, options *ClientOptions) (*Client, error) {
 func (client *Client) NewReceiverForQueue(queueName string, options *ReceiverOptions) (*Receiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	receiver, err := newReceiver(newReceiverArgs{
-		cleanupOnClose: cleanupOnClose,
-		ns:             client.namespace,
-		entity:         entity{Queue: queueName},
+		cleanupOnClose:      cleanupOnClose,
+		ns:                  client.namespace,
+		entity:              entity{Queue: queueName},
+		getRecoveryKindFunc: internal.GetRecoveryKind,
 	}, options)
 
 	if err != nil {
@@ -173,9 +174,10 @@ func (client *Client) NewReceiverForQueue(queueName string, options *ReceiverOpt
 func (client *Client) NewReceiverForSubscription(topicName string, subscriptionName string, options *ReceiverOptions) (*Receiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	receiver, err := newReceiver(newReceiverArgs{
-		cleanupOnClose: cleanupOnClose,
-		ns:             client.namespace,
-		entity:         entity{Topic: topicName, Subscription: subscriptionName},
+		cleanupOnClose:      cleanupOnClose,
+		ns:                  client.namespace,
+		entity:              entity{Topic: topicName, Subscription: subscriptionName},
+		getRecoveryKindFunc: internal.GetRecoveryKind,
 	}, options)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -346,5 +346,5 @@ func assertRPCNotFound(t *testing.T, err error) {
 	}
 
 	require.ErrorAs(t, err, &rpcError)
-	require.Equal(t, 404, rpcError.RPCCode())
+	require.Equal(t, internal.RPCResponseCodeNotFound, rpcError.RPCCode())
 }

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -346,5 +347,5 @@ func assertRPCNotFound(t *testing.T, err error) {
 	}
 
 	require.ErrorAs(t, err, &rpcError)
-	require.Equal(t, internal.RPCResponseCodeNotFound, rpcError.RPCCode())
+	require.Equal(t, http.StatusNotFound, rpcError.RPCCode())
 }

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -72,8 +72,13 @@ func TestAMQPLinksBasic(t *testing.T) {
 	ns, err := NewNamespace(NamespaceWithConnectionString(cs))
 	require.NoError(t, err)
 
-	links := NewAMQPLinks(ns, entityPath, func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-		return newLinksForAMQPLinksTest(entityPath, session)
+	links := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: entityPath,
+		CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+			return newLinksForAMQPLinksTest(entityPath, session)
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
 	})
 
 	defer func() {
@@ -102,9 +107,14 @@ func TestAMQPLinksLive(t *testing.T) {
 
 	createLinksCalled := 0
 
-	links := NewAMQPLinks(ns, entityPath, func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-		createLinksCalled++
-		return newLinksForAMQPLinksTest(entityPath, session)
+	links := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: entityPath,
+		CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+			createLinksCalled++
+			return newLinksForAMQPLinksTest(entityPath, session)
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
 	})
 
 	defer func() {
@@ -170,9 +180,14 @@ func TestAMQPLinksLiveRecoverLink(t *testing.T) {
 
 	createLinksCalled := 0
 
-	links := NewAMQPLinks(ns, entityPath, func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-		createLinksCalled++
-		return newLinksForAMQPLinksTest(entityPath, session)
+	links := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: entityPath,
+		CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+			createLinksCalled++
+			return newLinksForAMQPLinksTest(entityPath, session)
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
 	})
 
 	defer func() {
@@ -203,9 +218,14 @@ func TestAMQPLinksLiveRace(t *testing.T) {
 
 	createLinksCalled := 0
 
-	links := NewAMQPLinks(ns, entityPath, func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-		createLinksCalled++
-		return newLinksForAMQPLinksTest(entityPath, session)
+	links := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: entityPath,
+		CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+			createLinksCalled++
+			return newLinksForAMQPLinksTest(entityPath, session)
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
 	})
 
 	defer func() {
@@ -250,9 +270,14 @@ func TestAMQPLinksLiveRaceLink(t *testing.T) {
 
 	createLinksCalled := 0
 
-	links := NewAMQPLinks(ns, entityPath, func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-		createLinksCalled++
-		return newLinksForAMQPLinksTest(entityPath, session)
+	links := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: entityPath,
+		CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+			createLinksCalled++
+			return newLinksForAMQPLinksTest(entityPath, session)
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
 	})
 
 	defer func() {
@@ -289,9 +314,14 @@ func TestAMQPLinksRetry(t *testing.T) {
 
 	createLinksCalled := 0
 
-	links := NewAMQPLinks(ns, entityPath, func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-		createLinksCalled++
-		return newLinksForAMQPLinksTest(entityPath, session)
+	links := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: entityPath,
+		CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+			createLinksCalled++
+			return newLinksForAMQPLinksTest(entityPath, session)
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
 	})
 
 	defer func() {
@@ -326,9 +356,14 @@ func TestAMQPLinksMultipleWithSameConnection(t *testing.T) {
 
 	createLinksCalled := 0
 
-	links := NewAMQPLinks(ns, entityPath, func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-		createLinksCalled++
-		return newLinksForAMQPLinksTest(entityPath, session)
+	links := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: entityPath,
+		CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+			createLinksCalled++
+			return newLinksForAMQPLinksTest(entityPath, session)
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
 	})
 
 	defer func() {
@@ -337,9 +372,14 @@ func TestAMQPLinksMultipleWithSameConnection(t *testing.T) {
 
 	createLinksCalled2 := 0
 
-	links2 := NewAMQPLinks(ns, entityPath, func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-		createLinksCalled2++
-		return newLinksForAMQPLinksTest(entityPath, session)
+	links2 := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: entityPath,
+		CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+			createLinksCalled2++
+			return newLinksForAMQPLinksTest(entityPath, session)
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
 	})
 
 	defer func() {
@@ -411,8 +451,13 @@ func TestAMQPLinksCloseIfNeeded(t *testing.T) {
 			sender := &FakeAMQPSender{}
 			ns := &FakeNS{}
 
-			links := NewAMQPLinks(ns, "entityPath", func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-				return sender, receiver, nil
+			links := NewAMQPLinks(NewAMQPLinksArgs{
+				NS:         ns,
+				EntityPath: "entityPath",
+				CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+					return sender, receiver, nil
+				},
+				GetRecoveryKindFunc: GetRecoveryKind,
 			})
 
 			defer func() {
@@ -436,8 +481,13 @@ func TestAMQPLinksCloseIfNeeded(t *testing.T) {
 		sender := &FakeAMQPSender{}
 		ns := &FakeNS{}
 
-		links := NewAMQPLinks(ns, "entityPath", func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-			return sender, receiver, nil
+		links := NewAMQPLinks(NewAMQPLinksArgs{
+			NS:         ns,
+			EntityPath: "entityPath",
+			CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+				return sender, receiver, nil
+			},
+			GetRecoveryKindFunc: GetRecoveryKind,
 		})
 
 		defer func() {
@@ -460,8 +510,13 @@ func TestAMQPLinksCloseIfNeeded(t *testing.T) {
 		sender := &FakeAMQPSender{}
 		ns := &FakeNS{}
 
-		links := NewAMQPLinks(ns, "entityPath", func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-			return sender, receiver, nil
+		links := NewAMQPLinks(NewAMQPLinksArgs{
+			NS:         ns,
+			EntityPath: "entityPath",
+			CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+				return sender, receiver, nil
+			},
+			GetRecoveryKindFunc: GetRecoveryKind,
 		})
 
 		defer func() {
@@ -484,8 +539,13 @@ func TestAMQPLinksCloseIfNeeded(t *testing.T) {
 		sender := &FakeAMQPSender{}
 		ns := &FakeNS{}
 
-		links := NewAMQPLinks(ns, "entityPath", func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-			return sender, receiver, nil
+		links := NewAMQPLinks(NewAMQPLinksArgs{
+			NS:         ns,
+			EntityPath: "entityPath",
+			CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+				return sender, receiver, nil
+			},
+			GetRecoveryKindFunc: GetRecoveryKind,
 		})
 
 		defer func() {
@@ -542,8 +602,13 @@ func TestAMQPLinksRetriesUnit(t *testing.T) {
 			sender := &FakeAMQPSender{}
 			ns := &FakeNS{}
 
-			links := NewAMQPLinks(ns, "entityPath", func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-				return sender, receiver, nil
+			links := NewAMQPLinks(NewAMQPLinksArgs{
+				NS:         ns,
+				EntityPath: "entityPath",
+				CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+					return sender, receiver, nil
+				},
+				GetRecoveryKindFunc: GetRecoveryKind,
 			})
 
 			defer func() {
@@ -581,8 +646,13 @@ func TestAMQPLinks_Logging(t *testing.T) {
 		receiver := &FakeAMQPReceiver{}
 		ns := &FakeNS{}
 
-		links := NewAMQPLinks(ns, "entityPath", func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-			return nil, receiver, nil
+		links := NewAMQPLinks(NewAMQPLinksArgs{
+			NS:         ns,
+			EntityPath: "entityPath",
+			CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+				return nil, receiver, nil
+			},
+			GetRecoveryKindFunc: GetRecoveryKind,
 		})
 
 		defer func() {
@@ -609,8 +679,12 @@ func TestAMQPLinks_Logging(t *testing.T) {
 		receiver := &FakeAMQPReceiver{}
 		ns := &FakeNS{}
 
-		links := NewAMQPLinks(ns, "entityPath", func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
-			return nil, receiver, nil
+		links := NewAMQPLinks(NewAMQPLinksArgs{
+			NS:         ns,
+			EntityPath: "entityPath",
+			CreateLinkFunc: func(ctx context.Context, session AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+				return nil, receiver, nil
+			}, GetRecoveryKindFunc: GetRecoveryKind,
 		})
 
 		defer func() {

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -168,7 +168,7 @@ func (l *FakeAMQPLinks) Close(ctx context.Context, permanently bool) error {
 	return nil
 }
 
-func (l *FakeAMQPLinks) CloseIfNeeded(ctx context.Context, err error) recoveryKind {
+func (l *FakeAMQPLinks) CloseIfNeeded(ctx context.Context, err error) RecoveryKind {
 	l.CloseIfNeededCalled++
 	return GetRecoveryKind(err)
 }
@@ -223,6 +223,6 @@ func (ns *FakeNS) Check() error {
 	return nil
 }
 
-func (ns *FakeNS) NewAMQPLinks(entityPath string, createLinkFunc CreateLinkFunc) AMQPLinks {
+func (ns *FakeNS) NewAMQPLinks(entityPath string, createLinkFunc CreateLinkFunc, getRecoveryKindFunc func(err error) RecoveryKind) AMQPLinks {
 	return ns.AMQPLinks
 }

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -30,10 +30,12 @@ func (e errNonRetriable) Error() string { return e.Message }
 // GetRecoveryKind().
 type RecoveryKind string
 
-const RecoveryKindNone RecoveryKind = ""
-const RecoveryKindFatal RecoveryKind = "fatal"
-const RecoveryKindLink RecoveryKind = "link"
-const RecoveryKindConn RecoveryKind = "connection"
+const (
+	RecoveryKindNone  RecoveryKind = ""
+	RecoveryKindFatal RecoveryKind = "fatal"
+	RecoveryKindLink  RecoveryKind = "link"
+	RecoveryKindConn  RecoveryKind = "connection"
+)
 
 type SBErrInfo struct {
 	inner        error

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -238,11 +239,11 @@ func Test_ServiceBusError_Fatal(t *testing.T) {
 		require.EqualValues(t, RecoveryKindFatal, rk, fmt.Sprintf("[%d] %s", i, cond))
 	}
 
-	require.Equal(t, RecoveryKindFatal, GetSBErrInfo(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeNotFound}}).RecoveryKind)
+	require.Equal(t, RecoveryKindFatal, GetSBErrInfo(rpcError{Resp: &RPCResponse{Code: http.StatusNotFound}}).RecoveryKind)
 	require.Equal(t, RecoveryKindFatal, GetSBErrInfo(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}}).RecoveryKind)
 }
 
 func Test_IsLockLostError(t *testing.T) {
 	require.True(t, isLockLostError(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}}))
-	require.False(t, isLockLostError(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeNotFound}}))
+	require.False(t, isLockLostError(rpcError{Resp: &RPCResponse{Code: http.StatusNotFound}}))
 }

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -211,8 +211,6 @@ func Test_ServiceBusError_LinkRecoveryNeeded(t *testing.T) {
 		&amqp.DetachError{},
 		&amqp.Error{Condition: amqp.ErrorDetachForced},
 		&amqp.Error{Condition: amqp.ErrorTransferLimitExceeded},
-		// we lost the session lock, attempt link recovery
-		rpcError{Resp: &RPCResponse{Code: 410}},
 		// this can happen when we're recovering the link - the client gets closed and the old link is still being
 		// used by this instance of the client. It needs to recover and attempt it again.
 		rpcError{Resp: &RPCResponse{Code: 401}},
@@ -240,5 +238,11 @@ func Test_ServiceBusError_Fatal(t *testing.T) {
 		require.EqualValues(t, RecoveryKindFatal, rk, fmt.Sprintf("[%d] %s", i, cond))
 	}
 
-	require.Equal(t, RecoveryKindFatal, GetSBErrInfo(rpcError{Resp: &RPCResponse{Code: 404}}).RecoveryKind)
+	require.Equal(t, RecoveryKindFatal, GetSBErrInfo(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeNotFound}}).RecoveryKind)
+	require.Equal(t, RecoveryKindFatal, GetSBErrInfo(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}}).RecoveryKind)
+}
+
+func Test_IsLockLostError(t *testing.T) {
+	require.True(t, isLockLostError(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}}))
+	require.False(t, isLockLostError(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeNotFound}}))
 }

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -61,7 +61,7 @@ type (
 
 // NamespaceWithNewAMQPLinks is the Namespace surface for consumers of AMQPLinks.
 type NamespaceWithNewAMQPLinks interface {
-	NewAMQPLinks(entityPath string, createLinkFunc CreateLinkFunc) AMQPLinks
+	NewAMQPLinks(entityPath string, createLinkFunc CreateLinkFunc, getRecoveryKindFunc func(err error) RecoveryKind) AMQPLinks
 	Check() error
 }
 
@@ -231,8 +231,13 @@ func (ns *Namespace) NewRPCLink(ctx context.Context, managementPath string) (RPC
 
 // NewAMQPLinks creates an AMQPLinks struct, which groups together the commonly needed links for
 // working with Service Bus.
-func (ns *Namespace) NewAMQPLinks(entityPath string, createLinkFunc CreateLinkFunc) AMQPLinks {
-	return NewAMQPLinks(ns, entityPath, createLinkFunc)
+func (ns *Namespace) NewAMQPLinks(entityPath string, createLinkFunc CreateLinkFunc, getRecoveryKindFunc func(err error) RecoveryKind) AMQPLinks {
+	return NewAMQPLinks(NewAMQPLinksArgs{
+		NS:                  ns,
+		EntityPath:          entityPath,
+		CreateLinkFunc:      createLinkFunc,
+		GetRecoveryKindFunc: getRecoveryKindFunc,
+	})
 }
 
 // Close closes the current cached client.

--- a/sdk/messaging/azservicebus/internal/rpc.go
+++ b/sdk/messaging/azservicebus/internal/rpc.go
@@ -45,6 +45,8 @@ type (
 
 	// RPCResponse is the simplified response structure from an RPC like call
 	RPCResponse struct {
+		// Code is the response code - these originate from Service Bus. Some
+		// common values are called out below, with the RPCResponseCode* constants.
 		Code        int
 		Description string
 		Message     *amqp.Message
@@ -68,6 +70,14 @@ type (
 		Send(ctx context.Context, msg *amqp.Message) error
 		Close(ctx context.Context) error
 	}
+)
+
+// Response codes that come back over the "RPC" style links like cbs or management.
+const (
+	// RPCResponseCodeNotFound comes back if the entity (queue, topic, subscription) is not found.
+	RPCResponseCodeNotFound = 404
+	// RPCResponseCodeLockLost comes back if you lose a message lock _or_ a session lock.
+	RPCResponseCodeLockLost = 410
 )
 
 type rpcError struct {

--- a/sdk/messaging/azservicebus/internal/rpc.go
+++ b/sdk/messaging/azservicebus/internal/rpc.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -74,10 +75,10 @@ type (
 
 // Response codes that come back over the "RPC" style links like cbs or management.
 const (
-	// RPCResponseCodeNotFound comes back if the entity (queue, topic, subscription) is not found.
-	RPCResponseCodeNotFound = 404
 	// RPCResponseCodeLockLost comes back if you lose a message lock _or_ a session lock.
-	RPCResponseCodeLockLost = 410
+	// (NOTE: this is the one HTTP code that doesn't make intuitive sense. For all others I've just
+	// used the HTTP status code instead.
+	RPCResponseCodeLockLost = http.StatusGone
 )
 
 type rpcError struct {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -115,10 +115,11 @@ func applyReceiverOptions(receiver *Receiver, entity *entity, options *ReceiverO
 }
 
 type newReceiverArgs struct {
-	ns             internal.NamespaceWithNewAMQPLinks
-	entity         entity
-	cleanupOnClose func()
-	newLinkFn      func(ctx context.Context, session internal.AMQPSession) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error)
+	ns                  internal.NamespaceWithNewAMQPLinks
+	entity              entity
+	cleanupOnClose      func()
+	getRecoveryKindFunc func(err error) internal.RecoveryKind
+	newLinkFn           func(ctx context.Context, session internal.AMQPSession) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error)
 }
 
 func newReceiver(args newReceiverArgs, options *ReceiverOptions) (*Receiver, error) {
@@ -150,7 +151,7 @@ func newReceiver(args newReceiverArgs, options *ReceiverOptions) (*Receiver, err
 		newLinkFn = args.newLinkFn
 	}
 
-	receiver.amqpLinks = args.ns.NewAMQPLinks(receiver.entityPath, newLinkFn)
+	receiver.amqpLinks = args.ns.NewAMQPLinks(receiver.entityPath, newLinkFn, args.getRecoveryKindFunc)
 
 	// 'nil' settler handles returning an error message for receiveAndDelete links.
 	if receiver.receiveMode == ReceiveModePeekLock {

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -157,7 +157,7 @@ func newSender(args newSenderArgs, retryOptions RetryOptions) (*Sender, error) {
 		retryOptions:   utils.RetryOptions(retryOptions),
 	}
 
-	sender.links = args.ns.NewAMQPLinks(args.queueOrTopic, sender.createSenderLink)
+	sender.links = args.ns.NewAMQPLinks(args.queueOrTopic, sender.createSenderLink, internal.GetRecoveryKind)
 	return sender, nil
 }
 

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -55,10 +55,11 @@ func newSessionReceiver(ctx context.Context, sessionID *string, ns internal.Name
 	}
 
 	r, err := newReceiver(newReceiverArgs{
-		ns:             ns,
-		entity:         entity,
-		cleanupOnClose: cleanupOnClose,
-		newLinkFn:      sessionReceiver.newLink,
+		ns:                  ns,
+		entity:              entity,
+		cleanupOnClose:      cleanupOnClose,
+		newLinkFn:           sessionReceiver.newLink,
+		getRecoveryKindFunc: internal.GetRecoveryKindForSession,
 	}, options)
 
 	if err != nil {


### PR DESCRIPTION
410 (lock lost) handling needed to be separated for sessions and non-session links.

For non-session links losing a link is essentially unrecoverable - the lock cannot be reobtained with just the lock token so further retries will always fail.

For _session_ based links it's different since you actually obtain a session lock by opening a link for a particular session ID. You can retry re-opening the link and there are cases where, on detach, that you might have some overlap until the session is actually available again (this is shown in the `TestSessionReceiver_Detach` test).

So the split here is simple - all retrying is really handled in amqpLinks, so now it takes a parameter giving it the proper function to determine if an error is fatal or retryable. As part of this I also made the parameters to amqpLinks an arg, which had some small rippling effects in callers.

Fixes #17325
(probable fix for the latest issue mentioned in #17017 since this affects settlement time)