### PR TITLE
[azservicebus] Quality of life fixes for logging, fix for prefetch.

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 - Fixing issue where the AcceptNextSessionForQueue and AcceptNextSessionForSubscription 
   couldn't be cancelled, forcing the user to wait for the service to timeout. (#17598)
+- Fixing bug where there was a chance that internally cached messages would not be returned when
+  the receiver was draining. (#17893)
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -328,7 +328,7 @@ func (l *AMQPLinksImpl) Retry(ctx context.Context, eventName log.Event, operatio
 				// Whereas normally you'd do (for non-detach errors):
 				//   0th attempt
 				//   (actual retries)
-				log.Writef(exported.EventConn, "Link was previously detached. Attempting quick reconnect to recover from error: %s", err.Error())
+				log.Writef(exported.EventConn, "(%s) Link was previously detached. Attempting quick reconnect to recover from error: %s", operation, err.Error())
 				didQuickRetry = true
 				args.ResetAttempts()
 			}

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -33,7 +33,7 @@ func (pe fakeNetError) Timeout() bool   { return pe.timeout }
 func (pe fakeNetError) Temporary() bool { return pe.temp }
 func (pe fakeNetError) Error() string   { return "Fake but very permanent error" }
 
-func assertFailedLinks(t *testing.T, lwid *LinksWithID, expectedErr error) {
+func assertFailedLinks(t *testing.T, lwid *LinksWithID, expectedErr error, expectedRPCError error) {
 	err := lwid.Sender.Send(context.TODO(), &amqp.Message{
 		Data: [][]byte{
 			{0},
@@ -42,7 +42,7 @@ func assertFailedLinks(t *testing.T, lwid *LinksWithID, expectedErr error) {
 	require.ErrorIs(t, err, expectedErr)
 
 	_, err = PeekMessages(context.TODO(), lwid.RPC, 0, 1)
-	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, expectedRPCError)
 
 	msg, err := lwid.Receiver.Receive(context.TODO())
 	require.ErrorIs(t, err, expectedErr)
@@ -138,7 +138,7 @@ func TestAMQPLinksLive(t *testing.T) {
 	require.NoError(t, amqpClient.Close())
 
 	// all the links are dead because the connection is dead.
-	assertFailedLinks(t, lwr, amqp.ErrConnClosed)
+	assertFailedLinks(t, lwr, amqp.ErrConnClosed, amqp.ErrConnClosed)
 
 	// now we'll recover, which should recreate everything
 	require.NoError(t, links.RecoverIfNeeded(context.Background(), lwr.ID, amqp.ErrConnClosed))
@@ -156,7 +156,7 @@ func TestAMQPLinksLive(t *testing.T) {
 	_ = actualLinks.Receiver.Close(context.Background())
 	_ = actualLinks.RPCLink.Close(context.Background())
 
-	assertFailedLinks(t, lwr, amqp.ErrLinkClosed)
+	assertFailedLinks(t, lwr, amqp.ErrLinkClosed, context.Canceled)
 
 	lwr, err = links.Get(context.Background())
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -621,7 +621,7 @@ func TestAMQPLinksRetriesUnit(t *testing.T) {
 
 			var attempts []int32
 
-			err := links.Retry(context.Background(), log.Event("NotUsed"), "NotUsed", func(ctx context.Context, lwid *LinksWithID, args *utils.RetryFnArgs) error {
+			err := links.Retry(context.Background(), log.Event("NotUsed"), "OverallOperation", func(ctx context.Context, lwid *LinksWithID, args *utils.RetryFnArgs) error {
 				attempts = append(attempts, args.I)
 				return testData.Err
 			}, exported.RetryOptions{
@@ -634,7 +634,7 @@ func TestAMQPLinksRetriesUnit(t *testing.T) {
 			logMessages := endLogging()
 
 			if testData.ExpectReset {
-				require.Contains(t, logMessages, fmt.Sprintf("[azsb.Conn] Link was previously detached. Attempting quick reconnect to recover from error: %s", err.Error()))
+				require.Contains(t, logMessages, fmt.Sprintf("[azsb.Conn] (OverallOperation) Link was previously detached. Attempting quick reconnect to recover from error: %s", err.Error()))
 			} else {
 				for _, msg := range logMessages {
 					require.NotContains(t, msg, "Link was previously detached")

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -42,7 +42,7 @@ func assertFailedLinks(t *testing.T, lwid *LinksWithID, expectedErr error) {
 	require.ErrorIs(t, err, expectedErr)
 
 	_, err = PeekMessages(context.TODO(), lwid.RPC, 0, 1)
-	require.ErrorIs(t, err, expectedErr)
+	require.ErrorIs(t, err, context.Canceled)
 
 	msg, err := lwid.Receiver.Receive(context.TODO())
 	require.ErrorIs(t, err, expectedErr)

--- a/sdk/messaging/azservicebus/internal/cbs.go
+++ b/sdk/messaging/azservicebus/internal/cbs.go
@@ -25,8 +25,9 @@ const (
 // NegotiateClaim attempts to put a token to the $cbs management endpoint to negotiate auth for the given audience
 func NegotiateClaim(ctx context.Context, audience string, conn *amqp.Client, provider auth.TokenProvider) error {
 	link, err := NewRPCLink(RPCLinkArgs{
-		Client:  &amqpwrap.AMQPClientWrapper{Inner: conn},
-		Address: cbsAddress,
+		Client:   &amqpwrap.AMQPClientWrapper{Inner: conn},
+		Address:  cbsAddress,
+		LogEvent: exported.EventAuth,
 	})
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -214,8 +214,9 @@ func (ns *Namespace) NewRPCLink(ctx context.Context, managementPath string) (RPC
 	}
 
 	return NewRPCLink(RPCLinkArgs{
-		Client:  &amqpwrap.AMQPClientWrapper{Inner: client},
-		Address: managementPath,
+		Client:   &amqpwrap.AMQPClientWrapper{Inner: client},
+		Address:  managementPath,
+		LogEvent: exported.EventReceiver,
 	})
 }
 

--- a/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	"github.com/microsoft/ApplicationInsights-Go/appinsights"
 )
 
@@ -64,7 +65,7 @@ func MustCreateStressContext(testName string) *StressContext {
 
 	ctx, cancel := NewCtrlCContext()
 
-	azlog.SetEvents("azsb.Conn", "azsb.Auth", "azsb.Retry", "azsb.Mgmt")
+	azlog.SetEvents(azservicebus.EventAdmin, azservicebus.EventAuth, azservicebus.EventConn, azservicebus.EventReceiver, azservicebus.EventSender)
 
 	logMessages := make(chan string, 10000)
 


### PR DESCRIPTION
Found a bug while adding in some more debug logging.

- Fixing a bug where the prefetch cache might not be drained if the user had cancelled the receive call. The prefetch call was specifically made so it no longer incurs any network I/O, so cancellation is something we should NOT do as it could cause us to lose messages we've already received.
- Adding (and fixing) logging to make things easier on diagnostics later.
- Cleaning up the close of the RPCLink so you can distinguish errors from normal shutdown. This eliminates a source of noise where it appears the negotiateClaim()'s response router was dying, when it was actually just the client itself being closed.