### PR TITLE
(ARMSubscription) fixes Azure/azure-sdk-for-go#18620

### DIFF
--- a/sdk/resourcemanager/subscription/armsubscription/zz_generated_models.go
+++ b/sdk/resourcemanager/subscription/armsubscription/zz_generated_models.go
@@ -462,6 +462,12 @@ type Subscription struct {
 
 	// READ-ONLY; The subscription ID.
 	SubscriptionID *string `json:"subscriptionId,omitempty" azure:"ro"`
+	
+	// READ-ONLY; The Tenant ID.
+        SubscriptionTenantID *string `json:"subscriptionTenantId,omitempty" azure:"ro"`
+	
+	// READ-ONLY; The Tags.
+        Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
 }
 
 // SubscriptionsClientGetOptions contains the optional parameters for the SubscriptionsClient.Get method.


### PR DESCRIPTION
fixes Azure/azure-sdk-for-go#18620

The subscriptions Model struct includes a number of fields, but not all the fields available in the REST API according to the documentation. Specifically, the following fields are missing in the Go struct:

tenantId - The subscription tenant ID.
tags - The tags attached to the subscription.

Note that these fields are returned by the API and are documented here: https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list?tabs=HTTP#subscription

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
