### PR TITLE
Fix broken pkg.go.dev link in azkeys README

### DIFF
--- a/sdk/keyvault/azkeys/README.md
+++ b/sdk/keyvault/azkeys/README.md
@@ -442,6 +442,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [default_cred_ref]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#NewDefaultAzureCredential
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [keyvault_docs]: https://docs.microsoft.com/azure/key-vault/
+[goget_azkeys]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys
 [rbac_guide]: https://docs.microsoft.com/azure/key-vault/general/rbac-guide
 [reference_docs]: https://aka.ms/azsdk/go/keyvault-keys/docs
 [key_client_docs]: https://aka.ms/azsdk/go/keyvault-keys/docs#Client


### PR DESCRIPTION
This adds back the `goget_azkeys` link reference which seems to have
been accidentally deleted in https://github.com/Azure/azure-sdk-for-go/commit/32be770a92b5199ac7fee8340344d1b7520b8a46,
making the rendered Markdown link clickable again.