### PR TITLE
[azservicebus] Changing ReceivedMessage.Body() to ReceivedMessage.Body (a field)

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - `admin.Client` can now be configured using `azcore.Options`. (#17796)
 - `ReceivedMessage.TransactionPartitionKey` has been removed as this library doesn't support transactions.
+- `ReceivedMessage.Body()` is now a field. `Body` will be nil in the cases where it would have returned an error (where the underlying AMQP message had a payload in .Value, .Sequence or had multiple byte slices in .Data). (#TBD)
 
 ### Bugs Fixed
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - `admin.Client` can now be configured using `azcore.Options`. (#17796)
 - `ReceivedMessage.TransactionPartitionKey` has been removed as this library doesn't support transactions.
-- `ReceivedMessage.Body()` is now a field. `Body` will be nil in the cases where it would have returned an error (where the underlying AMQP message had a payload in .Value, .Sequence or had multiple byte slices in .Data). (#TBD)
+- `ReceivedMessage.Body()` is now a field. `Body` will be nil in the cases where it would have returned an error (where the underlying AMQP message had a payload in .Value, .Sequence or had multiple byte slices in .Data). (#17888)
 
 ### Bugs Fixed
 

--- a/sdk/messaging/azservicebus/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin_client_test.go
@@ -75,9 +75,7 @@ func TestAdminClient_Queue_Forwarding(t *testing.T) {
 	forwardedMessages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 
-	body, err := forwardedMessages[0].Body()
-	require.NoError(t, err)
-	require.EqualValues(t, "this message will be auto-forwarded", string(body))
+	require.EqualValues(t, "this message will be auto-forwarded", string(forwardedMessages[0].Body))
 }
 
 func TestAdminClient_GetQueueRuntimeProperties(t *testing.T) {

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -120,9 +120,7 @@ func TestNewClientWithWebsockets(t *testing.T) {
 	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 
-	bytes, err := messages[0].Body()
-	require.NoError(t, err)
-	require.EqualValues(t, "hello world", string(bytes))
+	require.EqualValues(t, "hello world", string(messages[0].Body))
 }
 
 func TestNewClientUsingSharedAccessSignature(t *testing.T) {
@@ -154,9 +152,7 @@ func TestNewClientUsingSharedAccessSignature(t *testing.T) {
 	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 
-	bytes, err := messages[0].Body()
-	require.NoError(t, err)
-	require.EqualValues(t, "hello world", string(bytes))
+	require.EqualValues(t, "hello world", string(messages[0].Body))
 }
 
 const fastNotFoundDuration = 10 * time.Second

--- a/sdk/messaging/azservicebus/example_receiver_test.go
+++ b/sdk/messaging/azservicebus/example_receiver_test.go
@@ -88,6 +88,11 @@ func ExampleReceiver_ReceiveMessages() {
 	}
 
 	for _, message := range messages {
+		// The message body is a []byte. For this example we're just assuming that the body
+		// was a string, converted to bytes but any []byte payload is valid.
+		var body []byte = message.Body
+		fmt.Printf("Message received with body: %s\n", string(body))
+
 		// For more information about settling messages:
 		// https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations
 		err = receiver.CompleteMessage(context.TODO(), message, nil)

--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -314,7 +314,7 @@ func newReceivedMessage(amqpMsg *amqp.Message) *ReceivedMessage {
 		State:          MessageStateActive,
 	}
 
-	if msg.rawAMQPMessage.Data != nil && len(msg.rawAMQPMessage.Data) == 1 {
+	if len(msg.rawAMQPMessage.Data) == 1 {
 		msg.Body = msg.rawAMQPMessage.Data[0]
 	}
 

--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -4,7 +4,6 @@
 package azservicebus
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -17,6 +16,11 @@ import (
 type ReceivedMessage struct {
 	// ApplicationProperties can be used to store custom metadata for a message.
 	ApplicationProperties map[string]interface{}
+
+	// Body corresponds to the first byte array in the Data section of an AMQP message.
+	// If the payload for the message is in the Value or Sequence section, or if the Data
+	// section has multiple byte arrays then this field will be nil.
+	Body []byte
 
 	// ContentType describes the payload of the message, with a descriptor following
 	// the format of Content-Type, specified by RFC2045 (ex: "application/json").
@@ -137,17 +141,6 @@ const (
 	// MessageStateScheduled indicates the message is scheduled.
 	MessageStateScheduled MessageState = 2
 )
-
-// Body returns the body for this received message.
-// If the body not compatible with ReceivedMessage this function will return an error.
-func (rm *ReceivedMessage) Body() ([]byte, error) {
-	// TODO: does this come back as a zero length array if the body is empty (which is allowed)
-	if rm.rawAMQPMessage.Data == nil || len(rm.rawAMQPMessage.Data) != 1 {
-		return nil, errors.New("AMQP message Data section is improperly encoded for ReceivedMessage")
-	}
-
-	return rm.rawAMQPMessage.Data[0], nil
-}
 
 // Message is a message with a body and commonly used properties.
 // Properties that are pointers are optional.
@@ -321,6 +314,10 @@ func newReceivedMessage(amqpMsg *amqp.Message) *ReceivedMessage {
 	msg := &ReceivedMessage{
 		rawAMQPMessage: amqpMsg,
 		State:          MessageStateActive,
+	}
+
+	if msg.rawAMQPMessage.Data != nil && len(msg.rawAMQPMessage.Data) == 1 {
+		msg.Body = msg.rawAMQPMessage.Data[0]
 	}
 
 	if amqpMsg.Properties != nil {

--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -17,9 +17,7 @@ type ReceivedMessage struct {
 	// ApplicationProperties can be used to store custom metadata for a message.
 	ApplicationProperties map[string]interface{}
 
-	// Body corresponds to the first byte array in the Data section of an AMQP message.
-	// If the payload for the message is in the Value or Sequence section, or if the Data
-	// section has multiple byte arrays then this field will be nil.
+	// Body is the payload for a message.
 	Body []byte
 
 	// ContentType describes the payload of the message, with a descriptor following

--- a/sdk/messaging/azservicebus/message_test.go
+++ b/sdk/messaging/azservicebus/message_test.go
@@ -143,9 +143,7 @@ func TestAMQPMessageToMessage(t *testing.T) {
 	require.EqualValues(t, msg.To, amqpMsg.Properties.To, "to")
 	require.EqualValues(t, MessageStateActive, msg.State)
 
-	body, err := msg.Body()
-	require.NoError(t, err)
-	require.EqualValues(t, body, amqpMsg.Data[0], "data")
+	require.EqualValues(t, msg.Body, amqpMsg.Data[0], "data")
 
 	expectedAMQPEncodedLockTokenGUID := [16]byte{187, 49, 89, 205, 253, 254, 205, 77, 162, 38, 172, 76, 45, 235, 91, 225}
 

--- a/sdk/messaging/azservicebus/message_test.go
+++ b/sdk/messaging/azservicebus/message_test.go
@@ -60,6 +60,9 @@ func TestAMQPMessageToReceivedMessage(t *testing.T) {
 		scheduledEnqueueTime := time.Now().Add(3 * time.Hour)
 
 		amqpMessage := &amqp.Message{
+			Data: [][]byte{
+				[]byte("hello"),
+			},
 			Annotations: map[interface{}]interface{}{
 				"x-opt-locked-until":            lockedUntil,
 				"x-opt-sequence-number":         int64(101),
@@ -72,6 +75,7 @@ func TestAMQPMessageToReceivedMessage(t *testing.T) {
 
 		receivedMessage := newReceivedMessage(amqpMessage)
 
+		require.Equal(t, []byte("hello"), receivedMessage.Body)
 		require.EqualValues(t, lockedUntil, *receivedMessage.LockedUntil)
 		require.EqualValues(t, int64(101), *receivedMessage.SequenceNumber)
 		require.EqualValues(t, "partitionKey1", *receivedMessage.PartitionKey)
@@ -186,4 +190,29 @@ func TestMessageState(t *testing.T) {
 		})
 		require.EqualValues(t, MessageStateActive, m.State)
 	})
+}
+
+func TestMessageWithIncorrectBody(t *testing.T) {
+	// these are cases where the simple ReceivedMessage can't represent the AMQP message's
+	// payload.
+	message := newReceivedMessage(&amqp.Message{})
+	require.Nil(t, message.Body)
+
+	message = newReceivedMessage(&amqp.Message{
+		Value: "hello",
+	})
+	require.Nil(t, message.Body)
+
+	message = newReceivedMessage(&amqp.Message{
+		Sequence: [][]any{},
+	})
+	require.Nil(t, message.Body)
+
+	message = newReceivedMessage(&amqp.Message{
+		Data: [][]byte{
+			[]byte("hello"),
+			[]byte("world"),
+		},
+	})
+	require.Nil(t, message.Body)
 }

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -60,12 +60,9 @@ func TestReceiverSendFiveReceiveFive(t *testing.T) {
 	require.EqualValues(t, 5, len(messages))
 
 	for i := 0; i < 5; i++ {
-		body, err := messages[i].Body()
-		require.NoError(t, err)
-
 		require.EqualValues(t,
 			fmt.Sprintf("[%d]: send five, receive five", i),
-			string(body))
+			string(messages[i].Body))
 
 		require.NoError(t, receiver.CompleteMessage(context.Background(), messages[i], nil))
 	}
@@ -380,11 +377,8 @@ func TestReceiverPeek(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1, len(repeekedMessages))
 
-	body, err := peekedMessages2[0].Body()
-	require.NoError(t, err)
-
 	require.EqualValues(t, []string{
-		string(body),
+		string(peekedMessages2[0].Body),
 	}, getSortedBodies(repeekedMessages))
 
 	// and peek again (note it won't reset so there'll be "nothing")
@@ -789,19 +783,7 @@ func (messages receivedMessageSlice) Len() int {
 }
 
 func (messages receivedMessageSlice) Less(i, j int) bool {
-	bodyI, err := messages[i].Body()
-
-	if err != nil {
-		panic(err)
-	}
-
-	bodyJ, err := messages[j].Body()
-
-	if err != nil {
-		panic(err)
-	}
-
-	return string(bodyI) < string(bodyJ)
+	return string(messages[i].Body) < string(messages[j].Body)
 }
 
 func (messages receivedMessageSlice) Swap(i, j int) {

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -198,9 +198,7 @@ func Test_Sender_SendMessages_resend(t *testing.T) {
 		require.NoError(t, err)
 
 		require.EqualValues(t, "first send", messages[0].ApplicationProperties["Status"])
-		body, err := messages[0].Body()
-		require.NoError(t, err)
-		require.EqualValues(t, "ResendableMessage", string(body))
+		require.EqualValues(t, "ResendableMessage", string(messages[0].Body))
 
 		if complete {
 			require.NoError(t, receiver.CompleteMessage(ctx, messages[0], nil))
@@ -215,9 +213,7 @@ func Test_Sender_SendMessages_resend(t *testing.T) {
 		messages, err = receiver.ReceiveMessages(ctx, 1, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, "resend", messages[0].ApplicationProperties["Status"])
-		body, err = messages[0].Body()
-		require.NoError(t, err)
-		require.EqualValues(t, "ResendableMessage", string(body))
+		require.EqualValues(t, "ResendableMessage", string(messages[0].Body))
 
 		if complete {
 			require.NoError(t, receiver.CompleteMessage(ctx, messages[0], nil))
@@ -229,14 +225,11 @@ func Test_Sender_SendMessages_resend(t *testing.T) {
 }
 
 func messageFromReceivedMessage(t *testing.T, receivedMessage *ReceivedMessage) *Message {
-	body, err := receivedMessage.Body()
-	require.NoError(t, err)
-
 	newMsg := &Message{
 		MessageID:             &receivedMessage.MessageID,
 		ContentType:           receivedMessage.ContentType,
 		CorrelationID:         receivedMessage.CorrelationID,
-		Body:                  body,
+		Body:                  receivedMessage.Body,
 		SessionID:             receivedMessage.SessionID,
 		Subject:               receivedMessage.Subject,
 		ReplyTo:               receivedMessage.ReplyTo,
@@ -430,13 +423,7 @@ func getSortedBodies(messages []*ReceivedMessage) []string {
 	var bodies []string
 
 	for _, msg := range messages {
-		body, err := msg.Body()
-
-		if err != nil {
-			panic(err)
-		}
-
-		bodies = append(bodies, string(body))
+		bodies = append(bodies, string(msg.Body))
 	}
 
 	return bodies
@@ -450,19 +437,7 @@ func (rm receivedMessages) Len() int {
 
 // Less compares the messages assuming the .Body field is a valid string.
 func (rm receivedMessages) Less(i, j int) bool {
-	bodyI, err := rm[i].Body()
-
-	if err != nil {
-		panic(err)
-	}
-
-	bodyJ, err := rm[j].Body()
-
-	if err != nil {
-		panic(err)
-	}
-
-	return string(bodyI) < string(bodyJ)
+	return string(rm[i].Body) < string(rm[j].Body)
 }
 
 func (rm receivedMessages) Swap(i, j int) {

--- a/sdk/messaging/azservicebus/session_receiver_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_test.go
@@ -43,10 +43,7 @@ func TestSessionReceiver_acceptSession(t *testing.T) {
 	messages, err := receiver.inner.ReceiveMessages(ctx, 1, nil)
 	require.NoError(t, err)
 
-	body, err := messages[0].Body()
-	require.NoError(t, err)
-
-	require.EqualValues(t, "session-based message", body)
+	require.EqualValues(t, "session-based message", messages[0].Body)
 	require.EqualValues(t, "session-1", *messages[0].SessionID)
 	require.NoError(t, receiver.CompleteMessage(ctx, messages[0], nil))
 
@@ -112,11 +109,8 @@ func TestSessionReceiver_blankSessionIDs(t *testing.T) {
 	}
 
 	for _, msg := range received {
-		body, err := msg.Body()
-		require.NoError(t, err)
 		require.EqualValues(t, "", *msg.SessionID)
-
-		require.EqualValues(t, "session-based message", string(body))
+		require.EqualValues(t, "session-based message", string(msg.Body))
 	}
 }
 
@@ -165,9 +159,7 @@ func TestSessionReceiver_acceptNextSession(t *testing.T) {
 	messages, err := receiver.inner.ReceiveMessages(ctx, 1, nil)
 	require.NoError(t, err)
 
-	body, err := messages[0].Body()
-	require.NoError(t, err)
-	require.EqualValues(t, "session-based message", body)
+	require.EqualValues(t, "session-based message", messages[0].Body)
 	require.EqualValues(t, "acceptnextsession-test", *messages[0].SessionID)
 	require.NoError(t, receiver.CompleteMessage(ctx, messages[0], nil))
 


### PR DESCRIPTION
Changed ReceivedMessage.Body() to be a field of type `[]byte`. 

The entire reason it was a function was to return an error in the rare case that the underlying AMQP message was using the Value or Sequence section, rather than Data (or that Data itself was multiple byte arrays, not just a single one). Being a function makes it harder for users to create tests where they pass around `ReceivedMessage` since they can't create it themselves.

In the end it was agreed that just having a nil Body was enough signal for users to know that something was wrong, and that the error that was returned wouldn't have really been actionable (much like Body being nil, it was basically a true/false with exactly one error message).

Thanks to @ItalyPaleAle for pointing this out!

Fixes #17877