### PR TITLE
Use correct argument name in function description

### DIFF
--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -108,7 +108,7 @@ func (r *SessionReceiver) newLink(ctx context.Context, session internal.AMQPSess
 	return nil, link, nil
 }
 
-// ReceiveMessages receives a fixed number of messages, up to numMessages.
+// ReceiveMessages receives a fixed number of messages, up to maxMessages.
 // There are two ways to stop receiving messages:
 // 1. Cancelling the `ctx` parameter.
 // 2. An implicit timeout (default: 1 second) that starts after the first


### PR DESCRIPTION
Use `maxMessages` instead of `numMessages` to match the right argument name

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
