### PR TITLE
Remove azcore version info from default User-Agent

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -32,6 +32,7 @@
   * The internal poller types had their methods updated to conform to the `runtime.PollingHandler` interface.
   * The creation of resume tokens has been refactored so that implementers of `runtime.PollingHandler` don't need to know about it.
 * `NewPipeline()` places policies from `ClientOptions` after policies from `PipelineOptions`
+* Default User-Agent headers no longer include `azcore` version information
 
 ## 0.23.1 (2022-04-14)
 

--- a/sdk/azcore/runtime/policy_telemetry.go
+++ b/sdk/azcore/runtime/policy_telemetry.go
@@ -45,9 +45,6 @@ func NewTelemetryPolicy(mod, ver string, o *policy.TelemetryOptions) policy.Poli
 	}
 	b.WriteString(formatTelemetry(mod, ver))
 	b.WriteRune(' ')
-	// inject azcore info
-	b.WriteString(formatTelemetry(shared.Module, shared.Version))
-	b.WriteRune(' ')
 	b.WriteString(platformInfo)
 	tp.telemetryValue = b.String()
 	return &tp

--- a/sdk/azcore/runtime/policy_telemetry_test.go
+++ b/sdk/azcore/runtime/policy_telemetry_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
 
-var defaultTelemetry = "azsdk-go-" + shared.Module + "/" + shared.Version + " " + platformInfo
-
 func TestPolicyTelemetryDefault(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
@@ -33,7 +31,7 @@ func TestPolicyTelemetryDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != "azsdk-go-test/v1.2.3 "+defaultTelemetry {
+	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != "azsdk-go-test/v1.2.3 "+platformInfo {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -53,7 +51,7 @@ func TestPolicyTelemetryPreserveExisting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != fmt.Sprintf("%s %s", "azsdk-go-test/v1.2.3 "+defaultTelemetry, otherValue) {
+	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != fmt.Sprintf("%s %s", "azsdk-go-test/v1.2.3 "+platformInfo, otherValue) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -72,7 +70,7 @@ func TestPolicyTelemetryWithAppID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != fmt.Sprintf("%s %s", appID, "azsdk-go-test/v1.2.3 "+defaultTelemetry) {
+	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != fmt.Sprintf("%s %s", appID, "azsdk-go-test/v1.2.3 "+platformInfo) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -92,7 +90,7 @@ func TestPolicyTelemetryWithAppIDSanitized(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	const newAppID = "This/will/get/the/spaces"
-	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != fmt.Sprintf("%s %s", newAppID, "azsdk-go-test/v1.2.3 "+defaultTelemetry) {
+	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != fmt.Sprintf("%s %s", newAppID, "azsdk-go-test/v1.2.3 "+platformInfo) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }
@@ -113,7 +111,7 @@ func TestPolicyTelemetryPreserveExistingWithAppID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != fmt.Sprintf("%s %s %s", appID, "azsdk-go-test/v1.2.3 "+defaultTelemetry, otherValue) {
+	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != fmt.Sprintf("%s %s %s", appID, "azsdk-go-test/v1.2.3 "+platformInfo, otherValue) {
 		t.Fatalf("unexpected user agent value: %s", v)
 	}
 }


### PR DESCRIPTION
Making this change was only a little more work than opening an issue to discuss the change, so here's a PR for discussion 😄 (I don't think this is a release blocker)

The other SDKs don't include their core library version in User-Agent strings, I suppose because the template in the [general design guidelines](https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy) doesn't include it. Does anyone recall the reasoning behind ourformat? Is `azcore` adoption interesting independent of client module adoption?