### PR TITLE
Unexport some types that aren't supposed to be

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Removed `arm/runtime.Poller[T]`, `arm/runtime.NewPoller[T]()` and `arm/runtime.NewPollerFromResumeToken[T]()`
 * Removed `arm/runtime.FinalStateVia` and related `const` values
 * Renamed `runtime.PageProcessor` to `runtime.PagingHandler`
+* The `arm/runtime.ProviderRepsonse` and `arm/runtime.Provider` types are no longer exported.
 
 ### Bugs Fixed
 * When per-try timeouts are enabled, only cancel the context after the body has been read and closed.

--- a/sdk/azcore/arm/runtime/policy_register_rp.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp.go
@@ -214,18 +214,18 @@ type providersOperations struct {
 }
 
 // Get - Gets the specified resource provider.
-func (client *providersOperations) Get(ctx context.Context, resourceProviderNamespace string) (*ProviderResponse, error) {
+func (client *providersOperations) Get(ctx context.Context, resourceProviderNamespace string) (providerResponse, error) {
 	req, err := client.getCreateRequest(ctx, resourceProviderNamespace)
 	if err != nil {
-		return nil, err
+		return providerResponse{}, err
 	}
 	resp, err := client.p.Do(req)
 	if err != nil {
-		return nil, err
+		return providerResponse{}, err
 	}
 	result, err := client.getHandleResponse(resp)
 	if err != nil {
-		return nil, err
+		return providerResponse{}, err
 	}
 	return result, nil
 }
@@ -246,31 +246,31 @@ func (client *providersOperations) getCreateRequest(ctx context.Context, resourc
 }
 
 // getHandleResponse handles the Get response.
-func (client *providersOperations) getHandleResponse(resp *http.Response) (*ProviderResponse, error) {
+func (client *providersOperations) getHandleResponse(resp *http.Response) (providerResponse, error) {
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return nil, exported.NewResponseError(resp)
+		return providerResponse{}, exported.NewResponseError(resp)
 	}
-	result := ProviderResponse{RawResponse: resp}
+	result := providerResponse{RawResponse: resp}
 	err := runtime.UnmarshalAsJSON(resp, &result.Provider)
 	if err != nil {
-		return nil, err
+		return providerResponse{}, err
 	}
-	return &result, err
+	return result, err
 }
 
 // Register - Registers a subscription with a resource provider.
-func (client *providersOperations) Register(ctx context.Context, resourceProviderNamespace string) (*ProviderResponse, error) {
+func (client *providersOperations) Register(ctx context.Context, resourceProviderNamespace string) (providerResponse, error) {
 	req, err := client.registerCreateRequest(ctx, resourceProviderNamespace)
 	if err != nil {
-		return nil, err
+		return providerResponse{}, err
 	}
 	resp, err := client.p.Do(req)
 	if err != nil {
-		return nil, err
+		return providerResponse{}, err
 	}
 	result, err := client.registerHandleResponse(resp)
 	if err != nil {
-		return nil, err
+		return providerResponse{}, err
 	}
 	return result, nil
 }
@@ -291,29 +291,29 @@ func (client *providersOperations) registerCreateRequest(ctx context.Context, re
 }
 
 // registerHandleResponse handles the Register response.
-func (client *providersOperations) registerHandleResponse(resp *http.Response) (*ProviderResponse, error) {
+func (client *providersOperations) registerHandleResponse(resp *http.Response) (providerResponse, error) {
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return nil, exported.NewResponseError(resp)
+		return providerResponse{}, exported.NewResponseError(resp)
 	}
-	result := ProviderResponse{RawResponse: resp}
+	result := providerResponse{RawResponse: resp}
 	err := runtime.UnmarshalAsJSON(resp, &result.Provider)
 	if err != nil {
-		return nil, err
+		return providerResponse{}, err
 	}
-	return &result, err
+	return result, err
 }
 
 // ProviderResponse is the response envelope for operations that return a Provider type.
-type ProviderResponse struct {
+type providerResponse struct {
 	// Resource provider information.
-	Provider *Provider
+	Provider *provider
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
 // Provider - Resource provider information.
-type Provider struct {
+type provider struct {
 	// The provider ID.
 	ID *string `json:"id,omitempty"`
 


### PR DESCRIPTION
Cleaned up response envelopes per latest pattern.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
