### PR TITLE
[azservicebus] Allow setting the MaxMessageSizeInKilobytes property

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.0.1 (2022-06-07)
 
+### Features Added
+
+- Adding in (QueueProperties|TopicProperties).MaxMessageSizeInKilobytes property, which can be used to increase the max message
+  size for Service Bus Premium namespaces. (#TBD)
+
 ### Bugs Fixed
 
 - Handle a missing CountDetails node in the returned responses for Get<Entity>RuntimeProperties which could cause a panic. (#18213)

--- a/sdk/messaging/azservicebus/admin/admin_client_queue.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_queue.go
@@ -75,6 +75,10 @@ type QueueProperties struct {
 
 	// AuthorizationRules are the authorization rules for this entity.
 	AuthorizationRules []AuthorizationRule
+
+	// Maximum size (in KB) of the message payload that can be accepted by the queue. This feature is only available when
+	// using Service Bus Premium.
+	MaxMessageSizeInKilobytes *int64
 }
 
 // QueueRuntimeProperties represent dynamic properties of a queue, such as the ActiveMessageCount.
@@ -395,6 +399,7 @@ func newQueueEnvelope(props *QueueProperties, tokenProvider auth.TokenProvider) 
 		ForwardDeadLetteredMessagesTo:       props.ForwardDeadLetteredMessagesTo,
 		UserMetadata:                        props.UserMetadata,
 		AuthorizationRules:                  publicAccessRightsToInternal(props.AuthorizationRules),
+		MaxMessageSizeInKilobytes:           props.MaxMessageSizeInKilobytes,
 	}
 
 	return atom.WrapWithQueueEnvelope(qpr, tokenProvider)
@@ -420,6 +425,7 @@ func newQueueItem(env *atom.QueueEnvelope) (*QueueItem, error) {
 		ForwardDeadLetteredMessagesTo:       desc.ForwardDeadLetteredMessagesTo,
 		UserMetadata:                        desc.UserMetadata,
 		AuthorizationRules:                  internalAccessRightsToPublic(desc.AuthorizationRules),
+		MaxMessageSizeInKilobytes:           desc.MaxMessageSizeInKilobytes,
 	}
 
 	return &QueueItem{

--- a/sdk/messaging/azservicebus/admin/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_test.go
@@ -129,6 +129,7 @@ func TestAdminClient_QueueWithMaxValues(t *testing.T) {
 		AutoDeleteOnIdle:                    MaxTimeSpanForTests,
 		UserMetadata:                        to.Ptr("some metadata"),
 		AuthorizationRules:                  authRules,
+		MaxMessageSizeInKilobytes:           to.Ptr(int64(102400)), // the default size for standard.
 	}, resp.QueueProperties)
 
 	runtimeResp, err := adminClient.GetQueueRuntimeProperties(context.Background(), queueName, nil)
@@ -144,20 +145,33 @@ func TestAdminClient_QueueWithMaxValues(t *testing.T) {
 	require.Zero(t, runtimeResp.TotalMessageCount)
 }
 
-func TestAdminClient_CreateQueue(t *testing.T) {
-	adminClient, err := NewClientFromConnectionString(test.GetConnectionString(t), nil)
+func TestAdminClient_CreateQueue_Standard(t *testing.T) {
+	testCreateQueue(t, false)
+}
+
+func TestAdminClient_CreateQueue_Premium(t *testing.T) {
+	testCreateQueue(t, true)
+}
+
+func testCreateQueue(t *testing.T, isPremium bool) {
+	var cs string
+
+	if isPremium {
+		cs = test.GetConnectionStringForPremiumSB(t)
+	} else {
+		cs = test.GetConnectionString(t)
+	}
+
+	adminClient, err := NewClientFromConnectionString(cs, nil)
 	require.NoError(t, err)
 
 	queueName := fmt.Sprintf("queue-%X", time.Now().UnixNano())
 
 	es := EntityStatusReceiveDisabled
-	createResp, err := adminClient.CreateQueue(context.Background(), queueName, &CreateQueueOptions{
+
+	createQueueOptions := &CreateQueueOptions{
 		Properties: &QueueProperties{
-			LockDuration: to.Ptr("PT45S"),
-			// when you enable partitioning Service Bus will automatically create 16 partitions, each with the size
-			// of MaxSizeInMegabytes. This means when we retrieve this queue we'll get 16*4096 as the size (ie: 64GB)
-			EnablePartitioning:                  to.Ptr(true),
-			MaxSizeInMegabytes:                  to.Ptr(int32(4096)),
+			LockDuration:                        to.Ptr("PT45S"),
 			RequiresDuplicateDetection:          to.Ptr(true),
 			RequiresSession:                     to.Ptr(true),
 			DefaultMessageTimeToLive:            to.Ptr("PT6H"),
@@ -168,18 +182,32 @@ func TestAdminClient_CreateQueue(t *testing.T) {
 			Status:                              &es,
 			AutoDeleteOnIdle:                    to.Ptr("PT10M"),
 		},
-	})
+	}
+
+	if isPremium {
+		createQueueOptions.Properties.MaxMessageSizeInKilobytes = to.Ptr(int64(102400))
+
+		// no partitioning in premium
+		createQueueOptions.Properties.EnablePartitioning = to.Ptr(false)
+	} else {
+		// can't update message size in standard
+		createQueueOptions.Properties.MaxMessageSizeInKilobytes = nil
+
+		// when you enable partitioning Service Bus will automatically create 16 partitions, each with the size
+		// of MaxSizeInMegabytes. This means when we retrieve this queue we'll get 16*4096 as the size (ie: 64GB)
+		createQueueOptions.Properties.EnablePartitioning = to.Ptr(true)
+		createQueueOptions.Properties.MaxSizeInMegabytes = to.Ptr(int32(4096))
+	}
+
+	createResp, err := adminClient.CreateQueue(context.Background(), queueName, createQueueOptions)
 	require.NoError(t, err)
 
 	defer func() {
 		deleteQueue(t, adminClient, queueName)
 	}()
 
-	require.EqualValues(t, QueueProperties{
-		LockDuration: to.Ptr("PT45S"),
-		// ie: this response was from a partitioned queue so the size is the original max size * # of partitions
-		EnablePartitioning:                  to.Ptr(true),
-		MaxSizeInMegabytes:                  to.Ptr(int32(16 * 4096)),
+	expectedQueueProperties := QueueProperties{
+		LockDuration:                        to.Ptr("PT45S"),
 		RequiresDuplicateDetection:          to.Ptr(true),
 		RequiresSession:                     to.Ptr(true),
 		DefaultMessageTimeToLive:            to.Ptr("PT6H"),
@@ -189,12 +217,33 @@ func TestAdminClient_CreateQueue(t *testing.T) {
 		EnableBatchedOperations:             to.Ptr(false),
 		Status:                              &es,
 		AutoDeleteOnIdle:                    to.Ptr("PT10M"),
-	}, createResp.QueueProperties)
+	}
+
+	if isPremium {
+		expectedQueueProperties.MaxMessageSizeInKilobytes = to.Ptr(int64(102400))
+
+		expectedQueueProperties.EnablePartitioning = to.Ptr(false)
+		expectedQueueProperties.MaxSizeInMegabytes = to.Ptr(int32(1024))
+	} else {
+		// (the message size for SB Standard)
+		expectedQueueProperties.MaxMessageSizeInKilobytes = to.Ptr(int64(256))
+
+		expectedQueueProperties.EnablePartitioning = to.Ptr(true)
+		expectedQueueProperties.MaxSizeInMegabytes = to.Ptr(int32(16 * 4096))
+	}
+
+	require.EqualValues(t, expectedQueueProperties, createResp.QueueProperties)
 
 	getResp, err := adminClient.GetQueue(context.Background(), queueName, nil)
 	require.NoError(t, err)
 
 	require.EqualValues(t, getResp.QueueProperties, createResp.QueueProperties)
+
+	// ensure we can round-trip
+	updateResp, err := adminClient.UpdateQueue(context.Background(), queueName, getResp.QueueProperties, nil)
+	require.NoError(t, err)
+
+	require.EqualValues(t, expectedQueueProperties, updateResp.QueueProperties)
 }
 
 func TestAdminClient_UpdateQueue(t *testing.T) {
@@ -373,8 +422,24 @@ func TestAdminClient_ISO8601StringToDuration(t *testing.T) {
 	require.EqualValues(t, utils.MaxTimeDuration, *duration)
 }
 
-func TestAdminClient_TopicAndSubscription(t *testing.T) {
-	adminClient, err := NewClientFromConnectionString(test.GetConnectionString(t), nil)
+func TestAdminClient_TopicAndSubscription_Standard(t *testing.T) {
+	testTopicCreation(t, false)
+}
+
+func TestAdminClient_TopicAndSubscription_Premium(t *testing.T) {
+	testTopicCreation(t, true)
+}
+
+func testTopicCreation(t *testing.T, isPremium bool) {
+	var cs string
+
+	if isPremium {
+		cs = test.GetConnectionStringForPremiumSB(t)
+	} else {
+		cs = test.GetConnectionString(t)
+	}
+
+	adminClient, err := NewClientFromConnectionString(cs, nil)
 	require.NoError(t, err)
 
 	topicName := fmt.Sprintf("topic-%X", time.Now().UnixNano())
@@ -382,11 +447,8 @@ func TestAdminClient_TopicAndSubscription(t *testing.T) {
 
 	status := EntityStatusActive
 
-	// check topic properties, existence
-	addResp, err := adminClient.CreateTopic(context.Background(), topicName, &CreateTopicOptions{
+	createTopicOptions := &CreateTopicOptions{
 		Properties: &TopicProperties{
-			EnablePartitioning:                  to.Ptr(true),
-			MaxSizeInMegabytes:                  to.Ptr(int32(2048)),
 			RequiresDuplicateDetection:          to.Ptr(true),
 			DefaultMessageTimeToLive:            to.Ptr("PT3M"),
 			DuplicateDetectionHistoryTimeWindow: to.Ptr("PT4M"),
@@ -395,14 +457,31 @@ func TestAdminClient_TopicAndSubscription(t *testing.T) {
 			AutoDeleteOnIdle:                    to.Ptr("PT7M"),
 			SupportOrdering:                     to.Ptr(true),
 			UserMetadata:                        to.Ptr("user metadata"),
-		}})
+		},
+	}
+
+	if isPremium {
+		// premium doesn't support partitioning.
+		createTopicOptions.Properties.EnablePartitioning = to.Ptr(false)
+
+		// premium allows you to update the max message size
+		createTopicOptions.Properties.MaxMessageSizeInKilobytes = to.Ptr(int64(102400))
+	} else {
+		createTopicOptions.Properties.EnablePartitioning = to.Ptr(true)
+		createTopicOptions.Properties.MaxSizeInMegabytes = to.Ptr(int32(2048))
+
+		// standard can't change MaxMessageSizeInKilobytes
+		createTopicOptions.Properties.MaxMessageSizeInKilobytes = nil
+	}
+
+	// check topic properties, existence
+	addResp, err := adminClient.CreateTopic(context.Background(), topicName, createTopicOptions)
 	require.NoError(t, err)
 
 	defer deleteTopic(t, adminClient, topicName)
 
-	require.EqualValues(t, TopicProperties{
-		EnablePartitioning:                  to.Ptr(true),
-		MaxSizeInMegabytes:                  to.Ptr(int32(16 * 2048)), // enabling partitioning increases our max size because of the 16 partition),
+	expectedTopicProps := TopicProperties{
+		MaxSizeInMegabytes:                  to.Ptr(int32(1024)),
 		RequiresDuplicateDetection:          to.Ptr(true),
 		DefaultMessageTimeToLive:            to.Ptr("PT3M"),
 		DuplicateDetectionHistoryTimeWindow: to.Ptr("PT4M"),
@@ -411,23 +490,29 @@ func TestAdminClient_TopicAndSubscription(t *testing.T) {
 		AutoDeleteOnIdle:                    to.Ptr("PT7M"),
 		SupportOrdering:                     to.Ptr(true),
 		UserMetadata:                        to.Ptr("user metadata"),
-	}, addResp.TopicProperties)
+	}
+
+	if isPremium {
+		expectedTopicProps.MaxMessageSizeInKilobytes = to.Ptr(int64(102400))
+
+		// no partitioning in premium.
+		expectedTopicProps.EnablePartitioning = to.Ptr(false)
+		expectedTopicProps.MaxSizeInMegabytes = to.Ptr(int32(1024))
+	} else {
+		expectedTopicProps.MaxMessageSizeInKilobytes = to.Ptr(int64(256))
+
+		// enabling partitioning increases our max size because of the 16 partition),
+		expectedTopicProps.EnablePartitioning = to.Ptr(true)
+		expectedTopicProps.MaxSizeInMegabytes = to.Ptr(int32(16 * 2048))
+
+	}
+
+	require.EqualValues(t, expectedTopicProps, addResp.TopicProperties)
 
 	getResp, err := adminClient.GetTopic(context.Background(), topicName, nil)
 	require.NoError(t, err)
 
-	require.EqualValues(t, TopicProperties{
-		EnablePartitioning:                  to.Ptr(true),
-		MaxSizeInMegabytes:                  to.Ptr(int32(16 * 2048)), // enabling partitioning increases our max size because of the 16 partition),
-		RequiresDuplicateDetection:          to.Ptr(true),
-		DefaultMessageTimeToLive:            to.Ptr("PT3M"),
-		DuplicateDetectionHistoryTimeWindow: to.Ptr("PT4M"),
-		EnableBatchedOperations:             to.Ptr(true),
-		Status:                              &status,
-		AutoDeleteOnIdle:                    to.Ptr("PT7M"),
-		SupportOrdering:                     to.Ptr(true),
-		UserMetadata:                        to.Ptr("user metadata"),
-	}, getResp.TopicProperties)
+	require.EqualValues(t, expectedTopicProps, getResp.TopicProperties)
 
 	runtimeResp, err := adminClient.GetTopicRuntimeProperties(context.Background(), topicName, nil)
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/admin/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_test.go
@@ -129,7 +129,7 @@ func TestAdminClient_QueueWithMaxValues(t *testing.T) {
 		AutoDeleteOnIdle:                    MaxTimeSpanForTests,
 		UserMetadata:                        to.Ptr("some metadata"),
 		AuthorizationRules:                  authRules,
-		MaxMessageSizeInKilobytes:           to.Ptr(int64(102400)), // the default size for standard.
+		MaxMessageSizeInKilobytes:           to.Ptr(int64(256)), // the default size for standard.
 	}, resp.QueueProperties)
 
 	runtimeResp, err := adminClient.GetQueueRuntimeProperties(context.Background(), queueName, nil)

--- a/sdk/messaging/azservicebus/admin/admin_client_topic.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_topic.go
@@ -54,6 +54,10 @@ type TopicProperties struct {
 
 	// AuthorizationRules are the authorization rules for this entity.
 	AuthorizationRules []AuthorizationRule
+
+	// Maximum size (in KB) of the message payload that can be accepted by the topic. This feature is only available when
+	// using Service Bus Premium.
+	MaxMessageSizeInKilobytes *int64
 }
 
 // TopicRuntimeProperties represent dynamic properties of a topic, such as the ActiveMessageCount.
@@ -352,12 +356,13 @@ func newTopicEnvelope(props *TopicProperties, tokenProvider auth.TokenProvider) 
 		DuplicateDetectionHistoryTimeWindow: props.DuplicateDetectionHistoryTimeWindow,
 		EnableBatchedOperations:             props.EnableBatchedOperations,
 
-		Status:             (*atom.EntityStatus)(props.Status),
-		UserMetadata:       props.UserMetadata,
-		SupportOrdering:    props.SupportOrdering,
-		AutoDeleteOnIdle:   props.AutoDeleteOnIdle,
-		EnablePartitioning: props.EnablePartitioning,
-		AuthorizationRules: publicAccessRightsToInternal(props.AuthorizationRules),
+		Status:                    (*atom.EntityStatus)(props.Status),
+		UserMetadata:              props.UserMetadata,
+		SupportOrdering:           props.SupportOrdering,
+		AutoDeleteOnIdle:          props.AutoDeleteOnIdle,
+		EnablePartitioning:        props.EnablePartitioning,
+		AuthorizationRules:        publicAccessRightsToInternal(props.AuthorizationRules),
+		MaxMessageSizeInKilobytes: props.MaxMessageSizeInKilobytes,
 	}
 
 	return atom.WrapWithTopicEnvelope(desc)
@@ -380,6 +385,7 @@ func newTopicItem(te *atom.TopicEnvelope) (*TopicItem, error) {
 			EnablePartitioning:                  td.EnablePartitioning,
 			SupportOrdering:                     td.SupportOrdering,
 			AuthorizationRules:                  internalAccessRightsToPublic(td.AuthorizationRules),
+			MaxMessageSizeInKilobytes:           td.MaxMessageSizeInKilobytes,
 		},
 	}, nil
 }

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -172,7 +172,7 @@ func (em *entityManager) execute(ctx context.Context, method string, entityPath 
 	}
 
 	q := req.Raw().URL.Query()
-	q.Add("api-version", "2017-04")
+	q.Add("api-version", "2021-05")
 	req.Raw().URL.RawQuery = q.Encode()
 
 	if body != nil && body != http.NoBody {

--- a/sdk/messaging/azservicebus/internal/atom/models.go
+++ b/sdk/messaging/azservicebus/internal/atom/models.go
@@ -85,6 +85,7 @@ type (
 		ForwardTo                           *string             `xml:"ForwardTo,omitempty"`
 		ForwardDeadLetteredMessagesTo       *string             `xml:"ForwardDeadLetteredMessagesTo,omitempty"` // ForwardDeadLetteredMessagesTo - absolute URI of the entity to forward dead letter messages
 		UserMetadata                        *string             `xml:"UserMetadata,omitempty"`
+		MaxMessageSizeInKilobytes           *int64              `xml:"MaxMessageSizeInKilobytes,omitempty"`
 	}
 )
 
@@ -145,6 +146,7 @@ type (
 		EnableExpress                       *bool               `xml:"EnableExpress,omitempty"`
 		CountDetails                        *CountDetails       `xml:"CountDetails,omitempty"`
 		SubscriptionCount                   *int32              `xml:"SubscriptionCount,omitempty"`
+		MaxMessageSizeInKilobytes           *int64              `xml:"MaxMessageSizeInKilobytes,omitempty"`
 	}
 )
 

--- a/sdk/messaging/azservicebus/internal/test/test_helpers.go
+++ b/sdk/messaging/azservicebus/internal/test/test_helpers.go
@@ -47,6 +47,16 @@ func GetConnectionString(t *testing.T) string {
 	return cs
 }
 
+func GetConnectionStringForPremiumSB(t *testing.T) string {
+	cs := os.Getenv("SERVICEBUS_CONNECTION_STRING_PREMIUM")
+
+	if cs == "" {
+		t.Skip()
+	}
+
+	return cs
+}
+
 func GetConnectionStringWithoutManagePerms(t *testing.T) string {
 	cs := os.Getenv("SERVICEBUS_CONNECTION_STRING_NO_MANAGE")
 

--- a/sdk/messaging/azservicebus/test-resources.bicep
+++ b/sdk/messaging/azservicebus/test-resources.bicep
@@ -10,6 +10,8 @@ var authorizationRuleName_var = '${baseName}/RootManageSharedAccessKey'
 var authorizationRuleNameNoManage_var = '${baseName}/NoManage'
 var serviceBusDataOwnerRoleId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/090c5cfd-751d-490a-894a-3ce6f1109419'
 
+var sbPremiumName = 'sb-premium-${baseName}'
+
 resource servicebus 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
   name: baseName
   location: location
@@ -21,6 +23,16 @@ resource servicebus 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
     zoneRedundant: false
   }
 }
+
+resource servicebusPremium 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
+  name: sbPremiumName
+  location: location
+  sku: {
+    name: 'Premium'
+    tier: 'Premium'
+  }
+}
+
 
 resource authorizationRuleName 'Microsoft.ServiceBus/namespaces/AuthorizationRules@2015-08-01' = {
   name: authorizationRuleName_var
@@ -102,6 +114,7 @@ resource testQueueWithSessions 'Microsoft.ServiceBus/namespaces/queues@2017-04-0
 
 output SERVICEBUS_CONNECTION_STRING string = listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', baseName, 'RootManageSharedAccessKey'), apiVersion).primaryConnectionString
 output SERVICEBUS_CONNECTION_STRING_NO_MANAGE string = listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', baseName, 'NoManage'), apiVersion).primaryConnectionString
+output SERVICEBUS_CONNECTION_STRING_PREMIUM string = listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', sbPremiumName, 'RootManageSharedAccessKey'), apiVersion).primaryConnectionString
 output SERVICEBUS_ENDPOINT string = replace(replace(servicebus.properties.serviceBusEndpoint, ':443/', ''), 'https://', '')
 output QUEUE_NAME string = 'testQueue'
 output QUEUE_NAME_WITH_SESSIONS string = 'testQueueWithSessions'


### PR DESCRIPTION
Service Bus Premium allows you to configure the maximum message size. This change exposes that property, bringing it to parity with other SDKs.

Fixes #15917