### PR TITLE
Renamed pager APIs per new guidelines

### DIFF
--- a/sdk/data/aztables/CHANGELOG.md
+++ b/sdk/data/aztables/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.7.1 (Unreleased)
+## 0.8.0 (2022-04-20)
 
 ### Features Added
 * Added `TableErrorCode` to help recover from and understand error responses
@@ -8,12 +8,13 @@
 ### Breaking Changes
 * Renamed `InsertEntityResponse/Options` to `UpsertEntityResponse/Options`
 * Renamed `PossibleGeoReplicationStatusTypeValues` to `PossibleGeoReplicationStatusValues`
+* Renamed the following methods
+    * `Client.ListEntities` to `Client.NewListEntitiesPager`
+    * `ServiceClient.ListTables` to `ServiceClient.NewListTablesPager`
 
 ### Bugs Fixed
 * Convert `Start` and `Expiry` times in `AccessPolicy` to UTC format as required by the service.
 * Fixed `moduleName` to report the module name as part of telemetry.
-
-### Other Changes
 
 ## 0.7.0 (2022-04-05)
 

--- a/sdk/data/aztables/README.md
+++ b/sdk/data/aztables/README.md
@@ -10,7 +10,7 @@ The Azure Tables client can be used to access Azure Storage or Cosmos accounts.
 The Azure Tables SDK can access an Azure Storage or CosmosDB account.
 
 ### Prerequisites
-* Go versions 1.16 or higher
+* Go versions 1.18 or higher
 * You must have an [Azure subscription][azure_subscription] and either
     * an [Azure Storage account][azure_storage_account] or
     * an [Azure Cosmos Account][azure_cosmos_account].

--- a/sdk/data/aztables/autorest.md
+++ b/sdk/data/aztables/autorest.md
@@ -11,12 +11,27 @@ clear-output-folder: false
 output-folder: internal
 tag: package-2019-02
 credential-scope: none
-use: "@autorest/go@4.0.0-preview.37"
-module-version: 0.7.0
+use: "@autorest/go@4.0.0-preview.39"
+module-version: 0.8.0
 security: "AADToken"
 security-scopes: "https://storage.azure.com/.default"
 modelerfour:
   group-parameters: false
+
+directive:
+  - from: source-file-go
+    where: $
+    transform: >-
+      return $.
+        replace(/moduleName\s+=\s+"internal"/, `moduleName = "aztables"`).
+        replace(/\(client \*TableClient\) deleteEntityCreateRequest\(/, `(client *TableClient) DeleteEntityCreateRequest(`).
+        replace(/\(client \*TableClient\) insertEntityCreateRequest\(/, `(client *TableClient) InsertEntityCreateRequest(`).
+        replace(/\(client \*TableClient\) mergeEntityCreateRequest\(/, `(client *TableClient) MergeEntityCreateRequest(`).
+        replace(/\(client \*TableClient\) updateEntityCreateRequest\(/, `(client *TableClient) UpdateEntityCreateRequest(`).
+        replace(/= client\.deleteEntityCreateRequest\(/, `= client.DeleteEntityCreateRequest(`).
+        replace(/= client\.insertEntityCreateRequest\(/, `= client.InsertEntityCreateRequest(`).
+        replace(/= client\.mergeEntityCreateRequest\(/, `= client.MergeEntityCreateRequest(`).
+        replace(/= client\.updateEntityCreateRequest\(/, `= client.UpdateEntityCreateRequest(`);
 ```
 
 ### Go multi-api

--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -201,7 +201,7 @@ func newListEntitiesPage(resp generated.TableClientQueryEntitiesResponse) (ListE
 	}, nil
 }
 
-// ListEntities queries the entities using the specified ListEntitiesOptions.
+// NewListEntitiesPager queries the entities using the specified ListEntitiesOptions.
 // ListEntitiesOptions can specify the following properties to affect the query results returned:
 //
 // Filter: An OData filter expression that limits results to those entities that satisfy the filter expression.
@@ -213,11 +213,11 @@ func newListEntitiesPage(resp generated.TableClientQueryEntitiesResponse) (ListE
 // Top: The maximum number of entities that will be returned per page of results.
 // Note: This value does not limit the total number of results if NextPage is called on the returned Pager until it returns false.
 //
-// ListEntities returns a Pager, which allows iteration through each page of results. Use nil for listOptions if you want to use the default options.
+// NewListEntitiesPager returns a Pager, which allows iteration through each page of results. Use nil for listOptions if you want to use the default options.
 // For more information about writing query strings, check out:
 //  - API Documentation: https://docs.microsoft.com/en-us/rest/api/storageservices/querying-tables-and-entities
 //  - README samples: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/data/aztables/README.md#writing-filters
-func (t *Client) ListEntities(listOptions *ListEntitiesOptions) *runtime.Pager[ListEntitiesResponse] {
+func (t *Client) NewListEntitiesPager(listOptions *ListEntitiesOptions) *runtime.Pager[ListEntitiesResponse] {
 	if listOptions == nil {
 		listOptions = &ListEntitiesOptions{}
 	}

--- a/sdk/data/aztables/client_test.go
+++ b/sdk/data/aztables/client_test.go
@@ -170,7 +170,7 @@ func TestMergeEntity(t *testing.T) {
 			require.Nil(t, updateErr)
 
 			var qResp ListEntitiesResponse
-			pager := client.ListEntities(listOptions)
+			pager := client.NewListEntitiesPager(listOptions)
 			for pager.More() {
 				qResp, err = pager.NextPage(ctx)
 				require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestInsertEntity(t *testing.T) {
 
 			// 5. Query for new entity
 			var qResp ListEntitiesResponse
-			pager := client.ListEntities(list)
+			pager := client.NewListEntitiesPager(list)
 			for pager.More() {
 				qResp, err = pager.NextPage(ctx)
 				require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestQuerySimpleEntity(t *testing.T) {
 			expectedCount := 4
 
 			var resp ListEntitiesResponse
-			pager := client.ListEntities(list)
+			pager := client.NewListEntitiesPager(list)
 			for pager.More() {
 				resp, err := pager.NextPage(ctx)
 				require.NoError(t, err)
@@ -357,7 +357,7 @@ func TestQueryComplexEntity(t *testing.T) {
 			expectedCount := 4
 			options := &ListEntitiesOptions{Filter: &filter}
 
-			pager := client.ListEntities(options)
+			pager := client.NewListEntitiesPager(options)
 			for pager.More() {
 				resp, err := pager.NextPage(ctx)
 				require.NoError(t, err)
@@ -412,7 +412,7 @@ func TestContinuationTokens(t *testing.T) {
 			err := insertNEntities("contToken", 10, client)
 			require.NoError(t, err)
 
-			pager := client.ListEntities(&ListEntitiesOptions{Top: to.Ptr(int32(1))})
+			pager := client.NewListEntitiesPager(&ListEntitiesOptions{Top: to.Ptr(int32(1))})
 			var pkContToken string
 			var rkContToken string
 			for pager.More() {
@@ -429,7 +429,7 @@ func TestContinuationTokens(t *testing.T) {
 			require.NotNil(t, pkContToken)
 			require.NotNil(t, rkContToken)
 
-			newPager := client.ListEntities(&ListEntitiesOptions{
+			newPager := client.NewListEntitiesPager(&ListEntitiesOptions{
 				NextPartitionKey: &pkContToken,
 				NextRowKey:       &rkContToken,
 			})
@@ -453,7 +453,7 @@ func TestContinuationTokensFilters(t *testing.T) {
 			err := insertNEntities("contToken", 10, client)
 			require.NoError(t, err)
 
-			pager := client.ListEntities(&ListEntitiesOptions{
+			pager := client.NewListEntitiesPager(&ListEntitiesOptions{
 				Top:    to.Ptr(int32(1)),
 				Filter: to.Ptr("Value le 5"),
 			})
@@ -473,7 +473,7 @@ func TestContinuationTokensFilters(t *testing.T) {
 			require.NotNil(t, pkContToken)
 			require.NotNil(t, rkContToken)
 
-			newPager := client.ListEntities(&ListEntitiesOptions{
+			newPager := client.NewListEntitiesPager(&ListEntitiesOptions{
 				NextPartitionKey: &pkContToken,
 				NextRowKey:       &rkContToken,
 				Filter:           to.Ptr("Value le 5"),
@@ -548,7 +548,7 @@ func TestAzurite(t *testing.T) {
 	require.NoError(t, err)
 
 	count := 0
-	pager := client.ListEntities(nil)
+	pager := client.NewListEntitiesPager(nil)
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
 		require.NoError(t, err)

--- a/sdk/data/aztables/entity_test.go
+++ b/sdk/data/aztables/entity_test.go
@@ -43,7 +43,7 @@ func TestAddBasicEntity(t *testing.T) {
 
 			queryString := "PartitionKey eq 'pk001'"
 			listOptions := ListEntitiesOptions{Filter: &queryString}
-			pager := client.ListEntities(&listOptions)
+			pager := client.NewListEntitiesPager(&listOptions)
 			count := 0
 			for pager.More() {
 				resp, err := pager.NextPage(ctx)

--- a/sdk/data/aztables/example_test.go
+++ b/sdk/data/aztables/example_test.go
@@ -410,7 +410,7 @@ func ExampleClient_DeleteEntity() {
 	}
 }
 
-func ExampleClient_ListEntities() {
+func ExampleClient_NewListEntitiesPager() {
 	accountName, ok := os.LookupEnv("TABLES_STORAGE_ACCOUNT_NAME")
 	if !ok {
 		panic("TABLES_STORAGE_ACCOUNT_NAME could not be found")
@@ -434,7 +434,7 @@ func ExampleClient_ListEntities() {
 	//  - API Documentation: https://docs.microsoft.com/en-us/rest/api/storageservices/querying-tables-and-entities
 	//  - README samples: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/data/aztables/README.md#writing-filters
 	filter := fmt.Sprintf("PartitionKey eq '%s' or PartitionKey eq '%s'", "pk001", "pk002")
-	pager := client.ListEntities(&aztables.ListEntitiesOptions{Filter: &filter})
+	pager := client.NewListEntitiesPager(&aztables.ListEntitiesOptions{Filter: &filter})
 
 	pageCount := 1
 	for pager.More() {
@@ -462,7 +462,7 @@ func ExampleClient_ListEntities() {
 	}
 
 	// To list all entities in a table, provide nil to Query()
-	listPager := client.ListEntities(nil)
+	listPager := client.NewListEntitiesPager(nil)
 	pageCount = 0
 	for listPager.More() {
 		response, err := listPager.NextPage(context.TODO())
@@ -489,7 +489,7 @@ func ExampleClient_ListEntities() {
 	}
 }
 
-func ExampleServiceClient_ListTables() {
+func ExampleServiceClient_NewListTablesPager() {
 	accountName, ok := os.LookupEnv("TABLES_STORAGE_ACCOUNT_NAME")
 	if !ok {
 		panic("TABLES_STORAGE_ACCOUNT_NAME could not be found")
@@ -511,7 +511,7 @@ func ExampleServiceClient_ListTables() {
 
 	myTable := "myTableName"
 	filter := fmt.Sprintf("TableName ge '%v'", myTable)
-	pager := service.ListTables(&aztables.ListTablesOptions{Filter: &filter})
+	pager := service.NewListTablesPager(&aztables.ListTablesOptions{Filter: &filter})
 
 	pageCount := 1
 	for pager.More() {

--- a/sdk/data/aztables/internal/connection.go
+++ b/sdk/data/aztables/internal/connection.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/data/aztables/internal/constants.go
+++ b/sdk/data/aztables/internal/constants.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,7 +10,7 @@ package internal
 
 const (
 	moduleName    = "aztables"
-	moduleVersion = "v0.7.1"
+	moduleVersion = "v0.8.0"
 )
 
 type Enum0 string
@@ -26,11 +26,6 @@ func PossibleEnum0Values() []Enum0 {
 	}
 }
 
-// ToPtr returns a *Enum0 pointing to the current value.
-func (c Enum0) ToPtr() *Enum0 {
-	return &c
-}
-
 type Enum1 string
 
 const (
@@ -42,11 +37,6 @@ func PossibleEnum1Values() []Enum1 {
 	return []Enum1{
 		Enum1Three0,
 	}
-}
-
-// ToPtr returns a *Enum1 pointing to the current value.
-func (c Enum1) ToPtr() *Enum1 {
-	return &c
 }
 
 type Enum4 string
@@ -62,11 +52,6 @@ func PossibleEnum4Values() []Enum4 {
 	}
 }
 
-// ToPtr returns a *Enum4 pointing to the current value.
-func (c Enum4) ToPtr() *Enum4 {
-	return &c
-}
-
 type Enum5 string
 
 const (
@@ -78,11 +63,6 @@ func PossibleEnum5Values() []Enum5 {
 	return []Enum5{
 		Enum5Service,
 	}
-}
-
-// ToPtr returns a *Enum5 pointing to the current value.
-func (c Enum5) ToPtr() *Enum5 {
-	return &c
 }
 
 type Enum6 string
@@ -98,11 +78,6 @@ func PossibleEnum6Values() []Enum6 {
 	}
 }
 
-// ToPtr returns a *Enum6 pointing to the current value.
-func (c Enum6) ToPtr() *Enum6 {
-	return &c
-}
-
 type Enum7 string
 
 const (
@@ -114,11 +89,6 @@ func PossibleEnum7Values() []Enum7 {
 	return []Enum7{
 		Enum7Stats,
 	}
-}
-
-// ToPtr returns a *Enum7 pointing to the current value.
-func (c Enum7) ToPtr() *Enum7 {
-	return &c
 }
 
 // GeoReplicationStatusType - The status of the secondary location.
@@ -139,11 +109,6 @@ func PossibleGeoReplicationStatusTypeValues() []GeoReplicationStatusType {
 	}
 }
 
-// ToPtr returns a *GeoReplicationStatusType pointing to the current value.
-func (c GeoReplicationStatusType) ToPtr() *GeoReplicationStatusType {
-	return &c
-}
-
 type ODataMetadataFormat string
 
 const (
@@ -161,11 +126,6 @@ func PossibleODataMetadataFormatValues() []ODataMetadataFormat {
 	}
 }
 
-// ToPtr returns a *ODataMetadataFormat pointing to the current value.
-func (c ODataMetadataFormat) ToPtr() *ODataMetadataFormat {
-	return &c
-}
-
 type ResponseFormat string
 
 const (
@@ -179,9 +139,4 @@ func PossibleResponseFormatValues() []ResponseFormat {
 		ResponseFormatReturnContent,
 		ResponseFormatReturnNoContent,
 	}
-}
-
-// ToPtr returns a *ResponseFormat pointing to the current value.
-func (c ResponseFormat) ToPtr() *ResponseFormat {
-	return &c
 }

--- a/sdk/data/aztables/internal/models.go
+++ b/sdk/data/aztables/internal/models.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/data/aztables/internal/models_serde.go
+++ b/sdk/data/aztables/internal/models_serde.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/data/aztables/internal/response_types.go
+++ b/sdk/data/aztables/internal/response_types.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/data/aztables/internal/service_client.go
+++ b/sdk/data/aztables/internal/service_client.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/data/aztables/internal/table_client.go
+++ b/sdk/data/aztables/internal/table_client.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -50,10 +50,10 @@ func NewTableClient(endpoint string, version Enum0, options *azcore.ClientOption
 // If the operation fails it returns an *azcore.ResponseError type.
 // dataServiceVersion - Specifies the data service version.
 // tableProperties - The Table properties.
-// TableClientCreateOptions - TableClientCreateOptions contains the optional parameters for the TableClient.Create method.
+// options - TableClientCreateOptions contains the optional parameters for the TableClient.Create method.
 // QueryOptions - QueryOptions contains a group of parameters for the TableClient.Query method.
-func (client *TableClient) Create(ctx context.Context, dataServiceVersion Enum1, tableProperties TableProperties, tableClientCreateOptions *TableClientCreateOptions, queryOptions *QueryOptions) (TableClientCreateResponse, error) {
-	req, err := client.createCreateRequest(ctx, dataServiceVersion, tableProperties, tableClientCreateOptions, queryOptions)
+func (client *TableClient) Create(ctx context.Context, dataServiceVersion Enum1, tableProperties TableProperties, options *TableClientCreateOptions, queryOptions *QueryOptions) (TableClientCreateResponse, error) {
+	req, err := client.createCreateRequest(ctx, dataServiceVersion, tableProperties, options, queryOptions)
 	if err != nil {
 		return TableClientCreateResponse{}, err
 	}
@@ -68,7 +68,7 @@ func (client *TableClient) Create(ctx context.Context, dataServiceVersion Enum1,
 }
 
 // createCreateRequest creates the Create request.
-func (client *TableClient) createCreateRequest(ctx context.Context, dataServiceVersion Enum1, tableProperties TableProperties, tableClientCreateOptions *TableClientCreateOptions, queryOptions *QueryOptions) (*policy.Request, error) {
+func (client *TableClient) createCreateRequest(ctx context.Context, dataServiceVersion Enum1, tableProperties TableProperties, options *TableClientCreateOptions, queryOptions *QueryOptions) (*policy.Request, error) {
 	urlPath := "/Tables"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -80,12 +80,12 @@ func (client *TableClient) createCreateRequest(ctx context.Context, dataServiceV
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if tableClientCreateOptions != nil && tableClientCreateOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *tableClientCreateOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("DataServiceVersion", string(dataServiceVersion))
-	if tableClientCreateOptions != nil && tableClientCreateOptions.ResponsePreference != nil {
-		req.Raw().Header.Set("Prefer", string(*tableClientCreateOptions.ResponsePreference))
+	if options != nil && options.ResponsePreference != nil {
+		req.Raw().Header.Set("Prefer", string(*options.ResponsePreference))
 	}
 	req.Raw().Header.Set("Accept", "application/json;odata=minimalmetadata")
 	return req, runtime.MarshalAsJSON(req, tableProperties)
@@ -187,11 +187,10 @@ func (client *TableClient) deleteHandleResponse(resp *http.Response) (TableClien
 // rowKey - The row key of the entity.
 // ifMatch - Match condition for an entity to be deleted. If specified and a matching entity is not found, an error will be
 // raised. To force an unconditional delete, set to the wildcard character (*).
-// TableClientDeleteEntityOptions - TableClientDeleteEntityOptions contains the optional parameters for the TableClient.DeleteEntity
-// method.
+// options - TableClientDeleteEntityOptions contains the optional parameters for the TableClient.DeleteEntity method.
 // QueryOptions - QueryOptions contains a group of parameters for the TableClient.Query method.
-func (client *TableClient) DeleteEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, ifMatch string, tableClientDeleteEntityOptions *TableClientDeleteEntityOptions, queryOptions *QueryOptions) (TableClientDeleteEntityResponse, error) {
-	req, err := client.DeleteEntityCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, ifMatch, tableClientDeleteEntityOptions, queryOptions)
+func (client *TableClient) DeleteEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, ifMatch string, options *TableClientDeleteEntityOptions, queryOptions *QueryOptions) (TableClientDeleteEntityResponse, error) {
+	req, err := client.DeleteEntityCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, ifMatch, options, queryOptions)
 	if err != nil {
 		return TableClientDeleteEntityResponse{}, err
 	}
@@ -205,8 +204,8 @@ func (client *TableClient) DeleteEntity(ctx context.Context, dataServiceVersion 
 	return client.deleteEntityHandleResponse(resp)
 }
 
-// DeleteEntityCreateRequest creates the DeleteEntity request.
-func (client *TableClient) DeleteEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, ifMatch string, tableClientDeleteEntityOptions *TableClientDeleteEntityOptions, queryOptions *QueryOptions) (*policy.Request, error) {
+// deleteEntityCreateRequest creates the DeleteEntity request.
+func (client *TableClient) DeleteEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, ifMatch string, options *TableClientDeleteEntityOptions, queryOptions *QueryOptions) (*policy.Request, error) {
 	urlPath := "/{table}(PartitionKey='{partitionKey}',RowKey='{rowKey}')"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -225,16 +224,16 @@ func (client *TableClient) DeleteEntityCreateRequest(ctx context.Context, dataSe
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if tableClientDeleteEntityOptions != nil && tableClientDeleteEntityOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*tableClientDeleteEntityOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	if queryOptions != nil && queryOptions.Format != nil {
 		reqQP.Set("$format", string(*queryOptions.Format))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if tableClientDeleteEntityOptions != nil && tableClientDeleteEntityOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *tableClientDeleteEntityOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("DataServiceVersion", string(dataServiceVersion))
 	req.Raw().Header.Set("If-Match", ifMatch)
@@ -339,11 +338,10 @@ func (client *TableClient) getAccessPolicyHandleResponse(resp *http.Response) (T
 // If the operation fails it returns an *azcore.ResponseError type.
 // dataServiceVersion - Specifies the data service version.
 // table - The name of the table.
-// TableClientInsertEntityOptions - TableClientInsertEntityOptions contains the optional parameters for the TableClient.InsertEntity
-// method.
+// options - TableClientInsertEntityOptions contains the optional parameters for the TableClient.InsertEntity method.
 // QueryOptions - QueryOptions contains a group of parameters for the TableClient.Query method.
-func (client *TableClient) InsertEntity(ctx context.Context, dataServiceVersion Enum1, table string, tableClientInsertEntityOptions *TableClientInsertEntityOptions, queryOptions *QueryOptions) (TableClientInsertEntityResponse, error) {
-	req, err := client.InsertEntityCreateRequest(ctx, dataServiceVersion, table, tableClientInsertEntityOptions, queryOptions)
+func (client *TableClient) InsertEntity(ctx context.Context, dataServiceVersion Enum1, table string, options *TableClientInsertEntityOptions, queryOptions *QueryOptions) (TableClientInsertEntityResponse, error) {
+	req, err := client.InsertEntityCreateRequest(ctx, dataServiceVersion, table, options, queryOptions)
 	if err != nil {
 		return TableClientInsertEntityResponse{}, err
 	}
@@ -357,8 +355,8 @@ func (client *TableClient) InsertEntity(ctx context.Context, dataServiceVersion 
 	return client.insertEntityHandleResponse(resp)
 }
 
-// InsertEntityCreateRequest creates the InsertEntity request.
-func (client *TableClient) InsertEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, tableClientInsertEntityOptions *TableClientInsertEntityOptions, queryOptions *QueryOptions) (*policy.Request, error) {
+// insertEntityCreateRequest creates the InsertEntity request.
+func (client *TableClient) InsertEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, options *TableClientInsertEntityOptions, queryOptions *QueryOptions) (*policy.Request, error) {
 	urlPath := "/{table}"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -369,24 +367,24 @@ func (client *TableClient) InsertEntityCreateRequest(ctx context.Context, dataSe
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if tableClientInsertEntityOptions != nil && tableClientInsertEntityOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*tableClientInsertEntityOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	if queryOptions != nil && queryOptions.Format != nil {
 		reqQP.Set("$format", string(*queryOptions.Format))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if tableClientInsertEntityOptions != nil && tableClientInsertEntityOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *tableClientInsertEntityOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("DataServiceVersion", string(dataServiceVersion))
-	if tableClientInsertEntityOptions != nil && tableClientInsertEntityOptions.ResponsePreference != nil {
-		req.Raw().Header.Set("Prefer", string(*tableClientInsertEntityOptions.ResponsePreference))
+	if options != nil && options.ResponsePreference != nil {
+		req.Raw().Header.Set("Prefer", string(*options.ResponsePreference))
 	}
 	req.Raw().Header.Set("Accept", "application/json;odata=minimalmetadata")
-	if tableClientInsertEntityOptions != nil && tableClientInsertEntityOptions.TableEntityProperties != nil {
-		return req, runtime.MarshalAsJSON(req, tableClientInsertEntityOptions.TableEntityProperties)
+	if options != nil && options.TableEntityProperties != nil {
+		return req, runtime.MarshalAsJSON(req, options.TableEntityProperties)
 	}
 	return req, nil
 }
@@ -431,11 +429,10 @@ func (client *TableClient) insertEntityHandleResponse(resp *http.Response) (Tabl
 // table - The name of the table.
 // partitionKey - The partition key of the entity.
 // rowKey - The row key of the entity.
-// TableClientMergeEntityOptions - TableClientMergeEntityOptions contains the optional parameters for the TableClient.MergeEntity
-// method.
+// options - TableClientMergeEntityOptions contains the optional parameters for the TableClient.MergeEntity method.
 // QueryOptions - QueryOptions contains a group of parameters for the TableClient.Query method.
-func (client *TableClient) MergeEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, tableClientMergeEntityOptions *TableClientMergeEntityOptions, queryOptions *QueryOptions) (TableClientMergeEntityResponse, error) {
-	req, err := client.MergeEntityCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, tableClientMergeEntityOptions, queryOptions)
+func (client *TableClient) MergeEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableClientMergeEntityOptions, queryOptions *QueryOptions) (TableClientMergeEntityResponse, error) {
+	req, err := client.MergeEntityCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, options, queryOptions)
 	if err != nil {
 		return TableClientMergeEntityResponse{}, err
 	}
@@ -449,8 +446,8 @@ func (client *TableClient) MergeEntity(ctx context.Context, dataServiceVersion E
 	return client.mergeEntityHandleResponse(resp)
 }
 
-// MergeEntityCreateRequest creates the MergeEntity request.
-func (client *TableClient) MergeEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, tableClientMergeEntityOptions *TableClientMergeEntityOptions, queryOptions *QueryOptions) (*policy.Request, error) {
+// mergeEntityCreateRequest creates the MergeEntity request.
+func (client *TableClient) MergeEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableClientMergeEntityOptions, queryOptions *QueryOptions) (*policy.Request, error) {
 	urlPath := "/{table}(PartitionKey='{partitionKey}',RowKey='{rowKey}')"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -469,24 +466,24 @@ func (client *TableClient) MergeEntityCreateRequest(ctx context.Context, dataSer
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if tableClientMergeEntityOptions != nil && tableClientMergeEntityOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*tableClientMergeEntityOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	if queryOptions != nil && queryOptions.Format != nil {
 		reqQP.Set("$format", string(*queryOptions.Format))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if tableClientMergeEntityOptions != nil && tableClientMergeEntityOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *tableClientMergeEntityOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("DataServiceVersion", string(dataServiceVersion))
-	if tableClientMergeEntityOptions != nil && tableClientMergeEntityOptions.IfMatch != nil {
-		req.Raw().Header.Set("If-Match", *tableClientMergeEntityOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Raw().Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Raw().Header.Set("Accept", "application/json")
-	if tableClientMergeEntityOptions != nil && tableClientMergeEntityOptions.TableEntityProperties != nil {
-		return req, runtime.MarshalAsJSON(req, tableClientMergeEntityOptions.TableEntityProperties)
+	if options != nil && options.TableEntityProperties != nil {
+		return req, runtime.MarshalAsJSON(req, options.TableEntityProperties)
 	}
 	return req, nil
 }
@@ -519,10 +516,10 @@ func (client *TableClient) mergeEntityHandleResponse(resp *http.Response) (Table
 // Query - Queries tables under the given account.
 // If the operation fails it returns an *azcore.ResponseError type.
 // dataServiceVersion - Specifies the data service version.
-// TableClientQueryOptions - TableClientQueryOptions contains the optional parameters for the TableClient.Query method.
+// options - TableClientQueryOptions contains the optional parameters for the TableClient.Query method.
 // QueryOptions - QueryOptions contains a group of parameters for the TableClient.Query method.
-func (client *TableClient) Query(ctx context.Context, dataServiceVersion Enum1, tableClientQueryOptions *TableClientQueryOptions, queryOptions *QueryOptions) (TableClientQueryResponse, error) {
-	req, err := client.queryCreateRequest(ctx, dataServiceVersion, tableClientQueryOptions, queryOptions)
+func (client *TableClient) Query(ctx context.Context, dataServiceVersion Enum1, options *TableClientQueryOptions, queryOptions *QueryOptions) (TableClientQueryResponse, error) {
+	req, err := client.queryCreateRequest(ctx, dataServiceVersion, options, queryOptions)
 	if err != nil {
 		return TableClientQueryResponse{}, err
 	}
@@ -537,7 +534,7 @@ func (client *TableClient) Query(ctx context.Context, dataServiceVersion Enum1, 
 }
 
 // queryCreateRequest creates the Query request.
-func (client *TableClient) queryCreateRequest(ctx context.Context, dataServiceVersion Enum1, tableClientQueryOptions *TableClientQueryOptions, queryOptions *QueryOptions) (*policy.Request, error) {
+func (client *TableClient) queryCreateRequest(ctx context.Context, dataServiceVersion Enum1, options *TableClientQueryOptions, queryOptions *QueryOptions) (*policy.Request, error) {
 	urlPath := "/Tables"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -556,13 +553,13 @@ func (client *TableClient) queryCreateRequest(ctx context.Context, dataServiceVe
 	if queryOptions != nil && queryOptions.Filter != nil {
 		reqQP.Set("$filter", *queryOptions.Filter)
 	}
-	if tableClientQueryOptions != nil && tableClientQueryOptions.NextTableName != nil {
-		reqQP.Set("NextTableName", *tableClientQueryOptions.NextTableName)
+	if options != nil && options.NextTableName != nil {
+		reqQP.Set("NextTableName", *options.NextTableName)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if tableClientQueryOptions != nil && tableClientQueryOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *tableClientQueryOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("DataServiceVersion", string(dataServiceVersion))
 	req.Raw().Header.Set("Accept", "application/json;odata=minimalmetadata")
@@ -601,11 +598,10 @@ func (client *TableClient) queryHandleResponse(resp *http.Response) (TableClient
 // If the operation fails it returns an *azcore.ResponseError type.
 // dataServiceVersion - Specifies the data service version.
 // table - The name of the table.
-// TableClientQueryEntitiesOptions - TableClientQueryEntitiesOptions contains the optional parameters for the TableClient.QueryEntities
-// method.
+// options - TableClientQueryEntitiesOptions contains the optional parameters for the TableClient.QueryEntities method.
 // QueryOptions - QueryOptions contains a group of parameters for the TableClient.Query method.
-func (client *TableClient) QueryEntities(ctx context.Context, dataServiceVersion Enum1, table string, tableClientQueryEntitiesOptions *TableClientQueryEntitiesOptions, queryOptions *QueryOptions) (TableClientQueryEntitiesResponse, error) {
-	req, err := client.queryEntitiesCreateRequest(ctx, dataServiceVersion, table, tableClientQueryEntitiesOptions, queryOptions)
+func (client *TableClient) QueryEntities(ctx context.Context, dataServiceVersion Enum1, table string, options *TableClientQueryEntitiesOptions, queryOptions *QueryOptions) (TableClientQueryEntitiesResponse, error) {
+	req, err := client.queryEntitiesCreateRequest(ctx, dataServiceVersion, table, options, queryOptions)
 	if err != nil {
 		return TableClientQueryEntitiesResponse{}, err
 	}
@@ -620,7 +616,7 @@ func (client *TableClient) QueryEntities(ctx context.Context, dataServiceVersion
 }
 
 // queryEntitiesCreateRequest creates the QueryEntities request.
-func (client *TableClient) queryEntitiesCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, tableClientQueryEntitiesOptions *TableClientQueryEntitiesOptions, queryOptions *QueryOptions) (*policy.Request, error) {
+func (client *TableClient) queryEntitiesCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, options *TableClientQueryEntitiesOptions, queryOptions *QueryOptions) (*policy.Request, error) {
 	urlPath := "/{table}()"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -631,8 +627,8 @@ func (client *TableClient) queryEntitiesCreateRequest(ctx context.Context, dataS
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if tableClientQueryEntitiesOptions != nil && tableClientQueryEntitiesOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*tableClientQueryEntitiesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	if queryOptions != nil && queryOptions.Format != nil {
 		reqQP.Set("$format", string(*queryOptions.Format))
@@ -646,16 +642,16 @@ func (client *TableClient) queryEntitiesCreateRequest(ctx context.Context, dataS
 	if queryOptions != nil && queryOptions.Filter != nil {
 		reqQP.Set("$filter", *queryOptions.Filter)
 	}
-	if tableClientQueryEntitiesOptions != nil && tableClientQueryEntitiesOptions.NextPartitionKey != nil {
-		reqQP.Set("NextPartitionKey", *tableClientQueryEntitiesOptions.NextPartitionKey)
+	if options != nil && options.NextPartitionKey != nil {
+		reqQP.Set("NextPartitionKey", *options.NextPartitionKey)
 	}
-	if tableClientQueryEntitiesOptions != nil && tableClientQueryEntitiesOptions.NextRowKey != nil {
-		reqQP.Set("NextRowKey", *tableClientQueryEntitiesOptions.NextRowKey)
+	if options != nil && options.NextRowKey != nil {
+		reqQP.Set("NextRowKey", *options.NextRowKey)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if tableClientQueryEntitiesOptions != nil && tableClientQueryEntitiesOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *tableClientQueryEntitiesOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("DataServiceVersion", string(dataServiceVersion))
 	req.Raw().Header.Set("Accept", "application/json;odata=minimalmetadata")
@@ -699,11 +695,11 @@ func (client *TableClient) queryEntitiesHandleResponse(resp *http.Response) (Tab
 // table - The name of the table.
 // partitionKey - The partition key of the entity.
 // rowKey - The row key of the entity.
-// TableClientQueryEntityWithPartitionAndRowKeyOptions - TableClientQueryEntityWithPartitionAndRowKeyOptions contains the
-// optional parameters for the TableClient.QueryEntityWithPartitionAndRowKey method.
+// options - TableClientQueryEntityWithPartitionAndRowKeyOptions contains the optional parameters for the TableClient.QueryEntityWithPartitionAndRowKey
+// method.
 // QueryOptions - QueryOptions contains a group of parameters for the TableClient.Query method.
-func (client *TableClient) QueryEntityWithPartitionAndRowKey(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, tableClientQueryEntityWithPartitionAndRowKeyOptions *TableClientQueryEntityWithPartitionAndRowKeyOptions, queryOptions *QueryOptions) (TableClientQueryEntityWithPartitionAndRowKeyResponse, error) {
-	req, err := client.queryEntityWithPartitionAndRowKeyCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, tableClientQueryEntityWithPartitionAndRowKeyOptions, queryOptions)
+func (client *TableClient) QueryEntityWithPartitionAndRowKey(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableClientQueryEntityWithPartitionAndRowKeyOptions, queryOptions *QueryOptions) (TableClientQueryEntityWithPartitionAndRowKeyResponse, error) {
+	req, err := client.queryEntityWithPartitionAndRowKeyCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, options, queryOptions)
 	if err != nil {
 		return TableClientQueryEntityWithPartitionAndRowKeyResponse{}, err
 	}
@@ -718,7 +714,7 @@ func (client *TableClient) QueryEntityWithPartitionAndRowKey(ctx context.Context
 }
 
 // queryEntityWithPartitionAndRowKeyCreateRequest creates the QueryEntityWithPartitionAndRowKey request.
-func (client *TableClient) queryEntityWithPartitionAndRowKeyCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, tableClientQueryEntityWithPartitionAndRowKeyOptions *TableClientQueryEntityWithPartitionAndRowKeyOptions, queryOptions *QueryOptions) (*policy.Request, error) {
+func (client *TableClient) queryEntityWithPartitionAndRowKeyCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableClientQueryEntityWithPartitionAndRowKeyOptions, queryOptions *QueryOptions) (*policy.Request, error) {
 	urlPath := "/{table}(PartitionKey='{partitionKey}',RowKey='{rowKey}')"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -737,8 +733,8 @@ func (client *TableClient) queryEntityWithPartitionAndRowKeyCreateRequest(ctx co
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if tableClientQueryEntityWithPartitionAndRowKeyOptions != nil && tableClientQueryEntityWithPartitionAndRowKeyOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*tableClientQueryEntityWithPartitionAndRowKeyOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	if queryOptions != nil && queryOptions.Format != nil {
 		reqQP.Set("$format", string(*queryOptions.Format))
@@ -751,8 +747,8 @@ func (client *TableClient) queryEntityWithPartitionAndRowKeyCreateRequest(ctx co
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if tableClientQueryEntityWithPartitionAndRowKeyOptions != nil && tableClientQueryEntityWithPartitionAndRowKeyOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *tableClientQueryEntityWithPartitionAndRowKeyOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("DataServiceVersion", string(dataServiceVersion))
 	req.Raw().Header.Set("Accept", "application/json;odata=minimalmetadata")
@@ -873,11 +869,10 @@ func (client *TableClient) setAccessPolicyHandleResponse(resp *http.Response) (T
 // table - The name of the table.
 // partitionKey - The partition key of the entity.
 // rowKey - The row key of the entity.
-// TableClientUpdateEntityOptions - TableClientUpdateEntityOptions contains the optional parameters for the TableClient.UpdateEntity
-// method.
+// options - TableClientUpdateEntityOptions contains the optional parameters for the TableClient.UpdateEntity method.
 // QueryOptions - QueryOptions contains a group of parameters for the TableClient.Query method.
-func (client *TableClient) UpdateEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, tableClientUpdateEntityOptions *TableClientUpdateEntityOptions, queryOptions *QueryOptions) (TableClientUpdateEntityResponse, error) {
-	req, err := client.UpdateEntityCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, tableClientUpdateEntityOptions, queryOptions)
+func (client *TableClient) UpdateEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableClientUpdateEntityOptions, queryOptions *QueryOptions) (TableClientUpdateEntityResponse, error) {
+	req, err := client.UpdateEntityCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, options, queryOptions)
 	if err != nil {
 		return TableClientUpdateEntityResponse{}, err
 	}
@@ -891,8 +886,8 @@ func (client *TableClient) UpdateEntity(ctx context.Context, dataServiceVersion 
 	return client.updateEntityHandleResponse(resp)
 }
 
-// UpdateEntityCreateRequest creates the UpdateEntity request.
-func (client *TableClient) UpdateEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, tableClientUpdateEntityOptions *TableClientUpdateEntityOptions, queryOptions *QueryOptions) (*policy.Request, error) {
+// updateEntityCreateRequest creates the UpdateEntity request.
+func (client *TableClient) UpdateEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableClientUpdateEntityOptions, queryOptions *QueryOptions) (*policy.Request, error) {
 	urlPath := "/{table}(PartitionKey='{partitionKey}',RowKey='{rowKey}')"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -911,24 +906,24 @@ func (client *TableClient) UpdateEntityCreateRequest(ctx context.Context, dataSe
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if tableClientUpdateEntityOptions != nil && tableClientUpdateEntityOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*tableClientUpdateEntityOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	if queryOptions != nil && queryOptions.Format != nil {
 		reqQP.Set("$format", string(*queryOptions.Format))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if tableClientUpdateEntityOptions != nil && tableClientUpdateEntityOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *tableClientUpdateEntityOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("DataServiceVersion", string(dataServiceVersion))
-	if tableClientUpdateEntityOptions != nil && tableClientUpdateEntityOptions.IfMatch != nil {
-		req.Raw().Header.Set("If-Match", *tableClientUpdateEntityOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Raw().Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Raw().Header.Set("Accept", "application/json")
-	if tableClientUpdateEntityOptions != nil && tableClientUpdateEntityOptions.TableEntityProperties != nil {
-		return req, runtime.MarshalAsJSON(req, tableClientUpdateEntityOptions.TableEntityProperties)
+	if options != nil && options.TableEntityProperties != nil {
+		return req, runtime.MarshalAsJSON(req, options.TableEntityProperties)
 	}
 	return req, nil
 }

--- a/sdk/data/aztables/internal/time_rfc1123.go
+++ b/sdk/data/aztables/internal/time_rfc1123.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/data/aztables/internal/time_rfc3339.go
+++ b/sdk/data/aztables/internal/time_rfc3339.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/data/aztables/proxy_test.go
+++ b/sdk/data/aztables/proxy_test.go
@@ -268,7 +268,7 @@ func createRandomName(t *testing.T, prefix string) (string, error) {
 }
 
 func clearAllTables(service *ServiceClient) error {
-	pager := service.ListTables(nil)
+	pager := service.NewListTablesPager(nil)
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
 		if err != nil {

--- a/sdk/data/aztables/service_client.go
+++ b/sdk/data/aztables/service_client.go
@@ -207,7 +207,7 @@ func fromGeneratedTableResponseProperties(g *generated.TableResponseProperties) 
 	}
 }
 
-// ListTables queries the existing tables using the specified ListTablesOptions.
+// NewListTablesPager queries the existing tables using the specified ListTablesOptions.
 // listOptions can specify the following properties to affect the query results returned:
 //
 // Filter: An OData filter expression that limits results to those tables that satisfy the filter expression.
@@ -216,11 +216,11 @@ func fromGeneratedTableResponseProperties(g *generated.TableResponseProperties) 
 // Top: The maximum number of tables that will be returned per page of results.
 // Note: This value does not limit the total number of results if NextPage is called on the returned Pager until it returns false.
 //
-// List returns a Pager, which allows iteration through each page of results. Specify nil for listOptions if you want to use the default options.
+// NewListTablesPager returns a Pager, which allows iteration through each page of results. Specify nil for listOptions if you want to use the default options.
 // For more information about writing query strings, check out:
 //  - API Documentation: https://docs.microsoft.com/en-us/rest/api/storageservices/querying-tables-and-entities
 //  - README samples: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/data/aztables/README.md#writing-filters
-func (t *ServiceClient) ListTables(listOptions *ListTablesOptions) *runtime.Pager[ListTablesResponse] {
+func (t *ServiceClient) NewListTablesPager(listOptions *ListTablesOptions) *runtime.Pager[ListTablesResponse] {
 	if listOptions == nil {
 		listOptions = &ListTablesOptions{}
 	}

--- a/sdk/data/aztables/service_client_test.go
+++ b/sdk/data/aztables/service_client_test.go
@@ -91,7 +91,7 @@ func TestQueryTable(t *testing.T) {
 
 			// Query for tables with no pagination. The filter should exclude one table from the results
 			filter := fmt.Sprintf("TableName ge '%s' and TableName lt '%s'", prefix1, prefix2)
-			pager := service.ListTables(&ListTablesOptions{Filter: &filter})
+			pager := service.NewListTablesPager(&ListTablesOptions{Filter: &filter})
 
 			resultCount := 0
 			for pager.More() {
@@ -104,7 +104,7 @@ func TestQueryTable(t *testing.T) {
 
 			// Query for tables with pagination
 			top := int32(2)
-			pager = service.ListTables(&ListTablesOptions{Filter: &filter, Top: &top})
+			pager = service.NewListTablesPager(&ListTablesOptions{Filter: &filter, Top: &top})
 
 			resultCount = 0
 			pageCount := 0
@@ -141,7 +141,7 @@ func TestListTables(t *testing.T) {
 			}
 
 			count := 0
-			pager := service.ListTables(nil)
+			pager := service.NewListTablesPager(nil)
 			for pager.More() {
 				resp, err := pager.NextPage(ctx)
 				require.NoError(t, err)

--- a/sdk/data/aztables/shared_access_signature_test.go
+++ b/sdk/data/aztables/shared_access_signature_test.go
@@ -178,7 +178,7 @@ func TestSASClientReadOnly(t *testing.T) {
 	require.Contains(t, PossibleTableErrorCodeValues(), TableErrorCode(httpErr.ErrorCode))
 
 	// Success on a list
-	pager := client.ListEntities(nil)
+	pager := client.NewListEntitiesPager(nil)
 	count := 0
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
@@ -247,7 +247,7 @@ func TestSASCosmosClientReadOnly(t *testing.T) {
 	require.Contains(t, PossibleTableErrorCodeValues(), TableErrorCode(httpErr.ErrorCode))
 
 	// Success on a list
-	pager := client.ListEntities(nil)
+	pager := client.NewListEntitiesPager(nil)
 	count := 0
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)

--- a/sdk/data/aztables/transaction_batch_test.go
+++ b/sdk/data/aztables/transaction_batch_test.go
@@ -35,7 +35,7 @@ func TestBatchAdd(t *testing.T) {
 			_, err = client.SubmitTransaction(ctx, batch, nil)
 			require.NoError(t, err)
 
-			pager := client.ListEntities(nil)
+			pager := client.NewListEntitiesPager(nil)
 			count := 0
 			for pager.More() {
 				response, err := pager.NextPage(ctx)
@@ -77,7 +77,7 @@ func TestBatchInsert(t *testing.T) {
 			_, err = client.SubmitTransaction(ctx, batch, nil)
 			require.NoError(t, err)
 
-			pager := client.ListEntities(nil)
+			pager := client.NewListEntitiesPager(nil)
 			count := 0
 			for pager.More() {
 				response, err := pager.NextPage(ctx)
@@ -118,7 +118,7 @@ func TestBatchMixed(t *testing.T) {
 			var qResp ListEntitiesResponse
 			filter := "RowKey eq '1'"
 			list := &ListEntitiesOptions{Filter: &filter}
-			pager := client.ListEntities(list)
+			pager := client.NewListEntitiesPager(list)
 			for pager.More() {
 				qResp, err = pager.NextPage(ctx)
 				require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestBatchMixed(t *testing.T) {
 			_, err = client.SubmitTransaction(ctx, batch2, nil)
 			require.NoError(t, err)
 
-			pager = client.ListEntities(list)
+			pager = client.NewListEntitiesPager(list)
 			for pager.More() {
 				qResp, err = pager.NextPage(ctx)
 				require.NoError(t, err)


### PR DESCRIPTION
Regenerated code with latest code generator (no public changes).
Added directive to autorest.md to fix up parts of codegen.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
