### PR TITLE
Do not include Authorization header if access token is empty

### DIFF
--- a/sdk/azcore/arm/runtime/policy_bearer_token.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token.go
@@ -68,6 +68,9 @@ func (b *BearerTokenPolicy) Do(req *azpolicy.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	if tk.Token == "" {
+		return req.Next()
+	}
 	req.Raw().Header.Set(shared.HeaderAuthorization, shared.BearerTokenPrefix+tk.Token)
 	auxTokens := []string{}
 	for tenant, er := range b.auxResources {


### PR DESCRIPTION
If the token provider returns an empty token, then do not include the Authorization header.

Why -> This is helpful when working against dev environments that do not use headers for authorization. This way, we can simply provide a "no-op" token provider like:

```go
type NoOpTokenProvider struct{}

func (NoOpTokenProvider) GetToken(ctx context.Context, options policy.TokenRequestOptions) (*azcore.AccessToken, error) {
	return &azcore.AccessToken{
		Token:     "",
		ExpiresOn: time.Now().Add(10000 * time.Hour),
	}, nil
}
```

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [X] The purpose of this PR is explained in this or a referenced issue.
- [ X The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [X] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
