### PR TITLE
[azservicebus] Update go-amqp

### DIFF
--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -173,7 +173,9 @@ func GetRecoveryKind(err error) RecoveryKind {
 		return RecoveryKindLink
 	}
 
-	if errors.Is(err, amqp.ErrConnClosed) ||
+	var connErr *amqp.ConnectionError
+
+	if errors.As(err, &connErr) ||
 		// session closures appear to leak through when the connection itself is going down.
 		errors.Is(err, amqp.ErrSessionClosed) {
 		return RecoveryKindConn

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -115,7 +115,7 @@ func Test_recoveryKind(t *testing.T) {
 		}
 
 		t.Run("sentinel errors", func(t *testing.T) {
-			rk := GetRecoveryKind(amqp.ErrConnClosed)
+			rk := GetRecoveryKind(&amqp.ConnectionError{})
 			require.EqualValues(t, RecoveryKindConn, rk)
 		})
 	})
@@ -188,7 +188,7 @@ func Test_ServiceBusError_ConnectionRecoveryNeeded(t *testing.T) {
 	var connErrors = []error{
 		&amqp.Error{Condition: amqp.ErrorConnectionForced},
 		&amqp.Error{Condition: amqp.ErrorInternalError},
-		amqp.ErrConnClosed,
+		&amqp.ConnectionError{},
 		amqp.ErrSessionClosed,
 		io.EOF,
 		fakeNetError{temp: true},
@@ -274,7 +274,7 @@ func Test_TransformError(t *testing.T) {
 	require.ErrorAs(t, err, &asExportedErr)
 	require.Equal(t, exported.CodeConnectionLost, asExportedErr.Code)
 
-	err = TransformError(amqp.ErrConnClosed)
+	err = TransformError(&amqp.ConnectionError{})
 	require.ErrorAs(t, err, &asExportedErr)
 	require.Equal(t, exported.CodeConnectionLost, asExportedErr.Code)
 

--- a/sdk/messaging/azservicebus/internal/go-amqp/conn.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/conn.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"net"
 	"net/url"

--- a/sdk/messaging/azservicebus/internal/go-amqp/errors.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/errors.go
@@ -63,13 +63,6 @@ func (e *DetachError) Error() string {
 
 // Errors
 var (
-	ErrTimeout = errors.New("amqp: timeout waiting for response")
-
-	// ErrConnClosed is propagated to Session and Senders/Receivers
-	// when Client.Close() is called or the server closes the connection
-	// without specifying an error.
-	ErrConnClosed = errors.New("amqp: connection closed")
-
 	// ErrSessionClosed is propagated to Sender/Receivers
 	// when Session.Close() is called.
 	ErrSessionClosed = errors.New("amqp: session closed")
@@ -78,6 +71,19 @@ var (
 	// Sender.Close() or Receiver.Close() are called.
 	ErrLinkClosed = errors.New("amqp: link closed")
 )
+
+// ConnectionError is propagated to Session and Senders/Receivers
+// when the connection has been closed or is no longer functional.
+type ConnectionError struct {
+	inner error
+}
+
+func (c *ConnectionError) Error() string {
+	if c.inner == nil {
+		return "amqp: connection closed"
+	}
+	return c.inner.Error()
+}
 
 // Default link options
 const (

--- a/sdk/messaging/azservicebus/internal/go-amqp/internal/frames/frames.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/internal/frames/frames.go
@@ -1353,7 +1353,7 @@ func (si *SASLInit) frameBody() {}
 func (si *SASLInit) Marshal(wr *buffer.Buffer) error {
 	return encoding.MarshalComposite(wr, encoding.TypeCodeSASLInit, []encoding.MarshalField{
 		{Value: &si.Mechanism, Omit: false},
-		{Value: &si.InitialResponse, Omit: len(si.InitialResponse) == 0},
+		{Value: &si.InitialResponse, Omit: false},
 		{Value: &si.Hostname, Omit: len(si.Hostname) == 0},
 	})
 }

--- a/sdk/messaging/azservicebus/internal/go-amqp/link.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/link.go
@@ -237,7 +237,9 @@ func attachLink(s *Session, r *Receiver, opts []LinkOption) (*link, error) {
 		l.Messages = make(chan Message, l.receiver.maxCredit)
 		l.unsettledMessages = map[string]struct{}{}
 		// copy the received filter values
-		l.Source.Filter = resp.Source.Filter
+		if resp.Source != nil {
+			l.Source.Filter = resp.Source.Filter
+		}
 	} else {
 		if l.Target == nil {
 			l.Target = new(frames.Target)
@@ -681,7 +683,7 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 		if !fr.Echo {
 			// if the 'drain' flag has been set in the frame sent to the _receiver_ then
 			// we signal whomever is waiting (the service has seen and acknowledged our drain)
-			if fr.Drain && l.receiver.manualCreditor != nil {
+			if fr.Drain && l.receiver != nil && l.receiver.manualCreditor != nil {
 				l.linkCredit = 0 // we have no active credits at this point.
 				l.receiver.manualCreditor.EndDrain()
 			}

--- a/sdk/messaging/azservicebus/internal/go-amqp/link_options.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/link_options.go
@@ -102,6 +102,24 @@ func LinkTargetAddress(addr string) LinkOption {
 	}
 }
 
+// LinkTargetCapabilities sets the target capabilities.
+func LinkTargetCapabilities(capabilities ...string) LinkOption {
+	return func(l *link) error {
+		if l.Target == nil {
+			l.Target = new(frames.Target)
+		}
+
+		// Convert string to symbol
+		symbolCapabilities := make([]encoding.Symbol, len(capabilities))
+		for i, v := range capabilities {
+			symbolCapabilities[i] = encoding.Symbol(v)
+		}
+
+		l.Target.Capabilities = append(l.Target.Capabilities, symbolCapabilities...)
+		return nil
+	}
+}
+
 // LinkAddressDynamic requests a dynamically created address from the server.
 func LinkAddressDynamic() LinkOption {
 	return func(l *link) error {

--- a/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
@@ -6,8 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Azure/go-amqp/internal/encoding"
-	"github.com/Azure/go-amqp/internal/frames"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/go-amqp/internal/encoding"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/go-amqp/internal/frames"
 )
 
 type messageDisposition struct {

--- a/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
@@ -1,5 +1,3 @@
-// Copyright (C) 2017 Kale Blankenship
-// Portions Copyright (c) Microsoft Corporation
 package amqp
 
 import (
@@ -8,8 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/go-amqp/internal/encoding"
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/go-amqp/internal/frames"
+	"github.com/Azure/go-amqp/internal/encoding"
+	"github.com/Azure/go-amqp/internal/frames"
 )
 
 type messageDisposition struct {
@@ -62,7 +60,7 @@ func (r *Receiver) Prefetched(ctx context.Context) (*Message, error) {
 	case msg := <-r.link.Messages:
 		debug(3, "Receive() non blocking %d", msg.deliveryID)
 		msg.link = r.link
-		return acceptIfModeFirst(ctx, r, &msg)
+		return &msg, nil
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
@@ -89,25 +87,12 @@ func (r *Receiver) Receive(ctx context.Context) (*Message, error) {
 	case msg := <-r.link.Messages:
 		debug(3, "Receive() blocking %d", msg.deliveryID)
 		msg.link = r.link
-		return acceptIfModeFirst(ctx, r, &msg)
+		return &msg, nil
 	case <-r.link.Detached:
 		return nil, r.link.err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
-}
-
-// acceptIfModeFirst auto-accepts a message if we are in mode first, otherwise it no-ops.
-func acceptIfModeFirst(ctx context.Context, r *Receiver, msg *Message) (*Message, error) {
-	// for ModeFirst, auto-accept the message
-	if receiverSettleModeValue(r.link.ReceiverSettleMode) == ModeSecond {
-		return msg, nil
-	}
-	if err := r.AcceptMessage(ctx, msg); err != nil {
-		return nil, err
-	}
-	return msg, nil
-
 }
 
 // Accept notifies the server that the message has been

--- a/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2017 Kale Blankenship
+// Portions Copyright (c) Microsoft Corporation
 package amqp
 
 import (

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -438,13 +438,13 @@ func TestReceiver_UserFacingErrors(t *testing.T) {
 	require.ErrorAs(t, err, &asSBError)
 	require.Equal(t, CodeConnectionLost, asSBError.Code)
 
-	fakeAMQPLinks.Err = amqp.ErrConnClosed
+	fakeAMQPLinks.Err = &amqp.ConnectionError{}
 	messages, err = receiver.ReceiveDeferredMessages(context.Background(), []int64{1}, nil)
 	require.Empty(t, messages)
 	require.ErrorAs(t, err, &asSBError)
 	require.Equal(t, CodeConnectionLost, asSBError.Code)
 
-	fakeAMQPLinks.Err = amqp.ErrConnClosed
+	fakeAMQPLinks.Err = &amqp.ConnectionError{}
 	messages, err = receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.Empty(t, messages)
 	require.ErrorAs(t, err, &asSBError)

--- a/sdk/messaging/azservicebus/sender_unit_test.go
+++ b/sdk/messaging/azservicebus/sender_unit_test.go
@@ -30,7 +30,7 @@ func TestSender_UserFacingError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	fakeAMQPLinks.Err = amqp.ErrConnClosed
+	fakeAMQPLinks.Err = &amqp.ConnectionError{}
 
 	var asSBError *Error
 

--- a/sdk/messaging/azservicebus/session_receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_unit_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestSessionReceiverUserFacingErrors(t *testing.T) {
 	fakeAMQPLinks := &internal.FakeAMQPLinks{
-		Err: amqp.ErrConnClosed,
+		Err: &amqp.ConnectionError{},
 	}
 
 	receiver, err := newSessionReceiver(context.Background(), newSessionReceiverArgs{
@@ -80,7 +80,7 @@ func TestSessionReceiverUserFacingErrors(t *testing.T) {
 
 	// there's an init() method that's a little harder to trigger, so we'll do that here.
 	// Unlike the others above it doesn't rely on the management$ link.
-	fakeAMQPLinks.Err = amqp.ErrConnClosed
+	fakeAMQPLinks.Err = &amqp.ConnectionError{}
 	err = receiver.init(context.Background())
 	require.ErrorAs(t, err, &asSBError)
 	require.Equal(t, CodeConnectionLost, asSBError.Code)


### PR DESCRIPTION
Updating our internally vendored go-amqp to `18d378101570d5469d237799a76b77c0bf0c6fe3`

This mostly impacted us because the connection error is no longer a sentinel error.