### PR TITLE
Added setup of sharedKey to azblob.NewBlockBlobClientWithSharedKey

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/azure-sdk-for-go.iml
+++ b/.idea/azure-sdk-for-go.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/azure-sdk-for-go.iml" filepath="$PROJECT_DIR$/.idea/azure-sdk-for-go.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/sdk/storage/azblob/zc_block_blob_client.go
+++ b/sdk/storage/azblob/zc_block_blob_client.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 )
@@ -47,7 +46,7 @@ func NewBlockBlobClientWithNoCredential(blobURL string, options *ClientOptions) 
 	con := newConnection(blobURL, nil, options.getConnectionOptions())
 	return &BlockBlobClient{
 		client:     &blockBlobClient{con: con},
-		BlobClient: BlobClient{client: &blobClient{con: con}},
+		BlobClient: BlobClient{client: &blobClient{con: con}, sharedKey},
 	}, nil
 }
 
@@ -56,8 +55,11 @@ func NewBlockBlobClientWithSharedKey(blobURL string, cred *SharedKeyCredential, 
 	authPolicy := newSharedKeyCredPolicy(cred)
 	con := newConnection(blobURL, authPolicy, options.getConnectionOptions())
 	return &BlockBlobClient{
-		client:     &blockBlobClient{con: con},
-		BlobClient: BlobClient{client: &blobClient{con: con}},
+		client: &blockBlobClient{con: con},
+		BlobClient: BlobClient{
+			client:    &blobClient{con: con},
+			sharedKey: cred,
+		},
 	}, nil
 }
 


### PR DESCRIPTION
Added setup of one of the field (sharedKey) to `azblob.NewBlockBlobClientWithSharedKey` constructor. Problem was about the using client generated by this constructor. 
Steps to reproduce: 
- Create client using  `azblob.NewBlockBlobClientWithSharedKey `
- Call `GetSASToken(permissions BlobSASPermissions, start time.Time, expiry time.Time) (SASQueryParameters, error)`
Expecting result is returning structure `azblob.SASQueryParameters`.
Actual result is error: `credential is not a SharedKeyCredential. SAS can only be signed with a SharedKeyCredential`.
It happens be cause `azblob.SASQueryParameters` has rows for checking of existing the `sharedKey`:
```
if b.sharedKey == nil {
		return SASQueryParameters{}, errors.New("credential is not a SharedKeyCredential. SAS can only be signed with a 
        SharedKeyCredential")
	}
```
Problem can be fixed if in the `azblob.NewBlockBlobClientWithSharedKey` field `sharedKey` will be set.