### PR TITLE
Service Bus: export NewReceivedMessage

### DIFF
--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -205,10 +205,10 @@ func (m *Message) toAMQPMessage() *amqp.Message {
 	return amqpMsg
 }
 
-// newReceivedMessage creates a received message from an AMQP message.
+// NewReceivedMessage creates a received message from an AMQP message.
 // NOTE: this converter assumes that the Body of this message will be the first
 // serialized byte array in the Data section of the messsage.
-func newReceivedMessage(amqpMsg *amqp.Message) *ReceivedMessage {
+func NewReceivedMessage(amqpMsg *amqp.Message) *ReceivedMessage {
 	msg := &ReceivedMessage{
 		rawAMQPMessage: amqpMsg,
 		State:          MessageStateActive,

--- a/sdk/messaging/azservicebus/message_test.go
+++ b/sdk/messaging/azservicebus/message_test.go
@@ -52,7 +52,7 @@ func TestMessageUnitTest(t *testing.T) {
 func TestAMQPMessageToReceivedMessage(t *testing.T) {
 	t.Run("empty_message", func(t *testing.T) {
 		// nothing should blow up.
-		rm := newReceivedMessage(&amqp.Message{})
+		rm := NewReceivedMessage(&amqp.Message{})
 		require.NotNil(t, rm)
 	})
 
@@ -72,7 +72,7 @@ func TestAMQPMessageToReceivedMessage(t *testing.T) {
 			},
 		}
 
-		receivedMessage := newReceivedMessage(amqpMessage)
+		receivedMessage := NewReceivedMessage(amqpMessage)
 
 		require.EqualValues(t, lockedUntil, *receivedMessage.LockedUntil)
 		require.EqualValues(t, int64(101), *receivedMessage.SequenceNumber)
@@ -132,7 +132,7 @@ func TestAMQPMessageToMessage(t *testing.T) {
 		Data: [][]byte{[]byte("foo")},
 	}
 
-	msg := newReceivedMessage(amqpMsg)
+	msg := NewReceivedMessage(amqpMsg)
 
 	require.EqualValues(t, msg.MessageID, amqpMsg.Properties.MessageID, "messageID")
 	require.EqualValues(t, msg.SessionID, amqpMsg.Properties.GroupID, "groupID")
@@ -175,7 +175,7 @@ func TestMessageState(t *testing.T) {
 
 	for _, td := range testData {
 		t.Run(fmt.Sprintf("Value '%v' => %d", td.PropValue, td.Expected), func(t *testing.T) {
-			m := newReceivedMessage(&amqp.Message{
+			m := NewReceivedMessage(&amqp.Message{
 				Annotations: amqp.Annotations{
 					messageStateAnnotation: td.PropValue,
 				},
@@ -185,7 +185,7 @@ func TestMessageState(t *testing.T) {
 	}
 
 	t.Run("NoAnnotations", func(t *testing.T) {
-		m := newReceivedMessage(&amqp.Message{
+		m := NewReceivedMessage(&amqp.Message{
 			Annotations: nil,
 		})
 		require.EqualValues(t, MessageStateActive, m.State)

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -219,7 +219,7 @@ func (r *Receiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers 
 		}
 
 		for _, amqpMsg := range amqpMessages {
-			receivedMsg := newReceivedMessage(amqpMsg)
+			receivedMsg := NewReceivedMessage(amqpMsg)
 			receivedMsg.deferred = true
 
 			receivedMessages = append(receivedMessages, receivedMsg)
@@ -264,7 +264,7 @@ func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, option
 		receivedMessages = make([]*ReceivedMessage, len(messages))
 
 		for i := 0; i < len(messages); i++ {
-			receivedMessages[i] = newReceivedMessage(messages[i])
+			receivedMessages[i] = NewReceivedMessage(messages[i])
 		}
 
 		if len(receivedMessages) > 0 && updateInternalSequenceNumber {
@@ -439,7 +439,7 @@ func fetchMessages(ctx context.Context, receiver internal.AMQPReceiver, maxMessa
 			return err
 		}
 
-		*messages = append(*messages, newReceivedMessage(amqpMessage))
+		*messages = append(*messages, NewReceivedMessage(amqpMessage))
 
 		if len(*messages) == maxMessages {
 			return nil
@@ -465,7 +465,7 @@ func flushPrefetchedMessages(ctx context.Context, receiver internal.AMQPReceiver
 			return
 		}
 
-		*messages = append(*messages, newReceivedMessage(am))
+		*messages = append(*messages, NewReceivedMessage(am))
 	}
 }
 


### PR DESCRIPTION
In sdk/messaging/azureservicebus, the method newReceivedMessage was not exported. This made it really hard for us (Dapr) to create our own unit tests, as without that method we cannot create a ReceivedMessage object with a body.

- [X] The purpose of this PR is explained in this or a referenced issue.
- [X] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [X] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [X] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
