### PR TITLE
[azservicebus] Export our log.Event constants 

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features Added
 
+- Exported log.Event constants for azservicebus. This will maek them easier to
+  discover and they are also documented. The text of log messages themselves 
+  are not guaranteed to be stable. (#TBD)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -247,16 +247,16 @@ azlog.SetListener(func(event azlog.Event, s string) {
 
 // pick the set of events to log
 azlog.SetEvents(
-  // connection/reconnect related events)
-  "azsb.Conn",
-  // authentication events
-  "azsb.Auth",
-  // receiver specific events
-  "azsb.Receiver",
-  // management link related events
-  "azsb.Mgmt",
-  // retry related events
-  "azsb.Retry",
+  // EventConn is used whenever we create a connection or any links (ie: receivers, senders).
+  azservicebus.EventConn,
+  // EventAuth is used when we're doing authentication/claims negotiation.
+  azservicebus.EventAuth,
+  // EventReceiver represents operations that happen on Receivers.
+  azservicebus.EventReceiver,
+  // EventSender represents operations that happen on Senders.
+  azservicebus.EventSender,
+  // EventAdmin is used for operations in the azservicebus/admin.Client
+  azservicebus.EventAdmin,
 )
 ```
 

--- a/sdk/messaging/azservicebus/example_client_test.go
+++ b/sdk/messaging/azservicebus/example_client_test.go
@@ -5,10 +5,14 @@ package azservicebus_test
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"time"
 
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/utils"
 	"nhooyr.io/websocket"
 )
 
@@ -61,4 +65,51 @@ func ExampleNewClient_usingWebsockets() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func ExampleNewClient_configuringRetries() {
+	// NOTE: If you'd like to authenticate via Azure Active Directory look at
+	// the `NewClient` function instead.
+	client, err = azservicebus.NewClientFromConnectionString(connectionString, &azservicebus.ClientOptions{
+		// NOTE: you don't need to configure these explicitly if you like the defaults.
+		// For more information see:
+		//  https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus#RetryOptions
+		RetryOptions: utils.RetryOptions{
+			// MaxRetries specifies the maximum number of attempts a failed operation will be retried
+			// before producing an error.
+			MaxRetries: 3,
+			// RetryDelay specifies the initial amount of delay to use before retrying an operation.
+			// The delay increases exponentially with each retry up to the maximum specified by MaxRetryDelay.
+			RetryDelay: 4 * time.Second,
+			// MaxRetryDelay specifies the maximum delay allowed before retrying an operation.
+			// Typically the value is greater than or equal to the value specified in RetryDelay.
+			MaxRetryDelay: 120 * time.Second,
+		},
+	})
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Example_enablingLogging() {
+	// Required import:
+	//   import azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
+
+	// print log output to stdout
+	azlog.SetListener(func(event azlog.Event, s string) {
+		fmt.Printf("[%s] %s\n", event, s)
+	})
+
+	// pick the set of events to log
+	azlog.SetEvents(
+		// EventConn is used whenever we create a connection or any links (ie: receivers, senders).
+		azservicebus.EventConn,
+		// EventAuth is used when we're doing authentication/claims negotiation.
+		azservicebus.EventAuth,
+		// EventReceiver represents operations that happen on Receivers.
+		azservicebus.EventReceiver,
+		// EventAdmin is used for operations in the azservicebus/admin.Client
+		azservicebus.EventAdmin,
+	)
 }

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -36,7 +36,7 @@ type AMQPLinks interface {
 	Get(ctx context.Context) (*LinksWithID, error)
 
 	// Retry will run your callback, recovering links when necessary.
-	Retry(ctx context.Context, name string, fn RetryWithLinksFn, o utils.RetryOptions) error
+	Retry(ctx context.Context, name log.Event, operation string, fn RetryWithLinksFn, o utils.RetryOptions) error
 
 	// RecoverIfNeeded will check if an error requires recovery, and will recover
 	// the link or, possibly, the connection.
@@ -298,7 +298,7 @@ func (l *AMQPLinksImpl) Get(ctx context.Context) (*LinksWithID, error) {
 	}, nil
 }
 
-func (l *AMQPLinksImpl) Retry(ctx context.Context, name string, fn RetryWithLinksFn, o utils.RetryOptions) error {
+func (l *AMQPLinksImpl) Retry(ctx context.Context, eventName log.Event, operation string, fn RetryWithLinksFn, o utils.RetryOptions) error {
 	var lastID LinkID
 
 	didQuickRetry := false
@@ -307,7 +307,7 @@ func (l *AMQPLinksImpl) Retry(ctx context.Context, name string, fn RetryWithLink
 		return l.getRecoveryKindFunc(err) == RecoveryKindFatal
 	}
 
-	return utils.Retry(ctx, name, func(ctx context.Context, args *utils.RetryFnArgs) error {
+	return utils.Retry(ctx, eventName, operation, func(ctx context.Context, args *utils.RetryFnArgs) error {
 		if err := l.RecoverIfNeeded(ctx, lastID, args.LastErr); err != nil {
 			return err
 		}

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/test"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/utils"
 	"github.com/Azure/go-amqp"
@@ -329,7 +330,7 @@ func TestAMQPLinksRetry(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	err = links.Retry(context.Background(), "retryOp", func(ctx context.Context, lwid *LinksWithID, args *utils.RetryFnArgs) error {
+	err = links.Retry(context.Background(), log.Event("NotUsed"), "NotUsed", func(ctx context.Context, lwid *LinksWithID, args *utils.RetryFnArgs) error {
 		// force recoveries
 		return amqp.ErrConnClosed
 	}, utils.RetryOptions{
@@ -618,7 +619,7 @@ func TestAMQPLinksRetriesUnit(t *testing.T) {
 
 			var attempts []int32
 
-			err := links.Retry(context.Background(), "test", func(ctx context.Context, lwid *LinksWithID, args *utils.RetryFnArgs) error {
+			err := links.Retry(context.Background(), log.Event("NotUsed"), "NotUsed", func(ctx context.Context, lwid *LinksWithID, args *utils.RetryFnArgs) error {
 				attempts = append(attempts, args.I)
 				return testData.Err
 			}, utils.RetryOptions{

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/utils"
 	"github.com/Azure/go-amqp"
 )
@@ -154,7 +155,7 @@ func (l *FakeAMQPLinks) Get(ctx context.Context) (*LinksWithID, error) {
 	}
 }
 
-func (l *FakeAMQPLinks) Retry(ctx context.Context, name string, fn RetryWithLinksFn, o utils.RetryOptions) error {
+func (l *FakeAMQPLinks) Retry(ctx context.Context, eventName log.Event, operation string, fn RetryWithLinksFn, o utils.RetryOptions) error {
 	lwr, err := l.Get(ctx)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/sbauth"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/utils"
@@ -27,9 +28,10 @@ import (
 )
 
 const (
-	serviceBusSchema = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-	atomSchema       = "http://www.w3.org/2005/Atom"
-	applicationXML   = "application/xml"
+	serviceBusSchema           = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+	atomSchema                 = "http://www.w3.org/2005/Atom"
+	applicationXML             = "application/xml"
+	EventAdmin       log.Event = "azsb.Admin"
 )
 
 type (
@@ -245,7 +247,7 @@ func (em *entityManager) Delete(ctx context.Context, entityPath string, mw ...Mi
 func (em *entityManager) execute(ctx context.Context, method string, entityPath string, body io.Reader, mw ...MiddlewareFunc) (*http.Response, error) {
 	var finalResp *http.Response
 
-	err := utils.Retry(ctx, fmt.Sprintf("%s %s", method, entityPath), func(ctx context.Context, args *utils.RetryFnArgs) error {
+	err := utils.Retry(ctx, EventAdmin, fmt.Sprintf("%s %s", method, entityPath), func(ctx context.Context, args *utils.RetryFnArgs) error {
 		ctx, span := em.startSpanFromContext(ctx, "sb.ATOM.Execute")
 		defer span.End()
 

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -419,7 +419,7 @@ func (ns *Namespace) startNegotiateClaimRenewer(ctx context.Context,
 				return
 			case <-time.After(nextClaimAt):
 				for {
-					err := utils.Retry(refreshCtx, "claimrefresh", func(ctx context.Context, args *utils.RetryFnArgs) error {
+					err := utils.Retry(refreshCtx, EventAuth, "NegotiateClaimRefresh", func(ctx context.Context, args *utils.RetryFnArgs) error {
 						tmpExpiresOn, err := refreshClaim(ctx)
 
 						if err != nil {

--- a/sdk/messaging/azservicebus/liveTestHelpers_test.go
+++ b/sdk/messaging/azservicebus/liveTestHelpers_test.go
@@ -79,7 +79,7 @@ func peekSingleMessageForTest(t *testing.T, receiver *Receiver) *ReceivedMessage
 
 	// Peek, unlike Receive, doesn't block until at least one message has arrived, so we have to poll
 	// to get a similar effect.
-	err := utils.Retry(context.Background(), "peek", func(ctx context.Context, args *utils.RetryFnArgs) error {
+	err := utils.Retry(context.Background(), EventReceiver, "peekSingleForTest", func(ctx context.Context, args *utils.RetryFnArgs) error {
 		peekedMessages, err := receiver.PeekMessages(context.Background(), 1, nil)
 		require.NoError(t, err)
 

--- a/sdk/messaging/azservicebus/log.go
+++ b/sdk/messaging/azservicebus/log.go
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package internal
+package azservicebus
 
-import (
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/atom"
-)
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 
-// NOTE: these are intended to mirror the constant values in azservicebus/log.go
 const (
 	// EventConn is used whenever we create a connection or any links (ie: receivers, senders).
 	EventConn log.Event = "azsb.Conn"
@@ -23,5 +19,5 @@ const (
 	EventSender log.Event = "azsb.Sender"
 
 	// EventAdmin is used for operations in the azservicebus/admin.Client
-	EventAdmin log.Event = atom.EventAdmin
+	EventAdmin log.Event = "azsb.Admin"
 )

--- a/sdk/messaging/azservicebus/log_test.go
+++ b/sdk/messaging/azservicebus/log_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azservicebus
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventConstantsDontDriftApart(t *testing.T) {
+	require.Equal(t, EventConn, internal.EventConn)
+	require.Equal(t, EventAuth, internal.EventAuth)
+	require.Equal(t, EventReceiver, internal.EventReceiver)
+	require.Equal(t, EventSender, internal.EventSender)
+	require.Equal(t, EventAdmin, internal.EventAdmin)
+}

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -44,7 +44,7 @@ func (s *messageSettler) settleWithRetries(ctx context.Context, message *Receive
 		return internal.NewErrNonRetriable("messages that are received in `ReceiveModeReceiveAndDelete` mode are not settleable")
 	}
 
-	err := s.links.Retry(ctx, "settle", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	err := s.links.Retry(ctx, EventReceiver, "settle", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		if err := settleFn(lwid.Receiver, lwid.RPC); err != nil {
 			return err
 		}

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -210,7 +210,7 @@ type ReceiveDeferredMessagesOptions struct {
 func (r *Receiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers []int64, options *ReceiveDeferredMessagesOptions) ([]*ReceivedMessage, error) {
 	var receivedMessages []*ReceivedMessage
 
-	err := r.amqpLinks.Retry(ctx, "receiveDeferredMessage", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	err := r.amqpLinks.Retry(ctx, EventReceiver, "receiveDeferredMessages", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		amqpMessages, err := internal.ReceiveDeferred(ctx, lwid.RPC, r.receiveMode, sequenceNumbers)
 
 		if err != nil {
@@ -248,7 +248,7 @@ type PeekMessagesOptions struct {
 func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekMessagesOptions) ([]*ReceivedMessage, error) {
 	var receivedMessages []*ReceivedMessage
 
-	err := r.amqpLinks.Retry(ctx, "peekMessages", func(ctx context.Context, links *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	err := r.amqpLinks.Retry(ctx, EventReceiver, "peekMessages", func(ctx context.Context, links *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		var sequenceNumber = r.lastPeekedSequenceNumber + 1
 		updateInternalSequenceNumber := true
 
@@ -291,7 +291,7 @@ type RenewMessageLockOptions struct {
 
 // RenewMessageLock renews the lock on a message, updating the `LockedUntil` field on `msg`.
 func (r *Receiver) RenewMessageLock(ctx context.Context, msg *ReceivedMessage, options *RenewMessageLockOptions) error {
-	return r.amqpLinks.Retry(ctx, "renewMessageLock", func(ctx context.Context, linksWithVersion *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	return r.amqpLinks.Retry(ctx, EventReceiver, "renewMessageLock", func(ctx context.Context, linksWithVersion *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		newExpirationTime, err := internal.RenewLocks(ctx, linksWithVersion.RPC, msg.rawAMQPMessage.LinkName(), []amqp.UUID{
 			(amqp.UUID)(msg.LockToken),
 		})
@@ -342,7 +342,7 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 
 	var linksWithID *internal.LinksWithID
 
-	err := r.amqpLinks.Retry(ctx, "receiveMessages.getlinks", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	err := r.amqpLinks.Retry(ctx, EventReceiver, "receiveMessages.getlinks", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		linksWithID = lwid
 		return nil
 	}, utils.RetryOptions(r.retryOptions))

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -564,7 +564,7 @@ func TestReceiver_RenewMessageLock(t *testing.T) {
 
 	failedOnFirstTry := false
 	for _, msg := range logMessages {
-		if strings.HasPrefix(msg, "[azsb.Retry] (renewMessageLock) Attempt 0 returned non-retryable error") {
+		if strings.HasPrefix(msg, "[azsb.Receiver] (renewMessageLock) Retry attempt 0 returned non-retryable error") {
 			failedOnFirstTry = true
 		}
 	}

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -43,7 +43,7 @@ type MessageBatchOptions struct {
 func (s *Sender) NewMessageBatch(ctx context.Context, options *MessageBatchOptions) (*MessageBatch, error) {
 	var batch *MessageBatch
 
-	err := s.links.Retry(ctx, "send", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	err := s.links.Retry(ctx, EventSender, "send", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		maxBytes := lwid.Sender.MaxMessageSize()
 
 		if options != nil && options.MaxBytes != 0 {
@@ -68,7 +68,7 @@ type SendMessageOptions struct {
 
 // SendMessage sends a Message to a queue or topic.
 func (s *Sender) SendMessage(ctx context.Context, message *Message, options *SendMessageOptions) error {
-	return s.links.Retry(ctx, "SendMessage", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	return s.links.Retry(ctx, EventSender, "SendMessage", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		ctx, span := s.startProducerSpanFromContext(ctx, spanNameSendMessage)
 		defer span.End()
 
@@ -84,7 +84,7 @@ type SendMessageBatchOptions struct {
 // SendMessageBatch sends a MessageBatch to a queue or topic.
 // Message batches can be created using `Sender.NewMessageBatch`.
 func (s *Sender) SendMessageBatch(ctx context.Context, batch *MessageBatch, options *SendMessageBatchOptions) error {
-	return s.links.Retry(ctx, "SendMessageBatch", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	return s.links.Retry(ctx, EventSender, "SendMessageBatch", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		ctx, span := s.startProducerSpanFromContext(ctx, spanNameSendBatch)
 		defer span.End()
 
@@ -119,7 +119,7 @@ type CancelScheduledMessagesOptions struct {
 
 // CancelScheduledMessages cancels multiple messages that were scheduled.
 func (s *Sender) CancelScheduledMessages(ctx context.Context, sequenceNumbers []int64, options *CancelScheduledMessagesOptions) error {
-	return s.links.Retry(ctx, "cancelScheduledMessage", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	return s.links.Retry(ctx, EventSender, "CancelScheduledMessages", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return internal.CancelScheduledMessages(ctx, lwv.RPC, sequenceNumbers)
 	}, s.retryOptions)
 }
@@ -133,7 +133,7 @@ func (s *Sender) Close(ctx context.Context) error {
 func (s *Sender) scheduleAMQPMessages(ctx context.Context, messages []*amqp.Message, scheduledEnqueueTime time.Time) ([]int64, error) {
 	var sequenceNumbers []int64
 
-	err := s.links.Retry(ctx, "scheduleMessages", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	err := s.links.Retry(ctx, EventSender, "ScheduleMessages", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		sn, err := internal.ScheduleMessages(ctx, lwv.RPC, scheduledEnqueueTime, messages)
 
 		if err != nil {

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -183,7 +183,7 @@ type GetSessionStateOptions struct {
 func (sr *SessionReceiver) GetSessionState(ctx context.Context, options *GetSessionStateOptions) ([]byte, error) {
 	var sessionState []byte
 
-	err := sr.inner.amqpLinks.Retry(ctx, "GetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "GetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		s, err := internal.GetSessionState(ctx, lwv.RPC, sr.SessionID())
 
 		if err != nil {
@@ -204,7 +204,7 @@ type SetSessionStateOptions struct {
 
 // SetSessionState sets the state associated with the session.
 func (sr *SessionReceiver) SetSessionState(ctx context.Context, state []byte, options *SetSessionStateOptions) error {
-	return sr.inner.amqpLinks.Retry(ctx, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	return sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return internal.SetSessionState(ctx, lwv.RPC, sr.SessionID(), state)
 	}, sr.inner.retryOptions)
 }
@@ -217,7 +217,7 @@ type RenewSessionLockOptions struct {
 // RenewSessionLock renews this session's lock. The new expiration time is available
 // using `LockedUntil`.
 func (sr *SessionReceiver) RenewSessionLock(ctx context.Context, options *RenewSessionLockOptions) error {
-	return sr.inner.amqpLinks.Retry(ctx, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	return sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		newLockedUntil, err := internal.RenewSessionLock(ctx, lwv.RPC, *sr.sessionID)
 
 		if err != nil {


### PR DESCRIPTION
Made the log constants publicly available so people can use them, rather than having to hardcode/know the strings that are there.

This also helps with intellisense to discover the set of available values.

Also:
- Added example for log constants and one for retry options
- Added a new log.Event for `Sender' (log.EventSender)
- Removed log.EventMgmtLink and just made them all log.EventReceiver or log.EventSender, which made more sense.
- Removed log.EventRetry in favor of inheriting/using whatever the actual client's EventType is.

Fixes #17553 