### PR TITLE
Log more information when MHSM provisioning fails

### DIFF
--- a/sdk/keyvault/azkeys/test-resources-post.ps1
+++ b/sdk/keyvault/azkeys/test-resources-post.ps1
@@ -95,7 +95,13 @@ if (Test-Path $sdpath) {
     Remove-Item $sdPath -Force
 }
 
-Export-AzKeyVaultSecurityDomain -Name $hsmName -Quorum 2 -Certificates $wrappingFiles -OutputPath $sdPath
+Export-AzKeyVaultSecurityDomain -Name $hsmName -Quorum 2 -Certificates $wrappingFiles -OutputPath $sdPath -ErrorAction SilentlyContinue -Verbose
+if ( !$? ) {
+    Write-Host $Error[0].Exception
+    Write-Error $Error[0]
+
+    exit
+}
 
 Log "Security domain downloaded to '$sdPath'; Managed HSM is now active at '$hsmUrl'"
 


### PR DESCRIPTION
Closes #18289 by copying .NET's test-resources-post script, which prints any error returned by `Export-AzKeyVaultSecurityDomain`.