### PR TITLE
Remove pollerID parameter from poller constructors

### DIFF
--- a/sdk/azcore/arm/runtime/poller.go
+++ b/sdk/azcore/arm/runtime/poller.go
@@ -23,8 +23,7 @@ import (
 )
 
 // NewPoller creates a Poller based on the provided initial response.
-// pollerID - a unique identifier for an LRO.  it's usually the client.Method string.
-func NewPoller[T any](pollerID string, finalState string, resp *http.Response, pl pipeline.Pipeline, rt *T) (*Poller[T], error) {
+func NewPoller[T any](finalState string, resp *http.Response, pl pipeline.Pipeline, rt *T) (*Poller[T], error) {
 	defer resp.Body.Close()
 	// this is a back-stop in case the swagger is incorrect (i.e. missing one or more status codes for success).
 	// ideally the codegen should return an error if the initial response failed and not even create a poller.
@@ -35,13 +34,13 @@ func NewPoller[T any](pollerID string, finalState string, resp *http.Response, p
 	var lro pollers.Operation
 	var err error
 	if async.Applicable(resp) {
-		lro, err = async.New(resp, finalState, pollerID)
+		lro, err = async.New(resp, finalState, pollers.PollerTypeName[T]())
 	} else if loc.Applicable(resp) {
-		lro, err = loc.New(resp, pollerID)
+		lro, err = loc.New(resp, pollers.PollerTypeName[T]())
 	} else if body.Applicable(resp) {
 		// must test body poller last as it's a subset of the other pollers.
 		// TODO: this is ambiguous for PATCH/PUT if it returns a 200 with no polling headers (sync completion)
-		lro, err = body.New(resp, pollerID)
+		lro, err = body.New(resp, pollers.PollerTypeName[T]())
 	} else if m := resp.Request.Method; resp.StatusCode == http.StatusAccepted && (m == http.MethodDelete || m == http.MethodPost) {
 		// if we get here it means we have a 202 with no polling headers.
 		// for DELETE and POST this is a hard error per ARM RPC spec.
@@ -59,9 +58,8 @@ func NewPoller[T any](pollerID string, finalState string, resp *http.Response, p
 }
 
 // NewPollerFromResumeToken creates a Poller from a resume token string.
-// pollerID - a unique identifier for an LRO.  it's usually the client.Method string.
-func NewPollerFromResumeToken[T any](pollerID string, token string, pl pipeline.Pipeline, rt *T) (*Poller[T], error) {
-	kind, err := pollers.KindFromToken(pollerID, token)
+func NewPollerFromResumeToken[T any](token string, pl pipeline.Pipeline, rt *T) (*Poller[T], error) {
+	kind, err := pollers.KindFromToken(pollers.PollerTypeName[T](), token)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azcore/arm/runtime/poller_test.go
+++ b/sdk/azcore/arm/runtime/poller_test.go
@@ -75,7 +75,7 @@ func TestNewPollerAsync(t *testing.T) {
 	resp.Header.Set(shared.HeaderAzureAsync, srv.URL())
 	resp.StatusCode = http.StatusCreated
 	pl := getPipeline(srv)
-	poller, err := NewPoller[mockType]("pollerID", "", resp, pl, nil)
+	poller, err := NewPoller[mockType]("", resp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestNewPollerAsync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = NewPollerFromResumeToken[mockType]("pollerID", tk, pl, nil)
+	poller, err = NewPollerFromResumeToken[mockType](tk, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestNewPollerBody(t *testing.T) {
 	resp, closed := initialResponse(http.MethodPatch, srv.URL(), strings.NewReader(provStateStarted))
 	resp.StatusCode = http.StatusCreated
 	pl := getPipeline(srv)
-	poller, err := NewPoller[mockType]("pollerID", "", resp, pl, nil)
+	poller, err := NewPoller[mockType]("", resp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestNewPollerBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = NewPollerFromResumeToken[mockType]("pollerID", tk, pl, nil)
+	poller, err = NewPollerFromResumeToken[mockType](tk, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestNewPollerLoc(t *testing.T) {
 	resp.Header.Set(shared.HeaderLocation, srv.URL())
 	resp.StatusCode = http.StatusAccepted
 	pl := getPipeline(srv)
-	poller, err := NewPoller[mockType]("pollerID", "", resp, pl, nil)
+	poller, err := NewPoller[mockType]("", resp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestNewPollerLoc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = NewPollerFromResumeToken[mockType]("pollerID", tk, pl, nil)
+	poller, err = NewPollerFromResumeToken[mockType](tk, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func TestNewPollerInitialRetryAfter(t *testing.T) {
 	resp.Header.Set("Retry-After", "1")
 	resp.StatusCode = http.StatusCreated
 	pl := getPipeline(srv)
-	poller, err := NewPoller[mockType]("pollerID", "", resp, pl, nil)
+	poller, err := NewPoller[mockType]("", resp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestNewPollerCanceled(t *testing.T) {
 	resp.Header.Set(shared.HeaderAzureAsync, srv.URL())
 	resp.StatusCode = http.StatusCreated
 	pl := getPipeline(srv)
-	poller, err := NewPoller[mockType]("pollerID", "", resp, pl, nil)
+	poller, err := NewPoller[mockType]("", resp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +256,7 @@ func TestNewPollerFailedWithError(t *testing.T) {
 	resp.Header.Set(shared.HeaderAzureAsync, srv.URL())
 	resp.StatusCode = http.StatusCreated
 	pl := getPipeline(srv)
-	poller, err := NewPoller[mockType]("pollerID", "", resp, pl, nil)
+	poller, err := NewPoller[mockType]("", resp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +283,7 @@ func TestNewPollerSuccessNoContent(t *testing.T) {
 	resp, closed := initialResponse(http.MethodPatch, srv.URL(), strings.NewReader(provStateStarted))
 	resp.StatusCode = http.StatusCreated
 	pl := getPipeline(srv)
-	poller, err := NewPoller[mockType]("pollerID", "", resp, pl, nil)
+	poller, err := NewPoller[mockType]("", resp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +297,7 @@ func TestNewPollerSuccessNoContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = NewPollerFromResumeToken[mockType]("pollerID", tk, pl, nil)
+	poller, err = NewPollerFromResumeToken[mockType](tk, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func TestNewPollerFail202NoHeaders(t *testing.T) {
 	resp, closed := initialResponse(http.MethodDelete, srv.URL(), http.NoBody)
 	resp.StatusCode = http.StatusAccepted
 	pl := getPipeline(srv)
-	poller, err := NewPoller[mockType]("pollerID", "", resp, pl, nil)
+	poller, err := NewPoller[mockType]("", resp, pl, nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -22,16 +22,10 @@ type TokenCredential = shared.TokenCredential
 // holds sentinel values used to send nulls
 var nullables map[reflect.Type]interface{} = map[reflect.Type]interface{}{}
 
-func typeOfT[T any]() reflect.Type {
-	// you can't, at present, obtain the type of
-	// a type parameter, so this is the trick
-	return reflect.TypeOf((*T)(nil)).Elem()
-}
-
 // NullValue is used to send an explicit 'null' within a request.
 // This is typically used in JSON-MERGE-PATCH operations to delete a value.
 func NullValue[T any]() T {
-	t := typeOfT[T]()
+	t := shared.TypeOfT[T]()
 	v, found := nullables[t]
 	if !found {
 		var o reflect.Value

--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -53,6 +53,17 @@ func IsValidURL(s string) bool {
 }
 
 const idSeparator = ";"
+const emptyTypeName = "-empty-"
+
+// PollerTypeName returns the type name to use when constructing the poller ID.
+// It handles the empty type struct{} with a special name instead of the empty string.
+func PollerTypeName[T any]() string {
+	n := shared.TypeOfT[T]().Name()
+	if n == "" {
+		n = emptyTypeName
+	}
+	return n
+}
 
 // MakeID returns the poller ID from the provided values.
 func MakeID(pollerID string, kind string) string {

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -51,6 +51,18 @@ func TestStatusCodeValid(t *testing.T) {
 	}
 }
 
+func TestPollerTypeName(t *testing.T) {
+	if n := PollerTypeName[int](); n != "int" {
+		t.Fatalf("unexpected type name %s", n)
+	}
+	if n := PollerTypeName[struct{}](); n != emptyTypeName {
+		t.Fatalf("unexpected type name %s", n)
+	}
+	if n := PollerTypeName[interface{}](); n != emptyTypeName {
+		t.Fatalf("unexpected type name %s", n)
+	}
+}
+
 func TestMakeID(t *testing.T) {
 	const (
 		pollerID = "pollerID"

--- a/sdk/azcore/internal/shared/shared.go
+++ b/sdk/azcore/internal/shared/shared.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strconv"
 	"time"
 )
@@ -196,4 +197,11 @@ func (r *NopClosingBytesReader) Seek(offset int64, whence int) (int64, error) {
 	}
 	r.i = i
 	return i, nil
+}
+
+// TypeOfT returns the type of the generic type param.
+func TypeOfT[T any]() reflect.Type {
+	// you can't, at present, obtain the type of
+	// a type parameter, so this is the trick
+	return reflect.TypeOf((*T)(nil)).Elem()
 }

--- a/sdk/azcore/internal/shared/shared_test.go
+++ b/sdk/azcore/internal/shared/shared_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -174,5 +175,14 @@ func TestNopClosingBytesReader(t *testing.T) {
 	_, err = ncbr.Seek(-int64(len(val2)+1), io.SeekCurrent)
 	if err == nil {
 		t.Fatal("unexpected nil error")
+	}
+}
+
+func TestTypeOfT(t *testing.T) {
+	if tt := TypeOfT[bool](); tt != reflect.TypeOf(true) {
+		t.Fatalf("unexpected type %s", tt)
+	}
+	if tt := TypeOfT[int32](); tt == reflect.TypeOf(3.14) {
+		t.Fatal("didn't expect types to match")
 	}
 }

--- a/sdk/azcore/runtime/poller_test.go
+++ b/sdk/azcore/runtime/poller_test.go
@@ -28,7 +28,7 @@ type widget struct {
 
 func TestNewPollerFail(t *testing.T) {
 	body, closed := mock.NewTrackedCloser(http.NoBody)
-	p, err := NewPoller[widget]("fake.poller", &http.Response{
+	p, err := NewPoller[widget](&http.Response{
 		Body:       body,
 		StatusCode: http.StatusBadRequest,
 	}, newTestPipeline(nil), nil)
@@ -57,7 +57,7 @@ func TestNewPollerFromResumeTokenFail(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p, err := NewPollerFromResumeToken[widget]("fake.poller", test.token, newTestPipeline(nil), nil)
+			p, err := NewPollerFromResumeToken[widget](test.token, newTestPipeline(nil), nil)
 			if err == nil {
 				t.Fatal("unexpected nil error")
 			}
@@ -85,7 +85,7 @@ func TestLocPollerSimple(t *testing.T) {
 	body, closed := mock.NewTrackedCloser(http.NoBody)
 	firstResp.Body = body
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[struct{}]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[struct{}](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestLocPollerWithWidget(t *testing.T) {
 	body, closed := mock.NewTrackedCloser(http.NoBody)
 	firstResp.Body = body
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[widget]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[widget](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestLocPollerCancelled(t *testing.T) {
 	body, closed := mock.NewTrackedCloser(http.NoBody)
 	firstResp.Body = body
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[widget]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[widget](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func TestLocPollerWithError(t *testing.T) {
 	body, closed := mock.NewTrackedCloser(http.NoBody)
 	firstResp.Body = body
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv, Retry: policy.RetryOptions{MaxRetries: -1}})
-	lro, err := NewPoller[widget]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[widget](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestLocPollerWithResumeToken(t *testing.T) {
 	body, closed := mock.NewTrackedCloser(http.NoBody)
 	firstResp.Body = body
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[struct{}]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[struct{}](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func TestLocPollerWithResumeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lro, err = NewPollerFromResumeToken[struct{}]("fake.poller", tk, pl, nil)
+	lro, err = NewPollerFromResumeToken[struct{}](tk, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,7 +276,7 @@ func TestLocPollerWithTimeout(t *testing.T) {
 	body, closed := mock.NewTrackedCloser(http.NoBody)
 	firstResp.Body = body
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[struct{}]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[struct{}](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func TestOpPollerSimple(t *testing.T) {
 		},
 	}
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[struct{}]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[struct{}](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +356,7 @@ func TestOpPollerWithWidgetPUT(t *testing.T) {
 		},
 	}
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[widget]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[widget](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestOpPollerWithWidgetPOSTLocation(t *testing.T) {
 		},
 	}
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[widget]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[widget](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -442,7 +442,7 @@ func TestOpPollerWithWidgetPOST(t *testing.T) {
 		},
 	}
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[widget]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[widget](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestOpPollerWithWidgetResourceLocation(t *testing.T) {
 		},
 	}
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[widget]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[widget](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -528,7 +528,7 @@ func TestOpPollerWithResumeToken(t *testing.T) {
 		},
 	}
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[struct{}]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[struct{}](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -553,7 +553,7 @@ func TestOpPollerWithResumeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lro, err = NewPollerFromResumeToken[struct{}]("fake.poller", tk, pl, nil)
+	lro, err = NewPollerFromResumeToken[struct{}](tk, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -570,7 +570,7 @@ func TestNopPoller(t *testing.T) {
 	body, closed := mock.NewTrackedCloser(http.NoBody)
 	firstResp.Body = body
 	pl := newTestPipeline(nil)
-	lro, err := NewPoller[struct{}]("fake.poller", firstResp, pl, nil)
+	lro, err := NewPoller[struct{}](firstResp, pl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The generic type parameter has removed the need for an explicit poller
ID parameter during construction.
Create the poller ID name from the generic type parameter.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
