### PR TITLE
Remove trailing slashes from parsed vault URLs

### DIFF
--- a/sdk/keyvault/internal/CHANGELOG.md
+++ b/sdk/keyvault/internal/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Release History
 
-## 0.5.1 (Unreleased)
+## 0.6.0 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
+* `ParseID()` no longer appends a trailing slash to vault URLs
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/internal/constants.go
+++ b/sdk/keyvault/internal/constants.go
@@ -7,5 +7,5 @@
 package internal
 
 const (
-	version = "v0.5.1" //nolint
+	version = "v0.6.0" //nolint
 )

--- a/sdk/keyvault/internal/parse.go
+++ b/sdk/keyvault/internal/parse.go
@@ -24,7 +24,7 @@ func ParseID(id *string) (*string, *string, *string) {
 		return nil, nil, nil
 	}
 
-	url := fmt.Sprintf("%s://%s/", parsed.Scheme, parsed.Host)
+	url := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
 	split := strings.Split(strings.TrimPrefix(parsed.Path, "/"), "/")
 	if len(split) < 3 {
 		if len(split) == 2 {

--- a/sdk/keyvault/internal/parse_test.go
+++ b/sdk/keyvault/internal/parse_test.go
@@ -14,9 +14,12 @@ import (
 
 func TestParseID(t *testing.T) {
 	examples := map[string]struct{ url, name, version *string }{
-		"https://myvaultname.vault.azure.net/keys/key1053998307/b86c2e6ad9054f4abf69cc185b99aa60": {to.Ptr("https://myvaultname.vault.azure.net/"), to.Ptr("key1053998307"), to.Ptr("b86c2e6ad9054f4abf69cc185b99aa60")},
-		"https://myvaultname.vault.azure.net/keys/key1053998307":                                  {to.Ptr("https://myvaultname.vault.azure.net/"), to.Ptr("key1053998307"), nil},
-		"https://myvaultname.vault.azure.net/":                                                    {to.Ptr("https://myvaultname.vault.azure.net/"), nil, nil},
+		"https://myvaultname.vault.azure.net/keys/key1053998307/b86c2e6ad9054f4abf69cc185b99aa60":      {to.Ptr("https://myvaultname.vault.azure.net/"), to.Ptr("key1053998307"), to.Ptr("b86c2e6ad9054f4abf69cc185b99aa60")},
+		"https://myvaultname.vault.azure.net:8080/keys/key1053998307/b86c2e6ad9054f4abf69cc185b99aa60": {to.Ptr("https://myvaultname.vault.azure.net:8080/"), to.Ptr("key1053998307"), to.Ptr("b86c2e6ad9054f4abf69cc185b99aa60")},
+		"https://myvaultname.vault.azure.net/keys/key1053998307":                                       {to.Ptr("https://myvaultname.vault.azure.net/"), to.Ptr("key1053998307"), nil},
+		"https://myvaultname.vault.azure.net:8080/keys/key1053998307":                                  {to.Ptr("https://myvaultname.vault.azure.net:8080/"), to.Ptr("key1053998307"), nil},
+		"https://myvaultname.vault.azure.net/":                                                         {to.Ptr("https://myvaultname.vault.azure.net/"), nil, nil},
+		"https://myvaultname.vault.azure.net:8080":                                                     {to.Ptr("https://myvaultname.vault.azure.net:8080/"), nil, nil},
 	}
 
 	for url, expected := range examples {

--- a/sdk/keyvault/internal/parse_test.go
+++ b/sdk/keyvault/internal/parse_test.go
@@ -14,12 +14,12 @@ import (
 
 func TestParseID(t *testing.T) {
 	examples := map[string]struct{ url, name, version *string }{
-		"https://myvaultname.vault.azure.net/keys/key1053998307/b86c2e6ad9054f4abf69cc185b99aa60":      {to.Ptr("https://myvaultname.vault.azure.net/"), to.Ptr("key1053998307"), to.Ptr("b86c2e6ad9054f4abf69cc185b99aa60")},
-		"https://myvaultname.vault.azure.net:8080/keys/key1053998307/b86c2e6ad9054f4abf69cc185b99aa60": {to.Ptr("https://myvaultname.vault.azure.net:8080/"), to.Ptr("key1053998307"), to.Ptr("b86c2e6ad9054f4abf69cc185b99aa60")},
-		"https://myvaultname.vault.azure.net/keys/key1053998307":                                       {to.Ptr("https://myvaultname.vault.azure.net/"), to.Ptr("key1053998307"), nil},
-		"https://myvaultname.vault.azure.net:8080/keys/key1053998307":                                  {to.Ptr("https://myvaultname.vault.azure.net:8080/"), to.Ptr("key1053998307"), nil},
-		"https://myvaultname.vault.azure.net/":                                                         {to.Ptr("https://myvaultname.vault.azure.net/"), nil, nil},
-		"https://myvaultname.vault.azure.net:8080":                                                     {to.Ptr("https://myvaultname.vault.azure.net:8080/"), nil, nil},
+		"https://myvaultname.vault.azure.net/keys/key1053998307/b86c2e6ad9054f4abf69cc185b99aa60":      {to.Ptr("https://myvaultname.vault.azure.net"), to.Ptr("key1053998307"), to.Ptr("b86c2e6ad9054f4abf69cc185b99aa60")},
+		"https://myvaultname.vault.azure.net:8080/keys/key1053998307/b86c2e6ad9054f4abf69cc185b99aa60": {to.Ptr("https://myvaultname.vault.azure.net:8080"), to.Ptr("key1053998307"), to.Ptr("b86c2e6ad9054f4abf69cc185b99aa60")},
+		"https://myvaultname.vault.azure.net/keys/key1053998307":                                       {to.Ptr("https://myvaultname.vault.azure.net"), to.Ptr("key1053998307"), nil},
+		"https://myvaultname.vault.azure.net:8080/keys/key1053998307":                                  {to.Ptr("https://myvaultname.vault.azure.net:8080"), to.Ptr("key1053998307"), nil},
+		"https://myvaultname.vault.azure.net/":                                                         {to.Ptr("https://myvaultname.vault.azure.net"), nil, nil},
+		"https://myvaultname.vault.azure.net:8080":                                                     {to.Ptr("https://myvaultname.vault.azure.net:8080"), nil, nil},
 	}
 
 	for url, expected := range examples {

--- a/sdk/keyvault/internal/parse_test.go
+++ b/sdk/keyvault/internal/parse_test.go
@@ -19,25 +19,25 @@ func TestParseID(t *testing.T) {
 		"https://myvaultname.vault.azure.net/":                                                    {to.Ptr("https://myvaultname.vault.azure.net/"), nil, nil},
 	}
 
-	for url, result := range examples {
+	for url, expected := range examples {
 		url, name, version := ParseID(&url)
-		if result.url == nil {
+		if expected.url == nil {
 			require.Nil(t, url)
 		} else {
 			require.NotNil(t, url)
-			require.Equal(t, *url, *result.url)
+			require.Equal(t, *expected.url, *url)
 		}
-		if result.name == nil {
+		if expected.name == nil {
 			require.Nil(t, name)
 		} else {
-			require.NotNilf(t, name, "expected %s", *result.name)
-			require.Equal(t, *name, *result.name)
+			require.NotNilf(t, name, "expected %s", *expected.name)
+			require.Equal(t, *expected.name, *name)
 		}
-		if result.version == nil {
+		if expected.version == nil {
 			require.Nil(t, version)
 		} else {
 			require.NotNil(t, version)
-			require.Equal(t, *version, *result.version)
+			require.Equal(t, *expected.version, *version)
 		}
 	}
 }


### PR DESCRIPTION
While adding test cases verifying we preserve ports when parsing Key Vault identifiers (closes #18190), I noticed we add trailing slashes to parsed vault URLs e.g., we return `https://foo.vault.com/` as the vault URL of `https://foo.vault.com/keys/mykey`. I think we should stop doing this because although I doubt the trailing slash breaks anything, it's unnecessary and semantically incorrect in implying a directory or an empty path.