### PR TITLE
Add options type for Key Vault clients

### DIFF
--- a/sdk/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/keyvault/azcertificates/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Release History
 
-## 0.6.0 (Unreleased)
-
-### Features Added
+## 0.6.0 (2022-08-09)
 
 ### Breaking Changes
 * Changed type of `NewClient` options parameter to `azcertificates.ClientOptions`, which embeds

--- a/sdk/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/keyvault/azcertificates/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Release History
 
-## 0.5.1 (Unreleased)
+## 0.6.0 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
+* Changed type of `NewClient` options parameter to `azcertificates.Options`, which embeds
+  the former type, `azcore.ClientOptions`
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/keyvault/azcertificates/CHANGELOG.md
@@ -6,10 +6,6 @@
 * Changed type of `NewClient` options parameter to `azcertificates.ClientOptions`, which embeds
   the former type, `azcore.ClientOptions`
 
-### Bugs Fixed
-
-### Other Changes
-
 ## 0.5.0 (2022-07-07)
 
 ### Breaking Changes

--- a/sdk/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/keyvault/azcertificates/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
-* Changed type of `NewClient` options parameter to `azcertificates.Options`, which embeds
+* Changed type of `NewClient` options parameter to `azcertificates.ClientOptions`, which embeds
   the former type, `azcore.ClientOptions`
 
 ### Bugs Fixed

--- a/sdk/keyvault/azcertificates/custom_client.go
+++ b/sdk/keyvault/azcertificates/custom_client.go
@@ -15,15 +15,15 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal"
 )
 
-// Options contains optional settings for Client.
-type Options struct {
+// ClientOptions contains optional settings for Client.
+type ClientOptions struct {
 	azcore.ClientOptions
 }
 
 // NewClient creates a client that accesses a Key Vault's certificates.
-func NewClient(vaultURL string, credential azcore.TokenCredential, options *Options) *Client {
+func NewClient(vaultURL string, credential azcore.TokenCredential, options *ClientOptions) *Client {
 	if options == nil {
-		options = &Options{}
+		options = &ClientOptions{}
 	}
 	authPolicy := internal.NewKeyVaultChallengePolicy(credential)
 	pl := runtime.NewPipeline(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, &options.ClientOptions)

--- a/sdk/keyvault/azcertificates/custom_client.go
+++ b/sdk/keyvault/azcertificates/custom_client.go
@@ -15,10 +15,18 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal"
 )
 
+// Options contains optional settings for Client.
+type Options struct {
+	azcore.ClientOptions
+}
+
 // NewClient creates a client that accesses a Key Vault's certificates.
-func NewClient(vaultURL string, credential azcore.TokenCredential, options *azcore.ClientOptions) *Client {
+func NewClient(vaultURL string, credential azcore.TokenCredential, options *Options) *Client {
+	if options == nil {
+		options = &Options{}
+	}
 	authPolicy := internal.NewKeyVaultChallengePolicy(credential)
-	pl := runtime.NewPipeline(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, options)
+	pl := runtime.NewPipeline(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, &options.ClientOptions)
 	return &Client{endpoint: vaultURL, pl: pl}
 }
 

--- a/sdk/keyvault/azcertificates/utils_test.go
+++ b/sdk/keyvault/azcertificates/utils_test.go
@@ -114,7 +114,7 @@ func startTest(t *testing.T) *azcertificates.Client {
 	})
 	transport, err := recording.NewRecordingHTTPClient(t, nil)
 	require.NoError(t, err)
-	opts := &azcertificates.Options{ClientOptions: azcore.ClientOptions{Transport: transport}}
+	opts := &azcertificates.ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}}
 	return azcertificates.NewClient(vaultURL, credential, opts)
 }
 

--- a/sdk/keyvault/azcertificates/utils_test.go
+++ b/sdk/keyvault/azcertificates/utils_test.go
@@ -114,7 +114,8 @@ func startTest(t *testing.T) *azcertificates.Client {
 	})
 	transport, err := recording.NewRecordingHTTPClient(t, nil)
 	require.NoError(t, err)
-	return azcertificates.NewClient(vaultURL, credential, &azcore.ClientOptions{Transport: transport})
+	opts := &azcertificates.Options{ClientOptions: azcore.ClientOptions{Transport: transport}}
+	return azcertificates.NewClient(vaultURL, credential, opts)
 }
 
 func getName(t *testing.T, prefix string) string {

--- a/sdk/keyvault/azcertificates/version.go
+++ b/sdk/keyvault/azcertificates/version.go
@@ -8,5 +8,5 @@ package azcertificates
 
 const (
 	moduleName = "azcertificates"
-	version    = "v0.5.1"
+	version    = "v0.6.0"
 )

--- a/sdk/keyvault/azkeys/CHANGELOG.md
+++ b/sdk/keyvault/azkeys/CHANGELOG.md
@@ -6,10 +6,6 @@
 * Changed type of `NewClient` options parameter to `azkeys.ClientOptions`, which embeds
   the former type, `azcore.ClientOptions`
 
-### Bugs Fixed
-
-### Other Changes
-
 ## 0.6.0 (2022-07-07)
 
 ### Breaking Changes

--- a/sdk/keyvault/azkeys/CHANGELOG.md
+++ b/sdk/keyvault/azkeys/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Release History
 
-## 0.7.0 (Unreleased)
-
-### Features Added
+## 0.7.0 (2022-08-09)
 
 ### Breaking Changes
 * Changed type of `NewClient` options parameter to `azkeys.ClientOptions`, which embeds

--- a/sdk/keyvault/azkeys/CHANGELOG.md
+++ b/sdk/keyvault/azkeys/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
-* Changed type of `NewClient` options parameter to `azkeys.Options`, which embeds
+* Changed type of `NewClient` options parameter to `azkeys.ClientOptions`, which embeds
   the former type, `azcore.ClientOptions`
 
 ### Bugs Fixed

--- a/sdk/keyvault/azkeys/CHANGELOG.md
+++ b/sdk/keyvault/azkeys/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Release History
 
-## 0.6.1 (Unreleased)
+## 0.7.0 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
+* Changed type of `NewClient` options parameter to `azkeys.Options`, which embeds
+  the former type, `azcore.ClientOptions`
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/azkeys/custom_client.go
+++ b/sdk/keyvault/azkeys/custom_client.go
@@ -15,10 +15,18 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal"
 )
 
+// Options contains optional settings for Client.
+type Options struct {
+	azcore.ClientOptions
+}
+
 // NewClient creates a client that accesses a Key Vault's keys.
-func NewClient(vaultURL string, credential azcore.TokenCredential, options *azcore.ClientOptions) *Client {
+func NewClient(vaultURL string, credential azcore.TokenCredential, options *Options) *Client {
+	if options == nil {
+		options = &Options{}
+	}
 	authPolicy := internal.NewKeyVaultChallengePolicy(credential)
-	pl := runtime.NewPipeline(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, options)
+	pl := runtime.NewPipeline(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, &options.ClientOptions)
 	return &Client{endpoint: vaultURL, pl: pl}
 }
 

--- a/sdk/keyvault/azkeys/custom_client.go
+++ b/sdk/keyvault/azkeys/custom_client.go
@@ -15,15 +15,15 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal"
 )
 
-// Options contains optional settings for Client.
-type Options struct {
+// ClientOptions contains optional settings for Client.
+type ClientOptions struct {
 	azcore.ClientOptions
 }
 
 // NewClient creates a client that accesses a Key Vault's keys.
-func NewClient(vaultURL string, credential azcore.TokenCredential, options *Options) *Client {
+func NewClient(vaultURL string, credential azcore.TokenCredential, options *ClientOptions) *Client {
 	if options == nil {
-		options = &Options{}
+		options = &ClientOptions{}
 	}
 	authPolicy := internal.NewKeyVaultChallengePolicy(credential)
 	pl := runtime.NewPipeline(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, &options.ClientOptions)

--- a/sdk/keyvault/azkeys/utils_test.go
+++ b/sdk/keyvault/azkeys/utils_test.go
@@ -169,7 +169,8 @@ func startTest(t *testing.T, MHSMtest bool) *azkeys.Client {
 	if MHSMtest {
 		URL = mhsmURL
 	}
-	return azkeys.NewClient(URL, credential, &azcore.ClientOptions{Transport: transport})
+	opts := &azkeys.Options{ClientOptions: azcore.ClientOptions{Transport: transport}}
+	return azkeys.NewClient(URL, credential, opts)
 }
 
 func createRandomName(t *testing.T, prefix string) string {

--- a/sdk/keyvault/azkeys/utils_test.go
+++ b/sdk/keyvault/azkeys/utils_test.go
@@ -169,7 +169,7 @@ func startTest(t *testing.T, MHSMtest bool) *azkeys.Client {
 	if MHSMtest {
 		URL = mhsmURL
 	}
-	opts := &azkeys.Options{ClientOptions: azcore.ClientOptions{Transport: transport}}
+	opts := &azkeys.ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}}
 	return azkeys.NewClient(URL, credential, opts)
 }
 

--- a/sdk/keyvault/azkeys/version.go
+++ b/sdk/keyvault/azkeys/version.go
@@ -8,5 +8,5 @@ package azkeys
 
 const (
 	moduleName = "azkeys"
-	version    = "v0.6.1"
+	version    = "v0.7.0"
 )

--- a/sdk/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/keyvault/azsecrets/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
-* Changed type of `NewClient` options parameter to `azsecrets.Options`, which embeds
+* Changed type of `NewClient` options parameter to `azsecrets.ClientOptions`, which embeds
   the former type, `azcore.ClientOptions`
 
 ### Bugs Fixed

--- a/sdk/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/keyvault/azsecrets/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Release History
 
-## 0.9.0 (Unreleased)
-
-### Features Added
+## 0.9.0 (2022-08-09)
 
 ### Breaking Changes
 * Changed type of `NewClient` options parameter to `azsecrets.ClientOptions`, which embeds

--- a/sdk/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/keyvault/azsecrets/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Release History
 
-## 0.8.1 (Unreleased)
+## 0.9.0 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
+* Changed type of `NewClient` options parameter to `azsecrets.Options`, which embeds
+  the former type, `azcore.ClientOptions`
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/keyvault/azsecrets/CHANGELOG.md
@@ -6,10 +6,6 @@
 * Changed type of `NewClient` options parameter to `azsecrets.ClientOptions`, which embeds
   the former type, `azcore.ClientOptions`
 
-### Bugs Fixed
-
-### Other Changes
-
 ## 0.8.0 (2022-07-07)
 
 ### Breaking Changes

--- a/sdk/keyvault/azsecrets/custom_client.go
+++ b/sdk/keyvault/azsecrets/custom_client.go
@@ -15,10 +15,18 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal"
 )
 
+// Options contains optional settings for Client.
+type Options struct {
+	azcore.ClientOptions
+}
+
 // NewClient creates a client that accesses a Key Vault's secrets.
-func NewClient(vaultURL string, credential azcore.TokenCredential, options *azcore.ClientOptions) *Client {
+func NewClient(vaultURL string, credential azcore.TokenCredential, options *Options) *Client {
+	if options == nil {
+		options = &Options{}
+	}
 	authPolicy := internal.NewKeyVaultChallengePolicy(credential)
-	pl := runtime.NewPipeline(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, options)
+	pl := runtime.NewPipeline(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, &options.ClientOptions)
 	return &Client{endpoint: vaultURL, pl: pl}
 }
 

--- a/sdk/keyvault/azsecrets/custom_client.go
+++ b/sdk/keyvault/azsecrets/custom_client.go
@@ -15,15 +15,15 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal"
 )
 
-// Options contains optional settings for Client.
-type Options struct {
+// ClientOptions contains optional settings for Client.
+type ClientOptions struct {
 	azcore.ClientOptions
 }
 
 // NewClient creates a client that accesses a Key Vault's secrets.
-func NewClient(vaultURL string, credential azcore.TokenCredential, options *Options) *Client {
+func NewClient(vaultURL string, credential azcore.TokenCredential, options *ClientOptions) *Client {
 	if options == nil {
-		options = &Options{}
+		options = &ClientOptions{}
 	}
 	authPolicy := internal.NewKeyVaultChallengePolicy(credential)
 	pl := runtime.NewPipeline(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, &options.ClientOptions)

--- a/sdk/keyvault/azsecrets/utils_test.go
+++ b/sdk/keyvault/azsecrets/utils_test.go
@@ -110,7 +110,7 @@ func startTest(t *testing.T) *azsecrets.Client {
 	})
 	transport, err := recording.NewRecordingHTTPClient(t, nil)
 	require.NoError(t, err)
-	opts := &azsecrets.Options{ClientOptions: azcore.ClientOptions{Transport: transport}}
+	opts := &azsecrets.ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}}
 	return azsecrets.NewClient(vaultURL, credential, opts)
 }
 

--- a/sdk/keyvault/azsecrets/utils_test.go
+++ b/sdk/keyvault/azsecrets/utils_test.go
@@ -110,7 +110,8 @@ func startTest(t *testing.T) *azsecrets.Client {
 	})
 	transport, err := recording.NewRecordingHTTPClient(t, nil)
 	require.NoError(t, err)
-	return azsecrets.NewClient(vaultURL, credential, &azcore.ClientOptions{Transport: transport})
+	opts := &azsecrets.Options{ClientOptions: azcore.ClientOptions{Transport: transport}}
+	return azsecrets.NewClient(vaultURL, credential, opts)
 }
 
 func createRandomName(t *testing.T, prefix string) string {

--- a/sdk/keyvault/azsecrets/version.go
+++ b/sdk/keyvault/azsecrets/version.go
@@ -8,5 +8,5 @@ package azsecrets
 
 const (
 	moduleName = "azsecrets"
-	version    = "v0.8.1"
+	version    = "v0.9.0"
 )


### PR DESCRIPTION
Future features will require client options, so here's a type to hold them.