### PR TITLE
[Tables] improving testing for access policies

### DIFF
--- a/sdk/data/aztables/access_policy_test.go
+++ b/sdk/data/aztables/access_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +16,7 @@ func TestSetEmptyAccessPolicy(t *testing.T) {
 	client, delete := initClientTest(t, "storage", true)
 	defer delete()
 
-	_, err := client.SetAccessPolicy(ctx, &SetAccessPolicyOptions{})
+	_, err := client.SetAccessPolicy(ctx, nil)
 	require.NoError(t, err)
 }
 
@@ -45,6 +46,22 @@ func TestSetAccessPolicy(t *testing.T) {
 
 	_, err := client.SetAccessPolicy(ctx, &param)
 	require.NoError(t, err)
+
+	recording.Sleep(60 * time.Second)
+
+	resp, err := client.GetAccessPolicy(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(resp.SignedIdentifiers))
+
+	// set nil access policy
+	_, err = client.SetAccessPolicy(ctx, nil)
+	require.NoError(t, err)
+
+	recording.Sleep(60 * time.Second)
+
+	resp, err = client.GetAccessPolicy(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(resp.SignedIdentifiers))
 }
 
 func TestSetMultipleAccessPolicies(t *testing.T) {

--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -652,6 +652,7 @@ func (s *SetAccessPolicyOptions) toGenerated() *generated.TableClientSetAccessPo
 // If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
 // Specify nil for options if you want to use the default options.
 func (t *Client) SetAccessPolicy(ctx context.Context, options *SetAccessPolicyOptions) (SetAccessPolicyResponse, error) {
+	if options == nil {options = &SetAccessPolicyOptions{}}
 	response, err := t.client.SetAccessPolicy(ctx, t.name, generated.Enum4ACL, options.toGenerated())
 	if len(options.TableACL) > 5 {
 		err = errTooManyAccessPoliciesError

--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -656,7 +656,7 @@ func (t *Client) SetAccessPolicy(ctx context.Context, options *SetAccessPolicyOp
 		options = &SetAccessPolicyOptions{}
 	}
 	response, err := t.client.SetAccessPolicy(ctx, t.name, generated.Enum4ACL, options.toGenerated())
-	if err != nil && options != nil && len(options.TableACL) > 5 {
+	if err != nil && len(options.TableACL) > 5 {
 		err = errTooManyAccessPoliciesError
 	}
 	return setAccessPolicyResponseFromGenerated(&response), err

--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -652,9 +652,11 @@ func (s *SetAccessPolicyOptions) toGenerated() *generated.TableClientSetAccessPo
 // If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
 // Specify nil for options if you want to use the default options.
 func (t *Client) SetAccessPolicy(ctx context.Context, options *SetAccessPolicyOptions) (SetAccessPolicyResponse, error) {
-	if options == nil {options = &SetAccessPolicyOptions{}}
+	if options == nil {
+		options = &SetAccessPolicyOptions{}
+	}
 	response, err := t.client.SetAccessPolicy(ctx, t.name, generated.Enum4ACL, options.toGenerated())
-	if len(options.TableACL) > 5 {
+	if err != nil && options != nil && len(options.TableACL) > 5 {
 		err = errTooManyAccessPoliciesError
 	}
 	return setAccessPolicyResponseFromGenerated(&response), err

--- a/sdk/data/aztables/testdata/recordings/TestSetAccessPolicy.json
+++ b/sdk/data/aztables/testdata/recordings/TestSetAccessPolicy.json
@@ -11,8 +11,8 @@
         "Content-Length": "35",
         "Content-Type": "application/json",
         "dataserviceversion": "3.0",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:08 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:09:55 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
@@ -22,19 +22,19 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 24 Jan 2022 20:59:09 GMT",
-        "Location": "https://rosebudprim.table.core.windows.net/Tables(\u0027tableName4016778387\u0027)",
+        "Date": "Wed, 13 Apr 2022 16:09:54 GMT",
+        "Location": "https://fakeaccount.table.core.windows.net/Tables(\u0027tableName4016778387\u0027)",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f99159f2-b002-0054-6e65-11ec4e000000",
+        "x-ms-request-id": "44898f8b-c002-0055-1450-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://rosebudprim.table.core.windows.net/$metadata#Tables/@Element",
+        "odata.metadata": "https://fakeaccount.table.core.windows.net/$metadata#Tables/@Element",
         "TableName": "tableName4016778387"
       }
     },
@@ -47,23 +47,103 @@
         "Authorization": "Sanitized",
         "Content-Length": "213",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:08 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:09:55 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": "\u003CSignedIdentifiers\u003E\u003CSignedIdentifier\u003E\u003CAccessPolicy\u003E\u003CPermission\u003Er\u003C/Permission\u003E\u003CExpiry\u003E2024-01-01T00:00:00Z\u003C/Expiry\u003E\u003CStart\u003E2020-01-01T00:00:00Z\u003C/Start\u003E\u003C/AccessPolicy\u003E\u003CId\u003E1\u003C/Id\u003E\u003C/SignedIdentifier\u003E\u003C/SignedIdentifiers\u003E",
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 24 Jan 2022 20:59:10 GMT",
+        "Date": "Wed, 13 Apr 2022 16:09:54 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "f9915a35-b002-0054-3065-11ec4e000000",
+        "x-ms-request-id": "44898f8d-c002-0055-1550-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://fakeaccount.table.core.windows.net/tableName4016778387?comp=acl",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":method": "GET",
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:10:55 GMT",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Wed, 13 Apr 2022 16:10:54 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "448997ca-c002-0055-4151-4ff8d9000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CSignedIdentifiers\u003E\u003CSignedIdentifier\u003E\u003CId\u003E1\u003C/Id\u003E\u003CAccessPolicy\u003E\u003CStart\u003E2020-01-01T00:00:00.0000000Z\u003C/Start\u003E\u003CExpiry\u003E2024-01-01T00:00:00.0000000Z\u003C/Expiry\u003E\u003CPermission\u003Er\u003C/Permission\u003E\u003C/AccessPolicy\u003E\u003C/SignedIdentifier\u003E\u003C/SignedIdentifiers\u003E"
+    },
+    {
+      "RequestUri": "https://fakeaccount.table.core.windows.net/tableName4016778387?comp=acl",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:10:55 GMT",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 13 Apr 2022 16:10:54 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "448997d5-c002-0055-4a51-4ff8d9000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://fakeaccount.table.core.windows.net/tableName4016778387?comp=acl",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        ":method": "GET",
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:11:55 GMT",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Wed, 13 Apr 2022 16:11:54 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "4489a097-c002-0055-0651-4ff8d9000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CSignedIdentifiers /\u003E"
     },
     {
       "RequestUri": "https://fakeaccount.table.core.windows.net/Tables(\u0027tableName4016778387\u0027)",
@@ -72,8 +152,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:09 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:11:55 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": null,
@@ -81,13 +161,13 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 24 Jan 2022 20:59:10 GMT",
+        "Date": "Wed, 13 Apr 2022 16:11:54 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f9915a7c-b002-0054-7665-11ec4e000000",
+        "x-ms-request-id": "4489a09a-c002-0055-0851-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null

--- a/sdk/data/aztables/testdata/recordings/TestSetEmptyAccessPolicy.json
+++ b/sdk/data/aztables/testdata/recordings/TestSetEmptyAccessPolicy.json
@@ -11,8 +11,8 @@
         "Content-Length": "35",
         "Content-Type": "application/json",
         "dataserviceversion": "3.0",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:08 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:09:54 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
@@ -22,19 +22,19 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 24 Jan 2022 20:59:09 GMT",
-        "Location": "https://rosebudprim.table.core.windows.net/Tables(\u0027tableName1201868612\u0027)",
+        "Date": "Wed, 13 Apr 2022 16:09:53 GMT",
+        "Location": "https://fakeaccount.table.core.windows.net/Tables(\u0027tableName1201868612\u0027)",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f9915909-b002-0054-0c65-11ec4e000000",
+        "x-ms-request-id": "44898f7e-c002-0055-0c50-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://rosebudprim.table.core.windows.net/$metadata#Tables/@Element",
+        "odata.metadata": "https://fakeaccount.table.core.windows.net/$metadata#Tables/@Element",
         "TableName": "tableName1201868612"
       }
     },
@@ -46,20 +46,20 @@
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:08 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:09:55 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 24 Jan 2022 20:59:09 GMT",
+        "Date": "Wed, 13 Apr 2022 16:09:53 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "f991593f-b002-0054-3e65-11ec4e000000",
+        "x-ms-request-id": "44898f81-c002-0055-0d50-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null
@@ -71,8 +71,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:08 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:09:55 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": null,
@@ -80,13 +80,13 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 24 Jan 2022 20:59:09 GMT",
+        "Date": "Wed, 13 Apr 2022 16:09:54 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f9915978-b002-0054-7765-11ec4e000000",
+        "x-ms-request-id": "44898f83-c002-0055-0f50-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null

--- a/sdk/data/aztables/testdata/recordings/TestSetNullAccessPolicy.json
+++ b/sdk/data/aztables/testdata/recordings/TestSetNullAccessPolicy.json
@@ -11,8 +11,8 @@
         "Content-Length": "34",
         "Content-Type": "application/json",
         "dataserviceversion": "3.0",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:09 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:11:55 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
@@ -22,19 +22,19 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 24 Jan 2022 20:59:11 GMT",
-        "Location": "https://rosebudprim.table.core.windows.net/Tables(\u0027tableName592901018\u0027)",
+        "Date": "Wed, 13 Apr 2022 16:11:54 GMT",
+        "Location": "https://fakeaccount.table.core.windows.net/Tables(\u0027tableName592901018\u0027)",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f9915c89-b002-0054-7a65-11ec4e000000",
+        "x-ms-request-id": "4489a09e-c002-0055-0c51-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://rosebudprim.table.core.windows.net/$metadata#Tables/@Element",
+        "odata.metadata": "https://fakeaccount.table.core.windows.net/$metadata#Tables/@Element",
         "TableName": "tableName592901018"
       }
     },
@@ -47,20 +47,20 @@
         "Authorization": "Sanitized",
         "Content-Length": "89",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:10 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:11:55 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": "\u003CSignedIdentifiers\u003E\u003CSignedIdentifier\u003E\u003CId\u003Enull\u003C/Id\u003E\u003C/SignedIdentifier\u003E\u003C/SignedIdentifiers\u003E",
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 24 Jan 2022 20:59:11 GMT",
+        "Date": "Wed, 13 Apr 2022 16:11:54 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "f9915ccb-b002-0054-3965-11ec4e000000",
+        "x-ms-request-id": "4489a0a2-c002-0055-0f51-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null
@@ -73,22 +73,21 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:10 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:11:56 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Mon, 24 Jan 2022 20:59:11 GMT",
+        "Date": "Wed, 13 Apr 2022 16:11:54 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-request-id": "f9915cf9-b002-0054-6665-11ec4e000000",
+        "x-ms-request-id": "4489a0a3-c002-0055-1051-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CSignedIdentifiers\u003E\u003CSignedIdentifier\u003E\u003CId\u003Enull\u003C/Id\u003E\u003C/SignedIdentifier\u003E\u003C/SignedIdentifiers\u003E"
@@ -100,8 +99,8 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-internal/v0.5.1 azsdk-go-azcore/v0.21.0 (go1.17; Windows_NT)",
-        "x-ms-date": "Mon, 24 Jan 2022 20:59:10 GMT",
+        "User-Agent": "azsdk-go-internal/v0.7.1 azsdk-go-azcore/v0.23.0 (go1.18; Windows_NT)",
+        "x-ms-date": "Wed, 13 Apr 2022 16:11:56 GMT",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": null,
@@ -109,13 +108,13 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 24 Jan 2022 20:59:11 GMT",
+        "Date": "Wed, 13 Apr 2022 16:11:54 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "X-Content-Type-Options": "nosniff",
-        "x-ms-request-id": "f9915d36-b002-0054-2165-11ec4e000000",
+        "x-ms-request-id": "4489a0a4-c002-0055-1151-4ff8d9000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null


### PR DESCRIPTION
Brought on by Joel's comment [here](https://github.com/Azure/azure-sdk-for-go/pull/17570/files#r849644507), there is a reason to pass in `nil` options for `SetAccessPolicy`, it will remove any previously set access policies. AccessPolicies is `nil`-able and doesn't fit the same mold as what I have generally used in named parameters (that they can not be nil by the service).