### PR TITLE
tool: release-v2, dep check and test generation support go semantic version convention

### DIFF
--- a/eng/scripts/MgmtTestLib.ps1
+++ b/eng/scripts/MgmtTestLib.ps1
@@ -20,7 +20,7 @@ function Invoke-MgmtTestgen ()
         [string]$config = "autorest.md",
         [string]$autorestVersion = "3.8.2",
         [string]$goExtension = "@autorest/go@4.0.0-preview.41",
-        [string]$testExtension = "@autorest/gotest@4.0.0",
+        [string]$testExtension = "@autorest/gotest@4.0.1",
         [string]$outputFolder
     )
     if ($clean)

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -175,13 +175,6 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(generateParam *GenerateP
 		return nil, err
 	}
 
-	if !generateParam.SkipGenerateExample {
-		log.Printf("Generate examples...")
-		if err := ExecuteExampleGenerate(packagePath, filepath.Join("resourcemanager", generateParam.RPName, generateParam.NamespaceName)); err != nil {
-			return nil, err
-		}
-	}
-
 	if onBoard {
 		log.Printf("Replace {{NewClientName}} placeholder in the README.md ")
 		if err = ReplaceNewClientNamePlaceholder(packagePath, newExports); err != nil {
@@ -193,6 +186,14 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(generateParam *GenerateP
 			log.Printf("Use specfic version: %s", generateParam.SpecficVersion)
 			version = generateParam.SpecficVersion
 		}
+
+		if !generateParam.SkipGenerateExample {
+			log.Printf("Generate examples...")
+			if err := ExecuteExampleGenerate(packagePath, filepath.Join("resourcemanager", generateParam.RPName, generateParam.NamespaceName)); err != nil {
+				return nil, err
+			}
+		}
+
 		return &GenerateResult{
 			Version:        version,
 			RPName:         generateParam.RPName,
@@ -223,9 +224,23 @@ func (ctx GenerateContext) GenerateForSingleRPNamespace(generateParam *GenerateP
 			return nil, err
 		}
 
+		log.Printf("Update module definition if v2+...")
+		err = UpdateModuleDefinition(packagePath, generateParam.RPName, generateParam.NamespaceName, version)
+		if err != nil {
+			return nil, err
+		}
+
 		log.Printf("Replace version in autorest.md and constants...")
 		if err = ReplaceVersion(packagePath, version.String()); err != nil {
 			return nil, err
+		}
+
+		// Example generation should be the last step because the package import relay on the new calculated version
+		if !generateParam.SkipGenerateExample {
+			log.Printf("Generate examples...")
+			if err := ExecuteExampleGenerate(packagePath, filepath.Join("resourcemanager", generateParam.RPName, generateParam.NamespaceName)); err != nil {
+				return nil, err
+			}
 		}
 
 		return &GenerateResult{

--- a/sdk/resourcemanager/eventgrid/armeventgrid/autorest.md
+++ b/sdk/resourcemanager/eventgrid/armeventgrid/autorest.md
@@ -4,7 +4,6 @@
 
 ``` yaml
 azure-arm: true
-tag: package-2021-12
 require:
 - https://github.com/Azure/azure-rest-api-specs/blob/c767823fdfd9d5e96bad245e3ea4d14d94a716bb/specification/eventgrid/resource-manager/readme.md
 - https://github.com/Azure/azure-rest-api-specs/blob/c767823fdfd9d5e96bad245e3ea4d14d94a716bb/specification/eventgrid/resource-manager/readme.go.md


### PR DESCRIPTION
This PR fix the release tool and script for mgmt. SDK new version. It will automatic add `vX` to module path to align with Go semantic version convention for SDK modules, test imports and dependency check script.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
