### PR TITLE
[azservicebus] Adding in raw AMQP support for sending and receiving messages.

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.0.2-beta.0 (Unreleased)
 
 ### Features Added
+
+- Full access to all AMQP message properties. Send AMQP messages using the new `AMQPMessage` type and `Sender.SendAMQPMessage()`. Access the full set of AMQP message properties using the new `ReceivedMessage.RawAMQPMessage` property. (#TBD)
 
 ### Breaking Changes
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Features Added
 
-- Full access to all AMQP message properties. Send AMQP messages using the new `AMQPMessage` type and `Sender.SendAMQPMessage()`. Access the full set of AMQP message properties using the new `ReceivedMessage.RawAMQPMessage` property. (#18413)
+- Full access to send and receive all AMQP message properties. (#18413) 
+  - Send AMQP messages using the new `AMQPMessage` type and `Sender.SendAMQPMessage()` (AMQP messages can be added to MessageBatch's as well using MessageBatch.AddAMQPMessage()). 
+  - Access the full set of AMQP message properties when receiving using the `ReceivedMessage.RawAMQPMessage` property. 
 
 ### Breaking Changes
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Full access to all AMQP message properties. Send AMQP messages using the new `AMQPMessage` type and `Sender.SendAMQPMessage()`. Access the full set of AMQP message properties using the new `ReceivedMessage.RawAMQPMessage` property. (#TBD)
+- Full access to all AMQP message properties. Send AMQP messages using the new `AMQPMessage` type and `Sender.SendAMQPMessage()`. Access the full set of AMQP message properties using the new `ReceivedMessage.RawAMQPMessage` property. (#18413)
 
 ### Breaking Changes
 

--- a/sdk/messaging/azservicebus/amqp_message.go
+++ b/sdk/messaging/azservicebus/amqp_message.go
@@ -29,7 +29,7 @@ type AMQPMessage struct {
 	ApplicationProperties map[string]any
 
 	// Body represents the body of an AMQP message.
-	Body AMQPBody
+	Body AMQPMessageBody
 
 	// DeliveryAnnotations corresponds to the "delivery-annotations" section in an AMQP message.
 	//
@@ -64,92 +64,55 @@ type AMQPMessage struct {
 	inner *amqp.Message
 }
 
+// AMQPMessageProperties represents the properties of an AMQP message.
+// See here for more details:
+// http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-properties
 type AMQPMessageProperties struct {
-	// An absolute time when this message is considered to be expired.
+	// AbsoluteExpiryTime corresponds to the 'absolute-expiry-time' property.
 	AbsoluteExpiryTime *time.Time
 
-	// The content-encoding property is used as a modifier to the content-type.
-	// When present, its value indicates what additional content encodings have been
-	// applied to the application-data, and thus what decoding mechanisms need to be
-	// applied in order to obtain the media-type referenced by the content-type header
-	// field.
-	//
-	// Content-encoding is primarily used to allow a document to be compressed without
-	// losing the identity of its underlying content type.
-	//
-	// Content-encodings are to be interpreted as per section 3.5 of RFC 2616 [RFC2616].
-	// Valid content-encodings are registered at IANA [IANAHTTPPARAMS].
-	//
-	// The content-encoding MUST NOT be set when the application-data section is other
-	// than data. The binary representation of all other application-data section types
-	// is defined completely in terms of the AMQP type system.
-	//
-	// Implementations MUST NOT use the identity encoding. Instead, implementations
-	// SHOULD NOT set this property. Implementations SHOULD NOT use the compress encoding,
-	// except as to remain compatible with messages originally sent with other protocols,
-	// e.g. HTTP or SMTP.
-	//
-	// Implementations SHOULD NOT specify multiple content-encoding values except as to
-	// be compatible with messages originally sent with other protocols, e.g. HTTP or SMTP.
+	// ContentEncoding corresponds to the 'content-encoding' property.
 	ContentEncoding *string
 
-	// The RFC-2046 [RFC2046] MIME type for the message's application-data section
-	// (body). As per RFC-2046 [RFC2046] this can contain a charset parameter defining
-	// the character encoding used: e.g., 'text/plain; charset="utf-8"'.
-	//
-	// For clarity, as per section 7.2.1 of RFC-2616 [RFC2616], where the content type
-	// is unknown the content-type SHOULD NOT be set. This allows the recipient the
-	// opportunity to determine the actual type. Where the section is known to be truly
-	// opaque binary data, the content-type SHOULD be set to application/octet-stream.
-	//
-	// When using an application-data section with a section code other than data,
-	// content-type SHOULD NOT be set.
+	// ContentType corresponds to the 'content-type' property
 	ContentType *string
 
-	// This is a client-specific id that can be used to mark or identify messages
-	// between clients.
+	// CorrelationID corresponds to the 'correlation-id' property.
 	// The type of CorrelationID can be a uint64, UUID, []byte, or a string
 	CorrelationID any
 
-	// An absolute time when this message was created.
+	// CreationTime corresponds to the 'creation-time' property.
 	CreationTime *time.Time
 
-	// Identifies the group the message belongs to.
+	// GroupID corresponds to the 'group-id' property.
 	GroupID *string
 
-	// The relative position of this message within its group.
-	// RFC-1982 sequence number
+	// GroupSequence corresponds to the 'group-sequence' property.
 	GroupSequence *uint32
 
-	// Message-id, if set, uniquely identifies a message within the message system.
-	// The message producer is usually responsible for setting the message-id in
-	// such a way that it is assured to be globally unique. A broker MAY discard a
-	// message as a duplicate if the value of the message-id matches that of a
-	// previously received message sent to the same node.
-	MessageID any // uint64, UUID, []byte, or string
+	// MessageID corresponds to the 'message-id' property.
+	// The type of MessageID can be a uint64, UUID, []byte, or string
+	MessageID any
 
-	// The address of the node to send replies to.
+	// ReplyTo corresponds to the 'reply-to' property.
 	ReplyTo *string
 
-	// This is a client-specific id that is used so that client can send replies to this
-	// message to a specific group.
+	// ReplyToGroupID corresponds to the 'reply-to-group-id' property.
 	ReplyToGroupID *string
 
-	// A common field for summary information about the message content and purpose.
+	// Subject corresponds to the 'subject' property.
 	Subject *string
 
-	// The to field identifies the node that is the intended destination of the message.
-	// On any given transfer this might not be the node at the receiving end of the link.
+	// To corresponds to the 'to' property.
 	To *string
 
-	// The identity of the user responsible for producing the message.
-	// The client sets this value, and it MAY be authenticated by intermediaries.
+	// UserID corresponds to the 'user-id' property.
 	UserID []byte
 }
 
-// AMQPBody represents the body of an AMQP message.
+// AMQPMessageBody represents the body of an AMQP message.
 // Only one of these fields can be used a a time. They are mutually exclusive.
-type AMQPBody struct {
+type AMQPMessageBody struct {
 	// Data is encoded/decoded as multiple data sections in the body.
 	Data [][]byte
 
@@ -292,7 +255,7 @@ func newAMQPMessage(goAMQPMessage *amqp.Message) *AMQPMessage {
 	return &AMQPMessage{
 		MessageAnnotations:    map[any]any(goAMQPMessage.Annotations),
 		ApplicationProperties: goAMQPMessage.ApplicationProperties,
-		Body: AMQPBody{
+		Body: AMQPMessageBody{
 			Data:     goAMQPMessage.Data,
 			Sequence: goAMQPMessage.Sequence,
 			Value:    goAMQPMessage.Value,

--- a/sdk/messaging/azservicebus/amqp_message.go
+++ b/sdk/messaging/azservicebus/amqp_message.go
@@ -1,0 +1,308 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azservicebus
+
+import (
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/go-amqp"
+)
+
+// AMQPMessage represents the AMQP message, as received from Service Bus.
+// For details about these properties, refer to the AMQP specification:
+//   https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
+//
+// Some fields in this struct are typed 'any', which means they will accept AMQP primitives, or in some
+// cases slices and maps.
+//
+// AMQP simple types include:
+// - int (any size), uint (any size)
+// - float (any size)
+// - string
+// - bool
+// - time.Time
+type AMQPMessage struct {
+	// ApplicationProperties corresponds to the "application-properties" section of an AMQP message.
+	//
+	// The values of the map are restricted to AMQP simple types, as listed in the comment for AMQPMessage.
+	ApplicationProperties map[string]any
+
+	// Body represents the body of an AMQP message.
+	Body AMQPBody
+
+	// DeliveryAnnotations corresponds to the "delivery-annotations" section in an AMQP message.
+	//
+	// The values of the map are restricted to AMQP simple types, as listed in the comment for AMQPMessage.
+	DeliveryAnnotations map[any]any
+
+	// DeliveryTag corresponds to the delivery-tag property of the TRANSFER frame
+	// for this message.
+	DeliveryTag []byte
+
+	// Footer is the transport footers for this AMQP message.
+	//
+	// The values of the map are restricted to AMQP simple types, as listed in the comment for AMQPMessage.
+	Footer map[any]any
+
+	// Header is the transport headers for this AMQP message.
+	Header *AMQPMessageHeader
+
+	// MessageAnnotations corresponds to the message-annotations section of an AMQP message.
+	//
+	// The values of the map are restricted to AMQP simple types, as listed in the comment for AMQPMessage.
+	MessageAnnotations map[any]any
+
+	// Properties corresponds to the properties section of an AMQP message.
+	Properties *AMQPMessageProperties
+
+	linkName string
+
+	// inner is the AMQP message we originally received, which contains some hidden
+	// data that's needed to settle with go-amqp. We strip out most of the underlying
+	// data so it's fairly minimal.
+	inner *amqp.Message
+}
+
+type AMQPMessageProperties struct {
+	// An absolute time when this message is considered to be expired.
+	AbsoluteExpiryTime *time.Time
+
+	// The content-encoding property is used as a modifier to the content-type.
+	// When present, its value indicates what additional content encodings have been
+	// applied to the application-data, and thus what decoding mechanisms need to be
+	// applied in order to obtain the media-type referenced by the content-type header
+	// field.
+	//
+	// Content-encoding is primarily used to allow a document to be compressed without
+	// losing the identity of its underlying content type.
+	//
+	// Content-encodings are to be interpreted as per section 3.5 of RFC 2616 [RFC2616].
+	// Valid content-encodings are registered at IANA [IANAHTTPPARAMS].
+	//
+	// The content-encoding MUST NOT be set when the application-data section is other
+	// than data. The binary representation of all other application-data section types
+	// is defined completely in terms of the AMQP type system.
+	//
+	// Implementations MUST NOT use the identity encoding. Instead, implementations
+	// SHOULD NOT set this property. Implementations SHOULD NOT use the compress encoding,
+	// except as to remain compatible with messages originally sent with other protocols,
+	// e.g. HTTP or SMTP.
+	//
+	// Implementations SHOULD NOT specify multiple content-encoding values except as to
+	// be compatible with messages originally sent with other protocols, e.g. HTTP or SMTP.
+	ContentEncoding *string
+
+	// The RFC-2046 [RFC2046] MIME type for the message's application-data section
+	// (body). As per RFC-2046 [RFC2046] this can contain a charset parameter defining
+	// the character encoding used: e.g., 'text/plain; charset="utf-8"'.
+	//
+	// For clarity, as per section 7.2.1 of RFC-2616 [RFC2616], where the content type
+	// is unknown the content-type SHOULD NOT be set. This allows the recipient the
+	// opportunity to determine the actual type. Where the section is known to be truly
+	// opaque binary data, the content-type SHOULD be set to application/octet-stream.
+	//
+	// When using an application-data section with a section code other than data,
+	// content-type SHOULD NOT be set.
+	ContentType *string
+
+	// This is a client-specific id that can be used to mark or identify messages
+	// between clients.
+	// The type of CorrelationID can be a uint64, UUID, []byte, or a string
+	CorrelationID any
+
+	// An absolute time when this message was created.
+	CreationTime *time.Time
+
+	// Identifies the group the message belongs to.
+	GroupID *string
+
+	// The relative position of this message within its group.
+	// RFC-1982 sequence number
+	GroupSequence *uint32
+
+	// Message-id, if set, uniquely identifies a message within the message system.
+	// The message producer is usually responsible for setting the message-id in
+	// such a way that it is assured to be globally unique. A broker MAY discard a
+	// message as a duplicate if the value of the message-id matches that of a
+	// previously received message sent to the same node.
+	MessageID any // uint64, UUID, []byte, or string
+
+	// The address of the node to send replies to.
+	ReplyTo *string
+
+	// This is a client-specific id that is used so that client can send replies to this
+	// message to a specific group.
+	ReplyToGroupID *string
+
+	// A common field for summary information about the message content and purpose.
+	Subject *string
+
+	// The to field identifies the node that is the intended destination of the message.
+	// On any given transfer this might not be the node at the receiving end of the link.
+	To *string
+
+	// The identity of the user responsible for producing the message.
+	// The client sets this value, and it MAY be authenticated by intermediaries.
+	UserID []byte
+}
+
+// AMQPBody represents the body of an AMQP message.
+// Only one of these fields can be used a a time. They are mutually exclusive.
+type AMQPBody struct {
+	// Data is encoded/decoded as multiple data sections in the body.
+	Data [][]byte
+
+	// Sequence is encoded/decoded as one or more amqp-sequence sections in the body.
+	//
+	// The values of the slices are are restricted to AMQP simple types, as listed in the comment for AMQPMessage.
+	Sequence [][]any
+
+	// Value is encoded/decoded as the amqp-value section in the body.
+	//
+	// The type of Value can be any of the AMQP simple types, as listed in the comment for AMQPMessage,
+	// as well as slices or maps of AMQP simple types.
+	Value any
+}
+
+// AMQPMessageHeader carries standard delivery details about the transfer
+// of a message.
+// See https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-header
+// for more details.
+type AMQPMessageHeader struct {
+	// DeliveryCount is the number of unsuccessful previous attempts to deliver this message.
+	DeliveryCount uint32
+
+	Durable       bool
+	FirstAcquirer bool
+	Priority      uint8
+	TTL           time.Duration // from milliseconds
+}
+
+// toAMQPMessage converts between our (azservicebus) AMQP message
+// to the underlying message used by go-amqp.
+func (am *AMQPMessage) toAMQPMessage() *amqp.Message {
+	var header *amqp.MessageHeader
+
+	if am.Header != nil {
+		header = &amqp.MessageHeader{
+			DeliveryCount: am.Header.DeliveryCount,
+			Durable:       am.Header.Durable,
+			FirstAcquirer: am.Header.FirstAcquirer,
+			Priority:      am.Header.Priority,
+			TTL:           am.Header.TTL,
+		}
+	}
+
+	var properties *amqp.MessageProperties
+
+	if am.Properties != nil {
+		properties = &amqp.MessageProperties{
+			AbsoluteExpiryTime: am.Properties.AbsoluteExpiryTime,
+			ContentEncoding:    am.Properties.ContentEncoding,
+			ContentType:        am.Properties.ContentType,
+			CorrelationID:      am.Properties.CorrelationID,
+			CreationTime:       am.Properties.CreationTime,
+			GroupID:            am.Properties.GroupID,
+			GroupSequence:      am.Properties.GroupSequence,
+			MessageID:          am.Properties.MessageID,
+			ReplyTo:            am.Properties.ReplyTo,
+			ReplyToGroupID:     am.Properties.ReplyToGroupID,
+			Subject:            am.Properties.Subject,
+			To:                 am.Properties.To,
+			UserID:             am.Properties.UserID,
+		}
+	} else {
+		properties = &amqp.MessageProperties{}
+	}
+
+	var footer amqp.Annotations
+
+	if am.Footer != nil {
+		footer = (amqp.Annotations)(am.Footer)
+	}
+
+	return &amqp.Message{
+		Annotations:           copyAnnotations(am.MessageAnnotations),
+		ApplicationProperties: am.ApplicationProperties,
+		Data:                  am.Body.Data,
+		DeliveryAnnotations:   amqp.Annotations(am.DeliveryAnnotations),
+		DeliveryTag:           am.DeliveryTag,
+		Footer:                footer,
+		Header:                header,
+		Properties:            properties,
+		Sequence:              am.Body.Sequence,
+		Value:                 am.Body.Value,
+	}
+}
+
+func copyAnnotations(src map[any]any) amqp.Annotations {
+	if src == nil {
+		return amqp.Annotations{}
+	}
+
+	dest := amqp.Annotations{}
+
+	for k, v := range src {
+		dest[k] = v
+	}
+
+	return dest
+}
+
+func newAMQPMessage(goAMQPMessage *amqp.Message) *AMQPMessage {
+	var header *AMQPMessageHeader
+
+	if goAMQPMessage.Header != nil {
+		header = &AMQPMessageHeader{
+			DeliveryCount: goAMQPMessage.Header.DeliveryCount,
+			Durable:       goAMQPMessage.Header.Durable,
+			FirstAcquirer: goAMQPMessage.Header.FirstAcquirer,
+			Priority:      goAMQPMessage.Header.Priority,
+			TTL:           goAMQPMessage.Header.TTL,
+		}
+	}
+
+	var properties *AMQPMessageProperties
+
+	if goAMQPMessage.Properties != nil {
+		properties = &AMQPMessageProperties{
+			AbsoluteExpiryTime: goAMQPMessage.Properties.AbsoluteExpiryTime,
+			ContentEncoding:    goAMQPMessage.Properties.ContentEncoding,
+			ContentType:        goAMQPMessage.Properties.ContentType,
+			CorrelationID:      goAMQPMessage.Properties.CorrelationID,
+			CreationTime:       goAMQPMessage.Properties.CreationTime,
+			GroupID:            goAMQPMessage.Properties.GroupID,
+			GroupSequence:      goAMQPMessage.Properties.GroupSequence,
+			MessageID:          goAMQPMessage.Properties.MessageID,
+			ReplyTo:            goAMQPMessage.Properties.ReplyTo,
+			ReplyToGroupID:     goAMQPMessage.Properties.ReplyToGroupID,
+			Subject:            goAMQPMessage.Properties.Subject,
+			To:                 goAMQPMessage.Properties.To,
+			UserID:             goAMQPMessage.Properties.UserID,
+		}
+	}
+
+	var footer map[any]any
+
+	if goAMQPMessage.Footer != nil {
+		footer = (map[any]any)(goAMQPMessage.Footer)
+	}
+
+	return &AMQPMessage{
+		MessageAnnotations:    map[any]any(goAMQPMessage.Annotations),
+		ApplicationProperties: goAMQPMessage.ApplicationProperties,
+		Body: AMQPBody{
+			Data:     goAMQPMessage.Data,
+			Sequence: goAMQPMessage.Sequence,
+			Value:    goAMQPMessage.Value,
+		},
+		DeliveryAnnotations: map[any]any(goAMQPMessage.DeliveryAnnotations),
+		DeliveryTag:         goAMQPMessage.DeliveryTag,
+		Footer:              footer,
+		Header:              header,
+		linkName:            goAMQPMessage.LinkName(),
+		Properties:          properties,
+		inner:               goAMQPMessage,
+	}
+}

--- a/sdk/messaging/azservicebus/amqp_message.go
+++ b/sdk/messaging/azservicebus/amqp_message.go
@@ -134,12 +134,20 @@ type AMQPMessageBody struct {
 // for more details.
 type AMQPMessageHeader struct {
 	// DeliveryCount is the number of unsuccessful previous attempts to deliver this message.
+	// It corresponds to the 'delivery-count' property.
 	DeliveryCount uint32
 
-	Durable       bool
+	// Durable corresponds to the 'durable' property.
+	Durable bool
+
+	// FirstAcquirer corresponds to the 'first-acquirer' property.
 	FirstAcquirer bool
-	Priority      uint8
-	TTL           time.Duration // from milliseconds
+
+	// Priority corresponds to the 'priority' property.
+	Priority uint8
+
+	// TTL corresponds to the 'ttl' property.
+	TTL time.Duration
 }
 
 // toAMQPMessage converts between our (azservicebus) AMQP message

--- a/sdk/messaging/azservicebus/amqp_message_test.go
+++ b/sdk/messaging/azservicebus/amqp_message_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azservicebus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAMQPMessageUnitTest(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		msg := &AMQPMessage{}
+		amqpMessage := msg.toAMQPMessage()
+
+		// we duplicate/inflate these since we modify them
+		// in various parts of the API.
+		require.NotNil(t, amqpMessage.Properties)
+		require.NotNil(t, amqpMessage.Annotations)
+	})
+}

--- a/sdk/messaging/azservicebus/example_receiver_test.go
+++ b/sdk/messaging/azservicebus/example_receiver_test.go
@@ -116,3 +116,41 @@ func ExampleReceiver_ReceiveMessages() {
 		fmt.Printf("Received and completed the message\n")
 	}
 }
+
+func ExampleReceiver_ReceiveMessages_amqpMessage() {
+	// AMQP is the underlying protocol for all interaction with Service Bus.
+	// You can, if needed, send and receive messages that have a 1:1 correspondence
+	// with an AMQP message. This gives you full control over details that are not
+	// exposed via the azservicebus.ReceivedMessage type.
+
+	messages, err := receiver.ReceiveMessages(context.TODO(), 1, nil)
+
+	if err != nil {
+		panic(err)
+	}
+
+	// NOTE: For this example we'll assume we received at least one message.
+
+	// Every received message carries a RawAMQPMessage.
+	rawAMQPMessage := messages[0].RawAMQPMessage
+
+	// All the various body encodings available for AMQP messages are exposed via Body
+	_ = rawAMQPMessage.Body.Data
+	_ = rawAMQPMessage.Body.Value
+	_ = rawAMQPMessage.Body.Sequence
+
+	// delivery and message annotations
+	_ = rawAMQPMessage.DeliveryAnnotations
+	_ = rawAMQPMessage.MessageAnnotations
+
+	// headers and footers
+	_ = rawAMQPMessage.Header
+	_ = rawAMQPMessage.Footer
+
+	// Settlement (if in azservicebus.ReceiveModePeekLockMode) stil works on the ReceivedMessage.
+	err = receiver.CompleteMessage(context.TODO(), messages[0], nil)
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/sdk/messaging/azservicebus/example_sender_test.go
+++ b/sdk/messaging/azservicebus/example_sender_test.go
@@ -87,3 +87,33 @@ func ExampleSender_ScheduleMessages() {
 		}, nil)
 	exitOnError("Failed to schedule messages using SendMessage", err)
 }
+
+func ExampleSender_SendAMQPMessage() {
+	// AMQP is the underlying protocol for all interaction with Service Bus.
+	// You can, if needed, send and receive messages that have a 1:1 correspondence
+	// with an AMQP message. This gives you full control over details that are not
+	// exposed via the azservicebus.ReceivedMessage type.
+
+	message := &azservicebus.AMQPMessage{
+		Body: azservicebus.AMQPBody{
+			// there are three kinds of different body encodings
+			// Data, Value and Sequence. See the azservicebus.AMQPBody
+			// documentation for more details.
+			Value: "hello",
+		},
+		// full access to fields not normally exposed in azservicebus.Message, like
+		// the delivery and message annotations.
+		MessageAnnotations: map[any]any{
+			"x-opt-message-test": "test-annotation-value",
+		},
+		DeliveryAnnotations: map[any]any{
+			"x-opt-delivery-test": "test-annotation-value",
+		},
+	}
+
+	err := sender.SendAMQPMessage(context.TODO(), message, nil)
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/sdk/messaging/azservicebus/example_sender_test.go
+++ b/sdk/messaging/azservicebus/example_sender_test.go
@@ -95,9 +95,9 @@ func ExampleSender_SendAMQPMessage() {
 	// exposed via the azservicebus.ReceivedMessage type.
 
 	message := &azservicebus.AMQPMessage{
-		Body: azservicebus.AMQPBody{
+		Body: azservicebus.AMQPMessageBody{
 			// there are three kinds of different body encodings
-			// Data, Value and Sequence. See the azservicebus.AMQPBody
+			// Data, Value and Sequence. See the azservicebus.AMQPMessageBody
 			// documentation for more details.
 			Value: "hello",
 		},

--- a/sdk/messaging/azservicebus/example_sender_test.go
+++ b/sdk/messaging/azservicebus/example_sender_test.go
@@ -40,6 +40,9 @@ func ExampleSender_SendMessage_messageBatch() {
 	// messages in a single send.
 	err = batch.AddMessage(&azservicebus.Message{Body: []byte("hello world")}, nil)
 
+	// We also support adding AMQPMessages directly to a batch as well
+	// batch.AddAMQPMessage(&azservicebus.AMQPMessage{})
+
 	if err != nil {
 		switch err {
 		case azservicebus.ErrMessageTooLarge:

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.0.2"
+const Version = "v1.0.2-beta.0"

--- a/sdk/messaging/azservicebus/internal/mgmt.go
+++ b/sdk/messaging/azservicebus/internal/mgmt.go
@@ -428,7 +428,10 @@ func ScheduleMessages(ctx context.Context, rpcLink RPCLink, linkName string, enq
 	enqueueTimeAsUTC := enqueueTime.UTC()
 
 	for i := range messages {
-		// TODO: don't like that we're modifying the underlying message here
+		if messages[i].Annotations == nil {
+			return nil, errors.New("message does not have an initialized Annotations property")
+		}
+
 		messages[i].Annotations["x-opt-scheduled-enqueue-time"] = &enqueueTimeAsUTC
 
 		if messages[i].Properties == nil {

--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -120,7 +120,11 @@ type ReceivedMessage struct {
 	// Applications can use this value to indicate the logical destination of the message.
 	To *string
 
-	rawAMQPMessage *amqp.Message
+	// RawAMQPMessage is the AMQP message, as received by the client. This can be useful to get access
+	// to properties that are not exposed by ReceivedMessage such as payloads encoded into the
+	// Value or Sequence section, payloads sent as multiple Data sections, as well as Footer
+	// and Header fields.
+	RawAMQPMessage *AMQPMessage
 
 	// deferred indicates we received it using ReceiveDeferredMessages. These messages
 	// will still go through the normal Receiver.Settle functions but internally will
@@ -310,12 +314,12 @@ func (m *Message) toAMQPMessage() *amqp.Message {
 // serialized byte array in the Data section of the messsage.
 func newReceivedMessage(amqpMsg *amqp.Message) *ReceivedMessage {
 	msg := &ReceivedMessage{
-		rawAMQPMessage: amqpMsg,
+		RawAMQPMessage: newAMQPMessage(amqpMsg),
 		State:          MessageStateActive,
 	}
 
-	if len(msg.rawAMQPMessage.Data) == 1 {
-		msg.Body = msg.rawAMQPMessage.Data[0]
+	if len(msg.RawAMQPMessage.Body.Data) == 1 {
+		msg.Body = msg.RawAMQPMessage.Body.Data[0]
 	}
 
 	if amqpMsg.Properties != nil {

--- a/sdk/messaging/azservicebus/message_batch.go
+++ b/sdk/messaging/azservicebus/message_batch.go
@@ -54,12 +54,12 @@ func (mb *MessageBatch) AddMessage(m *Message, options *AddMessageOptions) error
 	return mb.addAMQPMessage(m)
 }
 
-// AddMessageOptions contains optional parameters for the AddAMQPMessage function.
+// AddAMQPMessageOptions contains optional parameters for the AddAMQPMessage function.
 type AddAMQPMessageOptions struct {
 	// For future expansion
 }
 
-// AddMessage adds a message to the batch if the message will not exceed the max size of the batch
+// AddAMQPMessage adds a message to the batch if the message will not exceed the max size of the batch
 // Returns:
 // - ErrMessageTooLarge if the message cannot fit
 // - a non-nil error for other failures

--- a/sdk/messaging/azservicebus/message_batch.go
+++ b/sdk/messaging/azservicebus/message_batch.go
@@ -51,7 +51,21 @@ type AddMessageOptions struct {
 // - a non-nil error for other failures
 // - nil, otherwise
 func (mb *MessageBatch) AddMessage(m *Message, options *AddMessageOptions) error {
-	return mb.addAMQPMessage(m.toAMQPMessage())
+	return mb.addAMQPMessage(m)
+}
+
+// AddMessageOptions contains optional parameters for the AddAMQPMessage function.
+type AddAMQPMessageOptions struct {
+	// For future expansion
+}
+
+// AddMessage adds a message to the batch if the message will not exceed the max size of the batch
+// Returns:
+// - ErrMessageTooLarge if the message cannot fit
+// - a non-nil error for other failures
+// - nil, otherwise
+func (mb *MessageBatch) AddAMQPMessage(m *AMQPMessage, options *AddAMQPMessageOptions) error {
+	return mb.addAMQPMessage(m)
 }
 
 // NumBytes is the number of bytes in the message batch
@@ -84,7 +98,9 @@ func (mb *MessageBatch) toAMQPMessage() *amqp.Message {
 	return mb.batchEnvelope
 }
 
-func (mb *MessageBatch) addAMQPMessage(msg *amqp.Message) error {
+func (mb *MessageBatch) addAMQPMessage(tempMsg amqpCompatibleMessage) error {
+	msg := tempMsg.toAMQPMessage()
+
 	if msg.Properties.MessageID == nil || msg.Properties.MessageID == "" {
 		uid, err := uuid.New()
 		if err != nil {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -289,7 +289,7 @@ type RenewMessageLockOptions struct {
 // If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (r *Receiver) RenewMessageLock(ctx context.Context, msg *ReceivedMessage, options *RenewMessageLockOptions) error {
 	err := r.amqpLinks.Retry(ctx, EventReceiver, "renewMessageLock", func(ctx context.Context, linksWithVersion *internal.LinksWithID, args *utils.RetryFnArgs) error {
-		newExpirationTime, err := internal.RenewLocks(ctx, linksWithVersion.RPC, msg.rawAMQPMessage.LinkName(), []amqp.UUID{
+		newExpirationTime, err := internal.RenewLocks(ctx, linksWithVersion.RPC, msg.RawAMQPMessage.linkName, []amqp.UUID{
 			(amqp.UUID)(msg.LockToken),
 		})
 

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -103,7 +103,7 @@ func (s *Sender) ScheduleMessages(ctx context.Context, messages []*Message, sche
 	return scheduleMessages(ctx, s.links, s.retryOptions, messages, scheduledEnqueueTime)
 }
 
-// ScheduleMessagesOptions contains optional parameters for the ScheduleMessages function.
+// ScheduleAMQPMessagesOptions contains optional parameters for the ScheduleAMQPMessages function.
 type ScheduleAMQPMessagesOptions struct {
 	// For future expansion
 }

--- a/sdk/messaging/azservicebus/sender.go
+++ b/sdk/messaging/azservicebus/sender.go
@@ -63,11 +63,15 @@ type SendMessageOptions struct {
 // SendMessage sends a Message to a queue or topic.
 // If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (s *Sender) SendMessage(ctx context.Context, message *Message, options *SendMessageOptions) error {
-	err := s.links.Retry(ctx, EventSender, "SendMessage", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
-		return lwid.Sender.Send(ctx, message.toAMQPMessage())
-	}, RetryOptions(s.retryOptions))
+	return s.sendMessage(ctx, message, options)
+}
 
-	return internal.TransformError(err)
+// SendAMQPMessage sends an AMQPMessage to a queue or topic.
+// Using an AMQPMessage allows for advanced use cases, like payload encoding, as well as better
+// interoperability with pure AMQP clients.
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
+func (s *Sender) SendAMQPMessage(ctx context.Context, message *AMQPMessage, options *SendMessageOptions) error {
+	return s.sendMessage(ctx, message, options)
 }
 
 // SendMessageBatchOptions contains optional parameters for the SendMessageBatch function.
@@ -96,14 +100,42 @@ type ScheduleMessagesOptions struct {
 // delivered can be cancelled using `Receiver.CancelScheduleMessage(s)`
 // If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (s *Sender) ScheduleMessages(ctx context.Context, messages []*Message, scheduledEnqueueTime time.Time, options *ScheduleMessagesOptions) ([]int64, error) {
+	return scheduleMessages(ctx, s.links, s.retryOptions, messages, scheduledEnqueueTime)
+}
+
+// ScheduleMessagesOptions contains optional parameters for the ScheduleMessages function.
+type ScheduleAMQPMessagesOptions struct {
+	// For future expansion
+}
+
+// ScheduleAMQPMessages schedules a slice of Messages to appear on Service Bus Queue/Subscription at a later time.
+// Returns the sequence numbers of the messages that were scheduled.  Messages that haven't been
+// delivered can be cancelled using `Receiver.CancelScheduleMessage(s)`
+// If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
+func (s *Sender) ScheduleAMQPMessages(ctx context.Context, messages []*AMQPMessage, scheduledEnqueueTime time.Time, options *ScheduleAMQPMessagesOptions) ([]int64, error) {
+	return scheduleMessages(ctx, s.links, s.retryOptions, messages, scheduledEnqueueTime)
+}
+
+func scheduleMessages[T amqpCompatibleMessage](ctx context.Context, links internal.AMQPLinks, retryOptions RetryOptions, messages []T, scheduledEnqueueTime time.Time) ([]int64, error) {
 	var amqpMessages []*amqp.Message
 
 	for _, m := range messages {
 		amqpMessages = append(amqpMessages, m.toAMQPMessage())
 	}
 
-	ids, err := s.scheduleAMQPMessages(ctx, amqpMessages, scheduledEnqueueTime)
-	return ids, internal.TransformError(err)
+	var sequenceNumbers []int64
+
+	err := links.Retry(ctx, EventSender, "ScheduleMessages", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
+		sn, err := internal.ScheduleMessages(ctx, lwv.RPC, lwv.Sender.LinkName(), scheduledEnqueueTime, amqpMessages)
+
+		if err != nil {
+			return err
+		}
+		sequenceNumbers = sn
+		return nil
+	}, retryOptions)
+
+	return sequenceNumbers, internal.TransformError(err)
 }
 
 // MessageBatch changes
@@ -129,20 +161,12 @@ func (s *Sender) Close(ctx context.Context) error {
 	return s.links.Close(ctx, true)
 }
 
-func (s *Sender) scheduleAMQPMessages(ctx context.Context, messages []*amqp.Message, scheduledEnqueueTime time.Time) ([]int64, error) {
-	var sequenceNumbers []int64
+func (s *Sender) sendMessage(ctx context.Context, message amqpCompatibleMessage, options *SendMessageOptions) error {
+	err := s.links.Retry(ctx, EventSender, "SendMessage", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
+		return lwid.Sender.Send(ctx, message.toAMQPMessage())
+	}, RetryOptions(s.retryOptions))
 
-	err := s.links.Retry(ctx, EventSender, "ScheduleMessages", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
-		sn, err := internal.ScheduleMessages(ctx, lwv.RPC, lwv.Sender.LinkName(), scheduledEnqueueTime, messages)
-
-		if err != nil {
-			return err
-		}
-		sequenceNumbers = sn
-		return nil
-	}, s.retryOptions)
-
-	return sequenceNumbers, err
+	return internal.TransformError(err)
 }
 
 func (sender *Sender) createSenderLink(ctx context.Context, session amqpwrap.AMQPSession) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error) {
@@ -178,4 +202,11 @@ func newSender(args newSenderArgs) (*Sender, error) {
 
 	sender.links = args.ns.NewAMQPLinks(args.queueOrTopic, sender.createSenderLink, internal.GetRecoveryKind)
 	return sender, nil
+}
+
+// amqpCompatibleMessage is implemented by all the messages that can be
+// converted to amqp.Message
+// Implemented by AMQPMessage, MessageBatch and Message.
+type amqpCompatibleMessage interface {
+	toAMQPMessage() *amqp.Message
 }

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -72,7 +72,7 @@ func Test_Sender_SendBatchOfTwo(t *testing.T) {
 	require.NoError(t, err)
 
 	err = batch.AddAMQPMessage(&AMQPMessage{
-		Body: AMQPBody{
+		Body: AMQPMessageBody{
 			Data: [][]byte{
 				[]byte("[1] message in batch"),
 			},
@@ -272,8 +272,8 @@ func Test_Sender_ScheduleAMQPMessages(t *testing.T) {
 	// `Scheduled`
 	sequenceNumbers, err := sender.ScheduleAMQPMessages(ctx,
 		[]*AMQPMessage{
-			{Body: AMQPBody{Data: [][]byte{[]byte("To the future (that will be cancelled!)")}}},
-			{Body: AMQPBody{Data: [][]byte{[]byte("To the future (not cancelled)")}}},
+			{Body: AMQPMessageBody{Data: [][]byte{[]byte("To the future (that will be cancelled!)")}}},
+			{Body: AMQPMessageBody{Data: [][]byte{[]byte("To the future (not cancelled)")}}},
 		},
 		nearFuture, nil)
 
@@ -291,7 +291,7 @@ func Test_Sender_ScheduleAMQPMessages(t *testing.T) {
 	// rather than using the simpler ScheduleAMQPMessages
 	err = sender.SendAMQPMessage(ctx,
 		&AMQPMessage{
-			Body: AMQPBody{
+			Body: AMQPMessageBody{
 				Data: [][]byte{[]byte("To the future (scheduled using the field)")},
 			},
 			MessageAnnotations: map[any]any{
@@ -496,7 +496,7 @@ func TestSender_SendAMQPMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	err = sender.SendAMQPMessage(context.Background(), &AMQPMessage{
-		Body: AMQPBody{
+		Body: AMQPMessageBody{
 			Data: [][]byte{
 				[]byte("Hello World"),
 			},
@@ -546,7 +546,7 @@ func TestSender_SendAMQPMessageWithMultipleByteSlicesInData(t *testing.T) {
 			Priority: 100,
 			Durable:  true,
 		},
-		Body: AMQPBody{
+		Body: AMQPMessageBody{
 			Data: [][]byte{
 				// the defacto azservicebus.Message doesn't allow you to send multiple bytes in
 				// the .Data section.
@@ -598,7 +598,7 @@ func TestSender_SendAMQPMessageWithMultipleByteSlicesInData(t *testing.T) {
 		Properties: &AMQPMessageProperties{
 			MessageID: m.RawAMQPMessage.Properties.MessageID,
 		},
-		Body: AMQPBody{Data: [][]byte{
+		Body: AMQPMessageBody{Data: [][]byte{
 			[]byte("Hello World"),
 			[]byte("And another message!"),
 		}},
@@ -631,7 +631,7 @@ func TestSender_SendAMQPMessageWithValue(t *testing.T) {
 
 	for i, value := range values {
 		err = sender.SendAMQPMessage(context.Background(), &AMQPMessage{
-			Body: AMQPBody{Value: value},
+			Body: AMQPMessageBody{Value: value},
 			ApplicationProperties: map[string]interface{}{
 				"index": i,
 			},
@@ -673,7 +673,7 @@ func TestSender_SendAMQPMessageWithSequence(t *testing.T) {
 		require.NoError(t, err)
 
 		err = sender.SendAMQPMessage(context.Background(), &AMQPMessage{
-			Body: AMQPBody{Sequence: seq},
+			Body: AMQPMessageBody{Sequence: seq},
 			ApplicationProperties: map[string]interface{}{
 				"index": i,
 			},

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -71,8 +71,12 @@ func Test_Sender_SendBatchOfTwo(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	err = batch.AddMessage(&Message{
-		Body: []byte("[1] message in batch"),
+	err = batch.AddAMQPMessage(&AMQPMessage{
+		Body: AMQPBody{
+			Data: [][]byte{
+				[]byte("[1] message in batch"),
+			},
+		},
 	}, nil)
 	require.NoError(t, err)
 
@@ -244,6 +248,74 @@ func messageFromReceivedMessage(t *testing.T, receivedMessage *ReceivedMessage) 
 	return newMsg
 }
 
+func Test_Sender_ScheduleAMQPMessages(t *testing.T) {
+	ctx := context.Background()
+
+	client, cleanup, queueName := setupLiveTest(t, nil)
+	defer cleanup()
+
+	receiver, err := client.NewReceiverForQueue(
+		queueName, &ReceiverOptions{ReceiveMode: ReceiveModeReceiveAndDelete})
+	require.NoError(t, err)
+	defer receiver.Close(context.Background())
+
+	sender, err := client.NewSender(queueName, nil)
+	require.NoError(t, err)
+	defer sender.Close(context.Background())
+
+	now := time.Now()
+	nearFuture := now.Add(20 * time.Second)
+
+	// there are two ways to schedule a message - you can use the
+	// `ScheduleMessages` API (in which case you get a sequence number that
+	// you can use with CancelScheduledMessage(s)) or you can set the
+	// `Scheduled`
+	sequenceNumbers, err := sender.ScheduleAMQPMessages(ctx,
+		[]*AMQPMessage{
+			{Body: AMQPBody{Data: [][]byte{[]byte("To the future (that will be cancelled!)")}}},
+			{Body: AMQPBody{Data: [][]byte{[]byte("To the future (not cancelled)")}}},
+		},
+		nearFuture, nil)
+
+	require.NoError(t, err)
+	require.EqualValues(t, 2, len(sequenceNumbers))
+
+	peekedMsg := peekSingleMessageForTest(t, receiver)
+	require.EqualValues(t, MessageStateScheduled, peekedMsg.State)
+
+	// cancel one of the ones scheduled using `ScheduleMessages`
+	err = sender.CancelScheduledMessages(ctx, []int64{sequenceNumbers[0]}, nil)
+	require.NoError(t, err)
+
+	// this isn't a typical way of doing this, but it's possible to set the field directly
+	// rather than using the simpler ScheduleAMQPMessages
+	err = sender.SendAMQPMessage(ctx,
+		&AMQPMessage{
+			Body: AMQPBody{
+				Data: [][]byte{[]byte("To the future (scheduled using the field)")},
+			},
+			MessageAnnotations: map[any]any{
+				"x-opt-scheduled-enqueue-time": &nearFuture,
+			},
+		}, nil)
+
+	require.NoError(t, err)
+
+	messages, err := receiver.ReceiveMessages(ctx, 2, nil)
+	require.NoError(t, err)
+
+	// we cancelled one of the messages so it won't get enqueued (this is the one that survived)
+	require.EqualValues(t, []string{"To the future (not cancelled)", "To the future (scheduled using the field)"}, getSortedBodies(messages))
+
+	for _, m := range messages {
+		// and the scheduled enqueue time should match what we set pretty closely.
+		diff := m.ScheduledEnqueueTime.Sub(nearFuture.UTC())
+
+		// add a little wiggle room, but the scheduled time and the time we set when we scheduled it.
+		require.LessOrEqual(t, diff, time.Second, "The requested scheduled time and the actual scheduled time should be close [%s]", m.ScheduledEnqueueTime)
+	}
+}
+
 func Test_Sender_ScheduleMessages(t *testing.T) {
 	ctx := context.Background()
 
@@ -266,7 +338,6 @@ func Test_Sender_ScheduleMessages(t *testing.T) {
 	// `ScheduleMessages` API (in which case you get a sequence number that
 	// you can use with CancelScheduledMessage(s)) or you can set the
 	// `Scheduled`
-
 	sequenceNumbers, err := sender.ScheduleMessages(ctx,
 		[]*Message{
 			{Body: []byte("To the future (that will be cancelled!)")},
@@ -415,6 +486,224 @@ func TestSender_SendMessageBatchDetach(t *testing.T) {
 	}
 
 	require.EqualValues(t, []string{"0", "1", "2", "3", "4"}, getSortedBodies(all))
+}
+
+func TestSender_SendAMQPMessage(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, nil)
+	defer cleanup()
+
+	sender, err := client.NewSender(queueName, nil)
+	require.NoError(t, err)
+
+	err = sender.SendAMQPMessage(context.Background(), &AMQPMessage{
+		Body: AMQPBody{
+			Data: [][]byte{
+				[]byte("Hello World"),
+			},
+		},
+		ApplicationProperties: map[string]interface{}{
+			"hello": "world",
+		},
+	}, nil)
+
+	require.NoError(t, err)
+
+	receiver, err := client.NewReceiverForQueue(queueName, nil)
+	require.NoError(t, err)
+
+	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "Hello World", string(messages[0].Body))
+	require.Equal(t, "world", messages[0].ApplicationProperties["hello"])
+
+	require.Equal(t, [][]byte{
+		[]byte("Hello World"),
+	}, messages[0].RawAMQPMessage.Body.Data)
+
+	require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0], nil))
+}
+func TestSender_SendAMQPMessageWithMultipleByteSlicesInData(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, nil)
+	defer cleanup()
+
+	sender, err := client.NewSender(queueName, nil)
+	require.NoError(t, err)
+
+	err = sender.SendAMQPMessage(context.Background(), &AMQPMessage{
+		DeliveryAnnotations: map[any]any{
+			"x-opt-delivery-annotation-test": "test-value",
+		},
+		MessageAnnotations: map[any]any{
+			"x-opt-message-annotation-test": "test-value",
+		},
+		Footer: map[any]any{
+			"x-opt-footer-test": "footer-value",
+		},
+		Header: &AMQPMessageHeader{
+			// These flags are just passed through - Service Bus doesn't
+			// take any action.
+			Priority: 100,
+			Durable:  true,
+		},
+		Body: AMQPBody{
+			Data: [][]byte{
+				// the defacto azservicebus.Message doesn't allow you to send multiple bytes in
+				// the .Data section.
+				[]byte("Hello World"),
+				[]byte("And another message!"),
+			}},
+		ApplicationProperties: map[string]interface{}{
+			"hello": "world",
+		},
+	}, nil)
+
+	require.NoError(t, err)
+
+	receiver, err := client.NewReceiverForQueue(queueName, nil)
+	require.NoError(t, err)
+
+	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
+	require.NoError(t, err)
+
+	m := messages[0]
+
+	// when the Body is incompatible (in this case because of multiple Data sections)
+	// the Body is nil)
+	require.Nil(t, m.Body)
+	require.NotEmpty(t, m.RawAMQPMessage.DeliveryTag)
+
+	// kill some fields that aren't important for this comparison
+	m.RawAMQPMessage.linkName = ""
+	m.RawAMQPMessage.inner = nil
+
+	require.Equal(t, &AMQPMessage{
+		Header: &AMQPMessageHeader{
+			Priority: 100,
+			Durable:  true,
+		},
+		DeliveryAnnotations: map[any]any{
+			"x-opt-delivery-annotation-test": "test-value",
+			"x-opt-lock-token":               m.RawAMQPMessage.DeliveryAnnotations["x-opt-lock-token"],
+		},
+		MessageAnnotations: map[any]any{
+			"x-opt-message-annotation-test": "test-value",
+			"x-opt-enqueued-time":           m.RawAMQPMessage.MessageAnnotations["x-opt-enqueued-time"],
+			"x-opt-sequence-number":         m.RawAMQPMessage.MessageAnnotations["x-opt-sequence-number"],
+			"x-opt-locked-until":            m.RawAMQPMessage.MessageAnnotations["x-opt-locked-until"],
+		},
+		Footer: map[any]any{
+			"x-opt-footer-test": "footer-value",
+		},
+		Properties: &AMQPMessageProperties{
+			MessageID: m.RawAMQPMessage.Properties.MessageID,
+		},
+		Body: AMQPBody{Data: [][]byte{
+			[]byte("Hello World"),
+			[]byte("And another message!"),
+		}},
+		ApplicationProperties: map[string]any{
+			"hello": "world",
+		},
+		// some items come from the service so we'll just copy them over
+		// as we're not trying to test those necessarily
+		DeliveryTag: m.RawAMQPMessage.DeliveryTag,
+	}, messages[0].RawAMQPMessage)
+
+	require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0], nil))
+}
+
+func TestSender_SendAMQPMessageWithValue(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, nil)
+	defer cleanup()
+
+	sender, err := client.NewSender(queueName, nil)
+	require.NoError(t, err)
+
+	values := []any{
+		100.0,
+		int64(101),
+		"hello world",
+		[]byte("hello world as bytes"),
+		[]string{"a", "b", "c"},
+		nil,
+	}
+
+	for i, value := range values {
+		err = sender.SendAMQPMessage(context.Background(), &AMQPMessage{
+			Body: AMQPBody{Value: value},
+			ApplicationProperties: map[string]interface{}{
+				"index": i,
+			},
+		}, nil)
+		require.NoError(t, err)
+	}
+
+	receiver, err := client.NewReceiverForQueue(queueName, nil)
+	require.NoError(t, err)
+
+	messages := receiveAll(t, receiver, len(values))
+
+	sort.Slice(messages, func(i, j int) bool {
+		left := messages[i].ApplicationProperties["index"].(int64)
+		right := messages[j].ApplicationProperties["index"].(int64)
+		return left < right
+	})
+
+	for i, msg := range messages {
+		require.Equal(t, values[i], msg.RawAMQPMessage.Body.Value)
+		require.NoError(t, receiver.CompleteMessage(context.Background(), msg, nil))
+	}
+}
+
+func TestSender_SendAMQPMessageWithSequence(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, nil)
+	defer cleanup()
+
+	sequences := [][][]any{
+		{
+			{int64(1), "hello"},
+			{int64(2), "world"},
+		},
+		{},
+	}
+
+	for i, seq := range sequences {
+		sender, err := client.NewSender(queueName, nil)
+		require.NoError(t, err)
+
+		err = sender.SendAMQPMessage(context.Background(), &AMQPMessage{
+			Body: AMQPBody{Sequence: seq},
+			ApplicationProperties: map[string]interface{}{
+				"index": i,
+			},
+		}, nil)
+
+		require.NoError(t, err)
+	}
+
+	receiver, err := client.NewReceiverForQueue(queueName, nil)
+	require.NoError(t, err)
+
+	messages := receiveAll(t, receiver, len(sequences))
+
+	sort.Slice(messages, func(i, j int) bool {
+		left := messages[i].ApplicationProperties["index"].(int64)
+		right := messages[j].ApplicationProperties["index"].(int64)
+		return left < right
+	})
+
+	for i, msg := range messages {
+		if len(sequences[i]) == 0 {
+			// this is a bit special - when we send an empty sequence, as an optimization,
+			// no value is actually sent for the section.
+			require.Nil(t, msg.RawAMQPMessage.Body.Sequence)
+			require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0], nil))
+			continue
+		}
+		require.Equal(t, sequences[i], msg.RawAMQPMessage.Body.Sequence)
+		require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0], nil))
+	}
 }
 
 func getSortedBodies(messages []*ReceivedMessage) []string {


### PR DESCRIPTION
For sending AMQP messages you can use either Sender.SendAMQPMessages() or schedule them using Sender.ScheduleAMQPMessages().
    
For receiving, each ReceivedMessage now has a RawAMQPMessage property.

I've also added in a way to export the TLS pre-master key so you can easily wireshark and trace the actual AMQP interaction, which can be helpful in validating that things are encoding properly.

Fixes #15260