### PR TITLE
AppConfig: inline method parameters instead of using Setting struct

### DIFF
--- a/sdk/appconfig/azappconfig/CHANGELOG.md
+++ b/sdk/appconfig/azappconfig/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Release History
 
-## 0.2.1 (Unreleased)
+## 0.3.0 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
+* Changed argument semantics of `AddSetting`, `DeleteSetting`, `GetSetting`, `SetSetting`, and `SetReadOnly`.
 
 ### Bugs Fixed
 

--- a/sdk/appconfig/azappconfig/client.go
+++ b/sdk/appconfig/azappconfig/client.go
@@ -140,11 +140,19 @@ func fromGeneratedAdd(g generated.AzureAppConfigurationClientPutKeyValueResponse
 
 // AddSettingOptions contains the optional parameters for the AddSetting method.
 type AddSettingOptions struct {
-	// placeholder for future options
+	// Configuration setting label.
+	Label *string
 }
 
 // AddSetting creates a configuration setting only if the setting does not already exist in the configuration store.
-func (c *Client) AddSetting(ctx context.Context, setting Setting, options *AddSettingOptions) (AddSettingResponse, error) {
+func (c *Client) AddSetting(ctx context.Context, key string, value *string, options *AddSettingOptions) (AddSettingResponse, error) {
+	var label *string
+	if options != nil {
+		label = options.Label
+	}
+
+	setting := Setting{Key: &key, Value: value, Label: label}
+
 	etagAny := azcore.ETagAny
 	resp, err := c.appConfigClient.PutKeyValue(ctx, *setting.Key, setting.toGeneratedPutOptions(nil, &etagAny))
 	if err != nil {
@@ -171,6 +179,9 @@ func fromGeneratedDelete(g generated.AzureAppConfigurationClientDeleteKeyValueRe
 
 // DeleteSettingOptions contains the optional parameters for the DeleteSetting method.
 type DeleteSettingOptions struct {
+	// Configuration setting label.
+	Label *string
+
 	// If set to true and the configuration setting exists in the configuration store,
 	// delete the setting if the passed-in configuration setting is the same version as the one in the configuration store.
 	// The setting versions are the same if their ETag fields match.
@@ -185,7 +196,14 @@ func (cs Setting) toGeneratedDeleteOptions(ifMatch *azcore.ETag) *generated.Azur
 }
 
 // DeleteSetting deletes a configuration setting from the configuration store.
-func (c *Client) DeleteSetting(ctx context.Context, setting Setting, options *DeleteSettingOptions) (DeleteSettingResponse, error) {
+func (c *Client) DeleteSetting(ctx context.Context, key string, options *DeleteSettingOptions) (DeleteSettingResponse, error) {
+	var label *string
+	if options != nil {
+		label = options.Label
+	}
+
+	setting := Setting{Key: &key, Label: label}
+
 	var ifMatch *azcore.ETag
 	if options != nil && options.OnlyIfUnchanged {
 		ifMatch = setting.ETag
@@ -227,6 +245,9 @@ func fromGeneratedGet(g generated.AzureAppConfigurationClientGetKeyValueResponse
 
 // GetSettingOptions contains the optional parameters for the GetSetting method.
 type GetSettingOptions struct {
+	// Configuration setting label.
+	Label *string
+
 	// If set to true, only retrieve the setting from the configuration store if it has changed since the client last retrieved it.
 	// It is determined to have changed if the ETag field on the passed-in configuration setting is different from the ETag
 	// of the setting in the configuration store.
@@ -251,7 +272,14 @@ func (cs Setting) toGeneratedGetOptions(ifNoneMatch *azcore.ETag, acceptDateTime
 }
 
 // GetSetting retrieves an existing configuration setting from the configuration store.
-func (c *Client) GetSetting(ctx context.Context, setting Setting, options *GetSettingOptions) (GetSettingResponse, error) {
+func (c *Client) GetSetting(ctx context.Context, key string, options *GetSettingOptions) (GetSettingResponse, error) {
+	var label *string
+	if options != nil {
+		label = options.Label
+	}
+
+	setting := Setting{Key: &key, Label: label}
+
 	var ifNoneMatch *azcore.ETag
 	var acceptDateTime *time.Time
 	if options != nil {
@@ -294,6 +322,9 @@ func fromGeneratedDeleteLock(g generated.AzureAppConfigurationClientDeleteLockRe
 
 // SetReadOnlyOptions contains the optional parameters for the SetReadOnly method.
 type SetReadOnlyOptions struct {
+	// Configuration setting label.
+	Label *string
+
 	// If set to true and the configuration setting exists in the configuration store, update the setting
 	// if the passed-in configuration setting is the same version as the one in the configuration store.
 	// The setting versions are the same if their ETag fields match.
@@ -315,7 +346,14 @@ func (cs Setting) toGeneratedDeleteLockOptions(ifMatch *azcore.ETag) *generated.
 }
 
 // SetReadOnly sets an existing configuration setting to read only or read write state in the configuration store.
-func (c *Client) SetReadOnly(ctx context.Context, setting Setting, isReadOnly bool, options *SetReadOnlyOptions) (SetReadOnlyResponse, error) {
+func (c *Client) SetReadOnly(ctx context.Context, key string, isReadOnly bool, options *SetReadOnlyOptions) (SetReadOnlyResponse, error) {
+	var label *string
+	if options != nil {
+		label = options.Label
+	}
+
+	setting := Setting{Key: &key, Label: label}
+
 	var ifMatch *azcore.ETag
 	if options != nil && options.OnlyIfUnchanged {
 		ifMatch = setting.ETag
@@ -356,6 +394,9 @@ func fromGeneratedSet(g generated.AzureAppConfigurationClientPutKeyValueResponse
 
 // SetSettingOptions contains the optional parameters for the SetSetting method.
 type SetSettingOptions struct {
+	// Configuration setting label.
+	Label *string
+
 	// If set to true and the configuration setting exists in the configuration store, overwrite the setting
 	// if the passed-in configuration setting is the same version as the one in the configuration store.
 	// The setting versions are the same if their ETag fields match.
@@ -363,7 +404,14 @@ type SetSettingOptions struct {
 }
 
 // SetSetting creates a configuration setting if it doesn't exist or overwrites the existing setting in the configuration store.
-func (c *Client) SetSetting(ctx context.Context, setting Setting, options *SetSettingOptions) (SetSettingResponse, error) {
+func (c *Client) SetSetting(ctx context.Context, key string, value *string, options *SetSettingOptions) (SetSettingResponse, error) {
+	var label *string
+	if options != nil {
+		label = options.Label
+	}
+
+	setting := Setting{Key: &key, Value: value, Label: label}
+
 	var ifMatch *azcore.ETag
 	if options != nil && options.OnlyIfUnchanged {
 		ifMatch = setting.ETag

--- a/sdk/appconfig/azappconfig/client_test.go
+++ b/sdk/appconfig/azappconfig/client_test.go
@@ -29,7 +29,7 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, client)
 
-	addResp, err2 := client.AddSetting(context.TODO(), Setting{Key: &key, Label: &label, Value: &value}, nil)
+	addResp, err2 := client.AddSetting(context.TODO(), key, &value, AddSettingOptions{Label: &label})
 	require.NoError(t, err2)
 	require.NotEmpty(t, addResp)
 	require.NotNil(t, addResp.Key)
@@ -39,7 +39,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, label, *addResp.Label)
 	require.Equal(t, value, *addResp.Value)
 
-	getResp, err3 := client.GetSetting(context.TODO(), Setting{Key: &key, Label: &label}, nil)
+	getResp, err3 := client.GetSetting(context.TODO(), key, GetSettingOptions{Label: &label})
 	require.NoError(t, err3)
 	require.NotEmpty(t, getResp)
 	require.NotNil(t, getResp.Key)
@@ -50,7 +50,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, value, *getResp.Value)
 
 	value = "value2"
-	setResp, err4 := client.SetSetting(context.TODO(), Setting{Key: &key, Label: &label, Value: &value}, nil)
+	setResp, err4 := client.SetSetting(context.TODO(), key, &value, SetSettingOptions{Label: &label})
 	require.NoError(t, err4)
 	require.NotEmpty(t, setResp)
 	require.NotNil(t, setResp.Key)
@@ -60,7 +60,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, label, *setResp.Label)
 	require.Equal(t, value, *setResp.Value)
 
-	roResp, err5 := client.SetReadOnly(context.TODO(), Setting{Key: &key, Label: &label}, true, nil)
+	roResp, err5 := client.SetReadOnly(context.TODO(), key, true, SetReadOnlyOptions{Label: &label})
 	require.NoError(t, err5)
 	require.NotEmpty(t, roResp)
 	require.NotNil(t, roResp.Key)
@@ -72,7 +72,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, value, *roResp.Value)
 	require.True(t, *roResp.IsReadOnly)
 
-	roResp2, err6 := client.SetReadOnly(context.TODO(), Setting{Key: &key, Label: &label}, false, nil)
+	roResp2, err6 := client.SetReadOnly(context.TODO(), key, false, SetReadOnlyOptions{Label: &label})
 	require.NoError(t, err6)
 	require.NotEmpty(t, roResp2)
 	require.NotNil(t, roResp2.Key)
@@ -95,7 +95,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, key, *revResp.Settings[0].Key)
 	require.Equal(t, label, *revResp.Settings[0].Label)
 
-	delResp, err8 := client.DeleteSetting(context.TODO(), Setting{Key: &key, Label: &label}, nil)
+	delResp, err8 := client.DeleteSetting(context.TODO(), key, DeleteReadOnlyOptions{Label: &label})
 	require.NoError(t, err8)
 	require.NotEmpty(t, delResp)
 	require.NotNil(t, delResp.Key)

--- a/sdk/appconfig/azappconfig/client_test.go
+++ b/sdk/appconfig/azappconfig/client_test.go
@@ -29,7 +29,7 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, client)
 
-	addResp, err2 := client.AddSetting(context.TODO(), key, &value, AddSettingOptions{Label: &label})
+	addResp, err2 := client.AddSetting(context.TODO(), key, &value, &AddSettingOptions{Label: &label})
 	require.NoError(t, err2)
 	require.NotEmpty(t, addResp)
 	require.NotNil(t, addResp.Key)
@@ -39,7 +39,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, label, *addResp.Label)
 	require.Equal(t, value, *addResp.Value)
 
-	getResp, err3 := client.GetSetting(context.TODO(), key, GetSettingOptions{Label: &label})
+	getResp, err3 := client.GetSetting(context.TODO(), key, &GetSettingOptions{Label: &label})
 	require.NoError(t, err3)
 	require.NotEmpty(t, getResp)
 	require.NotNil(t, getResp.Key)
@@ -50,7 +50,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, value, *getResp.Value)
 
 	value = "value2"
-	setResp, err4 := client.SetSetting(context.TODO(), key, &value, SetSettingOptions{Label: &label})
+	setResp, err4 := client.SetSetting(context.TODO(), key, &value, &SetSettingOptions{Label: &label})
 	require.NoError(t, err4)
 	require.NotEmpty(t, setResp)
 	require.NotNil(t, setResp.Key)
@@ -60,7 +60,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, label, *setResp.Label)
 	require.Equal(t, value, *setResp.Value)
 
-	roResp, err5 := client.SetReadOnly(context.TODO(), key, true, SetReadOnlyOptions{Label: &label})
+	roResp, err5 := client.SetReadOnly(context.TODO(), key, true, &SetReadOnlyOptions{Label: &label})
 	require.NoError(t, err5)
 	require.NotEmpty(t, roResp)
 	require.NotNil(t, roResp.Key)
@@ -72,7 +72,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, value, *roResp.Value)
 	require.True(t, *roResp.IsReadOnly)
 
-	roResp2, err6 := client.SetReadOnly(context.TODO(), key, false, SetReadOnlyOptions{Label: &label})
+	roResp2, err6 := client.SetReadOnly(context.TODO(), key, false, &SetReadOnlyOptions{Label: &label})
 	require.NoError(t, err6)
 	require.NotEmpty(t, roResp2)
 	require.NotNil(t, roResp2.Key)
@@ -95,7 +95,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, key, *revResp.Settings[0].Key)
 	require.Equal(t, label, *revResp.Settings[0].Label)
 
-	delResp, err8 := client.DeleteSetting(context.TODO(), key, DeleteReadOnlyOptions{Label: &label})
+	delResp, err8 := client.DeleteSetting(context.TODO(), key, &DeleteReadOnlyOptions{Label: &label})
 	require.NoError(t, err8)
 	require.NotEmpty(t, delResp)
 	require.NotNil(t, delResp.Key)

--- a/sdk/appconfig/azappconfig/client_test.go
+++ b/sdk/appconfig/azappconfig/client_test.go
@@ -95,7 +95,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, key, *revResp.Settings[0].Key)
 	require.Equal(t, label, *revResp.Settings[0].Label)
 
-	delResp, err8 := client.DeleteSetting(context.TODO(), key, &DeleteReadOnlyOptions{Label: &label})
+	delResp, err8 := client.DeleteSetting(context.TODO(), key, &DeleteSettingOptions{Label: &label})
 	require.NoError(t, err8)
 	require.NotEmpty(t, delResp)
 	require.NotNil(t, delResp.Key)

--- a/sdk/appconfig/azappconfig/internal/generated/constants.go
+++ b/sdk/appconfig/azappconfig/internal/generated/constants.go
@@ -10,7 +10,7 @@ package generated
 
 const (
 	ModuleName    = "azappconfig"
-	ModuleVersion = "v0.2.1"
+	ModuleVersion = "v0.3.0"
 )
 
 type Enum6 string


### PR DESCRIPTION
We were using `Setting` struct as input parameter for client methods.

But it was not clear, which ones are mandatory (`key`, sometimes nullable `value`), which are optional (`label`), and which are ignored (the rest).

It was also confusing with `SetReadOnly()`: setting does have `IsReadOnly` field, and also `SetReadOnly()` has mandatory boolean argument. Now, `SetReadOnly()` takes `key`, and boolean `isReadOnly`.

Closes #17264.