### PR TITLE
Return AuthenticationFailedError by pointer

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Breaking Changes
 * Removed `AuthorizationCodeCredential`. Use `InteractiveBrowserCredential` instead
   to authenticate a user with the authorization code flow.
+* Instances of `AuthenticationFailedError` are now returned by pointer.
 
 ### Bugs Fixed
 * `AzureCLICredential` panics after receiving an unexpected error type

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -90,7 +90,7 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.Token
 			break
 		}
 		errs = append(errs, err)
-		if _, ok := err.(credentialUnavailableError); !ok {
+		if _, ok := err.(*credentialUnavailableError); !ok {
 			break
 		}
 	}
@@ -105,7 +105,7 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.Token
 	if err != nil {
 		// return credentialUnavailableError iff all sources did so; return AuthenticationFailedError otherwise
 		msg := createChainedErrorMessage(errs)
-		if _, ok := err.(credentialUnavailableError); ok {
+		if _, ok := err.(*credentialUnavailableError); ok {
 			err = newCredentialUnavailableError(c.name, msg)
 		} else {
 			res := getResponseFromError(err)

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -117,7 +117,7 @@ func TestChainedTokenCredential_GetTokenFail(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
-	var authErr AuthenticationFailedError
+	var authErr *AuthenticationFailedError
 	if !errors.As(err, &authErr) {
 		t.Fatalf("Expected AuthenticationFailedError, received %T", err)
 	}
@@ -141,7 +141,7 @@ func TestChainedTokenCredential_MultipleCredentialsGetTokenUnavailable(t *testin
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
-	var authErr credentialUnavailableError
+	var authErr *credentialUnavailableError
 	if !errors.As(err, &authErr) {
 		t.Fatalf("Expected CredentialUnavailableError, received %T", err)
 	}
@@ -170,7 +170,7 @@ func TestChainedTokenCredential_MultipleCredentialsGetTokenAuthenticationFailed(
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
-	var authErr AuthenticationFailedError
+	var authErr *AuthenticationFailedError
 	if !errors.As(err, &authErr) {
 		t.Fatalf("Expected AuthenticationFailedError, received %T", err)
 	}
@@ -196,7 +196,7 @@ func TestChainedTokenCredential_MultipleCredentialsGetTokenCustomName(t *testing
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
-	var authErr credentialUnavailableError
+	var authErr *credentialUnavailableError
 	if !errors.As(err, &authErr) {
 		t.Fatalf("Expected credentialUnavailableError, received %T", err)
 	}

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -232,7 +232,7 @@ func TestClientCertificateCredential_InvalidCertLive(t *testing.T) {
 	if tk != nil {
 		t.Fatal("GetToken returned a token")
 	}
-	var e AuthenticationFailedError
+	var e *AuthenticationFailedError
 	if !errors.As(err, &e) {
 		t.Fatal("expected AuthenticationFailedError")
 	}

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -58,7 +58,7 @@ func TestClientSecretCredential_InvalidSecretLive(t *testing.T) {
 	if tk != nil {
 		t.Fatal("GetToken returned a token")
 	}
-	var e AuthenticationFailedError
+	var e *AuthenticationFailedError
 	if !errors.As(err, &e) {
 		t.Fatal("expected AuthenticationFailedError")
 	}

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -120,7 +120,7 @@ type defaultCredentialErrorReporter struct {
 }
 
 func (d *defaultCredentialErrorReporter) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (token *azcore.AccessToken, err error) {
-	if _, ok := d.err.(credentialUnavailableError); ok {
+	if _, ok := d.err.(*credentialUnavailableError); ok {
 		return nil, d.err
 	}
 	return nil, newCredentialUnavailableError(d.credType, d.err.Error())

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -221,7 +221,7 @@ func TestEnvironmentCredential_InvalidClientSecretLive(t *testing.T) {
 	if tk != nil {
 		t.Fatal("GetToken returned a token")
 	}
-	var e AuthenticationFailedError
+	var e *AuthenticationFailedError
 	if !errors.As(err, &e) {
 		t.Fatal("expected AuthenticationFailedError")
 	}
@@ -265,7 +265,7 @@ func TestEnvironmentCredential_InvalidPasswordLive(t *testing.T) {
 	if tk != nil {
 		t.Fatal("GetToken returned a token")
 	}
-	var e AuthenticationFailedError
+	var e *AuthenticationFailedError
 	if !errors.As(err, &e) {
 		t.Fatal("expected AuthenticationFailedError")
 	}

--- a/sdk/azidentity/errors.go
+++ b/sdk/azidentity/errors.go
@@ -18,7 +18,7 @@ import (
 // getResponseFromError retrieves the response carried by
 // an AuthenticationFailedError or MSAL CallErr, if any
 func getResponseFromError(err error) *http.Response {
-	var a AuthenticationFailedError
+	var a *AuthenticationFailedError
 	var c msal.CallErr
 	var res *http.Response
 	if errors.As(err, &c) {
@@ -38,17 +38,17 @@ type AuthenticationFailedError struct {
 	message  string
 }
 
-func newAuthenticationFailedError(credType string, message string, resp *http.Response) AuthenticationFailedError {
-	return AuthenticationFailedError{credType: credType, message: message, RawResponse: resp}
+func newAuthenticationFailedError(credType string, message string, resp *http.Response) error {
+	return &AuthenticationFailedError{credType: credType, message: message, RawResponse: resp}
 }
 
-func newAuthenticationFailedErrorFromMSALError(credType string, err error) AuthenticationFailedError {
+func newAuthenticationFailedErrorFromMSALError(credType string, err error) error {
 	res := getResponseFromError(err)
 	return newAuthenticationFailedError(credType, err.Error(), res)
 }
 
 // Error implements the error interface. Note that the message contents are not contractual and can change over time.
-func (e AuthenticationFailedError) Error() string {
+func (e *AuthenticationFailedError) Error() string {
 	if e.RawResponse == nil {
 		return e.credType + ": " + e.message
 	}
@@ -76,7 +76,7 @@ func (e AuthenticationFailedError) Error() string {
 }
 
 // NonRetriable indicates the request which provoked this error shouldn't be retried.
-func (AuthenticationFailedError) NonRetriable() {
+func (*AuthenticationFailedError) NonRetriable() {
 	// marker method
 }
 
@@ -89,16 +89,16 @@ type credentialUnavailableError struct {
 	message  string
 }
 
-func newCredentialUnavailableError(credType, message string) credentialUnavailableError {
-	return credentialUnavailableError{credType: credType, message: message}
+func newCredentialUnavailableError(credType, message string) error {
+	return &credentialUnavailableError{credType: credType, message: message}
 }
 
-func (e credentialUnavailableError) Error() string {
+func (e *credentialUnavailableError) Error() string {
 	return e.credType + ": " + e.message
 }
 
 // NonRetriable indicates that this error should not be retried.
-func (e credentialUnavailableError) NonRetriable() {
+func (e *credentialUnavailableError) NonRetriable() {
 	// marker method
 }
 

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -230,7 +230,7 @@ func TestManagedIdentityCredential_GetTokenIMDS400(t *testing.T) {
 		t.Fatal(err)
 	}
 	// cred should return credentialUnavailableError when IMDS responds 400 to a token request
-	var expected credentialUnavailableError
+	var expected *credentialUnavailableError
 	for i := 0; i < 3; i++ {
 		_, err = cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 		if !errors.As(err, &expected) {
@@ -510,7 +510,7 @@ func TestManagedIdentityCredential_IMDSTimeoutExceeded(t *testing.T) {
 	}
 	cred.client.imdsTimeout = time.Nanosecond
 	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
-	var expected credentialUnavailableError
+	var expected *credentialUnavailableError
 	if !errors.As(err, &expected) {
 		t.Fatalf(`expected credentialUnavailableError, got %T: "%v"`, err, err)
 	}

--- a/sdk/azidentity/username_password_credential_test.go
+++ b/sdk/azidentity/username_password_credential_test.go
@@ -56,7 +56,7 @@ func TestUsernamePasswordCredential_InvalidPasswordLive(t *testing.T) {
 	if tk != nil {
 		t.Fatal("GetToken returned a token")
 	}
-	var e AuthenticationFailedError
+	var e *AuthenticationFailedError
 	if !errors.As(err, &e) {
 		t.Fatal("expected AuthenticationFailedError")
 	}


### PR DESCRIPTION
To be consistent with other errors returned from our SDKs.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
