### PR TITLE
[azservicebus] Updating to latest go-amqp to get fixes around wasted message locking

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -14,9 +14,10 @@
 
 ### Bugs Fixed
 
-Updating to the latest go-amqp, which fixes several bugs related to incorrect message locking (PR#TBD)
-  - Requesting large quantities of mesages could result in messages not being delivered, but still incrementing
-    their delivery count and requiring the message lock timeout to expire.
+Updating to the latest go-amqp (TBD:), which fixes several bugs related to incorrect message locking (PR#18599)
+  - Requesting large quantities of messages in a single ReceiveMessages() call  could result in messages 
+    not being delivered, but still incrementing their delivery count and requiring the message lock 
+    timeout to expire.
   - Link detach could result in messages being ignored, requiring the message lock timeout to expire.
 
 ### Other Changes

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,12 +1,23 @@
 # Release History
 
-## 1.0.2-beta.1 (Unreleased)
+## 1.1.0 (Unreleased)
 
 ### Features Added
+
+- Full access to send and receive all AMQP message properties. (#18413) 
+  - Send AMQP messages using the new `AMQPAnnotatedMessage` type and `Sender.SendAMQPAnnotatedMessage()`.
+  - AMQP messages can be added to MessageBatch's as well using `MessageBatch.AddAMQPAnnotatedMessage()`.
+  - AMQP messages can be scheduled using `Sender.ScheduleAMQPAnnotatedMessages`.
+  - Access the full set of AMQP message properties when receiving using the `ReceivedMessage.RawAMQPMessage` property. 
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
+Updating to the latest go-amqp, which fixes several bugs related to incorrect message locking (PR#TBD)
+  - Requesting large quantities of mesages could result in messages not being delivered, but still incrementing
+    their delivery count and requiring the message lock timeout to expire.
+  - Link detach could result in messages being ignored, requiring the message lock timeout to expire.
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.0.2-beta.1"
+const Version = "v1.1.0"

--- a/sdk/messaging/azservicebus/internal/go-amqp/link.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/link.go
@@ -708,8 +708,8 @@ func (l *link) muxReceive(fr frames.PerformTransfer) error {
 	select {
 	case l.Messages <- l.msg:
 		// message received
-	case <-l.close:
-		// link is being closed
+	case <-l.Detached:
+		// link has been detached
 		return l.err
 	}
 
@@ -988,9 +988,14 @@ Loop:
 			// after sending the detach frame, break the read loop
 			break Loop
 		case fr := <-l.RX:
-			// discard incoming frames to avoid blocking session.mux
-			if fr, ok := fr.(*frames.PerformDetach); ok && fr.Closed {
-				l.detachReceived = true
+			// read from link to avoid blocking session.mux
+			switch fr := fr.(type) {
+			case *frames.PerformDetach:
+				if fr.Closed {
+					l.detachReceived = true
+				}
+			case *frames.PerformTransfer:
+				_ = l.muxReceive(*fr)
 			}
 		case <-l.Session.done:
 			if l.err == nil {
@@ -1008,11 +1013,15 @@ Loop:
 
 	for {
 		select {
-		// read from link until detach with Close == true is received,
-		// other frames are discarded.
+		// read from link until detach with Close == true is received
 		case fr := <-l.RX:
-			if fr, ok := fr.(*frames.PerformDetach); ok && fr.Closed {
-				return
+			switch fr := fr.(type) {
+			case *frames.PerformDetach:
+				if fr.Closed {
+					return
+				}
+			case *frames.PerformTransfer:
+				_ = l.muxReceive(*fr)
 			}
 
 		// connection has ended

--- a/sdk/messaging/azservicebus/internal/go-amqp/manualCreditor.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/manualCreditor.go
@@ -43,8 +43,13 @@ func (mc *manualCreditor) FlowBits(currentCredits uint32) (bool, uint32) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 
-	drain := mc.drained != nil
+	drain := mc.pendingDrain
 	var credits uint32
+
+	if mc.pendingDrain {
+		// only send one drain request
+		mc.pendingDrain = false
+	}
 
 	// either:
 	// drain is true (ie, we're going to send a drain frame, and the credits for it should be 0)
@@ -56,7 +61,6 @@ func (mc *manualCreditor) FlowBits(currentCredits uint32) (bool, uint32) {
 	}
 
 	mc.creditsToAdd = 0
-	mc.pendingDrain = false
 
 	return drain, credits
 }
@@ -73,6 +77,7 @@ func (mc *manualCreditor) Drain(ctx context.Context, l *link) error {
 	mc.drained = make(chan struct{})
 	// use a local copy to avoid racing with EndDrain()
 	drained := mc.drained
+	mc.pendingDrain = true
 
 	mc.mu.Unlock()
 


### PR DESCRIPTION
Updating to the latest go-amqp (2d5210a953428af866002b3e28061cfa92d471bd), which fixes several bugs which could lead to incorrect message locking and deliveries:
  - Requesting large quantities of messages in a single ReceiveMessages() call  could result in messages 
    not being delivered, but still incrementing their delivery count and requiring the message lock 
    timeout to expire.
  - Link detach could result in messages being ignored, requiring the message lock timeout to expire.

In addition this also cleans up an issue where we would send excessive FLOW frames. There was no harm here, but it was unnecessary.