### PR TITLE
Update azkeys test-resources.json

### DIFF
--- a/sdk/keyvault/azkeys/client_test.go
+++ b/sdk/keyvault/azkeys/client_test.go
@@ -779,8 +779,8 @@ func TestGetKeyRotationPolicy(t *testing.T) {
 	}
 }
 
-// This test is not ready, it will be ready in the 7.4 swagger, leaving this test for once that change is made.
 func TestReleaseKey(t *testing.T) {
+	t.Skip("key release isn't supported yet")
 	for _, testType := range testTypes {
 		t.Run(fmt.Sprintf("%s_%s", t.Name(), testType), func(t *testing.T) {
 			alwaysSkipHSM(t, testType)

--- a/sdk/keyvault/azkeys/test-resources.json
+++ b/sdk/keyvault/azkeys/test-resources.json
@@ -37,25 +37,36 @@
         },
         "hsmLocation": {
             "type": "string",
-            "defaultValue": "southcentralus",
+            "defaultValue": "westus3",
             "allowedValues": [
                 "australiacentral",
+                "australiaeast",
                 "canadacentral",
+                "canadaeast",
+                "centralindia",
                 "centralus",
                 "eastasia",
+                "eastus",
                 "eastus2",
+                "francecentral",
+                "japaneast",
                 "koreacentral",
+                "northcentralus",
                 "northeurope",
                 "southafricanorth",
                 "southcentralus",
-                "southeastasia",
                 "switzerlandnorth",
+                "switzerlandwest",
+                "uaenorth",
                 "uksouth",
+                "westcentralus",
                 "westeurope",
-                "westus"
+                "westus",
+                "westus2",
+                "westus3"
             ],
             "metadata": {
-                "description": "The location of the Managed HSM. By default, this is 'southcentralus'."
+                "description": "The location of the Managed HSM. By default, this is 'westus3'."
             }
         },
         "enableHsm": {
@@ -86,6 +97,8 @@
         "attestationUri": "[concat('DOCKER|azsdkengsys.azurecr.io/', parameters('attestationImage'))]",
         "kvApiVersion": "2019-09-01",
         "kvName": "[parameters('baseName')]",
+        "kvAdminDefinitionId": "00482a5a-887f-4fb3-b363-3b7fe8e74483",
+        "kvAdminAssignmentName": "[guid(resourceGroup().id, variables('kvAdminDefinitionId'), parameters('testApplicationOid'))]",
         "hsmApiVersion": "2021-04-01-preview",
         "hsmName": "[concat(parameters('baseName'), 'hsm')]",
         "mgmtApiVersion": "2019-04-01",
@@ -118,69 +131,22 @@
                     "name": "[parameters('keyVaultSku')]"
                 },
                 "tenantId": "[parameters('tenantId')]",
-                "accessPolicies": [
-                    {
-                        "tenantId": "[parameters('tenantId')]",
-                        "objectId": "[parameters('testApplicationOid')]",
-                        "permissions": {
-                            "keys": [
-                                "backup",
-                                "create",
-                                "decrypt",
-                                "delete",
-                                "encrypt",
-                                "get",
-                                "import",
-                                "list",
-                                "purge",
-                                "recover",
-                                "release",
-                                "restore",
-                                "rotate",
-                                "setrotationpolicy",
-                                "getrotationpolicy",
-                                "sign",
-                                "unwrapKey",
-                                "update",
-                                "verify",
-                                "wrapKey"
-                            ],
-                            "secrets": [
-                                "backup",
-                                "delete",
-                                "get",
-                                "list",
-                                "purge",
-                                "recover",
-                                "restore",
-                                "set"
-                            ],
-                            "certificates": [
-                                "backup",
-                                "create",
-                                "delete",
-                                "deleteissuers",
-                                "get",
-                                "getissuers",
-                                "import",
-                                "list",
-                                "listissuers",
-                                "managecontacts",
-                                "manageissuers",
-                                "purge",
-                                "recover",
-                                "restore",
-                                "setissuers",
-                                "update"
-                            ]
-                        }
-                    }
-                ],
                 "enabledForDeployment": false,
                 "enabledForDiskEncryption": false,
                 "enabledForTemplateDeployment": false,
                 "enableSoftDelete": true,
+                "enableRbacAuthorization": true,
                 "softDeleteRetentionInDays": 7
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-04-01-preview",
+            "name": "[variables('kvAdminAssignmentName')]",
+            "properties": {
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('kvAdminDefinitionId'))]",
+                "principalId": "[parameters('testApplicationOid')]",
+                "scope": "[resourceGroup().id]"
             }
         },
         {
@@ -257,7 +223,6 @@
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2020-12-01",
             "name": "[variables('attestationFarm')]",
-            "condition": "[parameters('enableHsm')]",
             "location": "[parameters('location')]",
             "kind": "linux",
             "sku": {
@@ -272,7 +237,6 @@
             "type": "Microsoft.Web/sites",
             "apiVersion": "2020-12-01",
             "name": "[variables('attestationSite')]",
-            "condition": "[parameters('enableHsm')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('attestationFarm'))]"
             ],
@@ -326,7 +290,6 @@
         },
         "AZURE_KEYVAULT_ATTESTATION_URL": {
             "type": "string",
-            "condition": "[parameters('enableHsm')]",
             "value": "[format('https://{0}/', reference(variables('attestationSite')).defaultHostName)]"
         }
     }


### PR DESCRIPTION
Copying the latest `test-resources.json` from .NET, setting the MHSM deployment region to westus3 to avoid contention, and skipping a troublesome test (which I'll unskip in a future PR). That should get the azkeys nightly run to pass 🤞 