### PR TITLE
Add NewRecordingWithOptions constructor

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.1.0 (Unreleased)
 
 ### Features Added
+* Added `recording.NewRecordingWithOptions` and corresponding `NewRecordingOptions` type to allow specifying custom recordings directory.
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+* The default recordings directory for `recording.NewRecordingWithOptions` is now under `testdata`.  The old constructor is unaffected.
 
 ## 1.0.0 (2022-05-12)
 

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -614,3 +614,13 @@ func TestVariables(t *testing.T) {
 		require.NoError(t, err)
 	}()
 }
+
+func TestGetFilePaths(t *testing.T) {
+	path, vars := getFilePaths("custom/path1", "test1")
+	require.Equal(t, "custom/path1/test1", path)
+	require.Equal(t, "custom/path1/test1-variables.yaml", vars)
+
+	path, vars = getFilePaths("custom/path2/", "test1")
+	require.Equal(t, "custom/path2/test1", path)
+	require.Equal(t, "custom/path2/test1-variables.yaml", vars)
+}

--- a/sdk/internal/version.go
+++ b/sdk/internal/version.go
@@ -11,5 +11,5 @@ const (
 	Module = "internal"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.0.1"
+	Version = "v1.1.0"
 )


### PR DESCRIPTION
The NewRecording constructor defaults to a poor location for the
recording files and provides no facilities to override it.
Added a new constructor with options for specifying a custom recordings
directory.  The default is to now place the recordings under the
testdata directory.  The old constructor maintains its poor behavior.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
