### PR TITLE
Add azidentity migration guide

### DIFF
--- a/sdk/azidentity/MIGRATION.md
+++ b/sdk/azidentity/MIGRATION.md
@@ -1,0 +1,308 @@
+# Migrating from autorest/adal to azidentity
+
+`azidentity` provides Azure Active Directory (Azure AD) authentication for the newest Azure SDK modules (`github.com/azure-sdk-for-go/sdk/...`). Older Azure SDK packages (`github.com/azure-sdk-for-go/services/...`) use types from `github.com/go-autorest/autorest/adal` instead.
+
+This guide shows common authentication code using `autorest/adal` and its equivalent using `azidentity`.
+
+## Table of contents
+
+- [Acquiring a token](#acquiring-a-token)
+- [Client certificate authentication](#client-certificate-authentication)
+- [Client secret authentication](#client-secret-authentication)
+- [Configuration](#configuration)
+- [Device code authentication](#device-code-authentication)
+- [Managed identity](#managed-identity)
+- [Using azidentity credentials with older packages](#using-azidentity-credentials-with-older-packages)
+
+## Configuration
+
+### `autorest/adal`
+
+Token providers require a token audience (resource identifier) and an instance of `adal.OAuthConfig`, which requires an Azure AD endpoint and tenant:
+
+```go
+import "github.com/Azure/go-autorest/autorest/adal"
+
+oauthCfg, err := adal.NewOAuthConfig("https://login.chinacloudapi.cn", tenantID)
+handle(err)
+
+spt, err := adal.NewServicePrincipalTokenWithSecret(
+    *oauthCfg, clientID, "https://management.chinacloudapi.cn/", &adal.ServicePrincipalTokenSecret{ClientSecret: secret},
+)
+```
+
+### `azidentity`
+
+A credential instance can acquire tokens for any audience, and the audience for each token is determined by the client requesting it. Credentials require endpoint configuration only for sovereign or private clouds. The `azcore/cloud` package has predefined configuration for sovereign clouds such as Azure China:
+
+```go
+import (
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+    "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+)
+
+clientOpts := azcore.ClientOptions{Cloud: cloud.AzureChina}
+
+cred, err := azidentity.NewClientSecretCredential(
+    tenantID, clientID, secret, &azidentity.ClientSecretCredentialOptions{ClientOptions: clientOpts},
+)
+handle(err)
+```
+
+## Client secret authentication
+
+### `autorest/adal`:
+
+```go
+import (
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
+    "github.com/Azure/go-autorest/autorest"
+    "github.com/Azure/go-autorest/autorest/adal"
+)
+
+oauthCfg, err := adal.NewOAuthConfig("https://login.microsoftonline.com", tenantID)
+handle(err)
+spt, err := adal.NewServicePrincipalTokenWithSecret(
+    *oauthCfg, clientID, "https://management.azure.com/", &adal.ServicePrincipalTokenSecret{ClientSecret: secret},
+)
+handle(err)
+
+client := subscriptions.NewClient()
+client.Authorizer = autorest.NewBearerAuthorizer(spt)
+```
+
+### `azidentity`:
+
+```go
+import (
+    "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+    "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+)
+
+cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, secret, nil)
+handle(err)
+
+client, err := armsubscriptions.NewClient(cred, nil)
+handle(err)
+```
+
+## Client certificate authentication
+
+### `autorest/adal`:
+
+```go
+import (
+    "os"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
+    "github.com/Azure/go-autorest/autorest"
+    "github.com/Azure/go-autorest/autorest/adal"
+)
+certData, err := os.ReadFile("./example.pfx")
+handle(err)
+
+certificate, rsaPrivateKey, err := decodePkcs12(certData, "")
+handle(err)
+
+oauthCfg, err := adal.NewOAuthConfig("https://login.microsoftonline.com", tenantID)
+handle(err)
+
+spt, err := adal.NewServicePrincipalTokenFromCertificate(
+	*oauthConfig, clientID, certificate, rsaPrivateKey, "https://management.azure.com/",
+)
+
+client := subscriptions.NewClient()
+client.Authorizer = autorest.NewBearerAuthorizer(spt)
+```
+
+### `azidentity`:
+
+```go
+import (
+    "os"
+
+    "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+    "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+)
+
+certData, err := os.ReadFile("./example.pfx")
+handle(err)
+
+certs, key, err := azidentity.ParseCertificates(certData, nil)
+handle(err)
+
+cred, err = azidentity.NewClientCertificateCredential(tenantID, clientID, certs, key, nil)
+handle(err)
+
+client, err := armsubscriptions.NewClient(cred, nil)
+handle(err)
+```
+
+### Managed identity
+
+### `autorest/adal`:
+
+```go
+import (
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
+    "github.com/Azure/go-autorest/autorest"
+    "github.com/Azure/go-autorest/autorest/adal"
+)
+
+spt, err := adal.NewServicePrincipalTokenFromManagedIdentity("https://management.azure.com/", nil)
+handle(err)
+
+client := subscriptions.NewClient()
+client.Authorizer = autorest.NewBearerAuthorizer(spt)
+```
+
+### `azidentity`:
+
+```go
+import (
+    "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+    "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+)
+
+cred, err := azidentity.NewManagedIdentityCredential(nil)
+handle(err)
+
+client, err := armsubscriptions.NewClient(cred, nil)
+handle(err)
+```
+
+#### User assigned identities
+
+`autorest/adal`:
+
+```go
+import "github.com/Azure/go-autorest/autorest/adal"
+
+opts := &adal.ManagedIdentityOptions{ClientID: "..."}
+spt, err := adal.NewServicePrincipalTokenFromManagedIdentity("https://management.azure.com/")
+handle(err)
+```
+
+`azidentity`:
+
+```go
+import "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
+opts := azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ClientID("...")}
+cred, err := azidentity.NewManagedIdentityCredential(&opts)
+handle(err)
+```
+
+### Device code authentication
+
+### `autorest/adal`:
+
+```go
+import (
+    "fmt"
+    "net/http"
+
+    "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
+    "github.com/Azure/go-autorest/autorest"
+    "github.com/Azure/go-autorest/autorest/adal"
+)
+
+oauthClient := &http.Client{}
+oauthCfg, err := adal.NewOAuthConfig("https://login.microsoftonline.com", tenantID)
+handle(err)
+resource := "https://management.azure.com/"
+deviceCode, err := adal.InitiateDeviceAuth(oauthClient, *oauthCfg, clientID, resource)
+handle(err)
+
+// display instructions, wait for the user to authenticate
+fmt.Println(*deviceCode.Message)
+token, err := adal.WaitForUserCompletion(oauthClient, deviceCode)
+handle(err)
+
+spt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthCfg, clientID, resource, *token)
+handle(err)
+
+client := subscriptions.NewClient()
+client.Authorizer = autorest.NewBearerAuthorizer(spt)
+```
+
+### `azidentity`:
+
+```go
+import (
+    "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+    "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+)
+
+cred, err := azidentity.NewDeviceCodeCredential(nil)
+handle(err)
+
+client, err := armsubscriptions.NewSubscriptionsClient(cred, nil)
+handle(err)
+```
+
+`azidentity.DeviceCodeCredential` will guide a user through authentication, printing instructions to the console by default. The user prompt is customizable; see
+the [package documentation](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#DeviceCodeCredential) for details.
+
+## Acquiring a token
+
+### `autorest/adal`:
+
+```go
+import "github.com/Azure/go-autorest/autorest/adal"
+
+oauthCfg, err := adal.NewOAuthConfig("https://login.microsoftonline.com", tenantID)
+handle(err)
+
+spt, err := adal.NewServicePrincipalTokenWithSecret(
+    *oauthCfg, clientID, "https://vault.azure.net", &adal.ServicePrincipalTokenSecret{ClientSecret: secret},
+)
+
+err = spt.Refresh()
+if err == nil {
+    token := spt.Token
+}
+```
+
+### `azidentity`:
+
+In ordinary usage application code doesn't need to request tokens from credentials directly because Azure SDK clients handle token acquisition and refreshing internally. However, applications may call `GetToken()` to do so (all credential types have this method):
+
+```go
+import (
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+    "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+)
+
+cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, secret, nil)
+handle(err)
+
+tk, err := cred.GetToken(
+    context.TODO(), policy.TokenRequestOptions{Scopes: []string{"https://vault.azure.net/.default"}},
+)
+if err == nil {
+    token := tk.Token
+}
+```
+
+Note that `azidentity` credentials use the Azure AD v2.0 endpoint, which requires OAuth 2 scopes instead of the resource identifiers `autorest/adal` expects. See [Azure AD documentation](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent) for more information.
+
+## Using azidentity credentials with older packages
+
+The [azidext module](https://pkg.go.dev/github.com/jongio/azidext/go/azidext) provides an adapter for `azidentity` credential types that enables using them with older Azure SDK clients. For example:
+
+```go
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
+	"github.com/jongio/azidext/go/azidext"
+)
+
+cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, secret, nil)
+handle(err)
+
+client := subscriptions.NewClient()
+client.Authorizer = azidext.NewTokenCredentialAdapter(cred, []string{"https://management.azure.com//.default"})
+```
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fazidentity%2FMIGRATION.png)

--- a/sdk/azidentity/MIGRATION.md
+++ b/sdk/azidentity/MIGRATION.md
@@ -55,7 +55,7 @@ handle(err)
 
 ```go
 import (
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
+    "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
     "github.com/Azure/go-autorest/autorest"
     "github.com/Azure/go-autorest/autorest/adal"
 )
@@ -94,7 +94,7 @@ handle(err)
 import (
     "os"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
+    "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
     "github.com/Azure/go-autorest/autorest"
     "github.com/Azure/go-autorest/autorest/adal"
 )
@@ -108,7 +108,7 @@ oauthCfg, err := adal.NewOAuthConfig("https://login.microsoftonline.com", tenant
 handle(err)
 
 spt, err := adal.NewServicePrincipalTokenFromCertificate(
-	*oauthConfig, clientID, certificate, rsaPrivateKey, "https://management.azure.com/",
+    *oauthConfig, clientID, certificate, rsaPrivateKey, "https://management.azure.com/",
 )
 
 client := subscriptions.NewClient()
@@ -144,7 +144,7 @@ handle(err)
 
 ```go
 import (
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
+    "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
     "github.com/Azure/go-autorest/autorest"
     "github.com/Azure/go-autorest/autorest/adal"
 )
@@ -292,9 +292,9 @@ The [azidext module](https://pkg.go.dev/github.com/jongio/azidext/go/azidext) pr
 
 ```go
 import (
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
-	"github.com/jongio/azidext/go/azidext"
+    "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+    "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions"
+    "github.com/jongio/azidext/go/azidext"
 )
 
 cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, secret, nil)

--- a/sdk/azidentity/MIGRATION.md
+++ b/sdk/azidentity/MIGRATION.md
@@ -6,13 +6,13 @@ This guide shows common authentication code using `autorest/adal` and its equiva
 
 ## Table of contents
 
-- [Acquiring a token](#acquiring-a-token)
+- [Acquire a token](#acquire-a-token)
 - [Client certificate authentication](#client-certificate-authentication)
 - [Client secret authentication](#client-secret-authentication)
 - [Configuration](#configuration)
 - [Device code authentication](#device-code-authentication)
 - [Managed identity](#managed-identity)
-- [Using azidentity credentials with older packages](#using-azidentity-credentials-with-older-packages)
+- [Use azidentity credentials with older packages](#use-azidentity-credentials-with-older-packages)
 
 ## Configuration
 
@@ -33,7 +33,7 @@ spt, err := adal.NewServicePrincipalTokenWithSecret(
 
 ### `azidentity`
 
-A credential instance can acquire tokens for any audience, and the audience for each token is determined by the client requesting it. Credentials require endpoint configuration only for sovereign or private clouds. The `azcore/cloud` package has predefined configuration for sovereign clouds such as Azure China:
+A credential instance can acquire tokens for any audience. The audience for each token is determined by the client requesting it. Credentials require endpoint configuration only for sovereign or private clouds. The `azcore/cloud` package has predefined configuration for sovereign clouds such as Azure China:
 
 ```go
 import (
@@ -51,7 +51,7 @@ handle(err)
 
 ## Client secret authentication
 
-### `autorest/adal`:
+### `autorest/adal`
 
 ```go
 import (
@@ -71,7 +71,7 @@ client := subscriptions.NewClient()
 client.Authorizer = autorest.NewBearerAuthorizer(spt)
 ```
 
-### `azidentity`:
+### `azidentity`
 
 ```go
 import (
@@ -88,7 +88,7 @@ handle(err)
 
 ## Client certificate authentication
 
-### `autorest/adal`:
+### `autorest/adal`
 
 ```go
 import (
@@ -115,7 +115,7 @@ client := subscriptions.NewClient()
 client.Authorizer = autorest.NewBearerAuthorizer(spt)
 ```
 
-### `azidentity`:
+### `azidentity`
 
 ```go
 import (
@@ -140,7 +140,7 @@ handle(err)
 
 ### Managed identity
 
-### `autorest/adal`:
+#### `autorest/adal`
 
 ```go
 import (
@@ -156,7 +156,7 @@ client := subscriptions.NewClient()
 client.Authorizer = autorest.NewBearerAuthorizer(spt)
 ```
 
-### `azidentity`:
+#### `azidentity`
 
 ```go
 import (
@@ -171,7 +171,7 @@ client, err := armsubscriptions.NewClient(cred, nil)
 handle(err)
 ```
 
-#### User assigned identities
+#### User-assigned identities
 
 `autorest/adal`:
 
@@ -195,7 +195,7 @@ handle(err)
 
 ### Device code authentication
 
-### `autorest/adal`:
+#### `autorest/adal`
 
 ```go
 import (
@@ -226,7 +226,7 @@ client := subscriptions.NewClient()
 client.Authorizer = autorest.NewBearerAuthorizer(spt)
 ```
 
-### `azidentity`:
+#### `azidentity`
 
 ```go
 import (
@@ -241,12 +241,11 @@ client, err := armsubscriptions.NewSubscriptionsClient(cred, nil)
 handle(err)
 ```
 
-`azidentity.DeviceCodeCredential` will guide a user through authentication, printing instructions to the console by default. The user prompt is customizable; see
-the [package documentation](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#DeviceCodeCredential) for details.
+`azidentity.DeviceCodeCredential` will guide a user through authentication, printing instructions to the console by default. The user prompt is customizable. For more information, see the [package documentation](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#DeviceCodeCredential).
 
-## Acquiring a token
+## Acquire a token
 
-### `autorest/adal`:
+### `autorest/adal`
 
 ```go
 import "github.com/Azure/go-autorest/autorest/adal"
@@ -264,9 +263,9 @@ if err == nil {
 }
 ```
 
-### `azidentity`:
+### `azidentity`
 
-In ordinary usage application code doesn't need to request tokens from credentials directly because Azure SDK clients handle token acquisition and refreshing internally. However, applications may call `GetToken()` to do so (all credential types have this method):
+In ordinary usage, application code doesn't need to request tokens from credentials directly. Azure SDK clients handle token acquisition and refreshing internally. However, applications may call `GetToken()` to do so. All credential types have this method.
 
 ```go
 import (
@@ -285,11 +284,11 @@ if err == nil {
 }
 ```
 
-Note that `azidentity` credentials use the Azure AD v2.0 endpoint, which requires OAuth 2 scopes instead of the resource identifiers `autorest/adal` expects. See [Azure AD documentation](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent) for more information.
+Note that `azidentity` credentials use the Azure AD v2.0 endpoint, which requires OAuth 2 scopes instead of the resource identifiers `autorest/adal` expects. For more information, see [Azure AD documentation](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent).
 
-## Using azidentity credentials with older packages
+## Use azidentity credentials with older packages
 
-The [azidext module](https://pkg.go.dev/github.com/jongio/azidext/go/azidext) provides an adapter for `azidentity` credential types that enables using them with older Azure SDK clients. For example:
+The [azidext module](https://pkg.go.dev/github.com/jongio/azidext/go/azidext) provides an adapter for `azidentity` credential types. The adapter enables using the credential types with older Azure SDK clients. For example:
 
 ```go
 import (

--- a/sdk/azidentity/MIGRATION.md
+++ b/sdk/azidentity/MIGRATION.md
@@ -138,9 +138,9 @@ client, err := armsubscriptions.NewClient(cred, nil)
 handle(err)
 ```
 
-### Managed identity
+## Managed identity
 
-#### `autorest/adal`
+### `autorest/adal`
 
 ```go
 import (
@@ -156,7 +156,7 @@ client := subscriptions.NewClient()
 client.Authorizer = autorest.NewBearerAuthorizer(spt)
 ```
 
-#### `azidentity`
+### `azidentity`
 
 ```go
 import (
@@ -171,7 +171,7 @@ client, err := armsubscriptions.NewClient(cred, nil)
 handle(err)
 ```
 
-#### User-assigned identities
+### User-assigned identities
 
 `autorest/adal`:
 
@@ -193,9 +193,9 @@ cred, err := azidentity.NewManagedIdentityCredential(&opts)
 handle(err)
 ```
 
-### Device code authentication
+## Device code authentication
 
-#### `autorest/adal`
+### `autorest/adal`
 
 ```go
 import (
@@ -226,7 +226,7 @@ client := subscriptions.NewClient()
 client.Authorizer = autorest.NewBearerAuthorizer(spt)
 ```
 
-#### `azidentity`
+### `azidentity`
 
 ```go
 import (


### PR DESCRIPTION
Migrating from track 1 to 2 authentication means rewriting code using `autorest/adal` to do the same thing with `azidentity`, so I focused this guide on before/after examples of common scenarios. Closes #17145