### PR TITLE
Cosmos DB: Update next release as version 0.3.0

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.1 (Unreleased)
+## 0.3.0 (Unreleased)
 
 ### Features Added
 * Added single partition query support.

--- a/sdk/data/azcosmos/version.go
+++ b/sdk/data/azcosmos/version.go
@@ -4,4 +4,4 @@
 package azcosmos
 
 // serviceLibVersion is the semantic version (see http://semver.org) of this module.
-const serviceLibVersion = "v0.2.1" //nolint
+const serviceLibVersion = "v0.3.0" //nolint


### PR DESCRIPTION
Next release will introduce new APIs, following semver, it should be `0.3.0`, not `0.2.1`