### PR TITLE
Skip invalid package modules

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -69,6 +69,12 @@ function Get-go-PackageInfoFromPackageFile($pkg, $workingDirectory)
     $releaseNotes = ""
     $packageProperties = Get-GoModuleProperties $pkg.Directory
 
+    # We have some cases when processing service directories that non-shipping projects like perfdata
+    # we just want to exclude them as opposed to returning a property with invalid data.
+    if (!$packageProperties) {
+      return $null
+    }
+
     if ($packageProperties.ChangeLogPath -and $packageProperties.Version)
     {
       $releaseNotes = Get-ChangeLogEntryAsString -ChangeLogLocation $packageProperties.ChangeLogPath `


### PR DESCRIPTION
For things where we find perfdata or other go.mod files
without the other required properties we should just skip
them in processing