### PR TITLE
[azblob] Enable errors.Is checking on wrapped InternalError error

### DIFF
--- a/sdk/storage/azblob/zc_storage_error.go
+++ b/sdk/storage/azblob/zc_storage_error.go
@@ -37,8 +37,10 @@ func (e *InternalError) Error() string {
 // Is casts err into InternalError
 func (e *InternalError) Is(err error) bool {
 	_, ok := err.(*InternalError)
-
-	return ok
+	if ok {
+		return ok
+	}
+	return errors.Is(e.cause, err)
 }
 
 // As casts target interface into InternalError


### PR DESCRIPTION
This changes the implementation of the Is method of azblob.InternalError
to check the target error against the wrapped error value instead of the
InternalError type itself, if the target type is not itself
InternalError. Prior to this commit, type information about the wrapped
error was not accessible. The motivation for this change is to allow the
caller to check a returned InternalError to see if it is wrapping a
context cancelation.

For instance, given a BlockBlobClient, one may like to call

    _, err := client.Download(ctx, nil)
    if err != nil {
      if errors.Is(err, context.Canceled) {
        return // all good
      }
      // handle error
    }

and be able to recognize that the failure was due to context
cancelation.

Existing logic around checking if an InternalError type assertion
succeeds is left in place to account for compatibility issues. New logic
is in place only if that check fails.