### PR TITLE
Remove create-go-workspace step from track 2 pipelines

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
@@ -36,8 +36,6 @@ stages:
           version: '$(go.version)'
         displayName: "Select Go Version"
 
-      - template: ../steps/create-go-workspace.yml
-
       - template: ../steps/build-test.yml
         parameters:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
@@ -57,8 +55,6 @@ stages:
         inputs:
           version: '1.18.2'
         displayName: "Select Go Version"
-
-      - template: ../steps/create-go-workspace.yml
 
       - template: ../steps/analyze.yml
         parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -104,8 +104,6 @@ stages:
           version: '$(go.version)'
         displayName: "Select Go Version"
 
-      - template: ../steps/create-go-workspace.yml
-
       - template: ../steps/build-test.yml
         parameters:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
@@ -135,8 +133,6 @@ stages:
         inputs:
           version: '1.18.2'
         displayName: "Select Go Version"
-
-      - template: ../steps/create-go-workspace.yml
 
       - template: ../steps/analyze.yml
         parameters:

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -80,8 +80,6 @@ jobs:
           version: '$(GoVersion)'
         displayName: "Select Go Version"
 
-      - template: ../steps/create-go-workspace.yml
-
       - template: ../steps/build-test.yml
         parameters:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}

--- a/eng/pipelines/templates/jobs/mgmt-mock-test.yml
+++ b/eng/pipelines/templates/jobs/mgmt-mock-test.yml
@@ -12,12 +12,11 @@ jobs:
     - script: |
         npm install -g autorest
       displayName: 'Install autorest'
+
     - task: GoTool@0
       inputs:
         version: '1.18.2'
       displayName: "Select Go Version"
-
-    - template: /eng/pipelines/templates/steps/create-go-workspace.yml
 
     - task: Powershell@2
       displayName: 'Create Mock Test'
@@ -58,7 +57,7 @@ jobs:
         rootFolderOrFile: $(Build.SourcesDirectory)/sdk/${{parameters.ServiceDirectory}}/
         includeRootFolder: true
         archiveFile: '$(Build.ArtifactStagingDirectory)/MockTestCodeAndReport.zip'
-        
+
     - task: PublishBuildArtifacts@1
       continueOnError: true
       displayName: 'Publish Code and Report'


### PR DESCRIPTION
I think these are unnecessary and add unnecessary time to the pipeline.
