### PR TITLE
fix: ignore deprecated package when dep check

### DIFF
--- a/eng/scripts/Invoke-DependencyCheck.ps1
+++ b/eng/scripts/Invoke-DependencyCheck.ps1
@@ -24,7 +24,11 @@ if ($LASTEXITCODE) { exit $LASTEXITCODE }
 function IsPackageDeprecated($sdk)
 {
     $RETRACT_SECTION_REGEX = "retract\s*((?<retract>(.|\s)*))"
+    $DEPRECATE_SECTION_REGEX = "\/\/\s*Deprecated:"
     $modContent = Get-Content (Join-Path $sdk.DirectoryPath 'go.mod') -Raw
+    if ($modContent -match $DEPRECATE_SECTION_REGEX) {
+        return $true
+    }
     if ($modContent -match $RETRACT_SECTION_REGEX) {
         return $($matches["retract"]).Indexof($sdk.Version) -ne -1
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
