### PR TITLE
[azservicebus] Adding `azservicebus.Error` to represent errors that a customer can use programatically.

### DIFF
--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -217,6 +217,7 @@ func (client *Client) NewSender(queueOrTopic string, options *NewSenderOptions) 
 
 // AcceptSessionForQueue accepts a session from a queue with a specific session ID.
 // NOTE: this receiver is initialized immediately, not lazily.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (client *Client) AcceptSessionForQueue(ctx context.Context, queueName string, sessionID string, options *SessionReceiverOptions) (*SessionReceiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	sessionReceiver, err := newSessionReceiver(
@@ -243,6 +244,7 @@ func (client *Client) AcceptSessionForQueue(ctx context.Context, queueName strin
 
 // AcceptSessionForSubscription accepts a session from a subscription with a specific session ID.
 // NOTE: this receiver is initialized immediately, not lazily.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (client *Client) AcceptSessionForSubscription(ctx context.Context, topicName string, subscriptionName string, sessionID string, options *SessionReceiverOptions) (*SessionReceiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	sessionReceiver, err := newSessionReceiver(
@@ -270,6 +272,7 @@ func (client *Client) AcceptSessionForSubscription(ctx context.Context, topicNam
 
 // AcceptNextSessionForQueue accepts the next available session from a queue.
 // NOTE: this receiver is initialized immediately, not lazily.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (client *Client) AcceptNextSessionForQueue(ctx context.Context, queueName string, options *SessionReceiverOptions) (*SessionReceiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	sessionReceiver, err := newSessionReceiver(
@@ -296,6 +299,7 @@ func (client *Client) AcceptNextSessionForQueue(ctx context.Context, queueName s
 
 // AcceptNextSessionForSubscription accepts the next available session from a subscription.
 // NOTE: this receiver is initialized immediately, not lazily.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (client *Client) AcceptNextSessionForSubscription(ctx context.Context, topicName string, subscriptionName string, options *SessionReceiverOptions) (*SessionReceiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	sessionReceiver, err := newSessionReceiver(

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -217,7 +217,7 @@ func (client *Client) NewSender(queueOrTopic string, options *NewSenderOptions) 
 
 // AcceptSessionForQueue accepts a session from a queue with a specific session ID.
 // NOTE: this receiver is initialized immediately, not lazily.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (client *Client) AcceptSessionForQueue(ctx context.Context, queueName string, sessionID string, options *SessionReceiverOptions) (*SessionReceiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	sessionReceiver, err := newSessionReceiver(
@@ -244,7 +244,7 @@ func (client *Client) AcceptSessionForQueue(ctx context.Context, queueName strin
 
 // AcceptSessionForSubscription accepts a session from a subscription with a specific session ID.
 // NOTE: this receiver is initialized immediately, not lazily.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (client *Client) AcceptSessionForSubscription(ctx context.Context, topicName string, subscriptionName string, sessionID string, options *SessionReceiverOptions) (*SessionReceiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	sessionReceiver, err := newSessionReceiver(
@@ -272,7 +272,7 @@ func (client *Client) AcceptSessionForSubscription(ctx context.Context, topicNam
 
 // AcceptNextSessionForQueue accepts the next available session from a queue.
 // NOTE: this receiver is initialized immediately, not lazily.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (client *Client) AcceptNextSessionForQueue(ctx context.Context, queueName string, options *SessionReceiverOptions) (*SessionReceiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	sessionReceiver, err := newSessionReceiver(
@@ -299,7 +299,7 @@ func (client *Client) AcceptNextSessionForQueue(ctx context.Context, queueName s
 
 // AcceptNextSessionForSubscription accepts the next available session from a subscription.
 // NOTE: this receiver is initialized immediately, not lazily.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (client *Client) AcceptNextSessionForSubscription(ctx context.Context, topicName string, subscriptionName string, options *SessionReceiverOptions) (*SessionReceiver, error) {
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	sessionReceiver, err := newSessionReceiver(

--- a/sdk/messaging/azservicebus/error.go
+++ b/sdk/messaging/azservicebus/error.go
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azservicebus
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
+)
+
+// Code is an error code, usable by consuming code to work with
+// programatically.
+type Code = exported.Code
+
+const (
+	// CodeConnectionLost means our connection was lost and all retry attempts failed.
+	// This typicall reflects an extended outage or connection disruption and may
+	// require manual intervention.
+	CodeConnectionLost = exported.CodeConnectionLost
+
+	// CodeLockLost means that the lock token you have for a message has expired.
+	// This message will be available again after the lock period expires, or, potentially
+	// go to the dead letter queue if delivery attempts have been exceeded.
+	CodeLockLost = exported.CodeLockLost
+)
+
+// Error represents a Service Bus specific error.
+type Error = exported.Error

--- a/sdk/messaging/azservicebus/error.go
+++ b/sdk/messaging/azservicebus/error.go
@@ -24,4 +24,7 @@ const (
 )
 
 // Error represents a Service Bus specific error.
+// NOTE: the Code is considered part of the published API but the message that
+// comes back from Error(), as well as the underlying wrapped error, are NOT and
+// are subject to change.
 type Error = exported.Error

--- a/sdk/messaging/azservicebus/error.go
+++ b/sdk/messaging/azservicebus/error.go
@@ -13,7 +13,7 @@ type Code = exported.Code
 
 const (
 	// CodeConnectionLost means our connection was lost and all retry attempts failed.
-	// This typicall reflects an extended outage or connection disruption and may
+	// This typically reflects an extended outage or connection disruption and may
 	// require manual intervention.
 	CodeConnectionLost = exported.CodeConnectionLost
 

--- a/sdk/messaging/azservicebus/example_receiver_test.go
+++ b/sdk/messaging/azservicebus/example_receiver_test.go
@@ -93,7 +93,7 @@ func ExampleReceiver_ReceiveMessages() {
 		err = receiver.CompleteMessage(context.TODO(), message, nil)
 
 		if err != nil {
-			var sbErr azservicebus.Error
+			var sbErr *azservicebus.Error
 
 			if errors.As(err, &sbErr) && sbErr.Code == azservicebus.CodeLockLost {
 				// The message lock has expired. This isn't fatal for the client, but it does mean

--- a/sdk/messaging/azservicebus/example_receiver_test.go
+++ b/sdk/messaging/azservicebus/example_receiver_test.go
@@ -20,6 +20,9 @@ func ExampleClient_NewReceiverForSubscription() {
 		},
 	)
 	exitOnError("Failed to create Receiver", err)
+
+	// close the receiver when it's no longer needed
+	defer receiver.Close(context.TODO())
 }
 
 func ExampleClient_NewReceiverForQueue() {
@@ -30,6 +33,9 @@ func ExampleClient_NewReceiverForQueue() {
 		},
 	)
 	exitOnError("Failed to create Receiver", err)
+
+	// close the receiver when it's no longer needed
+	defer receiver.Close(context.TODO())
 }
 
 func ExampleClient_NewReceiverForQueue_deadLetterQueue() {
@@ -41,6 +47,9 @@ func ExampleClient_NewReceiverForQueue_deadLetterQueue() {
 		},
 	)
 	exitOnError("Failed to create Receiver for DeadLetterQueue", err)
+
+	// close the receiver when it's no longer needed
+	defer receiver.Close(context.TODO())
 }
 
 func ExampleClient_NewReceiverForSubscription_deadLetterQueue() {
@@ -53,6 +62,9 @@ func ExampleClient_NewReceiverForSubscription_deadLetterQueue() {
 		},
 	)
 	exitOnError("Failed to create Receiver for DeadLetterQueue", err)
+
+	// close the receiver when it's no longer needed
+	defer receiver.Close(context.TODO())
 }
 
 func ExampleReceiver_ReceiveMessages() {

--- a/sdk/messaging/azservicebus/example_sender_test.go
+++ b/sdk/messaging/azservicebus/example_sender_test.go
@@ -17,6 +17,9 @@ func ExampleClient_NewSender() {
 	if err != nil {
 		panic(err)
 	}
+
+	// close the sender when it's no longer needed
+	defer sender.Close(context.TODO())
 }
 
 func ExampleSender_SendMessage_message() {

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -82,6 +82,19 @@ type FakeAMQPReceiver struct {
 	}
 }
 
+type FakeRPCLink struct {
+	Resp  *RPCResponse
+	Error error
+}
+
+func (r *FakeRPCLink) Close(ctx context.Context) error {
+	return nil
+}
+
+func (r *FakeRPCLink) RPC(ctx context.Context, msg *amqp.Message) (*RPCResponse, error) {
+	return r.Resp, r.Error
+}
+
 func (r *FakeAMQPReceiver) IssueCredit(credit uint32) error {
 	r.RequestedCredits += credit
 

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -52,7 +52,7 @@ func TransformError(err error) error {
 		return nil
 	}
 
-	_, ok := err.(exported.Error)
+	_, ok := err.(*exported.Error)
 
 	if ok {
 		// it's already been wrapped.

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
 	"github.com/Azure/go-amqp"
 )
 
@@ -37,38 +38,45 @@ const (
 	RecoveryKindConn  RecoveryKind = "connection"
 )
 
-type SBErrInfo struct {
-	inner        error
-	RecoveryKind RecoveryKind
-}
-
-func (sbe *SBErrInfo) String() string {
-	return sbe.inner.Error()
-}
-
-func (sbe *SBErrInfo) AsError() error {
-	return sbe.inner
-}
-
 func IsFatalSBError(err error) bool {
-	return GetSBErrInfo(err).RecoveryKind == RecoveryKindFatal
+	return GetRecoveryKind(err) == RecoveryKindFatal
 }
 
-// GetSBErrInfo wraps the passed in 'err' with a proper error with one of either:
-// - `fatalServiceBusError` if no recovery is possible.
-// - `serviceBusError` if the error is recoverable. The `recoveryKind` field contains the
-//   type of recovery needed.
-func GetSBErrInfo(err error) *SBErrInfo {
+// TransformError will create a proper error type that users
+// can potentially inspect.
+// If the error is actionable then it'll be of type exported.Error which
+// has a 'Code' field that can be used programatically.
+// If it's not actionable or if it's nil it'll just be returned.
+func TransformError(err error) error {
 	if err == nil {
 		return nil
 	}
 
-	sbe := &SBErrInfo{
-		inner:        err,
-		RecoveryKind: GetRecoveryKind(err),
+	_, ok := err.(exported.Error)
+
+	if ok {
+		// it's already been wrapped.
+		return err
 	}
 
-	return sbe
+	if isLockLostError(err) {
+		return exported.NewError(exported.CodeLockLost, err)
+	}
+
+	rk := GetRecoveryKind(err)
+
+	switch rk {
+	case RecoveryKindLink:
+		// note that we could give back a more differentiated error code
+		// here but it's probably best to just give the customer the simplest
+		// recovery mechanism possible.
+		return exported.NewError(exported.CodeConnectionLost, err)
+	case RecoveryKindConn:
+		return exported.NewError(exported.CodeConnectionLost, err)
+	default:
+		// isn't one of our specifically called out cases so we'll just return it.
+		return err
+	}
 }
 
 func IsDetachError(err error) bool {
@@ -97,6 +105,8 @@ func IsDrainingError(err error) bool {
 	return strings.Contains(err.Error(), "link is currently draining")
 }
 
+const errorConditionLockLost = amqp.ErrorCondition("com.microsoft:message-lock-lost")
+
 var amqpConditionsToRecoveryKind = map[amqp.ErrorCondition]RecoveryKind{
 	// no recovery needed, these are temporary errors.
 	amqp.ErrorCondition("com.microsoft:server-busy"):         RecoveryKindNone,
@@ -118,7 +128,7 @@ var amqpConditionsToRecoveryKind = map[amqp.ErrorCondition]RecoveryKind{
 	amqp.ErrorNotAllowed:                                          RecoveryKindFatal, // "amqp:not-allowed"
 	amqp.ErrorCondition("com.microsoft:entity-disabled"):          RecoveryKindFatal, // entity is disabled in the portal
 	amqp.ErrorCondition("com.microsoft:session-cannot-be-locked"): RecoveryKindFatal,
-	amqp.ErrorCondition("com.microsoft:message-lock-lost"):        RecoveryKindFatal,
+	errorConditionLockLost:                                        RecoveryKindFatal,
 }
 
 // GetRecoveryKindForSession determines the recovery type for session-based links.
@@ -187,7 +197,7 @@ func GetRecoveryKind(err error) RecoveryKind {
 		}
 	}
 
-	var rpcErr rpcError
+	var rpcErr RPCError
 
 	if errors.As(err, &rpcErr) {
 		// Described more here:
@@ -304,12 +314,20 @@ func (e ErrConnectionClosed) Error() string {
 }
 
 func isLockLostError(err error) bool {
-	var rpcErr rpcError
+	var rpcErr RPCError
 
-	if errors.As(err, &rpcErr) {
-		if rpcErr.Resp.Code == RPCResponseCodeLockLost {
-			return true
-		}
+	// this is the error you get if you settle on the management$ link
+	// with an expired locktoken.
+	if errors.As(err, &rpcErr) && rpcErr.Resp.Code == RPCResponseCodeLockLost {
+		return true
+	}
+
+	var amqpErr *amqp.Error
+
+	// this is the error you get if you settle on the actual receiver link you
+	// got the message on with an expired locktoken.
+	if errors.As(err, &amqpErr) && amqpErr.Condition == errorConditionLockLost {
+		return true
 	}
 
 	return false

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -252,7 +252,7 @@ func Test_IsLockLostError(t *testing.T) {
 }
 
 func Test_TransformError(t *testing.T) {
-	var asExportedErr exported.Error
+	var asExportedErr *exported.Error
 
 	err := TransformError(RPCError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}})
 	require.ErrorAs(t, err, &asExportedErr)

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
 	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,17 +87,17 @@ func Test_recoveryKind(t *testing.T) {
 
 		for _, code := range linkErrorCodes {
 			t.Run(code, func(t *testing.T) {
-				sbe := GetSBErrInfo(&amqp.Error{Condition: amqp.ErrorCondition(code)})
-				require.EqualValues(t, RecoveryKindLink, sbe.RecoveryKind, fmt.Sprintf("requires link recovery: %s", code))
+				rk := GetRecoveryKind(&amqp.Error{Condition: amqp.ErrorCondition(code)})
+				require.EqualValues(t, RecoveryKindLink, rk, fmt.Sprintf("requires link recovery: %s", code))
 			})
 		}
 
 		t.Run("sentinel errors", func(t *testing.T) {
-			sbe := GetSBErrInfo(amqp.ErrLinkClosed)
-			require.EqualValues(t, RecoveryKindLink, sbe.RecoveryKind)
+			rk := GetRecoveryKind(amqp.ErrLinkClosed)
+			require.EqualValues(t, RecoveryKindLink, rk)
 
-			sbe = GetSBErrInfo(amqp.ErrSessionClosed)
-			require.EqualValues(t, RecoveryKindConn, sbe.RecoveryKind)
+			rk = GetRecoveryKind(amqp.ErrSessionClosed)
+			require.EqualValues(t, RecoveryKindConn, rk)
 		})
 	})
 
@@ -108,14 +109,14 @@ func Test_recoveryKind(t *testing.T) {
 
 		for _, code := range codes {
 			t.Run(code, func(t *testing.T) {
-				sbe := GetSBErrInfo(&amqp.Error{Condition: amqp.ErrorCondition(code)})
-				require.EqualValues(t, RecoveryKindConn, sbe.RecoveryKind, fmt.Sprintf("requires connection recovery: %s", code))
+				rk := GetRecoveryKind(&amqp.Error{Condition: amqp.ErrorCondition(code)})
+				require.EqualValues(t, RecoveryKindConn, rk, fmt.Sprintf("requires connection recovery: %s", code))
 			})
 		}
 
 		t.Run("sentinel errors", func(t *testing.T) {
-			sbe := GetSBErrInfo(amqp.ErrConnClosed)
-			require.EqualValues(t, RecoveryKindConn, sbe.RecoveryKind)
+			rk := GetRecoveryKind(amqp.ErrConnClosed)
+			require.EqualValues(t, RecoveryKindConn, rk)
 		})
 	})
 
@@ -128,8 +129,8 @@ func Test_recoveryKind(t *testing.T) {
 
 		for _, code := range codes {
 			t.Run(code, func(t *testing.T) {
-				sbe := GetSBErrInfo(&amqp.Error{Condition: amqp.ErrorCondition(code)})
-				require.EqualValues(t, RecoveryKindFatal, sbe.RecoveryKind, fmt.Sprintf("cannot be recovered: %s", code))
+				rk := GetRecoveryKind(&amqp.Error{Condition: amqp.ErrorCondition(code)})
+				require.EqualValues(t, RecoveryKindFatal, rk, fmt.Sprintf("cannot be recovered: %s", code))
 			})
 		}
 	})
@@ -143,8 +144,8 @@ func Test_recoveryKind(t *testing.T) {
 
 		for _, code := range codes {
 			t.Run(code, func(t *testing.T) {
-				sbe := GetSBErrInfo(&amqp.Error{Condition: amqp.ErrorCondition(code)})
-				require.EqualValues(t, RecoveryKindNone, sbe.RecoveryKind, fmt.Sprintf("no recovery needed: %s", code))
+				rk := GetRecoveryKind(&amqp.Error{Condition: amqp.ErrorCondition(code)})
+				require.EqualValues(t, RecoveryKindNone, rk, fmt.Sprintf("no recovery needed: %s", code))
 			})
 		}
 	})
@@ -161,7 +162,7 @@ func Test_IsNonRetriable(t *testing.T) {
 	}
 
 	for _, err := range errs {
-		require.EqualValues(t, RecoveryKindFatal, GetSBErrInfo(err).RecoveryKind)
+		require.EqualValues(t, RecoveryKindFatal, GetRecoveryKind(err))
 	}
 }
 
@@ -172,13 +173,13 @@ func Test_ServiceBusError_NoRecoveryNeeded(t *testing.T) {
 		&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:operation-cancelled")},
 		errors.New("link is currently draining"), // not yet exposed from go-amqp
 		// simple timeouts from the mgmt link
-		rpcError{Resp: &RPCResponse{Code: 408}},
-		rpcError{Resp: &RPCResponse{Code: 503}},
-		rpcError{Resp: &RPCResponse{Code: 500}},
+		RPCError{Resp: &RPCResponse{Code: 408}},
+		RPCError{Resp: &RPCResponse{Code: 503}},
+		RPCError{Resp: &RPCResponse{Code: 500}},
 	}
 
 	for i, err := range tempErrors {
-		rk := GetSBErrInfo(err).RecoveryKind
+		rk := GetRecoveryKind(err)
 		require.EqualValues(t, RecoveryKindNone, rk, fmt.Sprintf("[%d] %v", i, err))
 	}
 }
@@ -197,12 +198,12 @@ func Test_ServiceBusError_ConnectionRecoveryNeeded(t *testing.T) {
 	}
 
 	for i, err := range connErrors {
-		rk := GetSBErrInfo(err).RecoveryKind
+		rk := GetRecoveryKind(err)
 		require.EqualValues(t, RecoveryKindConn, rk, fmt.Sprintf("[%d] %v", i, err))
 	}
 
 	// unknown errors will just result in a connection recovery
-	rk := GetSBErrInfo(errors.New("Some unknown error")).RecoveryKind
+	rk := GetRecoveryKind(errors.New("Some unknown error"))
 	require.EqualValues(t, RecoveryKindConn, rk, "some unknown error")
 }
 
@@ -214,11 +215,11 @@ func Test_ServiceBusError_LinkRecoveryNeeded(t *testing.T) {
 		&amqp.Error{Condition: amqp.ErrorTransferLimitExceeded},
 		// this can happen when we're recovering the link - the client gets closed and the old link is still being
 		// used by this instance of the client. It needs to recover and attempt it again.
-		rpcError{Resp: &RPCResponse{Code: 401}},
+		RPCError{Resp: &RPCResponse{Code: 401}},
 	}
 
 	for i, err := range linkErrors {
-		rk := GetSBErrInfo(err).RecoveryKind
+		rk := GetRecoveryKind(err)
 		require.EqualValues(t, RecoveryKindLink, rk, fmt.Sprintf("[%d] %v", i, err))
 	}
 }
@@ -235,15 +236,45 @@ func Test_ServiceBusError_Fatal(t *testing.T) {
 	}
 
 	for i, cond := range fatalConditions {
-		rk := GetSBErrInfo(&amqp.Error{Condition: cond}).RecoveryKind
+		rk := GetRecoveryKind(&amqp.Error{Condition: cond})
 		require.EqualValues(t, RecoveryKindFatal, rk, fmt.Sprintf("[%d] %s", i, cond))
 	}
 
-	require.Equal(t, RecoveryKindFatal, GetSBErrInfo(rpcError{Resp: &RPCResponse{Code: http.StatusNotFound}}).RecoveryKind)
-	require.Equal(t, RecoveryKindFatal, GetSBErrInfo(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}}).RecoveryKind)
+	require.Equal(t, RecoveryKindFatal, GetRecoveryKind(RPCError{Resp: &RPCResponse{Code: http.StatusNotFound}}))
+	require.Equal(t, RecoveryKindFatal, GetRecoveryKind(RPCError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}}))
 }
 
 func Test_IsLockLostError(t *testing.T) {
-	require.True(t, isLockLostError(rpcError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}}))
-	require.False(t, isLockLostError(rpcError{Resp: &RPCResponse{Code: http.StatusNotFound}}))
+	require.True(t, isLockLostError(RPCError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}}))
+	require.True(t, isLockLostError(&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:message-lock-lost")}))
+
+	require.True(t, isLockLostError(RPCError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}}))
+}
+
+func Test_TransformError(t *testing.T) {
+	var asExportedErr exported.Error
+
+	err := TransformError(RPCError{Resp: &RPCResponse{Code: RPCResponseCodeLockLost}})
+	require.ErrorAs(t, err, &asExportedErr)
+	require.Equal(t, exported.CodeLockLost, asExportedErr.Code)
+
+	// sanity check, an RPCError but it's not a azservicebus.Code type error.
+	err = TransformError(RPCError{Resp: &RPCResponse{Code: http.StatusNotFound}})
+	require.False(t, errors.As(err, &asExportedErr))
+
+	err = TransformError(&amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:message-lock-lost")})
+	require.ErrorAs(t, err, &asExportedErr)
+	require.Equal(t, exported.CodeLockLost, asExportedErr.Code)
+
+	// sanity check, an RPCError but it's not a azservicebus.Code type error.
+	err = TransformError(&amqp.Error{Condition: amqp.ErrorNotFound})
+	require.False(t, errors.As(err, &asExportedErr))
+
+	err = TransformError(amqp.ErrLinkClosed)
+	require.ErrorAs(t, err, &asExportedErr)
+	require.Equal(t, exported.CodeConnectionLost, asExportedErr.Code)
+
+	err = TransformError(amqp.ErrConnClosed)
+	require.ErrorAs(t, err, &asExportedErr)
+	require.Equal(t, exported.CodeConnectionLost, asExportedErr.Code)
 }

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -277,4 +277,12 @@ func Test_TransformError(t *testing.T) {
 	err = TransformError(amqp.ErrConnClosed)
 	require.ErrorAs(t, err, &asExportedErr)
 	require.Equal(t, exported.CodeConnectionLost, asExportedErr.Code)
+
+	// don't double wrap an already wrapped error
+	alreadyWrappedErr := &exported.Error{Code: exported.CodeConnectionLost}
+	err = TransformError(alreadyWrappedErr)
+	require.Equal(t, alreadyWrappedErr, err)
+
+	// and it's okay, for convenience, to pass a nil.
+	require.Nil(t, TransformError(nil))
 }

--- a/sdk/messaging/azservicebus/internal/exported/error.go
+++ b/sdk/messaging/azservicebus/internal/exported/error.go
@@ -41,16 +41,11 @@ func (e Error) Error() string {
 	return fmt.Sprintf("(%s): %s", e.Code, msg)
 }
 
-// Unwrap is implemented so this error can be used with errors.As()
-func (e Error) Unwrap() error {
-	return e.innerErr
-}
-
 // NewError creates a new `Error` instance.
 // NOTE: this function is only exported so it can be used by the `internal`
 // package. It is not available for customers.
 func NewError(code Code, innerErr error) error {
-	return Error{
+	return &Error{
 		Code:     code,
 		innerErr: innerErr,
 	}

--- a/sdk/messaging/azservicebus/internal/exported/error.go
+++ b/sdk/messaging/azservicebus/internal/exported/error.go
@@ -11,7 +11,7 @@ type Code string
 
 const (
 	// CodeConnectionLost means our connection was lost and all retry attempts failed.
-	// This typicall reflects an extended outage or connection disruption and may
+	// This typically reflects an extended outage or connection disruption and may
 	// require manual intervention.
 	CodeConnectionLost Code = "connlost"
 

--- a/sdk/messaging/azservicebus/internal/exported/error.go
+++ b/sdk/messaging/azservicebus/internal/exported/error.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package exported
+
+import "fmt"
+
+// Code is an error code, usable by consuming code to work with
+// programatically.
+type Code string
+
+const (
+	// CodeConnectionLost means our connection was lost and all retry attempts failed.
+	// This typicall reflects an extended outage or connection disruption and may
+	// require manual intervention.
+	CodeConnectionLost Code = "connlost"
+
+	// CodeLockLost means that the lock token you have for a message has expired.
+	// This message will be available again after the lock period expires, or, potentially
+	// go to the dead letter queue if delivery attempts have been exceeded.
+	CodeLockLost Code = "locklost"
+)
+
+// Error represents a Service Bus specific error.
+type Error struct {
+	// Code is a stable error code which can be used as part of programatic error handling.
+	// The codes can expand in the future, but the values (and their meaning) will remain the same.
+	Code     Code
+	innerErr error
+}
+
+// Error is an error message containing the code and a user friendly message, if any.
+func (e Error) Error() string {
+	return fmt.Sprintf("(%s): %s", e.Code, e.innerErr.Error())
+}
+
+// Unwrap is implemented so this error can be used with errors.As()
+func (e Error) Unwrap() error {
+	return e.innerErr
+}
+
+// NewError creates a new `Error` instance.
+// NOTE: this function is only exported so it can be used by the `internal`
+// package. It is not available for customers.
+func NewError(code Code, innerErr error) error {
+	return Error{
+		Code:     code,
+		innerErr: innerErr,
+	}
+}

--- a/sdk/messaging/azservicebus/internal/exported/error.go
+++ b/sdk/messaging/azservicebus/internal/exported/error.go
@@ -33,7 +33,7 @@ type Error struct {
 }
 
 // Error is an error message containing the code and a user friendly message, if any.
-func (e Error) Error() string {
+func (e *Error) Error() string {
 	msg := "unknown error"
 	if e.innerErr != nil {
 		msg = e.innerErr.Error()

--- a/sdk/messaging/azservicebus/internal/exported/error.go
+++ b/sdk/messaging/azservicebus/internal/exported/error.go
@@ -22,6 +22,9 @@ const (
 )
 
 // Error represents a Service Bus specific error.
+// NOTE: the Code is considered part of the published API but the message that
+// comes back from Error(), as well as the underlying wrapped error, are NOT and
+// are subject to change.
 type Error struct {
 	// Code is a stable error code which can be used as part of programatic error handling.
 	// The codes can expand in the future, but the values (and their meaning) will remain the same.

--- a/sdk/messaging/azservicebus/internal/exported/error.go
+++ b/sdk/messaging/azservicebus/internal/exported/error.go
@@ -31,7 +31,11 @@ type Error struct {
 
 // Error is an error message containing the code and a user friendly message, if any.
 func (e Error) Error() string {
-	return fmt.Sprintf("(%s): %s", e.Code, e.innerErr.Error())
+	msg := "unknown error"
+	if e.innerErr != nil {
+		msg = e.innerErr.Error()
+	}
+	return fmt.Sprintf("(%s): %s", e.Code, msg)
 }
 
 // Unwrap is implemented so this error can be used with errors.As()

--- a/sdk/messaging/azservicebus/internal/exported/error_test.go
+++ b/sdk/messaging/azservicebus/internal/exported/error_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package exported
+
+import (
+	"testing"
+
+	"github.com/Azure/go-amqp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicError(t *testing.T) {
+	err := NewError(CodeConnectionLost, nil)
+	require.Equal(t, err.Error(), "(connlost): unknown error")
+
+	err = NewError(CodeLockLost, &amqp.Error{Condition: amqp.ErrorCondition("com.microsoft:message-lock-lost")})
+	require.Equal(t, err.Error(), "(locklost): *Error{Condition: com.microsoft:message-lock-lost, Description: , Info: map[]}")
+}

--- a/sdk/messaging/azservicebus/internal/rpc_test.go
+++ b/sdk/messaging/azservicebus/internal/rpc_test.go
@@ -142,7 +142,7 @@ func TestRPCLinkNonErrorLockLostDoesNotBreakAnything(t *testing.T) {
 
 	// the 400 automatically gets translated into an RPC error. The response router should still be running.
 	require.Nil(t, resp)
-	var rpcErr rpcError
+	var rpcErr RPCError
 	require.ErrorAs(t, err, &rpcErr)
 	require.Equal(t, 400, rpcErr.RPCCode())
 

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -52,7 +52,7 @@ func (s *messageSettler) settleWithRetries(ctx context.Context, message *Receive
 		return nil
 	}, RetryOptions{})
 
-	return err
+	return internal.TransformError(err)
 }
 
 // CompleteMessageOptions contains optional parameters for the CompleteMessage function.

--- a/sdk/messaging/azservicebus/messageSettler_test.go
+++ b/sdk/messaging/azservicebus/messageSettler_test.go
@@ -109,10 +109,10 @@ func TestMessageSettlementUsingReceiverWithReceiveAndDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, messages)
 
-	require.EqualValues(t, internal.RecoveryKindFatal, internal.GetSBErrInfo(receiver.AbandonMessage(ctx, messages[0], nil)).RecoveryKind)
-	require.EqualValues(t, internal.RecoveryKindFatal, internal.GetSBErrInfo(receiver.CompleteMessage(ctx, messages[0], nil)).RecoveryKind)
-	require.EqualValues(t, internal.RecoveryKindFatal, internal.GetSBErrInfo(receiver.DeferMessage(ctx, messages[0], nil)).RecoveryKind)
-	require.EqualValues(t, internal.RecoveryKindFatal, internal.GetSBErrInfo(receiver.DeadLetterMessage(ctx, messages[0], nil)).RecoveryKind)
+	require.EqualValues(t, internal.RecoveryKindFatal, internal.GetRecoveryKind(receiver.AbandonMessage(ctx, messages[0], nil)))
+	require.EqualValues(t, internal.RecoveryKindFatal, internal.GetRecoveryKind(receiver.CompleteMessage(ctx, messages[0], nil)))
+	require.EqualValues(t, internal.RecoveryKindFatal, internal.GetRecoveryKind(receiver.DeferMessage(ctx, messages[0], nil)))
+	require.EqualValues(t, internal.RecoveryKindFatal, internal.GetRecoveryKind(receiver.DeadLetterMessage(ctx, messages[0], nil)))
 
 	require.EqualError(t, receiver.DeadLetterMessage(ctx, messages[0], nil), "messages that are received in `ReceiveModeReceiveAndDelete` mode are not settleable")
 }

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -177,7 +177,7 @@ type ReceiveMessagesOptions struct {
 // 1. Cancelling the `ctx` parameter.
 // 2. An implicit timeout (default: 1 second) that starts after the first
 //    message has been received.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *Receiver) ReceiveMessages(ctx context.Context, maxMessages int, options *ReceiveMessagesOptions) ([]*ReceivedMessage, error) {
 	r.mu.Lock()
 	isReceiving := r.receiving
@@ -207,7 +207,7 @@ type ReceiveDeferredMessagesOptions struct {
 }
 
 // ReceiveDeferredMessages receives messages that were deferred using `Receiver.DeferMessage`.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *Receiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers []int64, options *ReceiveDeferredMessagesOptions) ([]*ReceivedMessage, error) {
 	var receivedMessages []*ReceivedMessage
 
@@ -242,7 +242,7 @@ type PeekMessagesOptions struct {
 // Messages that are peeked do not have lock tokens, so settlement methods
 // like CompleteMessage, AbandonMessage, DeferMessage or DeadLetterMessage
 // will not work with them.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekMessagesOptions) ([]*ReceivedMessage, error) {
 	var receivedMessages []*ReceivedMessage
 
@@ -284,7 +284,7 @@ type RenewMessageLockOptions struct {
 }
 
 // RenewMessageLock renews the lock on a message, updating the `LockedUntil` field on `msg`.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *Receiver) RenewMessageLock(ctx context.Context, msg *ReceivedMessage, options *RenewMessageLockOptions) error {
 	err := r.amqpLinks.Retry(ctx, EventReceiver, "renewMessageLock", func(ctx context.Context, linksWithVersion *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		newExpirationTime, err := internal.RenewLocks(ctx, linksWithVersion.RPC, msg.rawAMQPMessage.LinkName(), []amqp.UUID{
@@ -309,7 +309,7 @@ func (r *Receiver) Close(ctx context.Context) error {
 }
 
 // CompleteMessage completes a message, deleting it from the queue or subscription.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *Receiver) CompleteMessage(ctx context.Context, message *ReceivedMessage, options *CompleteMessageOptions) error {
 	return r.settler.CompleteMessage(ctx, message, options)
 }
@@ -317,14 +317,14 @@ func (r *Receiver) CompleteMessage(ctx context.Context, message *ReceivedMessage
 // AbandonMessage will cause a message to be returned to the queue or subscription.
 // This will increment its delivery count, and potentially cause it to be dead lettered
 // depending on your queue or subscription's configuration.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *Receiver) AbandonMessage(ctx context.Context, message *ReceivedMessage, options *AbandonMessageOptions) error {
 	return r.settler.AbandonMessage(ctx, message, options)
 }
 
 // DeferMessage will cause a message to be deferred. Deferred messages
 // can be received using `Receiver.ReceiveDeferredMessages`.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *Receiver) DeferMessage(ctx context.Context, message *ReceivedMessage, options *DeferMessageOptions) error {
 	return r.settler.DeferMessage(ctx, message, options)
 }
@@ -332,7 +332,7 @@ func (r *Receiver) DeferMessage(ctx context.Context, message *ReceivedMessage, o
 // DeadLetterMessage settles a message by moving it to the dead letter queue for a
 // queue or subscription. To receive these messages create a receiver with `Client.NewReceiverForQueue()`
 // or `Client.NewReceiverForSubscription()` using the `ReceiverOptions.SubQueue` option.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *Receiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
 	return r.settler.DeadLetterMessage(ctx, message, options)
 }

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/test"
@@ -554,8 +555,10 @@ func TestReceiver_RenewMessageLock(t *testing.T) {
 	endCaptureFn := test.CaptureLogsForTest()
 	defer endCaptureFn()
 	expectedLockBadError := receiver.RenewMessageLock(context.Background(), messages[0], nil)
-	// String matching can go away once we fix #15644
-	// For now it at least provides the user with good context that something is incorrect about their lock token.
+
+	var asSBError Error
+	require.ErrorAs(t, expectedLockBadError, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
 	require.Contains(t, expectedLockBadError.Error(),
 		"status code 410 and description: The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue",
 		"error message from SB comes through")
@@ -750,6 +753,38 @@ func TestReceiverMultiTopic(t *testing.T) {
 	otherMessages, err = otherQueueReceiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"sent to other queue2"}, getSortedBodies(otherMessages))
+}
+
+func TestReceiverMessageLockExpires(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
+		LockDuration: to.Ptr("PT5S"),
+	})
+	defer cleanup()
+
+	sender, err := client.NewSender(queueName, nil)
+	require.NoError(t, err)
+
+	err = sender.SendMessage(context.Background(), &Message{Body: []byte("hello")}, nil)
+	require.NoError(t, err)
+
+	receiver, err := client.NewReceiverForQueue(queueName, nil)
+	require.NoError(t, err)
+
+	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
+	require.NoError(t, err)
+
+	// sleep so our message locks expire
+	time.Sleep(6 * time.Second)
+
+	err = receiver.CompleteMessage(context.Background(), messages[0], nil)
+
+	var asSBError Error
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
+
+	var amqpErr *amqp.Error
+	require.ErrorAs(t, err, &amqpErr)
+	require.Equal(t, amqp.ErrorCondition("com.microsoft:message-lock-lost"), amqpErr.Condition)
 }
 
 type badRPCLink struct {

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -5,7 +5,6 @@ package azservicebus
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -556,7 +555,7 @@ func TestReceiver_RenewMessageLock(t *testing.T) {
 	defer endCaptureFn()
 	expectedLockBadError := receiver.RenewMessageLock(context.Background(), messages[0], nil)
 
-	var asSBError Error
+	var asSBError *Error
 	require.ErrorAs(t, expectedLockBadError, &asSBError)
 	require.Equal(t, CodeLockLost, asSBError.Code)
 	require.Contains(t, expectedLockBadError.Error(),
@@ -778,21 +777,9 @@ func TestReceiverMessageLockExpires(t *testing.T) {
 
 	err = receiver.CompleteMessage(context.Background(), messages[0], nil)
 
-	var asSBError Error
+	var asSBError *Error
 	require.ErrorAs(t, err, &asSBError)
 	require.Equal(t, CodeLockLost, asSBError.Code)
-
-	var amqpErr *amqp.Error
-	require.ErrorAs(t, err, &amqpErr)
-	require.Equal(t, amqp.ErrorCondition("com.microsoft:message-lock-lost"), amqpErr.Condition)
-}
-
-type badRPCLink struct {
-	internal.RPCLink
-}
-
-func (br *badRPCLink) RPC(ctx context.Context, msg *amqp.Message) (*internal.RPCResponse, error) {
-	return nil, errors.New("receive deferred messages failed")
 }
 
 type receivedMessageSlice []*ReceivedMessage

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/amqpwrap"
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
 	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/require"
 )

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -417,7 +417,7 @@ func TestReceiver_UserFacingErrors(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	var asSBError Error
+	var asSBError *Error
 
 	fakeAMQPLinks.Err = amqp.ErrLinkClosed
 	messages, err := receiver.PeekMessages(context.Background(), 1, nil)

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -5,12 +5,13 @@ package azservicebus
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/amqpwrap"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
 	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/require"
 )
@@ -394,24 +395,73 @@ func TestReceiverOptions(t *testing.T) {
 	require.EqualValues(t, "topic/Subscriptions/subscription/$Transfer/$DeadLetterQueue", path)
 }
 
-func TestReceiverDeferUnitTests(t *testing.T) {
-	r := &Receiver{
-		amqpLinks: &internal.FakeAMQPLinks{
-			Err: errors.New("links are dead"),
+func TestReceiver_UserFacingErrors(t *testing.T) {
+	fakeAMQPLinks := &internal.FakeAMQPLinks{}
+
+	receiver, err := newReceiver(newReceiverArgs{
+		ns: &internal.FakeNS{
+			AMQPLinks: fakeAMQPLinks,
 		},
-	}
-
-	messages, err := r.ReceiveDeferredMessages(context.Background(), []int64{1}, nil)
-	require.EqualError(t, err, "links are dead")
-	require.Nil(t, messages)
-
-	r = &Receiver{
-		amqpLinks: &internal.FakeAMQPLinks{
-			RPC: &badRPCLink{},
+		entity: entity{
+			Queue: "queue",
 		},
-	}
+		cleanupOnClose:      func() {},
+		getRecoveryKindFunc: internal.GetRecoveryKind,
+		newLinkFn: func(ctx context.Context, session amqpwrap.AMQPSession) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error) {
+			return nil, nil, nil
+		},
+		retryOptions: exported.RetryOptions{
+			MaxRetries:    0,
+			RetryDelay:    0,
+			MaxRetryDelay: 0,
+		},
+	}, nil)
+	require.NoError(t, err)
 
-	messages, err = r.ReceiveDeferredMessages(context.Background(), []int64{1}, nil)
-	require.EqualError(t, err, "receive deferred messages failed")
-	require.Nil(t, messages)
+	var asSBError Error
+
+	fakeAMQPLinks.Err = amqp.ErrLinkClosed
+	messages, err := receiver.PeekMessages(context.Background(), 1, nil)
+	require.Empty(t, messages)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+
+	fakeAMQPLinks.Err = amqp.ErrConnClosed
+	messages, err = receiver.ReceiveDeferredMessages(context.Background(), []int64{1}, nil)
+	require.Empty(t, messages)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+
+	fakeAMQPLinks.Err = amqp.ErrConnClosed
+	messages, err = receiver.ReceiveMessages(context.Background(), 1, nil)
+	require.Empty(t, messages)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+
+	fakeAMQPLinks.Err = internal.RPCError{Resp: &internal.RPCResponse{Code: internal.RPCResponseCodeLockLost}}
+
+	err = receiver.AbandonMessage(context.Background(), &ReceivedMessage{}, nil)
+	require.Empty(t, messages)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
+
+	err = receiver.CompleteMessage(context.Background(), &ReceivedMessage{}, nil)
+	require.Empty(t, messages)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
+
+	err = receiver.DeadLetterMessage(context.Background(), &ReceivedMessage{}, nil)
+	require.Empty(t, messages)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
+
+	err = receiver.DeferMessage(context.Background(), &ReceivedMessage{}, nil)
+	require.Empty(t, messages)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
+
+	err = receiver.RenewMessageLock(context.Background(), &ReceivedMessage{}, nil)
+	require.Empty(t, messages)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
 }

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -322,7 +322,7 @@ func TestReceiver_CanCancelLinkCreation(t *testing.T) {
 
 	receiver, err := createReceiverLink(ctx, session, []amqp.LinkOption{})
 	require.Nil(t, receiver)
-	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, context.Canceled, fmt.Sprintf("%s is context.Cancelled", err.Error()))
 
 	// also, the receiver we returned should be closed as part of the gourtine
 	// unwinding.

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -410,7 +410,7 @@ func TestReceiver_UserFacingErrors(t *testing.T) {
 		newLinkFn: func(ctx context.Context, session amqpwrap.AMQPSession) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error) {
 			return nil, nil, nil
 		},
-		retryOptions: exported.RetryOptions{
+		retryOptions: RetryOptions{
 			MaxRetries:    0,
 			RetryDelay:    0,
 			MaxRetryDelay: 0,

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -33,7 +33,7 @@ type MessageBatchOptions struct {
 // NewMessageBatch can be used to create a batch that contain multiple
 // messages. Sending a batch of messages is more efficient than sending the
 // messages one at a time.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (s *Sender) NewMessageBatch(ctx context.Context, options *MessageBatchOptions) (*MessageBatch, error) {
 	var batch *MessageBatch
 
@@ -61,7 +61,7 @@ type SendMessageOptions struct {
 }
 
 // SendMessage sends a Message to a queue or topic.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (s *Sender) SendMessage(ctx context.Context, message *Message, options *SendMessageOptions) error {
 	err := s.links.Retry(ctx, EventSender, "SendMessage", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return lwid.Sender.Send(ctx, message.toAMQPMessage())
@@ -77,7 +77,7 @@ type SendMessageBatchOptions struct {
 
 // SendMessageBatch sends a MessageBatch to a queue or topic.
 // Message batches can be created using `Sender.NewMessageBatch`.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (s *Sender) SendMessageBatch(ctx context.Context, batch *MessageBatch, options *SendMessageBatchOptions) error {
 	err := s.links.Retry(ctx, EventSender, "SendMessageBatch", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return lwid.Sender.Send(ctx, batch.toAMQPMessage())
@@ -94,7 +94,7 @@ type ScheduleMessagesOptions struct {
 // ScheduleMessages schedules a slice of Messages to appear on Service Bus Queue/Subscription at a later time.
 // Returns the sequence numbers of the messages that were scheduled.  Messages that haven't been
 // delivered can be cancelled using `Receiver.CancelScheduleMessage(s)`
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (s *Sender) ScheduleMessages(ctx context.Context, messages []*Message, scheduledEnqueueTime time.Time, options *ScheduleMessagesOptions) ([]int64, error) {
 	var amqpMessages []*amqp.Message
 
@@ -114,7 +114,7 @@ type CancelScheduledMessagesOptions struct {
 }
 
 // CancelScheduledMessages cancels multiple messages that were scheduled.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (s *Sender) CancelScheduledMessages(ctx context.Context, sequenceNumbers []int64, options *CancelScheduledMessagesOptions) error {
 	err := s.links.Retry(ctx, EventSender, "CancelScheduledMessages", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return internal.CancelScheduledMessages(ctx, lwv.RPC, sequenceNumbers)

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -33,6 +33,7 @@ type MessageBatchOptions struct {
 // NewMessageBatch can be used to create a batch that contain multiple
 // messages. Sending a batch of messages is more efficient than sending the
 // messages one at a time.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (s *Sender) NewMessageBatch(ctx context.Context, options *MessageBatchOptions) (*MessageBatch, error) {
 	var batch *MessageBatch
 
@@ -60,6 +61,7 @@ type SendMessageOptions struct {
 }
 
 // SendMessage sends a Message to a queue or topic.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (s *Sender) SendMessage(ctx context.Context, message *Message, options *SendMessageOptions) error {
 	err := s.links.Retry(ctx, EventSender, "SendMessage", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return lwid.Sender.Send(ctx, message.toAMQPMessage())
@@ -75,6 +77,7 @@ type SendMessageBatchOptions struct {
 
 // SendMessageBatch sends a MessageBatch to a queue or topic.
 // Message batches can be created using `Sender.NewMessageBatch`.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (s *Sender) SendMessageBatch(ctx context.Context, batch *MessageBatch, options *SendMessageBatchOptions) error {
 	err := s.links.Retry(ctx, EventSender, "SendMessageBatch", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return lwid.Sender.Send(ctx, batch.toAMQPMessage())
@@ -91,6 +94,7 @@ type ScheduleMessagesOptions struct {
 // ScheduleMessages schedules a slice of Messages to appear on Service Bus Queue/Subscription at a later time.
 // Returns the sequence numbers of the messages that were scheduled.  Messages that haven't been
 // delivered can be cancelled using `Receiver.CancelScheduleMessage(s)`
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (s *Sender) ScheduleMessages(ctx context.Context, messages []*Message, scheduledEnqueueTime time.Time, options *ScheduleMessagesOptions) ([]int64, error) {
 	var amqpMessages []*amqp.Message
 
@@ -110,6 +114,7 @@ type CancelScheduledMessagesOptions struct {
 }
 
 // CancelScheduledMessages cancels multiple messages that were scheduled.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (s *Sender) CancelScheduledMessages(ctx context.Context, sequenceNumbers []int64, options *CancelScheduledMessagesOptions) error {
 	err := s.links.Retry(ctx, EventSender, "CancelScheduledMessages", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return internal.CancelScheduledMessages(ctx, lwv.RPC, sequenceNumbers)

--- a/sdk/messaging/azservicebus/sender_unit_test.go
+++ b/sdk/messaging/azservicebus/sender_unit_test.go
@@ -23,7 +23,7 @@ func TestSender_UserFacingError(t *testing.T) {
 		},
 		queueOrTopic:   "queue",
 		cleanupOnClose: func() {},
-		retryOptions: exported.RetryOptions{
+		retryOptions: RetryOptions{
 			MaxRetries:    0,
 			RetryDelay:    0,
 			MaxRetryDelay: 0,

--- a/sdk/messaging/azservicebus/sender_unit_test.go
+++ b/sdk/messaging/azservicebus/sender_unit_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
 	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/require"
 )

--- a/sdk/messaging/azservicebus/sender_unit_test.go
+++ b/sdk/messaging/azservicebus/sender_unit_test.go
@@ -32,7 +32,7 @@ func TestSender_UserFacingError(t *testing.T) {
 
 	fakeAMQPLinks.Err = amqp.ErrConnClosed
 
-	var asSBError Error
+	var asSBError *Error
 
 	batch, err := sender.NewMessageBatch(context.Background(), nil)
 	require.Nil(t, batch)

--- a/sdk/messaging/azservicebus/sender_unit_test.go
+++ b/sdk/messaging/azservicebus/sender_unit_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azservicebus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
+	"github.com/Azure/go-amqp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSender_UserFacingError(t *testing.T) {
+	fakeAMQPLinks := &internal.FakeAMQPLinks{}
+
+	sender, err := newSender(newSenderArgs{
+		ns: &internal.FakeNS{
+			AMQPLinks: fakeAMQPLinks,
+		},
+		queueOrTopic:   "queue",
+		cleanupOnClose: func() {},
+		retryOptions: exported.RetryOptions{
+			MaxRetries:    0,
+			RetryDelay:    0,
+			MaxRetryDelay: 0,
+		},
+	})
+	require.NoError(t, err)
+
+	fakeAMQPLinks.Err = amqp.ErrConnClosed
+
+	var asSBError Error
+
+	batch, err := sender.NewMessageBatch(context.Background(), nil)
+	require.Nil(t, batch)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+
+	err = sender.CancelScheduledMessages(context.Background(), []int64{1}, nil)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+
+	seqNumbers, err := sender.ScheduleMessages(context.Background(), []*Message{}, time.Now(), nil)
+	require.Empty(t, seqNumbers)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+
+	err = sender.SendMessage(context.Background(), &Message{}, nil)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+
+	err = sender.SendMessageBatch(context.Background(), nil, nil)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+}

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -124,11 +124,13 @@ func (r *SessionReceiver) newLink(ctx context.Context, session amqpwrap.AMQPSess
 // 1. Cancelling the `ctx` parameter.
 // 2. An implicit timeout (default: 1 second) that starts after the first
 //    message has been received.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) ReceiveMessages(ctx context.Context, maxMessages int, options *ReceiveMessagesOptions) ([]*ReceivedMessage, error) {
 	return r.inner.ReceiveMessages(ctx, maxMessages, options)
 }
 
 // ReceiveDeferredMessages receives messages that were deferred using `Receiver.DeferMessage`.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers []int64, options *ReceiveDeferredMessagesOptions) ([]*ReceivedMessage, error) {
 	return r.inner.ReceiveDeferredMessages(ctx, sequenceNumbers, options)
 }
@@ -137,6 +139,7 @@ func (r *SessionReceiver) ReceiveDeferredMessages(ctx context.Context, sequenceN
 // Messages that are peeked do not have lock tokens, so settlement methods
 // like CompleteMessage, AbandonMessage, DeferMessage or DeadLetterMessage
 // will not work with them.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekMessagesOptions) ([]*ReceivedMessage, error) {
 	return r.inner.PeekMessages(ctx, maxMessageCount, options)
 }
@@ -147,6 +150,7 @@ func (r *SessionReceiver) Close(ctx context.Context) error {
 }
 
 // CompleteMessage completes a message, deleting it from the queue or subscription.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) CompleteMessage(ctx context.Context, message *ReceivedMessage, options *CompleteMessageOptions) error {
 	return r.inner.CompleteMessage(ctx, message, options)
 }
@@ -154,12 +158,14 @@ func (r *SessionReceiver) CompleteMessage(ctx context.Context, message *Received
 // AbandonMessage will cause a message to be returned to the queue or subscription.
 // This will increment its delivery count, and potentially cause it to be dead lettered
 // depending on your queue or subscription's configuration.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) AbandonMessage(ctx context.Context, message *ReceivedMessage, options *AbandonMessageOptions) error {
 	return r.inner.AbandonMessage(ctx, message, options)
 }
 
 // DeferMessage will cause a message to be deferred. Deferred messages
 // can be received using `Receiver.ReceiveDeferredMessages`.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) DeferMessage(ctx context.Context, message *ReceivedMessage, options *DeferMessageOptions) error {
 	return r.inner.DeferMessage(ctx, message, options)
 }
@@ -167,6 +173,7 @@ func (r *SessionReceiver) DeferMessage(ctx context.Context, message *ReceivedMes
 // DeadLetterMessage settles a message by moving it to the dead letter queue for a
 // queue or subscription. To receive these messages create a receiver with `Client.NewReceiverForQueue()`
 // or `Client.NewReceiverForSubscription()` using the `ReceiverOptions.SubQueue` option.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
 	return r.inner.DeadLetterMessage(ctx, message, options)
 }
@@ -190,6 +197,7 @@ type GetSessionStateOptions struct {
 }
 
 // GetSessionState retrieves state associated with the session.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (sr *SessionReceiver) GetSessionState(ctx context.Context, options *GetSessionStateOptions) ([]byte, error) {
 	var sessionState []byte
 
@@ -213,6 +221,7 @@ type SetSessionStateOptions struct {
 }
 
 // SetSessionState sets the state associated with the session.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (sr *SessionReceiver) SetSessionState(ctx context.Context, state []byte, options *SetSessionStateOptions) error {
 	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return internal.SetSessionState(ctx, lwv.RPC, sr.SessionID(), state)
@@ -228,6 +237,7 @@ type RenewSessionLockOptions struct {
 
 // RenewSessionLock renews this session's lock. The new expiration time is available
 // using `LockedUntil`.
+// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
 func (sr *SessionReceiver) RenewSessionLock(ctx context.Context, options *RenewSessionLockOptions) error {
 	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		newLockedUntil, err := internal.RenewSessionLock(ctx, lwv.RPC, *sr.sessionID)

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -124,13 +124,13 @@ func (r *SessionReceiver) newLink(ctx context.Context, session amqpwrap.AMQPSess
 // 1. Cancelling the `ctx` parameter.
 // 2. An implicit timeout (default: 1 second) that starts after the first
 //    message has been received.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) ReceiveMessages(ctx context.Context, maxMessages int, options *ReceiveMessagesOptions) ([]*ReceivedMessage, error) {
 	return r.inner.ReceiveMessages(ctx, maxMessages, options)
 }
 
 // ReceiveDeferredMessages receives messages that were deferred using `Receiver.DeferMessage`.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers []int64, options *ReceiveDeferredMessagesOptions) ([]*ReceivedMessage, error) {
 	return r.inner.ReceiveDeferredMessages(ctx, sequenceNumbers, options)
 }
@@ -139,7 +139,7 @@ func (r *SessionReceiver) ReceiveDeferredMessages(ctx context.Context, sequenceN
 // Messages that are peeked do not have lock tokens, so settlement methods
 // like CompleteMessage, AbandonMessage, DeferMessage or DeadLetterMessage
 // will not work with them.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) PeekMessages(ctx context.Context, maxMessageCount int, options *PeekMessagesOptions) ([]*ReceivedMessage, error) {
 	return r.inner.PeekMessages(ctx, maxMessageCount, options)
 }
@@ -150,7 +150,7 @@ func (r *SessionReceiver) Close(ctx context.Context) error {
 }
 
 // CompleteMessage completes a message, deleting it from the queue or subscription.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) CompleteMessage(ctx context.Context, message *ReceivedMessage, options *CompleteMessageOptions) error {
 	return r.inner.CompleteMessage(ctx, message, options)
 }
@@ -158,14 +158,14 @@ func (r *SessionReceiver) CompleteMessage(ctx context.Context, message *Received
 // AbandonMessage will cause a message to be returned to the queue or subscription.
 // This will increment its delivery count, and potentially cause it to be dead lettered
 // depending on your queue or subscription's configuration.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) AbandonMessage(ctx context.Context, message *ReceivedMessage, options *AbandonMessageOptions) error {
 	return r.inner.AbandonMessage(ctx, message, options)
 }
 
 // DeferMessage will cause a message to be deferred. Deferred messages
 // can be received using `Receiver.ReceiveDeferredMessages`.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) DeferMessage(ctx context.Context, message *ReceivedMessage, options *DeferMessageOptions) error {
 	return r.inner.DeferMessage(ctx, message, options)
 }
@@ -173,7 +173,7 @@ func (r *SessionReceiver) DeferMessage(ctx context.Context, message *ReceivedMes
 // DeadLetterMessage settles a message by moving it to the dead letter queue for a
 // queue or subscription. To receive these messages create a receiver with `Client.NewReceiverForQueue()`
 // or `Client.NewReceiverForSubscription()` using the `ReceiverOptions.SubQueue` option.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *SessionReceiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
 	return r.inner.DeadLetterMessage(ctx, message, options)
 }
@@ -197,7 +197,7 @@ type GetSessionStateOptions struct {
 }
 
 // GetSessionState retrieves state associated with the session.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (sr *SessionReceiver) GetSessionState(ctx context.Context, options *GetSessionStateOptions) ([]byte, error) {
 	var sessionState []byte
 
@@ -221,7 +221,7 @@ type SetSessionStateOptions struct {
 }
 
 // SetSessionState sets the state associated with the session.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (sr *SessionReceiver) SetSessionState(ctx context.Context, state []byte, options *SetSessionStateOptions) error {
 	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return internal.SetSessionState(ctx, lwv.RPC, sr.SessionID(), state)
@@ -237,7 +237,7 @@ type RenewSessionLockOptions struct {
 
 // RenewSessionLock renews this session's lock. The new expiration time is available
 // using `LockedUntil`.
-// If the operation fails it can return an azservicebus.Error type if the failure is actionable.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (sr *SessionReceiver) RenewSessionLock(ctx context.Context, options *RenewSessionLockOptions) error {
 	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		newLockedUntil, err := internal.RenewSessionLock(ctx, lwv.RPC, *sr.sessionID)

--- a/sdk/messaging/azservicebus/session_receiver_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_test.go
@@ -136,8 +136,7 @@ func TestSessionReceiver_acceptSessionButAlreadyLocked(t *testing.T) {
 	// messages where the lock token is not a predefined value)
 	receiver, err = client.AcceptSessionForQueue(ctx, queueName, "session-1", nil)
 
-	sbe := internal.GetSBErrInfo(err)
-	require.EqualValues(t, internal.RecoveryKindFatal, sbe.RecoveryKind)
+	require.EqualValues(t, internal.RecoveryKindFatal, internal.GetRecoveryKind(err))
 	require.Nil(t, receiver)
 }
 

--- a/sdk/messaging/azservicebus/session_receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_unit_test.go
@@ -31,7 +31,7 @@ func TestSessionReceiverUserFacingErrors(t *testing.T) {
 	}, nil)
 
 	require.Nil(t, receiver)
-	var asSBError Error
+	var asSBError *Error
 	require.ErrorAs(t, err, &asSBError)
 	require.Equal(t, CodeConnectionLost, asSBError.Code)
 

--- a/sdk/messaging/azservicebus/session_receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_unit_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azservicebus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
+	"github.com/Azure/go-amqp"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestSessionReceiverUserFacingErrors(t *testing.T) {
+	fakeAMQPLinks := &internal.FakeAMQPLinks{
+		Err: amqp.ErrConnClosed,
+	}
+
+	receiver, err := newSessionReceiver(context.Background(), newSessionReceiverArgs{
+		ns: &internal.FakeNS{
+			AMQPLinks: fakeAMQPLinks,
+		},
+		retryOptions:   noRetriesNeeded,
+		sessionID:      to.Ptr("session ID"),
+		entity:         entity{Queue: "queue"},
+		cleanupOnClose: func() {},
+	}, nil)
+
+	require.Nil(t, receiver)
+	var asSBError Error
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+
+	// now let's let the receiver work for the first shot and then we'll invalidate it.
+	fakeAMQPLinks.Err = nil
+	fakeAMQPLinks.Receiver = &internal.FakeAMQPReceiver{}
+	fakeRPCLink := &internal.FakeRPCLink{}
+	fakeAMQPLinks.RPC = fakeRPCLink
+
+	fakeRPCLink.Resp = &internal.RPCResponse{
+		Message: &amqp.Message{
+			Value: map[string]interface{}{
+				"expiration": time.Now(),
+			},
+		},
+	}
+
+	receiver, err = newSessionReceiver(context.Background(), newSessionReceiverArgs{
+		ns: &internal.FakeNS{
+			AMQPLinks: fakeAMQPLinks,
+		},
+		retryOptions:   noRetriesNeeded,
+		sessionID:      to.Ptr("session ID"),
+		entity:         entity{Queue: "queue"},
+		cleanupOnClose: func() {},
+	}, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, receiver)
+
+	fakeRPCLink.Resp = nil
+	fakeRPCLink.Error = internal.RPCError{Resp: &internal.RPCResponse{Code: internal.RPCResponseCodeLockLost}}
+
+	state, err := receiver.GetSessionState(context.Background(), nil)
+	require.Nil(t, state)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
+
+	err = receiver.SetSessionState(context.Background(), []byte{}, nil)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
+
+	err = receiver.RenewSessionLock(context.Background(), nil)
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeLockLost, asSBError.Code)
+
+	// there's an init() method that's a little harder to trigger, so we'll do that here.
+	// Unlike the others above it doesn't rely on the management$ link.
+	fakeAMQPLinks.Err = amqp.ErrConnClosed
+	err = receiver.init(context.Background())
+	require.ErrorAs(t, err, &asSBError)
+	require.Equal(t, CodeConnectionLost, asSBError.Code)
+}
+
+var noRetriesNeeded = exported.RetryOptions{
+	MaxRetries:    0,
+	RetryDelay:    0,
+	MaxRetryDelay: 0,
+}


### PR DESCRIPTION
Created `azservicebus.Error` to represent errors that a customer can use programatically.

azservicebus.Error contains a code that customers can use, which is considered stable and part of the supported API. 

Today we only have two codes - CodeLockLost, which comes back if the lock has expired and CodeConnectionLost, which comes back if we failed on an error that is retryable.

Fixes #17283