### PR TITLE
Fixing an issue where we wouldn't return cancellation errors even whe…

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fixed the RPCLink so it does better handling of connection/link failures. (#17389)
 - Fixed issue where a message lock expiring would cause unnecessary retries. These retries could cause message settlement calls (ex: Receiver.CompleteMessage) 
   to appear to hang. (#17382)
-- Fixed issue where a cancellation on ReceiveMessages() would work, but wouldn't return the proper cancellation error. (#TBD)
+- Fixed issue where a cancellation on ReceiveMessages() would work, but wouldn't return the proper cancellation error. (#17422)
 
 ## 0.3.6 (2022-03-08)
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed the RPCLink so it does better handling of connection/link failures. (#17389)
 - Fixed issue where a message lock expiring would cause unnecessary retries. These retries could cause message settlement calls (ex: Receiver.CompleteMessage) 
   to appear to hang. (#17382)
+- Fixed issue where a cancellation on ReceiveMessages() would work, but wouldn't return the proper cancellation error. (#TBD)
 
 ## 0.3.6 (2022-03-08)
 

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -62,6 +62,7 @@ type FakeAMQPReceiver struct {
 
 	PrefetchedCalled int
 	ReceiveCalled    int
+	ReceiveFn        func(ctx context.Context) (*amqp.Message, error)
 
 	ReceiveResults []struct {
 		M *amqp.Message
@@ -103,6 +104,10 @@ func (r *FakeAMQPReceiver) DrainCredit(ctx context.Context) error {
 // is empty, will block on ctx.Done().
 func (r *FakeAMQPReceiver) Receive(ctx context.Context) (*amqp.Message, error) {
 	r.ReceiveCalled++
+
+	if r.ReceiveFn != nil {
+		return r.ReceiveFn(ctx)
+	}
 
 	if len(r.ReceiveResults) == 0 {
 		<-ctx.Done()

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -371,7 +371,7 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 		return nil, err
 	}
 
-	flushAndReturn := func(err error) ([]*ReceivedMessage, error) {
+	cleanup := func(err error) {
 		if err != nil {
 			if internal.IsCancelError(err) {
 				// if the user cancelled any of the "cleanup" operations then the link
@@ -384,20 +384,19 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 				_ = r.amqpLinks.CloseIfNeeded(context.Background(), err)
 			}
 		}
+	}
 
-		// in receiveAndDelete messages are assumed to deleted by the service "spontaneously", which means
-		// they can't be received again once we've gotten them here. So, unlike peekLock mode above, we
-		// make sure we flush any messages that we might be holding onto, even on error.
+	flushAndReturn := func(lastErr error) ([]*ReceivedMessage, error) {
 		flushPrefetchedMessages(ctx, linksWithID.Receiver, &all)
 
 		if len(all) > 0 {
 			// users don't typically check the other values in the return if the 'err' is non-nil
-			// so if we have any results we'll just return them and get rid of the error.
+			// so if we have any messages we'll just return them and nil out the error.
 			// If it's persistent they'll see it on their next ReceiveMessages() call.
 			return all, nil
 		} else {
-			if internal.GetRecoveryKind(err) == internal.RecoveryKindFatal {
-				return nil, err
+			if internal.GetRecoveryKind(lastErr) == internal.RecoveryKindFatal {
+				return nil, lastErr
 			}
 
 			// there's no material difference here, so let them fail on the next call to ReceiveMessages() instead.
@@ -406,28 +405,31 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 	}
 
 	if err := fetchMessages(ctx, linksWithID.Receiver, maxMessages, r.defaultTimeAfterFirstMsg, &all); err != nil {
-		// if the user's cancelled the fetch, we should clean up the link by draining it.
+		// if the user's cancelled the fetch we'll fall through and let the drain happen.
 		if !internal.IsCancelError(err) {
-			// link is dead so we'll just skip draining altogether.
+			// If the user didn't cancel then we had an actual failure that's going to require a
+			// link/connection reset. Close links and return whatever we can.
+			cleanup(err)
 			return flushAndReturn(err)
 		}
+
+		// user cancelled, fall through so we drain the link since it's still active.
 	}
 
 	if len(all) < maxMessages { // drain if there are excess credits
-		// NOTE: there is a very intermittent issue where the drain frame doesn't seem to come back. Still investigating
-		// but it's best to not leave their program in a completely hung state during this time.
-		ctx, cancel := context.WithTimeout(context.Background(), r.defaultDrainTimeout)
-		defer cancel()
+		drainCtx, drainCtxcancel := context.WithTimeout(context.Background(), r.defaultDrainTimeout)
+		defer drainCtxcancel()
 
-		// start the drain asynchronously. Note that we ignore the user's context at this point
+		// Start the drain asynchronously. Note that we ignore the user's context at this point
 		// since draining makes sure we don't get messages when nobody is receiving.
-		if err := linksWithID.Receiver.DrainCredit(ctx); err != nil {
-			// note that cancelling a DrainCredit means we're in an indeterminate state
+		if err := linksWithID.Receiver.DrainCredit(drainCtx); err != nil {
+			// Cancelling a DrainCredit means we're in an indeterminate state
 			// so we treat that as a "must recover" error.
+			cleanup(err)
 			return flushAndReturn(err)
 		}
 
-		return flushAndReturn(nil)
+		return flushAndReturn(ctx.Err())
 	}
 
 	// we only get here if we got exactly the # of messages they asked for
@@ -464,12 +466,9 @@ func fetchMessages(ctx context.Context, receiver internal.AMQPReceiver, maxMessa
 	}
 }
 
-// flushPrefetchedMessages makes a best-effort attempt at draining any messages on the link. If the link is dead,
-// or times out when draining we will close it quickly. The next operation on the link will
-// recover it.
+// flushPrefetchedMessages makes a best-effort attempt at flushing the internal channel for the link. This is
+// a purely in-memory operation so should work even if the link itself has failed.
 func flushPrefetchedMessages(ctx context.Context, receiver internal.AMQPReceiver, messages *[]*ReceivedMessage) {
-	// Draining data from the receiver's prefetched queue. This won't wait for new messages to
-	// arrive, so it'll only receive messages that arrived prior to the drain.
 	for {
 		am, err := receiver.Prefetched(ctx)
 

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -426,6 +426,14 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 			// Cancelling a DrainCredit means we're in an indeterminate state
 			// so we treat that as a "must recover" error.
 			cleanup(err)
+
+			if internal.IsCancelError(err) {
+				// this cancellation is entirely on us - we cleaned up as best we can
+				// but the user isn't expected to know about this detail so we don't
+				// return the cancellation error.
+				err = nil
+			}
+
 			return flushAndReturn(err)
 		}
 

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -19,6 +19,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestReceiverCancel(t *testing.T) {
+	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
+	defer cleanup()
+
+	receiver, err := serviceBusClient.NewReceiverForQueue(queueName, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	messages, err := receiver.ReceiveMessages(ctx, 5, nil)
+	require.NoError(t, err)
+	require.Empty(t, messages)
+}
+
 func TestReceiverSendFiveReceiveFive(t *testing.T) {
 	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -30,7 +30,7 @@ func TestReceiverCancel(t *testing.T) {
 	defer cancel()
 
 	messages, err := receiver.ReceiveMessages(ctx, 5, nil)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Empty(t, messages)
 }
 
@@ -319,7 +319,7 @@ func TestReceiverDeferWithReceiveAndDelete(t *testing.T) {
 	defer cancel()
 
 	messages, err = receiveAndDeleteReceiver.ReceiveMessages(ctx, len(sequenceNumbers), nil)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Empty(t, messages)
 }
 

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -127,7 +127,7 @@ func TestReceiver_ReceiveMessages_NoMessagesReceivedAndError(t *testing.T) {
 	}
 }
 
-func TestReceiver_ReceiveMessages_DrainTimeout(t *testing.T) {
+func TestReceiver_ReceiveMessages_DrainTimeout_SomeMessagesReceived(t *testing.T) {
 	// all the receive modes work the same when there are no messages
 	for _, mode := range receiveModesForTests {
 		t.Run(mode.Name, func(t *testing.T) {
@@ -166,6 +166,55 @@ func TestReceiver_ReceiveMessages_DrainTimeout(t *testing.T) {
 			// even if that means "erasing" the error.
 			require.NoError(t, err)
 			require.Equal(t, []string{"hello"}, getSortedBodies(messages))
+
+			// since ReceiveAndDelete messages would be lost we always flush any messages that might
+			// be sitting in the link before we throw the instance away.
+			require.Equal(t, 1, fakeAMQPReceiver.PrefetchedCalled, "prefetched before throwing away the broken link")
+
+			// a drain timeout means we need to close our links as we no longer know the true state of it.
+			require.Equal(t, 1, fakeAMQPLinks.Closed, "links are closed using Close(), not CloseIfNeeded()")
+			require.Equal(t, 0, fakeAMQPLinks.CloseIfNeededCalled, "links are not closed using CloseIfNeeded()")
+		})
+	}
+}
+
+func TestReceiver_ReceiveMessages_DrainTimeout_NoMessagesReceived(t *testing.T) {
+	// When no messages are received we enter into a separate flow where we are deciding
+	// if we want to return the error or not.
+	for _, mode := range receiveModesForTests {
+		t.Run(mode.Name, func(t *testing.T) {
+			fakeAMQPReceiver := &internal.FakeAMQPReceiver{
+				ReceiveResults: []struct {
+					M *amqp.Message
+					E error
+				}{
+					{E: context.DeadlineExceeded},
+				},
+				DrainCreditImpl: func(ctx context.Context) error {
+					// simulate the "drain never comes back" situation.
+					// We have a timer now that stops it from hanging forever.
+					<-ctx.Done()
+					return ctx.Err()
+				},
+			}
+
+			fakeAMQPLinks := &internal.FakeAMQPLinks{
+				Receiver: fakeAMQPReceiver,
+			}
+
+			receiver, err := newReceiver(newReceiverArgs{
+				ns:     &internal.FakeNS{AMQPLinks: fakeAMQPLinks},
+				entity: entity{Queue: "queue"},
+			}, &ReceiverOptions{ReceiveMode: mode.Val})
+			require.NoError(t, err)
+
+			messages, err := receiver.ReceiveMessages(context.Background(), 2, nil)
+			// the timeout occurred in drain. This isn't fatal to the user, even if we received
+			// _no_ messages.
+			require.NoError(t, err)
+			require.Empty(t, messages)
+
+			require.Equal(t, 1, fakeAMQPReceiver.DrainCalled, "drain was called")
 
 			// since ReceiveAndDelete messages would be lost we always flush any messages that might
 			// be sitting in the link before we throw the instance away.


### PR DESCRIPTION
Fixing an issue where we wouldn't return cancellation errors even when it made sense.

This would manifest as a user getting an empty array on a ReceiveMessages() call, even if the actual problem is that the cancellation timeout is being set too low.

Small cleanups on some comments as well.

Fixes #17412