### PR TITLE
Removed dependency on TokenRequestOptions.TenantID

### DIFF
--- a/sdk/keyvault/internal/CHANGELOG.md
+++ b/sdk/keyvault/internal/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Release History
 
-## 0.3.1 (Unreleased)
+## 0.4.0 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
+* Updated `ExpiringResource` and its dependent types to use generics.
 
 ### Bugs Fixed
 
 ### Other Changes
+* Remove reference to `TokenRequestOptions.TenantID` as it's been removed and wasn't working anyways.
 
 ## 0.3.0 (2022-04-04)
 

--- a/sdk/keyvault/internal/constants.go
+++ b/sdk/keyvault/internal/constants.go
@@ -7,5 +7,5 @@
 package internal
 
 const (
-	version = "v0.3.1" //nolint
+	version = "v0.4.0" //nolint
 )

--- a/sdk/keyvault/internal/expiring_resource_test.go
+++ b/sdk/keyvault/internal/expiring_resource_test.go
@@ -15,15 +15,14 @@ import (
 )
 
 func TestNewExpiringResource(t *testing.T) {
-	er := NewExpiringResource(func(state interface{}) (newResource interface{}, newExpiration time.Time, err error) {
-		s := state.(string)
-		switch s {
+	er := NewExpiringResource(func(state string) (newResource string, newExpiration time.Time, err error) {
+		switch state {
 		case "initial":
 			return "updated", time.Now(), nil
 		case "updated":
 			return "refreshed", time.Now().Add(1 * time.Hour), nil
 		default:
-			t.Fatalf("unexpected state %s", s)
+			t.Fatalf("unexpected state %s", state)
 			return "", time.Time{}, errors.New("unexpected")
 		}
 	})


### PR DESCRIPTION
It wasn't working anyways and has been removed in the upcoming release.
Refactored the expiring resource machinery to use generics.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
