### PR TITLE
Fix broken aka links

### DIFF
--- a/documentation/new-version-quickstart.md
+++ b/documentation/new-version-quickstart.md
@@ -316,7 +316,7 @@ func main() {
 
 In addition to resource groups, we will also use Virtual Machine as an example and show how to manage how to create a Virtual Machine which involves three Azure services (Resource Group, Network and Compute)
 
-Due to the complexity of this scenario, please [click here](https://aka.ms/azsdk/go/mgmt/samples?path=sdk/resourcemanager/compute/createVM) for the complete sample.
+Due to the complexity of this scenario, please [click here](https://aka.ms/azsdk/go/mgmt/samples?path=sdk/resourcemanager/compute/create_vm) for the complete sample.
 
 ## Code Samples
 

--- a/sdk/resourcemanager/compute/armcompute/README.md
+++ b/sdk/resourcemanager/compute/armcompute/README.md
@@ -55,7 +55,7 @@ client, err := armcompute.NewLogAnalyticsClient(<subscription ID>, cred, &option
 ## More sample code
 
 - [Availability Set](https://aka.ms/azsdk/go/mgmt/samples?path=sdk/resourcemanager/compute/availabilityset)
-- [Virtual Machine](https://aka.ms/azsdk/go/mgmt/samples?path=sdk/resourcemanager/compute/createVM)
+- [Virtual Machine](https://aka.ms/azsdk/go/mgmt/samples?path=sdk/resourcemanager/compute/create_vm)
 - [Dedicated Host](https://aka.ms/azsdk/go/mgmt/samples?path=sdk/resourcemanager/compute/dedicated_host)
 - [Disk](https://aka.ms/azsdk/go/mgmt/samples?path=sdk/resourcemanager/compute/disk)
 - [Gallery](https://aka.ms/azsdk/go/mgmt/samples?path=sdk/resourcemanager/compute/gallery)


### PR DESCRIPTION
The path appears to have changed with https://github.com/Azure-Samples/azure-sdk-for-go-samples/pull/348 and is now
breaking the link verification check in CI. FYI @tadelesh
