### PR TITLE
Consistent Update*Properties methods for Key Vault clients

### DIFF
--- a/sdk/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/keyvault/azcertificates/CHANGELOG.md
@@ -14,6 +14,7 @@
   * `ListCertificatesOptions` to `ListPropertiesOfCertificatesOptions`
   * `ListCertificateVersionsOptions` to `ListPropertiesOfCertificateVersionsOptions`
 * Renamed `ListDeletedCertificatesResponse.Certificates` to `.DeletedCertificates`
+* `UpdateCertificateProperties()` has a `Properties` parameter instead of a `string` parameter
 
 ### Bugs Fixed
 * LROs now correctly exit the polling loop in `PollUntilDone()` when the operations reach a terminal state.

--- a/sdk/keyvault/azcertificates/client.go
+++ b/sdk/keyvault/azcertificates/client.go
@@ -1062,10 +1062,7 @@ type UpdateCertificatePropertiesResponse struct {
 
 // UpdateCertificateProperties applies the specified update on the given certificate; the only elements updated are the certificate's
 // attributes. This operation requires the certificates/update permission.
-func (c *Client) UpdateCertificateProperties(ctx context.Context, certificateName string, properties Properties, options *UpdateCertificatePropertiesOptions) (UpdateCertificatePropertiesResponse, error) {
-	if options == nil {
-		options = &UpdateCertificatePropertiesOptions{}
-	}
+func (c *Client) UpdateCertificateProperties(ctx context.Context, properties Properties, options *UpdateCertificatePropertiesOptions) (UpdateCertificatePropertiesResponse, error) {
 	version := ""
 	if properties.Version != nil {
 		version = *properties.Version
@@ -1073,13 +1070,13 @@ func (c *Client) UpdateCertificateProperties(ctx context.Context, certificateNam
 	resp, err := c.genClient.UpdateCertificate(
 		ctx,
 		c.vaultURL,
-		certificateName,
+		*properties.Name,
 		version,
 		generated.CertificateUpdateParameters{
 			CertificateAttributes: properties.toGenerated(),
 			Tags:                  properties.Tags,
 		},
-		options.toGenerated(),
+		nil,
 	)
 	if err != nil {
 		return UpdateCertificatePropertiesResponse{}, err

--- a/sdk/keyvault/azcertificates/client_test.go
+++ b/sdk/keyvault/azcertificates/client_test.go
@@ -605,15 +605,17 @@ func TestCRUDOperations(t *testing.T) {
 		received.Properties.Tags = map[string]*string{}
 	}
 	received.Properties.Tags["tag1"] = to.Ptr("updated_values1")
-	updatePropsResp, err := client.UpdateCertificateProperties(ctx, certName, *received.Properties, nil)
+	updatePropsResp, err := client.UpdateCertificateProperties(ctx, *received.Properties, nil)
 	require.NoError(t, err)
 	require.Equal(t, "updated_values1", *updatePropsResp.Properties.Tags["tag1"])
 	require.Equal(t, *received.ID, *updatePropsResp.ID)
 	require.True(t, *updatePropsResp.Properties.Enabled)
 
-	resp, err := client.UpdateCertificateProperties(ctx, *updatePropsResp.Name, Properties{Enabled: to.Ptr(false)}, nil)
+	received.Properties.Enabled = to.Ptr(false)
+	resp, err := client.UpdateCertificateProperties(ctx, *received.Properties, nil)
 	require.NoError(t, err)
 	require.False(t, *resp.Properties.Enabled)
+	require.Equal(t, "updated_values1", *resp.Properties.Tags["tag1"])
 }
 
 // https://stackoverflow.com/questions/42643048/signing-certificate-request-with-certificate-authority

--- a/sdk/keyvault/azcertificates/example_test.go
+++ b/sdk/keyvault/azcertificates/example_test.go
@@ -122,10 +122,10 @@ func ExampleClient_UpdateCertificateProperties() {
 	if err != nil {
 		panic(err)
 	}
+
 	getResp.Properties.Enabled = to.Ptr(false)
 	getResp.Properties.Tags["Tag1"] = to.Ptr("Val1")
-
-	resp, err := client.UpdateCertificateProperties(context.TODO(), "myCertName", *getResp.Properties, nil)
+	resp, err := client.UpdateCertificateProperties(context.TODO(), *getResp.Properties, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/sdk/keyvault/azcertificates/testdata/recordings/TestCRUDOperations.json
+++ b/sdk/keyvault/azcertificates/testdata/recordings/TestCRUDOperations.json
@@ -15,7 +15,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 01 Jun 2022 16:09:58 GMT",
+        "Date": "Thu, 02 Jun 2022 23:19:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
@@ -23,8 +23,8 @@
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "72fbc486-5137-4095-87ce-de6fdd056e21"
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "25e3feb8-a7eb-4d2b-be5d-32a0627b83dc"
       },
       "ResponseBody": {
         "error": {
@@ -93,32 +93,217 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1333",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 01 Jun 2022 16:10:02 GMT",
+        "Date": "Thu, 02 Jun 2022 23:19:58 GMT",
         "Expires": "-1",
-        "Location": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=927cbbf69a934faea62c293282750695",
+        "Location": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=e2593a2b01da4829adc38934b813a743",
         "Pragma": "no-cache",
         "Retry-After": "10",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "83a90c69-a409-46a8-bf5a-f1a37f2debbb"
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "5c93d085-daa1-4b85-bdb4-bbef218c8fd6"
       },
       "ResponseBody": {
         "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL83WsCMVqcMeQMKkNO1Epuf7zBq4CBHpZDN8McgnF4Uj\u002BVfhPZiKznnaWtFLP9XZSgLunEQMk/LFpRcVSrkmPtoGlvY28saOy\u002BeJlR9JPjhvh2S5m\u002B\u002Bn86h6IdHnouRL8vgg8zBoQSAD2ewviR04k/VUBHWf7smLTIpKKlUxXb8Hoe8zlxLeKO1CnQ5LeT\u002BBwiyqBcQUoHr90LS6DnwqjjDKKQFy\u002BXbUXOedBsK9ot\u002BhDI5cpCh1hXvANIxk4/jnzQtnLcnz04etlhV6QN5XhXlKeKjDgVLrxoBMDI/jvehxmPADa4y01SRn1SaH/Slxbv4StvwDKex50yHwu4kOZUCAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEAsoPlIgdN38SCI3zzNB2yNsgx3bJ9nuwyBarcgTIWzI5WFXgzoJYtRKlzUSRWw2feRKqgtD9viQQHaMDxnYwSAcxAuamgeunFp3HvlLqUWvzoKSSlHheVBCBKcMkEw5KRUVBhE7BZt7/t1htmCpf52OrrvPUN/ZmdEBZ1dW/Zew3KiNnNst7\u002BiWbZFqwjHQJQjjQwlYzAlLCeWBTjpfhvYpPoQoTR7kl5Ucs2CPVzgXOfSmOsaSO6U6wTbREU4eka6qQp/F63iZXGM1anEbud6\u002BrMN9cZCuiFqz0AYrqFXktjD1\u002BMddrDtuVbDhmgABaCb1lhNFSTtQPcSXPjeSan9A==",
+        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEARQZGkjWfF2GzY4QL\u002BwjnI9HO02UMbWsFBofxNGcokpzq1E/eNdLrer9WfWy5aV6B6RdQ1r7iRFZiuvW5vhxL9WTka\u002BTsdDXavw8Q/sNIy6SIMVXB/rS13gMAsIhEvIfQzMabDZKrAHmMVVWMWS7MJPzMtW8/b5Yu7/0e5GNz5U3OAd0jEEjyA6mv1NkGoaeirAuTdjVA\u002BGcOD8kthxM9jSWi\u002BOAlQB5k402aIYfSG7fseIQaSY/F8F4C\u002B9\u002BF88itEifgWl4n2gZeS7cPzv9eWcrs5ulOhofniw\u002BqY1L1AohWf4Elplv6EJyXzJiwRoJu4/wptQVFhYYk8ZAnXy3R0A==",
         "cancellation_requested": false,
         "status": "inProgress",
         "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
-        "request_id": "927cbbf69a934faea62c293282750695"
+        "request_id": "e2593a2b01da4829adc38934b813a743"
       }
     },
     {
-      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=927cbbf69a934faea62c293282750695",
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=e2593a2b01da4829adc38934b813a743",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1333",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 02 Jun 2022 23:20:08 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Retry-After": "10",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "90ab9771-13a4-47df-9e44-97813271b797"
+      },
+      "ResponseBody": {
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending",
+        "issuer": {
+          "name": "Self"
+        },
+        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEARQZGkjWfF2GzY4QL\u002BwjnI9HO02UMbWsFBofxNGcokpzq1E/eNdLrer9WfWy5aV6B6RdQ1r7iRFZiuvW5vhxL9WTka\u002BTsdDXavw8Q/sNIy6SIMVXB/rS13gMAsIhEvIfQzMabDZKrAHmMVVWMWS7MJPzMtW8/b5Yu7/0e5GNz5U3OAd0jEEjyA6mv1NkGoaeirAuTdjVA\u002BGcOD8kthxM9jSWi\u002BOAlQB5k402aIYfSG7fseIQaSY/F8F4C\u002B9\u002BF88itEifgWl4n2gZeS7cPzv9eWcrs5ulOhofniw\u002BqY1L1AohWf4Elplv6EJyXzJiwRoJu4/wptQVFhYYk8ZAnXy3R0A==",
+        "cancellation_requested": false,
+        "status": "inProgress",
+        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
+        "request_id": "e2593a2b01da4829adc38934b813a743"
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=e2593a2b01da4829adc38934b813a743",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1333",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 02 Jun 2022 23:20:19 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Retry-After": "10",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "1a40769a-4f13-4a19-910b-faff704a6920"
+      },
+      "ResponseBody": {
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending",
+        "issuer": {
+          "name": "Self"
+        },
+        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEARQZGkjWfF2GzY4QL\u002BwjnI9HO02UMbWsFBofxNGcokpzq1E/eNdLrer9WfWy5aV6B6RdQ1r7iRFZiuvW5vhxL9WTka\u002BTsdDXavw8Q/sNIy6SIMVXB/rS13gMAsIhEvIfQzMabDZKrAHmMVVWMWS7MJPzMtW8/b5Yu7/0e5GNz5U3OAd0jEEjyA6mv1NkGoaeirAuTdjVA\u002BGcOD8kthxM9jSWi\u002BOAlQB5k402aIYfSG7fseIQaSY/F8F4C\u002B9\u002BF88itEifgWl4n2gZeS7cPzv9eWcrs5ulOhofniw\u002BqY1L1AohWf4Elplv6EJyXzJiwRoJu4/wptQVFhYYk8ZAnXy3R0A==",
+        "cancellation_requested": false,
+        "status": "inProgress",
+        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
+        "request_id": "e2593a2b01da4829adc38934b813a743"
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=e2593a2b01da4829adc38934b813a743",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1333",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 02 Jun 2022 23:20:29 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Retry-After": "10",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "512673d6-1d90-441b-8a1a-46fa29033db9"
+      },
+      "ResponseBody": {
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending",
+        "issuer": {
+          "name": "Self"
+        },
+        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEARQZGkjWfF2GzY4QL\u002BwjnI9HO02UMbWsFBofxNGcokpzq1E/eNdLrer9WfWy5aV6B6RdQ1r7iRFZiuvW5vhxL9WTka\u002BTsdDXavw8Q/sNIy6SIMVXB/rS13gMAsIhEvIfQzMabDZKrAHmMVVWMWS7MJPzMtW8/b5Yu7/0e5GNz5U3OAd0jEEjyA6mv1NkGoaeirAuTdjVA\u002BGcOD8kthxM9jSWi\u002BOAlQB5k402aIYfSG7fseIQaSY/F8F4C\u002B9\u002BF88itEifgWl4n2gZeS7cPzv9eWcrs5ulOhofniw\u002BqY1L1AohWf4Elplv6EJyXzJiwRoJu4/wptQVFhYYk8ZAnXy3R0A==",
+        "cancellation_requested": false,
+        "status": "inProgress",
+        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
+        "request_id": "e2593a2b01da4829adc38934b813a743"
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=e2593a2b01da4829adc38934b813a743",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1333",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 02 Jun 2022 23:20:39 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Retry-After": "10",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "269599c4-cc40-40c3-b3b7-f61e8071d34d"
+      },
+      "ResponseBody": {
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending",
+        "issuer": {
+          "name": "Self"
+        },
+        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEARQZGkjWfF2GzY4QL\u002BwjnI9HO02UMbWsFBofxNGcokpzq1E/eNdLrer9WfWy5aV6B6RdQ1r7iRFZiuvW5vhxL9WTka\u002BTsdDXavw8Q/sNIy6SIMVXB/rS13gMAsIhEvIfQzMabDZKrAHmMVVWMWS7MJPzMtW8/b5Yu7/0e5GNz5U3OAd0jEEjyA6mv1NkGoaeirAuTdjVA\u002BGcOD8kthxM9jSWi\u002BOAlQB5k402aIYfSG7fseIQaSY/F8F4C\u002B9\u002BF88itEifgWl4n2gZeS7cPzv9eWcrs5ulOhofniw\u002BqY1L1AohWf4Elplv6EJyXzJiwRoJu4/wptQVFhYYk8ZAnXy3R0A==",
+        "cancellation_requested": false,
+        "status": "inProgress",
+        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
+        "request_id": "e2593a2b01da4829adc38934b813a743"
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=e2593a2b01da4829adc38934b813a743",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept-Encoding": "gzip",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1333",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 02 Jun 2022 23:20:50 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Retry-After": "10",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "96e4d051-3c55-4918-a93e-83b1e62afb5b"
+      },
+      "ResponseBody": {
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending",
+        "issuer": {
+          "name": "Self"
+        },
+        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEARQZGkjWfF2GzY4QL\u002BwjnI9HO02UMbWsFBofxNGcokpzq1E/eNdLrer9WfWy5aV6B6RdQ1r7iRFZiuvW5vhxL9WTka\u002BTsdDXavw8Q/sNIy6SIMVXB/rS13gMAsIhEvIfQzMabDZKrAHmMVVWMWS7MJPzMtW8/b5Yu7/0e5GNz5U3OAd0jEEjyA6mv1NkGoaeirAuTdjVA\u002BGcOD8kthxM9jSWi\u002BOAlQB5k402aIYfSG7fseIQaSY/F8F4C\u002B9\u002BF88itEifgWl4n2gZeS7cPzv9eWcrs5ulOhofniw\u002BqY1L1AohWf4Elplv6EJyXzJiwRoJu4/wptQVFhYYk8ZAnXy3R0A==",
+        "cancellation_requested": false,
+        "status": "inProgress",
+        "status_details": "Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.",
+        "request_id": "e2593a2b01da4829adc38934b813a743"
+      }
+    },
+    {
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending?api-version=7.3\u0026request_id=e2593a2b01da4829adc38934b813a743",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept-Encoding": "gzip",
@@ -131,26 +316,26 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1241",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 01 Jun 2022 16:10:12 GMT",
+        "Date": "Thu, 02 Jun 2022 23:21:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "694a377e-96e2-4964-a679-04dfaa71d2e0"
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "c78168de-b324-4fde-898a-3a497045f456"
       },
       "ResponseBody": {
         "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending",
         "issuer": {
           "name": "Self"
         },
-        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL83WsCMVqcMeQMKkNO1Epuf7zBq4CBHpZDN8McgnF4Uj\u002BVfhPZiKznnaWtFLP9XZSgLunEQMk/LFpRcVSrkmPtoGlvY28saOy\u002BeJlR9JPjhvh2S5m\u002B\u002Bn86h6IdHnouRL8vgg8zBoQSAD2ewviR04k/VUBHWf7smLTIpKKlUxXb8Hoe8zlxLeKO1CnQ5LeT\u002BBwiyqBcQUoHr90LS6DnwqjjDKKQFy\u002BXbUXOedBsK9ot\u002BhDI5cpCh1hXvANIxk4/jnzQtnLcnz04etlhV6QN5XhXlKeKjDgVLrxoBMDI/jvehxmPADa4y01SRn1SaH/Slxbv4StvwDKex50yHwu4kOZUCAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEAsoPlIgdN38SCI3zzNB2yNsgx3bJ9nuwyBarcgTIWzI5WFXgzoJYtRKlzUSRWw2feRKqgtD9viQQHaMDxnYwSAcxAuamgeunFp3HvlLqUWvzoKSSlHheVBCBKcMkEw5KRUVBhE7BZt7/t1htmCpf52OrrvPUN/ZmdEBZ1dW/Zew3KiNnNst7\u002BiWbZFqwjHQJQjjQwlYzAlLCeWBTjpfhvYpPoQoTR7kl5Ucs2CPVzgXOfSmOsaSO6U6wTbREU4eka6qQp/F63iZXGM1anEbud6\u002BrMN9cZCuiFqz0AYrqFXktjD1\u002BMddrDtuVbDhmgABaCb1lhNFSTtQPcSXPjeSan9A==",
+        "csr": "MIICxzCCAa8CAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaBqMGgGCSqGSIb3DQEJDjFbMFkwDwYDVR0PAQH/BAUDAwcAgDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRc2RrLmF6dXJlLWludC5uZXQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOCAQEARQZGkjWfF2GzY4QL\u002BwjnI9HO02UMbWsFBofxNGcokpzq1E/eNdLrer9WfWy5aV6B6RdQ1r7iRFZiuvW5vhxL9WTka\u002BTsdDXavw8Q/sNIy6SIMVXB/rS13gMAsIhEvIfQzMabDZKrAHmMVVWMWS7MJPzMtW8/b5Yu7/0e5GNz5U3OAd0jEEjyA6mv1NkGoaeirAuTdjVA\u002BGcOD8kthxM9jSWi\u002BOAlQB5k402aIYfSG7fseIQaSY/F8F4C\u002B9\u002BF88itEifgWl4n2gZeS7cPzv9eWcrs5ulOhofniw\u002BqY1L1AohWf4Elplv6EJyXzJiwRoJu4/wptQVFhYYk8ZAnXy3R0A==",
         "cancellation_requested": false,
         "status": "completed",
         "target": "https://fakekvurl.vault.azure.net/certificates/cert2501394451",
-        "request_id": "927cbbf69a934faea62c293282750695"
+        "request_id": "e2593a2b01da4829adc38934b813a743"
       }
     },
     {
@@ -168,28 +353,28 @@
         "Cache-Control": "no-cache",
         "Content-Length": "2415",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 01 Jun 2022 16:10:12 GMT",
+        "Date": "Thu, 02 Jun 2022 23:21:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "05977c59-d9d5-4c7d-9b92-e3fa2088d3aa"
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "8f8aefa8-4db8-42df-9bfb-a399baeb5088"
       },
       "ResponseBody": {
-        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "x5t": "ZSzPqjjjW6eoF_nwM0gt7J922lk",
-        "cer": "MIIDVzCCAj\u002BgAwIBAgIQJMUbe0ehRtq5JQNSJcCwazANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDYwMTE2MDAwNloXDTIzMDYwMTE2MTAwNlowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL83WsCMVqcMeQMKkNO1Epuf7zBq4CBHpZDN8McgnF4Uj\u002BVfhPZiKznnaWtFLP9XZSgLunEQMk/LFpRcVSrkmPtoGlvY28saOy\u002BeJlR9JPjhvh2S5m\u002B\u002Bn86h6IdHnouRL8vgg8zBoQSAD2ewviR04k/VUBHWf7smLTIpKKlUxXb8Hoe8zlxLeKO1CnQ5LeT\u002BBwiyqBcQUoHr90LS6DnwqjjDKKQFy\u002BXbUXOedBsK9ot\u002BhDI5cpCh1hXvANIxk4/jnzQtnLcnz04etlhV6QN5XhXlKeKjDgVLrxoBMDI/jvehxmPADa4y01SRn1SaH/Slxbv4StvwDKex50yHwu4kOZUCAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFDi/EQVjPbYmZVs6/nBewwdVrZ/1MB0GA1UdDgQWBBQ4vxEFYz22JmVbOv5wXsMHVa2f9TANBgkqhkiG9w0BAQsFAAOCAQEAf5SrHAYA3vaRRXEzYGI6D5maezVk7A0ymd3Rcx7HxnjHAi6ntTH01wVwtc3GEGlKbN4lWat2IFv4k6VR37C5o\u002BHjXCwKBgnACVVmhs5M\u002B3ByQuhGj/6B5JRCSD8h4T/So9ayFVs6u5S3\u002BWuHe2PrihbY\u002B204bpuRMlp/8iE\u002Bk4j4AE4qEnhbo9a8Ej3qqpNF4Elqme8dE4z1ug9ItZIwWubTuF6mNXNvd9Nte6HEEzR6Ps0wJgoaSQ2jN8ai6svPkRWjwQp5nBwO9bXMBePiGpKQ7d4qTdRcUyz9jFExzqt7KymbERntWZ/72xKMwtAMjeqLw/CU/4ptKQLa8oM7kQ==",
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "x5t": "FACUQtp7ZpuQOlKA1PJ4CeE8itM",
+        "cer": "MIIDVzCCAj\u002BgAwIBAgIQF3RbYvuQRgWSYSQtH5lBJjANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDYwMjIzMTA1N1oXDTIzMDYwMjIzMjA1N1owGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFFZkx8TLPLnwu97CM5\u002BpKVeKz6zgMB0GA1UdDgQWBBRWZMfEyzy58LvewjOfqSlXis\u002Bs4DANBgkqhkiG9w0BAQsFAAOCAQEAUhHCIxwAhT7xGdBVsjkh5r61nmw0HkKRlWTlZCSLwPuU0B9RLGoaa4fjuIbimKO4PdqfVjE9kk/JVj1g5rle5P2kFdMzuH1JzeG1IDmPWOyyQJp4rn50mAip05CIUY2qqXAhH7Ev1oBvDbiTWi1fqocaHRVv/g46tMZcT8XR0W2guLpsxoYzNQ5TRC6mff6bMbDiA75fM0j9XUuakUna0JvaMdMHVDmJ3bpXFcMcLeK6DWdvEzg7EPRJr24VBimmwDl0ylW0inUWjL2mmZUNAfV3JUI5yKqy69G6hrtDy92Sm/2g3Jk6saJ1iis/hC7zE45eursH6/18HApHlNd3IA==",
         "attributes": {
           "enabled": true,
-          "nbf": 1654099206,
-          "exp": 1685635806,
-          "created": 1654099806,
-          "updated": 1654099806,
+          "nbf": 1654211457,
+          "exp": 1685748057,
+          "created": 1654212057,
+          "updated": 1654212057,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -239,8 +424,8 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1654099802,
-            "updated": 1654099802
+            "created": 1654211998,
+            "updated": 1654211998
           }
         },
         "pending": {
@@ -263,28 +448,28 @@
         "Cache-Control": "no-cache",
         "Content-Length": "2415",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 01 Jun 2022 16:10:12 GMT",
+        "Date": "Thu, 02 Jun 2022 23:21:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "3898a25f-9c69-4e1c-b32a-5a4c280ab634"
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "2caace7e-8c0a-460b-bf62-a943275426d2"
       },
       "ResponseBody": {
-        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "x5t": "ZSzPqjjjW6eoF_nwM0gt7J922lk",
-        "cer": "MIIDVzCCAj\u002BgAwIBAgIQJMUbe0ehRtq5JQNSJcCwazANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDYwMTE2MDAwNloXDTIzMDYwMTE2MTAwNlowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL83WsCMVqcMeQMKkNO1Epuf7zBq4CBHpZDN8McgnF4Uj\u002BVfhPZiKznnaWtFLP9XZSgLunEQMk/LFpRcVSrkmPtoGlvY28saOy\u002BeJlR9JPjhvh2S5m\u002B\u002Bn86h6IdHnouRL8vgg8zBoQSAD2ewviR04k/VUBHWf7smLTIpKKlUxXb8Hoe8zlxLeKO1CnQ5LeT\u002BBwiyqBcQUoHr90LS6DnwqjjDKKQFy\u002BXbUXOedBsK9ot\u002BhDI5cpCh1hXvANIxk4/jnzQtnLcnz04etlhV6QN5XhXlKeKjDgVLrxoBMDI/jvehxmPADa4y01SRn1SaH/Slxbv4StvwDKex50yHwu4kOZUCAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFDi/EQVjPbYmZVs6/nBewwdVrZ/1MB0GA1UdDgQWBBQ4vxEFYz22JmVbOv5wXsMHVa2f9TANBgkqhkiG9w0BAQsFAAOCAQEAf5SrHAYA3vaRRXEzYGI6D5maezVk7A0ymd3Rcx7HxnjHAi6ntTH01wVwtc3GEGlKbN4lWat2IFv4k6VR37C5o\u002BHjXCwKBgnACVVmhs5M\u002B3ByQuhGj/6B5JRCSD8h4T/So9ayFVs6u5S3\u002BWuHe2PrihbY\u002B204bpuRMlp/8iE\u002Bk4j4AE4qEnhbo9a8Ej3qqpNF4Elqme8dE4z1ug9ItZIwWubTuF6mNXNvd9Nte6HEEzR6Ps0wJgoaSQ2jN8ai6svPkRWjwQp5nBwO9bXMBePiGpKQ7d4qTdRcUyz9jFExzqt7KymbERntWZ/72xKMwtAMjeqLw/CU/4ptKQLa8oM7kQ==",
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "x5t": "FACUQtp7ZpuQOlKA1PJ4CeE8itM",
+        "cer": "MIIDVzCCAj\u002BgAwIBAgIQF3RbYvuQRgWSYSQtH5lBJjANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDYwMjIzMTA1N1oXDTIzMDYwMjIzMjA1N1owGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFFZkx8TLPLnwu97CM5\u002BpKVeKz6zgMB0GA1UdDgQWBBRWZMfEyzy58LvewjOfqSlXis\u002Bs4DANBgkqhkiG9w0BAQsFAAOCAQEAUhHCIxwAhT7xGdBVsjkh5r61nmw0HkKRlWTlZCSLwPuU0B9RLGoaa4fjuIbimKO4PdqfVjE9kk/JVj1g5rle5P2kFdMzuH1JzeG1IDmPWOyyQJp4rn50mAip05CIUY2qqXAhH7Ev1oBvDbiTWi1fqocaHRVv/g46tMZcT8XR0W2guLpsxoYzNQ5TRC6mff6bMbDiA75fM0j9XUuakUna0JvaMdMHVDmJ3bpXFcMcLeK6DWdvEzg7EPRJr24VBimmwDl0ylW0inUWjL2mmZUNAfV3JUI5yKqy69G6hrtDy92Sm/2g3Jk6saJ1iis/hC7zE45eursH6/18HApHlNd3IA==",
         "attributes": {
           "enabled": true,
-          "nbf": 1654099206,
-          "exp": 1685635806,
-          "created": 1654099806,
-          "updated": 1654099806,
+          "nbf": 1654211457,
+          "exp": 1685748057,
+          "created": 1654212057,
+          "updated": 1654212057,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -334,8 +519,8 @@
           },
           "attributes": {
             "enabled": true,
-            "created": 1654099802,
-            "updated": 1654099802
+            "created": 1654211998,
+            "updated": 1654211998
           }
         },
         "pending": {
@@ -401,15 +586,15 @@
         "Cache-Control": "no-cache",
         "Content-Length": "663",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 01 Jun 2022 16:10:13 GMT",
+        "Date": "Thu, 02 Jun 2022 23:21:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "1232c49f-2030-4672-bf7a-08c04c451ad6"
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "83d194e4-b0bc-498d-9df2-20dfc603eaf0"
       },
       "ResponseBody": {
         "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/policy",
@@ -458,13 +643,13 @@
         },
         "attributes": {
           "enabled": true,
-          "created": 1654099802,
-          "updated": 1654099813
+          "created": 1654211998,
+          "updated": 1654212062
         }
       }
     },
     {
-      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/091e7c4fcce14674bfe3e759a17c5144?api-version=7.3",
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/43e86e7b2ce24e0aa953234db20c9592?api-version=7.3",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -477,8 +662,8 @@
       "RequestBody": {
         "attributes": {
           "enabled": true,
-          "exp": 1685635806,
-          "nbf": 1654099206
+          "exp": 1685748057,
+          "nbf": 1654211457
         },
         "tags": {
           "tag1": "updated_values1"
@@ -489,28 +674,28 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 01 Jun 2022 16:10:13 GMT",
+        "Date": "Thu, 02 Jun 2022 23:21:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "e915dc40-1d3c-411f-bf60-be1181b0de71"
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "b3bd5fe8-5566-4589-b384-f3dfebceec04"
       },
       "ResponseBody": {
-        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "x5t": "ZSzPqjjjW6eoF_nwM0gt7J922lk",
-        "cer": "MIIDVzCCAj\u002BgAwIBAgIQJMUbe0ehRtq5JQNSJcCwazANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDYwMTE2MDAwNloXDTIzMDYwMTE2MTAwNlowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL83WsCMVqcMeQMKkNO1Epuf7zBq4CBHpZDN8McgnF4Uj\u002BVfhPZiKznnaWtFLP9XZSgLunEQMk/LFpRcVSrkmPtoGlvY28saOy\u002BeJlR9JPjhvh2S5m\u002B\u002Bn86h6IdHnouRL8vgg8zBoQSAD2ewviR04k/VUBHWf7smLTIpKKlUxXb8Hoe8zlxLeKO1CnQ5LeT\u002BBwiyqBcQUoHr90LS6DnwqjjDKKQFy\u002BXbUXOedBsK9ot\u002BhDI5cpCh1hXvANIxk4/jnzQtnLcnz04etlhV6QN5XhXlKeKjDgVLrxoBMDI/jvehxmPADa4y01SRn1SaH/Slxbv4StvwDKex50yHwu4kOZUCAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFDi/EQVjPbYmZVs6/nBewwdVrZ/1MB0GA1UdDgQWBBQ4vxEFYz22JmVbOv5wXsMHVa2f9TANBgkqhkiG9w0BAQsFAAOCAQEAf5SrHAYA3vaRRXEzYGI6D5maezVk7A0ymd3Rcx7HxnjHAi6ntTH01wVwtc3GEGlKbN4lWat2IFv4k6VR37C5o\u002BHjXCwKBgnACVVmhs5M\u002B3ByQuhGj/6B5JRCSD8h4T/So9ayFVs6u5S3\u002BWuHe2PrihbY\u002B204bpuRMlp/8iE\u002Bk4j4AE4qEnhbo9a8Ej3qqpNF4Elqme8dE4z1ug9ItZIwWubTuF6mNXNvd9Nte6HEEzR6Ps0wJgoaSQ2jN8ai6svPkRWjwQp5nBwO9bXMBePiGpKQ7d4qTdRcUyz9jFExzqt7KymbERntWZ/72xKMwtAMjeqLw/CU/4ptKQLa8oM7kQ==",
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "x5t": "FACUQtp7ZpuQOlKA1PJ4CeE8itM",
+        "cer": "MIIDVzCCAj\u002BgAwIBAgIQF3RbYvuQRgWSYSQtH5lBJjANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDYwMjIzMTA1N1oXDTIzMDYwMjIzMjA1N1owGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFFZkx8TLPLnwu97CM5\u002BpKVeKz6zgMB0GA1UdDgQWBBRWZMfEyzy58LvewjOfqSlXis\u002Bs4DANBgkqhkiG9w0BAQsFAAOCAQEAUhHCIxwAhT7xGdBVsjkh5r61nmw0HkKRlWTlZCSLwPuU0B9RLGoaa4fjuIbimKO4PdqfVjE9kk/JVj1g5rle5P2kFdMzuH1JzeG1IDmPWOyyQJp4rn50mAip05CIUY2qqXAhH7Ev1oBvDbiTWi1fqocaHRVv/g46tMZcT8XR0W2guLpsxoYzNQ5TRC6mff6bMbDiA75fM0j9XUuakUna0JvaMdMHVDmJ3bpXFcMcLeK6DWdvEzg7EPRJr24VBimmwDl0ylW0inUWjL2mmZUNAfV3JUI5yKqy69G6hrtDy92Sm/2g3Jk6saJ1iis/hC7zE45eursH6/18HApHlNd3IA==",
         "attributes": {
           "enabled": true,
-          "nbf": 1654099206,
-          "exp": 1685635806,
-          "created": 1654099806,
-          "updated": 1654099814,
+          "nbf": 1654211457,
+          "exp": 1685748057,
+          "created": 1654212057,
+          "updated": 1654212062,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
@@ -523,104 +708,58 @@
       }
     },
     {
-      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/?api-version=7.3",
+      "RequestUri": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/43e86e7b2ce24e0aa953234db20c9592?api-version=7.3",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip",
         "Authorization": "Sanitized",
-        "Content-Length": "32",
+        "Content-Length": "100",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-go-azcertificates/v0.5.0 (go1.18; linux)"
       },
       "RequestBody": {
         "attributes": {
-          "enabled": false
+          "enabled": false,
+          "exp": 1685748057,
+          "nbf": 1654211457
+        },
+        "tags": {
+          "tag1": "updated_values1"
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2462",
+        "Content-Length": "1789",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 01 Jun 2022 16:10:14 GMT",
+        "Date": "Thu, 02 Jun 2022 23:21:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;",
         "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.9.395.1",
-        "x-ms-request-id": "c7634eb9-c837-4ff2-9489-6fd072f651e4"
+        "x-ms-keyvault-service-version": "1.9.422.1",
+        "x-ms-request-id": "b07dfb78-92b0-4ac6-93eb-e55e91a17c20"
       },
       "ResponseBody": {
-        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/091e7c4fcce14674bfe3e759a17c5144",
-        "x5t": "ZSzPqjjjW6eoF_nwM0gt7J922lk",
-        "cer": "MIIDVzCCAj\u002BgAwIBAgIQJMUbe0ehRtq5JQNSJcCwazANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDYwMTE2MDAwNloXDTIzMDYwMTE2MTAwNlowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL83WsCMVqcMeQMKkNO1Epuf7zBq4CBHpZDN8McgnF4Uj\u002BVfhPZiKznnaWtFLP9XZSgLunEQMk/LFpRcVSrkmPtoGlvY28saOy\u002BeJlR9JPjhvh2S5m\u002B\u002Bn86h6IdHnouRL8vgg8zBoQSAD2ewviR04k/VUBHWf7smLTIpKKlUxXb8Hoe8zlxLeKO1CnQ5LeT\u002BBwiyqBcQUoHr90LS6DnwqjjDKKQFy\u002BXbUXOedBsK9ot\u002BhDI5cpCh1hXvANIxk4/jnzQtnLcnz04etlhV6QN5XhXlKeKjDgVLrxoBMDI/jvehxmPADa4y01SRn1SaH/Slxbv4StvwDKex50yHwu4kOZUCAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFDi/EQVjPbYmZVs6/nBewwdVrZ/1MB0GA1UdDgQWBBQ4vxEFYz22JmVbOv5wXsMHVa2f9TANBgkqhkiG9w0BAQsFAAOCAQEAf5SrHAYA3vaRRXEzYGI6D5maezVk7A0ymd3Rcx7HxnjHAi6ntTH01wVwtc3GEGlKbN4lWat2IFv4k6VR37C5o\u002BHjXCwKBgnACVVmhs5M\u002B3ByQuhGj/6B5JRCSD8h4T/So9ayFVs6u5S3\u002BWuHe2PrihbY\u002B204bpuRMlp/8iE\u002Bk4j4AE4qEnhbo9a8Ej3qqpNF4Elqme8dE4z1ug9ItZIwWubTuF6mNXNvd9Nte6HEEzR6Ps0wJgoaSQ2jN8ai6svPkRWjwQp5nBwO9bXMBePiGpKQ7d4qTdRcUyz9jFExzqt7KymbERntWZ/72xKMwtAMjeqLw/CU/4ptKQLa8oM7kQ==",
+        "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "kid": "https://fakekvurl.vault.azure.net/keys/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "sid": "https://fakekvurl.vault.azure.net/secrets/cert2501394451/43e86e7b2ce24e0aa953234db20c9592",
+        "x5t": "FACUQtp7ZpuQOlKA1PJ4CeE8itM",
+        "cer": "MIIDVzCCAj\u002BgAwIBAgIQF3RbYvuQRgWSYSQtH5lBJjANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIyMDYwMjIzMTA1N1oXDTIzMDYwMjIzMjA1N1owGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbYACy0A1nuV1g7XYQRmmZVyiXWxC0ljNsp8YFg\u002BNCwYlrwN3GROTnj\u002BYQ92ocGH1h\u002BncxiIoALEB\u002BZ5dNyNl5Ufr6GRNFG0yDjBJdz3n9XTcEZ/2t2erp7eiVHVl9Uv0FC\u002BqazheSo233el/JWRQsBuZpd6fkXkvcKBwvH2lkHU/WoqqpIlO5ToVotm97EoVBuhG35PymbHDnsemZeC9YkupCCGZ7bzWzYmsKMKHfRZCaR\u002BaV8uIzp7pXm7Qu7QlMB/Hld4aq9aTuKeOcoczjRGZXfaqkoRyLu4do\u002BP8h9XBYbGpMkvWIq7EyfGzk09XX4iKn8R76iG0G8B41JTeUCAwEAAaOBnDCBmTAPBgNVHQ8BAf8EBQMDBwCAMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFFZkx8TLPLnwu97CM5\u002BpKVeKz6zgMB0GA1UdDgQWBBRWZMfEyzy58LvewjOfqSlXis\u002Bs4DANBgkqhkiG9w0BAQsFAAOCAQEAUhHCIxwAhT7xGdBVsjkh5r61nmw0HkKRlWTlZCSLwPuU0B9RLGoaa4fjuIbimKO4PdqfVjE9kk/JVj1g5rle5P2kFdMzuH1JzeG1IDmPWOyyQJp4rn50mAip05CIUY2qqXAhH7Ev1oBvDbiTWi1fqocaHRVv/g46tMZcT8XR0W2guLpsxoYzNQ5TRC6mff6bMbDiA75fM0j9XUuakUna0JvaMdMHVDmJ3bpXFcMcLeK6DWdvEzg7EPRJr24VBimmwDl0ylW0inUWjL2mmZUNAfV3JUI5yKqy69G6hrtDy92Sm/2g3Jk6saJ1iis/hC7zE45eursH6/18HApHlNd3IA==",
         "attributes": {
           "enabled": false,
-          "nbf": 1654099206,
-          "exp": 1685635806,
-          "created": 1654099806,
-          "updated": 1654099814,
+          "nbf": 1654211457,
+          "exp": 1685748057,
+          "created": 1654212057,
+          "updated": 1654212063,
           "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
           "recoverableDays": 7
         },
         "tags": {
           "tag1": "updated_values1"
-        },
-        "policy": {
-          "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/policy",
-          "key_props": {
-            "exportable": true,
-            "kty": "EC",
-            "key_size": 256,
-            "reuse_key": true,
-            "crv": "P-256"
-          },
-          "secret_props": {
-            "contentType": "application/x-pkcs12"
-          },
-          "x509_props": {
-            "subject": "CN=DefaultPolicy",
-            "sans": {
-              "dns_names": [
-                "sdk.azure-int.net"
-              ]
-            },
-            "ekus": [
-              "1.3.6.1.5.5.7.3.1",
-              "1.3.6.1.5.5.7.3.2"
-            ],
-            "key_usage": [
-              "decipherOnly"
-            ],
-            "validity_months": 12,
-            "basic_constraints": {
-              "ca": false
-            }
-          },
-          "lifetime_actions": [
-            {
-              "trigger": {
-                "lifetime_percentage": 98
-              },
-              "action": {
-                "action_type": "EmailContacts"
-              }
-            }
-          ],
-          "issuer": {
-            "name": "Self",
-            "cert_transparency": false
-          },
-          "attributes": {
-            "enabled": true,
-            "created": 1654099802,
-            "updated": 1654099813
-          }
         },
         "pending": {
           "id": "https://fakekvurl.vault.azure.net/certificates/cert2501394451/pending"

--- a/sdk/keyvault/azkeys/CHANGELOG.md
+++ b/sdk/keyvault/azkeys/CHANGELOG.md
@@ -20,6 +20,8 @@
 * Changed type of key `Tags` to `map[string]*string`
 * Changed type of `ListPropertiesOfKeyVersionsResponse.Keys` to `[]*KeyItem`
 * Changed type of `JSONWebKey.KeyOps` to `[]*Operation`
+* Moved `Key.ReleasePolicy` to `Key.Properties.ReleasePolicy`
+* `UpdateKeyProperties()` has a `Properties` parameter instead of a `Key` parameter
 
 ### Bugs Fixed
 * `ReleaseKey()` returns an error when no key version is specified

--- a/sdk/keyvault/azkeys/client_test.go
+++ b/sdk/keyvault/azkeys/client_test.go
@@ -89,7 +89,7 @@ func TestCreateKeyRSATags(t *testing.T) {
 
 	resp.Key.Properties.Tags = map[string]*string{}
 	// Remove the tag
-	resp2, err := client.UpdateKeyProperties(ctx, resp.Key, nil)
+	resp2, err := client.UpdateKeyProperties(ctx, *resp.Key.Properties, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(resp2.Properties.Tags))
 	validateKey(t, &resp2.Key)
@@ -449,14 +449,14 @@ func TestUpdateKeyProperties(t *testing.T) {
 			}
 			createResp.Key.Properties.ExpiresOn = to.Ptr(time.Now().AddDate(1, 0, 0))
 
-			resp, err := client.UpdateKeyProperties(ctx, createResp.Key, nil)
+			resp, err := client.UpdateKeyProperties(ctx, *createResp.Key.Properties, nil)
 			require.NoError(t, err)
 			require.NotNil(t, resp.Properties)
 			require.Equal(t, *resp.Properties.Tags["Tag1"], "Val1")
 			require.NotNil(t, resp.Properties.ExpiresOn)
 
 			createResp.Key.Properties.Name = to.Ptr("doesnotexist")
-			invalid, err := client.UpdateKeyProperties(ctx, createResp.Key, nil)
+			invalid, err := client.UpdateKeyProperties(ctx, *createResp.Key.Properties, nil)
 			require.Error(t, err)
 			require.Nil(t, invalid.Properties)
 		})
@@ -500,7 +500,7 @@ func TestUpdateKeyPropertiesImmutable(t *testing.T) {
 			require.NoError(t, err)
 			defer cleanUpKey(t, client, key)
 
-			createResp.Key.ReleasePolicy = &ReleasePolicy{
+			createResp.Key.Properties.ReleasePolicy = &ReleasePolicy{
 				Immutable:     to.Ptr(true),
 				EncodedPolicy: getMarshalledReleasePolicy(fakeAttestationUrl),
 			}
@@ -510,7 +510,7 @@ func TestUpdateKeyPropertiesImmutable(t *testing.T) {
 				createResp.Key.Properties.Version = nil
 			}
 
-			_, err = client.UpdateKeyProperties(ctx, createResp.Key, nil)
+			_, err = client.UpdateKeyProperties(ctx, *createResp.Key.Properties, nil)
 			require.Contains(t, strings.ToLower(err.Error()), "release policy cannot be modified")
 		})
 	}

--- a/sdk/keyvault/azkeys/example_test.go
+++ b/sdk/keyvault/azkeys/example_test.go
@@ -111,7 +111,7 @@ func ExampleClient_UpdateKeyProperties() {
 	resp.Key.Properties.Tags = map[string]*string{"Tag1": to.Ptr("val1")}
 	resp.Key.Properties.Enabled = to.Ptr(true)
 
-	updateResp, err := client.UpdateKeyProperties(context.TODO(), resp.Key, nil)
+	updateResp, err := client.UpdateKeyProperties(context.TODO(), *resp.Key.Properties, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/sdk/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/keyvault/azsecrets/CHANGELOG.md
@@ -19,6 +19,7 @@
   `Properties` fields, for example `SecretItem.Properties`.
 * Changed paged API content values to pointer types. For example, `ListPropertiesOfSecretsResponse.Secrets`
   changed type from `[]SecretItem` to `[]*SecretItem`.
+* `UpdateSecretProperties()` has a `Properties` parameter instead of a `Secret` parameter
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/azsecrets/client.go
+++ b/sdk/keyvault/azsecrets/client.go
@@ -277,22 +277,22 @@ func updateSecretPropertiesResponseFromGenerated(i generated.KeyVaultClientUpdat
 
 // UpdateSecretProperties updates a secret's properties, such as whether it's enabled. See the Properties type for a complete list.
 // nil fields will keep their current values. This method can't change the secret's value; use SetSecret to do that.
-func (c *Client) UpdateSecretProperties(ctx context.Context, secret Secret, options *UpdateSecretPropertiesOptions) (UpdateSecretPropertiesResponse, error) {
-	name, version := "", ""
-	if secret.Properties != nil && secret.Properties.Name != nil {
-		name = *secret.Properties.Name
+func (c *Client) UpdateSecretProperties(ctx context.Context, properties Properties, options *UpdateSecretPropertiesOptions) (UpdateSecretPropertiesResponse, error) {
+	version := ""
+	if properties.Version != nil {
+		version = *properties.Version
 	}
-	if secret.Properties != nil && secret.Properties.Version != nil {
-		version = *secret.Properties.Version
-	}
-
 	resp, err := c.kvClient.UpdateSecret(
 		ctx,
 		c.vaultUrl,
-		name,
+		*properties.Name,
 		version,
-		secret.toGeneratedProperties(),
-		&generated.KeyVaultClientUpdateSecretOptions{},
+		generated.SecretUpdateParameters{
+			ContentType:      properties.ContentType,
+			SecretAttributes: properties.toGenerated(),
+			Tags:             properties.Tags,
+		},
+		nil,
 	)
 	if err != nil {
 		return UpdateSecretPropertiesResponse{}, err

--- a/sdk/keyvault/azsecrets/client_test.go
+++ b/sdk/keyvault/azsecrets/client_test.go
@@ -74,14 +74,14 @@ func TestSecretTags(t *testing.T) {
 	require.NotNil(t, getResp.Secret.Properties.Name)
 
 	getResp.Secret.Properties.ExpiresOn = to.Ptr(time.Date(2040, time.April, 1, 1, 1, 1, 1, time.UTC))
-	updateResp, err := client.UpdateSecretProperties(context.Background(), getResp.Secret, nil)
+	updateResp, err := client.UpdateSecretProperties(context.Background(), *getResp.Secret.Properties, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(updateResp.Secret.Properties.Tags))
 	require.Equal(t, "Val1", *updateResp.Secret.Properties.Tags["Tag1"])
 
 	// Delete the tags
 	updateResp.Secret.Properties.Tags = map[string]*string{}
-	updateResp, err = client.UpdateSecretProperties(context.Background(), updateResp.Secret, nil)
+	updateResp, err = client.UpdateSecretProperties(context.Background(), *updateResp.Secret.Properties, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(updateResp.Secret.Properties.Tags))
 }
@@ -308,7 +308,7 @@ func TestUpdateSecretProperties(t *testing.T) {
 		Name:      setResp.Secret.Properties.Name,
 	}
 
-	_, err = client.UpdateSecretProperties(context.Background(), setResp.Secret, nil)
+	_, err = client.UpdateSecretProperties(context.Background(), *setResp.Secret.Properties, nil)
 	require.NoError(t, err)
 
 	getResp, err := client.GetSecret(context.Background(), name, nil)

--- a/sdk/keyvault/azsecrets/example_test.go
+++ b/sdk/keyvault/azsecrets/example_test.go
@@ -245,7 +245,7 @@ func ExampleClient_UpdateSecretProperties() {
 		Name:    getResp.Secret.Properties.Name,
 		Version: getResp.Secret.Properties.Version,
 	}
-	resp, err := client.UpdateSecretProperties(context.Background(), getResp.Secret, nil)
+	resp, err := client.UpdateSecretProperties(context.Background(), *getResp.Secret.Properties, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/sdk/keyvault/azsecrets/models.go
+++ b/sdk/keyvault/azsecrets/models.go
@@ -49,22 +49,6 @@ type Secret struct {
 	Value *string `json:"value,omitempty"`
 }
 
-func (s Secret) toGeneratedProperties() generated.SecretUpdateParameters {
-	var contentType *string
-	if s.Properties != nil && s.Properties.ContentType != nil {
-		contentType = s.Properties.ContentType
-	}
-	var tags map[string]*string
-	if s.Properties != nil && s.Properties.Tags != nil {
-		tags = s.Properties.Tags
-	}
-	return generated.SecretUpdateParameters{
-		ContentType:      contentType,
-		SecretAttributes: s.Properties.toGenerated(),
-		Tags:             tags,
-	}
-}
-
 // Properties - The secret management properties.
 type Properties struct {
 	// The content type of the secret.


### PR DESCRIPTION
Methods for updating Key Vault resource properties are inconsistent across our 3 clients. The cert client is the odd duck, taking a resource name and a `Properties` struct instead of a certificate model:
```go
UpdateCertificateProperties(ctx context.Context, certificateName string, properties Properties, options *UpdateCertificatePropertiesOptions)
UpdateKeyProperties(ctx context.Context, key Key, options *UpdateKeyPropertiesOptions)
UpdateSecretProperties(ctx context.Context, secret Secret, options *UpdateSecretPropertiesOptions)
```

First thought then is, why not have `UpdateCertificateProperties` follow along by taking a `Certificate` instead of the string and `Properties`? Well, there are two models representing certificates, reflecting a quirk of the REST API; either of these would work for `UpdateCertificateProperties`. Both certificate model types have a `Properties` field, as do all resource models, so I chose instead to have all update methods take one of those. That gives us these signatures:

```go
UpdateCertificateProperties(ctx context.Context, properties Properties, options *UpdateCertificatePropertiesOptions)
UpdateKeyProperties(ctx context.Context, properties Properties, options *UpdateKeyPropertiesOptions)
UpdateSecretProperties(ctx context.Context, properties Properties, options *UpdateSecretPropertiesOptions)
```

This design has a practical problem: `UpdateKeyProperties` can update a key's release policy, but the policy is part of `Key` and not `Properties`. So, I moved that field to `Properties`, as have the other SDKs (I suppose for this reason).