### PR TITLE
Delete JSON tags on Key Vault convenience models

### DIFF
--- a/sdk/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/keyvault/azcertificates/CHANGELOG.md
@@ -14,6 +14,7 @@
   * `ListCertificatesOptions` to `ListPropertiesOfCertificatesOptions`
   * `ListCertificateVersionsOptions` to `ListPropertiesOfCertificateVersionsOptions`
 * Renamed `ListDeletedCertificatesResponse.Certificates` to `.DeletedCertificates`
+* Removed JSON tags from models
 
 ### Bugs Fixed
 * LROs now correctly exit the polling loop in `PollUntilDone()` when the operations reach a terminal state.

--- a/sdk/keyvault/azcertificates/client.go
+++ b/sdk/keyvault/azcertificates/client.go
@@ -67,10 +67,10 @@ func NewClient(vaultURL string, credential azcore.TokenCredential, options *Clie
 // BeginCreateCertificateOptions contains optional parameters for Client.BeginCreateCertificate
 type BeginCreateCertificateOptions struct {
 	// Determines whether the object is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Application specific metadata in the form of key-value pairs
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// ResumeToken is a token for resuming long running operations from a previous poller
 	ResumeToken string
@@ -359,7 +359,7 @@ func (b *BackupCertificateOptions) toGenerated() *generated.KeyVaultClientBackup
 // BackupCertificateResponse contains response field for Client.BackupCertificate
 type BackupCertificateResponse struct {
 	// READ-ONLY; The backup blob containing the backed up certificate.
-	Value []byte `json:"value,omitempty" azure:"ro"`
+	Value []byte
 }
 
 // BackupCertificate requests that a backup of the specified certificate be downloaded to the client. All versions of the certificate will be downloaded.
@@ -378,16 +378,16 @@ func (c *Client) BackupCertificate(ctx context.Context, certificateName string, 
 // ImportCertificateOptions contains optional parameters for Client.ImportCertificate
 type ImportCertificateOptions struct {
 	// The management policy for the certificate.
-	CertificatePolicy *Policy `json:"policy,omitempty"`
+	CertificatePolicy *Policy
 
 	// Determines whether the object is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// If the private key in base64EncodedCertificate is encrypted, the password used for encryption.
-	Password *string `json:"pwd,omitempty"`
+	Password *string
 
 	// Application specific metadata in the form of key-value pairs
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // ImportCertificateResponse contains response fields for Client.ImportCertificate
@@ -442,7 +442,7 @@ type ListPropertiesOfCertificatesOptions struct {
 // ListPropertiesOfCertificatesResponse contains response fields for ListCertificatesPager.NextPage
 type ListPropertiesOfCertificatesResponse struct {
 	// READ-ONLY; A response message containing a list of certificates in the key vault along with a link to the next page of certificates.
-	Certificates []*CertificateItem `json:"value,omitempty" azure:"ro"`
+	Certificates []*CertificateItem
 
 	// NextLink is a link to the next page of results
 	NextLink *string
@@ -493,7 +493,7 @@ type ListPropertiesOfCertificateVersionsOptions struct {
 // ListPropertiesOfCertificateVersionsResponse contains response fields for ListCertificateVersionsPager.NextPage
 type ListPropertiesOfCertificateVersionsResponse struct {
 	// READ-ONLY; A response message containing a list of certificates in the key vault along with a link to the next page of certificates.
-	Certificates []*CertificateItem `json:"value,omitempty" azure:"ro"`
+	Certificates []*CertificateItem
 
 	// NextLink is a link to the next page of results to fetch
 	NextLink *string
@@ -537,16 +537,16 @@ func (c *Client) NewListPropertiesOfCertificateVersionsPager(certificateName str
 // CreateIssuerOptions contains optional parameters for Client.CreateIssuer
 type CreateIssuerOptions struct {
 	// Determines whether the issuer is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// The credentials to be used for the issuer.
-	Credentials *IssuerCredentials `json:"credentials,omitempty"`
+	Credentials *IssuerCredentials
 
 	// Details of the organization administrator.
-	AdministratorContacts []*AdministratorContact `json:"admin_details,omitempty"`
+	AdministratorContacts []*AdministratorContact
 
 	// Id of the organization.
-	OrganizationID *string `json:"id,omitempty"`
+	OrganizationID *string
 }
 
 func (c *CreateIssuerOptions) toGenerated() *generated.KeyVaultClientSetCertificateIssuerOptions {
@@ -700,7 +700,7 @@ type ListPropertiesOfIssuersOptions struct {
 // ListPropertiesOfIssuersResponse contains response fields for ListPropertiesOfIssuersPager.NextPage
 type ListPropertiesOfIssuersResponse struct {
 	// READ-ONLY; A response message containing a list of certificates in the key vault along with a link to the next page of certificates.
-	Issuers []*IssuerItem `json:"value,omitempty" azure:"ro"`
+	Issuers []*IssuerItem
 
 	// NextLink is the next link of pages to fetch
 	NextLink *string
@@ -1092,7 +1092,7 @@ func (c *Client) UpdateCertificateProperties(ctx context.Context, certificateNam
 // MergeCertificateOptions contains optional parameters for Client.MergeCertificate
 type MergeCertificateOptions struct {
 	// The attributes of the certificate (optional).
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 }
 
 func (m *MergeCertificateOptions) toGenerated() *generated.KeyVaultClientMergeCertificateOptions {
@@ -1240,7 +1240,7 @@ func (c *Client) BeginRecoverDeletedCertificate(ctx context.Context, certificate
 // ListDeletedCertificatesResponse contains response field for ListDeletedCertificatesPager.NextPage
 type ListDeletedCertificatesResponse struct {
 	// READ-ONLY; A response message containing a list of deleted certificates in the vault along with a link to the next page of deleted certificates
-	DeletedCertificates []*DeletedCertificateItem `json:"value,omitempty" azure:"ro"`
+	DeletedCertificates []*DeletedCertificateItem
 
 	// NextLink gives the next page of items to fetch
 	NextLink *string

--- a/sdk/keyvault/azcertificates/models.go
+++ b/sdk/keyvault/azcertificates/models.go
@@ -19,42 +19,42 @@ import (
 // AdministratorContact - Details of the organization administrator of the certificate issuer.
 type AdministratorContact struct {
 	// Email address.
-	Email *string `json:"email,omitempty"`
+	Email *string
 
 	// First name.
-	FirstName *string `json:"first_name,omitempty"`
+	FirstName *string
 
 	// Last name.
-	LastName *string `json:"last_name,omitempty"`
+	LastName *string
 
 	// Phone number.
-	Phone *string `json:"phone,omitempty"`
+	Phone *string
 }
 
 // Properties - The certificate management properties.
 type Properties struct {
 	// READ-ONLY; Creation time in UTC.
-	CreatedOn *time.Time `json:"created,omitempty" azure:"ro"`
+	CreatedOn *time.Time
 
 	// Determines whether the object is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Expiry date in UTC.
-	ExpiresOn *time.Time `json:"exp,omitempty"`
+	ExpiresOn *time.Time
 
 	// Not before date in UTC.
-	NotBefore *time.Time `json:"nbf,omitempty"`
+	NotBefore *time.Time
 
 	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
-	RecoverableDays *int32 `json:"recoverableDays,omitempty" azure:"ro"`
+	RecoverableDays *int32
 
 	// READ-ONLY; Reflects the deletion recovery level currently in effect for certificates in the current vault. If it contains
 	// 'Purgeable', the certificate can be permanently deleted by a privileged user; otherwise,
 	// only the system can purge the certificate, at the end of the retention interval.
-	RecoveryLevel *string `json:"recoveryLevel,omitempty" azure:"ro"`
+	RecoveryLevel *string
 
 	// READ-ONLY; Last updated time in UTC.
-	UpdatedOn *time.Time `json:"updated,omitempty" azure:"ro"`
+	UpdatedOn *time.Time
 
 	// READ-ONLY; The ID of the certificate
 	ID *string
@@ -63,7 +63,7 @@ type Properties struct {
 	Name *string
 
 	// Application specific metadata in the form of key-value pairs
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; The vault URL for the certificate
 	VaultURL *string
@@ -72,7 +72,7 @@ type Properties struct {
 	Version *string
 
 	// Thumbprint of the certificate.
-	X509Thumbprint []byte `json:"x5t,omitempty"`
+	X509Thumbprint []byte
 }
 
 func (c *Properties) toGenerated() *generated.CertificateAttributes {
@@ -118,46 +118,46 @@ func propertiesFromGenerated(g *generated.CertificateAttributes, tags map[string
 // Certificate - A certificate bundle consists of a certificate (X509) plus its properties.
 type Certificate struct {
 	// The certificate attributes.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// CER contents of x509 certificate.
-	CER []byte `json:"cer,omitempty"`
+	CER []byte
 
 	// READ-ONLY; The certificate id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the certificate
 	Name *string
 
 	// READ-ONLY; The key ID.
-	KeyID *string `json:"kid,omitempty" azure:"ro"`
+	KeyID *string
 
 	// READ-ONLY; The secret ID.
-	SecretID *string `json:"sid,omitempty" azure:"ro"`
+	SecretID *string
 }
 
 // CertificateWithPolicy - A certificate bundle consists of a certificate (X509) with a policy, and its properties.
 type CertificateWithPolicy struct {
 	// The certificate attributes.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// CER contents of x509 certificate.
-	CER []byte `json:"cer,omitempty"`
+	CER []byte
 
 	// The content type of the secret. eg. 'application/x-pem-file' or 'application/x-pkcs12',
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// READ-ONLY; The certificate id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The key ID.
-	KeyID *string `json:"kid,omitempty" azure:"ro"`
+	KeyID *string
 
 	// READ-ONLY; The management policy.
-	Policy *Policy `json:"policy,omitempty" azure:"ro"`
+	Policy *Policy
 
 	// READ-ONLY; The secret ID.
-	SecretID *string `json:"sid,omitempty" azure:"ro"`
+	SecretID *string
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for the CertificateWithPolicy type.
@@ -196,7 +196,7 @@ func certificateFromGenerated(g *generated.CertificateBundle) Certificate {
 // CertificateOperationError - The key vault server error.
 type CertificateOperationError struct {
 	// READ-ONLY; The error code.
-	Code *string `json:"code,omitempty" azure:"ro"`
+	Code *string
 
 	// READ-ONLY; The key vault server error.
 	innerError *CertificateOperationError
@@ -232,10 +232,10 @@ func certificateErrorFromGenerated(g *generated.Error) *CertificateOperationErro
 // IssuerItem - The certificate issuer item containing certificate issuer metadata.
 type IssuerItem struct {
 	// Certificate Identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The issuer provider.
-	Provider *string `json:"provider,omitempty"`
+	Provider *string
 }
 
 func certificateIssuerItemFromGenerated(g *generated.CertificateIssuerItem) *IssuerItem {
@@ -249,40 +249,40 @@ func certificateIssuerItemFromGenerated(g *generated.CertificateIssuerItem) *Iss
 // CertificateItem - The certificate item containing certificate metadata.
 type CertificateItem struct {
 	// The certificate management attributes.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// Certificate identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // Operation - A certificate operation is returned in case of asynchronous requests.
 type Operation struct {
 	// Indicates if cancellation was requested on the certificate operation.
-	CancellationRequested *bool `json:"cancellation_requested,omitempty"`
+	CancellationRequested *bool
 
 	// The certificate signing request (CSR) that is being used in the certificate operation.
-	CSR []byte `json:"csr,omitempty"`
+	CSR []byte
 
 	// Error encountered, if any, during the certificate operation.
-	Error *CertificateOperationError `json:"error,omitempty"`
+	Error *CertificateOperationError
 
 	// Parameters for the issuer of the X509 component of a certificate.
-	IssuerParameters *IssuerParameters `json:"issuer,omitempty"`
+	IssuerParameters *IssuerParameters
 
 	// Identifier for the certificate operation.
-	RequestID *string `json:"request_id,omitempty"`
+	RequestID *string
 
 	// Status of the certificate operation.
-	Status *string `json:"status,omitempty"`
+	Status *string
 
 	// The status details of the certificate operation.
-	StatusDetails *string `json:"status_details,omitempty"`
+	StatusDetails *string
 
 	// Location which contains the result of the certificate operation.
-	Target *string `json:"target,omitempty"`
+	Target *string
 
 	// READ-ONLY; The certificate id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 func certificateOperationFromGenerated(g generated.CertificateOperation) Operation {
@@ -302,34 +302,34 @@ func certificateOperationFromGenerated(g generated.CertificateOperation) Operati
 // Policy - Management policy for a certificate.
 type Policy struct {
 	// The certificate properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// Parameters for the issuer of the X509 component of a certificate.
-	IssuerParameters *IssuerParameters `json:"issuer,omitempty"`
+	IssuerParameters *IssuerParameters
 
 	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
-	KeyCurveName *KeyCurveName `json:"crv,omitempty"`
+	KeyCurveName *KeyCurveName
 
 	// Indicates if the private key can be exported.
-	Exportable *bool `json:"exportable,omitempty"`
+	Exportable *bool
 
 	// The key size in bits. For example: 2048, 3072, or 4096 for RSA.
-	KeySize *int32 `json:"key_size,omitempty"`
+	KeySize *int32
 
 	// The type of key pair to be used for the certificate.
-	KeyType *KeyType `json:"kty,omitempty"`
+	KeyType *KeyType
 
 	// Indicates if the same key pair will be used on certificate renewal.
-	ReuseKey *bool `json:"reuse_key,omitempty"`
+	ReuseKey *bool
 
 	// Actions that will be performed by Key Vault over the lifetime of a certificate.
-	LifetimeActions []*LifetimeAction `json:"lifetime_actions,omitempty"`
+	LifetimeActions []*LifetimeAction
 
 	// ContentType of the downloaded certificate
-	ContentType *CertificateContentType `json:"secret_props,omitempty"`
+	ContentType *CertificateContentType
 
 	// Properties of the X509 component of a certificate.
-	X509Properties *X509CertificateProperties `json:"x509_props,omitempty"`
+	X509Properties *X509CertificateProperties
 }
 
 // NewDefaultCertificatePolicy returns a Policy with IssuerName "Self" and Subject "CN=DefaultPolicy"
@@ -400,13 +400,13 @@ func certificatePolicyFromGenerated(g *generated.CertificatePolicy) *Policy {
 // Contact - The contact information for the vault certificates.
 type Contact struct {
 	// Email address.
-	Email *string `json:"email,omitempty"`
+	Email *string
 
 	// Name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Phone number.
-	Phone *string `json:"phone,omitempty"`
+	Phone *string
 }
 
 func contactListFromGenerated(g []*generated.Contact) []*Contact {
@@ -424,10 +424,10 @@ func contactListFromGenerated(g []*generated.Contact) []*Contact {
 // Contacts - The contacts for the vault certificates.
 type Contacts struct {
 	// The contact list for the vault certificates.
-	ContactList []*Contact `json:"contacts,omitempty"`
+	ContactList []*Contact
 
 	// READ-ONLY; Identifier for the contacts collection.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 func (c *Contacts) toGenerated() generated.Contacts {
@@ -453,85 +453,85 @@ func (c *Contacts) toGenerated() generated.Contacts {
 // DeletedCertificate consists of its previous id, attributes and its tags, as well as information on when it will be purged.
 type DeletedCertificate struct {
 	// The certificate properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// CER contents of x509 certificate.
-	CER []byte `json:"cer,omitempty"`
+	CER []byte
 
 	// The content type of the secret. eg. 'application/x-pem-file' or 'application/x-pkcs12',
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// The url of the recovery object, used to identify and recover the deleted certificate.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// READ-ONLY; The time when the certificate was deleted, in UTC
-	DeletedOn *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedOn *time.Time
 
 	// READ-ONLY; The certificate id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the certificate
 	Name *string
 
 	// READ-ONLY; The key ID.
-	KeyID *string `json:"kid,omitempty" azure:"ro"`
+	KeyID *string
 
 	// READ-ONLY; The management policy.
-	Policy *Policy `json:"policy,omitempty" azure:"ro"`
+	Policy *Policy
 
 	// READ-ONLY; The time when the certificate is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 
 	// READ-ONLY; The secret ID.
-	SecretID *string `json:"sid,omitempty" azure:"ro"`
+	SecretID *string
 }
 
 // DeletedCertificateItem - The deleted certificate item containing metadata about the deleted certificate.
 type DeletedCertificateItem struct {
 	// The certificate management properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// Certificate identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// READ-ONLY; The name of the certificate
 	Name *string
 
 	// The url of the recovery object, used to identify and recover the deleted certificate.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// READ-ONLY; The time when the certificate was deleted, in UTC
-	DeletedOn *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedOn *time.Time
 
 	// READ-ONLY; The time when the certificate is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 // Issuer - The issuer for Key Vault certificate.
 type Issuer struct {
 	// Determines whether the issuer is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// READ-ONLY; Creation time in UTC.
-	CreatedOn *time.Time `json:"created,omitempty" azure:"ro"`
+	CreatedOn *time.Time
 
 	// READ-ONLY; Last updated time in UTC.
-	UpdatedOn *time.Time `json:"updated,omitempty" azure:"ro"`
+	UpdatedOn *time.Time
 
 	// The credentials to be used for the issuer.
-	Credentials *IssuerCredentials `json:"credentials,omitempty"`
+	Credentials *IssuerCredentials
 
 	// Details of the organization administrator.
-	AdministratorContacts []*AdministratorContact `json:"admin_details,omitempty"`
+	AdministratorContacts []*AdministratorContact
 
 	// Id of the organization.
-	OrganizationID *string `json:"organization_id,omitempty"`
+	OrganizationID *string
 
 	// The issuer provider.
-	Provider *string `json:"provider,omitempty"`
+	Provider *string
 
 	// READ-ONLY; Identifier for the issuer object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Name is the name of the issuer
 	Name *string
@@ -540,10 +540,10 @@ type Issuer struct {
 // IssuerCredentials - The credentials to be used for the certificate issuer.
 type IssuerCredentials struct {
 	// The user name/account name/account id.
-	AccountID *string `json:"account_id,omitempty"`
+	AccountID *string
 
 	// The password/secret/account key.
-	Password *string `json:"pwd,omitempty"`
+	Password *string
 }
 
 func issuerCredentialsFromGenerated(g *generated.IssuerCredentials) *IssuerCredentials {
@@ -568,13 +568,13 @@ func (i *IssuerCredentials) toGenerated() *generated.IssuerCredentials {
 // IssuerParameters - Parameters for the issuer of the X509 component of a certificate.
 type IssuerParameters struct {
 	// Indicates if the certificates generated under this policy should be published to certificate transparency logs.
-	CertificateTransparency *bool `json:"cert_transparency,omitempty"`
+	CertificateTransparency *bool
 
 	// Certificate type as supported by the provider (optional); for example 'OV-SSL', 'EV-SSL'
-	CertificateType *string `json:"cty,omitempty"`
+	CertificateType *string
 
 	// IssuerName of the referenced issuer object or reserved names; for example, 'Self' or 'Unknown'.
-	IssuerName *string `json:"name,omitempty"`
+	IssuerName *string
 }
 
 func (i *IssuerParameters) toGenerated() *generated.IssuerParameters {
@@ -604,13 +604,13 @@ func issuerParametersFromGenerated(g *generated.IssuerParameters) *IssuerParamet
 // LifetimeAction - Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
 type LifetimeAction struct {
 	// The action that will be executed.
-	Action *PolicyAction `json:"action,omitempty"`
+	Action *PolicyAction
 	// Days before expiry to attempt renewal. Value should be between 1 and validityinmonths multiplied by 27. If validityinmonths is 36, then value should
 	// be between 1 and 972 (36 * 27).
-	DaysBeforeExpiry *int32 `json:"days_before_expiry,omitempty"`
+	DaysBeforeExpiry *int32
 
 	// Percentage of lifetime at which to trigger. Value should be between 1 and 99.
-	LifetimePercentage *int32 `json:"lifetime_percentage,omitempty"`
+	LifetimePercentage *int32
 }
 
 func (l LifetimeAction) toGenerated() *generated.LifetimeAction {
@@ -640,13 +640,13 @@ func lifetimeActionFromGenerated(g *generated.LifetimeAction) *LifetimeAction {
 // SubjectAlternativeNames - The subject alternate names of a X509 object.
 type SubjectAlternativeNames struct {
 	// Domain names.
-	DNSNames []*string `json:"dns_names,omitempty"`
+	DNSNames []*string
 
 	// Email addresses.
-	Emails []*string `json:"emails,omitempty"`
+	Emails []*string
 
 	// User principal names.
-	UserPrincipalNames []*string `json:"upns,omitempty"`
+	UserPrincipalNames []*string
 }
 
 func (s *SubjectAlternativeNames) toGenerated() *generated.SubjectAlternativeNames {
@@ -676,19 +676,19 @@ func subjectAlternativeNamesFromGenerated(g *generated.SubjectAlternativeNames) 
 // X509CertificateProperties - Properties of the X509 component of a certificate.
 type X509CertificateProperties struct {
 	// The enhanced key usage.
-	EnhancedKeyUsages []*string `json:"ekus,omitempty"`
+	EnhancedKeyUsages []*string
 
 	// List of key usages.
-	KeyUsages []*KeyUsage `json:"key_usage,omitempty"`
+	KeyUsages []*KeyUsage
 
 	// The subject name. Should be a valid X509 distinguished Name.
-	Subject *string `json:"subject,omitempty"`
+	Subject *string
 
 	// The subject alternative names.
-	SubjectAlternativeNames *SubjectAlternativeNames `json:"sans,omitempty"`
+	SubjectAlternativeNames *SubjectAlternativeNames
 
 	// The duration that the certificate is valid in months.
-	ValidityInMonths *int32 `json:"validity_months,omitempty"`
+	ValidityInMonths *int32
 }
 
 func (x *X509CertificateProperties) toGenerated() *generated.X509CertificateProperties {

--- a/sdk/keyvault/azkeys/CHANGELOG.md
+++ b/sdk/keyvault/azkeys/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Changed type of key `Tags` to `map[string]*string`
 * Changed type of `ListPropertiesOfKeyVersionsResponse.Keys` to `[]*KeyItem`
 * Changed type of `JSONWebKey.KeyOps` to `[]*Operation`
+* Removed JSON tags from models
 
 ### Bugs Fixed
 * `ReleaseKey()` returns an error when no key version is specified

--- a/sdk/keyvault/azkeys/client.go
+++ b/sdk/keyvault/azkeys/client.go
@@ -85,25 +85,25 @@ func (c *Client) NewCryptoClient(keyName string, keyVersion *string) *crypto.Cli
 // CreateKeyOptions contains optional parameters for CreateKey.
 type CreateKeyOptions struct {
 	// Curve is the elliptic curve name. For valid values, see PossibleCurveNameValues.
-	Curve *CurveName `json:"crv,omitempty"`
+	Curve *CurveName
 
 	// Properties is the key's management properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// Operations are the operations Key Vault will allow for the key.
-	Operations []*Operation `json:"key_ops,omitempty"`
+	Operations []*Operation
 
 	// ReleasePolicy specifies conditions under which the key can be exported.
-	ReleasePolicy *ReleasePolicy `json:"release_policy,omitempty"`
+	ReleasePolicy *ReleasePolicy
 
 	// Size is the key size in bits. For example: 2048, 3072, or 4096 for RSA.
-	Size *int32 `json:"key_size,omitempty"`
+	Size *int32
 
 	// PublicExponent is the public exponent of an RSA key.
-	PublicExponent *int32 `json:"public_exponent,omitempty"`
+	PublicExponent *int32
 
 	// Tags is application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // convert CreateKeyOptions to *generated.KeyVaultClientCreateKeyOptions
@@ -175,22 +175,22 @@ func (c *Client) CreateKey(ctx context.Context, name string, keyType KeyType, op
 // CreateECKeyOptions contains optional parameters for CreateECKey
 type CreateECKeyOptions struct {
 	// Curve is the elliptic curve name. For valid values, see PossibleCurveNameValues.
-	Curve *CurveName `json:"crv,omitempty"`
+	Curve *CurveName
 
 	// Tags is application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// HardwareProtected determines whether the key is is created in a hardware security module (HSM).
 	HardwareProtected *bool
 
 	// Properties is the key's management properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// Operations are the operations Key Vault will allow for the key.
-	Operations []*Operation `json:"key_ops,omitempty"`
+	Operations []*Operation
 
 	// ReleasePolicy specifies conditions under which the key can be exported
-	ReleasePolicy *ReleasePolicy `json:"release_policy,omitempty"`
+	ReleasePolicy *ReleasePolicy
 }
 
 // convert CreateECKeyOptions to generated.KeyCreateParameters
@@ -256,19 +256,19 @@ type CreateOctKeyOptions struct {
 	HardwareProtected *bool
 
 	// Size is the key size in bits. For example: 128, 192 or 256.
-	Size *int32 `json:"key_size,omitempty"`
+	Size *int32
 
 	// Properties is the key's management properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// Operations are the operations Key Vault will allow for the key.
-	Operations []*Operation `json:"key_ops,omitempty"`
+	Operations []*Operation
 
 	// ReleasePolicy specifies conditions under which the key can be exported
-	ReleasePolicy *ReleasePolicy `json:"release_policy,omitempty"`
+	ReleasePolicy *ReleasePolicy
 
 	// Tags is application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // conver the CreateOctKeyOptions to generated.KeyCreateParameters
@@ -332,22 +332,22 @@ type CreateRSAKeyOptions struct {
 	HardwareProtected *bool
 
 	// Size is the key size in bits. For example: 2048, 3072, or 4096.
-	Size *int32 `json:"key_size,omitempty"`
+	Size *int32
 
 	// PublicExponent is the key's public exponent.
-	PublicExponent *int32 `json:"public_exponent,omitempty"`
+	PublicExponent *int32
 
 	// Tags is application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// Properties is the key's management properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// Operations are the operations Key Vault will allow for the key.
-	Operations []*Operation `json:"key_ops,omitempty"`
+	Operations []*Operation
 
 	// ReleasePolicy specifies conditions under which the key can be exported
-	ReleasePolicy *ReleasePolicy `json:"release_policy,omitempty"`
+	ReleasePolicy *ReleasePolicy
 }
 
 // convert CreateRSAKeyOptions to generated.KeyCreateParameters
@@ -418,10 +418,10 @@ type ListPropertiesOfKeysOptions struct {
 // ListPropertiesOfKeysResponse contains a page of key properties.
 type ListPropertiesOfKeysResponse struct {
 	// NextLink is the URL to get the next page.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// Keys is the page's content.
-	Keys []*KeyItem `json:"value,omitempty" azure:"ro"`
+	Keys []*KeyItem
 }
 
 // convert internal Response to ListKeysPage
@@ -645,7 +645,7 @@ func (b BackupKeyOptions) toGenerated() *generated.KeyVaultClientBackupKeyOption
 // BackupKeyResponse contains the response from the Client.BackupKey method
 type BackupKeyResponse struct {
 	// READ-ONLY; The backup blob containing the backed up key.
-	Value []byte `json:"value,omitempty" azure:"ro"`
+	Value []byte
 }
 
 // convert internal reponse to BackupKeyResponse
@@ -786,10 +786,10 @@ func (c *Client) UpdateKeyProperties(ctx context.Context, key Key, options *Upda
 // ListDeletedKeysResponse holds the data for a single page.
 type ListDeletedKeysResponse struct {
 	// NextLink is the URL to get the next page.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// DeletedKeys is the page's content.
-	DeletedKeys []*DeletedKeyItem `json:"value,omitempty" azure:"ro"`
+	DeletedKeys []*DeletedKeyItem
 }
 
 // ListDeletedKeysOptions contains optional parameters for NewListDeletedKeysPager.
@@ -860,10 +860,10 @@ func (l *ListPropertiesOfKeyVersionsOptions) toGenerated() *generated.KeyVaultCl
 // ListPropertiesOfKeyVersionsResponse contains a page of key versions.
 type ListPropertiesOfKeyVersionsResponse struct {
 	// NextLink is the URL to get the next page.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// Keys is the page's content.
-	Keys []*KeyItem `json:"value,omitempty" azure:"ro"`
+	Keys []*KeyItem
 }
 
 // create ListKeysPage from generated pager
@@ -958,10 +958,10 @@ func (c *Client) RestoreKeyBackup(ctx context.Context, keyBackup []byte, options
 // ImportKeyOptions contains optional parameters for ImportKeyOptions.
 type ImportKeyOptions struct {
 	// HardwareProtected determines whether Key Vault protects the imported key with an HSM.
-	HardwareProtected *bool `json:"Hsm,omitempty"`
+	HardwareProtected *bool
 
 	// Properties is the properties of the key.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 }
 
 func (i ImportKeyOptions) toImportKeyParameters(key JSONWebKey) generated.KeyImportParameters {
@@ -1020,7 +1020,7 @@ func (g GetRandomBytesOptions) toGenerated() *generated.KeyVaultClientGetRandomB
 // GetRandomBytesResponse is returned by GetRandomBytes.
 type GetRandomBytesResponse struct {
 	// Value is the random bytes.
-	Value []byte `json:"value,omitempty"`
+	Value []byte
 }
 
 // GetRandomBytes gets the requested number of random bytes from Azure Managed HSM. Pass nil for options to accept default values.
@@ -1148,16 +1148,16 @@ type ReleaseKeyOptions struct {
 	Version *string
 
 	// Algorithm is the encryption algorithm used to protected exported key material.
-	Algorithm *ExportEncryptionAlg `json:"algorithm,omitempty"`
+	Algorithm *ExportEncryptionAlg
 
 	// Nonce is client-provided nonce for freshness.
-	Nonce *string `json:"nonce,omitempty"`
+	Nonce *string
 }
 
 // ReleaseKeyResponse is returned by ReleaseKey.
 type ReleaseKeyResponse struct {
 	// Value is a signed token containing the released key.
-	Value *string `json:"value,omitempty" azure:"ro"`
+	Value *string
 }
 
 // ReleaseKey is applicable to all key types. The target key must be exportable. Pass nil for options to accept default values.

--- a/sdk/keyvault/azkeys/models.go
+++ b/sdk/keyvault/azkeys/models.go
@@ -17,42 +17,42 @@ import (
 // Properties - The properties of a key managed by the key vault service.
 type Properties struct {
 	// READ-ONLY; Creation time in UTC.
-	CreatedOn *time.Time `json:"created,omitempty" azure:"ro"`
+	CreatedOn *time.Time
 
 	// Determines whether the object is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Expiry date in UTC.
-	ExpiresOn *time.Time `json:"exp,omitempty"`
+	ExpiresOn *time.Time
 
 	// Indicates if the private key can be exported.
-	Exportable *bool `json:"exportable,omitempty"`
+	Exportable *bool
 
 	// ID identifies the key
 	ID *string
 
 	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 
 	// Name of the key
 	Name *string
 
 	// Not before date in UTC.
-	NotBefore *time.Time `json:"nbf,omitempty"`
+	NotBefore *time.Time
 
 	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
-	RecoverableDays *int32 `json:"recoverableDays,omitempty" azure:"ro"`
+	RecoverableDays *int32
 
 	// READ-ONLY; Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable'
 	// the key can be permanently deleted by a privileged user; otherwise, only the system
 	// can purge the key, at the end of the retention interval.
-	RecoveryLevel *string `json:"recoveryLevel,omitempty" azure:"ro"`
+	RecoveryLevel *string
 
 	// Tags contain application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Last updated time in UTC.
-	UpdatedOn *time.Time `json:"updated,omitempty" azure:"ro"`
+	UpdatedOn *time.Time
 
 	// VaultURL for the key
 	VaultURL *string
@@ -105,13 +105,13 @@ func keyPropertiesFromGenerated(i *generated.KeyAttributes, id *string, name *st
 // Key - A Key consists of a WebKey plus its attributes.
 type Key struct {
 	// The key management properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// The Json web key.
-	JSONWebKey *JSONWebKey `json:"key,omitempty"`
+	JSONWebKey *JSONWebKey
 
 	// The policy rules under which the key can be exported.
-	ReleasePolicy *ReleasePolicy `json:"release_policy,omitempty"`
+	ReleasePolicy *ReleasePolicy
 
 	// ID identifies the key
 	ID *string
@@ -142,50 +142,50 @@ func (k Key) toKeyUpdateParameters() generated.KeyUpdateParameters {
 // JSONWebKey - As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18
 type JSONWebKey struct {
 	// Elliptic curve name. For valid values, see PossibleCurveNameValues.
-	Crv *CurveName `json:"crv,omitempty"`
+	Crv *CurveName
 
 	// RSA private exponent, or the D component of an EC private key.
-	D []byte `json:"d,omitempty"`
+	D []byte
 
 	// RSA private key parameter.
-	DP []byte `json:"dp,omitempty"`
+	DP []byte
 
 	// RSA private key parameter.
-	DQ []byte `json:"dq,omitempty"`
+	DQ []byte
 
 	// RSA public exponent.
-	E []byte `json:"e,omitempty"`
+	E []byte
 
 	// Symmetric key.
-	K      []byte       `json:"k,omitempty"`
-	KeyOps []*Operation `json:"key_ops,omitempty"`
+	K      []byte
+	KeyOps []*Operation
 
 	// ID identifies the key
-	ID *string `json:"kid,omitempty"`
+	ID *string
 
 	// JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
-	KeyType *KeyType `json:"kty,omitempty"`
+	KeyType *KeyType
 
 	// RSA modulus.
-	N []byte `json:"n,omitempty"`
+	N []byte
 
 	// RSA secret prime.
-	P []byte `json:"p,omitempty"`
+	P []byte
 
 	// RSA secret prime, with p < q.
-	Q []byte `json:"q,omitempty"`
+	Q []byte
 
 	// RSA private key parameter.
-	QI []byte `json:"qi,omitempty"`
+	QI []byte
 
 	// Protected Key, used with 'Bring Your Own Key'.
-	T []byte `json:"key_hsm,omitempty"`
+	T []byte
 
 	// X component of an EC public key.
-	X []byte `json:"x,omitempty"`
+	X []byte
 
 	// Y component of an EC public key.
-	Y []byte `json:"y,omitempty"`
+	Y []byte
 }
 
 // converts generated.JSONWebKey to publicly exposed version
@@ -248,10 +248,10 @@ func (j JSONWebKey) toGenerated() *generated.JSONWebKey {
 // KeyItem - The key item containing key metadata.
 type KeyItem struct {
 	// The key management properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// ID identifies the key
-	ID *string `json:"kid,omitempty"`
+	ID *string
 
 	// Name of the key
 	Name *string
@@ -274,43 +274,43 @@ func keyItemFromGenerated(i *generated.KeyItem) *KeyItem {
 // DeletedKey - A DeletedKey consisting of a WebKey plus its Attributes and deletion info
 type DeletedKey struct {
 	// The key management properties.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// The Json web key.
-	Key *JSONWebKey `json:"key,omitempty"`
+	Key *JSONWebKey
 
 	// The url of the recovery object, used to identify and recover the deleted key.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// The policy rules under which the key can be exported.
-	ReleasePolicy *ReleasePolicy `json:"release_policy,omitempty"`
+	ReleasePolicy *ReleasePolicy
 
 	// READ-ONLY; The time when the key was deleted, in UTC
-	DeletedOn *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedOn *time.Time
 
 	// READ-ONLY; The time when the key is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 // DeletedKeyItem - The deleted key item containing the deleted key metadata and information about deletion.
 type DeletedKeyItem struct {
 	// The key management attributes.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// ID identifies the key
-	ID *string `json:"kid,omitempty"`
+	ID *string
 
 	// Name of the key
 	Name *string
 
 	// The url of the recovery object, used to identify and recover the deleted key.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// READ-ONLY; The time when the key was deleted, in UTC
-	DeletedOn *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedOn *time.Time
 
 	// READ-ONLY; The time when the key is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 // convert *generated.DeletedKeyItem to *DeletedKeyItem
@@ -336,14 +336,14 @@ func deletedKeyItemFromGenerated(i *generated.DeletedKeyItem) *DeletedKeyItem {
 //  - https://aka.ms/policygrammarhsm for Azure Managed HSM release policy grammar.
 type ReleasePolicy struct {
 	// Content type and version of key release policy
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// Blob encoding the policy rules under which the key can be released.
-	EncodedPolicy []byte `json:"data,omitempty"`
+	EncodedPolicy []byte
 
 	// Defines the mutability state of the policy. Once marked immutable, this flag cannot be reset and the policy cannot be changed
 	// under any circumstances.
-	Immutable *bool `json:"immutable,omitempty"`
+	Immutable *bool
 }
 
 func (k *ReleasePolicy) toGenerated() *generated.KeyReleasePolicy {
@@ -372,15 +372,15 @@ func keyReleasePolicyFromGenerated(i *generated.KeyReleasePolicy) *ReleasePolicy
 // RotationPolicy - Management policy for a key.
 type RotationPolicy struct {
 	// The key rotation policy attributes.
-	Attributes *RotationPolicyAttributes `json:"attributes,omitempty"`
+	Attributes *RotationPolicyAttributes
 
 	// Actions that will be performed by Key Vault over the lifetime of a key. For preview, lifetimeActions can only have two items at maximum: one for rotate,
 	// one for notify. Notification time would be
 	// default to 30 days before expiry and it is not configurable.
-	LifetimeActions []*LifetimeActions `json:"lifetimeActions,omitempty"`
+	LifetimeActions []*LifetimeActions
 
 	// READ-ONLY; The key policy id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 func (u RotationPolicy) toGenerated() generated.KeyRotationPolicy {
@@ -405,13 +405,13 @@ type RotationPolicyAttributes struct {
 	// ExpiresIn will be applied on the new key version. It should be at least 28 days.
 	// It will be in ISO 8601 Format. Examples: 90 days: P90D, 3 months: P3M, 48 hours: PT48H, 1 year and 10 days: P1Y10D
 	// It should be at least 28 days.
-	ExpiresIn *string `json:"expiryTime,omitempty"`
+	ExpiresIn *string
 
 	// READ-ONLY; The key rotation policy created time in UTC.
-	CreatedOn *time.Time `json:"created,omitempty" azure:"ro"`
+	CreatedOn *time.Time
 
 	// READ-ONLY; The key rotation policy's last updated time in UTC.
-	UpdatedOn *time.Time `json:"updated,omitempty" azure:"ro"`
+	UpdatedOn *time.Time
 }
 
 func (k RotationPolicyAttributes) toGenerated() *generated.KeyRotationPolicyAttributes {
@@ -425,10 +425,10 @@ func (k RotationPolicyAttributes) toGenerated() *generated.KeyRotationPolicyAttr
 // LifetimeActions - Action and its trigger that will be performed by Key Vault over the lifetime of a key.
 type LifetimeActions struct {
 	// The action that will be executed.
-	Action *LifetimeActionsType `json:"action,omitempty"`
+	Action *LifetimeActionsType
 
 	// The condition that will execute the action.
-	Trigger *LifetimeActionsTrigger `json:"trigger,omitempty"`
+	Trigger *LifetimeActionsTrigger
 }
 
 func (l *LifetimeActions) toGenerated() *generated.LifetimeActions {
@@ -464,14 +464,14 @@ func lifetimeActionsFromGenerated(i *generated.LifetimeActions) *LifetimeActions
 // LifetimeActionsType - The action that will be executed.
 type LifetimeActionsType struct {
 	// The type of the action.
-	Type *RotationAction `json:"type,omitempty"`
+	Type *RotationAction
 }
 
 // LifetimeActionsTrigger - A condition to be satisfied for an action to be executed.
 type LifetimeActionsTrigger struct {
 	// Time after creation to attempt to rotate. It only applies to rotate. It will be in ISO 8601 duration format. Example: 90 days : "P90D"
-	TimeAfterCreate *string `json:"timeAfterCreate,omitempty"`
+	TimeAfterCreate *string
 
 	// Time before expiry to attempt to rotate or notify. It will be in ISO 8601 duration format. Example: 90 days : "P90D"
-	TimeBeforeExpiry *string `json:"timeBeforeExpiry,omitempty"`
+	TimeBeforeExpiry *string
 }

--- a/sdk/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/keyvault/azsecrets/CHANGELOG.md
@@ -19,6 +19,7 @@
   `Properties` fields, for example `SecretItem.Properties`.
 * Changed paged API content values to pointer types. For example, `ListPropertiesOfSecretsResponse.Secrets`
   changed type from `[]SecretItem` to `[]*SecretItem`.
+* Removed JSON tags from models
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/azsecrets/client.go
+++ b/sdk/keyvault/azsecrets/client.go
@@ -95,10 +95,10 @@ func (c *Client) GetSecret(ctx context.Context, name string, options *GetSecretO
 // SetSecretOptions contains optional parameters for SetSecret.
 type SetSecretOptions struct {
 	// Type of the secret value such as a password.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// The secret management attributes.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 }
 
 // Convert the exposed struct to the generated code version
@@ -313,7 +313,7 @@ func (b *BackupSecretOptions) toGenerated() *generated.KeyVaultClientBackupSecre
 // BackupSecretResponse is returned by BackupSecret.
 type BackupSecretResponse struct {
 	// READ-ONLY; The backup blob containing the backed up secret.
-	Value []byte `json:"value,omitempty" azure:"ro"`
+	Value []byte
 }
 
 // convert generated response to the publicly exposed version.
@@ -472,10 +472,10 @@ func (c *Client) BeginRecoverDeletedSecret(ctx context.Context, name string, opt
 // ListDeletedSecretsResponse contains a page of deleted secrets.
 type ListDeletedSecretsResponse struct {
 	// NextLink is the URL to get the next page.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// DeletedSecrets is the page's content.
-	DeletedSecrets []*DeletedSecretItem `json:"value,omitempty" azure:"ro"`
+	DeletedSecrets []*DeletedSecretItem
 }
 
 func listDeletedSecretsPageFromGenerated(g generated.KeyVaultClientGetDeletedSecretsResponse) ListDeletedSecretsResponse {
@@ -536,10 +536,10 @@ type ListPropertiesOfSecretVersionsOptions struct {
 // ListPropertiesOfSecretVersionsResponse contains a page of secret versions.
 type ListPropertiesOfSecretVersionsResponse struct {
 	// NextLink is the URL to get the next page.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// Secrets is the page's content.
-	Secrets []*SecretItem `json:"value,omitempty" azure:"ro"`
+	Secrets []*SecretItem
 }
 
 // create ListSecretsPage from generated pager
@@ -595,10 +595,10 @@ type ListPropertiesOfSecretsOptions struct {
 // ListPropertiesOfSecretsResponse contains a page of secret properties.
 type ListPropertiesOfSecretsResponse struct {
 	// NextLink is the URL to get the next page.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// Secrets is the page's content.
-	Secrets []*SecretItem `json:"value,omitempty" azure:"ro"`
+	Secrets []*SecretItem
 }
 
 // create a ListSecretsPage from a generated code response

--- a/sdk/keyvault/azsecrets/models.go
+++ b/sdk/keyvault/azsecrets/models.go
@@ -16,37 +16,37 @@ import (
 // DeletedSecret consists of the previous ID, attributes, tags, and information on when it will be purged.
 type DeletedSecret struct {
 	// The secret management attributes.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// The secret id.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the secret
 	Name *string
 
 	// The url of the recovery object, used to identify and recover the deleted secret.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// READ-ONLY; The time when the secret was deleted, in UTC
-	DeletedOn *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedOn *time.Time
 
 	// READ-ONLY; The time when the secret is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 // Secret - A secret consisting of a value, id and its attributes.
 type Secret struct {
 	// The secret management attributes.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// The secret id.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the secret
 	Name *string
 
 	// The secret value.
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 func (s Secret) toGeneratedProperties() generated.SecretUpdateParameters {
@@ -68,41 +68,41 @@ func (s Secret) toGeneratedProperties() generated.SecretUpdateParameters {
 // Properties - The secret management properties.
 type Properties struct {
 	// The content type of the secret.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// READ-ONLY; Creation time in UTC.
-	CreatedOn *time.Time `json:"created,omitempty" azure:"ro"`
+	CreatedOn *time.Time
 
 	// Determines whether the object is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Expiry date in UTC.
-	ExpiresOn *time.Time `json:"exp,omitempty"`
+	ExpiresOn *time.Time
 
 	// READ-ONLY; True if the secret's lifetime is managed by key vault. If this is a secret backing a certificate, then managed
 	// will be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 
 	// READ-ONLY; If this is a secret backing a KV certificate, then this field specifies the corresponding key backing the KV
 	// certificate.
-	KeyID *string `json:"kid,omitempty" azure:"ro"`
+	KeyID *string
 
 	// NotBefore is the secret's not before date in UTC.
-	NotBefore *time.Time `json:"nbf,omitempty"`
+	NotBefore *time.Time
 
 	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
-	RecoverableDays *int32 `json:"recoverableDays,omitempty" azure:"ro"`
+	RecoverableDays *int32
 
 	// READ-ONLY; Reflects the deletion recovery level currently in effect for secrets in the current vault. If it contains 'Purgeable', the secret can be permanently
 	// deleted by a privileged user; otherwise, only the
 	// system can purge the secret, at the end of the retention interval.
-	RecoveryLevel *string `json:"recoveryLevel,omitempty" azure:"ro"`
+	RecoveryLevel *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Last updated time in UTC.
-	UpdatedOn *time.Time `json:"updated,omitempty" azure:"ro"`
+	UpdatedOn *time.Time
 
 	// VaultURL is the vault url the secret came from
 	VaultURL *string
@@ -156,10 +156,10 @@ func secretPropertiesFromGenerated(i *generated.SecretAttributes, ID, contentTyp
 // SecretItem contains secret metadata.
 type SecretItem struct {
 	// The secret management attributes.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// Secret identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the secret
 	Name *string
@@ -182,22 +182,22 @@ func secretItemFromGenerated(i *generated.SecretItem) *SecretItem {
 // DeletedSecretItem - The deleted secret item containing metadata about the deleted secret.
 type DeletedSecretItem struct {
 	// The secret management attributes.
-	Properties *Properties `json:"attributes,omitempty"`
+	Properties *Properties
 
 	// Secret identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the deleted secret
 	Name *string
 
 	// The url of the recovery object, used to identify and recover the deleted secret.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// READ-ONLY; The time when the secret was deleted, in UTC
-	DeletedOn *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedOn *time.Time
 
 	// READ-ONLY; The time when the secret is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 func deletedSecretItemFromGenerated(i *generated.DeletedSecretItem) *DeletedSecretItem {


### PR DESCRIPTION
These are unnecessary because convenience models never go on the wire, and we don't have a feature like cross-language interop that requires a particular JSON representation.