### PR TITLE
Check for provisioning state during location polling

### DIFF
--- a/sdk/azcore/internal/pollers/body/body_test.go
+++ b/sdk/azcore/internal/pollers/body/body_test.go
@@ -157,16 +157,16 @@ func TestPollFailed(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, strings.NewReader(`{ "properties": { "provisioningState": "Started" } }`))
 	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
-			StatusCode: http.StatusBadRequest,
+			StatusCode: http.StatusOK,
 			Header:     http.Header{},
-			Body:       io.NopCloser(strings.NewReader(`{ "provisioningState": "failed" }`)),
+			Body:       io.NopCloser(strings.NewReader(`{ "properties": { "provisioningState": "failed" } }`)),
 		}, nil
 	})), resp)
 	require.NoError(t, err)
 	require.False(t, poller.Done())
 	resp, err = poller.Poll(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
 	var result widget
 	err = poller.Result(context.Background(), &result)

--- a/sdk/azcore/internal/pollers/loc/loc.go
+++ b/sdk/azcore/internal/pollers/loc/loc.go
@@ -46,7 +46,7 @@ type Poller[T any] struct {
 
 	Type     string `json:"type"`
 	PollURL  string `json:"pollURL"`
-	CurState int    `json:"state"`
+	CurState string `json:"state"`
 }
 
 // New creates a new Poller from the provided initial response.
@@ -69,13 +69,12 @@ func New[T any](pl exported.Pipeline, resp *http.Response) (*Poller[T], error) {
 		resp:     resp,
 		Type:     kind,
 		PollURL:  locURL,
-		CurState: resp.StatusCode,
+		CurState: pollers.StatusInProgress,
 	}, nil
 }
 
 func (p *Poller[T]) Done() bool {
-	// anything other than a 202 indicates a terminal state
-	return p.CurState != http.StatusAccepted
+	return pollers.IsTerminalState(p.CurState)
 }
 
 func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
@@ -84,15 +83,22 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 		if h := resp.Header.Get(shared.HeaderLocation); h != "" {
 			p.PollURL = h
 		}
-		p.CurState = resp.StatusCode
+		// if provisioning state is available, use that.  this is only
+		// for some ARM LRO scenarios (e.g. DELETE with a Location header)
+		// so if it's missing then use HTTP status code.
+		provState, _ := pollers.GetProvisioningState(resp)
 		p.resp = resp
-		if p.CurState == http.StatusAccepted {
-			return pollers.StatusInProgress, nil
-		} else if p.CurState > 199 && p.CurState < 300 {
+		if provState != "" {
+			p.CurState = provState
+		} else if resp.StatusCode == http.StatusAccepted {
+			p.CurState = pollers.StatusInProgress
+		} else if resp.StatusCode > 199 && resp.StatusCode < 300 {
 			// any 2xx other than a 202 indicates success
-			return pollers.StatusSucceeded, nil
+			p.CurState = pollers.StatusSucceeded
+		} else {
+			p.CurState = pollers.StatusFailed
 		}
-		return pollers.StatusFailed, nil
+		return p.CurState, nil
 	})
 	if err != nil {
 		return nil, err
@@ -101,5 +107,5 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 func (p *Poller[T]) Result(ctx context.Context, out *T) error {
-	return pollers.ResultHelper(p.resp, p.resp.StatusCode > 399, out)
+	return pollers.ResultHelper(p.resp, pollers.Failed(p.CurState), out)
 }


### PR DESCRIPTION
There are a few corner-cases for location polling where ARM can reply
with a provisioning state, so use it if available.
Fixed a test bug for body polling.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
