### PR TITLE
Define log constants in the log package

### DIFF
--- a/sdk/azcore/log/log.go
+++ b/sdk/azcore/log/log.go
@@ -17,18 +17,18 @@ type Event = log.Event
 const (
 	// EventRequest entries contain information about HTTP requests.
 	// This includes information like the URL, query parameters, and headers.
-	EventRequest = log.EventRequest
+	EventRequest Event = "Request"
 
 	// EventResponse entries contain information about HTTP responses.
 	// This includes information like the HTTP status code, headers, and request URL.
-	EventResponse = log.EventResponse
+	EventResponse Event = "Response"
 
 	// EventRetryPolicy entries contain information specific to the retry policy in use.
-	EventRetryPolicy = log.EventRetryPolicy
+	EventRetryPolicy Event = "Retry"
 
 	// EventLRO entries contain information specific to long-running operations.
-	// This includes information like polling location, operation state and sleep intervals.
-	EventLRO = log.EventLRO
+	// This includes information like polling location, operation state, and sleep intervals.
+	EventLRO Event = "LongRunningOperation"
 )
 
 // SetEvents is used to control which events are written to


### PR DESCRIPTION
The constants in the internal package are going away.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
