### PR TITLE
Override live test location default to westus

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -40,8 +40,14 @@ parameters:
     default:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        # TODO: Migrate location override into azure-sdk-tools eng/common
+        # See https://github.com/Azure/azure-sdk-tools/issues/3398
+        Location: 'westus'
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+        # TODO: Migrate location override into azure-sdk-tools eng/common
+        # See https://github.com/Azure/azure-sdk-tools/issues/3398
+        Location: 'westus'
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'


### PR DESCRIPTION
Temporary location override at the go repo level as part of https://github.com/Azure/azure-sdk-tools/issues/3398 to
address capacity restrictions.
