### PR TITLE
Move LRO failure detection to the implementing poller

### DIFF
--- a/sdk/azcore/internal/pollers/armloc/loc.go
+++ b/sdk/azcore/internal/pollers/armloc/loc.go
@@ -60,9 +60,14 @@ func (p *Poller) URL() string {
 	return p.PollURL
 }
 
-// Done returns true if the LRO has reached a terminal state.
-func (p *Poller) Done() bool {
-	return pollers.IsTerminalState(p.Status())
+// State returns the current state of the LRO.
+func (p *Poller) State() pollers.OperationState {
+	if p.CurState == pollers.StatusSucceeded {
+		return pollers.OperationStateSucceeded
+	} else if pollers.IsTerminalState(p.CurState) {
+		return pollers.OperationStateFailed
+	}
+	return pollers.OperationStateInProgress
 }
 
 // Update updates the Poller from the polling response.
@@ -95,9 +100,4 @@ func (p *Poller) Update(resp *http.Response) error {
 // FinalGetURL returns the empty string as no final GET is required for this poller type.
 func (p *Poller) FinalGetURL() string {
 	return ""
-}
-
-// Status returns the status of the LRO.
-func (p *Poller) Status() string {
-	return p.CurState
 }

--- a/sdk/azcore/internal/pollers/armloc/loc_test.go
+++ b/sdk/azcore/internal/pollers/armloc/loc_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 )
 
@@ -57,13 +58,10 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatal("expected empty final GET URL")
 	}
-	if s := poller.Status(); s != "InProgress" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakePollingURL1 {
@@ -80,13 +78,13 @@ func TestNew(t *testing.T) {
 	if err := poller.Update(pollingResponse(http.StatusNoContent, http.NoBody)); err != nil {
 		t.Fatal(err)
 	}
-	if s := poller.Status(); s != "Succeeded" {
+	if s := poller.State(); s != pollers.OperationStateSucceeded {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if err := poller.Update(pollingResponse(http.StatusConflict, http.NoBody)); err != nil {
 		t.Fatal(err)
 	}
-	if s := poller.Status(); s != "Failed" {
+	if s := poller.State(); s != pollers.OperationStateFailed {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -98,13 +96,10 @@ func TestUpdateWithProvState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatal("expected empty final GET URL")
 	}
-	if s := poller.Status(); s != "InProgress" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakePollingURL1 {
@@ -121,13 +116,13 @@ func TestUpdateWithProvState(t *testing.T) {
 	if err := poller.Update(pollingResponse(http.StatusOK, strings.NewReader(`{ "properties": { "provisioningState": "Updating" } }`))); err != nil {
 		t.Fatal(err)
 	}
-	if s := poller.Status(); s != "Updating" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if err := poller.Update(pollingResponse(http.StatusOK, http.NoBody)); err != nil {
 		t.Fatal(err)
 	}
-	if s := poller.Status(); s != "Succeeded" {
+	if s := poller.State(); s != pollers.OperationStateSucceeded {
 		t.Fatalf("unexpected status %s", s)
 	}
 }

--- a/sdk/azcore/internal/pollers/async/async.go
+++ b/sdk/azcore/internal/pollers/async/async.go
@@ -85,9 +85,14 @@ func New(resp *http.Response, finalState pollers.FinalStateVia, pollerID string)
 	return p, nil
 }
 
-// Done returns true if the LRO has reached a terminal state.
-func (p *Poller) Done() bool {
-	return pollers.IsTerminalState(p.Status())
+// State returns the current state of the LRO.
+func (p *Poller) State() pollers.OperationState {
+	if p.CurState == pollers.StatusSucceeded {
+		return pollers.OperationStateSucceeded
+	} else if pollers.IsTerminalState(p.CurState) {
+		return pollers.OperationStateFailed
+	}
+	return pollers.OperationStateInProgress
 }
 
 // Update updates the Poller from the polling response.
@@ -124,9 +129,4 @@ func (p *Poller) FinalGetURL() string {
 // URL returns the polling URL.
 func (p *Poller) URL() string {
 	return p.AsyncURL
-}
-
-// Status returns the status of the LRO.
-func (p *Poller) Status() string {
-	return p.CurState
 }

--- a/sdk/azcore/internal/pollers/async/async_test.go
+++ b/sdk/azcore/internal/pollers/async/async_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 )
 
@@ -61,13 +62,10 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
 	if u := poller.FinalGetURL(); u != fakeResourceURL {
 		t.Fatalf("unexpected final get URL %s", u)
 	}
-	if s := poller.Status(); s != "Started" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakePollingURL {
@@ -76,7 +74,7 @@ func TestNew(t *testing.T) {
 	if err := poller.Update(pollingResponse(strings.NewReader(`{ "status": "InProgress" }`))); err != nil {
 		t.Fatal(err)
 	}
-	if s := poller.Status(); s != "InProgress" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -88,10 +86,7 @@ func TestNewDeleteNoProvState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
-	if s := poller.Status(); s != "InProgress" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -105,10 +100,7 @@ func TestNewPutNoProvState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
-	if s := poller.Status(); s != "InProgress" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -125,8 +117,8 @@ func TestNewFinalGetLocation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
+	if s := poller.State(); s != pollers.OperationStateInProgress {
+		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.FinalGetURL(); u != locURL {
 		t.Fatalf("unexpected final get URL %s", u)
@@ -148,8 +140,8 @@ func TestNewFinalGetOrigin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
+	if s := poller.State(); s != pollers.OperationStateInProgress {
+		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.FinalGetURL(); u != fakeResourceURL {
 		t.Fatalf("unexpected final get URL %s", u)
@@ -168,10 +160,7 @@ func TestNewPutNoProvStateOnUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
-	if s := poller.Status(); s != "InProgress" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if err := poller.Update(pollingResponse(strings.NewReader("{}"))); err == nil {

--- a/sdk/azcore/internal/pollers/body/body.go
+++ b/sdk/azcore/internal/pollers/body/body.go
@@ -73,9 +73,14 @@ func (p *Poller) URL() string {
 	return p.PollURL
 }
 
-// Done returns true if the LRO has reached a terminal state.
-func (p *Poller) Done() bool {
-	return pollers.IsTerminalState(p.Status())
+// State returns the current state of the LRO.
+func (p *Poller) State() pollers.OperationState {
+	if p.CurState == pollers.StatusSucceeded {
+		return pollers.OperationStateSucceeded
+	} else if pollers.IsTerminalState(p.CurState) {
+		return pollers.OperationStateFailed
+	}
+	return pollers.OperationStateInProgress
 }
 
 // Update updates the Poller from the polling response.
@@ -101,9 +106,4 @@ func (p *Poller) Update(resp *http.Response) error {
 // FinalGetURL returns the empty string as no final GET is required for this poller type.
 func (*Poller) FinalGetURL() string {
 	return ""
-}
-
-// Status returns the status of the LRO.
-func (p *Poller) Status() string {
-	return p.CurState
 }

--- a/sdk/azcore/internal/pollers/body/body_test.go
+++ b/sdk/azcore/internal/pollers/body/body_test.go
@@ -69,13 +69,10 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatal("expected empty final GET URL")
 	}
-	if s := poller.Status(); s != "Started" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakeResourceURL {
@@ -84,7 +81,7 @@ func TestNew(t *testing.T) {
 	if err := poller.Update(pollingResponse(http.StatusOK, strings.NewReader(`{ "properties": { "provisioningState": "InProgress" } }`))); err != nil {
 		t.Fatal(err)
 	}
-	if s := poller.Status(); s != "InProgress" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -97,13 +94,10 @@ func TestUpdateNoProvStateFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatal("expected empty final GET URL")
 	}
-	if s := poller.Status(); s != "Started" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakeResourceURL {
@@ -126,13 +120,10 @@ func TestUpdateNoProvStateSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatal("expected empty final GET URL")
 	}
-	if s := poller.Status(); s != "Started" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakeResourceURL {
@@ -152,13 +143,10 @@ func TestUpdateNoProvState204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("poller should not be done")
-	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatal("expected empty final GET URL")
 	}
-	if s := poller.Status(); s != "Started" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakeResourceURL {
@@ -177,13 +165,10 @@ func TestNewNoInitialProvStateOK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !poller.Done() {
-		t.Fatal("poller not be done")
-	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatal("expected empty final GET URL")
 	}
-	if s := poller.Status(); s != "Succeeded" {
+	if s := poller.State(); s != pollers.OperationStateSucceeded {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -195,13 +180,10 @@ func TestNewNoInitialProvStateNC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !poller.Done() {
-		t.Fatal("poller not be done")
-	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatal("expected empty final GET URL")
 	}
-	if s := poller.Status(); s != "Succeeded" {
+	if s := poller.State(); s != pollers.OperationStateSucceeded {
 		t.Fatalf("unexpected status %s", s)
 	}
 }

--- a/sdk/azcore/internal/pollers/loc/loc.go
+++ b/sdk/azcore/internal/pollers/loc/loc.go
@@ -56,8 +56,14 @@ func (p *Poller) URL() string {
 	return p.PollURL
 }
 
-func (p *Poller) Done() bool {
-	return pollers.IsTerminalState(p.Status())
+func (p *Poller) State() pollers.OperationState {
+	if p.CurState == http.StatusAccepted {
+		return pollers.OperationStateInProgress
+	} else if p.CurState > 199 && p.CurState < 300 {
+		// any 2xx other than a 202 indicates success
+		return pollers.OperationStateSucceeded
+	}
+	return pollers.OperationStateFailed
 }
 
 func (p *Poller) Update(resp *http.Response) error {
@@ -71,14 +77,4 @@ func (p *Poller) Update(resp *http.Response) error {
 
 func (p *Poller) FinalGetURL() string {
 	return p.FinalGET
-}
-
-func (p *Poller) Status() string {
-	if p.CurState == http.StatusAccepted {
-		return pollers.StatusInProgress
-	} else if p.CurState > 199 && p.CurState < 300 {
-		// any 2xx other than a 202 indicates success
-		return pollers.StatusSucceeded
-	}
-	return pollers.StatusFailed
 }

--- a/sdk/azcore/internal/pollers/loc/loc_test.go
+++ b/sdk/azcore/internal/pollers/loc/loc_test.go
@@ -46,13 +46,10 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("unexpected done")
-	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatalf("unexpected final get URL %s", u)
 	}
-	if s := poller.Status(); s != pollers.StatusInProgress {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakeLocationURL {
@@ -90,19 +87,13 @@ func TestUpdateSucceeded(t *testing.T) {
 	if err := poller.Update(resp); err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("unexpected done")
-	}
 	if u := poller.URL(); u != fakeLocationURL2 {
 		t.Fatalf("unexpected polling URL %s", u)
 	}
 	if err := poller.Update(&http.Response{StatusCode: http.StatusOK}); err != nil {
 		t.Fatal(err)
 	}
-	if !poller.Done() {
-		t.Fatal("expected done")
-	}
-	if s := poller.Status(); s != pollers.StatusSucceeded {
+	if s := poller.State(); s != pollers.OperationStateSucceeded {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -118,8 +109,8 @@ func TestUpdateFailed(t *testing.T) {
 	if err := poller.Update(resp); err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("unexpected done")
+	if s := poller.State(); s != pollers.OperationStateInProgress {
+		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakeLocationURL2 {
 		t.Fatalf("unexpected polling URL %s", u)
@@ -127,10 +118,7 @@ func TestUpdateFailed(t *testing.T) {
 	if err := poller.Update(&http.Response{StatusCode: http.StatusConflict}); err != nil {
 		t.Fatal(err)
 	}
-	if !poller.Done() {
-		t.Fatal("expected done")
-	}
-	if s := poller.Status(); s != pollers.StatusFailed {
+	if s := poller.State(); s != pollers.OperationStateFailed {
 		t.Fatalf("unexpected status %s", s)
 	}
 }

--- a/sdk/azcore/internal/pollers/op/op.go
+++ b/sdk/azcore/internal/pollers/op/op.go
@@ -81,8 +81,14 @@ func (p *Poller) URL() string {
 	return p.PollURL
 }
 
-func (p *Poller) Done() bool {
-	return pollers.IsTerminalState(p.Status())
+// State returns the current state of the LRO.
+func (p *Poller) State() pollers.OperationState {
+	if p.CurState == pollers.StatusSucceeded {
+		return pollers.OperationStateSucceeded
+	} else if pollers.IsTerminalState(p.CurState) {
+		return pollers.OperationStateFailed
+	}
+	return pollers.OperationStateInProgress
 }
 
 func (p *Poller) Update(resp *http.Response) error {
@@ -109,10 +115,6 @@ func (p *Poller) Update(resp *http.Response) error {
 
 func (p *Poller) FinalGetURL() string {
 	return p.FinalGET
-}
-
-func (p *Poller) Status() string {
-	return p.CurState
 }
 
 func getValue(resp *http.Response, val string) (string, error) {

--- a/sdk/azcore/internal/pollers/op/op_test.go
+++ b/sdk/azcore/internal/pollers/op/op_test.go
@@ -64,13 +64,10 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("unexpected done")
-	}
 	if u := poller.FinalGetURL(); u != fakeResourceURL {
 		t.Fatalf("unexpected final get URL %s", u)
 	}
-	if s := poller.Status(); s != pollers.StatusInProgress {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakePollingURL {
@@ -86,10 +83,7 @@ func TestNewWithInitialStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("unexpected done")
-	}
-	if s := poller.Status(); s != "Updating" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -102,8 +96,8 @@ func TestNewWithPost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("unexpected done")
+	if s := poller.State(); s != pollers.OperationStateInProgress {
+		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.FinalGetURL(); u != fakeLocationURL {
 		t.Fatalf("unexpected final get URL %s", u)
@@ -118,8 +112,8 @@ func TestNewWithDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("unexpected done")
+	if s := poller.State(); s != pollers.OperationStateInProgress {
+		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.FinalGetURL(); u != "" {
 		t.Fatalf("unexpected final get URL %s", u)
@@ -167,10 +161,7 @@ func TestUpdateSucceeded(t *testing.T) {
 	if err := poller.Update(resp); err != nil {
 		t.Fatal(err)
 	}
-	if poller.Done() {
-		t.Fatal("unexpected done")
-	}
-	if s := poller.Status(); s != "Running" {
+	if s := poller.State(); s != pollers.OperationStateInProgress {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.URL(); u != fakePollingURL2 {
@@ -180,10 +171,7 @@ func TestUpdateSucceeded(t *testing.T) {
 	if err := poller.Update(resp); err != nil {
 		t.Fatal(err)
 	}
-	if !poller.Done() {
-		t.Fatal("expected done")
-	}
-	if s := poller.Status(); s != pollers.StatusSucceeded {
+	if s := poller.State(); s != pollers.OperationStateSucceeded {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -200,10 +188,7 @@ func TestUpdateResourceLocation(t *testing.T) {
 	if err := poller.Update(resp); err != nil {
 		t.Fatal(err)
 	}
-	if !poller.Done() {
-		t.Fatal("expected done")
-	}
-	if s := poller.Status(); s != pollers.StatusSucceeded {
+	if s := poller.State(); s != pollers.OperationStateSucceeded {
 		t.Fatalf("unexpected status %s", s)
 	}
 	if u := poller.FinalGetURL(); u != "https://foo.bar.baz/resource2" {
@@ -223,10 +208,7 @@ func TestUpdateFailed(t *testing.T) {
 	if err := poller.Update(resp); err != nil {
 		t.Fatal(err)
 	}
-	if !poller.Done() {
-		t.Fatal("expected done")
-	}
-	if s := poller.Status(); s != pollers.StatusFailed {
+	if s := poller.State(); s != pollers.OperationStateFailed {
 		t.Fatalf("unexpected status %s", s)
 	}
 }
@@ -243,7 +225,7 @@ func TestUpdateMissingStatus(t *testing.T) {
 	if err := poller.Update(resp); err == nil {
 		t.Fatal("unexpected nil error")
 	}
-	if poller.Done() {
-		t.Fatal("unexpected done")
+	if s := poller.State(); s != pollers.OperationStateInProgress {
+		t.Fatalf("unexpected status %s", s)
 	}
 }

--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 )
 
+// the well-known set of LRO status/provisioning state values.
 const (
 	StatusSucceeded  = "Succeeded"
 	StatusCanceled   = "Canceled"
@@ -26,13 +27,45 @@ const (
 	StatusInProgress = "InProgress"
 )
 
-// Operation abstracts the differences between concrete poller types.
+// OperationState contains the set of non-terminal and terminal states for an LRO.
+type OperationState int
+
+const (
+	OperationStateInProgress OperationState = 1
+	OperationStateSucceeded  OperationState = 2
+	OperationStateFailed     OperationState = 3
+)
+
+// String implements the fmt.Stringer interface for the OperationState type.
+func (o OperationState) String() string {
+	switch o {
+	case OperationStateInProgress:
+		return "InProgress"
+	case OperationStateSucceeded:
+		return "Succeeded"
+	case OperationStateFailed:
+		return "Failed"
+	default:
+		return fmt.Sprintf("unknown state %d", o)
+	}
+}
+
+// Operation abstracts the differences among long-running operation implementations.
 type Operation interface {
-	Done() bool
+	// State returns the current state of the LRO.
+	// Calls to Update() will update the state as required.
+	State() OperationState
+
+	// Update provides the implementation with the latest HTTP response so it can react accordingly.
 	Update(resp *http.Response) error
+
+	// FinalGetURL returns the URL to GET when the LRO has reached a terminal, success state.
+	// Can return the empty string to indicate no final GET is required.  This usually indicates
+	// that the final response payload (if applicable) was within the terminal success response.
 	FinalGetURL() string
+
+	// URL returns the polling URL.
 	URL() string
-	Status() string
 }
 
 // IsTerminalState returns true if the LRO's state is terminal.
@@ -178,8 +211,8 @@ func (*NopPoller) URL() string {
 	return ""
 }
 
-func (*NopPoller) Done() bool {
-	return true
+func (*NopPoller) State() OperationState {
+	return OperationStateSucceeded
 }
 
 func (*NopPoller) Update(*http.Response) error {
@@ -188,8 +221,4 @@ func (*NopPoller) Update(*http.Response) error {
 
 func (*NopPoller) FinalGetURL() string {
 	return ""
-}
-
-func (*NopPoller) Status() string {
-	return StatusSucceeded
 }

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -246,14 +246,11 @@ func TestGetProvisioningStateError(t *testing.T) {
 
 func TestNopPoller(t *testing.T) {
 	np := NopPoller{}
-	if !np.Done() {
-		t.Fatal("expected done")
+	if np.State() != OperationStateSucceeded {
+		t.Fatal("expected Succeeded")
 	}
 	if np.FinalGetURL() != "" {
 		t.Fatal("expected empty final get URL")
-	}
-	if np.Status() != StatusSucceeded {
-		t.Fatal("expected Succeeded")
 	}
 	if np.URL() != "" {
 		t.Fatal("expected empty URL")


### PR DESCRIPTION
Previously, the Poller.Poll() method was determining when an LRO failed.
While this works for well-known states, it's not extensible.  Instead,
the underlying polling implementation should be responsible for
determining if it's reached a terminal state (failure or otherwise).

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
