### PR TITLE
adds a claims field placeholder

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+* Added a placeholder `Claims` field to `TokenRequestOptions` to allow consumers to start passing the value.
+
 ## 1.0.0 (2022-05-12)
 
 ### Features Added

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -111,6 +111,8 @@ type TelemetryOptions struct {
 type TokenRequestOptions struct {
 	// Scopes contains the list of permission scopes required for the token.
 	Scopes []string
+	// Claims contains the additional claims to be included in the token. See https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter for more information on format and content. Note this parameter is a placeholder and hasn't been implemented yet.
+	Claims string
 }
 
 // BearerTokenOptions configures the bearer token policy's behavior.


### PR DESCRIPTION
partial #14284 adds a claims field placeholder to unlock Microsoft Graph SDKs work.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- ~[ ] Tests are included and/or updated for code changes.~ N/A
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
