### PR TITLE
Renamed PageProcessor to PagingHandler

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -14,6 +14,7 @@
 * `Poller[T].PollUntilDone()` now takes an `options *PollUntilDoneOptions` param instead of `freq time.Duration`
 * Removed `arm/runtime.Poller[T]`, `arm/runtime.NewPoller[T]()` and `arm/runtime.NewPollerFromResumeToken[T]()`
 * Removed `arm/runtime.FinalStateVia` and related `const` values
+* Renamed `runtime.PageProcessor` to `runtime.PagingHandler`
 
 ### Bugs Fixed
 * When per-try timeouts are enabled, only cancel the context after the body has been read and closed.

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -48,7 +48,7 @@ func TestPagerSinglePage(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [1, 2, 3, 4, 5]}`)))
 	pl := exported.NewPipeline(srv)
 
-	pager := NewPager(PageProcessor[PageResponse]{
+	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
 			return current.NextPage
 		},
@@ -81,7 +81,7 @@ func TestPagerMultiplePages(t *testing.T) {
 	pl := exported.NewPipeline(srv)
 
 	pageCount := 0
-	pager := NewPager(PageProcessor[PageResponse]{
+	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
 			return current.NextPage
 		},
@@ -124,7 +124,7 @@ func TestPagerLROMultiplePages(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [6, 7, 8]}`)))
 	pl := exported.NewPipeline(srv)
 
-	pager := NewPager(PageProcessor[PageResponse]{
+	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
 			return current.NextPage
 		},
@@ -157,7 +157,7 @@ func TestPagerLROMultiplePages(t *testing.T) {
 }
 
 func TestPagerFetcherError(t *testing.T) {
-	pager := NewPager(PageProcessor[PageResponse]{
+	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
 			return current.NextPage
 		},
@@ -178,7 +178,7 @@ func TestPagerPipelineError(t *testing.T) {
 	srv.SetError(errors.New("pipeline failed"))
 	pl := exported.NewPipeline(srv)
 
-	pager := NewPager(PageProcessor[PageResponse]{
+	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
 			return current.NextPage
 		},
@@ -201,7 +201,7 @@ func TestPagerSecondPageError(t *testing.T) {
 	pl := exported.NewPipeline(srv)
 
 	pageCount := 0
-	pager := NewPager(PageProcessor[PageResponse]{
+	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
 			return current.NextPage
 		},
@@ -242,7 +242,7 @@ func TestPagerResponderError(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`incorrect JSON response`)))
 	pl := exported.NewPipeline(srv)
 
-	pager := NewPager(PageProcessor[PageResponse]{
+	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
 			return current.NextPage
 		},


### PR DESCRIPTION
This is to align the naming with PollingHandler which is similar in
concept but for pollers.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
