### PR TITLE
fix: add azcore and azidentity to the go.mod template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ _testmain.go
 .DS_Store
 .vscode
 .vs
+.idea
 
 # ignore vendor/
 vendor/

--- a/eng/tools/generator/template/rpName/packageName/go.mod.tpl
+++ b/eng/tools/generator/template/rpName/packageName/go.mod.tpl
@@ -1,3 +1,8 @@
 module github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/{{rpName}}/{{packageName}}
 
 go {{goVersion}}
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.0.0
+)


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md

When onboarding, release tool will use template to generate an empty `go.mod`. Add `azcore` and `azidentity` dep to it to align with this [change](https://github.com/Azure/autorest.go/pull/835).