### PR TITLE
Added SignerForKey to azkeys.Client

### DIFF
--- a/sdk/keyvault/azkeys/constants.go
+++ b/sdk/keyvault/azkeys/constants.go
@@ -251,6 +251,26 @@ func PossibleJSONWebKeyTypeValues() []JSONWebKeyType {
 	}
 }
 
+// IsRSAKey returns true if the key is an RSA key (RSA or RSA-HSM).
+func (kt JSONWebKeyType) IsRSAKey() bool {
+	return kt == JSONWebKeyTypeRSA || kt == JSONWebKeyTypeRSAHSM
+}
+
+// IsECKey returns true if the key is an EC key (EC or EC-HSM).
+func (kt JSONWebKeyType) IsECKey() bool {
+	return kt == JSONWebKeyTypeEC || kt == JSONWebKeyTypeECHSM
+}
+
+// IsSymmetricKey returns true if the key is a symmetric key (Oct or OctHSM).
+func (kt JSONWebKeyType) IsSymmetricKey() bool {
+	return kt == JSONWebKeyTypeOct || kt == JSONWebKeyTypeOctHSM
+}
+
+// IsAsymmetric returns true if the key type is asymmetric.
+func (kt JSONWebKeyType) IsAsymmetric() bool {
+	return kt.IsECKey() || kt.IsRSAKey()
+}
+
 // KeyEncryptionAlgorithm - The encryption algorithm to use to protected the exported key material
 type KeyEncryptionAlgorithm string
 

--- a/sdk/keyvault/azkeys/custom_client.go
+++ b/sdk/keyvault/azkeys/custom_client.go
@@ -109,12 +109,9 @@ func (signer *signer) Sign(_ io.Reader, value []byte, opts crypto.SignerOpts) ([
 		// If we have an opts object and that is of type *rsa.PSSOptions, then use RSA-PSS
 		// (however, we are ignoring the SaltLength property of the object as it's not supported by Key Vault).
 		// Otherwise, use RSA in PKCS #1 v1.5 mode.
-		if opts != nil {
-			if _, ok := opts.(*rsa.PSSOptions); ok {
-				signAlg = "PS"
-			}
-		}
-		if signAlg == "" {
+		if _, ok := opts.(*rsa.PSSOptions); ok {
+			signAlg = "PS"
+		} else {
 			signAlg = "RS"
 		}
 	case *ecdsa.PublicKey:

--- a/sdk/keyvault/azkeys/custom_client.go
+++ b/sdk/keyvault/azkeys/custom_client.go
@@ -9,10 +9,21 @@ package azkeys
 // this file contains handwritten additions to the generated code
 
 import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"errors"
+	"io"
+	"math/big"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
 )
 
 // NewClient creates a client that accesses a Key Vault's keys.
@@ -38,4 +49,142 @@ func (i *ID) Version() string {
 		return ""
 	}
 	return *version
+}
+
+// SignerForKey - Returns an object that implements the crypto.Signer interface, using asymmetric keys stored in Azure Key Vault.
+// The context is maintained for all operations performed by the signer object.
+// The operations performed by the Signer require the keys/sign and keys/list permissions.
+// name - The name of the key.
+// version - The version of the key.
+func (client *Client) SignerForKey(ctx context.Context, name string, version string) crypto.Signer {
+	return &signer{
+		client:     client,
+		keyName:    name,
+		keyVersion: version,
+		ctx:        ctx,
+	}
+}
+
+// signer implements the crypto.Signer interface and allows performing signing operations using asymmetric
+type signer struct {
+	client     *Client
+	keyName    string
+	keyVersion string
+	ctx        context.Context
+
+	// Cached public key
+	publicKey crypto.PublicKey
+}
+
+// Public returns the public key corresponding to the private key stored in the Key Vault..
+func (signer *signer) Public() crypto.PublicKey {
+	pk, _ := signer.getPublicKey()
+	return pk
+}
+
+// Sign signs a value with the private key stored in the Key Vault.
+// For an RSA key, the resulting signature should be either a
+// PKCS #1 v1.5 or PSS signature (as indicated by opts). For an (EC)DSA
+// key, it should be a DER-serialised, ASN.1 signature structure.
+//
+// Hash implements the SignerOpts interface and, in most cases, one can
+// simply pass in the hash function used as opts. Sign may also attempt
+// to type assert opts to other types in order to obtain algorithm
+// specific values. See the documentation in each package for details.
+func (signer *signer) Sign(_ io.Reader, value []byte, opts crypto.SignerOpts) ([]byte, error) {
+	params := SignParameters{
+		Value: value,
+	}
+
+	// We need the public key to be able to determine the algorithm to use
+	pk, err := signer.getPublicKey()
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine the algorithm
+	signAlg := ""
+	switch pk.(type) {
+	case *rsa.PublicKey:
+		// If we have an opts object and that is of type *rsa.PSSOptions, then use RSA-PSS
+		// (however, we are ignoring the SaltLength property of the object as it's not supported by Key Vault).
+		// Otherwise, use RSA in PKCS #1 v1.5 mode.
+		if opts != nil {
+			if _, ok := opts.(*rsa.PSSOptions); ok {
+				signAlg = "PS"
+			}
+		}
+		if signAlg == "" {
+			signAlg = "RS"
+		}
+	case *ecdsa.PublicKey:
+		signAlg = "ES"
+	default:
+		return nil, errors.New("unsupported key type")
+	}
+
+	// Determine the hashing function
+	var hf crypto.Hash = crypto.SHA256
+	if opts != nil {
+		hf = opts.HashFunc()
+	}
+	switch hf {
+	case crypto.SHA256:
+		params.Algorithm = to.Ptr(JSONWebKeySignatureAlgorithm(signAlg + "256"))
+	case crypto.SHA384:
+		params.Algorithm = to.Ptr(JSONWebKeySignatureAlgorithm(signAlg + "384"))
+	case crypto.SHA512:
+		params.Algorithm = to.Ptr(JSONWebKeySignatureAlgorithm(signAlg + "512"))
+	default:
+		return nil, errors.New("unsupported hashing function")
+	}
+
+	// Make the request
+	res, err := signer.client.Sign(signer.ctx, signer.keyName, signer.keyVersion, params, nil)
+	if err != nil {
+		return nil, err
+	}
+	l := len(res.Result)
+	if l == 0 {
+		return nil, errors.New("response did not contain a result")
+	}
+
+	// When using ECDSA, Azure Key Vault returns a signature formatted per ANSI X9.62 (that is: "r|s")
+	// We need to convert that to ASN DER.1 which is the format crypto.Signer.Sign expects
+	if signAlg == "ES" {
+		r := (&big.Int{}).SetBytes(res.Result[:(l / 2)])
+		s := (&big.Int{}).SetBytes(res.Result[(l / 2):])
+		var b cryptobyte.Builder
+		b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+			b.AddASN1BigInt(r)
+			b.AddASN1BigInt(s)
+		})
+		return b.Bytes()
+	}
+
+	return res.Result, nil
+}
+
+func (signer *signer) getPublicKey() (crypto.PublicKey, error) {
+	if signer.publicKey != nil {
+		return signer.publicKey, nil
+	}
+
+	res, err := signer.client.GetKey(signer.ctx, signer.keyName, signer.keyVersion, nil)
+	if err != nil || res.Key == nil {
+		return nil, err
+	}
+
+	pk, err := res.Key.Public()
+	if err != nil {
+		return nil, err
+	}
+
+	signer.publicKey = pk
+
+	if signer.keyVersion == "" && res.Key.KID != nil {
+		signer.keyVersion = res.Key.KID.Version()
+	}
+
+	return pk, nil
 }

--- a/sdk/keyvault/azkeys/custom_models.go
+++ b/sdk/keyvault/azkeys/custom_models.go
@@ -1,0 +1,154 @@
+package azkeys
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"errors"
+	"math/big"
+)
+
+// Public returns the public key included the object, as a crypto.PublicKey object.
+// This method returns an error if it's invoked on a JSONWebKey object representing a symmetric key.
+func (key JSONWebKey) Public() (crypto.PublicKey, error) {
+	if key.Kty == nil {
+		return nil, errors.New("property Kty is nil")
+	}
+
+	switch {
+	case key.Kty.IsRSAKey():
+		return key.publicRSA()
+	case key.Kty.IsECKey():
+		return key.publicEC()
+	}
+
+	return nil, errors.New("unsupported key type")
+}
+
+func (key JSONWebKey) publicRSA() (*rsa.PublicKey, error) {
+	res := &rsa.PublicKey{}
+
+	// N = modulus
+	if len(key.N) == 0 {
+		return nil, errors.New("property N is empty")
+	}
+	res.N = &big.Int{}
+	res.N.SetBytes(key.N)
+
+	// e = public exponent
+	if len(key.E) == 0 {
+		return nil, errors.New("property e is empty")
+	}
+	res.E = int(big.NewInt(0).SetBytes(key.E).Uint64())
+
+	return res, nil
+}
+
+func (key JSONWebKey) publicEC() (*ecdsa.PublicKey, error) {
+	res := &ecdsa.PublicKey{}
+
+	if key.Crv == nil {
+		return nil, errors.New("property Crv is nil")
+	}
+	switch *key.Crv {
+	case JSONWebKeyCurveNameP256:
+		res.Curve = elliptic.P256()
+	case JSONWebKeyCurveNameP384:
+		res.Curve = elliptic.P384()
+	case JSONWebKeyCurveNameP521:
+		res.Curve = elliptic.P521()
+	case JSONWebKeyCurveNameP256K:
+		return nil, errors.New("curves of type P-256K are not supported by this method")
+	}
+
+	// X coordinate
+	if len(key.X) == 0 {
+		return nil, errors.New("property X is empty")
+	}
+	res.X = &big.Int{}
+	res.X.SetBytes(key.X)
+
+	// Y coordinate
+	if len(key.Y) == 0 {
+		return nil, errors.New("property Y is empty")
+	}
+	res.Y = &big.Int{}
+	res.Y.SetBytes(key.Y)
+
+	return res, nil
+}
+
+// Private returns the private key included in the object, as a crypto.PrivateKey object.
+// This method returns an error if it's invoked on a JSONWebKey object representing a symmetric key.
+func (key JSONWebKey) Private() (crypto.PrivateKey, error) {
+	if key.Kty == nil {
+		return nil, errors.New("property Kty is nil")
+	}
+
+	switch {
+	case key.Kty.IsRSAKey():
+		return key.privateRSA()
+	case key.Kty.IsECKey():
+		return key.privateEC()
+	}
+
+	return nil, errors.New("unsupported key type")
+}
+
+func (key JSONWebKey) privateRSA() (*rsa.PrivateKey, error) {
+	// Parse the public part first
+	pk, err := key.publicRSA()
+	if err != nil {
+		return nil, err
+	}
+
+	res := &rsa.PrivateKey{
+		PublicKey: *pk,
+	}
+
+	// D = private exponent
+	if len(key.D) == 0 {
+		return nil, errors.New("property D is empty")
+	}
+	res.D = &big.Int{}
+	res.D.SetBytes(key.D)
+
+	// Precomputed values
+	// These are optional
+	if len(key.DP) > 0 {
+		res.Precomputed.Dp = &big.Int{}
+		res.Precomputed.Dp.SetBytes(key.DP)
+	}
+	if len(key.DQ) > 0 {
+		res.Precomputed.Dq = &big.Int{}
+		res.Precomputed.Dq.SetBytes(key.DQ)
+	}
+	if len(key.QI) > 0 {
+		res.Precomputed.Qinv = &big.Int{}
+		res.Precomputed.Qinv.SetBytes(key.QI)
+	}
+
+	return res, nil
+}
+
+func (key JSONWebKey) privateEC() (*ecdsa.PrivateKey, error) {
+	// Parse the public part first
+	pk, err := key.publicEC()
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ecdsa.PrivateKey{
+		PublicKey: *pk,
+	}
+
+	// D = private key
+	if len(key.D) == 0 {
+		return nil, errors.New("property D is empty")
+	}
+	res.D = &big.Int{}
+	res.D.SetBytes(key.D)
+
+	return res, nil
+}

--- a/sdk/keyvault/azkeys/custom_models.go
+++ b/sdk/keyvault/azkeys/custom_models.go
@@ -1,4 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 package azkeys
+
+// this file contains handwritten additions to the generated code
 
 import (
 	"crypto"


### PR DESCRIPTION
This change adds a new method `SignerForKey` to `azkeys.Client`, handwritten.

This method allows creating an object that implements the `crypto.Signer` interface. It allows using keys stored in Azure Key Vault to create digital signatures in Go applications anywhere where `crypto.Signer` is supported. It makes the SDK essentially a "plug-in" for a lot more systems.

Example:

```go
cred, err := azidentity.NewDefaultAzureCredential(nil)
if err != nil {
	panic(err)
}

client := azkeys.NewClient("https://<vault name>.vault.azure.net", cred, nil)
signer := client.SignerForKey(context.Background(), "<key name>", "")

msg := sha256.Sum256([]byte("hello world"))
res, err := signer.Sign(nil, msg[:], crypto.SHA256)
fmt.Println(res, err)
```

- [X] The purpose of this PR is explained in this or a referenced issue.
- [X] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [X] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
