### PR TITLE
Remove multi- and cross-tenant authentication API

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 * Renamed `cloud.Configuration.LoginEndpoint` to `.ActiveDirectoryAuthorityHost`
+* Removed `AuxiliaryTenants` field from `arm/ClientOptions` and `arm/policy/BearerTokenOptions`
+* Removed `TokenRequestOptions.TenantID`
 
 ### Bugs Fixed
 

--- a/sdk/azcore/arm/client_options.go
+++ b/sdk/azcore/arm/client_options.go
@@ -12,9 +12,6 @@ import "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 type ClientOptions struct {
 	policy.ClientOptions
 
-	// AuxiliaryTenants contains a list of additional tenants for cross-tenant requests.
-	AuxiliaryTenants []string
-
 	// DisableRPRegistration disables the auto-RP registration policy. Defaults to false.
 	DisableRPRegistration bool
 }

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -16,9 +16,6 @@ import (
 type BearerTokenOptions struct {
 	// Scopes contains the list of permission scopes required for the token.
 	Scopes []string
-	// AuxiliaryTenants contains a list of additional tenant IDs to be used to authenticate
-	// in cross-tenant applications.
-	AuxiliaryTenants []string
 }
 
 // RegistrationOptions configures the registration policy's behavior.

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -28,10 +28,7 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 	if err != nil {
 		return azruntime.Pipeline{}, err
 	}
-	authPolicy := NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{
-		Scopes:           []string{conf.Audience + "/.default"},
-		AuxiliaryTenants: options.AuxiliaryTenants,
-	})
+	authPolicy := NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{Scopes: []string{conf.Audience + "/.default"}})
 	perRetry := make([]azpolicy.Policy, 0, len(plOpts.PerRetry)+1)
 	copy(perRetry, plOpts.PerRetry)
 	plOpts.PerRetry = append(perRetry, authPolicy)

--- a/sdk/azcore/arm/runtime/policy_bearer_token.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token.go
@@ -25,10 +25,7 @@ type acquiringResourceState struct {
 // acquire acquires or updates the resource; only one
 // thread/goroutine at a time ever calls this function
 func acquire(state acquiringResourceState) (newResource *azcore.AccessToken, newExpiration time.Time, err error) {
-	tk, err := state.p.cred.GetToken(state.ctx, azpolicy.TokenRequestOptions{
-		Scopes:   state.p.options.Scopes,
-		TenantID: state.tenant,
-	})
+	tk, err := state.p.cred.GetToken(state.ctx, azpolicy.TokenRequestOptions{Scopes: state.p.options.Scopes})
 	if err != nil {
 		return nil, time.Time{}, err
 	}
@@ -57,13 +54,6 @@ func NewBearerTokenPolicy(cred azcore.TokenCredential, opts *armpolicy.BearerTok
 		cred:         cred,
 		options:      *opts,
 		mainResource: shared.NewExpiringResource(acquire),
-	}
-	if len(opts.AuxiliaryTenants) > 0 {
-		p.auxResources = map[string]*shared.ExpiringResource[*azcore.AccessToken, acquiringResourceState]{}
-	}
-	for _, t := range opts.AuxiliaryTenants {
-		p.auxResources[t] = shared.NewExpiringResource(acquire)
-
 	}
 	return p
 }

--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -172,6 +172,7 @@ func TestBearerPolicy_GetTokenFailsNoDeadlock(t *testing.T) {
 }
 
 func TestBearerTokenWithAuxiliaryTenants(t *testing.T) {
+	t.Skip("this feature isn't implemented yet")
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
@@ -186,8 +187,8 @@ func TestBearerTokenWithAuxiliaryTenants(t *testing.T) {
 	b := NewBearerTokenPolicy(
 		mockCredential{},
 		&armpolicy.BearerTokenOptions{
-			Scopes:           []string{scope},
-			AuxiliaryTenants: []string{"tenant1", "tenant2", "tenant3"},
+			Scopes: []string{scope},
+			//AuxiliaryTenants: []string{"tenant1", "tenant2", "tenant3"},
 		},
 	)
 	pipeline := newTestPipeline(&azpolicy.ClientOptions{Transport: srv, Retry: retryOpts, PerRetryPolicies: []azpolicy.Policy{b}})

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -111,9 +111,6 @@ type TelemetryOptions struct {
 type TokenRequestOptions struct {
 	// Scopes contains the list of permission scopes required for the token.
 	Scopes []string
-	// TenantID contains the tenant ID to use in a multi-tenant authentication scenario, if TenantID is set
-	// it will override the tenant ID that was added at credential creation time.
-	TenantID string
 }
 
 // BearerTokenOptions configures the bearer token policy's behavior.


### PR DESCRIPTION
...because the related features require implementation in `azidentity` we intend to add after the next release (tracked by #14932, #17159). Closes #17580.