### PR TITLE
Rename PossibleGeoReplicationStatusTypeValues to match new type name

### DIFF
--- a/sdk/data/aztables/CHANGELOG.md
+++ b/sdk/data/aztables/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
+* Renamed `PossibleGeoReplicationStatusTypeValues` to `PossibleGeoReplicationStatusValues`
 
 ### Bugs Fixed
 

--- a/sdk/data/aztables/models.go
+++ b/sdk/data/aztables/models.go
@@ -315,8 +315,8 @@ const (
 	GeoReplicationStatusUnavailable GeoReplicationStatus = "unavailable"
 )
 
-// PossibleGeoReplicationStatusTypeValues returns the possible values for the GeoReplicationStatusType const type.
-func PossibleGeoReplicationStatusTypeValues() []GeoReplicationStatus {
+// PossibleGeoReplicationStatusValues returns the possible values for the GeoReplicationStatus const type.
+func PossibleGeoReplicationStatusValues() []GeoReplicationStatus {
 	return []GeoReplicationStatus{
 		GeoReplicationStatusBootstrap,
 		GeoReplicationStatusLive,


### PR DESCRIPTION
Appears this should be PossibleGeoReplicationStatus~Type~Values, following the GeoReplicationStatus~Type~ rename in the latest release