### PR TITLE
Fail tool installation when writing to stderr

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -41,11 +41,14 @@ steps:
 
   - pwsh: |
       go install github.com/jstemmer/go-junit-report@v0.9.1
+      if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       go install github.com/axw/gocov/gocov@v1.1.0
+      if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       go install github.com/AlekSi/gocov-xml@v1.0.0
+      if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       go install github.com/matm/gocov-html@v0.0.0-20200509184451-71874e2e203b
+      if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     displayName: "Install Coverage and Junit Dependencies"
-    failOnStderr: true
     retryCountOnTaskFailure: 3
 
   - ${{ if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -45,6 +45,8 @@ steps:
       go install github.com/AlekSi/gocov-xml@v1.0.0
       go install github.com/matm/gocov-html@v0.0.0-20200509184451-71874e2e203b
     displayName: "Install Coverage and Junit Dependencies"
+    failOnStderr: true
+    retryCountOnTaskFailure: 3
 
   - ${{ if eq(parameters.TestProxy, true) }}:
     - template: /eng/common/testproxy/test-proxy-tool.yml


### PR DESCRIPTION
Fail the "install coverage and junit dependencies" step if any of the
tools fail to install.
Add a few retries if the step fails.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
