### PR TITLE
RetryOptions were not being propagated throughout all the clients (mi…

### DIFF
--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -298,21 +298,19 @@ func TestClientPropagatesRetryOptionsForSessions(t *testing.T) {
 
 	defer cleanupTopic()
 
+	expectedRetryOptions := RetryOptions{
+		MaxRetries:    1,
+		RetryDelay:    time.Second,
+		MaxRetryDelay: time.Millisecond,
+	}
+
 	client, err := NewClientFromConnectionString(connectionString, &ClientOptions{
-		RetryOptions: RetryOptions{
-			MaxRetries:    1,
-			RetryDelay:    time.Second,
-			MaxRetryDelay: time.Millisecond,
-		},
+		RetryOptions: expectedRetryOptions,
 	})
 	require.NoError(t, err)
 
 	actualNS := client.namespace.(*internal.Namespace)
-	require.Equal(t, RetryOptions{
-		MaxRetries:    1,
-		RetryDelay:    time.Second,
-		MaxRetryDelay: time.Millisecond,
-	}, actualNS.RetryOptions)
+	require.Equal(t, expectedRetryOptions, actualNS.RetryOptions)
 
 	queueSender, err := client.NewSender(queue, nil)
 	require.NoError(t, err)
@@ -334,41 +332,25 @@ func TestClientPropagatesRetryOptionsForSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sessionReceiver.Close(context.Background()))
 
-	require.Equal(t, RetryOptions{
-		MaxRetries:    101,
-		RetryDelay:    6 * time.Hour,
-		MaxRetryDelay: 12 * time.Hour,
-	}, sessionReceiver.inner.retryOptions)
+	require.Equal(t, expectedRetryOptions, sessionReceiver.inner.retryOptions)
 
 	sessionReceiver, err = client.AcceptSessionForSubscription(context.Background(), topic, "sub", "hello", nil)
 	require.NoError(t, err)
 	require.NoError(t, sessionReceiver.Close(context.Background()))
 
-	require.Equal(t, RetryOptions{
-		MaxRetries:    101,
-		RetryDelay:    6 * time.Hour,
-		MaxRetryDelay: 12 * time.Hour,
-	}, sessionReceiver.inner.retryOptions)
+	require.Equal(t, expectedRetryOptions, sessionReceiver.inner.retryOptions)
 
 	sessionReceiver, err = client.AcceptNextSessionForQueue(context.Background(), queue, nil)
 	require.NoError(t, err)
 	require.NoError(t, sessionReceiver.Close(context.Background()))
 
-	require.Equal(t, RetryOptions{
-		MaxRetries:    101,
-		RetryDelay:    6 * time.Hour,
-		MaxRetryDelay: 12 * time.Hour,
-	}, sessionReceiver.inner.retryOptions)
+	require.Equal(t, expectedRetryOptions, sessionReceiver.inner.retryOptions)
 
 	sessionReceiver, err = client.AcceptNextSessionForSubscription(context.Background(), topic, "sub", nil)
 	require.NoError(t, err)
 	require.NoError(t, sessionReceiver.Close(context.Background()))
 
-	require.Equal(t, RetryOptions{
-		MaxRetries:    101,
-		RetryDelay:    6 * time.Hour,
-		MaxRetryDelay: 12 * time.Hour,
-	}, sessionReceiver.inner.retryOptions)
+	require.Equal(t, expectedRetryOptions, sessionReceiver.inner.retryOptions)
 }
 
 func TestNewClientUnitTests(t *testing.T) {

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -283,6 +283,94 @@ func TestClientNewSessionReceiverCancel(t *testing.T) {
 	require.Nil(t, receiver)
 }
 
+func TestClientPropagatesRetryOptionsForSessions(t *testing.T) {
+	connectionString := test.GetConnectionString(t)
+
+	queue, cleanupQueue := createQueue(t, connectionString, &admin.QueueProperties{
+		RequiresSession: to.Ptr(true),
+	})
+
+	defer cleanupQueue()
+
+	topic, cleanupTopic := createSubscription(t, connectionString, nil, &admin.SubscriptionProperties{
+		RequiresSession: to.Ptr(true),
+	})
+
+	defer cleanupTopic()
+
+	client, err := NewClientFromConnectionString(connectionString, &ClientOptions{
+		RetryOptions: RetryOptions{
+			MaxRetries:    1,
+			RetryDelay:    time.Second,
+			MaxRetryDelay: time.Millisecond,
+		},
+	})
+	require.NoError(t, err)
+
+	actualNS := client.namespace.(*internal.Namespace)
+	require.Equal(t, RetryOptions{
+		MaxRetries:    1,
+		RetryDelay:    time.Second,
+		MaxRetryDelay: time.Millisecond,
+	}, actualNS.RetryOptions)
+
+	queueSender, err := client.NewSender(queue, nil)
+	require.NoError(t, err)
+
+	topicSender, err := client.NewSender(topic, nil)
+	require.NoError(t, err)
+
+	err = queueSender.SendMessage(context.Background(), &Message{
+		SessionID: to.Ptr("hello"),
+	}, nil)
+	require.NoError(t, err)
+
+	err = topicSender.SendMessage(context.Background(), &Message{
+		SessionID: to.Ptr("hello"),
+	}, nil)
+	require.NoError(t, err)
+
+	sessionReceiver, err := client.AcceptSessionForQueue(context.Background(), queue, "hello", nil)
+	require.NoError(t, err)
+	require.NoError(t, sessionReceiver.Close(context.Background()))
+
+	require.Equal(t, RetryOptions{
+		MaxRetries:    101,
+		RetryDelay:    6 * time.Hour,
+		MaxRetryDelay: 12 * time.Hour,
+	}, sessionReceiver.inner.retryOptions)
+
+	sessionReceiver, err = client.AcceptSessionForSubscription(context.Background(), topic, "sub", "hello", nil)
+	require.NoError(t, err)
+	require.NoError(t, sessionReceiver.Close(context.Background()))
+
+	require.Equal(t, RetryOptions{
+		MaxRetries:    101,
+		RetryDelay:    6 * time.Hour,
+		MaxRetryDelay: 12 * time.Hour,
+	}, sessionReceiver.inner.retryOptions)
+
+	sessionReceiver, err = client.AcceptNextSessionForQueue(context.Background(), queue, nil)
+	require.NoError(t, err)
+	require.NoError(t, sessionReceiver.Close(context.Background()))
+
+	require.Equal(t, RetryOptions{
+		MaxRetries:    101,
+		RetryDelay:    6 * time.Hour,
+		MaxRetryDelay: 12 * time.Hour,
+	}, sessionReceiver.inner.retryOptions)
+
+	sessionReceiver, err = client.AcceptNextSessionForSubscription(context.Background(), topic, "sub", nil)
+	require.NoError(t, err)
+	require.NoError(t, sessionReceiver.Close(context.Background()))
+
+	require.Equal(t, RetryOptions{
+		MaxRetries:    101,
+		RetryDelay:    6 * time.Hour,
+		MaxRetryDelay: 12 * time.Hour,
+	}, sessionReceiver.inner.retryOptions)
+}
+
 func TestNewClientUnitTests(t *testing.T) {
 	t.Run("WithTokenCredential", func(t *testing.T) {
 		fakeTokenCredential := struct{ azcore.TokenCredential }{}
@@ -360,6 +448,67 @@ func TestNewClientUnitTests(t *testing.T) {
 		require.NoError(t, client.Close(context.Background()))
 		require.Empty(t, client.links)
 		require.EqualValues(t, 1, ns.AMQPLinks.Closed)
+	})
+
+	t.Run("RetryOptionsArePropagated", func(t *testing.T) {
+		// retry options are passed and copied along several routes, just make sure it's properly propagated.
+		// NOTE: session receivers are checked in a separate test because they require actual SB access.
+		client, err := NewClient("fake.something", struct{ azcore.TokenCredential }{}, &ClientOptions{
+			RetryOptions: RetryOptions{
+				MaxRetries:    101,
+				RetryDelay:    6 * time.Hour,
+				MaxRetryDelay: 12 * time.Hour,
+			},
+		})
+
+		client.namespace = &internal.FakeNS{
+			AMQPLinks: &internal.FakeAMQPLinks{
+				Receiver: &internal.FakeAMQPReceiver{},
+			},
+		}
+
+		require.NoError(t, err)
+
+		require.Equal(t, RetryOptions{
+			MaxRetries:    101,
+			RetryDelay:    6 * time.Hour,
+			MaxRetryDelay: 12 * time.Hour,
+		}, client.retryOptions)
+
+		sender, err := client.NewSender("hello", nil)
+		require.NoError(t, err)
+
+		require.Equal(t, RetryOptions{
+			MaxRetries:    101,
+			RetryDelay:    6 * time.Hour,
+			MaxRetryDelay: 12 * time.Hour,
+		}, sender.retryOptions)
+
+		receiver, err := client.NewReceiverForQueue("hello", nil)
+		require.NoError(t, err)
+
+		require.Equal(t, RetryOptions{
+			MaxRetries:    101,
+			RetryDelay:    6 * time.Hour,
+			MaxRetryDelay: 12 * time.Hour,
+		}, receiver.retryOptions)
+
+		actualSettler := receiver.settler.(*messageSettler)
+
+		require.Equal(t, RetryOptions{
+			MaxRetries:    101,
+			RetryDelay:    6 * time.Hour,
+			MaxRetryDelay: 12 * time.Hour,
+		}, actualSettler.retryOptions)
+
+		subscriptionReceiver, err := client.NewReceiverForSubscription("hello", "world", nil)
+		require.NoError(t, err)
+
+		require.Equal(t, RetryOptions{
+			MaxRetries:    101,
+			RetryDelay:    6 * time.Hour,
+			MaxRetryDelay: 12 * time.Hour,
+		}, subscriptionReceiver.retryOptions)
 	})
 }
 

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -45,7 +45,8 @@ type (
 
 		newWebSocketConn func(ctx context.Context, args exported.NewWebSocketConnArgs) (net.Conn, error)
 
-		retryOptions exported.RetryOptions
+		// NOTE: exported only so it can be checked in a test
+		RetryOptions exported.RetryOptions
 
 		clientMu         sync.RWMutex
 		client           *amqp.Client
@@ -133,7 +134,7 @@ func NamespaceWithTokenCredential(fullyQualifiedNamespace string, tokenCredentia
 
 func NamespaceWithRetryOptions(retryOptions exported.RetryOptions) NamespaceOption {
 	return func(ns *Namespace) error {
-		ns.retryOptions = retryOptions
+		ns.RetryOptions = retryOptions
 		return nil
 	}
 }
@@ -407,7 +408,7 @@ func (ns *Namespace) startNegotiateClaimRenewer(ctx context.Context,
 
 						expiresOn = tmpExpiresOn
 						return nil
-					}, IsFatalSBError, ns.retryOptions)
+					}, IsFatalSBError, ns.RetryOptions)
 
 					if err == nil {
 						break

--- a/sdk/messaging/azservicebus/internal/namespace_test.go
+++ b/sdk/messaging/azservicebus/internal/namespace_test.go
@@ -33,7 +33,7 @@ func TestNamespaceNegotiateClaim(t *testing.T) {
 	expires := time.Now().Add(24 * time.Hour)
 
 	ns := &Namespace{
-		retryOptions:  retryOptionsOnlyOnce,
+		RetryOptions:  retryOptionsOnlyOnce,
 		TokenProvider: sbauth.NewTokenProvider(&fakeTokenCredential{expires: expires}),
 	}
 
@@ -78,7 +78,7 @@ func TestNamespaceNegotiateClaimRenewal(t *testing.T) {
 	expires := time.Now().Add(24 * time.Hour)
 
 	ns := &Namespace{
-		retryOptions:  retryOptionsOnlyOnce,
+		RetryOptions:  retryOptionsOnlyOnce,
 		TokenProvider: sbauth.NewTokenProvider(&fakeTokenCredential{expires: expires}),
 	}
 
@@ -156,7 +156,7 @@ func TestNamespaceNegotiateClaimFailsToGetClient(t *testing.T) {
 
 func TestNamespaceNegotiateClaimNonRenewableToken(t *testing.T) {
 	ns := &Namespace{
-		retryOptions: retryOptionsOnlyOnce,
+		RetryOptions: retryOptionsOnlyOnce,
 		TokenProvider: sbauth.NewTokenProvider(&fakeTokenCredential{
 			// credentials that don't renew return a zero-initialized time.
 			expires: time.Time{},

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -81,14 +81,11 @@ type ReceiverOptions struct {
 	// SubQueue should be set to connect to the sub queue (ex: dead letter queue)
 	// of the queue or subscription.
 	SubQueue SubQueue
-
-	retryOptions RetryOptions
 }
 
 const defaultLinkRxBuffer = 2048
 
 func applyReceiverOptions(receiver *Receiver, entity *entity, options *ReceiverOptions) error {
-
 	if options == nil {
 		receiver.receiveMode = ReceiveModePeekLock
 	} else {
@@ -101,8 +98,6 @@ func applyReceiverOptions(receiver *Receiver, entity *entity, options *ReceiverO
 		if err := entity.SetSubQueue(options.SubQueue); err != nil {
 			return err
 		}
-
-		receiver.retryOptions = options.retryOptions
 	}
 
 	entityPath, err := entity.String()
@@ -121,6 +116,7 @@ type newReceiverArgs struct {
 	cleanupOnClose      func()
 	getRecoveryKindFunc func(err error) internal.RecoveryKind
 	newLinkFn           func(ctx context.Context, session amqpwrap.AMQPSession) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error)
+	retryOptions        RetryOptions
 }
 
 func newReceiver(args newReceiverArgs, options *ReceiverOptions) (*Receiver, error) {
@@ -133,6 +129,7 @@ func newReceiver(args newReceiverArgs, options *ReceiverOptions) (*Receiver, err
 		cleanupOnClose:           args.cleanupOnClose,
 		defaultDrainTimeout:      time.Second,
 		defaultTimeAfterFirstMsg: 20 * time.Millisecond,
+		retryOptions:             args.retryOptions,
 	}
 
 	if err := applyReceiverOptions(receiver, &args.entity, options); err != nil {

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -386,16 +386,12 @@ func TestReceiverOptions(t *testing.T) {
 	require.NoError(t, applyReceiverOptions(receiver, e, &ReceiverOptions{
 		ReceiveMode: ReceiveModeReceiveAndDelete,
 		SubQueue:    SubQueueTransfer,
-		retryOptions: RetryOptions{
-			MaxRetries: 101,
-		},
 	}))
 
 	require.EqualValues(t, ReceiveModeReceiveAndDelete, receiver.receiveMode)
 	path, err = e.String()
 	require.NoError(t, err)
 	require.EqualValues(t, "topic/Subscriptions/subscription/$Transfer/$DeadLetterQueue", path)
-	require.EqualValues(t, 101, receiver.retryOptions.MaxRetries)
 }
 
 func TestReceiverDeferUnitTests(t *testing.T) {

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -150,9 +150,10 @@ type newSenderArgs struct {
 	ns             internal.NamespaceWithNewAMQPLinks
 	queueOrTopic   string
 	cleanupOnClose func()
+	retryOptions   RetryOptions
 }
 
-func newSender(args newSenderArgs, retryOptions RetryOptions) (*Sender, error) {
+func newSender(args newSenderArgs) (*Sender, error) {
 	if err := args.ns.Check(); err != nil {
 		return nil, err
 	}
@@ -160,7 +161,7 @@ func newSender(args newSenderArgs, retryOptions RetryOptions) (*Sender, error) {
 	sender := &Sender{
 		queueOrTopic:   args.queueOrTopic,
 		cleanupOnClose: args.cleanupOnClose,
-		retryOptions:   RetryOptions(retryOptions),
+		retryOptions:   args.retryOptions,
 	}
 
 	sender.links = args.ns.NewAMQPLinks(args.queueOrTopic, sender.createSenderLink, internal.GetRecoveryKind)


### PR DESCRIPTION
RetryOptions were not being propagated throughout all the clients (mismatch in old vs new system).

Fixed and added tests for the various spots that inherit these options to make sure they're properly getting copied over:
- Sender
- All the session receiver functions (AcceptNext, Accept)
- Receivers
- Namespace

Fixes #17686