### PR TITLE
[azservicebus] Adding in `options` structures everywhere that that ever expand in the future

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.3.7 (Unreleased)
+## 0.4.0 (Unreleased)
 
 ### Features Added
 
@@ -17,6 +17,9 @@
 
 ### Breaking Changes
 
+- This module now requires Go 1.18
+- Multiple functions have had `options` parameters added.
+- `SessionReceiver.RenewMessageLock` has been removed - it isn't used for sessions. SessionReceivers should use `SessionReceiver.RenewSessionLock`.
 - The `admin.Client` type has been changed to conform with the latest Azure Go SDK guidelines. As part of this:
   - Embedded `*Result` structs in `admin.Client`'s APIs have been removed. Inner *Properties values have been hoisted up to the `*Response` instead.
   - `.Response` fields have been removed for successful results. These will be added back using a     different pattern in the next release.

--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -27,7 +27,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus
 ```
 
 ### Prerequisites
-- Go, version 1.16 or higher
+- Go, version 1.18 or higher
 - An [Azure subscription](https://azure.microsoft.com/free/)
 - A [Service Bus Namespace](https://docs.microsoft.com/azure/service-bus-messaging/).
 - A Service Bus Queue, Topic or Subscription. You can create an entity in your Service Bus Namespace using the [Azure Portal](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-quickstart-portal), or the [Azure CLI](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-quickstart-cli).

--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -123,7 +123,7 @@ if err != nil {
 // send a single message
 err = sender.SendMessage(context.TODO(), &azservicebus.Message{
   Body: []byte("hello world!"),
-})
+}, nil)
 ```
 
 You can also send messages in batches, which can be more efficient than sending them individually
@@ -140,13 +140,13 @@ if err != nil {
 // Add a message to our message batch. This can be called multiple times.
 err = messageBatch.AddMessage(&azservicebus.Message{
     Body: []byte(fmt.Sprintf("hello world")),
-})
+}, nil)
 
 if errors.Is(err, azservicebus.ErrMessageTooLarge) {
   fmt.Printf("Message batch is full. We should send it and create a new one.\n")
 
   // send what we have since the batch is full
-  err := sender.SendMessageBatch(context.TODO(), messageBatch)
+  err := sender.SendMessageBatch(context.TODO(), messageBatch, nil)
 
   if err != nil {
     panic(err)
@@ -193,7 +193,7 @@ if err != nil {
 for _, message := range messages {
   // For more information about settling messages:
   // https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations
-  err = receiver.CompleteMessage(context.TODO(), message)
+  err = receiver.CompleteMessage(context.TODO(), message, nil)
 
   if err != nil {
     panic(err)

--- a/sdk/messaging/azservicebus/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin_client_test.go
@@ -66,16 +66,16 @@ func TestAdminClient_Queue_Forwarding(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("this message will be auto-forwarded"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	receiver, err := client.NewReceiverForQueue(forwardToQueueName, nil)
 	require.NoError(t, err)
 
-	forwardedMessage, err := receiver.receiveMessage(context.Background(), nil)
+	forwardedMessages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 
-	body, err := forwardedMessage.Body()
+	body, err := forwardedMessages[0].Body()
 	require.NoError(t, err)
 	require.EqualValues(t, "this message will be auto-forwarded", string(body))
 }
@@ -100,13 +100,13 @@ func TestAdminClient_GetQueueRuntimeProperties(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		err = sender.SendMessage(context.Background(), &Message{
 			Body: []byte("hello"),
-		})
+		}, nil)
 		require.NoError(t, err)
 	}
 
 	sequenceNumbers, err := sender.ScheduleMessages(context.Background(), []*Message{
 		{Body: []byte("hello")},
-	}, time.Now().Add(2*time.Hour))
+	}, time.Now().Add(2*time.Hour), nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, sequenceNumbers)
 
@@ -164,7 +164,7 @@ func TestAdminClient_TopicAndSubscriptionRuntimeProperties(t *testing.T) {
 	//  Scheduled messages are accounted for in the topic stats.
 	_, err = sender.ScheduleMessages(context.Background(), []*Message{
 		{Body: []byte("hello")},
-	}, time.Now().Add(2*time.Hour))
+	}, time.Now().Add(2*time.Hour), nil)
 	require.NoError(t, err)
 
 	// validate the topic runtime properties

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -55,7 +55,7 @@ func TestNewClientWithAzureIdentity(t *testing.T) {
 	sender, err := client.NewSender(queue, nil)
 	require.NoError(t, err)
 
-	err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")})
+	err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")}, nil)
 	require.NoError(t, err)
 
 	receiver, err := client.NewReceiverForQueue(queue, nil)
@@ -69,7 +69,7 @@ func TestNewClientWithAzureIdentity(t *testing.T) {
 	require.EqualValues(t, []string{"hello - authenticating with a TokenCredential"}, getSortedBodies(messages))
 
 	for _, m := range messages {
-		err = receiver.CompleteMessage(context.TODO(), m)
+		err = receiver.CompleteMessage(context.TODO(), m, nil)
 		require.NoError(t, err)
 	}
 
@@ -104,7 +104,7 @@ func TestNewClientWithWebsockets(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("hello world"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// we have to test this down here since the connection is lazy initialized.
@@ -141,7 +141,7 @@ func TestNewClientUsingSharedAccessSignature(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("hello world"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	receiver, err := client.NewReceiverForQueue(queue, &ReceiverOptions{
@@ -172,7 +172,7 @@ func TestNewClientNewSenderNotFound(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), fastNotFoundDuration)
 	defer cancel()
 
-	err = sender.SendMessage(ctx, &Message{Body: []byte("hello")})
+	err = sender.SendMessage(ctx, &Message{Body: []byte("hello")}, nil)
 	assertRPCNotFound(t, err)
 }
 

--- a/sdk/messaging/azservicebus/example_receiver_test.go
+++ b/sdk/messaging/azservicebus/example_receiver_test.go
@@ -77,7 +77,7 @@ func ExampleReceiver_ReceiveMessages() {
 	for _, message := range messages {
 		// For more information about settling messages:
 		// https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations
-		err = receiver.CompleteMessage(context.TODO(), message)
+		err = receiver.CompleteMessage(context.TODO(), message, nil)
 
 		if err != nil {
 			panic(err)

--- a/sdk/messaging/azservicebus/example_sender_test.go
+++ b/sdk/messaging/azservicebus/example_sender_test.go
@@ -24,7 +24,7 @@ func ExampleSender_SendMessage_message() {
 		Body: []byte("hello, this is a message"),
 	}
 
-	err = sender.SendMessage(context.TODO(), message)
+	err = sender.SendMessage(context.TODO(), message, nil)
 	exitOnError("Failed to send message", err)
 }
 
@@ -35,7 +35,7 @@ func ExampleSender_SendMessage_messageBatch() {
 	// By calling AddMessage multiple times you can add multiple messages into a
 	// batch. This can help with message throughput, as you can send multiple
 	// messages in a single send.
-	err = batch.AddMessage(&azservicebus.Message{Body: []byte("hello world")})
+	err = batch.AddMessage(&azservicebus.Message{Body: []byte("hello world")}, nil)
 
 	if err != nil {
 		switch err {
@@ -54,7 +54,7 @@ func ExampleSender_SendMessage_messageBatch() {
 
 	// After you add all the messages to the batch you send it using
 	// Sender.SendMessageBatch()
-	err = sender.SendMessageBatch(context.TODO(), batch)
+	err = sender.SendMessageBatch(context.TODO(), batch, nil)
 	exitOnError("Failed to send message batch", err)
 }
 
@@ -67,10 +67,10 @@ func ExampleSender_ScheduleMessages() {
 	sequenceNumbers, err := sender.ScheduleMessages(context.TODO(),
 		[]*azservicebus.Message{
 			{Body: []byte("hello world")},
-		}, time.Now().Add(time.Hour))
+		}, time.Now().Add(time.Hour), nil)
 	exitOnError("Failed to schedule messages", err)
 
-	err = sender.CancelScheduledMessages(context.TODO(), sequenceNumbers)
+	err = sender.CancelScheduledMessages(context.TODO(), sequenceNumbers, nil)
 	exitOnError("Failed to cancel scheduled messages", err)
 
 	// or you can set the `ScheduledEnqueueTime` field on a message when you send it
@@ -81,6 +81,6 @@ func ExampleSender_ScheduleMessages() {
 			Body: []byte("hello world"),
 			// schedule the message to be delivered in an hour.
 			ScheduledEnqueueTime: &future,
-		})
+		}, nil)
 	exitOnError("Failed to schedule messages using SendMessage", err)
 }

--- a/sdk/messaging/azservicebus/example_session_receiver_test.go
+++ b/sdk/messaging/azservicebus/example_session_receiver_test.go
@@ -17,7 +17,7 @@ func ExampleClient_AcceptSessionForQueue() {
 	exitOnError("Failed to receive a message", err)
 
 	for _, message := range messages {
-		err = sessionReceiver.CompleteMessage(context.TODO(), message)
+		err = sessionReceiver.CompleteMessage(context.TODO(), message, nil)
 		exitOnError("Failed to complete message", err)
 
 		fmt.Printf("Received message from session ID \"%s\" and completed it", *message.SessionID)

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -19,4 +19,4 @@ const (
 // TODO: this should move into a proper file. Need to resolve some interdependency
 // issues between the public and internal packages first.
 // Version is the semantic version number
-const Version = "v0.3.7"
+const Version = "v0.4.0"

--- a/sdk/messaging/azservicebus/internal/stress/shared/streaming_batch.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/streaming_batch.go
@@ -18,7 +18,7 @@ type internalBatchSender interface {
 }
 
 type internalBatch interface {
-	AddMessage(m *azservicebus.Message) error
+	AddMessage(m *azservicebus.Message, options *azservicebus.AddMessageOptions) error
 	NumMessages() int32
 }
 
@@ -27,7 +27,7 @@ type senderWrapper struct {
 }
 
 func (sw *senderWrapper) SendMessageBatch(ctx context.Context, batch internalBatch) error {
-	return sw.inner.SendMessageBatch(ctx, batch.(*azservicebus.MessageBatch))
+	return sw.inner.SendMessageBatch(ctx, batch.(*azservicebus.MessageBatch), nil)
 }
 
 func (sw *senderWrapper) NewMessageBatch(ctx context.Context, options *azservicebus.MessageBatchOptions) (internalBatch, error) {
@@ -55,8 +55,8 @@ type StreamingMessageBatch struct {
 }
 
 // Add appends to the current batch. If it's full it'll send it, allocate a new one.
-func (sb *StreamingMessageBatch) Add(ctx context.Context, msg *azservicebus.Message) error {
-	err := sb.currentBatch.AddMessage(msg)
+func (sb *StreamingMessageBatch) Add(ctx context.Context, msg *azservicebus.Message, options *azservicebus.AddMessageOptions) error {
+	err := sb.currentBatch.AddMessage(msg, options)
 
 	if err == nil {
 		// sent, we're done
@@ -84,7 +84,7 @@ func (sb *StreamingMessageBatch) Add(ctx context.Context, msg *azservicebus.Mess
 		return err
 	}
 
-	if err := batch.AddMessage(msg); err != nil {
+	if err := batch.AddMessage(msg, nil); err != nil {
 		// if we can't add this message here (ie, by itself) into the batch then
 		// we'll just error out.
 		return err

--- a/sdk/messaging/azservicebus/internal/stress/shared/streaming_batch_test.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/streaming_batch_test.go
@@ -18,7 +18,7 @@ type fakeBatch struct {
 	messages []*azservicebus.Message
 }
 
-func (fb *fakeBatch) AddMessage(msg *azservicebus.Message) error {
+func (fb *fakeBatch) AddMessage(msg *azservicebus.Message, options *azservicebus.AddMessageOptions) error {
 	if len(fb.messages) == fb.max {
 		return azservicebus.ErrMessageTooLarge
 	}
@@ -66,7 +66,7 @@ func TestStreamingBatch(t *testing.T) {
 	for i := 0; i < currentBatch().max; i++ {
 		err = streamingBatch.Add(ctx, &azservicebus.Message{
 			Body: []byte(fmt.Sprintf("%d", i)),
-		})
+		}, nil)
 		require.NoError(t, err)
 		require.Empty(t, sender.sent, "Nothing will be sent yet, since the batch is not yet full")
 	}
@@ -77,7 +77,7 @@ func TestStreamingBatch(t *testing.T) {
 	// 3. Add this new message to the new batch
 	err = streamingBatch.Add(ctx, &azservicebus.Message{
 		Body: []byte("last"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// check what's been sent.
@@ -109,7 +109,7 @@ func TestStreamingBatchTooLargeToFitByItself(t *testing.T) {
 	// 3. Add this new message to the new batch
 	err = streamingBatch.Add(ctx, &azservicebus.Message{
 		Body: []byte("last"),
-	})
+	}, nil)
 
 	// This is the only fatal case for the streaming batch - when we have a message that literally can't be sent.
 	// There's no good strategy here, the user has to make a decision about whether to keep the message, etc...

--- a/sdk/messaging/azservicebus/internal/stress/shared/utils.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/utils.go
@@ -41,7 +41,7 @@ func MustGenerateMessages(sc *StressContext, sender *azservicebus.Sender, messag
 			ApplicationProperties: map[string]interface{}{
 				"Number": i,
 			},
-		})
+		}, nil)
 		sc.PanicOnError("failed add/sending a batch", err)
 	}
 

--- a/sdk/messaging/azservicebus/internal/stress/tests/constant_detachment_sender.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/constant_detachment_sender.go
@@ -37,7 +37,7 @@ func ConstantDetachmentSender(remainingArgs []string) {
 
 			err = sender.SendMessage(sc.Context, &azservicebus.Message{
 				Body: []byte(fmt.Sprintf("test body %d", i)),
-			})
+			}, nil)
 			sc.PanicOnError("failed to send message", err)
 			stats.AddSent(1)
 		}
@@ -58,13 +58,13 @@ func ConstantDetachmentSender(remainingArgs []string) {
 
 			err = batch.AddMessage(&azservicebus.Message{
 				Body: []byte(fmt.Sprintf("batch test body %d", i)),
-			})
+			}, nil)
 			sc.PanicOnError("failed to add message", err)
 
 			err = shared.ForceQueueDetach(sc.Context, adminClient, queueName)
 			sc.PanicOnError("failed updating queue", err)
 
-			err = sender.SendMessageBatch(sc.Context, batch)
+			err = sender.SendMessageBatch(sc.Context, batch, nil)
 			sc.PanicOnError("failed to send message batch", err)
 			stats.AddSent(1)
 		}

--- a/sdk/messaging/azservicebus/internal/stress/tests/finite_peeks.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/finite_peeks.go
@@ -30,7 +30,7 @@ func FinitePeeks(remainingArgs []string) {
 
 	err = sender.SendMessage(sc.Context, &azservicebus.Message{
 		Body: []byte("peekable message"),
-	})
+	}, nil)
 	sc.PanicOnError("failed to send message", err)
 
 	_ = sender.Close(sc.Context)

--- a/sdk/messaging/azservicebus/internal/stress/tests/finite_send_and_receive.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/finite_send_and_receive.go
@@ -75,7 +75,7 @@ func FiniteSendAndReceiveTest(remainingArgs []string) {
 				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 				defer cancel()
 
-				err := receiver.CompleteMessage(ctx, msg)
+				err := receiver.CompleteMessage(ctx, msg, nil)
 
 				var rpcCodeErr interface{ RPCCode() int }
 

--- a/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
@@ -49,7 +49,7 @@ func IdleFastReconnect(remainingArgs []string) {
 
 	err = sender.SendMessage(context.Background(), &azservicebus.Message{
 		Body: []byte("hello"),
-	})
+	}, nil)
 
 	if err != nil {
 		log.Printf("%#v", err)
@@ -86,7 +86,7 @@ func IdleFastReconnect(remainingArgs []string) {
 
 	err = sender.SendMessage(ctx, &azservicebus.Message{
 		Body: []byte("hello"),
-	})
+	}, nil)
 
 	if err != nil {
 		panic(err)

--- a/sdk/messaging/azservicebus/internal/stress/tests/infinite_send_and_receive.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/infinite_send_and_receive.go
@@ -72,7 +72,7 @@ func runBatchReceiver(sc *shared.StressContext, topicName string, subscriptionNa
 
 		for _, msg := range messages {
 			go func(msg *azservicebus.ReceivedMessage) {
-				err := receiver.CompleteMessage(sc.Context, msg)
+				err := receiver.CompleteMessage(sc.Context, msg, nil)
 				sc.LogIfFailed("complete failed", err, stats)
 
 				if err == nil {
@@ -103,7 +103,7 @@ func continuallySend(sc *shared.StressContext, queueName string) {
 	for t := range ticker.C {
 		err := sender.SendMessage(ctx, &azservicebus.Message{
 			Body: []byte(fmt.Sprintf("hello world: %s", t.String())),
-		})
+		}, nil)
 
 		atomic.AddInt32(&senderStats.Sent, 1)
 		sc.TrackMetric(MetricMessageSent, 1)

--- a/sdk/messaging/azservicebus/internal/stress/tests/long_running_renew_lock.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/long_running_renew_lock.go
@@ -27,7 +27,7 @@ func LongRunningRenewLockTest(remainingArgs []string) {
 
 	err = sender.SendMessage(context.Background(), &azservicebus.Message{
 		Body: []byte("ping"),
-	})
+	}, nil)
 	sc.PanicOnError("failed to send message", err)
 
 	receiver, err := client.NewReceiverForQueue(queueName, nil)
@@ -48,12 +48,12 @@ func LongRunningRenewLockTest(remainingArgs []string) {
 		}
 
 		i++
-		err := receiver.RenewMessageLock(ctx, messages[0])
+		err := receiver.RenewMessageLock(ctx, messages[0], nil)
 
 		if err == context.Canceled || err == context.DeadlineExceeded {
 			log.Printf("Cancellation/deadline exceeded. Can stop, will complete message now")
 
-			err = receiver.CompleteMessage(context.Background(), messages[0])
+			err = receiver.CompleteMessage(context.Background(), messages[0], nil)
 			sc.PanicOnError("failed to complete message", err)
 			break
 		}

--- a/sdk/messaging/azservicebus/internal/stress/tests/mostly_idle_receiver.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/mostly_idle_receiver.go
@@ -71,7 +71,7 @@ func MostlyIdleReceiver(remainingArgs []string) {
 				log.Printf("Sending message for duration %s", duration)
 				err := sender.SendMessage(sc.Context, &azservicebus.Message{
 					Body: []byte(fmt.Sprintf("Message for %s", duration)),
-				})
+				}, nil)
 				sc.PanicOnError(fmt.Sprintf("failed sending message for duration %s", duration), err)
 			})
 
@@ -83,7 +83,7 @@ func MostlyIdleReceiver(remainingArgs []string) {
 			stats.AddReceived(int32(len(messages)))
 
 			for _, msg := range messages {
-				err := receiver.CompleteMessage(sc.Context, msg)
+				err := receiver.CompleteMessage(sc.Context, msg, nil)
 				sc.PanicOnError("failed to complete message", err)
 			}
 		}(stats, duration)

--- a/sdk/messaging/azservicebus/internal/stress/tests/rapid_open_close.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/rapid_open_close.go
@@ -29,7 +29,7 @@ func RapidOpenCloseTest(remainingArgs []string) {
 
 		err = sender.SendMessage(context.Background(), &azservicebus.Message{
 			Body: []byte("ping"),
-		})
+		}, nil)
 		sc.PanicOnError("failed to send message", err)
 
 		err = sender.Close(sc.Context)

--- a/sdk/messaging/azservicebus/internal/test/test_helpers.go
+++ b/sdk/messaging/azservicebus/internal/test/test_helpers.go
@@ -99,7 +99,10 @@ func CreateExpiringQueue(t *testing.T, qd *atom.QueueDescription) (string, func(
 //
 func CaptureLogsForTest() func() []string {
 	messagesCh := make(chan string, 10000)
+	return CaptureLogsForTestWithChannel(messagesCh)
+}
 
+func CaptureLogsForTestWithChannel(messagesCh chan string) func() []string {
 	setAzLogListener(func(e azlog.Event, s string) {
 		messagesCh <- fmt.Sprintf("[%s] %s", e, s)
 	})

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -12,7 +12,7 @@ import (
 )
 
 type settler interface {
-	CompleteMessage(ctx context.Context, message *ReceivedMessage) error
+	CompleteMessage(ctx context.Context, message *ReceivedMessage, options *CompleteMessageOptions) error
 	AbandonMessage(ctx context.Context, message *ReceivedMessage, options *AbandonMessageOptions) error
 	DeferMessage(ctx context.Context, message *ReceivedMessage, options *DeferMessageOptions) error
 	DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error
@@ -55,8 +55,13 @@ func (s *messageSettler) settleWithRetries(ctx context.Context, message *Receive
 	return err
 }
 
+// CompleteMessageOptions contains optional parameters for the CompleteMessage function.
+type CompleteMessageOptions struct {
+	// For future expansion
+}
+
 // CompleteMessage completes a message, deleting it from the queue or subscription.
-func (s *messageSettler) CompleteMessage(ctx context.Context, message *ReceivedMessage) error {
+func (s *messageSettler) CompleteMessage(ctx context.Context, message *ReceivedMessage, options *CompleteMessageOptions) error {
 	return s.settleWithRetries(ctx, message, func(receiver internal.AMQPReceiver, rpcLink internal.RPCLink) error {
 		if s.useManagementLink(message, receiver) {
 			return internal.SendDisposition(ctx, rpcLink, bytesToAMQPUUID(message.LockToken), internal.Disposition{Status: internal.CompletedDisposition}, nil)

--- a/sdk/messaging/azservicebus/message_batch.go
+++ b/sdk/messaging/azservicebus/message_batch.go
@@ -40,12 +40,17 @@ func newMessageBatch(maxBytes uint64) *MessageBatch {
 	return mb
 }
 
+// AddMessageOptions contains optional parameters for the AddMessage function.
+type AddMessageOptions struct {
+	// For future expansion
+}
+
 // AddMessage adds a message to the batch if the message will not exceed the max size of the batch
 // Returns:
 // - ErrMessageTooLarge if the message cannot fit
 // - a non-nil error for other failures
 // - nil, otherwise
-func (mb *MessageBatch) AddMessage(m *Message) error {
+func (mb *MessageBatch) AddMessage(m *Message, options *AddMessageOptions) error {
 	return mb.addAMQPMessage(m.toAMQPMessage())
 }
 

--- a/sdk/messaging/azservicebus/message_batch_test.go
+++ b/sdk/messaging/azservicebus/message_batch_test.go
@@ -37,7 +37,7 @@ func TestMessageBatchUnitTests(t *testing.T) {
 			ApplicationProperties: map[string]interface{}{
 				"small": "value",
 			},
-		})
+		}, nil)
 
 		require.NoError(t, err)
 		require.EqualValues(t, 1, mb.NumMessages())
@@ -60,7 +60,7 @@ func TestMessageBatchUnitTests(t *testing.T) {
 				"aFLoat":     100.1,
 				"lotsOfData": string(as2k[:]),
 			},
-		})
+		}, nil)
 
 		require.NoError(t, err)
 		require.EqualValues(t, 1, mb.NumMessages())
@@ -79,7 +79,7 @@ func TestMessageBatchUnitTests(t *testing.T) {
 
 		err := mb.AddMessage(&Message{
 			Body: []byte("hello world"),
-		})
+		}, nil)
 
 		require.EqualError(t, err, ErrMessageTooLarge.Error())
 
@@ -93,7 +93,7 @@ func TestMessageBatchUnitTests(t *testing.T) {
 		require.EqualValues(t, 0, mb.currentSize)
 		err := mb.AddMessage(&Message{
 			Body: []byte("hello world"),
-		})
+		}, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, 145, mb.currentSize)
 
@@ -102,7 +102,7 @@ func TestMessageBatchUnitTests(t *testing.T) {
 
 		err = mb.AddMessage(&Message{
 			Body: as2k[:],
-		})
+		}, nil)
 		require.EqualError(t, err, ErrMessageTooLarge.Error())
 
 		require.Equal(t, sizeBefore, mb.NumBytes(), "size is unchanged when a message fails to get added")
@@ -121,7 +121,7 @@ func TestMessageBatchUnitTests(t *testing.T) {
 
 				err := mb.AddMessage(&Message{
 					Body: []byte{i},
-				})
+				}, nil)
 
 				require.NoError(t, err)
 			}(i)

--- a/sdk/messaging/azservicebus/migrationguide.md
+++ b/sdk/messaging/azservicebus/migrationguide.md
@@ -55,7 +55,7 @@ sender, err := client.NewSender(queueOrTopicName, nil)
 
 sender.SendMessage(context.TODO(), &azservicebus.Message{
   Body: []byte("hello world"),
-})
+}, nil)
 ```
 
 ### Sending messages in batches
@@ -75,13 +75,13 @@ if err != nil {
 // Add a message to our message batch. This can be called multiple times.
 err = messageBatch.AddMessage(&azservicebus.Message{
     Body: []byte(fmt.Sprintf("hello world")),
-})
+}, nil)
 
 if errors.Is(err, azservicebus.ErrMessageTooLarge) {
   fmt.Printf("Message batch is full. We should send it and create a new one.\n")
 
   // send what we have since the batch is full
-  err := sender.SendMessageBatch(context.TODO(), messageBatch)
+  err := sender.SendMessageBatch(context.TODO(), messageBatch, nil)
 
   if err != nil {
     panic(err)
@@ -182,7 +182,7 @@ Now, using `azservicebus`:
 messages, err := receiver.ReceiveMessages(ctx, 10, nil)
 
 for _, message := range messages {
-  err = receiver.CompleteMessage(ctx, message)
+  err = receiver.CompleteMessage(ctx, message, nil)
 }
 ```
 

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -45,7 +45,7 @@ func TestReceiverSendFiveReceiveFive(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		err = sender.SendMessage(context.Background(), &Message{
 			Body: []byte(fmt.Sprintf("[%d]: send five, receive five", i)),
-		})
+		}, nil)
 		require.NoError(t, err)
 	}
 
@@ -67,7 +67,7 @@ func TestReceiverSendFiveReceiveFive(t *testing.T) {
 			fmt.Sprintf("[%d]: send five, receive five", i),
 			string(body))
 
-		require.NoError(t, receiver.CompleteMessage(context.Background(), messages[i]))
+		require.NoError(t, receiver.CompleteMessage(context.Background(), messages[i], nil))
 	}
 }
 
@@ -81,7 +81,7 @@ func TestReceiverForceTimeoutWithTooFewMessages(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("hello"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	receiver, err := serviceBusClient.NewReceiverForQueue(queueName, nil)
@@ -97,7 +97,7 @@ func TestReceiverForceTimeoutWithTooFewMessages(t *testing.T) {
 		[]string{"hello"},
 		getSortedBodies(messages))
 
-	require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0]))
+	require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0], nil))
 }
 
 func TestReceiverDrainHasError(t *testing.T) {
@@ -110,7 +110,7 @@ func TestReceiverDrainHasError(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("hello"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	receiver, err := serviceBusClient.NewReceiverForQueue(queueName, nil)
@@ -142,7 +142,7 @@ func TestReceiverAbandon(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("send and abandon test"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	receiver, err := serviceBusClient.NewReceiverForQueue(queueName, nil)
@@ -159,7 +159,7 @@ func TestReceiverAbandon(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1, len(abandonedMessages))
 
-	require.NoError(t, receiver.CompleteMessage(context.Background(), abandonedMessages[0]))
+	require.NoError(t, receiver.CompleteMessage(context.Background(), abandonedMessages[0], nil))
 }
 
 // Receive has two timeouts - an explicit one (passed in via ReceiveOptions.MaxWaitTime)
@@ -174,7 +174,7 @@ func TestReceiveWithEarlyFirstMessageTimeout(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("send and abandon test"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	receiver, err := serviceBusClient.NewReceiverForQueue(queueName, nil)
@@ -205,7 +205,7 @@ func TestReceiverSendAndReceiveManyTimes(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		err = sender.SendMessage(context.Background(), &Message{
 			Body: []byte(fmt.Sprintf("[%d]: many messages", i)),
-		})
+		}, nil)
 		require.NoError(t, err)
 	}
 
@@ -223,7 +223,7 @@ func TestReceiverSendAndReceiveManyTimes(t *testing.T) {
 		allMessages = append(allMessages, messages...)
 
 		for _, message := range messages {
-			require.NoError(t, receiver.CompleteMessage(context.Background(), message))
+			require.NoError(t, receiver.CompleteMessage(context.Background(), message, nil))
 		}
 	}
 
@@ -245,7 +245,7 @@ func TestReceiverDeferAndReceiveDeferredMessages(t *testing.T) {
 
 	err = sender.SendMessage(ctx, &Message{
 		Body: []byte("deferring a message"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	receiver, err := client.NewReceiverForQueue(queueName, nil)
@@ -263,14 +263,14 @@ func TestReceiverDeferAndReceiveDeferredMessages(t *testing.T) {
 		sequenceNumbers = append(sequenceNumbers, *m.SequenceNumber)
 	}
 
-	deferredMessages, err := receiver.ReceiveDeferredMessages(ctx, sequenceNumbers)
+	deferredMessages, err := receiver.ReceiveDeferredMessages(ctx, sequenceNumbers, nil)
 	require.NoError(t, err)
 
 	require.EqualValues(t, []string{"deferring a message"}, getSortedBodies(deferredMessages))
 	require.True(t, deferredMessages[0].deferred, "internal flag indicating it was from a deferred receiver method is set")
 
 	for _, m := range deferredMessages {
-		err = receiver.CompleteMessage(ctx, m)
+		err = receiver.CompleteMessage(ctx, m, nil)
 		require.NoError(t, err)
 	}
 }
@@ -288,7 +288,7 @@ func TestReceiverDeferWithReceiveAndDelete(t *testing.T) {
 
 	err = sender.SendMessage(ctx, &Message{
 		Body: []byte("deferring a message"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	receiver, err := client.NewReceiverForQueue(queueName, nil)
@@ -311,7 +311,7 @@ func TestReceiverDeferWithReceiveAndDelete(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	messages, err = receiveAndDeleteReceiver.ReceiveDeferredMessages(ctx, sequenceNumbers)
+	messages, err = receiveAndDeleteReceiver.ReceiveDeferredMessages(ctx, sequenceNumbers, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, len(sequenceNumbers), len(messages))
 
@@ -340,12 +340,12 @@ func TestReceiverPeek(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		err := batch.AddMessage(&Message{
 			Body: []byte(fmt.Sprintf("Message %d", i)),
-		})
+		}, nil)
 
 		require.NoError(t, err)
 	}
 
-	err = sender.SendMessageBatch(ctx, batch)
+	err = sender.SendMessageBatch(ctx, batch, nil)
 	require.NoError(t, err)
 
 	receiver, err := serviceBusClient.NewReceiverForQueue(queueName, nil)
@@ -417,7 +417,7 @@ func TestReceiverDetachWithPeekLock(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("hello world"),
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.NoError(t, sender.Close(context.Background()))
 
@@ -484,7 +484,7 @@ func TestReceiverDetachWithReceiveAndDelete(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("hello world"),
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.NoError(t, sender.Close(context.Background()))
 
@@ -528,7 +528,7 @@ func TestReceiver_RenewMessageLock(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("hello world"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	receiver, err := client.NewReceiverForQueue(queueName, nil)
@@ -540,7 +540,7 @@ func TestReceiver_RenewMessageLock(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	lockedUntilOld := messages[0].LockedUntil
 
-	require.NoError(t, receiver.RenewMessageLock(context.Background(), messages[0]))
+	require.NoError(t, receiver.RenewMessageLock(context.Background(), messages[0], nil))
 
 	// these should hopefully be unaffected by clock drift since both values come from
 	// the service's times, not ours.
@@ -553,7 +553,7 @@ func TestReceiver_RenewMessageLock(t *testing.T) {
 
 	endCaptureFn := test.CaptureLogsForTest()
 	defer endCaptureFn()
-	expectedLockBadError := receiver.RenewMessageLock(context.Background(), messages[0])
+	expectedLockBadError := receiver.RenewMessageLock(context.Background(), messages[0], nil)
 	// String matching can go away once we fix #15644
 	// For now it at least provides the user with good context that something is incorrect about their lock token.
 	require.Contains(t, expectedLockBadError.Error(),
@@ -625,7 +625,7 @@ func TestReceiverAMQPDataTypes(t *testing.T) {
 			"bool": true,
 			"uuid": amqp.UUID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}),
 		},
-	}))
+	}, nil))
 
 	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
@@ -675,23 +675,23 @@ func TestReceiverMultiReceiver(t *testing.T) {
 
 	err = sender.SendMessage(context.Background(), &Message{
 		Body: []byte("hello world"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"hello world"}, getSortedBodies(messages))
-	require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0]))
+	require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0], nil))
 
 	err = sender2.SendMessage(context.Background(), &Message{
 		Body: []byte("hello world 2"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	messages, err = receiver2.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"hello world 2"}, getSortedBodies(messages))
-	require.NoError(t, receiver2.CompleteMessage(context.Background(), messages[0]))
+	require.NoError(t, receiver2.CompleteMessage(context.Background(), messages[0], nil))
 }
 
 func TestReceiverMultiTopic(t *testing.T) {
@@ -715,32 +715,32 @@ func TestReceiverMultiTopic(t *testing.T) {
 
 	err = queueSender.SendMessage(context.Background(), &Message{
 		Body: []byte("sent to queue"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err = otherQueueSender.SendMessage(context.Background(), &Message{
 		Body: []byte("sent to other queue"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	messages, err := queueReceiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"sent to queue"}, getSortedBodies(messages))
-	require.NoError(t, queueReceiver.CompleteMessage(context.Background(), messages[0]))
+	require.NoError(t, queueReceiver.CompleteMessage(context.Background(), messages[0], nil))
 
 	otherMessages, err := otherQueueReceiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"sent to other queue"}, getSortedBodies(otherMessages))
-	require.NoError(t, otherQueueReceiver.CompleteMessage(context.Background(), otherMessages[0]))
+	require.NoError(t, otherQueueReceiver.CompleteMessage(context.Background(), otherMessages[0], nil))
 
 	err = otherQueueSender.SendMessage(context.Background(), &Message{
 		Body: []byte("sent to other queue2"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err = queueSender.SendMessage(context.Background(), &Message{
 		Body: []byte("sent to queue2"),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	messages, err = queueReceiver.ReceiveMessages(context.Background(), 1, nil)

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -376,7 +376,7 @@ func TestReceiverDeferUnitTests(t *testing.T) {
 		},
 	}
 
-	messages, err := r.ReceiveDeferredMessages(context.Background(), []int64{1})
+	messages, err := r.ReceiveDeferredMessages(context.Background(), []int64{1}, nil)
 	require.EqualError(t, err, "links are dead")
 	require.Nil(t, messages)
 
@@ -386,7 +386,7 @@ func TestReceiverDeferUnitTests(t *testing.T) {
 		},
 	}
 
-	messages, err = r.ReceiveDeferredMessages(context.Background(), []int64{1})
+	messages, err = r.ReceiveDeferredMessages(context.Background(), []int64{1}, nil)
 	require.EqualError(t, err, "receive deferred messages failed")
 	require.Nil(t, messages)
 }

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -61,8 +61,13 @@ func (s *Sender) NewMessageBatch(ctx context.Context, options *MessageBatchOptio
 	return batch, nil
 }
 
+// SendMessageOptions contains optional parameters for the SendMessage function.
+type SendMessageOptions struct {
+	// For future expansion
+}
+
 // SendMessage sends a Message to a queue or topic.
-func (s *Sender) SendMessage(ctx context.Context, message *Message) error {
+func (s *Sender) SendMessage(ctx context.Context, message *Message, options *SendMessageOptions) error {
 	return s.links.Retry(ctx, "SendMessage", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		ctx, span := s.startProducerSpanFromContext(ctx, spanNameSendMessage)
 		defer span.End()
@@ -71,9 +76,14 @@ func (s *Sender) SendMessage(ctx context.Context, message *Message) error {
 	}, utils.RetryOptions(s.retryOptions))
 }
 
+// SendMessageBatchOptions contains optional parameters for the SendMessageBatch function.
+type SendMessageBatchOptions struct {
+	// For future expansion
+}
+
 // SendMessageBatch sends a MessageBatch to a queue or topic.
 // Message batches can be created using `Sender.NewMessageBatch`.
-func (s *Sender) SendMessageBatch(ctx context.Context, batch *MessageBatch) error {
+func (s *Sender) SendMessageBatch(ctx context.Context, batch *MessageBatch, options *SendMessageBatchOptions) error {
 	return s.links.Retry(ctx, "SendMessageBatch", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		ctx, span := s.startProducerSpanFromContext(ctx, spanNameSendBatch)
 		defer span.End()
@@ -82,10 +92,15 @@ func (s *Sender) SendMessageBatch(ctx context.Context, batch *MessageBatch) erro
 	}, utils.RetryOptions(s.retryOptions))
 }
 
+// ScheduleMessagesOptions contains optional parameters for the ScheduleMessages function.
+type ScheduleMessagesOptions struct {
+	// For future expansion
+}
+
 // ScheduleMessages schedules a slice of Messages to appear on Service Bus Queue/Subscription at a later time.
 // Returns the sequence numbers of the messages that were scheduled.  Messages that haven't been
 // delivered can be cancelled using `Receiver.CancelScheduleMessage(s)`
-func (s *Sender) ScheduleMessages(ctx context.Context, messages []*Message, scheduledEnqueueTime time.Time) ([]int64, error) {
+func (s *Sender) ScheduleMessages(ctx context.Context, messages []*Message, scheduledEnqueueTime time.Time, options *ScheduleMessagesOptions) ([]int64, error) {
 	var amqpMessages []*amqp.Message
 
 	for _, m := range messages {
@@ -97,8 +112,13 @@ func (s *Sender) ScheduleMessages(ctx context.Context, messages []*Message, sche
 
 // MessageBatch changes
 
+// CancelScheduledMessagesOptions contains optional parameters for the CancelScheduledMessages function.
+type CancelScheduledMessagesOptions struct {
+	// For future expansion
+}
+
 // CancelScheduledMessages cancels multiple messages that were scheduled.
-func (s *Sender) CancelScheduledMessages(ctx context.Context, sequenceNumbers []int64) error {
+func (s *Sender) CancelScheduledMessages(ctx context.Context, sequenceNumbers []int64, options *CancelScheduledMessagesOptions) error {
 	return s.links.Retry(ctx, "cancelScheduledMessage", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return internal.CancelScheduledMessages(ctx, lwv.RPC, sequenceNumbers)
 	}, s.retryOptions)


### PR DESCRIPTION
- Adding in `options` structures everywhere that that ever expand in the future.
- Updating changelog and readme to indicate that Go 1.18 is the minimum Go release.
- Fixing a race condition in a test
- Removing the hidden `receiveMessage` and `receiveDeferredMessage` functions to avoid having to optionalize them as well, etc...

Also, bumping version to 0.4.0 to accomodate the required Go version and other interface/api changes.