### PR TITLE
[azservicebus] Reference `messaging/internal` by semver, rather than commit tag.

### DIFF
--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3
-	github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.0.0-20220314210312-9302dcfe9a45
+	github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.1.0
 	github.com/Azure/go-amqp v0.17.4
 	github.com/devigned/tab v0.1.1
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/sdk/messaging/azservicebus/go.sum
+++ b/sdk/messaging/azservicebus/go.sum
@@ -7,8 +7,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0/go.mod h1:TmXReXZ9yPp5D
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.2/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
-github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.0.0-20220314210312-9302dcfe9a45 h1:2iK++BgVHH5TR4I3zeVmikeiAxE/C/gisBNxMlv1UBw=
-github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.0.0-20220314210312-9302dcfe9a45/go.mod h1:7hMUlcqiMXDUJtU1EWQlhhkC4BfIr6pEsiyuRYq4xLQ=
+github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.1.0 h1:mvQhIGmKI3vmdNDUMG0ZHaZ1p+JcHE3m0q1RMOyKxRo=
+github.com/Azure/azure-sdk-for-go/sdk/messaging/internal v0.1.0/go.mod h1:7hMUlcqiMXDUJtU1EWQlhhkC4BfIr6pEsiyuRYq4xLQ=
 github.com/Azure/go-amqp v0.17.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/Azure/go-amqp v0.17.4 h1:6t9wEiwA4uXMRoUj3Cd3K2gmH8cW8ylizmBnSeF0bzM=
 github.com/Azure/go-amqp v0.17.4/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=


### PR DESCRIPTION
Reference by semver, rather than commit tag.
    
Without this `go get -u` will just grab the latest _commit_ for the package, even when you reference a specific commit in main. This is just an internal package so it's interface has changed in breaking ways - future updates are not guaranteed to be compatible with older packages until we reach GA.

Fixes #17357