### PR TITLE
Update Key Vault documentation

### DIFF
--- a/sdk/keyvault/azcertificates/README.md
+++ b/sdk/keyvault/azcertificates/README.md
@@ -1,7 +1,7 @@
 # Azure Key Vault Certificates client module for Go
 
 * Certificate management (this module) - create, manage, and deploy public and private SSL/TLS certificates
-* Cryptographic key management (([azkeys](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys))) - create, store, and control access to the keys used to encrypt your data
+* Cryptographic key management ([azkeys](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys)) - create, store, and control access to the keys used to encrypt your data
 * Secrets management ([azsecrets](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets)) - securely store and control access to tokens, passwords, certificates, API keys, and other secrets
 
 [Source code][certificates_client_src] | [Package (pkg.go.dev)][reference_docs] |  [Product documentation][keyvault_docs] | [Samples][certificates_samples]
@@ -20,91 +20,16 @@ go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
 ### Prerequisites
 
 * An [Azure subscription][azure_sub]
-* Go 1.18 or later
-* A Key Vault. If you need to create one, you can use the [Azure Cloud Shell][azure_cloud_shell] to create one with these commands (replace `"my-resource-group"` and `"my-key-vault"` with your own, unique names):
+* A supported Go version (the Azure SDK supports the two most recent Go releases)
+* A Key Vault. If you need to create one, see the Key Vault documentation for instructions on doing so in the [Azure Portal][azure_keyvault_portal] or with the [Azure CLI][azure_keyvault_cli].
 
-  (Optional) if you want a new resource group to hold the Key Vault:
-  ```sh
-  az group create --name my-resource-group --location westus2
-  ```
+### Authentication
 
-  Create the Key Vault:
-  ```Bash
-  az keyvault create --resource-group my-resource-group --name my-key-vault
-  ```
+This document demonstrates using [azidentity.NewDefaultAzureCredential][default_cred_ref] to authenticate. This credential type works in both local development and production environments. We recommend using a [managed identity][managed_identity] in production.
 
-  Output:
-  ```json
-  {
-      "id": "...",
-      "location": "westus2",
-      "name": "my-key-vault",
-      "properties": {
-          "accessPolicies": [...],
-          "createMode": null,
-          "enablePurgeProtection": null,
-          "enableSoftDelete": null,
-          "enabledForDeployment": false,
-          "enabledForDiskEncryption": null,
-          "enabledForTemplateDeployment": null,
-          "networkAcls": null,
-          "provisioningState": "Succeeded",
-          "sku": { "name": "standard" },
-          "tenantId": "...",
-          "vaultUri": "https://my-key-vault.vault.azure.net/"
-      },
-      "resourceGroup": "my-resource-group",
-      "type": "Microsoft.KeyVault/vaults"
-  }
-  ```
-
-  > The `"vaultUri"` property is the `vaultURL` argument for [NewClient][certificate_client_docs]
-
-### Authenticate the client
-
-This document demonstrates using [DefaultAzureCredential][default_cred_ref] to authenticate as a service principal. However, [NewClient][certificate_client_docs]
-accepts any [azidentity][azure_identity] credential. See the [azidentity][azure_identity] documentation for more information about other credentials.
-
-#### Create a service principal (optional)
-
-This [Azure Cloud Shell][azure_cloud_shell] snippet shows how to create a new service principal. Before using it, replace "my-application" with an appropriate name for your application.
-
-Create a service principal:
-```Bash
-az ad sp create-for-rbac --name http://my-application --skip-assignment
-```
-
-> Output:
-> ```json
-> {
->     "appId": "generated app id",
->     "displayName": "my-application",
->     "name": "http://my-application",
->     "password": "random password",
->     "tenant": "tenant id"
-> }
-> ```
-
-Use the output to set **AZURE_CLIENT_ID** ("appId" above), **AZURE_CLIENT_SECRET**
-("password" above) and **AZURE_TENANT_ID** ("tenant" above) environment variables.
-The following example shows a way to do this in Bash:
-```Bash
-export AZURE_CLIENT_ID="generated app id"
-export AZURE_CLIENT_SECRET="random password"
-export AZURE_TENANT_ID="tenant id"
-```
-
-Authorize the service principal to perform certificate operations in your Key Vault:
-```Bash
-az keyvault set-policy --name my-key-vault --spn $AZURE_CLIENT_ID --certificate-permissions backup create delete get import list purge recover restore update
-```
-> Possible certificate permissions: backup, create, delete, deleteissuers, get, getissuers, import, list, listissuers, managecontacts, manageissuers, purge, recover, restore, setissuers, update
-
-If you have enabled role-based access control (RBAC) for Key Vault instead, you can find roles like "Key Vault Certificates Officer" in our [RBAC guide][rbac_guide].
+[Client][client_docs] accepts any [azidentity][azure_identity] credential. See the [azidentity][azure_identity] documentation for more information about other credential types.
 
 #### Create a client
-
-Once the **AZURE_CLIENT_ID**, **AZURE_CLIENT_SECRET** and **AZURE_TENANT_ID** environment variables are set, [DefaultAzureCredential][default_cred_ref] will be able to authenticate the [Client][key_client_docs].
 
 Constructing the client also requires your vault's URL, which you can get from the Azure CLI or the Azure Portal.
 
@@ -128,7 +53,7 @@ func main() {
 
 ### Client
 
-With a [Client][certificate_client_docs] you can get certificates from the vault, create new certificates and
+With a [Client][client_docs] you can get certificates from the vault, create new certificates and
 new versions of existing certificates, update certificate metadata, and delete certificates. You
 can also manage certificate issuers, contacts, and management policies of certificates. This is
 illustrated in the [examples](#examples) below.
@@ -393,15 +318,16 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 This project has adopted the [Microsoft Open Source Code of Conduct][code_of_conduct]. For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact opencode@microsoft.com with any additional questions or comments.
 
 [default_cred_ref]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/azidentity#defaultazurecredential
-[azure_cloud_shell]: https://shell.azure.com/bash
 [azure_identity]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/azidentity
+[azure_keyvault_cli]: https://docs.microsoft.com/azure/key-vault/general/quick-create-cli
+[azure_keyvault_portal]: https://docs.microsoft.com/azure/key-vault/general/quick-create-portal
 [azure_sub]: https://azure.microsoft.com/free/
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [keyvault_docs]: https://docs.microsoft.com/azure/key-vault/
-[certificate_client_docs]: https://aka.ms/azsdk/go/azcertificates
-[rbac_guide]: https://docs.microsoft.com/azure/key-vault/general/rbac-guide
+[client_docs]: https://aka.ms/azsdk/go/azcertificates
 [reference_docs]: https://aka.ms/azsdk/go/keyvault-certificates/docs
 [certificates_client_src]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/keyvault/azcertificates
 [certificates_samples]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/keyvault/azcertificates/example_test.go
+[managed_identity]: https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fkeyvault%2Fazcertificates%2FREADME.png)

--- a/sdk/keyvault/azcertificates/README.md
+++ b/sdk/keyvault/azcertificates/README.md
@@ -21,7 +21,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
 
 * An [Azure subscription][azure_sub]
 * A supported Go version (the Azure SDK supports the two most recent Go releases)
-* A Key Vault. If you need to create one, see the Key Vault documentation for instructions on doing so in the [Azure Portal][azure_keyvault_portal] or with the [Azure CLI][azure_keyvault_cli].
+* A key vault. If you need to create one, see the Key Vault documentation for instructions on doing so in the [Azure Portal][azure_keyvault_portal] or with the [Azure CLI][azure_keyvault_cli].
 
 ### Authentication
 
@@ -70,7 +70,7 @@ This section contains code snippets covering common tasks:
 ### Create a Certificate
 
 [CreateCertificate](https://aka.ms/azsdk/go/keyvault-certificates/docs#Client.CreateCertificate)
-creates a certificate to be stored in the Azure Key Vault. If a certificate with the same name already exists, a new
+creates a certificate to be stored in the key vault. If a certificate with the same name already exists, a new
 version of the certificate is created.
 
 ```go

--- a/sdk/keyvault/azkeys/README.md
+++ b/sdk/keyvault/azkeys/README.md
@@ -21,7 +21,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
 
 * An [Azure subscription][azure_sub]
 * A supported Go version (the Azure SDK supports the two most recent Go releases)
-* A Key Vault. If you need to create one, see the Key Vault documentation for instructions on doing so in the [Azure Portal][azure_keyvault_portal] or with the [Azure CLI][azure_keyvault_cli].
+* A key vault. If you need to create one, see the Key Vault documentation for instructions on doing so in the [Azure Portal][azure_keyvault_portal] or with the [Azure CLI][azure_keyvault_cli].
 
 ### Authentication
 
@@ -146,7 +146,7 @@ func main() {
 ### Update an existing key
 
 [`UpdateKey`](https://aka.ms/azsdk/go/keyvault-keys/docs#Client.UpdateKey)
-updates the properties of a key previously stored in the Key Vault.
+updates the properties of a key previously stored in the key vault.
 
 ```go
 import (

--- a/sdk/keyvault/azkeys/README.md
+++ b/sdk/keyvault/azkeys/README.md
@@ -20,94 +20,18 @@ go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
 ### Prerequisites
 
 * An [Azure subscription][azure_sub]
-* Go version 1.18 or higher
-* A Key Vault. If you need to create one, you can use the [Azure Cloud Shell][azure_cloud_shell] to create one with these commands (replace `"my-resource-group"` and `"my-key-vault"` with your own, unique
-names):
+* A supported Go version (the Azure SDK supports the two most recent Go releases)
+* A Key Vault. If you need to create one, see the Key Vault documentation for instructions on doing so in the [Azure Portal][azure_keyvault_portal] or with the [Azure CLI][azure_keyvault_cli].
 
-  (Optional) if you want a new resource group to hold the Key Vault:
-  ```sh
-  az group create --name my-resource-group --location westus2
-  ```
+### Authentication
 
-  Create the Key Vault:
-  ```Bash
-  az keyvault create --resource-group my-resource-group --name my-key-vault
-  ```
+This document demonstrates using [azidentity.NewDefaultAzureCredential][default_cred_ref] to authenticate. This credential type works in both local development and production environments. We recommend using a [managed identity][managed_identity] in production.
 
-  ```json
-  {
-      "id": "...",
-      "location": "westus2",
-      "name": "my-key-vault",
-      "properties": {
-          "accessPolicies": [...],
-          "createMode": null,
-          "enablePurgeProtection": null,
-          "enableSoftDelete": null,
-          "enabledForDeployment": false,
-          "enabledForDiskEncryption": null,
-          "enabledForTemplateDeployment": null,
-          "networkAcls": null,
-          "provisioningState": "Succeeded",
-          "sku": { "name": "standard" },
-          "tenantId": "...",
-          "vaultUri": "https://my-key-vault.vault.azure.net/"
-      },
-      "resourceGroup": "my-resource-group",
-      "type": "Microsoft.KeyVault/vaults"
-  }
-  ```
-
-  > The `"vaultUri"` property is the ``vaultURL` argument for [NewClient][key_client_docs]
-
-### Authenticate the client
-
-This document demonstrates using [azidentity.NewDefaultAzureCredential][default_cred_ref] to authenticate as a service principal. However, [Client][key_client_docs] accepts any [azidentity][azure_identity] credential. See the [azidentity][azure_identity] documentation for more information about other credentials.
-
-#### Create a service principal (optional)
-
-This [Azure Cloud Shell][azure_cloud_shell] snippet shows how to create a new service principal. Before using it, replace "my-application" with an appropriate name for your application.
-
-Create a service principal:
-```Bash
-az ad sp create-for-rbac --name http://my-application --skip-assignment
-```
-
-> Output:
-> ```json
-> {
->     "appId": "generated app id",
->     "displayName": "my-application",
->     "name": "http://my-application",
->     "password": "random password",
->     "tenant": "tenant id"
-> }
-> ```
-
-Use the output to set **AZURE_CLIENT_ID** ("appId" above), **AZURE_CLIENT_SECRET**
-("password" above) and **AZURE_TENANT_ID** ("tenant" above) environment variables.
-The following example shows a way to do this in Bash:
-```Bash
-export AZURE_CLIENT_ID="generated app id"
-export AZURE_CLIENT_SECRET="random password"
-export AZURE_TENANT_ID="tenant id"
-```
-
-Authorize the service principal to perform key operations in your Key Vault:
-```Bash
-az keyvault set-policy --name my-key-vault --spn $AZURE_CLIENT_ID --key-permissions backup delete get list create update decrypt encrypt
-```
-> Possible permissions:
-> - Key management: backup, delete, get, list, purge, recover, restore, create, update, import
-> - Cryptographic operations: decrypt, encrypt, unwrapKey, wrapKey, verify, sign
-
-If you have enabled role-based access control (RBAC) for Key Vault instead, you can find roles like "Key Vault Crypto Officer" in our [RBAC guide][rbac_guide].
-If you are managing your keys using Managed HSM, read about its [access control][mhsm_access_control], which supports different roles isolated from Azure Resource Manager (ARM).
+[Client][client_docs] accepts any [azidentity][azure_identity] credential. See the [azidentity][azure_identity] documentation for more information about other credential types.
 
 #### Create a client
-Once the **AZURE_CLIENT_ID**, **AZURE_CLIENT_SECRET** and **AZURE_TENANT_ID** environment variables are set, [DefaultAzureCredential][default_cred_ref] will be able to authenticate the [Client][key_client_docs].
 
-Constructing the client also requires your vault's URL, which you can get from the Azure CLI or the Azure Portal.
+Constructing the client requires your vault's URL, which you can get from the Azure CLI or the Azure Portal.
 
 ```go
 import (
@@ -131,7 +55,7 @@ func main() {
 
 Azure Key Vault can create and store RSA and elliptic curve keys. Both can optionally be protected by hardware security modules (HSMs). Azure Key Vault can also perform cryptographic operations with them. For more information about keys and supported operations and algorithms, see the [Key Vault documentation](https://docs.microsoft.com/azure/key-vault/keys/about-keys).
 
-[Client][key_client_docs] can create keys in the vault, get existing keys from the vault, update key metadata, and delete keys, as shown in the examples below.
+[Client][client_docs] can create keys in the vault, get existing keys from the vault, update key metadata, and delete keys, as shown in the examples below.
 
 ## Examples
 
@@ -435,18 +359,18 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 This project has adopted the [Microsoft Open Source Code of Conduct][code_of_conduct]. For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact opencode@microsoft.com with any additional questions or comments.
 
 
-[mhsm_access_control]: https://docs.microsoft.com/azure/key-vault/managed-hsm/access-control
-[azure_cloud_shell]: https://shell.azure.com/bash
 [azure_identity]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
+[azure_keyvault_cli]: https://docs.microsoft.com/azure/key-vault/general/quick-create-cli
+[azure_keyvault_portal]: https://docs.microsoft.com/azure/key-vault/general/quick-create-portal
 [azure_sub]: https://azure.microsoft.com/free/
 [default_cred_ref]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#NewDefaultAzureCredential
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [keyvault_docs]: https://docs.microsoft.com/azure/key-vault/
 [goget_azkeys]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys
-[rbac_guide]: https://docs.microsoft.com/azure/key-vault/general/rbac-guide
 [reference_docs]: https://aka.ms/azsdk/go/keyvault-keys/docs
-[key_client_docs]: https://aka.ms/azsdk/go/keyvault-keys/docs#Client
+[client_docs]: https://aka.ms/azsdk/go/keyvault-keys/docs#Client
 [key_client_src]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/keyvault/azkeys/client.go
 [keys_samples]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/keyvault/azkeys/example_test.go
+[managed_identity]: https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fkeyvault%2Fazkeys%2FREADME.png)

--- a/sdk/keyvault/azkeys/autorest.md
+++ b/sdk/keyvault/azkeys/autorest.md
@@ -1,17 +1,17 @@
 ## Go
 
-``` yaml
+```yaml
 clear-output-folder: false
 export-clients: true
 go: true
-input-file: https://github.com/Azure/azure-rest-api-specs/blob/ac155b972d0619a6e5bf665a863fb05ee7eeb30f/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
+input-file: https://github.com/Azure/azure-rest-api-specs/blob/323a8c3fabad74fe18f4202926b8fd826551a7ce/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
 license-header: MICROSOFT_MIT_NO_VERSION
 module: github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys
 openapi-type: "data-plane"
 output-folder: ../azkeys
 override-client-name: Client
 security: "AADToken"
-security-scopes:  "https://vault.azure.net/.default"
+security-scopes: "https://vault.azure.net/.default"
 use: "@autorest/go@4.0.0-preview.43"
 version: "^3.0.0"
 

--- a/sdk/keyvault/azkeys/client.go
+++ b/sdk/keyvault/azkeys/client.go
@@ -137,7 +137,10 @@ func (client *Client) createKeyHandleResponse(resp *http.Response) (CreateKeyRes
 // algorithm. This operation is the reverse of the ENCRYPT operation; only a single block of
 // data may be decrypted, the size of this block is dependent on the target key and the algorithm to be used. The DECRYPT
 // operation applies to asymmetric and symmetric keys stored in Azure Key Vault
-// since it uses the private portion of the key. This operation requires the keys/decrypt permission.
+// since it uses the private portion of the key. This operation requires the keys/decrypt permission. Microsoft recommends
+// not to use CBC algorithms for decryption without first ensuring the integrity of
+// the ciphertext using an HMAC, for example. See https://docs.microsoft.com/dotnet/standard/security/vulnerabilities-cbc-mode
+// for more information.
 // If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.3
 // name - The name of the key.

--- a/sdk/keyvault/azkeys/models.go
+++ b/sdk/keyvault/azkeys/models.go
@@ -309,7 +309,8 @@ type KeyAttributes struct {
 	// Expiry date in UTC.
 	Expires *time.Time `json:"exp,omitempty"`
 
-	// Indicates if the private key can be exported.
+	// Indicates if the private key can be exported. Release policy must be provided when creating the 1st version of an exportable
+	// key.
 	Exportable *bool `json:"exportable,omitempty"`
 
 	// Not before date in UTC.
@@ -403,7 +404,7 @@ type KeyOperationsParameters struct {
 	// Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms.
 	AAD []byte `json:"aad,omitempty"`
 
-	// Initialization vector for symmetric algorithms.
+	// Cryptographically random, non-repeating initialization vector for symmetric algorithms.
 	IV []byte `json:"iv,omitempty"`
 
 	// The tag to authenticate when performing decryption with an authenticated algorithm.
@@ -415,7 +416,7 @@ type KeyReleasePolicy struct {
 	// Content type and version of key release policy
 	ContentType *string `json:"contentType,omitempty"`
 
-	// Blob encoding the policy rules under which the key can be released.
+	// Blob encoding the policy rules under which the key can be released. Blob must be base64 URL encoded.
 	EncodedPolicy []byte `json:"data,omitempty"`
 
 	// Defines the mutability state of the policy. Once marked immutable, this flag cannot be reset and the policy cannot be changed

--- a/sdk/keyvault/azsecrets/README.md
+++ b/sdk/keyvault/azsecrets/README.md
@@ -22,88 +22,16 @@ go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
 ### Prerequisites
 
 * An [Azure subscription][azure_sub]
-* Go version 1.18 or later
-* A Key Vault. If you need to create one, you can use the [Azure Cloud Shell][azure_cloud_shell] to create one with these commands (replace `"my-resource-group"` and `"my-key-vault"` with your own, unique names):
+* A supported Go version (the Azure SDK supports the two most recent Go releases)
+* A Key Vault. If you need to create one, see the Key Vault documentation for instructions on doing so in the [Azure Portal][azure_keyvault_portal] or with the [Azure CLI][azure_keyvault_cli].
 
-  (Optional) if you want a new resource group to hold the Key Vault:
-  ```sh
-  az group create --name my-resource-group --location westus2
-  ```
+### Authentication
 
-  Create the Key Vault:
-  ```Bash
-  az keyvault create --resource-group my-resource-group --name my-key-vault
-  ```
+This document demonstrates using [azidentity.NewDefaultAzureCredential][default_cred_ref] to authenticate. This credential type works in both local development and production environments. We recommend using a [managed identity][managed_identity] in production.
 
-  Output:
-  ```json
-  {
-      "id": "...",
-      "location": "westus2",
-      "name": "my-key-vault",
-      "properties": {
-          "accessPolicies": [...],
-          "createMode": null,
-          "enablePurgeProtection": null,
-          "enableSoftDelete": null,
-          "enabledForDeployment": false,
-          "enabledForDiskEncryption": null,
-          "enabledForTemplateDeployment": null,
-          "networkAcls": null,
-          "provisioningState": "Succeeded",
-          "sku": { "name": "standard" },
-          "tenantId": "...",
-          "vaultUri": "https://my-key-vault.vault.azure.net/"
-      },
-      "resourceGroup": "my-resource-group",
-      "type": "Microsoft.KeyVault/vaults"
-  }
-  ```
-
-  > The `"vaultUri"` property is the `vaultURL` argument for [NewClient][secret_client_docs]
-
-### Authenticate the client
-This document demonstrates using [azidentity.DefaultAzureCredential][default_cred] to authenticate as a service principal. However, [Client][secret_client_docs] accepts any `azidentity` credential. See the [azidentity documentation][azure_identity] for information about other credentials.
-
-#### Create a service principal (optional)
-
-This [Azure Cloud Shell][azure_cloud_shell] snippet shows how to create a new service principal. Before using it, replace "my-application" with an appropriate name for your application.
-
-Create a service principal:
-```Bash
-az ad sp create-for-rbac --name http://my-application --skip-assignment
-```
-
-> Output:
-> ```json
-> {
->     "appId": "generated app id",
->     "displayName": "my-application",
->     "name": "http://my-application",
->     "password": "random password",
->     "tenant": "tenant id"
-> }
-> ```
-
-Use the output to set **AZURE_CLIENT_ID** ("appId" above), **AZURE_CLIENT_SECRET** ("password" above) and **AZURE_TENANT_ID** ("tenant" above) environment variables. The following example shows a way to do this in Bash:
-```Bash
-export AZURE_CLIENT_ID="generated app id"
-export AZURE_CLIENT_SECRET="random password"
-export AZURE_TENANT_ID="tenant id"
-```
-
-Authorize the service principal to access secrets in your Key Vault:
-```Bash
-az keyvault set-policy --name my-key-vault --spn $AZURE_CLIENT_ID --secret-permissions get set list delete backup recover restore purge
-```
-> Possible permissions:
-> - Secret management: set, backup, delete, get, list, purge, recover, restore
-
-If you have enabled role-based access control (RBAC) for Key Vault instead, you can find roles like "Key Vault Secrets Officer" in our [RBAC guide][rbac_guide].
+[Client][client_docs] accepts any [azidentity][azure_identity] credential. See the [azidentity][azure_identity] documentation for more information about other credential types.
 
 #### Create a client
-
-Once the **AZURE_CLIENT_ID**, **AZURE_CLIENT_SECRET** and **AZURE_TENANT_ID** environment variables are set, [DefaultAzureCredential][default_cred] will be able to authenticate the Client.
 
 Constructing the client also requires your vault's URL, which you can get from the Azure CLI or the Azure Portal.
 
@@ -375,15 +303,16 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 
 This project has adopted the [Microsoft Open Source Code of Conduct][code_of_conduct]. For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact opencode@microsoft.com with any additional questions or comments.
 
-[azure_cloud_shell]: https://shell.azure.com/bash
 [azure_identity]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
+[azure_keyvault_cli]: https://docs.microsoft.com/azure/key-vault/general/quick-create-cli
+[azure_keyvault_portal]: https://docs.microsoft.com/azure/key-vault/general/quick-create-portal
 [azure_sub]: https://azure.microsoft.com/free/
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
-[default_cred]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/azidentity#defaultazurecredential
+[default_cred_ref]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/azidentity#defaultazurecredential
 [keyvault_docs]: https://docs.microsoft.com/azure/key-vault/
-[rbac_guide]: https://docs.microsoft.com/azure/key-vault/general/rbac-guide
+[managed_identity]: https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
 [reference_docs]: https://aka.ms/azsdk/go/keyvault-secrets/docs
-[secret_client_docs]: https://aka.ms/azsdk/go/keyvault-secrets/docs#Client
+[client_docs]: https://aka.ms/azsdk/go/keyvault-secrets/docs#Client
 [module_source]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/keyvault/azsecrets
 [secrets_samples]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/keyvault/azsecrets/example_test.go
 

--- a/sdk/keyvault/azsecrets/README.md
+++ b/sdk/keyvault/azsecrets/README.md
@@ -23,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
 
 * An [Azure subscription][azure_sub]
 * A supported Go version (the Azure SDK supports the two most recent Go releases)
-* A Key Vault. If you need to create one, see the Key Vault documentation for instructions on doing so in the [Azure Portal][azure_keyvault_portal] or with the [Azure CLI][azure_keyvault_cli].
+* A key vault. If you need to create one, see the Key Vault documentation for instructions on doing so in the [Azure Portal][azure_keyvault_portal] or with the [Azure CLI][azure_keyvault_cli].
 
 ### Authentication
 
@@ -103,7 +103,7 @@ func main() {
 
 ### Retrieve a Secret
 
-[GetSecret](https://aka.ms/azsdk/go/keyvault-secrets/docs#Client.GetSecret) retrieves a secret previously stored in the Key Vault.
+[GetSecret](https://aka.ms/azsdk/go/keyvault-secrets/docs#Client.GetSecret) retrieves a secret previously stored in the key vault.
 
 ```golang
 import (


### PR DESCRIPTION
Closes #18505 by regenerating `azkeys` and replacing authentication and vault creation instructions with links to more comprehensive docs.