### PR TITLE
ci: add retry to the golangci-lint install step to prevent failure of network issue

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -23,6 +23,7 @@ steps:
       golangci-lint --version
     displayName: 'Install GoLintCLI and dependencies.'
     workingDirectory: $(System.DefaultWorkingDirectory)
+    retryCountOnTaskFailure: 3
 
   - pwsh: |
       $modDirs = ./eng/scripts/get_module_dirs.ps1 '${{ parameters.ServiceDirectory }}'


### PR DESCRIPTION
There are many daily ci failure (e.g. [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1598529&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=45ee1ca9-5b97-59ac-94ed-a114ab499701)) because of the failure of golangci-lint install step. Add retry to resolve it.
Resolve https://github.com/Azure/azure-sdk-for-go/issues/18179

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
