### PR TITLE
[Core] extending parsing for storage

### DIFF
--- a/sdk/azcore/internal/shared/response_error.go
+++ b/sdk/azcore/internal/shared/response_error.go
@@ -59,10 +59,8 @@ func extractErrorCodeJSON(body []byte) string {
 			return ""
 		}
 		rawObj = unwrapped
-	}
-
-	// check if this a wrapped odata error, i.e. { "odata.error": { ... } }
-	if wrapped, ok := rawObj["odata.error"]; ok {
+	} else if wrapped, ok := rawObj["odata.error"]; ok {
+		// check if this a wrapped odata error, i.e. { "odata.error": { ... } }
 		unwrapped, ok := wrapped.(map[string]any)
 		if !ok {
 			return ""

--- a/sdk/azcore/internal/shared/response_error.go
+++ b/sdk/azcore/internal/shared/response_error.go
@@ -61,6 +61,15 @@ func extractErrorCodeJSON(body []byte) string {
 		rawObj = unwrapped
 	}
 
+	// check if this a wrapped odata error, i.e. { "odata.error": { ... } }
+	if wrapped, ok := rawObj["odata.error"]; ok {
+		unwrapped, ok := wrapped.(map[string]any)
+		if !ok {
+			return ""
+		}
+		rawObj = unwrapped
+	}
+
 	// now check for the error code
 	code, ok := rawObj["code"]
 	if !ok {

--- a/sdk/azcore/internal/shared/response_error_test.go
+++ b/sdk/azcore/internal/shared/response_error_test.go
@@ -383,3 +383,31 @@ ERROR CODE UNAVAILABLE
 		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
 	}
 }
+
+func TestExtractErrorCodeFromJSON(t *testing.T) {
+	errorBody := []byte(`{"odata.error": {
+		"code": "ResourceNotFound",
+		"message": {
+		  "lang": "en-us",
+		  "value": "The specified resource does not exist.\nRequestID:b2437f3b-ca2d-47a1-95a7-92f73a768a1c\n"
+		}
+	  }
+	}`)
+	code := extractErrorCodeJSON(errorBody)
+	if code != "ResourceNotFound" {
+		t.Fatalf("expected %s got %s", "ResourceNotFound", code)
+	}
+
+	errorBody = []byte(`{"error": {
+		"code": "ResourceNotFound",
+		"message": {
+		  "lang": "en-us",
+		  "value": "The specified resource does not exist.\nRequestID:b2437f3b-ca2d-47a1-95a7-92f73a768a1c\n"
+		}
+	  }
+	}`)
+	code = extractErrorCodeJSON(errorBody)
+	if code != "ResourceNotFound" {
+		t.Fatalf("expected %s got %s", "ResourceNotFound", code)
+	}
+}


### PR DESCRIPTION
Extending parsing on ResponseError to handle `odata.error` case from storage/tables