### PR TITLE
GetToken() returns an error when the caller specifies no scope

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+* `GetToken()` returns an error when the caller specifies no scope
 
 ## 0.14.0 (2022-04-05)
 

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -88,6 +88,9 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 // ctx: Context controlling the request lifetime.
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
+	if len(opts.Scopes) == 0 {
+		return nil, errors.New(credNameCert + ": GetToken() requires at least one scope")
+	}
 	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes)
 	if err == nil {
 		logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -59,6 +59,9 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 // ctx: Context used to control the request lifetime.
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *ClientSecretCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
+	if len(opts.Scopes) == 0 {
+		return nil, errors.New(credNameSecret + ": GetToken() requires at least one scope")
+	}
 	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes)
 	if err == nil {
 		logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -99,6 +99,9 @@ func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeC
 // ctx: Context used to control the request lifetime.
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
+	if len(opts.Scopes) == 0 {
+		return nil, errors.New(credNameDeviceCode + ": GetToken() requires at least one scope")
+	}
 	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, public.WithSilentAccount(c.account))
 	if err == nil {
 		return &azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -75,6 +75,9 @@ func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOption
 // ctx: Context used to control the request lifetime.
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *InteractiveBrowserCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
+	if len(opts.Scopes) == 0 {
+		return nil, errors.New(credNameBrowser + ": GetToken() requires at least one scope")
+	}
 	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, public.WithSilentAccount(c.account))
 	if err == nil {
 		logGetTokenSuccess(c, opts)

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -62,6 +62,9 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 // ctx: Context used to control the request lifetime.
 // opts: Options for the token request, in particular the desired scope of the access token.
 func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (*azcore.AccessToken, error) {
+	if len(opts.Scopes) == 0 {
+		return nil, errors.New(credNameUserPassword + ": GetToken() requires at least one scope")
+	}
 	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, public.WithSilentAccount(c.account))
 	if err == nil {
 		logGetTokenSuccess(c, opts)


### PR DESCRIPTION
Calling `GetToken()` without specifying a scope doesn't make sense--it's like saying "I want to access something but don't know what"--but our API allows it. I think that's okay because calling `GetToken()` directly is an advanced scenario whose users should know they must specify a scope. However, the error experience through MSAL is poor for users who don't know that, because MSAL will request a token for its implicit default scopes and return a confusing error (https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/304).