### PR TITLE
dont block release on perf go.mod files

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -37,7 +37,7 @@ function Get-GoModuleVersionInfo($modPath)
 function Get-GoModuleProperties($goModPath)
 {
   $goModPath = $goModPath -replace "\\", "/"
-  if ($goModPath -match "(?<modPath>sdk/(?<serviceDir>(resourcemanager/)?([^/]+/)?(?<modName>[^/]+$)))")
+  if ($goModPath -match "(?<modPath>sdk/(?<serviceDir>(\w*/)?([^/]+/)?(?<modName>[^/]+$)))")
   {
     $modPath = $matches["modPath"]
     $modName = $matches["modName"] # We may need to start readong this from the go.mod file if the path and mod config start to differ

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -37,7 +37,7 @@ function Get-GoModuleVersionInfo($modPath)
 function Get-GoModuleProperties($goModPath)
 {
   $goModPath = $goModPath -replace "\\", "/"
-  if ($goModPath -match "(?<modPath>sdk/(?<serviceDir>(\w*/)?([^/]+/)?(?<modName>[^/]+$)))")
+  if ($goModPath -match "(?<modPath>sdk/(?<serviceDir>(resourcemanager/)?([^/]+/)?(?<modName>[^/]+$)))")
   {
     $modPath = $matches["modPath"]
     $modName = $matches["modName"] # We may need to start readong this from the go.mod file if the path and mod config start to differ

--- a/eng/scripts/validate_go_mod.ps1
+++ b/eng/scripts/validate_go_mod.ps1
@@ -15,10 +15,8 @@ if ($goModFiles.Length -eq 0) {
 
 $hasError = $false
 foreach ($goMod in $goModFiles) {
-    Write-Host $goMod.Directory
-    $packageProperties = Get-GoModuleProperties $goMod.Directory
-    Write-Host "Props $packageProperties"
-    if (-Not ($goMod.FullName -Like "*testdata*")) {
+    $mod = Get-GoModuleProperties ($goMod -replace ".*\/azure-sdk-for-go\/")
+    if ($mod -ne $null) {
         $name = $goMod.FullName
         $patternMatches = Get-Content $name | Select-String -Pattern "replace "
         if ($patternMatches.Length -ne 0) {

--- a/eng/scripts/validate_go_mod.ps1
+++ b/eng/scripts/validate_go_mod.ps1
@@ -7,14 +7,13 @@ Push-Location sdk/$serviceDir
 $goModFiles = Get-ChildItem -Path . -Filter go.mod -Recurse
 
 if ($goModFiles.Length -eq 0) {
-    Write-Host "Could not find a go.mod file in the directory $(pwd)"
+    Write-Host "Could not find a go.mod file in the directory $(Get-Location)"
     exit 1
 }
 
 $hasError = $false
 foreach ($goMod in $goModFiles) {
     if (-Not ($goMod.FullName -Like "*testdata*")) {
-        Write-Host $goMod.FullName
         $name = $goMod.FullName
         $patternMatches = Get-Content $name | Select-String -Pattern "replace "
         if ($patternMatches.Length -ne 0) {

--- a/eng/scripts/validate_go_mod.ps1
+++ b/eng/scripts/validate_go_mod.ps1
@@ -15,7 +15,7 @@ if ($goModFiles.Length -eq 0) {
 
 $hasError = $false
 foreach ($goMod in $goModFiles) {
-    $mod = Get-GoModuleProperties ($goMod -replace ".*\/azure-sdk-for-go\/")
+    $mod = Get-GoModuleProperties ($goMod.Directory -replace ".*\/azure-sdk-for-go\/")
     if ($mod) {
         $name = $goMod.FullName
         $patternMatches = Get-Content $name | Select-String -Pattern "replace "

--- a/eng/scripts/validate_go_mod.ps1
+++ b/eng/scripts/validate_go_mod.ps1
@@ -2,6 +2,8 @@ Param(
     [string] $serviceDir
 )
 
+. (Join-Path $PSScriptRoot . Language-Settings.ps1)
+
 Push-Location sdk/$serviceDir
 
 $goModFiles = Get-ChildItem -Path . -Filter go.mod -Recurse
@@ -13,12 +15,17 @@ if ($goModFiles.Length -eq 0) {
 
 $hasError = $false
 foreach ($goMod in $goModFiles) {
+    Write-Host $goMod.Directory
+    $packageProperties = Get-GoModuleProperties $goMod.Directory
+    Write-Host "Props $packageProperties"
     if (-Not ($goMod.FullName -Like "*testdata*")) {
         $name = $goMod.FullName
         $patternMatches = Get-Content $name | Select-String -Pattern "replace "
         if ($patternMatches.Length -ne 0) {
             Write-Host "Found a replace directive in go.mod file at $name"
             $hasError = $true
+        } else {
+            Write-Host "Valid go.mod file at $name"
         }
     }
 }

--- a/eng/scripts/validate_go_mod.ps1
+++ b/eng/scripts/validate_go_mod.ps1
@@ -2,7 +2,7 @@ Param(
     [string] $serviceDir
 )
 
-. (Join-Path $PSScriptRoot . Language-Settings.ps1)
+. (Join-Path $PSScriptRoot .. common scripts common.ps1)
 
 Push-Location sdk/$serviceDir
 
@@ -16,7 +16,7 @@ if ($goModFiles.Length -eq 0) {
 $hasError = $false
 foreach ($goMod in $goModFiles) {
     $mod = Get-GoModuleProperties ($goMod -replace ".*\/azure-sdk-for-go\/")
-    if ($mod -ne $null) {
+    if ($mod) {
         $name = $goMod.FullName
         $patternMatches = Get-Content $name | Select-String -Pattern "replace "
         if ($patternMatches.Length -ne 0) {

--- a/eng/scripts/validate_go_mod.ps1
+++ b/eng/scripts/validate_go_mod.ps1
@@ -13,11 +13,14 @@ if ($goModFiles.Length -eq 0) {
 
 $hasError = $false
 foreach ($goMod in $goModFiles) {
-    $name = $goMod.FullName
-    $patternMatches = Get-Content $name | Select-String -Pattern "replace "
-    if ($patternMatches.Length -ne 0) {
-        Write-Host "Found a replace directive in go.mod file at $name"
-        $hasError = $true
+    if (-Not ($goMod.FullName -Like "*testdata*")) {
+        Write-Host $goMod.FullName
+        $name = $goMod.FullName
+        $patternMatches = Get-Content $name | Select-String -Pattern "replace "
+        if ($patternMatches.Length -ne 0) {
+            Write-Host "Found a replace directive in go.mod file at $name"
+            $hasError = $true
+        }
     }
 }
 


### PR DESCRIPTION
@benbp based on my searches this was the most elegant way to tackle this situation. I don't want to block a release if a perf test's go.mod file uses a replace directive, this checks if `testdata` is in the path for a go.mod file and skips it if this is correct.

Closes #17441