### PR TITLE
Prepare azidentity 1.1.0 release

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 1.1.0 (2022-06-07)
+
+### Features Added
+* `ClientCertificateCredential` and `ClientSecretCredential` support ESTS-R. First-party
+  applications can set environment variable `AZURE_REGIONAL_AUTHORITY_NAME` with a
+  region name.
+
 ## 1.0.1 (2022-06-07)
 
 ### Other Changes

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	azureAuthorityHost = "AZURE_AUTHORITY_HOST"
-	azureClientID      = "AZURE_CLIENT_ID"
+	azureAuthorityHost         = "AZURE_AUTHORITY_HOST"
+	azureClientID              = "AZURE_CLIENT_ID"
+	azureRegionalAuthorityName = "AZURE_REGIONAL_AUTHORITY_NAME"
 
 	organizationsTenantID   = "organizations"
 	developerSignOnClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -12,10 +12,10 @@ import (
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/x509"
-
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
+	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -71,6 +71,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 	o := []confidential.Option{
 		confidential.WithAuthority(runtime.JoinPaths(authorityHost, tenantID)),
 		confidential.WithHTTPClient(newPipelineAdapter(&options.ClientOptions)),
+		confidential.WithAzureRegion(os.Getenv(azureRegionalAuthorityName)),
 	}
 	if options.SendCertificateChain {
 		o = append(o, confidential.WithX5C())

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -244,3 +244,25 @@ func TestClientCertificateCredential_InvalidCertLive(t *testing.T) {
 		t.Fatal("expected a non-nil RawResponse")
 	}
 }
+
+func TestClientCertificateCredential_Regional(t *testing.T) {
+	t.Setenv(azureRegionalAuthorityName, "westus2")
+	opts, stop := initRecording(t)
+	defer stop()
+
+	f, err := os.ReadFile(liveSP.sniPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, key, err := ParseCertificates(f, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cred, err := NewClientCertificateCredential(
+		liveSP.tenantID, liveSP.clientID, cert, key, &ClientCertificateCredentialOptions{SendCertificateChain: true, ClientOptions: opts},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testGetTokenSuccess(t, cred)
+}

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -9,6 +9,7 @@ package azidentity
 import (
 	"context"
 	"errors"
+	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -47,6 +48,7 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 	c, err := confidential.New(clientID, cred,
 		confidential.WithAuthority(runtime.JoinPaths(authorityHost, tenantID)),
 		confidential.WithHTTPClient(newPipelineAdapter(&options.ClientOptions)),
+		confidential.WithAzureRegion(os.Getenv(azureRegionalAuthorityName)),
 	)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/testdata/recordings/TestClientCertificateCredential_Regional.json
+++ b/sdk/azidentity/testdata/recordings/TestClientCertificateCredential_Regional.json
@@ -1,0 +1,120 @@
+{
+    "Entries": [
+      {
+        "RequestUri": "https://westus2.r.login.microsoftonline.com/fake-tenant/v2.0/.well-known/openid-configuration",
+        "RequestMethod": "GET",
+        "RequestHeaders": {
+          ":method": "GET",
+          "Accept-Encoding": "gzip",
+          "User-Agent": "azsdk-go-azidentity/v1.0.1 (go1.18.3; linux)"
+        },
+        "RequestBody": null,
+        "StatusCode": 200,
+        "ResponseHeaders": {
+          "Cache-Control": "max-age=86400, private",
+          "Content-Length": "1245",
+          "Content-Type": "application/json; charset=utf-8",
+          "Date": "Thu, 02 Jun 2022 16:27:23 GMT",
+          "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+          "Set-Cookie": "fpc=Alg0CxoeRidMjWt5yaT51Z4; expires=Sat, 02-Jul-2022 16:27:24 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "X-Content-Type-Options": "nosniff",
+          "x-ms-ests-server": "2.1.12794.7 - WUS2 ProdSlices",
+          "x-ms-request-id": "19ce7346-9009-4435-9704-b567248f0802",
+          "X-XSS-Protection": "0"
+        },
+        "ResponseBody": {
+          "token_endpoint": "https://westus2.r.login.microsoftonline.com/fake-tenant/oauth2/v2.0/token",
+          "token_endpoint_auth_methods_supported": [
+            "client_secret_post",
+            "private_key_jwt",
+            "client_secret_basic"
+          ],
+          "jwks_uri": "https://westus2.r.login.microsoftonline.com/fake-tenant/discovery/v2.0/keys",
+          "response_modes_supported": [
+            "query",
+            "fragment",
+            "form_post"
+          ],
+          "subject_types_supported": [
+            "pairwise"
+          ],
+          "id_token_signing_alg_values_supported": [
+            "RS256"
+          ],
+          "response_types_supported": [
+            "code",
+            "id_token",
+            "code id_token",
+            "id_token token"
+          ],
+          "scopes_supported": [
+            "openid",
+            "profile",
+            "email",
+            "offline_access"
+          ],
+          "issuer": "https://login.microsoftonline.com/fake-tenant/v2.0",
+          "request_uri_parameter_supported": false,
+          "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+          "authorization_endpoint": "unsupported",
+          "claims_supported": [
+            "sub",
+            "iss",
+            "cloud_instance_name",
+            "cloud_instance_host_name",
+            "cloud_graph_host_name",
+            "msgraph_host",
+            "aud",
+            "exp",
+            "iat",
+            "auth_time",
+            "acr",
+            "nonce",
+            "tid",
+            "ver",
+            "at_hash",
+            "c_hash"
+          ],
+          "tenant_region_scope": "NA",
+          "cloud_instance_name": "microsoftonline.com",
+          "cloud_graph_host_name": "graph.windows.net",
+          "msgraph_host": "graph.microsoft.com",
+          "rbac_url": "https://pas.windows.net"
+        }
+      },
+      {
+        "RequestUri": "https://westus2.r.login.microsoftonline.com/fake-tenant/oauth2/v2.0/token",
+        "RequestMethod": "POST",
+        "RequestHeaders": {
+          ":method": "POST",
+          "Accept-Encoding": "gzip",
+          "Content-Length": "2",
+          "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+          "User-Agent": "azsdk-go-azidentity/v1.0.1 (go1.18.3; linux)"
+        },
+        "RequestBody": {},
+        "StatusCode": 200,
+        "ResponseHeaders": {
+          "Cache-Control": "no-store, no-cache",
+          "Content-Length": "89",
+          "Content-Type": "application/json; charset=utf-8",
+          "Date": "Thu, 02 Jun 2022 16:27:23 GMT",
+          "Expires": "-1",
+          "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+          "Pragma": "no-cache",
+          "Set-Cookie": "fpc=Alg0CxoeRidMjWt5yaT51Z4; expires=Sat, 02-Jul-2022 16:27:24 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "X-Content-Type-Options": "nosniff",
+          "x-ms-ests-server": "2.1.12794.7 - WUS2 ProdSlices",
+          "x-ms-request-id": "e32199b8-7d70-45ec-b403-d1b39593e301",
+          "X-XSS-Protection": "0"
+        },
+        "ResponseBody": {
+          "token_type": "Bearer",
+          "expires_in": 3599,
+          "ext_expires_in": 3599,
+          "access_token": "redacted"
+        }
+      }
+    ],
+    "Variables": {}
+  }

--- a/sdk/azidentity/version.go
+++ b/sdk/azidentity/version.go
@@ -11,5 +11,5 @@ const (
 	component = "azidentity"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	version = "v1.0.1"
+	version = "v1.1.0"
 )


### PR DESCRIPTION
Cherry-picking #18308 onto a release branch off the 1.0.1 tag because the beta feature comes before ESTS-R on main.