### PR TITLE
Add options bag to PollUntilDone method

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Renamed `cloud.Configuration.LoginEndpoint` to `.ActiveDirectoryAuthorityHost`
 * Removed `AuxiliaryTenants` field from `arm/ClientOptions` and `arm/policy/BearerTokenOptions`
 * Removed `TokenRequestOptions.TenantID`
+* `Poller[T].PollUntilDone()` now takes an `options *PollUntilDoneOptions` param instead of `freq time.Duration`
 
 ### Bugs Fixed
 

--- a/sdk/azcore/arm/runtime/poller.go
+++ b/sdk/azcore/arm/runtime/poller.go
@@ -155,14 +155,15 @@ func (p *Poller[T]) PollUntilDone(ctx context.Context, options *PollUntilDoneOpt
 	if options == nil {
 		options = &PollUntilDoneOptions{}
 	}
-	if options.Frequency == 0 {
-		options.Frequency = 30 * time.Second
+	cp := *options
+	if cp.Frequency == 0 {
+		cp.Frequency = 30 * time.Second
 	}
 	var resp T
 	if p.rt != nil {
 		resp = *p.rt
 	}
-	_, err := p.pt.PollUntilDone(ctx, options.Frequency, &resp)
+	_, err := p.pt.PollUntilDone(ctx, cp.Frequency, &resp)
 	return resp, err
 }
 

--- a/sdk/azcore/arm/runtime/poller.go
+++ b/sdk/azcore/arm/runtime/poller.go
@@ -134,6 +134,13 @@ func NewPollerFromResumeToken[T any](token string, pl runtime.Pipeline, options 
 	}, nil
 }
 
+// PollUntilDoneOptions contains the optional values for the Poller[T].PollUntilDone() method.
+type PollUntilDoneOptions struct {
+	// Frequency is the time to wait between polling intervals in absence of a Retry-After header. Allowed minimum is one second.
+	// Pass zero to accept the default value (30s).
+	Frequency time.Duration
+}
+
 // Poller encapsulates a long-running operation, providing polling facilities until the operation reaches a terminal state.
 type Poller[T any] struct {
 	pt *pollers.Poller
@@ -141,13 +148,21 @@ type Poller[T any] struct {
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached, an error is received, or the context expires.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (p *Poller[T]) PollUntilDone(ctx context.Context, freq time.Duration) (T, error) {
+// options: pass nil to accept the default values.
+// NOTE: the default polling frequency is 30 seconds which works well for most services.  However, some services might
+// benefit from a shorter or longer duration.
+func (p *Poller[T]) PollUntilDone(ctx context.Context, options *PollUntilDoneOptions) (T, error) {
+	if options == nil {
+		options = &PollUntilDoneOptions{}
+	}
+	if options.Frequency == 0 {
+		options.Frequency = 30 * time.Second
+	}
 	var resp T
 	if p.rt != nil {
 		resp = *p.rt
 	}
-	_, err := p.pt.PollUntilDone(ctx, freq, &resp)
+	_, err := p.pt.PollUntilDone(ctx, options.Frequency, &resp)
 	return resp, err
 }
 

--- a/sdk/azcore/arm/runtime/poller_test.go
+++ b/sdk/azcore/arm/runtime/poller_test.go
@@ -93,7 +93,7 @@ func TestNewPollerAsync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	result, err := poller.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestNewPollerBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	result, err := poller.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestNewPollerInitialRetryAfter(t *testing.T) {
 	if pt := pollers.PollerType(poller.pt); pt != reflect.TypeOf(&async.Poller{}) {
 		t.Fatalf("unexpected poller type %s", pt.String())
 	}
-	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	result, err := poller.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func TestNewPollerFailedWithError(t *testing.T) {
 	if pt := pollers.PollerType(poller.pt); pt != reflect.TypeOf(&async.Poller{}) {
 		t.Fatalf("unexpected poller type %s", pt.String())
 	}
-	_, err = poller.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -301,7 +301,7 @@ func TestNewPollerSuccessNoContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	result, err := poller.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +363,7 @@ func TestNewPollerWithResponseType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	result, err := poller.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -123,6 +123,13 @@ func NewPollerFromResumeToken[T any](token string, pl exported.Pipeline, options
 	}, nil
 }
 
+// PollUntilDoneOptions contains the optional values for the Poller[T].PollUntilDone() method.
+type PollUntilDoneOptions struct {
+	// Frequency is the time to wait between polling intervals in absence of a Retry-After header. Allowed minimum is one second.
+	// Pass zero to accept the default value (30s).
+	Frequency time.Duration
+}
+
 // Poller encapsulates a long-running operation, providing polling facilities until the operation reaches a terminal state.
 type Poller[T any] struct {
 	pt *pollers.Poller
@@ -130,13 +137,21 @@ type Poller[T any] struct {
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached, an error is received, or the context expires.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (p *Poller[T]) PollUntilDone(ctx context.Context, freq time.Duration) (T, error) {
+// options: pass nil to accept the default values.
+// NOTE: the default polling frequency is 30 seconds which works well for most services.  However, some services might
+// benefit from a shorter or longer duration.
+func (p *Poller[T]) PollUntilDone(ctx context.Context, options *PollUntilDoneOptions) (T, error) {
+	if options == nil {
+		options = &PollUntilDoneOptions{}
+	}
+	if options.Frequency == 0 {
+		options.Frequency = 30 * time.Second
+	}
 	var resp T
 	if p.rt != nil {
 		resp = *p.rt
 	}
-	_, err := p.pt.PollUntilDone(ctx, freq, &resp)
+	_, err := p.pt.PollUntilDone(ctx, options.Frequency, &resp)
 	return resp, err
 }
 

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -144,14 +144,15 @@ func (p *Poller[T]) PollUntilDone(ctx context.Context, options *PollUntilDoneOpt
 	if options == nil {
 		options = &PollUntilDoneOptions{}
 	}
-	if options.Frequency == 0 {
-		options.Frequency = 30 * time.Second
+	cp := *options
+	if cp.Frequency == 0 {
+		cp.Frequency = 30 * time.Second
 	}
 	var resp T
 	if p.rt != nil {
 		resp = *p.rt
 	}
-	_, err := p.pt.PollUntilDone(ctx, options.Frequency, &resp)
+	_, err := p.pt.PollUntilDone(ctx, cp.Frequency, &resp)
 	return resp, err
 }
 

--- a/sdk/azcore/runtime/poller_test.go
+++ b/sdk/azcore/runtime/poller_test.go
@@ -96,7 +96,7 @@ func TestLocPollerSimple(t *testing.T) {
 	}
 	var respFromCtx *http.Response
 	ctxWithResp := WithCaptureResponse(context.Background(), &respFromCtx)
-	_, err = lro.PollUntilDone(ctxWithResp, time.Second)
+	_, err = lro.PollUntilDone(ctxWithResp, &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestLocPollerWithWidget(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	w, err := lro.PollUntilDone(context.Background(), time.Second)
+	w, err := lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestLocPollerCancelled(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	w, err := lro.PollUntilDone(context.Background(), time.Second)
+	w, err := lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -198,7 +198,7 @@ func TestLocPollerWithError(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	w, err := lro.PollUntilDone(context.Background(), time.Second)
+	w, err := lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -256,7 +256,7 @@ func TestLocPollerWithResumeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = lro.PollUntilDone(context.Background(), time.Second)
+	_, err = lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +286,7 @@ func TestLocPollerWithTimeout(t *testing.T) {
 		t.Fatal("initial response body wasn't closed")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	_, err = lro.PollUntilDone(ctx, time.Second)
+	_, err = lro.PollUntilDone(ctx, &PollUntilDoneOptions{Frequency: time.Second})
 	cancel()
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -325,7 +325,7 @@ func TestOpPollerSimple(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	_, err = lro.PollUntilDone(context.Background(), time.Second)
+	_, err = lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +365,7 @@ func TestOpPollerWithWidgetPUT(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	w, err := lro.PollUntilDone(context.Background(), time.Second)
+	w, err := lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +409,7 @@ func TestOpPollerWithWidgetPOSTLocation(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	w, err := lro.PollUntilDone(context.Background(), time.Second)
+	w, err := lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +451,7 @@ func TestOpPollerWithWidgetPOST(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	w, err := lro.PollUntilDone(context.Background(), time.Second)
+	w, err := lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -496,7 +496,7 @@ func TestOpPollerWithWidgetResourceLocation(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	w, err := lro.PollUntilDone(context.Background(), time.Second)
+	w, err := lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -559,7 +559,7 @@ func TestOpPollerWithResumeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = lro.PollUntilDone(context.Background(), time.Second)
+	_, err = lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -592,7 +592,7 @@ func TestNopPoller(t *testing.T) {
 	if resp != firstResp {
 		t.Fatal("unexpected response")
 	}
-	_, err = lro.PollUntilDone(context.Background(), time.Second)
+	_, err = lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -648,7 +648,7 @@ func TestOpPollerWithResponseType(t *testing.T) {
 	if !closed() {
 		t.Fatal("initial response body wasn't closed")
 	}
-	w, err := lro.PollUntilDone(context.Background(), time.Second)
+	w, err := lro.PollUntilDone(context.Background(), &PollUntilDoneOptions{Frequency: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Passing nil/zero-value options defaults to 30s polling frequency.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
