### PR TITLE
Prevent AzureCLICredential panic on unexpected error

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* `AzureCLICredential` panics after receiving an unexpected error type
+  ([#17490](https://github.com/Azure/azure-sdk-for-go/issues/17490))
 
 ### Other Changes
 

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -127,7 +127,7 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 		if err != nil {
 			msg := stderr.String()
 			var exErr *exec.ExitError
-			if errors.As(err, &exErr); exErr.ExitCode() == 127 || strings.HasPrefix(msg, "'az' is not recognized") {
+			if errors.As(err, &exErr) && exErr.ExitCode() == 127 || strings.HasPrefix(msg, "'az' is not recognized") {
 				msg = "Azure CLI not found on path"
 			}
 			if msg == "" {


### PR DESCRIPTION
The credential assumes `exec.Cmd.Output()` returns only `exec.ExitError`. However, that method can return other errors in uncommon cases, causing a panic. The fix is simple: handle the error as an `exec.ExitError` only when `errors.As` returns `true`.

Closes #17490