### PR TITLE
Handle RELO LRO synchronous completion

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Avoid polling when a RELO LRO synchronously terminates.
 
 ### Other Changes
 

--- a/sdk/azcore/internal/pollers/loc/loc.go
+++ b/sdk/azcore/internal/pollers/loc/loc.go
@@ -64,12 +64,19 @@ func New[T any](pl exported.Pipeline, resp *http.Response) (*Poller[T], error) {
 	if !pollers.IsValidURL(locURL) {
 		return nil, fmt.Errorf("invalid polling URL %s", locURL)
 	}
+	// check for provisioning state.  if the operation is a RELO
+	// and terminates synchronously this will prevent extra polling.
+	// it's ok if there's no provisioning state.
+	state, _ := pollers.GetProvisioningState(resp)
+	if state == "" {
+		state = pollers.StatusInProgress
+	}
 	return &Poller[T]{
 		pl:       pl,
 		resp:     resp,
 		Type:     kind,
 		PollURL:  locURL,
-		CurState: pollers.StatusInProgress,
+		CurState: state,
 	}, nil
 }
 


### PR DESCRIPTION
If the initial response contains a provisioning state use it.  This will
prevent extra polling in the case the operation is in a terminal state.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
