### PR TITLE
[azservicebus] ReceiveMessages() algorithm change to use amqpReceiver.Release() instead of flow+drain

### DIFF
--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -374,19 +374,25 @@ func (l *AMQPLinksImpl) CloseIfNeeded(ctx context.Context, err error) RecoveryKi
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	if IsCancelError(err) {
+		log.Writef(exported.EventConn, "No close needed for cancellation")
+		return RecoveryKindNone
+	}
+
 	rk := l.getRecoveryKindFunc(err)
 
 	switch rk {
 	case RecoveryKindLink:
-		_ = l.closeWithoutLocking(ctx, false)
-		return rk
-	case RecoveryKindConn:
-		_ = l.ns.Close(ctx, false)
+		log.Writef(exported.EventConn, "Closing links for error %s", err.Error())
 		_ = l.closeWithoutLocking(ctx, false)
 		return rk
 	case RecoveryKindFatal:
-		// it's not entirely clear what the right cleanup would be here, so we leave that up to the
-		// calling application.
+		log.Writef(exported.EventConn, "Fatal error cleanup")
+		fallthrough
+	case RecoveryKindConn:
+		log.Writef(exported.EventConn, "Closing connection AND links for error %s", err.Error())
+		_ = l.ns.Close(ctx, false)
+		_ = l.closeWithoutLocking(ctx, false)
 		return rk
 	case RecoveryKindNone:
 		return rk

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -97,7 +97,6 @@ func TestAMQPLinksBasic(t *testing.T) {
 
 	assertLinks(t, lwr)
 
-	require.EqualValues(t, entityPath, links.EntityPath())
 }
 
 func TestAMQPLinksLive(t *testing.T) {
@@ -453,7 +452,7 @@ func TestAMQPLinksMultipleWithSameConnection(t *testing.T) {
 
 func TestAMQPLinksCloseIfNeeded(t *testing.T) {
 	t.Run("fatal", func(t *testing.T) {
-		for _, fatalErr := range []error{NewErrNonRetriable(""), context.Canceled, context.DeadlineExceeded} {
+		for _, fatalErr := range []error{NewErrNonRetriable("")} {
 			receiver := &FakeAMQPReceiver{}
 			sender := &FakeAMQPSender{}
 			ns := &FakeNS{}
@@ -477,9 +476,9 @@ func TestAMQPLinksCloseIfNeeded(t *testing.T) {
 
 			rk := links.CloseIfNeeded(context.Background(), fatalErr)
 			require.Equal(t, RecoveryKindFatal, rk)
-			require.Equal(t, 0, receiver.Closed)
-			require.Equal(t, 0, sender.Closed)
-			require.Equal(t, 0, ns.CloseCalled)
+			require.Equal(t, 1, receiver.Closed)
+			require.Equal(t, 1, sender.Closed)
+			require.Equal(t, 1, ns.CloseCalled)
 		}
 	})
 
@@ -564,6 +563,18 @@ func TestAMQPLinksCloseIfNeeded(t *testing.T) {
 		require.NoError(t, err)
 
 		rk := links.CloseIfNeeded(context.Background(), nil)
+		require.Equal(t, RecoveryKindNone, rk)
+		require.Equal(t, 0, receiver.Closed)
+		require.Equal(t, 0, sender.Closed)
+		require.Equal(t, 0, ns.CloseCalled)
+
+		rk = links.CloseIfNeeded(context.Background(), context.Canceled)
+		require.Equal(t, RecoveryKindNone, rk)
+		require.Equal(t, 0, receiver.Closed)
+		require.Equal(t, 0, sender.Closed)
+		require.Equal(t, 0, ns.CloseCalled)
+
+		rk = links.CloseIfNeeded(context.Background(), context.DeadlineExceeded)
 		require.Equal(t, RecoveryKindNone, rk)
 		require.Equal(t, 0, receiver.Closed)
 		require.Equal(t, 0, sender.Closed)
@@ -715,6 +726,94 @@ func TestAMQPLinks_Logging(t *testing.T) {
 	})
 }
 
+func TestAMQPLinksCreditTracking(t *testing.T) {
+	entityPath, cleanup := test.CreateExpiringQueue(t, nil)
+	defer cleanup()
+
+	cs := test.GetConnectionString(t)
+	ns, err := NewNamespace(NamespaceWithConnectionString(cs))
+	require.NoError(t, err)
+
+	links := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: entityPath,
+		CreateLinkFunc: func(ctx context.Context, session amqpwrap.AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
+			return newLinksForAMQPLinksTest(entityPath, session)
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
+	})
+
+	defer func() {
+		err := links.Close(context.Background(), true)
+		require.NoError(t, err)
+	}()
+
+	lwr, err := links.Get(context.Background())
+	require.NoError(t, err)
+
+	err = lwr.Sender.Send(context.Background(), &amqp.Message{
+		Data: [][]byte{[]byte("Received")},
+	})
+	require.NoError(t, err)
+
+	err = lwr.Receiver.IssueCredit(1)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), lwr.Receiver.Credits())
+
+	message, err := lwr.Receiver.Receive(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{[]byte("Received")}, message.Data)
+	require.Equal(t, uint32(0), lwr.Receiver.Credits())
+
+	err = lwr.Receiver.AcceptMessage(context.Background(), message)
+	require.NoError(t, err)
+
+	err = lwr.Sender.Send(context.Background(), &amqp.Message{
+		Data: [][]byte{[]byte("Received")},
+	})
+	require.NoError(t, err)
+
+	err = lwr.Receiver.IssueCredit(1)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), lwr.Receiver.Credits())
+
+	// prefetched messages arrive, but we don't block in Prefetched() so
+	// we'll have to poll our receiver for this part.
+	deadline := time.Now().Add(time.Minute)
+
+	for time.Until(deadline) > 0 {
+		message := lwr.Receiver.Prefetched()
+
+		if message != nil {
+			require.Equal(t, [][]byte{[]byte("Received")}, message.Data)
+			require.Equal(t, uint32(0), lwr.Receiver.Credits())
+
+			err = lwr.Receiver.AcceptMessage(context.Background(), message)
+			require.NoError(t, err)
+			break
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	// now that the link is empty, let's test:
+
+	// A receive where an error happens (cancellation, in this case)
+	// this won't touch the credit since nothing is actually received.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = lwr.Receiver.Receive(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, uint32(0), lwr.Receiver.Credits())
+
+	// a prefetch where there isn't anything.
+	message = lwr.Receiver.Prefetched()
+	require.Nil(t, message)
+	require.Equal(t, uint32(0), lwr.Receiver.Credits())
+}
+
+// newLinksForAMQPLinksTest creates a AMQPSenderCloser and a AMQPReceiverCloser linkwith the same options
+// we use when we create them with the azservicebus.Receiver/Sender.
 func newLinksForAMQPLinksTest(entityPath string, session amqpwrap.AMQPSession) (AMQPSenderCloser, AMQPReceiverCloser, error) {
 	receiverOpts := &amqp.ReceiverOptions{
 		SettlementMode: amqp.ModeSecond.Ptr(),

--- a/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap_test.go
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package amqpwrap
+
+

--- a/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap_test.go
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-package amqpwrap

--- a/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap_test.go
@@ -2,5 +2,3 @@
 // Licensed under the MIT License.
 
 package amqpwrap
-
-

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -454,6 +454,7 @@ func (ns *Namespace) updateClientWithoutLock(ctx context.Context) (amqpwrap.AMQP
 		return ns.client, ns.connID, nil
 	}
 
+	connStart := time.Now()
 	log.Writef(exported.EventConn, "Creating new client, current rev: %d", ns.connID)
 	tempClient, err := ns.newClientFn(ctx)
 
@@ -463,7 +464,7 @@ func (ns *Namespace) updateClientWithoutLock(ctx context.Context) (amqpwrap.AMQP
 
 	ns.connID++
 	ns.client = tempClient
-	log.Writef(exported.EventConn, "Client created, new rev: %d", ns.connID)
+	log.Writef(exported.EventConn, "Client created, new rev: %d, took %dms", ns.connID, time.Since(connStart)/time.Millisecond)
 
 	return ns.client, ns.connID, err
 }

--- a/sdk/messaging/azservicebus/internal/stress/.helmignore
+++ b/sdk/messaging/azservicebus/internal/stress/.helmignore
@@ -1,0 +1,5 @@
+stress
+stress.exe
+.env
+Dockerfile
+*.go

--- a/sdk/messaging/azservicebus/internal/stress/Chart.lock
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.16
-digest: sha256:75061792fdbebe57c664322579af6dc240ce8f464280ac5e192de72a29d4f63f
-generated: "2022-04-29T00:43:35.81502307Z"
+  version: 0.1.19
+digest: sha256:f401505f7f7d7711217fa043e98c419f99b992a0c69a4128df885edd31f03713
+generated: "2022-07-18T19:53:00.950931623-07:00"

--- a/sdk/messaging/azservicebus/internal/stress/Chart.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.yaml
@@ -10,6 +10,5 @@ annotations:
   dockerfile: './Dockerfile'
 dependencies:
 - name: stress-test-addons
-  version: 0.1.16
+  version: ~0.1.16
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  

--- a/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
@@ -152,6 +152,12 @@ func (tracker *StressContext) PanicOnError(message string, err error) {
 	}
 }
 
+func (tracker *StressContext) Failf(format string, args ...any) {
+	err := fmt.Errorf(format, args...)
+	tracker.LogIfFailed(err.Error(), err, nil)
+	panic(err)
+}
+
 func (tracker *StressContext) Assert(condition bool, message string) {
 	tracker.LogIfFailed(message, nil, nil)
 

--- a/sdk/messaging/azservicebus/internal/stress/shared/utils.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/utils.go
@@ -50,7 +50,7 @@ func MustGenerateMessages(sc *StressContext, sender *azservicebus.Sender, messag
 }
 
 // MustCreateAutoDeletingQueue creates a queue that will auto-delete 10 minutes after activity has ceased.
-func MustCreateAutoDeletingQueue(sc *StressContext, queueName string, qp *admin.QueueProperties) {
+func MustCreateAutoDeletingQueue(sc *StressContext, queueName string, qp *admin.QueueProperties) *admin.Client {
 	adminClient, err := admin.NewClientFromConnectionString(sc.ConnectionString, nil)
 	sc.PanicOnError("failed to create adminClient", err)
 
@@ -70,6 +70,8 @@ func MustCreateAutoDeletingQueue(sc *StressContext, queueName string, qp *admin.
 		Properties: &newQP,
 	})
 	sc.PanicOnError("failed to create queue", err)
+
+	return adminClient
 }
 
 func MustCreateSubscriptions(sc *StressContext, topicName string, subscriptionNames []string) func() {

--- a/sdk/messaging/azservicebus/internal/stress/tests/tests.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/tests.go
@@ -36,12 +36,12 @@ func Run(remainingArgs []string) {
 		"constantDetachmentSender": ConstantDetachmentSender,
 		"finitePeeks":              FinitePeeks,
 		"finiteSendAndReceive":     FiniteSendAndReceiveTest,
+		"idleFastReconnect":        IdleFastReconnect,
 		"infiniteSendAndReceive":   InfiniteSendAndReceiveRun,
 		"longRunningRenewLock":     LongRunningRenewLockTest,
+		"mostlyIdleReceiver":       MostlyIdleReceiver,
 		"rapidOpenClose":           RapidOpenCloseTest,
 		"receiveCancellation":      ReceiveCancellation,
-		"idleFastReconnect":        IdleFastReconnect,
-		"mostlyIdleReceiver":       MostlyIdleReceiver,
 		"sendAndReceiveDrain":      SendAndReceiveDrain,
 	}
 

--- a/sdk/messaging/azservicebus/internal/stress/values.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/values.yaml
@@ -12,3 +12,5 @@ scenarios:
 - "mostlyIdleReceiver"
 - "rapidOpenClose"
 - "receiveCancellation"
+- "sendAndReceiveDrain"
+debugFileShareName: "nothing"

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
@@ -59,6 +60,8 @@ type Receiver struct {
 
 	defaultDrainTimeout      time.Duration
 	defaultTimeAfterFirstMsg time.Duration
+
+	cancelReleaser *atomic.Value
 }
 
 // ReceiverOptions contains options for the `Client.NewReceiverForQueue` or `Client.NewReceiverForSubscription`
@@ -119,6 +122,10 @@ type newReceiverArgs struct {
 	retryOptions        RetryOptions
 }
 
+var emptyCancelFn = func() string {
+	return "empty"
+}
+
 func newReceiver(args newReceiverArgs, options *ReceiverOptions) (*Receiver, error) {
 	if err := args.ns.Check(); err != nil {
 		return nil, err
@@ -130,7 +137,10 @@ func newReceiver(args newReceiverArgs, options *ReceiverOptions) (*Receiver, err
 		defaultDrainTimeout:      time.Second,
 		defaultTimeAfterFirstMsg: 20 * time.Millisecond,
 		retryOptions:             args.retryOptions,
+		cancelReleaser:           &atomic.Value{},
 	}
+
+	receiver.cancelReleaser.Store(emptyCancelFn)
 
 	if err := applyReceiverOptions(receiver, &args.entity, options); err != nil {
 		return nil, err
@@ -306,6 +316,10 @@ func (r *Receiver) RenewMessageLock(ctx context.Context, msg *ReceivedMessage, o
 
 // Close permanently closes the receiver.
 func (r *Receiver) Close(ctx context.Context) error {
+	cancelReleaser := r.cancelReleaser.Swap(emptyCancelFn).(func() string)
+	releaserID := cancelReleaser()
+	log.Writef(EventReceiver, "Stopped message releaser with ID '%s'", releaserID)
+
 	r.cleanupOnClose()
 	return r.amqpLinks.Close(ctx, true)
 }
@@ -344,7 +358,8 @@ func (r *Receiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessa
 }
 
 func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, options *ReceiveMessagesOptions) ([]*ReceivedMessage, error) {
-	var all []*ReceivedMessage
+	cancelReleaser := r.cancelReleaser.Swap(emptyCancelFn).(func() string)
+	_ = cancelReleaser()
 
 	var linksWithID *internal.LinksWithID
 
@@ -357,141 +372,59 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 		return nil, err
 	}
 
-	cleanup := func(err error) {
-		if err != nil {
-			if internal.IsCancelError(err) {
-				// if the user cancelled any of the "cleanup" operations then the link
-				// is an indeterminate state and should just be closed. It'll get recreated
-				// on the next operation.
-				log.Writef(EventReceiver, "Closing link due to cancellation")
-				_ = r.amqpLinks.Close(context.Background(), false)
-			} else {
-				log.Writef(EventReceiver, "Closing link/connection (potentially) for error %v", err)
-				_ = r.amqpLinks.CloseIfNeeded(context.Background(), err)
-			}
+	creditsToIssue := int64(maxMessages) - int64(linksWithID.Receiver.Credits())
+	log.Writef(EventReceiver, "Asking for %d credits", maxMessages)
+
+	if creditsToIssue > 0 {
+		log.Writef(EventReceiver, "Only need to issue %d additional credits", maxMessages)
+
+		if err := linksWithID.Receiver.IssueCredit(uint32(creditsToIssue)); err != nil {
+			return nil, err
 		}
 	}
 
-	flushAndReturn := func(lastErr error) ([]*ReceivedMessage, error) {
-		flushPrefetchedMessages(linksWithID.Receiver, &all)
+	result := r.fetchMessages(ctx, linksWithID.Receiver, maxMessages, r.defaultTimeAfterFirstMsg)
 
-		if len(all) > 0 {
-			// users don't typically check the other values in the return if the 'err' is non-nil
-			// so if we have any messages we'll just return them and nil out the error.
-			// If it's persistent they'll see it on their next ReceiveMessages() call.
-			log.Writef(EventReceiver, "Received %d/%d messages", len(all), maxMessages)
-			return all, nil
-		} else {
-			if internal.GetRecoveryKind(lastErr) == internal.RecoveryKindFatal {
-				log.Writef(EventReceiver, "Fatal error when receiving: %#v", lastErr)
-				return nil, lastErr
-			}
-
-			// there's no material difference here, so let them fail on the next call to ReceiveMessages() instead.
-			log.Writef(EventReceiver, "Non-fatal error occurred and no messages were received. Will recover on next call: %v", lastErr)
-			return nil, nil
-		}
+	if result.Messages != nil {
+		log.Writef(EventReceiver, "Received %d/%d messages", len(result.Messages), maxMessages)
 	}
 
-	if err := fetchMessages(ctx, linksWithID.Receiver, maxMessages, r.defaultTimeAfterFirstMsg, &all); err != nil {
-		// if the user's cancelled the fetch we'll fall through and let the drain happen.
-		if !internal.IsCancelError(err) {
-			// If the user didn't cancel then we had an actual failure that's going to require a
-			// link/connection reset. Close links and return whatever we can.
-			cleanup(err)
-			return flushAndReturn(err)
-		}
+	// this'll only close anything if the error indicates that the link/connection is bad.
+	// it's safe to call with cancellation errors.
+	rk := r.amqpLinks.CloseIfNeeded(context.Background(), result.Error)
 
-		// user cancelled (or we hit our "afte first message" timer).
-		// Fall through so we drain the link since it's still active.
-		log.Writef(EventReceiver, "Context has been cancelled")
+	if rk == internal.RecoveryKindNone {
+		// The link is still alive, so we'll just start up a listener that'll keep
+		// releasing any messages that arrive between this call and the next call
+		// to ReceiveMessages().
+		// This prevents us from holding onto messages for a long period of time in our
+		// internal cache, where they'll just keep expiring.
+		releaserFunc := r.newReleaserFunc(linksWithID.Receiver)
+		go releaserFunc()
+	} else {
+		log.Writef(EventReceiver, "Failure when receiving messages: %s", result.Error)
 	}
 
-	if len(all) < maxMessages { // drain if there are excess credits
-		log.Writef(EventReceiver, "Draining to clear %d credits", maxMessages-len(all))
-
-		drainCtx, drainCtxcancel := context.WithTimeout(context.Background(), r.defaultDrainTimeout)
-		defer drainCtxcancel()
-
-		// Start the drain asynchronously. Note that we ignore the user's context at this point
-		// since draining makes sure we don't get messages when nobody is receiving.
-		if err := linksWithID.Receiver.DrainCredit(drainCtx); err != nil {
-			// Cancelling a DrainCredit means we're in an indeterminate state
-			// so we treat that as a "must recover" error.
-			cleanup(err)
-
-			if internal.IsCancelError(err) {
-				log.Writef(EventReceiver, "Drain didn't complete in %s, link was recreated", r.defaultDrainTimeout)
-
-				// this cancellation is entirely on us - we cleaned up as best we can
-				// but the user isn't expected to know about this detail so we don't
-				// return the cancellation error.
-				err = nil
-			}
-
-			return flushAndReturn(err)
+	if len(result.Messages) == 0 {
+		// If we didn't receive any messages then we don't need to do anything special
+		// here - they can just have the error.
+		// We do this to avoid the situation where we return both an error _and_ messages,
+		// which would be non-iodmatic since most people will just bail out when they see
+		// that 'err != nil'.
+		if internal.IsCancelError(result.Error) || rk == internal.RecoveryKindFatal {
+			return nil, result.Error
 		}
 
-		return flushAndReturn(ctx.Err())
+		return nil, nil
 	}
 
-	// we only get here if we got exactly the # of messages they asked for
-	// in the initial set of link.Receive() calls above.
-	log.Writef(EventReceiver, "Received %d/%d messages", len(all), maxMessages)
-	return all, nil
-}
+	var receivedMessages []*ReceivedMessage
 
-func fetchMessages(ctx context.Context, receiver internal.AMQPReceiver, maxMessages int, defaultTimeAfterFirstMessage time.Duration, messages *[]*ReceivedMessage) error {
-	log.Writef(EventReceiver, "Fetching messages, issuing %d credits", maxMessages)
-
-	if err := receiver.IssueCredit(uint32(maxMessages)); err != nil {
-		return err
+	for _, msg := range result.Messages {
+		receivedMessages = append(receivedMessages, newReceivedMessage(msg))
 	}
 
-	var cancel context.CancelFunc
-
-	for {
-		amqpMessage, err := receiver.Receive(ctx)
-
-		if err != nil {
-			return err
-		}
-
-		*messages = append(*messages, newReceivedMessage(amqpMessage))
-
-		if len(*messages) == maxMessages {
-			return nil
-		}
-
-		if cancel == nil {
-			// replace the context that we're using for everything with a new one that will cancel
-			// after a period of time.
-			ctx, cancel = context.WithTimeout(ctx, defaultTimeAfterFirstMessage)
-			defer cancel()
-		}
-	}
-}
-
-// flushPrefetchedMessages makes a best-effort attempt at flushing the internal channel for the link. This is
-// a purely in-memory operation so should work even if the link itself has failed.
-func flushPrefetchedMessages(receiver internal.AMQPReceiver, messages *[]*ReceivedMessage) {
-	count := 0
-	defer func() {
-		if count > 0 {
-			log.Writef(EventReceiver, "Flushed %d messages from receiver's internal cache", count)
-		}
-	}()
-
-	for {
-		am := receiver.Prefetched()
-
-		if am == nil {
-			return
-		}
-
-		*messages = append(*messages, newReceivedMessage(am))
-		count++
-	}
+	return receivedMessages, nil
 }
 
 type entity struct {
@@ -558,4 +491,141 @@ func checkReceiverMode(receiveMode ReceiveMode) error {
 	}
 
 	return fmt.Errorf("invalid receive mode %d, must be either azservicebus.PeekLock or azservicebus.ReceiveAndDelete", receiveMode)
+}
+
+// fetchMessagesResult is the result from a fetchMessages
+// call. Note that you can get both an error and messages!
+type fetchMessagesResult struct {
+	Messages []*amqp.Message
+	Error    error
+}
+
+// fetchMessages receives messages, blocking indefinitely until at least one
+// message arrives, the parentCtx parameter is cancelled, or the receiver itself
+// is disconnected from Service Bus.
+//
+// Note, if you want to only receive prefetched messages send the parentCtx in
+// pre-cancelled. This will cause us to only flush the prefetch buffer.
+func (r *Receiver) fetchMessages(parentCtx context.Context, receiver amqpwrap.AMQPReceiver, count int, timeAfterFirstMessage time.Duration) fetchMessagesResult {
+	firstMsg, err := receiver.Receive(parentCtx)
+
+	if err != nil {
+		// drain the prefetch buffer - we're stopping because of a
+		// failure on the link/connection _or_ the user cancelled the
+		// operation.
+		return fetchMessagesResult{
+			Error: err,
+			// Since our link is always active it's possible some
+			// messages were sitting in the prefetched buffer from before
+			//
+			// This particularly affects us in ReceiveAndDelete mode since we
+			// can't release those messages since they come presettled.
+			Messages: getAllPrefetched(receiver, count),
+		}
+	}
+
+	messages := []*amqp.Message{firstMsg}
+
+	// after we get one message we will try to receive as much as we can
+	// during the `timeAfterFirstMessage` duration.
+	ctx, cancel := context.WithTimeout(parentCtx, timeAfterFirstMessage)
+	defer cancel()
+
+	var lastErr error
+
+	for i := 0; i < count-1; i++ {
+		msg, err := receiver.Receive(ctx)
+
+		if err != nil {
+			lastErr = err
+			break
+		}
+
+		messages = append(messages, msg)
+	}
+
+	// drain the prefetch buffer - we're stopping because of a
+	// failure on the link/connection _or_ the user cancelled the
+	// operation.
+	messages = append(messages, getAllPrefetched(receiver, count-len(messages))...)
+
+	if internal.IsCancelError(lastErr) {
+		return fetchMessagesResult{
+			Messages: messages,
+			// we might have cancelled here (because we stop receiving after `timeAfterFirstMessage` expires)
+			// or _they_ cancelled the ReceiveMessages() call.
+			//
+			// If we cancel: we want a nil error since there's no failure. In that case parentCtx.Err() is nil
+			// If they cancel: we want to forward on their cancellation error.
+			Error: parentCtx.Err(),
+		}
+	} else {
+		return fetchMessagesResult{
+			Error:    lastErr,
+			Messages: messages,
+		}
+	}
+}
+
+// newReleaserFunc creates a function
+// The returned function will block
+func (r *Receiver) newReleaserFunc(receiver amqpwrap.AMQPReceiver) func() {
+	if r.receiveMode == ReceiveModeReceiveAndDelete {
+		// you can't disposition messages that are received in this mode - these messages
+		// are "presettled".
+		return func() {}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	released := 0
+
+	r.cancelReleaser.Store(func() string {
+		cancel()
+		<-done
+		return receiver.LinkName()
+	})
+
+	return func() {
+		defer close(done)
+
+		log.Writef(EventReceiver, "[%s] Message releaser starting...", receiver.LinkName())
+
+		for {
+			// we might not have all the messages we need here.
+			msg, err := receiver.Receive(ctx)
+
+			if err == nil {
+				err = receiver.ReleaseMessage(ctx, msg)
+			}
+
+			if err == nil {
+				released++
+			}
+
+			if internal.IsCancelError(err) {
+				log.Writef(exported.EventConn, "[%s] Message releaser pausing. Released %d messages", receiver.LinkName(), released)
+				break
+			} else if internal.GetRecoveryKind(err) != internal.RecoveryKindNone {
+				log.Writef(exported.EventConn, "[%s] Message releaser stopping because of link failure. Released %d messages. Will start again after next receive: %s", receiver.LinkName(), released, err)
+				break
+			}
+		}
+	}
+}
+
+func getAllPrefetched(receiver amqpwrap.AMQPReceiver, max int) []*amqp.Message {
+	var messages []*amqp.Message
+
+	for i := 0; i < max; i++ {
+		msg := receiver.Prefetched()
+
+		if msg == nil {
+			break
+		}
+
+		messages = append(messages, msg)
+	}
+
+	return messages
 }

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -391,9 +391,7 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 
 	result := r.fetchMessages(ctx, linksWithID.Receiver, maxMessages, r.defaultTimeAfterFirstMsg)
 
-	if result.Messages != nil {
-		log.Writef(EventReceiver, "Received %d/%d messages", len(result.Messages), maxMessages)
-	}
+	log.Writef(EventReceiver, "Received %d/%d messages", len(result.Messages), maxMessages)
 
 	// this'll only close anything if the error indicates that the link/connection is bad.
 	// it's safe to call with cancellation errors.

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -623,10 +623,10 @@ func (r *Receiver) newReleaserFunc(receiver amqpwrap.AMQPReceiver) func() {
 			}
 
 			if internal.IsCancelError(err) {
-				log.Writef(exported.EventConn, "[%s] Message releaser pausing. Released %d messages", receiver.LinkName(), released)
+				log.Writef(exported.EventReceiver, "[%s] Message releaser pausing. Released %d messages", receiver.LinkName(), released)
 				break
 			} else if internal.GetRecoveryKind(err) != internal.RecoveryKindNone {
-				log.Writef(exported.EventConn, "[%s] Message releaser stopping because of link failure. Released %d messages. Will start again after next receive: %s", receiver.LinkName(), released, err)
+				log.Writef(exported.EventReceiver, "[%s] Message releaser stopping because of link failure. Released %d messages. Will start again after next receive: %s", receiver.LinkName(), released, err)
 				break
 			}
 		}

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -380,7 +380,7 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 	log.Writef(EventReceiver, "Asking for %d credits", maxMessages)
 
 	if creditsToIssue > 0 {
-		log.Writef(EventReceiver, "Only need to issue %d additional credits", maxMessages)
+		log.Writef(EventReceiver, "Only need to issue %d additional credits", creditsToIssue)
 
 		if err := linksWithID.Receiver.IssueCredit(uint32(creditsToIssue)); err != nil {
 			return nil, err

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -6,12 +6,15 @@ package azservicebus
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/amqpwrap"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/go-amqp"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +26,11 @@ func TestReceiver_ReceiveMessages_AMQPLinksFailure(t *testing.T) {
 	receiver := &Receiver{
 		amqpLinks:   fakeAMQPLinks,
 		receiveMode: ReceiveModePeekLock,
+		// TODO: need to make this test rely less on stubbing.
+		cancelReleaser: &atomic.Value{},
 	}
+
+	receiver.cancelReleaser.Store(emptyCancelFn)
 
 	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.Equal(t, internal.RecoveryKindFatal, internal.GetRecoveryKind(err))
@@ -66,13 +73,9 @@ func TestReceiver_ReceiveMessages_SomeMessagesAndCancelled(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, []string{"hello"}, getSortedBodies(messages))
 
-			// check that we did attempt to flush the prefetch cache
-			require.Equal(t, 1, fakeAMQPReceiver.DrainCalled, "drain is called")
-			require.Equal(t, 1, fakeAMQPReceiver.PrefetchedCalled, "prefetched is called")
-
 			// and the links did not need to be closed for a cancellation
 			require.Equal(t, 0, fakeAMQPLinks.Closed)
-			require.Equal(t, 0, fakeAMQPLinks.CloseIfNeededCalled)
+			require.Equal(t, 1, fakeAMQPLinks.CloseIfNeededCalled)
 		})
 	}
 }
@@ -115,7 +118,6 @@ func TestReceiver_ReceiveMessages_NoMessagesReceivedAndError(t *testing.T) {
 				require.EqualValues(t, data.Expected, err)
 				require.Empty(t, messages)
 
-				require.Equal(t, 0, fakeAMQPReceiver.DrainCalled, "didn't drain on a broken link/connection")
 				require.Equal(t, 1, fakeAMQPReceiver.PrefetchedCalled, "prefetched before throwing away the broken link")
 
 				// a fatal error happened, links should be closed.
@@ -123,106 +125,6 @@ func TestReceiver_ReceiveMessages_NoMessagesReceivedAndError(t *testing.T) {
 				require.Equal(t, 1, fakeAMQPLinks.CloseIfNeededCalled, "links are closed on receive errors")
 			})
 		}
-	}
-}
-
-func TestReceiver_ReceiveMessages_DrainTimeout_SomeMessagesReceived(t *testing.T) {
-	// all the receive modes work the same when there are no messages
-	for _, mode := range receiveModesForTests {
-		t.Run(mode.Name, func(t *testing.T) {
-			fakeAMQPReceiver := &internal.FakeAMQPReceiver{
-				ReceiveResults: []struct {
-					M *amqp.Message
-					E error
-				}{
-					// we're 1 message short, so we'll need to drain and we're going
-					// to make that "hang" so it's cancelled.
-					{M: &amqp.Message{Data: [][]byte{[]byte("hello")}}},
-					{E: context.DeadlineExceeded},
-				},
-				DrainCreditImpl: func(ctx context.Context) error {
-					// simulate the "drain never comes back" situation.
-					// We have a timer now that stops it from hanging forever.
-					<-ctx.Done()
-					return ctx.Err()
-				},
-			}
-
-			fakeAMQPLinks := &internal.FakeAMQPLinks{
-				Receiver: fakeAMQPReceiver,
-			}
-
-			receiver, err := newReceiver(newReceiverArgs{
-				ns:     &internal.FakeNS{AMQPLinks: fakeAMQPLinks},
-				entity: entity{Queue: "queue"},
-			}, &ReceiverOptions{ReceiveMode: mode.Val})
-			require.NoError(t, err)
-
-			messages, err := receiver.ReceiveMessages(context.Background(), 2, nil)
-			require.Equal(t, 1, fakeAMQPReceiver.DrainCalled, "drain was called")
-
-			// in ReceiveAndDelete mode we make sure we return any messages we've retrieved,
-			// even if that means "erasing" the error.
-			require.NoError(t, err)
-			require.Equal(t, []string{"hello"}, getSortedBodies(messages))
-
-			// since ReceiveAndDelete messages would be lost we always flush any messages that might
-			// be sitting in the link before we throw the instance away.
-			require.Equal(t, 1, fakeAMQPReceiver.PrefetchedCalled, "prefetched before throwing away the broken link")
-
-			// a drain timeout means we need to close our links as we no longer know the true state of it.
-			require.Equal(t, 1, fakeAMQPLinks.Closed, "links are closed using Close(), not CloseIfNeeded()")
-			require.Equal(t, 0, fakeAMQPLinks.CloseIfNeededCalled, "links are not closed using CloseIfNeeded()")
-		})
-	}
-}
-
-func TestReceiver_ReceiveMessages_DrainTimeout_NoMessagesReceived(t *testing.T) {
-	// When no messages are received we enter into a separate flow where we are deciding
-	// if we want to return the error or not.
-	for _, mode := range receiveModesForTests {
-		t.Run(mode.Name, func(t *testing.T) {
-			fakeAMQPReceiver := &internal.FakeAMQPReceiver{
-				ReceiveResults: []struct {
-					M *amqp.Message
-					E error
-				}{
-					{E: context.DeadlineExceeded},
-				},
-				DrainCreditImpl: func(ctx context.Context) error {
-					// simulate the "drain never comes back" situation.
-					// We have a timer now that stops it from hanging forever.
-					<-ctx.Done()
-					return ctx.Err()
-				},
-			}
-
-			fakeAMQPLinks := &internal.FakeAMQPLinks{
-				Receiver: fakeAMQPReceiver,
-			}
-
-			receiver, err := newReceiver(newReceiverArgs{
-				ns:     &internal.FakeNS{AMQPLinks: fakeAMQPLinks},
-				entity: entity{Queue: "queue"},
-			}, &ReceiverOptions{ReceiveMode: mode.Val})
-			require.NoError(t, err)
-
-			messages, err := receiver.ReceiveMessages(context.Background(), 2, nil)
-			// the timeout occurred in drain. This isn't fatal to the user, even if we received
-			// _no_ messages.
-			require.NoError(t, err)
-			require.Empty(t, messages)
-
-			require.Equal(t, 1, fakeAMQPReceiver.DrainCalled, "drain was called")
-
-			// since ReceiveAndDelete messages would be lost we always flush any messages that might
-			// be sitting in the link before we throw the instance away.
-			require.Equal(t, 1, fakeAMQPReceiver.PrefetchedCalled, "prefetched before throwing away the broken link")
-
-			// a drain timeout means we need to close our links as we no longer know the true state of it.
-			require.Equal(t, 1, fakeAMQPLinks.Closed, "links are closed using Close(), not CloseIfNeeded()")
-			require.Equal(t, 0, fakeAMQPLinks.CloseIfNeededCalled, "links are not closed using CloseIfNeeded()")
-		})
 	}
 }
 
@@ -253,13 +155,9 @@ func TestReceiver_ReceiveMessages_AllMessagesReceived(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, []string{"hello", "world"}, getSortedBodies(messages))
 
-			// no flushing needed, all messages were received in the normal `Receive()` loop.
-			require.Equal(t, 0, fakeAMQPReceiver.DrainCalled, "drain is called")
-			require.Equal(t, 0, fakeAMQPReceiver.PrefetchedCalled, "prefetched is called")
-
 			// and the links did not need to be closed for a cancellation
 			require.Equal(t, 0, fakeAMQPLinks.Closed)
-			require.Equal(t, 0, fakeAMQPLinks.CloseIfNeededCalled)
+			require.Equal(t, 1, fakeAMQPLinks.CloseIfNeededCalled, "called, but with a benign error")
 		})
 	}
 }
@@ -289,11 +187,6 @@ func TestReceiver_ReceiveMessages_SomeMessagesAndError(t *testing.T) {
 	require.Equal(t, []string{"hello"}, getSortedBodies(messages))
 	require.NoError(t, err, "error is 'erased' when there are some messages to return")
 
-	// we should NOT bother flushing the prefetch cache here - we're going to invalidate
-	// the link and we don't need to delay returning messages to the customer.
-	require.Equal(t, 0, fakeAMQPReceiver.DrainCalled, "didn't drain on a broken link/connection")
-	require.Equal(t, 1, fakeAMQPReceiver.PrefetchedCalled, "prefet")
-
 	// a fatal error happened, links should be closed.
 	require.Equal(t, 0, fakeAMQPLinks.Closed, "links are closed using CloseIfNeeded")
 	require.Equal(t, 1, fakeAMQPLinks.CloseIfNeededCalled, "prefetch is called")
@@ -305,7 +198,10 @@ func TestReceiverCancellationUnitTests(t *testing.T) {
 			amqpLinks: &internal.FakeAMQPLinks{
 				Receiver: &internal.FakeAMQPReceiver{},
 			},
+			cancelReleaser: &atomic.Value{},
 		}
+
+		r.cancelReleaser.Store(emptyCancelFn)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -329,7 +225,10 @@ func TestReceiverCancellationUnitTests(t *testing.T) {
 					},
 				},
 			},
+			cancelReleaser: &atomic.Value{},
 		}
+
+		r.cancelReleaser.Store(emptyCancelFn)
 
 		msgs, err := r.ReceiveMessages(ctx, 95, nil)
 		require.Empty(t, msgs)
@@ -433,4 +332,442 @@ func TestReceiver_UserFacingErrors(t *testing.T) {
 	require.Empty(t, messages)
 	require.ErrorAs(t, err, &asSBError)
 	require.Equal(t, CodeLockLost, asSBError.Code)
+}
+
+func TestReceiver_releaserFunc(t *testing.T) {
+	receiver, err := newReceiver(defaultNewReceiverArgsForTest(), nil)
+	require.NoError(t, err)
+
+	successfulReleases := 0
+
+	amqpReceiver := internal.FakeAMQPReceiver{
+		ReceiveFn: func(ctx context.Context) (*amqp.Message, error) {
+			return &amqp.Message{
+				Data: [][]byte{[]byte("hello")},
+			}, nil
+		},
+		ReleaseMessageFn: func(ctx context.Context, msg *amqp.Message) error {
+			require.Equal(t, "hello", string(msg.Data[0]))
+			successfulReleases++
+			go receiver.cancelReleaser.Load().(func() string)()
+			return nil
+		},
+	}
+
+	logsFn := test.CaptureLogsForTest()
+
+	releaserFn := receiver.newReleaserFunc(&amqpReceiver)
+	releaserFn()
+
+	// some non-determinism since we launched the cancel asynchronously
+	// but we'll get at least one.
+	require.LessOrEqual(t, 1, amqpReceiver.ReceiveCalled)
+	require.LessOrEqual(t, 1, amqpReceiver.ReleaseMessageCalled)
+
+	require.Equal(t, []string{
+		fmt.Sprintf("[azsb.Conn] Message releaser pausing. Released %d messages", successfulReleases),
+	}, logsFn())
+}
+
+func TestReceiver_releaserFunc_errorOnFirstMessage(t *testing.T) {
+	receiver, err := newReceiver(defaultNewReceiverArgsForTest(), nil)
+	require.NoError(t, err)
+
+	amqpReceiver := internal.FakeAMQPReceiver{
+		ReleaseMessageFn: func(ctx context.Context, msg *amqp.Message) error {
+			panic("Not called for this test since Receive() is returning an error")
+		},
+	}
+
+	amqpReceiver.ReceiveFn = func(ctx context.Context) (*amqp.Message, error) {
+		if amqpReceiver.ReceiveCalled > 2 {
+			return nil, amqp.ErrLinkClosed
+		}
+
+		// This is one of the few error types classified as RecoveryKindNone
+		// in the releaser this means we'll just retry since the link is still
+		// considered good at this point.
+		return nil, &amqp.Error{
+			Condition: amqp.ErrorCondition("com.microsoft:server-busy"),
+		}
+	}
+
+	logsFn := test.CaptureLogsForTest()
+
+	releaserFn := receiver.newReleaserFunc(&amqpReceiver)
+	releaserFn()
+
+	// we got called a few times, but none of them succeeded.
+	require.Equal(t, 2+1, amqpReceiver.ReceiveCalled)
+
+	require.Equal(t, []string{
+		fmt.Sprintf("[azsb.Conn] Message releaser stopping because of link failure. Released 0 messages. Will start again after next receive: %s", amqp.ErrLinkClosed),
+	}, logsFn())
+}
+
+func TestReceiver_releaserFunc_receiveAndDeleteIsNoop(t *testing.T) {
+	receiver, err := newReceiver(defaultNewReceiverArgsForTest(), &ReceiverOptions{
+		ReceiveMode: ReceiveModeReceiveAndDelete,
+	})
+	require.NoError(t, err)
+
+	amqpReceiver := internal.FakeAMQPReceiver{
+		ReceiveFn: func(ctx context.Context) (*amqp.Message, error) {
+			panic("Should not be used in this test")
+		},
+		ReleaseMessageFn: func(ctx context.Context, msg *amqp.Message) error {
+			panic("Should not be used in this test")
+		},
+	}
+
+	releaserFn := receiver.newReleaserFunc(&amqpReceiver)
+
+	// cancelling is still the empty function
+	cancelFn := receiver.cancelReleaser.Load().(func() string)
+	require.Equal(t, "empty", cancelFn())
+
+	// in this case you don't need to cancel anything - it's just no-op
+	// Note it'll just exit immediately, the "releaser" doesn't block here.
+	releaserFn()
+
+	require.LessOrEqual(t, 0, amqpReceiver.ReceiveCalled)
+	require.LessOrEqual(t, 0, amqpReceiver.ReleaseMessageCalled)
+}
+
+func TestReceiver_fetchMessages_FirstMessageFailure(t *testing.T) {
+	errors := []error{amqp.ErrLinkClosed, context.Canceled}
+
+	for _, err := range errors {
+		t.Run("error: "+err.Error(), func(t *testing.T) {
+			receiver, err := newReceiver(defaultNewReceiverArgsForTest(), &ReceiverOptions{
+				ReceiveMode: ReceiveModeReceiveAndDelete,
+			})
+			require.NoError(t, err)
+
+			amqpReceiver := &internal.FakeAMQPReceiver{
+				ReceiveResults: []struct {
+					M *amqp.Message
+					E error
+				}{
+					{
+						M: nil,
+						E: amqp.ErrLinkClosed,
+					},
+				},
+				PrefetchedResults: []*amqp.Message{
+					{Data: [][]byte{[]byte(("prefetched message 1"))}},
+					{Data: [][]byte{[]byte(("prefetched message 2"))}},
+					{Data: [][]byte{[]byte(("prefetched message 3"))}},
+					// not used since we'd return too many results (they onlyu requested '3' below)
+					{Data: [][]byte{[]byte(("prefetched message 4"))}},
+				},
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			res := receiver.fetchMessages(ctx, amqpReceiver, 3, time.Hour)
+			require.ErrorIs(t, res.Error, amqp.ErrLinkClosed)
+
+			require.Equal(t, []*amqp.Message{
+				{Data: [][]byte{[]byte(("prefetched message 1"))}},
+				{Data: [][]byte{[]byte(("prefetched message 2"))}},
+				{Data: [][]byte{[]byte(("prefetched message 3"))}},
+			}, res.Messages)
+
+			// and we should have messages remaining in our prefetch
+			require.Equal(t, []*amqp.Message{
+				{Data: [][]byte{[]byte(("prefetched message 4"))}},
+			}, amqpReceiver.PrefetchedResults)
+		})
+	}
+}
+
+func TestReceiver_fetchMessages_DontOverflow(t *testing.T) {
+	receiver, err := newReceiver(defaultNewReceiverArgsForTest(), &ReceiverOptions{
+		ReceiveMode: ReceiveModeReceiveAndDelete,
+	})
+	require.NoError(t, err)
+
+	amqpReceiver := &internal.FakeAMQPReceiver{
+		ReceiveResults: []struct {
+			M *amqp.Message
+			E error
+		}{
+			{M: &amqp.Message{Data: [][]byte{[]byte(("received message 1"))}}},
+			{M: &amqp.Message{Data: [][]byte{[]byte(("received message 2"))}}},
+			{M: &amqp.Message{Data: [][]byte{[]byte(("received message 3"))}}},
+			{M: &amqp.Message{Data: [][]byte{[]byte(("<receive: will not get received here>"))}}},
+		},
+		PrefetchedResults: []*amqp.Message{
+			{Data: [][]byte{[]byte(("<prefetched: will not get used>"))}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	res := receiver.fetchMessages(ctx, amqpReceiver, 3, time.Hour)
+	require.NoError(t, res.Error)
+
+	require.Equal(t, []*amqp.Message{
+		{Data: [][]byte{[]byte(("received message 1"))}},
+		{Data: [][]byte{[]byte(("received message 2"))}},
+		{Data: [][]byte{[]byte(("received message 3"))}},
+	}, res.Messages)
+
+	require.Equal(t, 1, len(amqpReceiver.ReceiveResults))
+	require.Equal(t,
+		&amqp.Message{Data: [][]byte{[]byte(("<receive: will not get received here>"))}},
+		amqpReceiver.ReceiveResults[0].M)
+
+	require.Equal(t,
+		[]*amqp.Message{{Data: [][]byte{[]byte(("<prefetched: will not get used>"))}}},
+		amqpReceiver.PrefetchedResults)
+}
+
+func TestReceiver_fetchMessages_TimeAfterFirstMessageCancels(t *testing.T) {
+	receiver, err := newReceiver(defaultNewReceiverArgsForTest(), &ReceiverOptions{
+		ReceiveMode: ReceiveModeReceiveAndDelete,
+	})
+	require.NoError(t, err)
+
+	amqpReceiver := &internal.FakeAMQPReceiver{
+		ReceiveResults: []struct {
+			M *amqp.Message
+			E error
+		}{
+			{M: &amqp.Message{Data: [][]byte{[]byte("Received message 1")}}},
+			{M: &amqp.Message{Data: [][]byte{[]byte("Received message 2")}}},
+		},
+		PrefetchedResults: []*amqp.Message{
+			{Data: [][]byte{[]byte("Prefetched message 1")}},
+			{Data: [][]byte{[]byte("<will be ignored 1>")}},
+			{Data: [][]byte{[]byte("<will be ignored 2>")}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	timeAfterFirstMessage := time.Second
+	res := receiver.fetchMessages(ctx, amqpReceiver, 3, timeAfterFirstMessage)
+	require.NoError(t, res.Error, "No error since it was just the timeAfterFirstMessage cancellation")
+
+	require.Equal(t, []*amqp.Message{
+		{Data: [][]byte{[]byte("Received message 1")}},
+		{Data: [][]byte{[]byte("Received message 2")}},
+		{Data: [][]byte{[]byte("Prefetched message 1")}},
+	}, res.Messages)
+
+	require.Empty(t, 0, len(amqpReceiver.ReceiveResults))
+	require.Equal(t,
+		[]*amqp.Message{
+			{Data: [][]byte{[]byte("<will be ignored 1>")}},
+			{Data: [][]byte{[]byte("<will be ignored 2>")}},
+		},
+		amqpReceiver.PrefetchedResults)
+}
+
+func TestReceiver_fetchMessages_UserCancelsAfterFirstMessage(t *testing.T) {
+	receiver, err := newReceiver(defaultNewReceiverArgsForTest(), &ReceiverOptions{
+		ReceiveMode: ReceiveModeReceiveAndDelete,
+	})
+	require.NoError(t, err)
+
+	testMessages := []*amqp.Message{
+		{Data: [][]byte{[]byte("Received message 1")}},
+		{Data: [][]byte{[]byte("Received message 2")}},
+	}
+
+	usersCtx, cancelUsersCtx := context.WithCancel(context.Background())
+	defer cancelUsersCtx()
+
+	amqpReceiver := &internal.FakeAMQPReceiver{
+		ReceiveFn: func(ctx context.Context) (*amqp.Message, error) {
+			msg := testMessages[0]
+			testMessages = testMessages[1:]
+
+			if len(testMessages) == 0 {
+				cancelUsersCtx()
+			}
+
+			return msg, nil
+		},
+		PrefetchedResults: []*amqp.Message{
+			{Data: [][]byte{[]byte("Prefetched message 1")}},
+			{Data: [][]byte{[]byte("<will be ignored 1>")}},
+			{Data: [][]byte{[]byte("<will be ignored 2>")}},
+		},
+	}
+
+	timeAfterFirstMessage := time.Second
+	res := receiver.fetchMessages(usersCtx, amqpReceiver, 3, timeAfterFirstMessage)
+	require.ErrorIs(t, res.Error, context.Canceled, "Users cancellation error is propagated")
+
+	require.Equal(t, []*amqp.Message{
+		{Data: [][]byte{[]byte("Received message 1")}},
+		{Data: [][]byte{[]byte("Received message 2")}},
+		{Data: [][]byte{[]byte("Prefetched message 1")}},
+	}, res.Messages)
+
+	require.Empty(t, 0, len(amqpReceiver.ReceiveResults))
+	require.Equal(t,
+		[]*amqp.Message{
+			{Data: [][]byte{[]byte("<will be ignored 1>")}},
+			{Data: [][]byte{[]byte("<will be ignored 2>")}},
+		},
+		amqpReceiver.PrefetchedResults)
+}
+
+func TestReceiver_ReceiveMessages_RollingCredits_NoMessages(t *testing.T) {
+	amqpReceiver := &internal.FakeAMQPReceiver{
+		ReceiveResults: nil,
+	}
+
+	args := defaultNewReceiverArgsForTest()
+
+	ns := args.ns.(*internal.FakeNS)
+	ns.AMQPLinks = &internal.FakeAMQPLinks{
+		Receiver: amqpReceiver,
+	}
+
+	receiver, err := newReceiver(args, &ReceiverOptions{
+		ReceiveMode: ReceiveModeReceiveAndDelete,
+	})
+	require.NoError(t, err)
+
+	t.Run("no initial credits, must issue new credit", func(t *testing.T) {
+		amqpReceiver.ReceiveResults = []struct {
+			M *amqp.Message
+			E error
+		}{
+			{M: &amqp.Message{Data: [][]byte{[]byte("Received message 1")}}},
+			{E: context.Canceled},
+		}
+
+		messages, err := receiver.ReceiveMessages(context.Background(), 10, nil)
+		require.NoError(t, err, "User didn't cancel so cancellation is erased")
+		require.Equal(t, []string{"Received message 1"}, getSortedBodies(messages))
+
+		// note, our AMQPReceiver is a stub so the credits here are whatever
+		// RecieveMessages() actually just IssueCredit'd.
+		require.Equal(t, uint32(10), amqpReceiver.Credits())
+		require.Empty(t, amqpReceiver.ReceiveResults)
+	})
+
+	t.Run("existing credit, but not enough to cover all the requested credits", func(t *testing.T) {
+		amqpReceiver.ReceiveResults = []struct {
+			M *amqp.Message
+			E error
+		}{
+			{M: &amqp.Message{Data: [][]byte{[]byte("Received message 2")}}},
+			{E: context.Canceled},
+		}
+
+		// now this time we have 10 credits, so our next receive won't need to add as many
+		messages, err := receiver.ReceiveMessages(context.Background(), 101, nil)
+		require.NoError(t, err, "User didn't cancel so cancellation is erased")
+		require.Equal(t, []string{"Received message 2"}, getSortedBodies(messages))
+
+		require.Equal(t, uint32(10)+uint32(101-10), amqpReceiver.Credits(), "Credits includes the existing credits on the line and adds more to make up the difference to get to 101")
+		require.Empty(t, amqpReceiver.ReceiveResults)
+	})
+
+	t.Run("credits on the line are already enough to cover our request", func(t *testing.T) {
+		amqpReceiver.ReceiveResults = []struct {
+			M *amqp.Message
+			E error
+		}{
+			{M: &amqp.Message{Data: [][]byte{[]byte("Received message 3")}}},
+			{E: context.Canceled},
+		}
+
+		// now we're going to request messages but this time our current credit should cover it
+		messages, err := receiver.ReceiveMessages(context.Background(), 5, nil)
+		require.NoError(t, err, "User didn't cancel so cancellation is erased")
+		require.Equal(t, []string{"Received message 3"}, getSortedBodies(messages))
+
+		require.Equal(t, uint32(101), amqpReceiver.Credits(), "No new credit needed to be issued - existing credits cover it all")
+
+		require.NoError(t, receiver.Close(context.Background()))
+	})
+}
+
+func TestReceiver_ReceiveMessages_MessagesArrivingBetweenReceiveMessagesCallsAreReleased(t *testing.T) {
+	released := make(chan *amqp.Message, 2)
+
+	amqpReceiver := &internal.FakeAMQPReceiver{
+		ReceiveResults: []struct {
+			M *amqp.Message
+			E error
+		}{
+			{M: &amqp.Message{Data: [][]byte{[]byte(("received message 1"))}}},
+			{M: &amqp.Message{Data: [][]byte{[]byte(("received message 2"))}}},
+
+			// our expectation is that the messageReleaser will pick these up
+			{M: &amqp.Message{Data: [][]byte{[]byte(("will be released 1"))}}},
+			{M: &amqp.Message{Data: [][]byte{[]byte(("will be released 2"))}}},
+		},
+		ReleaseMessageFn: func(ctx context.Context, msg *amqp.Message) error {
+			select {
+			case released <- msg:
+			default:
+				require.Fail(t, "More messages were released than expected")
+			}
+			return nil
+		},
+	}
+
+	args := defaultNewReceiverArgsForTest()
+
+	ns := args.ns.(*internal.FakeNS)
+	ns.AMQPLinks = &internal.FakeAMQPLinks{
+		Receiver: amqpReceiver,
+	}
+
+	receiver, err := newReceiver(args, &ReceiverOptions{
+		ReceiveMode: ReceiveModePeekLock,
+	})
+	require.NoError(t, err)
+
+	messages, err := receiver.ReceiveMessages(context.Background(), 2, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"received message 1", "received message 2"}, getSortedBodies(messages))
+
+	// now, we can just wait - the messages will be drained by the background goroutine.
+	for i := 0; i < 2; i++ {
+		msg := <-released
+		require.Equal(t, fmt.Sprintf("will be released %d", i+1), string(msg.Data[0]))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// there aren't any messages in there now since they were all released by
+	// the messageReleaser.
+	messages, err = receiver.ReceiveMessages(ctx, 1, nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Empty(t, messages)
+
+	// closing also shuts down the releaser
+	err = receiver.Close(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, amqpReceiver.ReceiveResults)
+	require.Equal(t, 2, amqpReceiver.ReleaseMessageCalled)
+}
+
+func defaultNewReceiverArgsForTest() newReceiverArgs {
+	return newReceiverArgs{
+		entity: entity{
+			Queue: "queue",
+		},
+		ns:                  &internal.FakeNS{},
+		cleanupOnClose:      func() {},
+		getRecoveryKindFunc: internal.GetRecoveryKind,
+		newLinkFn: func(ctx context.Context, session amqpwrap.AMQPSession) (internal.AMQPSenderCloser, internal.AMQPReceiverCloser, error) {
+			return nil, nil, nil
+		},
+		retryOptions: exported.RetryOptions{},
+	}
 }

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -364,9 +364,10 @@ func TestReceiver_releaserFunc(t *testing.T) {
 	require.LessOrEqual(t, 1, amqpReceiver.ReceiveCalled)
 	require.LessOrEqual(t, 1, amqpReceiver.ReleaseMessageCalled)
 
-	require.Equal(t, []string{
-		fmt.Sprintf("[azsb.Conn] Message releaser pausing. Released %d messages", successfulReleases),
-	}, logsFn())
+	require.Contains(t,
+		logsFn(),
+		fmt.Sprintf("[azsb.Receiver] [fakelink] Message releaser pausing. Released %d messages", successfulReleases),
+	)
 }
 
 func TestReceiver_releaserFunc_errorOnFirstMessage(t *testing.T) {
@@ -400,9 +401,9 @@ func TestReceiver_releaserFunc_errorOnFirstMessage(t *testing.T) {
 	// we got called a few times, but none of them succeeded.
 	require.Equal(t, 2+1, amqpReceiver.ReceiveCalled)
 
-	require.Equal(t, []string{
-		fmt.Sprintf("[azsb.Conn] Message releaser stopping because of link failure. Released 0 messages. Will start again after next receive: %s", amqp.ErrLinkClosed),
-	}, logsFn())
+	require.Contains(t,
+		logsFn(),
+		fmt.Sprintf("[azsb.Receiver] [fakelink] Message releaser stopping because of link failure. Released 0 messages. Will start again after next receive: %s", amqp.ErrLinkClosed))
 }
 
 func TestReceiver_releaserFunc_receiveAndDeleteIsNoop(t *testing.T) {


### PR DESCRIPTION
Changing Receiver.ReceiveMessages() from the existing implementation, which uses AMQP's flow+drain to doing amqp.Release() on messages that arrive when there is not an active listener.
    
It seems particularly hard for our AMQP stack to properly recover if we drain and then have to cancel, which can happen in some cases where the drain ACK takes a longer time to arrive. Switching over to simply releasing messages when there's not an active ReceiveMessages() call allows us to avoid waiting for the ACK (faster exit) as well as allowing us to keep the link alive for longer, which also avoids some scenarios where the link would get closed.

This change also modifies some stress tests that help demonstrate this problem and show that it now works properly.