### PR TITLE
Revise azcertificates models

### DIFF
--- a/sdk/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/keyvault/azcertificates/CHANGELOG.md
@@ -7,6 +7,13 @@
 * Methods `BeginCreateCertificate`, `BeginDeleteCertificate`, and `BeginRecoverDeletedCertificate` now return a `*runtime.Poller[T]` with their respective response types.
 * Options types with a `ResumeToken` field now take the token by value.
 * The poller for `BeginCreateCertificate` now returns the created certificate from its `PollUntilDone` method.
+* Changed type of certificate `Tags` to `map[string]*string`
+* Deleted `UpdateCertificatePropertiesOptions` fields
+* Renamed types
+  * `ListIssuersPropertiesOfIssuersResponse` to `ListPropertiesOfIssuersResponse`
+  * `ListCertificatesOptions` to `ListPropertiesOfCertificatesOptions`
+  * `ListCertificateVersionsOptions` to `ListPropertiesOfCertificateVersionsOptions`
+* Renamed `ListDeletedCertificatesResponse.Certificates` to `.DeletedCertificates`
 
 ### Bugs Fixed
 * LROs now correctly exit the polling loop in `PollUntilDone()` when the operations reach a terminal state.

--- a/sdk/keyvault/azcertificates/client.go
+++ b/sdk/keyvault/azcertificates/client.go
@@ -434,8 +434,8 @@ func (c *Client) ImportCertificate(ctx context.Context, certificateName string, 
 	}, nil
 }
 
-// ListCertificatesOptions contains optional parameters for Client.ListCertificates
-type ListCertificatesOptions struct {
+// ListPropertiesOfCertificatesOptions contains optional parameters for Client.ListCertificates
+type ListPropertiesOfCertificatesOptions struct {
 	// placeholder for future optional parameters.
 }
 
@@ -469,7 +469,7 @@ func listCertsPageFromGenerated(i generated.KeyVaultClientGetCertificatesRespons
 // public part of a stored certificate. The LIST operation is applicable to all certificate types, however only the
 // base certificate identifier, attributes, and tags are provided in the response. Individual versions of a
 // certificate are not listed in the response. This operation requires the certificates/list permission.
-func (c *Client) NewListPropertiesOfCertificatesPager(options *ListCertificatesOptions) *runtime.Pager[ListPropertiesOfCertificatesResponse] {
+func (c *Client) NewListPropertiesOfCertificatesPager(options *ListPropertiesOfCertificatesOptions) *runtime.Pager[ListPropertiesOfCertificatesResponse] {
 	pager := c.genClient.NewGetCertificatesPager(c.vaultURL, nil)
 	return runtime.NewPager(runtime.PagingHandler[ListPropertiesOfCertificatesResponse]{
 		More: func(page ListPropertiesOfCertificatesResponse) bool {
@@ -485,8 +485,8 @@ func (c *Client) NewListPropertiesOfCertificatesPager(options *ListCertificatesO
 	})
 }
 
-// ListCertificateVersionsOptions contains optional parameters for Client.ListCertificateVersions
-type ListCertificateVersionsOptions struct {
+// ListPropertiesOfCertificateVersionsOptions contains optional parameters for Client.ListCertificateVersions
+type ListPropertiesOfCertificateVersionsOptions struct {
 	// placeholder for future optional parameters.
 }
 
@@ -518,7 +518,7 @@ func listCertificateVersionsPageFromGenerated(i generated.KeyVaultClientGetCerti
 // NewListPropertiesOfCertificateVersionsPager lists all versions of the specified certificate. The full certificate identifer and
 // attributes are provided in the response. No values are returned for the certificates. This operation
 // requires the certificates/list permission.
-func (c *Client) NewListPropertiesOfCertificateVersionsPager(certificateName string, options *ListCertificateVersionsOptions) *runtime.Pager[ListPropertiesOfCertificateVersionsResponse] {
+func (c *Client) NewListPropertiesOfCertificateVersionsPager(certificateName string, options *ListPropertiesOfCertificateVersionsOptions) *runtime.Pager[ListPropertiesOfCertificateVersionsResponse] {
 	pager := c.genClient.NewGetCertificateVersionsPager(c.vaultURL, certificateName, nil)
 	return runtime.NewPager(runtime.PagingHandler[ListPropertiesOfCertificateVersionsResponse]{
 		More: func(page ListPropertiesOfCertificateVersionsResponse) bool {

--- a/sdk/keyvault/azcertificates/client.go
+++ b/sdk/keyvault/azcertificates/client.go
@@ -70,7 +70,7 @@ type BeginCreateCertificateOptions struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Application specific metadata in the form of key-value pairs
-	Tags map[string]string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// ResumeToken is a token for resuming long running operations from a previous poller
 	ResumeToken string
@@ -89,11 +89,6 @@ type CreateCertificateResponse struct {
 func (c *Client) BeginCreateCertificate(ctx context.Context, certificateName string, policy Policy, options *BeginCreateCertificateOptions) (*runtime.Poller[CreateCertificateResponse], error) {
 	if options == nil {
 		options = &BeginCreateCertificateOptions{}
-	}
-
-	var tags map[string]*string
-	if options.Tags != nil {
-		tags = convertToGeneratedMap(options.Tags)
 	}
 
 	handler := beginCreateCertificateOperation{
@@ -127,7 +122,7 @@ func (c *Client) BeginCreateCertificate(ctx context.Context, certificateName str
 		certificateName,
 		generated.CertificateCreateParameters{
 			CertificatePolicy:     policy.toGeneratedCertificateCreateParameters(),
-			Tags:                  tags,
+			Tags:                  options.Tags,
 			CertificateAttributes: &generated.CertificateAttributes{Enabled: options.Enabled},
 		},
 		options.toGenerated(),
@@ -170,7 +165,7 @@ func (c *Client) GetCertificate(ctx context.Context, certificateName string, opt
 
 	return GetCertificateResponse{
 		CertificateWithPolicy: CertificateWithPolicy{
-			Properties:  propertiesFromGenerated(resp.Attributes, convertGeneratedMap(resp.Tags), resp.ID, resp.X509Thumbprint),
+			Properties:  propertiesFromGenerated(resp.Attributes, resp.Tags, resp.ID, resp.X509Thumbprint),
 			CER:         resp.Cer,
 			ContentType: resp.ContentType,
 			ID:          resp.ID,
@@ -240,7 +235,7 @@ func deleteCertificateResponseFromGenerated(g generated.KeyVaultClientDeleteCert
 			RecoveryID:         g.RecoveryID,
 			DeletedOn:          g.DeletedDate,
 			ScheduledPurgeDate: g.ScheduledPurgeDate,
-			Properties:         propertiesFromGenerated(g.Attributes, convertGeneratedMap(g.Tags), g.ID, g.X509Thumbprint),
+			Properties:         propertiesFromGenerated(g.Attributes, g.Tags, g.ID, g.X509Thumbprint),
 			CER:                g.Cer,
 			ContentType:        g.ContentType,
 			ID:                 g.ID,
@@ -340,7 +335,7 @@ func (c *Client) GetDeletedCertificate(ctx context.Context, certificateName stri
 			RecoveryID:         resp.RecoveryID,
 			DeletedOn:          resp.DeletedDate,
 			ScheduledPurgeDate: resp.ScheduledPurgeDate,
-			Properties:         propertiesFromGenerated(resp.Attributes, convertGeneratedMap(resp.Tags), resp.ID, resp.X509Thumbprint),
+			Properties:         propertiesFromGenerated(resp.Attributes, resp.Tags, resp.ID, resp.X509Thumbprint),
 			CER:                resp.Cer,
 			ContentType:        resp.ContentType,
 			ID:                 resp.ID,
@@ -392,7 +387,7 @@ type ImportCertificateOptions struct {
 	Password *string `json:"pwd,omitempty"`
 
 	// Application specific metadata in the form of key-value pairs
-	Tags map[string]string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 }
 
 // ImportCertificateResponse contains response fields for Client.ImportCertificate
@@ -407,10 +402,6 @@ func (c *Client) ImportCertificate(ctx context.Context, certificateName string, 
 	if options == nil {
 		options = &ImportCertificateOptions{}
 	}
-	var tags map[string]*string
-	if options.Tags != nil {
-		tags = convertToGeneratedMap(options.Tags)
-	}
 	resp, err := c.genClient.ImportCertificate(
 		ctx,
 		c.vaultURL,
@@ -422,7 +413,7 @@ func (c *Client) ImportCertificate(ctx context.Context, certificateName string, 
 			},
 			CertificatePolicy: options.CertificatePolicy.toGeneratedCertificateCreateParameters(),
 			Password:          options.Password,
-			Tags:              tags,
+			Tags:              options.Tags,
 		},
 		&generated.KeyVaultClientImportCertificateOptions{},
 	)
@@ -432,7 +423,7 @@ func (c *Client) ImportCertificate(ctx context.Context, certificateName string, 
 
 	return ImportCertificateResponse{
 		CertificateWithPolicy: CertificateWithPolicy{
-			Properties:  propertiesFromGenerated(resp.Attributes, convertGeneratedMap(resp.Tags), resp.ID, resp.X509Thumbprint),
+			Properties:  propertiesFromGenerated(resp.Attributes, resp.Tags, resp.ID, resp.X509Thumbprint),
 			CER:         resp.Cer,
 			ContentType: resp.ContentType,
 			ID:          resp.ID,
@@ -463,7 +454,7 @@ func listCertsPageFromGenerated(i generated.KeyVaultClientGetCertificatesRespons
 
 	for _, v := range i.Value {
 		vals = append(vals, &CertificateItem{
-			Properties: propertiesFromGenerated(v.Attributes, convertGeneratedMap(v.Tags), v.ID, v.X509Thumbprint),
+			Properties: propertiesFromGenerated(v.Attributes, v.Tags, v.ID, v.X509Thumbprint),
 			ID:         v.ID,
 		})
 	}
@@ -513,7 +504,7 @@ func listCertificateVersionsPageFromGenerated(i generated.KeyVaultClientGetCerti
 	var vals []*CertificateItem
 	for _, v := range i.Value {
 		vals = append(vals, &CertificateItem{
-			Properties: propertiesFromGenerated(v.Attributes, convertGeneratedMap(v.Tags), v.ID, v.X509Thumbprint),
+			Properties: propertiesFromGenerated(v.Attributes, v.Tags, v.ID, v.X509Thumbprint),
 			ID:         v.ID,
 		})
 	}
@@ -1081,10 +1072,6 @@ func (c *Client) UpdateCertificateProperties(ctx context.Context, certificateNam
 	if options == nil {
 		options = &UpdateCertificatePropertiesOptions{}
 	}
-	var tags map[string]*string
-	if properties.Tags != nil {
-		tags = convertToGeneratedMap(properties.Tags)
-	}
 	resp, err := c.genClient.UpdateCertificate(
 		ctx,
 		c.vaultURL,
@@ -1092,7 +1079,7 @@ func (c *Client) UpdateCertificateProperties(ctx context.Context, certificateNam
 		options.Version,
 		generated.CertificateUpdateParameters{
 			CertificateAttributes: properties.toGenerated(),
-			Tags:                  tags,
+			Tags:                  properties.Tags,
 		},
 		options.toGenerated(),
 	)
@@ -1126,7 +1113,7 @@ func (c *Client) MergeCertificate(ctx context.Context, certificateName string, c
 	}
 	var tags map[string]*string
 	if options.Properties != nil && options.Properties.Tags != nil {
-		tags = convertToGeneratedMap(options.Properties.Tags)
+		tags = options.Properties.Tags
 	}
 	resp, err := c.genClient.MergeCertificate(
 		ctx, c.vaultURL,
@@ -1144,7 +1131,7 @@ func (c *Client) MergeCertificate(ctx context.Context, certificateName string, c
 
 	return MergeCertificateResponse{
 		CertificateWithPolicy: CertificateWithPolicy{
-			Properties:  propertiesFromGenerated(resp.Attributes, convertGeneratedMap(resp.Tags), resp.ID, resp.X509Thumbprint),
+			Properties:  propertiesFromGenerated(resp.Attributes, resp.Tags, resp.ID, resp.X509Thumbprint),
 			CER:         resp.Cer,
 			ContentType: resp.ContentType,
 			ID:          resp.ID,
@@ -1185,7 +1172,7 @@ func (c *Client) RestoreCertificateBackup(ctx context.Context, certificateBackup
 
 	return RestoreCertificateBackupResponse{
 		CertificateWithPolicy: CertificateWithPolicy{
-			Properties:  propertiesFromGenerated(resp.Attributes, convertGeneratedMap(resp.Tags), resp.ID, resp.X509Thumbprint),
+			Properties:  propertiesFromGenerated(resp.Attributes, resp.Tags, resp.ID, resp.X509Thumbprint),
 			CER:         resp.Cer,
 			ContentType: resp.ContentType,
 			ID:          resp.ID,
@@ -1270,7 +1257,7 @@ func listDeletedCertsPageFromGenerated(g generated.KeyVaultClientGetDeletedCerti
 		for i, c := range g.Value {
 			_, name, _ := shared.ParseID(c.ID)
 			certs[i] = &DeletedCertificateItem{
-				Properties:         propertiesFromGenerated(c.Attributes, convertGeneratedMap(c.Tags), c.ID, c.X509Thumbprint),
+				Properties:         propertiesFromGenerated(c.Attributes, c.Tags, c.ID, c.X509Thumbprint),
 				ID:                 c.ID,
 				Name:               name,
 				RecoveryID:         c.RecoveryID,

--- a/sdk/keyvault/azcertificates/client.go
+++ b/sdk/keyvault/azcertificates/client.go
@@ -697,8 +697,8 @@ type ListPropertiesOfIssuersOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ListIssuersPropertiesOfIssuersResponse contains response fields for ListPropertiesOfIssuersPager.NextPage
-type ListIssuersPropertiesOfIssuersResponse struct {
+// ListPropertiesOfIssuersResponse contains response fields for ListPropertiesOfIssuersPager.NextPage
+type ListPropertiesOfIssuersResponse struct {
 	// READ-ONLY; A response message containing a list of certificates in the key vault along with a link to the next page of certificates.
 	Issuers []*IssuerItem `json:"value,omitempty" azure:"ro"`
 
@@ -707,28 +707,28 @@ type ListIssuersPropertiesOfIssuersResponse struct {
 }
 
 // convert internal Response to ListPropertiesOfIssuersPage
-func listIssuersPageFromGenerated(i generated.KeyVaultClientGetCertificateIssuersResponse) ListIssuersPropertiesOfIssuersResponse {
+func listIssuersPageFromGenerated(i generated.KeyVaultClientGetCertificateIssuersResponse) ListPropertiesOfIssuersResponse {
 	var vals []*IssuerItem
 
 	for _, v := range i.Value {
 		vals = append(vals, certificateIssuerItemFromGenerated(v))
 	}
 
-	return ListIssuersPropertiesOfIssuersResponse{Issuers: vals, NextLink: i.NextLink}
+	return ListPropertiesOfIssuersResponse{Issuers: vals, NextLink: i.NextLink}
 }
 
 // NewListPropertiesOfIssuersPager returns a pager that can be used to get the set of certificate issuer resources in the specified key vault. This operation
 // requires the certificates/manageissuers/getissuers permission.
-func (c *Client) NewListPropertiesOfIssuersPager(options *ListPropertiesOfIssuersOptions) *runtime.Pager[ListIssuersPropertiesOfIssuersResponse] {
+func (c *Client) NewListPropertiesOfIssuersPager(options *ListPropertiesOfIssuersOptions) *runtime.Pager[ListPropertiesOfIssuersResponse] {
 	pager := c.genClient.NewGetCertificateIssuersPager(c.vaultURL, nil)
-	return runtime.NewPager(runtime.PagingHandler[ListIssuersPropertiesOfIssuersResponse]{
-		More: func(page ListIssuersPropertiesOfIssuersResponse) bool {
+	return runtime.NewPager(runtime.PagingHandler[ListPropertiesOfIssuersResponse]{
+		More: func(page ListPropertiesOfIssuersResponse) bool {
 			return pager.More()
 		},
-		Fetcher: func(ctx context.Context, cur *ListIssuersPropertiesOfIssuersResponse) (ListIssuersPropertiesOfIssuersResponse, error) {
+		Fetcher: func(ctx context.Context, cur *ListPropertiesOfIssuersResponse) (ListPropertiesOfIssuersResponse, error) {
 			page, err := pager.NextPage(ctx)
 			if err != nil {
-				return ListIssuersPropertiesOfIssuersResponse{}, err
+				return ListPropertiesOfIssuersResponse{}, err
 			}
 			return listIssuersPageFromGenerated(page), nil
 		},

--- a/sdk/keyvault/azcertificates/client.go
+++ b/sdk/keyvault/azcertificates/client.go
@@ -1240,7 +1240,7 @@ func (c *Client) BeginRecoverDeletedCertificate(ctx context.Context, certificate
 // ListDeletedCertificatesResponse contains response field for ListDeletedCertificatesPager.NextPage
 type ListDeletedCertificatesResponse struct {
 	// READ-ONLY; A response message containing a list of deleted certificates in the vault along with a link to the next page of deleted certificates
-	Certificates []*DeletedCertificateItem `json:"value,omitempty" azure:"ro"`
+	DeletedCertificates []*DeletedCertificateItem `json:"value,omitempty" azure:"ro"`
 
 	// NextLink gives the next page of items to fetch
 	NextLink *string
@@ -1266,8 +1266,8 @@ func listDeletedCertsPageFromGenerated(g generated.KeyVaultClientGetDeletedCerti
 	}
 
 	return ListDeletedCertificatesResponse{
-		Certificates: certs,
-		NextLink:     g.NextLink,
+		DeletedCertificates: certs,
+		NextLink:            g.NextLink,
 	}
 }
 

--- a/sdk/keyvault/azcertificates/client.go
+++ b/sdk/keyvault/azcertificates/client.go
@@ -1047,14 +1047,8 @@ func (c *Client) GetCertificatePolicy(ctx context.Context, certificateName strin
 
 // UpdateCertificatePropertiesOptions contains optional parameters for Client.UpdateCertificateProperties
 type UpdateCertificatePropertiesOptions struct {
-	// The version of the certificate to update
-	Version string
+	// placeholder for future optional parameters
 
-	// The attributes of the certificate (optional).
-	Properties *Properties `json:"attributes,omitempty"`
-
-	// The management policy for the certificate.
-	CertificatePolicy *Policy `json:"policy,omitempty"`
 }
 
 func (u *UpdateCertificatePropertiesOptions) toGenerated() *generated.KeyVaultClientUpdateCertificateOptions {
@@ -1072,11 +1066,15 @@ func (c *Client) UpdateCertificateProperties(ctx context.Context, certificateNam
 	if options == nil {
 		options = &UpdateCertificatePropertiesOptions{}
 	}
+	version := ""
+	if properties.Version != nil {
+		version = *properties.Version
+	}
 	resp, err := c.genClient.UpdateCertificate(
 		ctx,
 		c.vaultURL,
 		certificateName,
-		options.Version,
+		version,
 		generated.CertificateUpdateParameters{
 			CertificateAttributes: properties.toGenerated(),
 			Tags:                  properties.Tags,

--- a/sdk/keyvault/azcertificates/client_test.go
+++ b/sdk/keyvault/azcertificates/client_test.go
@@ -885,7 +885,7 @@ func TestClient_ListDeletedCertificates(t *testing.T) {
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		require.NoError(t, err)
-		for _, cert := range page.Certificates {
+		for _, cert := range page.DeletedCertificates {
 			purgeCert(t, client, *cert.Name)
 			deletedCount += 1
 		}

--- a/sdk/keyvault/azcertificates/client_test.go
+++ b/sdk/keyvault/azcertificates/client_test.go
@@ -616,7 +616,7 @@ func TestCRUDOperations(t *testing.T) {
 	received.Properties.Tags["tag1"] = to.Ptr("updated_values1")
 	updatePropsResp, err := client.UpdateCertificateProperties(ctx, certName, *received.Properties, nil)
 	require.NoError(t, err)
-	require.Equal(t, "updated_values1", updatePropsResp.Properties.Tags["tag1"])
+	require.Equal(t, "updated_values1", *updatePropsResp.Properties.Tags["tag1"])
 	require.Equal(t, *received.ID, *updatePropsResp.ID)
 }
 

--- a/sdk/keyvault/azcertificates/client_test.go
+++ b/sdk/keyvault/azcertificates/client_test.go
@@ -586,15 +586,6 @@ func TestCRUDOperations(t *testing.T) {
 	// Make sure certificates are the same
 	require.Equal(t, *finalResp.ID, *received.ID)
 
-	// // Make sure we can interface with x509 library
-	// mid := base64.StdEncoding.EncodeToString(received.Cer)
-	// cer := fmt.Sprintf("-----BEGIN CERTIFICATE-----\n%s\n-----END CERTIFICATE-----", mid)
-	// block, _ := pem.Decode([]byte(cer))
-	// require.NotNil(t, block)
-	// parsedCert, err := x509.ParseCertificate(block.Bytes)
-	// require.NoError(t, err)
-	// require.NotNil(t, parsedCert)
-
 	// Update the policy
 	policy.KeyType = to.Ptr(KeyTypeEC)
 	policy.KeySize = to.Ptr(int32(256))
@@ -618,6 +609,11 @@ func TestCRUDOperations(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "updated_values1", *updatePropsResp.Properties.Tags["tag1"])
 	require.Equal(t, *received.ID, *updatePropsResp.ID)
+	require.True(t, *updatePropsResp.Properties.Enabled)
+
+	resp, err := client.UpdateCertificateProperties(ctx, *updatePropsResp.Name, Properties{Enabled: to.Ptr(false)}, nil)
+	require.NoError(t, err)
+	require.False(t, *resp.Properties.Enabled)
 }
 
 // https://stackoverflow.com/questions/42643048/signing-certificate-request-with-certificate-authority

--- a/sdk/keyvault/azcertificates/client_test.go
+++ b/sdk/keyvault/azcertificates/client_test.go
@@ -611,9 +611,9 @@ func TestCRUDOperations(t *testing.T) {
 	require.Equal(t, *policy.KeyCurveName, *updateResp.KeyCurveName)
 
 	if received.Properties.Tags == nil {
-		received.Properties.Tags = map[string]string{}
+		received.Properties.Tags = map[string]*string{}
 	}
-	received.Properties.Tags["tag1"] = "updated_values1"
+	received.Properties.Tags["tag1"] = to.Ptr("updated_values1")
 	updatePropsResp, err := client.UpdateCertificateProperties(ctx, certName, *received.Properties, nil)
 	require.NoError(t, err)
 	require.Equal(t, "updated_values1", updatePropsResp.Properties.Tags["tag1"])

--- a/sdk/keyvault/azcertificates/example_test.go
+++ b/sdk/keyvault/azcertificates/example_test.go
@@ -123,7 +123,7 @@ func ExampleClient_UpdateCertificateProperties() {
 		panic(err)
 	}
 	getResp.Properties.Enabled = to.Ptr(false)
-	getResp.Properties.Tags["Tag1"] = "Val1"
+	getResp.Properties.Tags["Tag1"] = to.Ptr("Val1")
 
 	resp, err := client.UpdateCertificateProperties(context.TODO(), "myCertName", *getResp.Properties, nil)
 	if err != nil {

--- a/sdk/keyvault/azcertificates/models.go
+++ b/sdk/keyvault/azcertificates/models.go
@@ -63,7 +63,7 @@ type Properties struct {
 	Name *string
 
 	// Application specific metadata in the form of key-value pairs
-	Tags map[string]string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; The vault URL for the certificate
 	VaultURL *string
@@ -91,7 +91,7 @@ func (c *Properties) toGenerated() *generated.CertificateAttributes {
 	}
 }
 
-func propertiesFromGenerated(g *generated.CertificateAttributes, tags map[string]string, id *string, thumbprint []byte) *Properties {
+func propertiesFromGenerated(g *generated.CertificateAttributes, tags map[string]*string, id *string, thumbprint []byte) *Properties {
 	if g == nil {
 		return nil
 	}
@@ -167,7 +167,7 @@ func (c *CertificateWithPolicy) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	c.Properties = propertiesFromGenerated(g.Attributes, convertGeneratedMap(g.Tags), g.ID, g.X509Thumbprint)
+	c.Properties = propertiesFromGenerated(g.Attributes, g.Tags, g.ID, g.X509Thumbprint)
 	c.CER = g.Cer
 	c.ContentType = g.ContentType
 	c.ID = g.ID
@@ -184,7 +184,7 @@ func certificateFromGenerated(g *generated.CertificateBundle) Certificate {
 
 	_, name, _ := shared.ParseID(g.ID)
 	return Certificate{
-		Properties: propertiesFromGenerated(g.Attributes, convertGeneratedMap(g.Tags), g.ID, g.X509Thumbprint),
+		Properties: propertiesFromGenerated(g.Attributes, g.Tags, g.ID, g.X509Thumbprint),
 		CER:        g.Cer,
 		ID:         g.ID,
 		Name:       name,
@@ -727,28 +727,4 @@ func x509CertificatePropertiesFromGenerated(g *generated.X509CertificateProperti
 		SubjectAlternativeNames: subjectAlternativeNamesFromGenerated(g.SubjectAlternativeNames),
 		ValidityInMonths:        g.ValidityInMonths,
 	}
-}
-
-func convertToGeneratedMap(m map[string]string) map[string]*string {
-	if m == nil {
-		return nil
-	}
-
-	ret := make(map[string]*string)
-	for k, v := range m {
-		ret[k] = &v
-	}
-	return ret
-}
-
-func convertGeneratedMap(m map[string]*string) map[string]string {
-	if m == nil {
-		return nil
-	}
-
-	ret := make(map[string]string)
-	for k, v := range m {
-		ret[k] = *v
-	}
-	return ret
 }

--- a/sdk/keyvault/azcertificates/testdata/recordings/TestCRUDOperations.json
+++ b/sdk/keyvault/azcertificates/testdata/recordings/TestCRUDOperations.json
@@ -4,11 +4,10 @@
       "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/create?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        ":method": "POST",
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Content-Length": "0",
-        "User-Agent": "azsdk-go-azcertificates/v0.4.2 (go1.18; Windows_NT)"
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -16,16 +15,16 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 16 May 2022 18:13:51 GMT",
+        "Date": "Tue, 31 May 2022 22:38:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
-        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/00000000-0000-0000-0000-000000000000\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.83.78.150;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "87231d7b-60ea-4f46-bca8-e8a9c3c797b3"
+        "x-ms-request-id": "f2ee10fc-5dac-4bdc-8eef-784f2199549e"
       },
       "ResponseBody": {
         "error": {
@@ -38,13 +37,12 @@
       "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/create?api-version=7.3",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        ":method": "POST",
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
         "Content-Length": "497",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-azcertificates/v0.4.2 (go1.18; Windows_NT)"
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
       },
       "RequestBody": {
         "attributes": {},
@@ -95,38 +93,37 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1333",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 16 May 2022 18:13:52 GMT",
+        "Date": "Tue, 31 May 2022 22:38:17 GMT",
         "Expires": "-1",
-        "Location": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=993263a4d5a64318b0e34b9114adfcda",
+        "Location": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=3576a511c4f04dbb8130c2528c2e960a",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.83.78.150;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "57a61dd7-bfc1-44b8-9ec2-cfa5493bac00"
+        "x-ms-request-id": "f1236865-9a39-4e74-84dd-0db58c1fe14e"
       },
       "ResponseBody": {
         "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMF0nEGK3BijB9ktSCvycWH9vpBrh7C6mtKm01JjTT99NGq3JjRl12RiVlUfR9CBdnTwozIhmKOMc06VjqIp09W\u002B8mq\u002BEFYEMp0zESHuwqMFZeY2OTQwszSFE4Ja88f8iE4K0vJfSDwAfa4UX7/gLH9zmihNBeUPtudWyhbDNXZWMJXlVruuEa2nib0v5i\u002BuDrEG85THIn7Z5Do1khPlF/KohD3ezHELYugZhhMqFOR\u002B0K5USNcXCdxPWE6cVbiaw/RJSxczZIolvRy3uyxTfQESzVRNDRj1jWuvM95r2zjjp\u002BgmhBx\u002Bxt\u002BA4TvA040l8FySrBpD8BUWSOJ\u002Bfx5OLiECAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEAH863OJtk2Ol6Xtc6rSMxl1wTSQVy8imjY9Tk3tLeKKmSCVQT6b\u002B3kwXK\u002BExRhyG2iZIbrYINauZbg2VJNxRZwZgx3onVx26H4kjr1ZASLNAl9MLBAceE9vf9u2azdPGf/63M\u002Bfz5Mm3byncDvACwZg9Lf0u\u002BrlV4R8RuBWG5HB2Lbk9ZuIOMuX8WcDUvw8Pj\u002Bc8isRK09yXY9pTRtPGYJt2QMsrO2bDIJZUjPhpLNPPdamKfI408grdhfp7j6PVDervUEqS0SPtF\u002Bu2vZCVpmEXEe0Peh7PUOZjl91SHQiu1OFfhtFqskc2fNk\u002B7SoZ8oQjSwuzm3DnC7QsIgn9hNQ==",
+        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPN1Y1Ke2Q0QpbznH0e2Qaq8XyMoKmrEI0yvubWZKMKLZUJAZOt9fqlt5yWO/G2RV\u002Be0GcNAO9La6jViY2YYQJl/tGxQVkbl\u002BsuS5sF5PzbR8rmahXLRWE5PR6tQGNDhRdyxM30HOGjQPWUnX3lvdSf/FvegIHCXblLOyeUd1RXwg/Xg7OYmpxHZLWm9HGRNJDr1hGehHc2hxA/OD2BCPSTbP5FXBMp1ZvzzZpKqko\u002B8SHXOjOsUBAKfLDp5hAepZSssEiYALuirbDPSLT6Pk1gTb0A5in3\u002B/BGcou0SosYEEetfTKfdwM6SFYNz6CGVCfaEuv8D9Uc3pjuVz/bcqG0CAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEALdTYdwy3ce\u002BScjrMbefYs4Ydh8YFTwHAk8Ii9ixO2Y5VRXqCuloZspB2ZQ\u002Bbx6wgdI18R/7Dp89LoMS55tndKkm3aZWNTY59mZWBxGDmBICHFDymoZT5Lc03jDWwj2Kd17nWkzZQ\u002B38has4auRIevBURLUck92\u002Bt09aIKFEFcmZmYDQ4Rsq0fLNo0hcv3I8wzsQNh8rPfFV4xHTzW3TK4IJM0TGneKLuuv/1ZPqvHZqi\u002ByfqofSesEuVwc6igNjb6th5o4Kjcbkmz2S2PCVXzTlK4A7sEwqZTYtq4XTKVhGRIpZ04zC57jLCgNjIXM0HKHwr5Aryk7ifiJFYJxwyTA==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "993263a4d5a64318b0e34b9114adfcda"
+        "request_id": "3576a511c4f04dbb8130c2528c2e960a"
       }
     },
     {
-      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=993263a4d5a64318b0e34b9114adfcda",
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=3576a511c4f04dbb8130c2528c2e960a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        ":method": "GET",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-azcertificates/v0.4.2 (go1.18; Windows_NT)"
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -134,37 +131,36 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1241",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 16 May 2022 18:14:02 GMT",
+        "Date": "Tue, 31 May 2022 22:38:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.83.78.150;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "e07ec098-3137-4b9e-9a0b-a5fdaeec13c1"
+        "x-ms-request-id": "ee53fd7e-79b7-4196-bc43-7c00348657aa"
       },
       "ResponseBody": {
         "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMF0nEGK3BijB9ktSCvycWH9vpBrh7C6mtKm01JjTT99NGq3JjRl12RiVlUfR9CBdnTwozIhmKOMc06VjqIp09W\u002B8mq\u002BEFYEMp0zESHuwqMFZeY2OTQwszSFE4Ja88f8iE4K0vJfSDwAfa4UX7/gLH9zmihNBeUPtudWyhbDNXZWMJXlVruuEa2nib0v5i\u002BuDrEG85THIn7Z5Do1khPlF/KohD3ezHELYugZhhMqFOR\u002B0K5USNcXCdxPWE6cVbiaw/RJSxczZIolvRy3uyxTfQESzVRNDRj1jWuvM95r2zjjp\u002BgmhBx\u002Bxt\u002BA4TvA040l8FySrBpD8BUWSOJ\u002Bfx5OLiECAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEAH863OJtk2Ol6Xtc6rSMxl1wTSQVy8imjY9Tk3tLeKKmSCVQT6b\u002B3kwXK\u002BExRhyG2iZIbrYINauZbg2VJNxRZwZgx3onVx26H4kjr1ZASLNAl9MLBAceE9vf9u2azdPGf/63M\u002Bfz5Mm3byncDvACwZg9Lf0u\u002BrlV4R8RuBWG5HB2Lbk9ZuIOMuX8WcDUvw8Pj\u002Bc8isRK09yXY9pTRtPGYJt2QMsrO2bDIJZUjPhpLNPPdamKfI408grdhfp7j6PVDervUEqS0SPtF\u002Bu2vZCVpmEXEe0Peh7PUOZjl91SHQiu1OFfhtFqskc2fNk\u002B7SoZ8oQjSwuzm3DnC7QsIgn9hNQ==",
+        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPN1Y1Ke2Q0QpbznH0e2Qaq8XyMoKmrEI0yvubWZKMKLZUJAZOt9fqlt5yWO/G2RV\u002Be0GcNAO9La6jViY2YYQJl/tGxQVkbl\u002BsuS5sF5PzbR8rmahXLRWE5PR6tQGNDhRdyxM30HOGjQPWUnX3lvdSf/FvegIHCXblLOyeUd1RXwg/Xg7OYmpxHZLWm9HGRNJDr1hGehHc2hxA/OD2BCPSTbP5FXBMp1ZvzzZpKqko\u002B8SHXOjOsUBAKfLDp5hAepZSssEiYALuirbDPSLT6Pk1gTb0A5in3\u002B/BGcou0SosYEEetfTKfdwM6SFYNz6CGVCfaEuv8D9Uc3pjuVz/bcqG0CAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEALdTYdwy3ce\u002BScjrMbefYs4Ydh8YFTwHAk8Ii9ixO2Y5VRXqCuloZspB2ZQ\u002Bbx6wgdI18R/7Dp89LoMS55tndKkm3aZWNTY59mZWBxGDmBICHFDymoZT5Lc03jDWwj2Kd17nWkzZQ\u002B38has4auRIevBURLUck92\u002Bt09aIKFEFcmZmYDQ4Rsq0fLNo0hcv3I8wzsQNh8rPfFV4xHTzW3TK4IJM0TGneKLuuv/1ZPqvHZqi\u002ByfqofSesEuVwc6igNjb6th5o4Kjcbkmz2S2PCVXzTlK4A7sEwqZTYtq4XTKVhGRIpZ04zC57jLCgNjIXM0HKHwr5Aryk7ifiJFYJxwyTA==",
         "cancellation_requested": false,
         "status": "completed",
         "target": "https://fakekvurl.vault.azure.net/certificates/cert2501394451",
-        "request_id": "993263a4d5a64318b0e34b9114adfcda"
+        "request_id": "3576a511c4f04dbb8130c2528c2e960a"
       }
     },
     {
       "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/?api-version=7.3",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        ":method": "GET",
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-azcertificates/v0.4.2 (go1.18; Windows_NT)"
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -172,28 +168,28 @@
         "Cache-Control": "no-cache",
         "Content-Length": "2415",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 16 May 2022 18:14:02 GMT",
+        "Date": "Tue, 31 May 2022 22:38:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.83.78.150;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "fcc105fd-7c9d-44f0-ad33-695ea2b68dec"
+        "x-ms-request-id": "ffe301a7-5004-41ed-8a8d-ce9472c46356"
       },
       "ResponseBody": {
-        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/6595dd8432da4b0fb65fc4044fbb3311",
-        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/6595dd8432da4b0fb65fc4044fbb3311",
-        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/6595dd8432da4b0fb65fc4044fbb3311",
-        "x5t": "ruR6MXXj6hptJUSllM4nQyteZu4",
-        "cer": "MIIDVzCCAj\u002BgAwIBAgIQHvd9NY6eRRGkz\u002Be7w4\u002BQGzANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDUxNjE4MDM1NloXDTIzMDUxNjE4MTM1NlowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMF0nEGK3BijB9ktSCvycWH9vpBrh7C6mtKm01JjTT99NGq3JjRl12RiVlUfR9CBdnTwozIhmKOMc06VjqIp09W\u002B8mq\u002BEFYEMp0zESHuwqMFZeY2OTQwszSFE4Ja88f8iE4K0vJfSDwAfa4UX7/gLH9zmihNBeUPtudWyhbDNXZWMJXlVruuEa2nib0v5i\u002BuDrEG85THIn7Z5Do1khPlF/KohD3ezHELYugZhhMqFOR\u002B0K5USNcXCdxPWE6cVbiaw/RJSxczZIolvRy3uyxTfQESzVRNDRj1jWuvM95r2zjjp\u002BgmhBx\u002Bxt\u002BA4TvA040l8FySrBpD8BUWSOJ\u002Bfx5OLiECAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFBcDm/PzV0A\u002BloMqsPdHEfeAzLETMB0GA1UdDgQWBBQXA5vz81dAPpaDKrD3RxH3gMyxEzANBgkqhkiG9w0BAQsFAAOCAQEATDOx65w9hpDuobSYWTMrfDBN80jT2NX4PUz1UcT3/zANNogI5dBLT081VIPjfitLQqLziDs3oh2bxZ/AtzaPlOMk21WrORPmKzm/yivwPbCq\u002BrHRSq05lwkAN5iFJEsEtNx6VUKJqn\u002Byc/8ZHJUzaUTJm4uTn75QbkbbzKpfbwB1dswWLdFh7BXh9ehneZCD5T\u002BXOkFxw/ASRnqhcrsWaccLY2eQQZN0n15Pj4cMvilWcCI30s89n\u002B06C\u002BaO861sB9pAXFShc05IT0v9kLUTKqJBZMkJVBVUKcSiZu26vsZueRyMGq5beGOKtqWUv/z0H7e5kcU1KtqIrj8bM1gxBg==",
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "x5t": "D2ZXAnkLsd-ZLlpkcp5bg6qp9rc",
+        "cer": "MIIDVzCCAj\u002BgAwIBAgIQJId8aQc/RXSLcIK4/xL04DANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDUzMTIyMjgxOVoXDTIzMDUzMTIyMzgxOVowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPN1Y1Ke2Q0QpbznH0e2Qaq8XyMoKmrEI0yvubWZKMKLZUJAZOt9fqlt5yWO/G2RV\u002Be0GcNAO9La6jViY2YYQJl/tGxQVkbl\u002BsuS5sF5PzbR8rmahXLRWE5PR6tQGNDhRdyxM30HOGjQPWUnX3lvdSf/FvegIHCXblLOyeUd1RXwg/Xg7OYmpxHZLWm9HGRNJDr1hGehHc2hxA/OD2BCPSTbP5FXBMp1ZvzzZpKqko\u002B8SHXOjOsUBAKfLDp5hAepZSssEiYALuirbDPSLT6Pk1gTb0A5in3\u002B/BGcou0SosYEEetfTKfdwM6SFYNz6CGVCfaEuv8D9Uc3pjuVz/bcqG0CAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFHabK1nNgT/WNM2N0uX2uuQ8WZz5MB0GA1UdDgQWBBR2mytZzYE/1jTNjdLl9rrkPFmc\u002BTANBgkqhkiG9w0BAQsFAAOCAQEAjHHaJrfu7RkiInluwQr1N9018EdniiTdfACdtU3ZkzKr5\u002BCfTe3sDGktbxBHTXXQp2kc2cYpAexpZ6nsfWOwYoP4piaH2XByxi5JdRjc5vx9bz91nIgt3mzrY2yg3x3KW6bO3U8bUEB/a868eH/IOnCB4NnvVODN62jSQ5XQPPjfmMx/XReU8lw3Apk/4ait2qY8uiX/1S2Dr6bpCcCp67CCmaQHKcbMzo8e/AI8o9T2ssZffZDfV3xEaSXukwNWr6zcAWnvichb6lMoQLp1CleIQyXNY/g43oPCte0bUI0Cq1PkZi8Sef9giycnJOFc3GDVKIPq5\u002B5i/RXvxU5h0A==",
         "attributes": {
           "enabled": true,
-          "nbf": 1652724236,
-          "exp": 1684260836,
-          "created": 1652724836,
-          "updated": 1652724836,
+          "nbf": 1654036099,
+          "exp": 1685572699,
+          "created": 1654036699,
+          "updated": 1654036699,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -243,8 +239,8 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1652715904,
-            "updated": 1652724832
+            "created": 1654034548,
+            "updated": 1654036698
           }
         },
         "pending": {
@@ -256,11 +252,10 @@
       "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/?api-version=7.3",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        ":method": "GET",
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-go-azcertificates/v0.4.2 (go1.18; Windows_NT)"
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -268,28 +263,28 @@
         "Cache-Control": "no-cache",
         "Content-Length": "2415",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 16 May 2022 18:14:02 GMT",
+        "Date": "Tue, 31 May 2022 22:38:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.83.78.150;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "87115921-2007-43df-aee7-254d6f90ed95"
+        "x-ms-request-id": "0cb11b41-76f0-496d-a0d1-1d46fcbbfc91"
       },
       "ResponseBody": {
-        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/6595dd8432da4b0fb65fc4044fbb3311",
-        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/6595dd8432da4b0fb65fc4044fbb3311",
-        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/6595dd8432da4b0fb65fc4044fbb3311",
-        "x5t": "ruR6MXXj6hptJUSllM4nQyteZu4",
-        "cer": "MIIDVzCCAj\u002BgAwIBAgIQHvd9NY6eRRGkz\u002Be7w4\u002BQGzANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDUxNjE4MDM1NloXDTIzMDUxNjE4MTM1NlowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMF0nEGK3BijB9ktSCvycWH9vpBrh7C6mtKm01JjTT99NGq3JjRl12RiVlUfR9CBdnTwozIhmKOMc06VjqIp09W\u002B8mq\u002BEFYEMp0zESHuwqMFZeY2OTQwszSFE4Ja88f8iE4K0vJfSDwAfa4UX7/gLH9zmihNBeUPtudWyhbDNXZWMJXlVruuEa2nib0v5i\u002BuDrEG85THIn7Z5Do1khPlF/KohD3ezHELYugZhhMqFOR\u002B0K5USNcXCdxPWE6cVbiaw/RJSxczZIolvRy3uyxTfQESzVRNDRj1jWuvM95r2zjjp\u002BgmhBx\u002Bxt\u002BA4TvA040l8FySrBpD8BUWSOJ\u002Bfx5OLiECAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFBcDm/PzV0A\u002BloMqsPdHEfeAzLETMB0GA1UdDgQWBBQXA5vz81dAPpaDKrD3RxH3gMyxEzANBgkqhkiG9w0BAQsFAAOCAQEATDOx65w9hpDuobSYWTMrfDBN80jT2NX4PUz1UcT3/zANNogI5dBLT081VIPjfitLQqLziDs3oh2bxZ/AtzaPlOMk21WrORPmKzm/yivwPbCq\u002BrHRSq05lwkAN5iFJEsEtNx6VUKJqn\u002Byc/8ZHJUzaUTJm4uTn75QbkbbzKpfbwB1dswWLdFh7BXh9ehneZCD5T\u002BXOkFxw/ASRnqhcrsWaccLY2eQQZN0n15Pj4cMvilWcCI30s89n\u002B06C\u002BaO861sB9pAXFShc05IT0v9kLUTKqJBZMkJVBVUKcSiZu26vsZueRyMGq5beGOKtqWUv/z0H7e5kcU1KtqIrj8bM1gxBg==",
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "x5t": "D2ZXAnkLsd-ZLlpkcp5bg6qp9rc",
+        "cer": "MIIDVzCCAj\u002BgAwIBAgIQJId8aQc/RXSLcIK4/xL04DANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDUzMTIyMjgxOVoXDTIzMDUzMTIyMzgxOVowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPN1Y1Ke2Q0QpbznH0e2Qaq8XyMoKmrEI0yvubWZKMKLZUJAZOt9fqlt5yWO/G2RV\u002Be0GcNAO9La6jViY2YYQJl/tGxQVkbl\u002BsuS5sF5PzbR8rmahXLRWE5PR6tQGNDhRdyxM30HOGjQPWUnX3lvdSf/FvegIHCXblLOyeUd1RXwg/Xg7OYmpxHZLWm9HGRNJDr1hGehHc2hxA/OD2BCPSTbP5FXBMp1ZvzzZpKqko\u002B8SHXOjOsUBAKfLDp5hAepZSssEiYALuirbDPSLT6Pk1gTb0A5in3\u002B/BGcou0SosYEEetfTKfdwM6SFYNz6CGVCfaEuv8D9Uc3pjuVz/bcqG0CAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFHabK1nNgT/WNM2N0uX2uuQ8WZz5MB0GA1UdDgQWBBR2mytZzYE/1jTNjdLl9rrkPFmc\u002BTANBgkqhkiG9w0BAQsFAAOCAQEAjHHaJrfu7RkiInluwQr1N9018EdniiTdfACdtU3ZkzKr5\u002BCfTe3sDGktbxBHTXXQp2kc2cYpAexpZ6nsfWOwYoP4piaH2XByxi5JdRjc5vx9bz91nIgt3mzrY2yg3x3KW6bO3U8bUEB/a868eH/IOnCB4NnvVODN62jSQ5XQPPjfmMx/XReU8lw3Apk/4ait2qY8uiX/1S2Dr6bpCcCp67CCmaQHKcbMzo8e/AI8o9T2ssZffZDfV3xEaSXukwNWr6zcAWnvichb6lMoQLp1CleIQyXNY/g43oPCte0bUI0Cq1PkZi8Sef9giycnJOFc3GDVKIPq5\u002B5i/RXvxU5h0A==",
         "attributes": {
           "enabled": true,
-          "nbf": 1652724236,
-          "exp": 1684260836,
-          "created": 1652724836,
-          "updated": 1652724836,
+          "nbf": 1654036099,
+          "exp": 1685572699,
+          "created": 1654036699,
+          "updated": 1654036699,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -339,8 +334,8 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1652715904,
-            "updated": 1652724832
+            "created": 1654034548,
+            "updated": 1654036698
           }
         },
         "pending": {
@@ -357,7 +352,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "482",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-azcertificates/v0.4.2 (go1.18; Windows_NT)"
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
       },
       "RequestBody": {
         "issuer": {
@@ -406,15 +401,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "663",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 16 May 2022 18:14:02 GMT",
+        "Date": "Tue, 31 May 2022 22:38:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.83.78.150;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "3c8e30aa-4b5c-4740-bf8b-d2e8326b8b23"
+        "x-ms-request-id": "0a7cdf17-ddc4-4c10-96bd-dff54843bc4f"
       },
       "ResponseBody": {
         "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/policy",
@@ -463,13 +458,13 @@
         },
         "attributes": {
           "enabled": true,
-          "created": 1652715904,
-          "updated": 1652724842
+          "created": 1654034548,
+          "updated": 1654036710
         }
       }
     },
     {
-      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/?api-version=7.3",
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/cert2501394451?api-version=7.3",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -477,13 +472,13 @@
         "Authorization": "Sanitized",
         "Content-Length": "99",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-go-azcertificates/v0.4.2 (go1.18; Windows_NT)"
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
       },
       "RequestBody": {
         "attributes": {
           "enabled": true,
-          "exp": 1684260836,
-          "nbf": 1652724236
+          "exp": 1685572699,
+          "nbf": 1654036099
         },
         "tags": {
           "tag1": "updated_values1"
@@ -494,28 +489,28 @@
         "Cache-Control": "no-cache",
         "Content-Length": "2461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 16 May 2022 18:14:02 GMT",
+        "Date": "Tue, 31 May 2022 22:38:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=73.83.78.150;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
         "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "b8109604-705b-44fb-934f-aa8520804626"
+        "x-ms-request-id": "8bd33d44-d780-4768-b405-4c67c128db9d"
       },
       "ResponseBody": {
-        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/6595dd8432da4b0fb65fc4044fbb3311",
-        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/6595dd8432da4b0fb65fc4044fbb3311",
-        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/6595dd8432da4b0fb65fc4044fbb3311",
-        "x5t": "ruR6MXXj6hptJUSllM4nQyteZu4",
-        "cer": "MIIDVzCCAj\u002BgAwIBAgIQHvd9NY6eRRGkz\u002Be7w4\u002BQGzANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDUxNjE4MDM1NloXDTIzMDUxNjE4MTM1NlowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMF0nEGK3BijB9ktSCvycWH9vpBrh7C6mtKm01JjTT99NGq3JjRl12RiVlUfR9CBdnTwozIhmKOMc06VjqIp09W\u002B8mq\u002BEFYEMp0zESHuwqMFZeY2OTQwszSFE4Ja88f8iE4K0vJfSDwAfa4UX7/gLH9zmihNBeUPtudWyhbDNXZWMJXlVruuEa2nib0v5i\u002BuDrEG85THIn7Z5Do1khPlF/KohD3ezHELYugZhhMqFOR\u002B0K5USNcXCdxPWE6cVbiaw/RJSxczZIolvRy3uyxTfQESzVRNDRj1jWuvM95r2zjjp\u002BgmhBx\u002Bxt\u002BA4TvA040l8FySrBpD8BUWSOJ\u002Bfx5OLiECAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFBcDm/PzV0A\u002BloMqsPdHEfeAzLETMB0GA1UdDgQWBBQXA5vz81dAPpaDKrD3RxH3gMyxEzANBgkqhkiG9w0BAQsFAAOCAQEATDOx65w9hpDuobSYWTMrfDBN80jT2NX4PUz1UcT3/zANNogI5dBLT081VIPjfitLQqLziDs3oh2bxZ/AtzaPlOMk21WrORPmKzm/yivwPbCq\u002BrHRSq05lwkAN5iFJEsEtNx6VUKJqn\u002Byc/8ZHJUzaUTJm4uTn75QbkbbzKpfbwB1dswWLdFh7BXh9ehneZCD5T\u002BXOkFxw/ASRnqhcrsWaccLY2eQQZN0n15Pj4cMvilWcCI30s89n\u002B06C\u002BaO861sB9pAXFShc05IT0v9kLUTKqJBZMkJVBVUKcSiZu26vsZueRyMGq5beGOKtqWUv/z0H7e5kcU1KtqIrj8bM1gxBg==",
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "x5t": "D2ZXAnkLsd-ZLlpkcp5bg6qp9rc",
+        "cer": "MIIDVzCCAj\u002BgAwIBAgIQJId8aQc/RXSLcIK4/xL04DANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDUzMTIyMjgxOVoXDTIzMDUzMTIyMzgxOVowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPN1Y1Ke2Q0QpbznH0e2Qaq8XyMoKmrEI0yvubWZKMKLZUJAZOt9fqlt5yWO/G2RV\u002Be0GcNAO9La6jViY2YYQJl/tGxQVkbl\u002BsuS5sF5PzbR8rmahXLRWE5PR6tQGNDhRdyxM30HOGjQPWUnX3lvdSf/FvegIHCXblLOyeUd1RXwg/Xg7OYmpxHZLWm9HGRNJDr1hGehHc2hxA/OD2BCPSTbP5FXBMp1ZvzzZpKqko\u002B8SHXOjOsUBAKfLDp5hAepZSssEiYALuirbDPSLT6Pk1gTb0A5in3\u002B/BGcou0SosYEEetfTKfdwM6SFYNz6CGVCfaEuv8D9Uc3pjuVz/bcqG0CAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFHabK1nNgT/WNM2N0uX2uuQ8WZz5MB0GA1UdDgQWBBR2mytZzYE/1jTNjdLl9rrkPFmc\u002BTANBgkqhkiG9w0BAQsFAAOCAQEAjHHaJrfu7RkiInluwQr1N9018EdniiTdfACdtU3ZkzKr5\u002BCfTe3sDGktbxBHTXXQp2kc2cYpAexpZ6nsfWOwYoP4piaH2XByxi5JdRjc5vx9bz91nIgt3mzrY2yg3x3KW6bO3U8bUEB/a868eH/IOnCB4NnvVODN62jSQ5XQPPjfmMx/XReU8lw3Apk/4ait2qY8uiX/1S2Dr6bpCcCp67CCmaQHKcbMzo8e/AI8o9T2ssZffZDfV3xEaSXukwNWr6zcAWnvichb6lMoQLp1CleIQyXNY/g43oPCte0bUI0Cq1PkZi8Sef9giycnJOFc3GDVKIPq5\u002B5i/RXvxU5h0A==",
         "attributes": {
           "enabled": true,
-          "nbf": 1652724236,
-          "exp": 1684260836,
-          "created": 1652724836,
-          "updated": 1652724842,
+          "nbf": 1654036099,
+          "exp": 1685572699,
+          "created": 1654036699,
+          "updated": 1654036711,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -569,8 +564,113 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1652715904,
-            "updated": 1652724842
+            "created": 1654034548,
+            "updated": 1654036710
+          }
+        },
+        "pending": {
+          "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/?api-version=7.3",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "Content-Length": "32",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
+      },
+      "RequestBody": {
+        "attributes": {
+          "enabled": false
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "2462",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 31 May 2022 22:38:31 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.395.1",
+        "x-ms-request-id": "03335d60-3702-4e1e-86ec-36001eba3eb0"
+      },
+      "ResponseBody": {
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/c9c47c46d4ae470781284b1e6ac66d5a",
+        "x5t": "D2ZXAnkLsd-ZLlpkcp5bg6qp9rc",
+        "cer": "MIIDVzCCAj\u002BgAwIBAgIQJId8aQc/RXSLcIK4/xL04DANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDUzMTIyMjgxOVoXDTIzMDUzMTIyMzgxOVowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPN1Y1Ke2Q0QpbznH0e2Qaq8XyMoKmrEI0yvubWZKMKLZUJAZOt9fqlt5yWO/G2RV\u002Be0GcNAO9La6jViY2YYQJl/tGxQVkbl\u002BsuS5sF5PzbR8rmahXLRWE5PR6tQGNDhRdyxM30HOGjQPWUnX3lvdSf/FvegIHCXblLOyeUd1RXwg/Xg7OYmpxHZLWm9HGRNJDr1hGehHc2hxA/OD2BCPSTbP5FXBMp1ZvzzZpKqko\u002B8SHXOjOsUBAKfLDp5hAepZSssEiYALuirbDPSLT6Pk1gTb0A5in3\u002B/BGcou0SosYEEetfTKfdwM6SFYNz6CGVCfaEuv8D9Uc3pjuVz/bcqG0CAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFHabK1nNgT/WNM2N0uX2uuQ8WZz5MB0GA1UdDgQWBBR2mytZzYE/1jTNjdLl9rrkPFmc\u002BTANBgkqhkiG9w0BAQsFAAOCAQEAjHHaJrfu7RkiInluwQr1N9018EdniiTdfACdtU3ZkzKr5\u002BCfTe3sDGktbxBHTXXQp2kc2cYpAexpZ6nsfWOwYoP4piaH2XByxi5JdRjc5vx9bz91nIgt3mzrY2yg3x3KW6bO3U8bUEB/a868eH/IOnCB4NnvVODN62jSQ5XQPPjfmMx/XReU8lw3Apk/4ait2qY8uiX/1S2Dr6bpCcCp67CCmaQHKcbMzo8e/AI8o9T2ssZffZDfV3xEaSXukwNWr6zcAWnvichb6lMoQLp1CleIQyXNY/g43oPCte0bUI0Cq1PkZi8Sef9giycnJOFc3GDVKIPq5\u002B5i/RXvxU5h0A==",
+        "attributes": {
+          "enabled": false,
+          "nbf": 1654036099,
+          "exp": 1685572699,
+          "created": 1654036699,
+          "updated": 1654036712,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7
+        },
+        "tags": {
+          "tag1": "updated_values1"
+        },
+        "policy": {
+          "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/policy",
+          "key_props": {
+            "exportable": true,
+            "kty": "EC",
+            "key_size": 256,
+            "reuse_key": true,
+            "crv": "P-256"
+          },
+          "secret_props": {
+            "contentType": "application/x-pkcs12"
+          },
+          "x509_props": {
+            "subject": "CN=DefaultPolicy",
+            "sans": {
+              "dns_names": [
+                "sdk.azure-int.net"
+              ]
+            },
+            "ekus": [
+              "1.3.6.1.5.5.7.3.1",
+              "1.3.6.1.5.5.7.3.2"
+            ],
+            "key_usage": [
+              "decipherOnly"
+            ],
+            "validity_months": 12,
+            "basic_constraints": {
+              "ca": false
+            }
+          },
+          "lifetime_actions": [
+            {
+              "trigger": {
+                "lifetime_percentage": 98
+              },
+              "action": {
+                "action_type": "EmailContacts"
+              }
+            }
+          ],
+          "issuer": {
+            "name": "Self",
+            "cert_transparency": false
+          },
+          "attributes": {
+            "enabled": true,
+            "created": 1654034548,
+            "updated": 1654036710
           }
         },
         "pending": {

--- a/sdk/keyvault/azcertificates/utils_test.go
+++ b/sdk/keyvault/azcertificates/utils_test.go
@@ -58,12 +58,6 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			panic(err)
 		}
-
-		tenantID := os.Getenv("AZCERTIFICATES_TENANT_ID")
-		err = recording.AddHeaderRegexSanitizer("WWW-Authenticate", "00000000-0000-0000-0000-000000000000", tenantID, nil)
-		if err != nil {
-			panic(err)
-		}
 	}
 
 	// Run tests


### PR DESCRIPTION
Mostly renames in alignment with the other Key Vault modules. Deleting all the fields of `UpdateCertificatePropertiesOptions` looks drastic, but they were unused and/or redundant.