### PR TITLE
fix semver parse problem

### DIFF
--- a/eng/tools/smoketests/cmd/models.go
+++ b/eng/tools/smoketests/cmd/models.go
@@ -1,7 +1,5 @@
 package cmd
 
-import "fmt"
-
 type ConfigFile struct {
 	Packages []Package
 }
@@ -16,23 +14,4 @@ type Module struct {
 	Name    string
 	Version string
 	Replace string
-}
-
-type SemVer struct {
-	Major, Minor, Patch int
-}
-
-func (s SemVer) Newer(s2 SemVer) bool {
-	if s.Major > s2.Major {
-		return true
-	} else if s.Major == s2.Major && s.Minor > s2.Minor {
-		return true
-	} else if s.Major == s2.Major && s.Minor == s2.Minor && s.Patch > s2.Patch {
-		return true
-	}
-	return false
-}
-
-func (s SemVer) String() string {
-	return fmt.Sprintf("v%d.%d.%d", s.Major, s.Minor, s.Patch)
 }

--- a/eng/tools/smoketests/go.mod
+++ b/eng/tools/smoketests/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require github.com/spf13/cobra v1.4.0
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/eng/tools/smoketests/go.sum
+++ b/eng/tools/smoketests/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md

Old version cannot handle beta version like "1.1.0-beta.1". This fix will fix all the ci failure.