### PR TITLE
Removed log constants

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Release History
 
-## 0.9.3 (Unreleased)
+## 0.10.0 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
+* Removed logging constants from the `log` package.
 
 ### Bugs Fixed
 

--- a/sdk/internal/log/log.go
+++ b/sdk/internal/log/log.go
@@ -12,31 +12,12 @@ import (
 	"time"
 )
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// NOTE: The following are exported as public surface area from azcore.  DO NOT MODIFY
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
 // Event is used to group entries.  Each group can be toggled on or off.
 type Event string
-
-const (
-	// EventRequest entries contain information about HTTP requests.
-	// This includes information like the URL, query parameters, and headers.
-	EventRequest Event = "Request"
-
-	// EventResponse entries containe information about HTTP responses.
-	// This includes information like the HTTP status code, headers, and request URL.
-	EventResponse Event = "Response"
-
-	// EventRetryPolicy entries contain information specific to the rety policy in use.
-	EventRetryPolicy Event = "Retry"
-
-	// EventLRO entries contian information specific to long-running operations.
-	// This includes information like polling location, operation state, and sleep intervals.
-	EventLRO Event = "LongRunningOperation"
-)
-
-// logger controls which events to log and writing to the underlying log.
-type logger struct {
-	cls []Event
-	lst func(Event, string)
-}
 
 // SetEvents is used to control which events are written to
 // the log.  By default all log events are writen.
@@ -48,6 +29,10 @@ func SetEvents(cls ...Event) {
 func SetListener(lst func(Event, string)) {
 	log.lst = lst
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// END PUBLIC SURFACE AREA
+///////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Should returns true if the specified log event should be written to the log.
 // By default all log events will be logged.  Call SetEvents() to limit
@@ -88,9 +73,15 @@ func Writef(cls Event, format string, a ...interface{}) {
 	log.lst(cls, fmt.Sprintf(format, a...))
 }
 
-// TestResetEvents is used for testing purposes only.
+// TestResetEvents is used for TESTING PURPOSES ONLY.
 func TestResetEvents() {
 	log.cls = nil
+}
+
+// logger controls which events to log and writing to the underlying log.
+type logger struct {
+	cls []Event
+	lst func(Event, string)
 }
 
 // the process-wide logger

--- a/sdk/internal/log/log_test.go
+++ b/sdk/internal/log/log_test.go
@@ -10,6 +10,11 @@ import (
 	"testing"
 )
 
+const (
+	EventRequest  Event = "Request"
+	EventResponse Event = "Response"
+)
+
 func TestLoggingdefault(t *testing.T) {
 	// ensure logging with nil listener doesn't fail
 	SetListener(nil)

--- a/sdk/internal/version.go
+++ b/sdk/internal/version.go
@@ -11,5 +11,5 @@ const (
 	Module = "internal"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v0.9.3"
+	Version = "v0.10.0"
 )


### PR DESCRIPTION
They should be defined in azcore/log, not here.
Added comments indicating which parts of log are public surface area.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
