### PR TITLE
Place application specified policies after client default policies

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -31,6 +31,7 @@
   * The implementation in `internal/pollers/poller.go` has been merged into `runtime/poller.go` with some slight modification.
   * The internal poller types had their methods updated to conform to the `runtime.PollingHandler` interface.
   * The creation of resume tokens has been refactored so that implementers of `runtime.PollingHandler` don't need to know about it.
+* `NewPipeline()` places policies from `ClientOptions` after policies from `PipelineOptions`
 
 ## 0.23.1 (2022-04-14)
 

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -18,8 +18,9 @@ import (
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-// NewPipeline creates a pipeline from connection options.
-// The telemetry policy, when enabled, will use the specified module and version info.
+// NewPipeline creates a pipeline from connection options. Policies from ClientOptions are
+// placed after policies from PipelineOptions. The telemetry policy, when enabled, will
+// use the specified module and version info.
 func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azruntime.PipelineOptions, options *arm.ClientOptions) (azruntime.Pipeline, error) {
 	if options == nil {
 		options = &arm.ClientOptions{}

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -24,9 +24,8 @@ type PipelineOptions struct {
 type Pipeline = exported.Pipeline
 
 // NewPipeline creates a pipeline from connection options, with any additional policies as specified.
-// module, version: used by the telemetry policy, when enabled
-// perCall: additional policies to invoke once per request
-// perRetry: additional policies to invoke once per request and once per retry of that request
+// Policies from ClientOptions are placed after policies from PipelineOptions.
+// The module and version parameters are used by the telemetry policy, when enabled.
 func NewPipeline(module, version string, plOpts PipelineOptions, options *policy.ClientOptions) Pipeline {
 	cp := policy.ClientOptions{}
 	if options != nil {
@@ -50,11 +49,11 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 	if !cp.Telemetry.Disabled {
 		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))
 	}
-	policies = append(policies, cp.PerCallPolicies...)
 	policies = append(policies, plOpts.PerCall...)
+	policies = append(policies, cp.PerCallPolicies...)
 	policies = append(policies, NewRetryPolicy(&cp.Retry))
-	policies = append(policies, cp.PerRetryPolicies...)
 	policies = append(policies, plOpts.PerRetry...)
+	policies = append(policies, cp.PerRetryPolicies...)
 	policies = append(policies, NewLogPolicy(&cp.Logging))
 	policies = append(policies, policyFunc(httpHeaderPolicy), policyFunc(bodyDownloadPolicy))
 	transport := cp.Transport


### PR DESCRIPTION
This ensures applications are always able to work around or counteract a client's default policies.