### PR TITLE
Handle a missing CountDetails node in the returned responses for Get<Entity>RuntimeProperties

### DIFF
--- a/sdk/messaging/azservicebus/admin/admin_client_queue.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_queue.go
@@ -5,6 +5,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -429,6 +430,10 @@ func newQueueItem(env *atom.QueueEnvelope) (*QueueItem, error) {
 
 func newQueueRuntimePropertiesItem(env *atom.QueueEnvelope) (*QueueRuntimePropertiesItem, error) {
 	desc := env.Content.QueueDescription
+
+	if desc.CountDetails == nil {
+		return nil, errors.New("invalid queue runtime properties: no CountDetails element")
+	}
 
 	qrt := &QueueRuntimeProperties{
 		SizeInBytes:                    int64OrZero(desc.SizeInBytes),

--- a/sdk/messaging/azservicebus/admin/admin_client_subscription.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_subscription.go
@@ -5,6 +5,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -414,6 +415,10 @@ func newSubscriptionItem(env *atom.SubscriptionEnvelope, topicName string) (*Sub
 
 func newSubscriptionRuntimePropertiesItem(env *atom.SubscriptionEnvelope, topicName string) (*SubscriptionRuntimePropertiesItem, error) {
 	desc := env.Content.SubscriptionDescription
+
+	if desc.CountDetails == nil {
+		return nil, errors.New("invalid subscription runtime properties: no CountDetails element")
+	}
 
 	rtp := SubscriptionRuntimeProperties{
 		TotalMessageCount:              *desc.MessageCount,

--- a/sdk/messaging/azservicebus/admin/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_test.go
@@ -1750,3 +1750,17 @@ func createAuthorizationRulesForTest(t *testing.T) []AuthorizationRule {
 		},
 	}
 }
+
+func TestATOMNoCountDetails(t *testing.T) {
+	subRP, err := newSubscriptionRuntimePropertiesItem(&atom.SubscriptionEnvelope{Content: &atom.SubscriptionContent{}}, "topic")
+	require.Nil(t, subRP)
+	require.Error(t, err, "invalid subscription runtime properties: no CountDetails element")
+
+	qRP, err := newQueueRuntimePropertiesItem(&atom.QueueEnvelope{Content: &atom.QueueContent{}})
+	require.Nil(t, qRP)
+	require.Error(t, err, "invalid queue runtime properties: no CountDetails element")
+
+	tRP, err := newTopicRuntimePropertiesItem(&atom.TopicEnvelope{Content: &atom.TopicContent{}})
+	require.Nil(t, tRP)
+	require.Error(t, err, "invalid topic runtime properties: no CountDetails element")
+}

--- a/sdk/messaging/azservicebus/admin/admin_client_topic.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_topic.go
@@ -5,6 +5,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -385,6 +386,10 @@ func newTopicItem(te *atom.TopicEnvelope) (*TopicItem, error) {
 
 func newTopicRuntimePropertiesItem(env *atom.TopicEnvelope) (*TopicRuntimePropertiesItem, error) {
 	desc := env.Content.TopicDescription
+
+	if desc.CountDetails == nil {
+		return nil, errors.New("invalid topic runtime properties: no CountDetails element")
+	}
 
 	props := &TopicRuntimeProperties{
 		SizeInBytes:           int64OrZero(desc.SizeInBytes),

--- a/sdk/messaging/azservicebus/internal/atom/converters.go
+++ b/sdk/messaging/azservicebus/internal/atom/converters.go
@@ -15,7 +15,7 @@ func WrapWithQueueEnvelope(qd *QueueDescription, tokenProvider auth.TokenProvide
 		Entry: &Entry{
 			AtomSchema: atomSchema,
 		},
-		Content: &queueContent{
+		Content: &QueueContent{
 			Type:             applicationXML,
 			QueueDescription: *qd,
 		},
@@ -31,7 +31,7 @@ func WrapWithTopicEnvelope(td *TopicDescription) *TopicEnvelope {
 		Entry: &Entry{
 			AtomSchema: atomSchema,
 		},
-		Content: &topicContent{
+		Content: &TopicContent{
 			Type:             applicationXML,
 			TopicDescription: *td,
 		},
@@ -45,7 +45,7 @@ func WrapWithSubscriptionEnvelope(sd *SubscriptionDescription) *SubscriptionEnve
 		Entry: &Entry{
 			AtomSchema: atomSchema,
 		},
-		Content: &subscriptionContent{
+		Content: &SubscriptionContent{
 			Type:                    applicationXML,
 			SubscriptionDescription: *sd,
 		},

--- a/sdk/messaging/azservicebus/internal/atom/models.go
+++ b/sdk/messaging/azservicebus/internal/atom/models.go
@@ -46,11 +46,11 @@ type (
 	// QueueEnvelope is a specialized Queue feed entry
 	QueueEnvelope struct {
 		*Entry
-		Content *queueContent `xml:"content"`
+		Content *QueueContent `xml:"content"`
 	}
 
-	// queueContent is a specialized Queue body for an Atom entry
-	queueContent struct {
+	// QueueContent is a specialized Queue body for an Atom entry
+	QueueContent struct {
 		XMLName          xml.Name         `xml:"content"`
 		Type             string           `xml:"type,attr"`
 		QueueDescription QueueDescription `xml:"QueueDescription"`
@@ -103,11 +103,11 @@ type (
 	// TopicEnvelope is a specialized Topic feed entry
 	TopicEnvelope struct {
 		*Entry
-		Content *topicContent `xml:"content"`
+		Content *TopicContent `xml:"content"`
 	}
 
-	// topicContent is a specialized Topic body for an Atom entry
-	topicContent struct {
+	// TopicContent is a specialized Topic body for an Atom entry
+	TopicContent struct {
 		XMLName          xml.Name         `xml:"content"`
 		Type             string           `xml:"type,attr"`
 		TopicDescription TopicDescription `xml:"TopicDescription"`
@@ -296,11 +296,11 @@ type (
 	// subscriptionEntryContent is a specialized Topic feed Subscription
 	SubscriptionEnvelope struct {
 		*Entry
-		Content *subscriptionContent `xml:"content"`
+		Content *SubscriptionContent `xml:"content"`
 	}
 
-	// subscriptionContent is a specialized Subscription body for an Atom entry
-	subscriptionContent struct {
+	// SubscriptionContent is a specialized Subscription body for an Atom entry
+	SubscriptionContent struct {
 		XMLName                 xml.Name                `xml:"content"`
 		Type                    string                  `xml:"type,attr"`
 		SubscriptionDescription SubscriptionDescription `xml:"SubscriptionDescription"`


### PR DESCRIPTION
Return an error for a missing CountDetails node in the returned responses for Get<Entity>RuntimeProperties. This doesn't fix the issue in #17868 but it'll stop the panic, which is infinitely worse.