### PR TITLE
[azservicebus] Handle runtime statistics not yet being available.

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Fixing issue where the AcceptNextSessionForQueue and AcceptNextSessionForSubscription 
   couldn't be cancelled, forcing the user to wait for the service to timeout. (#17598)
+- Fixing issue where an entity can return without runtime properties, causing a panic. (#)
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 - Fixing issue where the AcceptNextSessionForQueue and AcceptNextSessionForSubscription 
   couldn't be cancelled, forcing the user to wait for the service to timeout. (#17598)
-- Fixing issue where an entity can return without runtime properties, causing a panic. (#)
+- Fixing issue where an entity can return without runtime properties, causing a panic. (#17873)
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/admin/admin_client_queue.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_queue.go
@@ -430,14 +430,20 @@ func newQueueItem(env *atom.QueueEnvelope) (*QueueItem, error) {
 func newQueueRuntimePropertiesItem(env *atom.QueueEnvelope) (*QueueRuntimePropertiesItem, error) {
 	desc := env.Content.QueueDescription
 
+	countDetails := desc.CountDetails
+
+	if countDetails == nil {
+		countDetails = &atom.CountDetails{}
+	}
+
 	qrt := &QueueRuntimeProperties{
 		SizeInBytes:                    int64OrZero(desc.SizeInBytes),
 		TotalMessageCount:              int64OrZero(desc.MessageCount),
-		ActiveMessageCount:             int32OrZero(desc.CountDetails.ActiveMessageCount),
-		DeadLetterMessageCount:         int32OrZero(desc.CountDetails.DeadLetterMessageCount),
-		ScheduledMessageCount:          int32OrZero(desc.CountDetails.ScheduledMessageCount),
-		TransferDeadLetterMessageCount: int32OrZero(desc.CountDetails.TransferDeadLetterMessageCount),
-		TransferMessageCount:           int32OrZero(desc.CountDetails.TransferMessageCount),
+		ActiveMessageCount:             countDetails.ActiveMessageCount,
+		DeadLetterMessageCount:         countDetails.DeadLetterMessageCount,
+		ScheduledMessageCount:          countDetails.ScheduledMessageCount,
+		TransferDeadLetterMessageCount: countDetails.TransferDeadLetterMessageCount,
+		TransferMessageCount:           countDetails.TransferMessageCount,
 	}
 
 	var err error

--- a/sdk/messaging/azservicebus/admin/admin_client_subscription.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_subscription.go
@@ -415,12 +415,18 @@ func newSubscriptionItem(env *atom.SubscriptionEnvelope, topicName string) (*Sub
 func newSubscriptionRuntimePropertiesItem(env *atom.SubscriptionEnvelope, topicName string) (*SubscriptionRuntimePropertiesItem, error) {
 	desc := env.Content.SubscriptionDescription
 
+	countDetails := desc.CountDetails
+
+	if countDetails == nil {
+		countDetails = &atom.CountDetails{}
+	}
+
 	rtp := SubscriptionRuntimeProperties{
 		TotalMessageCount:              *desc.MessageCount,
-		ActiveMessageCount:             *desc.CountDetails.ActiveMessageCount,
-		DeadLetterMessageCount:         *desc.CountDetails.DeadLetterMessageCount,
-		TransferMessageCount:           *desc.CountDetails.TransferMessageCount,
-		TransferDeadLetterMessageCount: *desc.CountDetails.TransferDeadLetterMessageCount,
+		ActiveMessageCount:             countDetails.ActiveMessageCount,
+		DeadLetterMessageCount:         countDetails.DeadLetterMessageCount,
+		TransferMessageCount:           countDetails.TransferMessageCount,
+		TransferDeadLetterMessageCount: countDetails.TransferDeadLetterMessageCount,
 	}
 
 	var err error

--- a/sdk/messaging/azservicebus/admin/admin_client_topic.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_topic.go
@@ -386,9 +386,15 @@ func newTopicItem(te *atom.TopicEnvelope) (*TopicItem, error) {
 func newTopicRuntimePropertiesItem(env *atom.TopicEnvelope) (*TopicRuntimePropertiesItem, error) {
 	desc := env.Content.TopicDescription
 
+	countDetails := desc.CountDetails
+
+	if countDetails == nil {
+		countDetails = &atom.CountDetails{}
+	}
+
 	props := &TopicRuntimeProperties{
 		SizeInBytes:           int64OrZero(desc.SizeInBytes),
-		ScheduledMessageCount: int32OrZero(desc.CountDetails.ScheduledMessageCount),
+		ScheduledMessageCount: countDetails.ScheduledMessageCount,
 		SubscriptionCount:     int32OrZero(desc.SubscriptionCount),
 	}
 

--- a/sdk/messaging/azservicebus/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin_client_test.go
@@ -72,7 +72,10 @@ func TestAdminClient_Queue_Forwarding(t *testing.T) {
 	receiver, err := client.NewReceiverForQueue(forwardToQueueName, nil)
 	require.NoError(t, err)
 
-	forwardedMessages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	forwardedMessages, err := receiver.ReceiveMessages(ctx, 1, nil)
 	require.NoError(t, err)
 
 	body, err := forwardedMessages[0].Body()

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -59,11 +59,11 @@ type (
 	// CountDetails has current active (and other) messages for queue/topic.
 	CountDetails struct {
 		XMLName                        xml.Name `xml:"CountDetails"`
-		ActiveMessageCount             *int32   `xml:"ActiveMessageCount,omitempty"`
-		DeadLetterMessageCount         *int32   `xml:"DeadLetterMessageCount,omitempty"`
-		ScheduledMessageCount          *int32   `xml:"ScheduledMessageCount,omitempty"`
-		TransferDeadLetterMessageCount *int32   `xml:"TransferDeadLetterMessageCount,omitempty"`
-		TransferMessageCount           *int32   `xml:"TransferMessageCount,omitempty"`
+		ActiveMessageCount             int32    `xml:"ActiveMessageCount,omitempty"`
+		DeadLetterMessageCount         int32    `xml:"DeadLetterMessageCount,omitempty"`
+		ScheduledMessageCount          int32    `xml:"ScheduledMessageCount,omitempty"`
+		TransferDeadLetterMessageCount int32    `xml:"TransferDeadLetterMessageCount,omitempty"`
+		TransferMessageCount           int32    `xml:"TransferMessageCount,omitempty"`
 	}
 
 	// EntityStatus enumerates the values for entity status.


### PR DESCRIPTION
It's possible for the `CountDetails` in a <Entity>Description to not exist. This is used when you're grabbing runtime properties for an entity.

Fixes #17868