### PR TITLE
feat: change logic of fetching previous version's exports

### DIFF
--- a/eng/tools/generator/cmd/v2/common/changlogProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/changlogProcessor.go
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/eng/tools/generator/repo"
+	"github.com/Azure/azure-sdk-for-go/eng/tools/internal/exports"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+const (
+	sdk_tag_fetch_url = "https://api.github.com/repos/Azure/azure-sdk-for-go/git/refs/tags"
+)
+
+func GetAllVersionTags(rpName, namespaceName string) ([]string, error) {
+	log.Printf("Fetching all release tags from GitHub for RP: '%s' Package: '%s' ...", rpName, namespaceName)
+	client := http.Client{}
+	res, err := client.Get(sdk_tag_fetch_url)
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	result := []map[string]interface{}{}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, err
+	}
+	var tags []string
+	for _, tag := range result {
+		tagName := tag["ref"].(string)
+		if strings.Contains(tagName, "sdk/resourcemanager/"+rpName+"/"+namespaceName) {
+			tags = append(tags, tag["ref"].(string))
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(tags)))
+
+	return tags, nil
+}
+
+func GetCurrentAPIVersion(packagePath string) (string, error) {
+	log.Printf("Get current release API version from '%s' ...", packagePath)
+
+	files, err := ioutil.ReadDir(packagePath)
+	if err != nil {
+		return "", err
+	}
+
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".go") {
+			b, err := ioutil.ReadFile(path.Join(packagePath, file.Name()))
+			if err != nil {
+				return "", err
+			}
+
+			lines := strings.Split(string(b), "\n")
+			for _, line := range lines {
+				if strings.Contains(line, "api-version") {
+					return strings.Split(line, "\"")[3], nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("Cannot find API version for current release")
+}
+
+func GetPreviousVersionTag(apiVersion string, allReleases []string) string {
+	if strings.Contains(apiVersion, "preview") {
+		// for preview api, always compare with latest release
+		return allReleases[0]
+	} else {
+		// for stable api, always compare with previous stable, if no stable, then latest release
+		for _, release := range allReleases {
+			if !strings.Contains(release, "beta") {
+				return release
+			}
+		}
+		return allReleases[0]
+	}
+}
+
+func GetExportsFromTag(sdkRepo repo.SDKRepository, packagePath, tag string) (*exports.Content, error) {
+	log.Printf("Get exports from specific tag '%s' ...", tag)
+
+	// get current head branch name
+	currentRef, err := sdkRepo.Head()
+	if err != nil {
+		return nil, err
+	}
+
+	// stash current change
+	err = sdkRepo.Stash()
+	if err != nil {
+		return nil, err
+	}
+
+	// checkout to the specific tag
+	err = sdkRepo.CheckoutTag(strings.TrimPrefix(tag, "ref/tags/"))
+	if err != nil {
+		return nil, err
+	}
+
+	// get exports
+	result, err := exports.Get(packagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// checkout back to head branch
+	err = sdkRepo.Checkout(&repo.CheckoutOptions{
+		Branch: plumbing.ReferenceName(currentRef.Name()),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// restore current change
+	err = sdkRepo.StashPop()
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/eng/tools/generator/cmd/v2/common/fileProcessor_test.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/eng/tools/generator/autorest/model"
+	"github.com/Azure/azure-sdk-for-go/eng/tools/internal/delta"
+	"github.com/Azure/azure-sdk-for-go/eng/tools/internal/exports"
+	"github.com/Azure/azure-sdk-for-go/eng/tools/internal/report"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateNewVersion(t *testing.T) {
+	fixChange := &model.Changelog{Modified: &report.Package{}}
+	breakingChange := &model.Changelog{RemovedPackage: true, Modified: &report.Package{}}
+	additiveChange := &model.Changelog{Modified: &report.Package{AdditiveChanges: &delta.Content{Content: exports.Content{Consts: map[string]exports.Const{"test": {}}}}}}
+
+	// previous 0.x.x
+	// fix with stable
+	newVersion, err := CalculateNewVersion(fixChange, "0.5.0", false)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "0.5.1")
+
+	// fix with beat
+	newVersion, err = CalculateNewVersion(fixChange, "0.5.0", true)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "0.5.1")
+
+	// breaking with stable
+	newVersion, err = CalculateNewVersion(breakingChange, "0.5.0", false)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "0.6.0")
+
+	// breaking with beta
+	newVersion, err = CalculateNewVersion(breakingChange, "0.5.0", true)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "0.6.0")
+
+	// additive with stable
+	newVersion, err = CalculateNewVersion(additiveChange, "0.5.0", false)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "0.6.0")
+
+	// additive with beta
+	newVersion, err = CalculateNewVersion(additiveChange, "0.5.0", true)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "0.6.0")
+
+	// previous 1.2.0
+	// fix with stable
+	newVersion, err = CalculateNewVersion(fixChange, "1.2.0", false)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "1.2.1")
+
+	// fix with beat
+	newVersion, err = CalculateNewVersion(fixChange, "1.2.0", true)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "1.2.1-beta.1")
+
+	// breaking with stable
+	newVersion, err = CalculateNewVersion(breakingChange, "1.2.0", false)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "2.0.0")
+
+	// breaking with beta
+	newVersion, err = CalculateNewVersion(breakingChange, "1.2.0", true)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "2.0.0-beta.1")
+
+	// additive with stable
+	newVersion, err = CalculateNewVersion(additiveChange, "1.2.0", false)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "1.3.0")
+
+	// additive with beta
+	newVersion, err = CalculateNewVersion(additiveChange, "1.2.0", true)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "1.3.0-beta.1")
+
+	// previous 1.2.0-beta.1
+	// fix with stable
+	newVersion, err = CalculateNewVersion(fixChange, "1.2.0-beta.1", false)
+	assert.NotEmpty(t, err)
+
+	// fix with beat
+	newVersion, err = CalculateNewVersion(fixChange, "1.2.0-beta.1", true)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "1.2.0-beta.2")
+
+	// breaking with stable
+	newVersion, err = CalculateNewVersion(breakingChange, "1.2.0-beta.1", false)
+	assert.NotEmpty(t, err)
+
+	// breaking with beta
+	newVersion, err = CalculateNewVersion(breakingChange, "1.2.0-beta.1", true)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "1.2.0-beta.2")
+
+	// additive with stable
+	newVersion, err = CalculateNewVersion(additiveChange, "1.2.0-beta.1", false)
+	assert.NotEmpty(t, err)
+
+	// additive with beta
+	newVersion, err = CalculateNewVersion(additiveChange, "1.2.0-beta.1", true)
+	assert.NoError(t, err)
+	assert.Equal(t, newVersion.String(), "1.2.0-beta.2")
+}

--- a/eng/tools/generator/go.mod
+++ b/eng/tools/generator/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 )
 
@@ -18,6 +19,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
@@ -36,4 +39,5 @@ require (
 	golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79 // indirect
 	google.golang.org/appengine v1.6.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/eng/tools/generator/repo/workTree.go
+++ b/eng/tools/generator/repo/workTree.go
@@ -19,6 +19,7 @@ type WorkTree interface {
 	Add(path string) error
 	Commit(message string) error
 	Checkout(opt *CheckoutOptions) error
+	CheckoutTag(tag string) error
 	CreateBranch(branch *Branch) error
 	DeleteBranch(name string) error
 	CherryPick(commit string) error
@@ -135,6 +136,16 @@ func (r *repository) checkoutBranch(branch string, create bool) error {
 
 func (r *repository) checkoutHash(hash string) error {
 	cmd := exec.Command("git", "checkout", hash)
+	cmd.Dir = r.root
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf(string(output))
+	}
+	return nil
+}
+
+func (r *repository) CheckoutTag(tag string) error {
+	cmd := exec.Command("git", "checkout", tag)
 	cmd.Dir = r.root
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
