### PR TITLE
Simplify the Result method on PollingHandler

### DIFF
--- a/sdk/azcore/internal/pollers/armloc/loc.go
+++ b/sdk/azcore/internal/pollers/armloc/loc.go
@@ -120,6 +120,6 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 // Result implements the Result method for the Operation interface.
-func (p *Poller[T]) Result(ctx context.Context, out *T) (T, error) {
+func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 	return pollers.ResultHelper(p.resp, pollers.Failed(p.CurState), out)
 }

--- a/sdk/azcore/internal/pollers/armloc/loc_test.go
+++ b/sdk/azcore/internal/pollers/armloc/loc_test.go
@@ -85,9 +85,8 @@ func TestProvisioningStateSuccessNoContent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	err = poller.Result(context.Background(), nil)
 	require.NoError(t, err)
-	require.Empty(t, result)
 }
 
 type widget struct {
@@ -112,7 +111,8 @@ func TestProvisioningStateSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "round", result.Shape)
 }
@@ -135,7 +135,8 @@ func TestProvisioningStateSuccessNoProvisioningState(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "round", result.Shape)
 }
@@ -159,7 +160,8 @@ func TestPollFailedBadRequest(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	var respErr *exported.ResponseError
 	require.ErrorAs(t, err, &respErr)
 	require.Empty(t, result)

--- a/sdk/azcore/internal/pollers/async/async.go
+++ b/sdk/azcore/internal/pollers/async/async.go
@@ -121,11 +121,11 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 	return p.resp, nil
 }
 
-func (p *Poller[T]) Result(ctx context.Context, out *T) (T, error) {
+func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 	if p.resp.StatusCode == http.StatusNoContent {
-		return *new(T), nil
+		return nil
 	} else if pollers.Failed(p.CurState) {
-		return *new(T), exported.NewResponseError(p.resp)
+		return exported.NewResponseError(p.resp)
 	}
 	var req *exported.Request
 	var err error
@@ -144,14 +144,14 @@ func (p *Poller[T]) Result(ctx context.Context, out *T) (T, error) {
 		}
 	}
 	if err != nil {
-		return *new(T), err
+		return err
 	}
 
 	// if a final GET request has been created, execute it
 	if req != nil {
 		resp, err := p.pl.Do(req)
 		if err != nil {
-			return *new(T), err
+			return err
 		}
 		p.resp = resp
 	}

--- a/sdk/azcore/internal/pollers/async/async_test.go
+++ b/sdk/azcore/internal/pollers/async/async_test.go
@@ -133,7 +133,8 @@ func TestFinalGetLocation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "triangle", result.Shape)
 }
@@ -162,7 +163,8 @@ func TestFinalGetOrigin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "circle", result.Shape)
 }
@@ -182,7 +184,8 @@ func TestNoFinalGet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "circle", result.Shape)
 }
@@ -202,7 +205,8 @@ func TestPatchNoFinalGet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "circle", result.Shape)
 }
@@ -223,7 +227,8 @@ func TestPollFailed(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	var respErr *exported.ResponseError
 	require.ErrorAs(t, err, &respErr)
 	require.Empty(t, result)

--- a/sdk/azcore/internal/pollers/body/body.go
+++ b/sdk/azcore/internal/pollers/body/body.go
@@ -125,6 +125,6 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 	return p.resp, nil
 }
 
-func (p *Poller[T]) Result(ctx context.Context, out *T) (T, error) {
+func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 	return pollers.ResultHelper(p.resp, pollers.Failed(p.CurState), out)
 }

--- a/sdk/azcore/internal/pollers/body/body_test.go
+++ b/sdk/azcore/internal/pollers/body/body_test.go
@@ -128,7 +128,8 @@ func TestUpdateNoProvStateSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "rectangle", result.Shape)
 }
@@ -148,9 +149,8 @@ func TestUpdateNoProvState204(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	err = poller.Result(context.Background(), nil)
 	require.NoError(t, err)
-	require.Empty(t, result)
 }
 
 func TestPollFailed(t *testing.T) {
@@ -168,7 +168,8 @@ func TestPollFailed(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	var respErr *exported.ResponseError
 	require.ErrorAs(t, err, &respErr)
 	require.Empty(t, result)

--- a/sdk/azcore/internal/pollers/loc/loc.go
+++ b/sdk/azcore/internal/pollers/loc/loc.go
@@ -100,6 +100,6 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 	return p.resp, nil
 }
 
-func (p *Poller[T]) Result(ctx context.Context, out *T) (T, error) {
+func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 	return pollers.ResultHelper(p.resp, p.resp.StatusCode > 399, out)
 }

--- a/sdk/azcore/internal/pollers/loc/loc_test.go
+++ b/sdk/azcore/internal/pollers/loc/loc_test.go
@@ -84,9 +84,8 @@ func TestUpdateSucceeded(t *testing.T) {
 	resp, err = poller.Poll(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	result, err := poller.Result(context.Background(), nil)
+	err = poller.Result(context.Background(), nil)
 	require.NoError(t, err)
-	require.Empty(t, result)
 }
 
 func TestUpdateFailed(t *testing.T) {
@@ -118,7 +117,6 @@ func TestUpdateFailed(t *testing.T) {
 	require.False(t, poller.Done())
 	resp, err = poller.Poll(context.Background())
 	require.NoError(t, err)
-	result, err := poller.Result(context.Background(), nil)
+	err = poller.Result(context.Background(), nil)
 	require.Error(t, err)
-	require.Empty(t, result)
 }

--- a/sdk/azcore/internal/pollers/op/op_test.go
+++ b/sdk/azcore/internal/pollers/op/op_test.go
@@ -116,7 +116,8 @@ func TestFinalStateViaLocation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "triangle", result.Shape)
 }
@@ -136,7 +137,8 @@ func TestFinalStateViaOperationLocationWithPost(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "rhombus", result.Shape)
 }
@@ -165,7 +167,8 @@ func TestFinalStateViaResourceLocation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "square", result.Shape)
 }
@@ -194,7 +197,8 @@ func TestResultForPatch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "square", result.Shape)
 }
@@ -224,7 +228,8 @@ func TestPostWithLocation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.NoError(t, err)
 	require.Equal(t, "triangle", result.Shape)
 }
@@ -244,7 +249,8 @@ func TestOperationFailed(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	require.True(t, poller.Done())
-	result, err := poller.Result(context.Background(), nil)
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	var respErr *exported.ResponseError
 	require.ErrorAs(t, err, &respErr)
 	require.Equal(t, "InvalidSomething", respErr.ErrorCode)

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -60,11 +60,15 @@ func NewPoller[T any](resp *http.Response, pl exported.Pipeline, options *NewPol
 	if options == nil {
 		options = &NewPollerOptions[T]{}
 	}
+	result := options.Response
+	if result == nil {
+		result = new(T)
+	}
 	if options.Handler != nil {
 		return &Poller[T]{
 			op:     options.Handler,
 			resp:   resp,
-			result: options.Response,
+			result: result,
 		}, nil
 	}
 
@@ -106,7 +110,7 @@ func NewPoller[T any](resp *http.Response, pl exported.Pipeline, options *NewPol
 	return &Poller[T]{
 		op:     opr,
 		resp:   resp,
-		result: options.Response,
+		result: result,
 	}, nil
 }
 
@@ -124,6 +128,10 @@ type NewPollerFromResumeTokenOptions[T any] struct {
 func NewPollerFromResumeToken[T any](token string, pl exported.Pipeline, options *NewPollerFromResumeTokenOptions[T]) (*Poller[T], error) {
 	if options == nil {
 		options = &NewPollerFromResumeTokenOptions[T]{}
+	}
+	result := options.Response
+	if result == nil {
+		result = new(T)
 	}
 
 	if err := pollers.IsTokenValid[T](token); err != nil {
@@ -160,7 +168,7 @@ func NewPollerFromResumeToken[T any](token string, pl exported.Pipeline, options
 	}
 	return &Poller[T]{
 		op:     opr,
-		result: options.Response,
+		result: result,
 	}, nil
 }
 
@@ -172,9 +180,9 @@ type PollingHandler[T any] interface {
 	// Poll fetches the latest state of the LRO.
 	Poll(context.Context) (*http.Response, error)
 
-	// Result is called once the LRO has reached a terminal state. It returns the result of the operation.
-	// The out parameter is an optional, preconstructed response type to receive the final payload.
-	Result(ctx context.Context, out *T) (T, error)
+	// Result is called once the LRO has reached a terminal state. It populates the out parameter
+	// with the result of the operation.
+	Result(ctx context.Context, out *T) error
 }
 
 // Poller encapsulates a long-running operation, providing polling facilities until the operation reaches a terminal state.
@@ -289,7 +297,7 @@ func (p *Poller[T]) Result(ctx context.Context) (T, error) {
 		}
 		return *p.result, nil
 	}
-	res, err := p.op.Result(ctx, p.result)
+	err := p.op.Result(ctx, p.result)
 	var respErr *exported.ResponseError
 	if errors.As(err, &respErr) {
 		// the LRO failed. record the error
@@ -297,9 +305,6 @@ func (p *Poller[T]) Result(ctx context.Context) (T, error) {
 	} else if err != nil {
 		// the call to Result failed, don't cache anything in this case
 		return *new(T), err
-	} else {
-		// the LRO succeeded. record the result
-		p.result = &res
 	}
 	p.done = true
 	if p.err != nil {


### PR DESCRIPTION
Always use the out parameter and remove the returned T.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
