### PR TITLE
Revert "Override live test location default to westus (#18307)"

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -40,14 +40,8 @@ parameters:
     default:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-        # TODO: Migrate location override into azure-sdk-tools eng/common
-        # See https://github.com/Azure/azure-sdk-tools/issues/3398
-        Location: 'westus'
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-        # TODO: Migrate location override into azure-sdk-tools eng/common
-        # See https://github.com/Azure/azure-sdk-tools/issues/3398
-        Location: 'westus'
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'


### PR DESCRIPTION
This reverts commit 9ba043237a826b0ee4b6b7be114828416066e878.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
