### PR TITLE
[azservicebus] Fixing bug where cancelling link creation could leak resources

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.2 (Unreleased)
+
+### Bugs Fixed
+
+- Cancelling link creation could leak a goroutine or, in rare conditions, a link. (#TBD)
+
 ## 1.0.1 (2022-06-07)
 
 ### Features Added

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Cancelling link creation could leak a goroutine or, in rare conditions, a link. (#TBD)
+- Cancelling link creation could leak a goroutine or, in rare conditions, a link. (#18479)
 
 ## 1.0.1 (2022-06-07)
 

--- a/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap.go
+++ b/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap.go
@@ -92,9 +92,21 @@ func (w *AMQPSessionWrapper) Close(ctx context.Context) error {
 }
 
 func (w *AMQPSessionWrapper) NewReceiver(opts ...amqp.LinkOption) (AMQPReceiverCloser, error) {
-	return w.Inner.NewReceiver(opts...)
+	receiver, err := w.Inner.NewReceiver(opts...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return receiver, nil
 }
 
 func (w *AMQPSessionWrapper) NewSender(opts ...amqp.LinkOption) (AMQPSenderCloser, error) {
-	return w.Inner.NewSender(opts...)
+	sender, err := w.Inner.NewSender(opts...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return sender, nil
 }

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.0.1"
+const Version = "v1.0.2"

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -541,34 +541,30 @@ func createReceiverLink(ctx context.Context, session amqpwrap.AMQPSession, linkO
 		Err      error
 	}
 
-	done := make(chan ret)
+	done := make(chan ret, 1)
 
 	go func(ctx context.Context) {
 		defer close(done)
 
 		tmpReceiver, tmpErr := session.NewReceiver(linkOptions...)
-
-		if tmpErr != nil {
-			done <- ret{Err: tmpErr}
-			return
-		}
-
-		select {
-		case <-ctx.Done():
-			// `createReceiverLink` will have already returned with a cancellation based error,
-			// so this goroutine just needs to make sure we close this link that nobody is going
-			// to use.
-			_ = tmpReceiver.Close(context.Background())
-			return
-		default:
-			done <- ret{Receiver: tmpReceiver}
-		}
+		done <- ret{Receiver: tmpReceiver, Err: tmpErr}
 	}(ctx)
 
 	select {
 	case data := <-done:
 		return data.Receiver, data.Err
 	case <-ctx.Done():
+		go func() {
+			data := <-done
+
+			if data.Err != nil {
+				// `createReceiverLink` will have already returned with a cancellation based error,
+				// so this goroutine just needs to make sure we close this link that nobody is going
+				// to use.
+				_ = data.Receiver.Close(context.Background())
+			}
+		}()
+
 		// we'll early exit if cancelled - the goroutine above
 		// will just close the no-longer-needed link if/when it
 		// returns successfully.

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -557,7 +557,7 @@ func createReceiverLink(ctx context.Context, session amqpwrap.AMQPSession, linkO
 		go func() {
 			data := <-done
 
-			if data.Err != nil {
+			if data.Err == nil {
 				// `createReceiverLink` will have already returned with a cancellation based error,
 				// so this goroutine just needs to make sure we close this link that nobody is going
 				// to use.

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -5,6 +5,7 @@ package azservicebus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -332,14 +333,43 @@ func TestReceiver_CanCancelLinkCreation(t *testing.T) {
 
 	receiver, err := createReceiverLink(ctx, session, []amqp.LinkOption{})
 	require.Nil(t, receiver)
-	require.NotNil(t, err)
 	require.ErrorIs(t, err, context.Canceled, fmt.Sprintf("%s is context.Cancelled", err.Error()))
 
 	close(done)
 
-	// also, the receiver we returned should be closed as part of the gourtine
+	// also, the receiver we returned should be closed as part of the goroutine
 	// unwinding.
 	<-receiverWasClosedCh
+}
+
+func TestReceiver_CanCancelLinkCreation_WithError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+
+	session := &internal.FakeAMQPSession{
+		NewReceiverFn: func(opts ...amqp.LinkOption) (internal.AMQPReceiverCloser, error) {
+			// simulate the client cancelling while we're stuck attempting to get the
+			// session receiver link.
+			cancel()
+
+			// "block" here. Basically what we're trying to simulate is that there's an
+			// active NewReceiver() and then we cancel.
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "Timed out waiting for the cancellation token to be respected.")
+			}
+
+			return nil, errors.New("an error happened so no receiver was created")
+		},
+	}
+
+	receiver, err := createReceiverLink(ctx, session, []amqp.LinkOption{})
+	require.Nil(t, receiver)
+	require.ErrorIs(t, err, context.Canceled, fmt.Sprintf("%s is context.Cancelled", err.Error()))
+
+	close(done)
 }
 
 func TestReceiverCancellationUnitTests(t *testing.T) {

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -339,7 +339,11 @@ func TestReceiver_CanCancelLinkCreation(t *testing.T) {
 
 	// also, the receiver we returned should be closed as part of the goroutine
 	// unwinding.
-	<-receiverWasClosedCh
+	select {
+	case <-receiverWasClosedCh:
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "10 seconds and the receiver wasn't closed")
+	}
 }
 
 func TestReceiver_CanCancelLinkCreation_WithError(t *testing.T) {


### PR DESCRIPTION
Attempting to shoe-horn the draining of the channel into the same goroutine doesn't work - it leads to a potential race condition or can lead to a blocking condition identified by @franklinkim in #18477.

The simplest fix is just to treat the original goroutine as a cancellable function call and then handle the return value logic inside of the main func instead. This ensures we always drain the 'done' channel, even if we decide to cancel early.

NOTE, this also unearthed a bug where we were sometimes passing (amqp.<type>, nil) instead of (<interface>, nil) in the amqp wrappers. This was fixed, along with the spot that was unintentionally using it even when there was an error.