### PR TITLE
fix: wrong ref for global variables

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
       name: $(pool.name)
 
     variables:
-      - template: ../variables/globals.yml
+      - template: ./eng/pipelines/templates/variables/globals.yml
       - name: GOPATH
         value: '$(system.defaultWorkingDirectory)/work'
       - name: sdkPath


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
