### PR TITLE
Move api review step into analyze job. Block on apiview failures/missing approvals

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -7,6 +7,35 @@ parameters:
 
 
 steps:
+  - task: Powershell@2
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/common/scripts/Save-Package-Properties.ps1
+      arguments: >
+        -ServiceDirectory ${{parameters.ServiceDirectory}}
+        -OutDirectory $(Build.ArtifactStagingDirectory)/PackageInfo
+      pwsh: true
+      workingDirectory: $(Pipeline.Workspace)
+    displayName: Dump Package properties
+    condition: succeeded()
+
+  - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+
+  - task: Powershell@2
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/scripts/Create-ApiReview.ps1
+      arguments: >
+        -ServiceDirectory ${{parameters.ServiceDirectory}}
+        -OutPath $(Build.ArtifactStagingDirectory)
+        -ApiviewUri "$(azuresdk-apiview-uri)"
+        -ApiKey "$(azuresdk-apiview-apikey)"
+        -ApiLabel "Auto Review - $(Build.SourceVersion)"
+        -SourceBranch $(Build.SourceBranchName)
+        -DefaultBranch $(DefaultBranch)
+        -ConfigFileDir $(Build.ArtifactStagingDirectory)/PackageInfo
+      pwsh: true
+      workingDirectory: $(Pipeline.Workspace)
+    displayName: Create API review for Go
+    condition: and(succeeded(), ne(variables['Skip.CreateApiReview'], 'true') , ne(variables['Build.Reason'],'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
 
   - task: Powershell@2
     displayName: 'Dependency Check'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -87,37 +87,6 @@ steps:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 
-  - task: Powershell@2
-    inputs:
-      filePath: $(Build.SourcesDirectory)/eng/common/scripts/Save-Package-Properties.ps1
-      arguments: >
-        -ServiceDirectory ${{parameters.ServiceDirectory}}
-        -OutDirectory $(Build.ArtifactStagingDirectory)/PackageInfo
-      pwsh: true
-      workingDirectory: $(Pipeline.Workspace)
-    displayName: Dump Package properties
-    condition: succeeded()
-
-  - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
-  
-  - task: Powershell@2
-    inputs:
-      filePath: $(Build.SourcesDirectory)/eng/scripts/Create-ApiReview.ps1
-      arguments: >
-        -ServiceDirectory ${{parameters.ServiceDirectory}}
-        -OutPath $(Build.ArtifactStagingDirectory)
-        -ApiviewUri "$(azuresdk-apiview-uri)"
-        -ApiKey "$(azuresdk-apiview-apikey)"
-        -ApiLabel "Auto Review - $(Build.SourceVersion)"
-        -SourceBranch $(Build.SourceBranchName)
-        -DefaultBranch $(DefaultBranch)
-        -ConfigFileDir $(Build.ArtifactStagingDirectory)/PackageInfo
-      pwsh: true
-      workingDirectory: $(Pipeline.Workspace)
-    displayName: Create API review for Go
-    continueOnError: true
-    condition: and(succeeded(), ne(variables['Skip.CreateApiReview'], 'true') , ne(variables['Build.Reason'],'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
-
   - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
     parameters:
       ArtifactPath: '$(Build.ArtifactStagingDirectory)/_manifest'


### PR DESCRIPTION
Normally the apiview step goes in the build job in other languages. Go has a combined build/test job, so the step was running multiple times as part of the job matrix. We don't want to fail all test steps if there is an apiview issue, so I'm moving the step into the Analyze job. I also removed the `continueOnError` line, so this will now block release if there is a failure due to lack of approvals. 