### PR TITLE
{AzureSubscription} Fixes Azure/azure-sdk-for-go#18619

### DIFF
--- a/services/subscription/mgmt/2020-09-01/subscription/models.go
+++ b/services/subscription/mgmt/2020-09-01/subscription/models.go
@@ -462,6 +462,20 @@ type TenantIDDescription struct {
 	ID *string `json:"id,omitempty"`
 	// TenantID - READ-ONLY; The tenant ID. For example, 00000000-0000-0000-0000-000000000000.
 	TenantID *string `json:"tenantId,omitempty"`
+        // TenantCategory - READ-ONLY; Category of the tenant. Possible values include: 'TenantCategoryHome', 'TenantCategoryProjectedBy', 'TenantCategoryManagedBy'
+	TenantCategory TenantCategory `json:"tenantCategory,omitempty"`
+	// Country - READ-ONLY; Country/region name of the address for the tenant.
+	Country *string `json:"country,omitempty"`
+	// CountryCode - READ-ONLY; Country/region abbreviation for the tenant.
+	CountryCode *string `json:"countryCode,omitempty"`
+	// DisplayName - READ-ONLY; The display name of the tenant.
+	DisplayName *string `json:"displayName,omitempty"`
+	// Domains - READ-ONLY; The list of domains for the tenant.
+	Domains *[]string `json:"domains,omitempty"`
+	// DefaultDomain - READ-ONLY; The default domain for the tenant.
+	DefaultDomain *string `json:"defaultDomain,omitempty"`
+	// TenantType - READ-ONLY; The tenant type. Only available for 'Home' tenant category.
+	TenantType *string `json:"tenantType,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for TenantIDDescription.


### PR DESCRIPTION
Fixes Azure/azure-sdk-for-go#18619

The TenantIDDescription struct returned by calls to TenantsClient.ListComplete contains only two fields: ID and TenantID:

However, the underlying API returns many more useful fields, including countryCode, displayName, domains, tenantCategory defaultDomain and tenantType. It would be great if these fields could also be made accessible through the Go SDK.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
