### PR TITLE
CLI Credential: Avoid calling Azure CLI via cmd.exe/sh

### DIFF
--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -110,8 +110,14 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 		var cliCmd *exec.Cmd
 		if runtime.GOOS == "windows" {
 			cliCmd = exec.CommandContext(ctx, "az", args...)
+			dir := os.Getenv("SYSTEMROOT")
+			if dir == "" {
+				return nil, newCredentialUnavailableError(credNameAzureCLI, "environment variable 'SYSTEMROOT' has no value")
+			}
+			cliCmd.Dir = dir
 		} else {
 			cliCmd = exec.CommandContext(ctx, "az", args...)
+			cliCmd.Dir = "/bin"
 		}
 		cliCmd.Env = os.Environ()
 		var stderr bytes.Buffer

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -103,21 +103,15 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 		ctx, cancel := context.WithTimeout(ctx, timeoutCLIRequest)
 		defer cancel()
 
-		commandLine := "az account get-access-token -o json --resource " + resource
+		args := []string{"account", "get-access-token", "-o", "json", "--resource", resource}
 		if tenantID != "" {
-			commandLine += " --tenant " + tenantID
+			args = append(args, " --tenant ", tenantID)
 		}
 		var cliCmd *exec.Cmd
 		if runtime.GOOS == "windows" {
-			dir := os.Getenv("SYSTEMROOT")
-			if dir == "" {
-				return nil, newCredentialUnavailableError(credNameAzureCLI, "environment variable 'SYSTEMROOT' has no value")
-			}
-			cliCmd = exec.CommandContext(ctx, "cmd.exe", "/c", commandLine)
-			cliCmd.Dir = dir
+			cliCmd = exec.CommandContext(ctx, "az", args...)
 		} else {
-			cliCmd = exec.CommandContext(ctx, "/bin/sh", "-c", commandLine)
-			cliCmd.Dir = "/bin"
+			cliCmd = exec.CommandContext(ctx, "az", args...)
 		}
 		cliCmd.Env = os.Environ()
 		var stderr bytes.Buffer


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md


It is not necessary to invoke Azure CLI via either `cmd.exe` or `sh`, as itself is
executable and has proper interpreter settings. This avoids some
unneeded assumptions to the running environment, e.g. in Windows it is
then not needed to always ensure `cmd.exe` is available and correctly
set in the %PATH% (see: https://github.com/Azure/aztfy/issues/119).

Also, the working directory for the spawned process is also not
needed to set. By default, it uses the current working directory, which
is just fine.