### PR TITLE
Add FinalStateVia to data-plane poller options

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 * Added `runtime.Pager[T any]` and `runtime.Poller[T any]` supporting types for central, generic, implementations.
 * Added `cloud` package with a new API for cloud configuration
+* Added `FinalStateVia` field to `runtime.NewPollerOptions[T any]` type.
 
 ### Breaking Changes
 * Removed the `Poller` type-alias to the internal poller implementation.
@@ -16,6 +17,7 @@
 * Refactored `NewPoller` and `NewPollerFromResumeToken` funcs in `arm/runtime` and `runtime` packages.
   * Removed the `pollerID` parameter as it's no longer required.
   * Created optional parameter structs and moved optional parameters into them.
+* Changed `FinalStateVia` field to a `const` type.
 
 ### Bugs Fixed
 

--- a/sdk/azcore/arm/internal/pollers/async/async.go
+++ b/sdk/azcore/arm/internal/pollers/async/async.go
@@ -20,12 +20,6 @@ import (
 // Kind is the identifier of this type in a resume token.
 const Kind = "Azure-AsyncOperation"
 
-const (
-	finalStateAsync = "azure-async-operation"
-	finalStateLoc   = "location" //nolint
-	finalStateOrig  = "original-uri"
-)
-
 // Applicable returns true if the LRO is using Azure-AsyncOperation.
 func Applicable(resp *http.Response) bool {
 	return resp.Header.Get(shared.HeaderAzureAsync) != ""
@@ -49,14 +43,14 @@ type Poller struct {
 	Method string `json:"method"`
 
 	// The value of final-state-via from swagger, can be the empty string.
-	FinalState string `json:"finalState"`
+	FinalState pollers.FinalStateVia `json:"finalState"`
 
 	// The LRO's current state.
 	CurState string `json:"state"`
 }
 
 // New creates a new Poller from the provided initial response and final-state type.
-func New(resp *http.Response, finalState string, pollerID string) (*Poller, error) {
+func New(resp *http.Response, finalState pollers.FinalStateVia, pollerID string) (*Poller, error) {
 	log.Write(log.EventLRO, "Using Azure-AsyncOperation poller.")
 	asyncURL := resp.Header.Get(shared.HeaderAzureAsync)
 	if asyncURL == "" {
@@ -115,9 +109,9 @@ func (p *Poller) FinalGetURL() string {
 		// for PATCH and PUT, the final GET is on the original resource URL
 		return p.OrigURL
 	} else if p.Method == http.MethodPost {
-		if p.FinalState == finalStateAsync {
+		if p.FinalState == pollers.FinalStateViaAzureAsyncOp {
 			return ""
-		} else if p.FinalState == finalStateOrig {
+		} else if p.FinalState == pollers.FinalStateViaOriginalURI {
 			return p.OrigURL
 		} else if p.LocURL != "" {
 			// ideally FinalState would be set to "location" but it isn't always.

--- a/sdk/azcore/arm/runtime/poller.go
+++ b/sdk/azcore/arm/runtime/poller.go
@@ -22,10 +22,27 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
+// FinalStateVia is the enumerated type for the possible final-state-via values.
+type FinalStateVia = pollers.FinalStateVia
+
+const (
+	// FinalStateViaAzureAsyncOp indicates the final payload comes from the Azure-AsyncOperation URL.
+	FinalStateViaAzureAsyncOp = pollers.FinalStateViaAzureAsyncOp
+
+	// FinalStateViaLocation indicates the final payload comes from the Location URL.
+	FinalStateViaLocation = pollers.FinalStateViaLocation
+
+	// FinalStateViaOriginalURI indicates the final payload comes from the original URL.
+	FinalStateViaOriginalURI = pollers.FinalStateViaOriginalURI
+
+	// FinalStateViaOpLocation indicates the final payload comes from the Operation-Location URL.
+	FinalStateViaOpLocation = pollers.FinalStateViaOpLocation
+)
+
 // NewPollerOptions contains the optional parameters for NewPoller.
 type NewPollerOptions[T any] struct {
 	// FinalStateVia contains the final-state-via value for the LRO.
-	FinalStateVia string
+	FinalStateVia FinalStateVia
 
 	// Response contains a preconstructed response type.
 	// The final payload will be unmarshaled into it and returned.

--- a/sdk/azcore/internal/pollers/loc/loc.go
+++ b/sdk/azcore/internal/pollers/loc/loc.go
@@ -28,11 +28,12 @@ func Applicable(resp *http.Response) bool {
 type Poller struct {
 	Type     string `json:"type"`
 	PollURL  string `json:"pollURL"`
+	FinalGET string `json:"finalGET"`
 	CurState int    `json:"state"`
 }
 
 // New creates a new Poller from the provided initial response.
-func New(resp *http.Response, pollerID string) (*Poller, error) {
+func New(resp *http.Response, finalState pollers.FinalStateVia, pollerID string) (*Poller, error) {
 	log.Write(log.EventLRO, "Using Location poller.")
 	locURL := resp.Header.Get(shared.HeaderLocation)
 	if locURL == "" {
@@ -41,9 +42,12 @@ func New(resp *http.Response, pollerID string) (*Poller, error) {
 	if !pollers.IsValidURL(locURL) {
 		return nil, fmt.Errorf("invalid polling URL %s", locURL)
 	}
+	// TODO: calculate the final GET URL.  can be empty
+	finalGET := ""
 	return &Poller{
 		Type:     pollers.MakeID(pollerID, Kind),
 		PollURL:  locURL,
+		FinalGET: finalGET,
 		CurState: resp.StatusCode,
 	}, nil
 }
@@ -65,8 +69,8 @@ func (p *Poller) Update(resp *http.Response) error {
 	return nil
 }
 
-func (*Poller) FinalGetURL() string {
-	return ""
+func (p *Poller) FinalGetURL() string {
+	return p.FinalGET
 }
 
 func (p *Poller) Status() string {

--- a/sdk/azcore/internal/pollers/loc/loc_test.go
+++ b/sdk/azcore/internal/pollers/loc/loc_test.go
@@ -42,7 +42,7 @@ func TestApplicable(t *testing.T) {
 func TestNew(t *testing.T) {
 	resp := initialResponse()
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestNew(t *testing.T) {
 
 func TestNewFail(t *testing.T) {
 	resp := initialResponse()
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -70,7 +70,7 @@ func TestNewFail(t *testing.T) {
 		t.Fatal("expected nil poller")
 	}
 	resp.Header.Set(shared.HeaderLocation, "/must/be/absolute")
-	poller, err = New(resp, "pollerID")
+	poller, err = New(resp, "", "pollerID")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -82,7 +82,7 @@ func TestNewFail(t *testing.T) {
 func TestUpdateSucceeded(t *testing.T) {
 	resp := initialResponse()
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestUpdateSucceeded(t *testing.T) {
 func TestUpdateFailed(t *testing.T) {
 	resp := initialResponse()
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azcore/internal/pollers/op/op.go
+++ b/sdk/azcore/internal/pollers/op/op.go
@@ -34,7 +34,7 @@ type Poller struct {
 }
 
 // New creates a new Poller from the provided initial response.
-func New(resp *http.Response, pollerID string) (*Poller, error) {
+func New(resp *http.Response, finalState pollers.FinalStateVia, pollerID string) (*Poller, error) {
 	log.Write(log.EventLRO, "Using Operation-Location poller.")
 	opURL := resp.Header.Get(shared.HeaderOperationLocation)
 	if opURL == "" {
@@ -61,6 +61,7 @@ func New(resp *http.Response, pollerID string) (*Poller, error) {
 	// calculate the tentative final GET URL.
 	// can change if we receive a resourceLocation.
 	// it's ok for it to be empty in some cases.
+	// TODO: finalState
 	finalGET := ""
 	if resp.Request.Method == http.MethodPatch || resp.Request.Method == http.MethodPut {
 		finalGET = resp.Request.URL.String()

--- a/sdk/azcore/internal/pollers/op/op_test.go
+++ b/sdk/azcore/internal/pollers/op/op_test.go
@@ -60,7 +60,7 @@ func TestNew(t *testing.T) {
 	resp := initialResponse(http.MethodPut, http.NoBody)
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestNewWithInitialStatus(t *testing.T) {
 	resp := initialResponse(http.MethodPut, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestNewWithPost(t *testing.T) {
 	resp := initialResponse(http.MethodPost, http.NoBody)
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestNewWithDelete(t *testing.T) {
 	resp := initialResponse(http.MethodDelete, http.NoBody)
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestNewWithDelete(t *testing.T) {
 
 func TestNewFail(t *testing.T) {
 	resp := initialResponse(http.MethodPut, http.NoBody)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -137,7 +137,7 @@ func TestNewFail(t *testing.T) {
 	}
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, "/must/be/absolute")
-	poller, err = New(resp, "pollerID")
+	poller, err = New(resp, "", "pollerID")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -145,7 +145,7 @@ func TestNewFail(t *testing.T) {
 		t.Fatal("expected nil poller")
 	}
 	resp.Header.Set(shared.HeaderOperationLocation, "/must/be/absolute")
-	poller, err = New(resp, "pollerID")
+	poller, err = New(resp, "", "pollerID")
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -158,7 +158,7 @@ func TestUpdateSucceeded(t *testing.T) {
 	resp := initialResponse(http.MethodPut, http.NoBody)
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestUpdateResourceLocation(t *testing.T) {
 	resp := initialResponse(http.MethodPut, http.NoBody)
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestUpdateFailed(t *testing.T) {
 	resp := initialResponse(http.MethodPut, http.NoBody)
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestUpdateMissingStatus(t *testing.T) {
 	resp := initialResponse(http.MethodPut, http.NoBody)
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New(resp, "pollerID")
+	poller, err := New(resp, "", "pollerID")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azcore/internal/pollers/poller.go
+++ b/sdk/azcore/internal/pollers/poller.go
@@ -20,6 +20,23 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
+// FinalStateVia is the enumerated type for the possible final-state-via values.
+type FinalStateVia string
+
+const (
+	// FinalStateViaAzureAsyncOp indicates the final payload comes from the Azure-AsyncOperation URL.
+	FinalStateViaAzureAsyncOp FinalStateVia = "azure-async-operation"
+
+	// FinalStateViaLocation indicates the final payload comes from the Location URL.
+	FinalStateViaLocation FinalStateVia = "location"
+
+	// FinalStateViaOriginalURI indicates the final payload comes from the original URL.
+	FinalStateViaOriginalURI FinalStateVia = "original-uri"
+
+	// FinalStateViaOpLocation indicates the final payload comes from the Operation-Location URL.
+	FinalStateViaOpLocation FinalStateVia = "operation-location"
+)
+
 // KindFromToken extracts the poller kind from the provided token.
 // If the pollerID doesn't match what's in the token an error is returned.
 func KindFromToken(pollerID, token string) (string, error) {

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -21,8 +21,28 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
+// FinalStateVia is the enumerated type for the possible final-state-via values.
+type FinalStateVia = pollers.FinalStateVia
+
+const (
+	// FinalStateViaAzureAsyncOp indicates the final payload comes from the Azure-AsyncOperation URL.
+	FinalStateViaAzureAsyncOp = pollers.FinalStateViaAzureAsyncOp
+
+	// FinalStateViaLocation indicates the final payload comes from the Location URL.
+	FinalStateViaLocation = pollers.FinalStateViaLocation
+
+	// FinalStateViaOriginalURI indicates the final payload comes from the original URL.
+	FinalStateViaOriginalURI = pollers.FinalStateViaOriginalURI
+
+	// FinalStateViaOpLocation indicates the final payload comes from the Operation-Location URL.
+	FinalStateViaOpLocation = pollers.FinalStateViaOpLocation
+)
+
 // NewPollerOptions contains the optional parameters for NewPoller.
 type NewPollerOptions[T any] struct {
+	// FinalStateVia contains the final-state-via value for the LRO.
+	FinalStateVia FinalStateVia
+
 	// Response contains a preconstructed response type.
 	// The final payload will be unmarshaled into it and returned.
 	Response *T
@@ -47,9 +67,9 @@ func NewPoller[T any](resp *http.Response, pl pipeline.Pipeline, options *NewPol
 	var lro pollers.Operation
 	// op poller must be checked first as it can also have a location header
 	if op.Applicable(resp) {
-		lro, err = op.New(resp, tName)
+		lro, err = op.New(resp, options.FinalStateVia, tName)
 	} else if loc.Applicable(resp) {
-		lro, err = loc.New(resp, tName)
+		lro, err = loc.New(resp, options.FinalStateVia, tName)
 	} else {
 		lro = &pollers.NopPoller{}
 	}


### PR DESCRIPTION
Converted FinalStateVia to a const as its values are constrained.

NOTE: this makes the necessary changes to public surface area.  However, we don't have coverage in autorest for data-plane LROs at present, so the implementation is incomplete.  This doesn't impact the current behavior though.

Partially fixes https://github.com/Azure/azure-sdk-for-go/issues/17415