### PR TITLE
Add Go 1.19 to test matrix

### DIFF
--- a/eng/pipelines/mgmt-auto-release.yml
+++ b/eng/pipelines/mgmt-auto-release.yml
@@ -23,7 +23,7 @@ stages:
 
           - task: GoTool@0
             inputs:
-              version: '1.19.0'
+              version: '1.19'
 
           - task: ShellScript@2
             inputs:

--- a/eng/pipelines/mgmt-auto-release.yml
+++ b/eng/pipelines/mgmt-auto-release.yml
@@ -23,7 +23,7 @@ stages:
 
           - task: GoTool@0
             inputs:
-              version: '1.18.2'
+              version: '1.19.0'
 
           - task: ShellScript@2
             inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
@@ -26,11 +26,11 @@ stages:
           Linux_Go119:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.19.0'
+            go.version: '1.19'
           Windows_Go119:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
-            go.version: '1.19.0'
+            go.version: '1.19'
       pool:
         name: $(pool.name)
         vmImage: $(image.name)
@@ -63,7 +63,7 @@ stages:
       steps:
       - task: GoTool@0
         inputs:
-          version: '1.18.5'
+          version: '1.19'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
@@ -18,11 +18,19 @@ stages:
           Linux_Go118:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.18.2'
+            go.version: '1.18.5'
           Windows_Go118:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
-            go.version: '1.18.2'
+            go.version: '1.18.5'
+          Linux_Go119:
+            pool.name: azsdk-pool-mms-ubuntu-2004-general
+            image.name: MMSUbuntu20.04
+            go.version: '1.19.0'
+          Windows_Go119:
+            pool.name: azsdk-pool-mms-win-2019-general
+            image.name: MMS2019
+            go.version: '1.19.0'
       pool:
         name: $(pool.name)
         vmImage: $(image.name)
@@ -55,7 +63,7 @@ stages:
       steps:
       - task: GoTool@0
         inputs:
-          version: '1.18.2'
+          version: '1.18.5'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -85,11 +85,20 @@ stages:
           Linux_Go118:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.18.2'
+            go.version: '1.18.5'
           Windows_Go118:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
-            go.version: '1.18.2'
+            go.version: '1.18.5'
+            generate.bom: true
+          Linux_Go119:
+            pool.name: azsdk-pool-mms-ubuntu-2004-general
+            image.name: MMSUbuntu20.04
+            go.version: '1.19.0'
+          Windows_Go119:
+            pool.name: azsdk-pool-mms-win-2019-general
+            image.name: MMS2019
+            go.version: '1.19.0'
             generate.bom: true
       pool:
         name: $(pool.name)
@@ -133,7 +142,7 @@ stages:
 
       - task: GoTool@0
         inputs:
-          version: '1.18.2'
+          version: '1.19.0'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -94,11 +94,11 @@ stages:
           Linux_Go119:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.19.0'
+            go.version: '1.19'
           Windows_Go119:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
-            go.version: '1.19.0'
+            go.version: '1.19'
             generate.bom: true
       pool:
         name: $(pool.name)
@@ -142,7 +142,7 @@ stages:
 
       - task: GoTool@0
         inputs:
-          version: '1.19.0'
+          version: '1.19'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
@@ -37,11 +37,11 @@ stages:
           Linux_Go119:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.19.0'
+            go.version: '1.19'
           Windows_Go119:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
-            go.version: '1.19.0'
+            go.version: '1.19'
             generate.bom: true
       pool:
         name: $(pool.name)
@@ -80,7 +80,7 @@ stages:
 
       - task: GoTool@0
         inputs:
-          version: '1.19.0'
+          version: '1.19'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
@@ -28,11 +28,20 @@ stages:
           Linux_Go118:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.18.2'
+            go.version: '1.18.5'
           Windows_Go118:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
-            go.version: '1.18.2'
+            go.version: '1.18.5'
+            generate.bom: true
+          Linux_Go119:
+            pool.name: azsdk-pool-mms-ubuntu-2004-general
+            image.name: MMSUbuntu20.04
+            go.version: '1.19.0'
+          Windows_Go119:
+            pool.name: azsdk-pool-mms-win-2019-general
+            image.name: MMS2019
+            go.version: '1.19.0'
             generate.bom: true
       pool:
         name: $(pool.name)
@@ -71,7 +80,7 @@ stages:
 
       - task: GoTool@0
         inputs:
-          version: '1.18.2'
+          version: '1.19.0'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/mgmt-mock-test.yml
+++ b/eng/pipelines/templates/jobs/mgmt-mock-test.yml
@@ -14,7 +14,7 @@ jobs:
       displayName: 'Install autorest'
     - task: GoTool@0
       inputs:
-        version: '1.19.0'
+        version: '1.19'
       displayName: "Select Go Version"
 
     - template: /eng/pipelines/templates/steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/mgmt-mock-test.yml
+++ b/eng/pipelines/templates/jobs/mgmt-mock-test.yml
@@ -14,7 +14,7 @@ jobs:
       displayName: 'Install autorest'
     - task: GoTool@0
       inputs:
-        version: '1.18.2'
+        version: '1.19.0'
       displayName: "Select Go Version"
 
     - template: /eng/pipelines/templates/steps/create-go-workspace.yml

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
-  GoLintCLIVersion: 'v1.47.1'
+  GoLintCLIVersion: 'v1.48.0'
   Package.EnableSBOMSigning: true
   # Enable go native component governance detection
   # https://docs.opensource.microsoft.com/tools/cg/index.html

--- a/eng/scripts/automation_init.sh
+++ b/eng/scripts/automation_init.sh
@@ -17,10 +17,10 @@ outputFile="$(realpath $outputFile)"
 echo "output json file: $outputFile"
 
 TMPDIR="/tmp"
-if [ ! "$(go version | awk '{print $3}' | cut -c 3-6)" = "1.18" ]
+if [ ! "$(go version | awk '{print $3}' | cut -c 3-6)" = "1.19" ]
 then
-  wget https://golang.org/dl/go1.18.linux-amd64.tar.gz
-  tar -C $TMPDIR -xzf go1.18.linux-amd64.tar.gz
+  wget https://golang.org/dl/go1.19.linux-amd64.tar.gz
+  tar -C $TMPDIR -xzf go1.19.linux-amd64.tar.gz
   export GOROOT=$TMPDIR/go
   export PATH=$GOROOT/bin:$PATH
 fi

--- a/eng/tools/generator/autorest/writer.go
+++ b/eng/tools/generator/autorest/writer.go
@@ -39,7 +39,6 @@ func NewWriterFromFile(file string) *Writer {
 	}
 }
 
-//
 // Write writes the new version changelog to the changelog file, also modify the links in the previous version
 func (w *Writer) Write(r *report.PkgsReport) error {
 	// first we read the changelog, get the lines as an array

--- a/eng/tools/generator/cmd/template/templateCmd.go
+++ b/eng/tools/generator/cmd/template/templateCmd.go
@@ -60,7 +60,7 @@ func BindFlags(flagSet *pflag.FlagSet) {
 	flagSet.String("commit", "", "Specifies the commit hash of azure-rest-api-specs")
 	flagSet.String("release-date", "", "Specifies the release date in changelog")
 	flagSet.String("package-config", "", "Additional config for package")
-	flagSet.String("go-version", "1.18", "Go version")
+	flagSet.String("go-version", "1.19", "Go version")
 	flagSet.String("package-version", "", "Specify the version number of this release")
 }
 

--- a/eng/tools/generator/cmd/v2/automation/automationCmd.go
+++ b/eng/tools/generator/cmd/v2/automation/automationCmd.go
@@ -31,7 +31,7 @@ func Command() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			goVersion := "1.18"
+			goVersion := "1.19"
 			if len(args) == 3 {
 				goVersion = args[2]
 			}

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -348,7 +348,7 @@ func AddChangelogToFile(changelog *model.Changelog, version *semver.Version, pac
 	return additionalChangelog, nil
 }
 
-// replace `{{NewClientName}}`` placeholder in README.md by first func name according to `^New.+Method$` pattern
+// replace `{{NewClientName}}` placeholder in README.md by first func name according to `^New.+Method$` pattern
 func ReplaceNewClientNamePlaceholder(packageRootPath string, exports exports.Content) error {
 	path := filepath.Join(packageRootPath, "README.md")
 	var clientName string

--- a/eng/tools/generator/cmd/v2/refresh/refreshCmd.go
+++ b/eng/tools/generator/cmd/v2/refresh/refreshCmd.go
@@ -64,7 +64,7 @@ func BindFlags(flagSet *pflag.FlagSet) {
 	flagSet.String("release-date", "", "Specifies the release date in changelog")
 	flagSet.Bool("skip-create-branch", false, "Skip create release branch after generation")
 	flagSet.Bool("skip-generate-example", false, "Skip generate example for SDK in the same time")
-	flagSet.String("go-version", "1.18", "Go version")
+	flagSet.String("go-version", "1.19", "Go version")
 	flagSet.String("rps", "", "Specify RP list to refresh, seperated by ','")
 }
 

--- a/eng/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/eng/tools/generator/cmd/v2/release/releaseCmd.go
@@ -86,7 +86,7 @@ func BindFlags(flagSet *pflag.FlagSet) {
 	flagSet.Bool("skip-create-branch", false, "Skip create release branch after generation")
 	flagSet.Bool("skip-generate-example", false, "Skip generate example for SDK in the same time")
 	flagSet.String("package-config", "", "Additional config for package")
-	flagSet.String("go-version", "1.18", "Go version")
+	flagSet.String("go-version", "1.19", "Go version")
 	flagSet.StringP("token", "t", "", "Specify the personal access token of Github")
 }
 

--- a/eng/tools/smoketests/cmd/root.go
+++ b/eng/tools/smoketests/cmd/root.go
@@ -58,7 +58,7 @@ func getVersion() string {
 	}
 
 	// Default, go is not from a tag
-	return "go 1.18"
+	return "go 1.19"
 }
 
 func inIgnoredDirectories(path string) bool {

--- a/sdk/azcore/example_test.go
+++ b/sdk/azcore/example_test.go
@@ -12,7 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -83,5 +83,5 @@ func ExampleResponseError() {
 		}
 	}
 	// Do something with response
-	fmt.Println(ioutil.ReadAll(resp.Body))
+	fmt.Println(io.ReadAll(resp.Body))
 }

--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -8,7 +8,6 @@ package exported
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
@@ -51,7 +50,7 @@ func Payload(resp *http.Response) ([]byte, error) {
 	if buf, ok := resp.Body.(*shared.NopClosingBytesReader); ok {
 		return buf.Bytes(), nil
 	}
-	bytesBody, err := ioutil.ReadAll(resp.Body)
+	bytesBody, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		return nil, err

--- a/sdk/azcore/internal/pollers/async/async_test.go
+++ b/sdk/azcore/internal/pollers/async/async_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -33,7 +32,7 @@ func initialResponse(method string, resp io.Reader) *http.Response {
 		panic(err)
 	}
 	return &http.Response{
-		Body:    ioutil.NopCloser(resp),
+		Body:    io.NopCloser(resp),
 		Header:  http.Header{},
 		Request: req,
 	}

--- a/sdk/azcore/internal/pollers/body/body_test.go
+++ b/sdk/azcore/internal/pollers/body/body_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -31,7 +30,7 @@ func initialResponse(method string, resp io.Reader) *http.Response {
 		panic(err)
 	}
 	return &http.Response{
-		Body:    ioutil.NopCloser(resp),
+		Body:    io.NopCloser(resp),
 		Header:  http.Header{},
 		Request: req,
 	}

--- a/sdk/azcore/internal/pollers/op/op_test.go
+++ b/sdk/azcore/internal/pollers/op/op_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -35,7 +34,7 @@ func initialResponse(method string, body io.Reader) *http.Response {
 		panic(err)
 	}
 	return &http.Response{
-		Body:    ioutil.NopCloser(body),
+		Body:    io.NopCloser(body),
 		Header:  http.Header{},
 		Request: req,
 	}

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -98,7 +97,7 @@ func TestGetJSON(t *testing.T) {
 	j, err := GetJSON(&http.Response{Body: http.NoBody})
 	require.ErrorIs(t, err, ErrNoBody)
 	require.Nil(t, j)
-	j, err = GetJSON(&http.Response{Body: ioutil.NopCloser(strings.NewReader(`{ "foo": "bar" }`))})
+	j, err = GetJSON(&http.Response{Body: io.NopCloser(strings.NewReader(`{ "foo": "bar" }`))})
 	require.NoError(t, err)
 	require.Equal(t, "bar", j["foo"])
 }
@@ -106,7 +105,7 @@ func TestGetJSON(t *testing.T) {
 func TestGetStatusSuccess(t *testing.T) {
 	const jsonBody = `{ "status": "InProgress" }`
 	resp := &http.Response{
-		Body: ioutil.NopCloser(strings.NewReader(jsonBody)),
+		Body: io.NopCloser(strings.NewReader(jsonBody)),
 	}
 	status, err := GetStatus(resp)
 	require.NoError(t, err)
@@ -127,7 +126,7 @@ func TestGetNoBody(t *testing.T) {
 
 func TestGetStatusError(t *testing.T) {
 	resp := &http.Response{
-		Body: ioutil.NopCloser(strings.NewReader("{}")),
+		Body: io.NopCloser(strings.NewReader("{}")),
 	}
 	status, err := GetStatus(resp)
 	require.NoError(t, err)
@@ -137,7 +136,7 @@ func TestGetStatusError(t *testing.T) {
 func TestGetProvisioningState(t *testing.T) {
 	const jsonBody = `{ "properties": { "provisioningState": "Canceled" } }`
 	resp := &http.Response{
-		Body: ioutil.NopCloser(strings.NewReader(jsonBody)),
+		Body: io.NopCloser(strings.NewReader(jsonBody)),
 	}
 	state, err := GetProvisioningState(resp)
 	require.NoError(t, err)
@@ -167,7 +166,7 @@ func TestGetResourceLocation(t *testing.T) {
 
 func TestGetProvisioningStateError(t *testing.T) {
 	resp := &http.Response{
-		Body: ioutil.NopCloser(strings.NewReader("{}")),
+		Body: io.NopCloser(strings.NewReader("{}")),
 	}
 	state, err := GetProvisioningState(resp)
 	require.NoError(t, err)

--- a/sdk/azcore/runtime/policy_logging.go
+++ b/sdk/azcore/runtime/policy_logging.go
@@ -9,7 +9,7 @@ package runtime
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -210,7 +210,7 @@ func writeReqBody(req *policy.Request, b *bytes.Buffer) error {
 	if ct := req.Raw().Header.Get(shared.HeaderContentType); !shouldLogBody(b, ct) {
 		return nil
 	}
-	body, err := ioutil.ReadAll(req.Raw().Body)
+	body, err := io.ReadAll(req.Raw().Body)
 	if err != nil {
 		fmt.Fprintf(b, "   Failed to read request body: %s\n", err.Error())
 		return err

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"strings"
@@ -99,11 +98,11 @@ func TestRetryPolicyFailOnStatusCodeRespBodyPreserved(t *testing.T) {
 	// add a per-request policy that reads and restores the request body.
 	// this is to simulate how something like httputil.DumpRequest works.
 	pl := exported.NewPipeline(srv, policyFunc(func(r *policy.Request) (*http.Response, error) {
-		b, err := ioutil.ReadAll(r.Raw().Body)
+		b, err := io.ReadAll(r.Raw().Body)
 		if err != nil {
 			t.Fatal(err)
 		}
-		r.Raw().Body = ioutil.NopCloser(bytes.NewReader(b))
+		r.Raw().Body = io.NopCloser(bytes.NewReader(b))
 		return r.Next()
 	}), NewRetryPolicy(testRetryOptions()))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
@@ -131,7 +130,7 @@ func TestRetryPolicyFailOnStatusCodeRespBodyPreserved(t *testing.T) {
 		t.Fatal("request body wasn't closed")
 	}
 	// ensure response body hasn't been drained
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azcore/runtime/request_test.go
+++ b/sdk/azcore/runtime/request_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -109,7 +108,7 @@ func TestRequestMarshalAsByteArrayURLFormat(t *testing.T) {
 	if req.Raw().ContentLength == 0 {
 		t.Fatal("unexpected zero content length")
 	}
-	b, err := ioutil.ReadAll(req.Raw().Body)
+	b, err := io.ReadAll(req.Raw().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +136,7 @@ func TestRequestMarshalAsByteArrayStdFormat(t *testing.T) {
 	if req.Raw().ContentLength == 0 {
 		t.Fatal("unexpected zero content length")
 	}
-	b, err := ioutil.ReadAll(req.Raw().Body)
+	b, err := io.ReadAll(req.Raw().Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,7 +344,7 @@ func TestCloneWithoutReadOnlyFieldsEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadAll(req.Raw().Body)
+	b, err := io.ReadAll(req.Raw().Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azcore/runtime/response.go
+++ b/sdk/azcore/runtime/response.go
@@ -13,7 +13,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
@@ -86,7 +85,7 @@ func UnmarshalAsXML(resp *http.Response, v interface{}) error {
 // Drain reads the response body to completion then closes it.  The bytes read are discarded.
 func Drain(resp *http.Response) {
 	if resp != nil && resp.Body != nil {
-		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}
 }

--- a/sdk/azcore/streaming/progress_test.go
+++ b/sdk/azcore/streaming/progress_test.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -52,7 +51,7 @@ func TestProgressReporting(t *testing.T) {
 		bytesReceived = bytesTransferred
 	})
 	defer respRpt.Close()
-	b, err := ioutil.ReadAll(respRpt)
+	b, err := io.ReadAll(respRpt)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/internal/diag/diag.go
+++ b/sdk/internal/diag/diag.go
@@ -15,7 +15,7 @@ import (
 // Caller returns the file and line number of a frame on the caller's stack.
 // If the funtion fails an empty string is returned.
 // skipFrames - the number of frames to skip when determining the caller.
-//  Passing a value of 0 will return the immediate caller of this function.
+// Passing a value of 0 will return the immediate caller of this function.
 func Caller(skipFrames int) string {
 	if pc, file, line, ok := runtime.Caller(skipFrames + 1); ok {
 		// the skipFrames + 1 is to skip ourselves

--- a/sdk/internal/mock/mock_test.go
+++ b/sdk/internal/mock/mock_test.go
@@ -8,7 +8,7 @@ package mock
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -221,7 +221,7 @@ func TestComplexResponse(t *testing.T) {
 	if h := resp.Header.Get("some"); h != "value" {
 		t.Fatalf("unexpected header value %s", h)
 	}
-	r, err := ioutil.ReadAll(resp.Body)
+	r, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func TestComplexResponseTLS(t *testing.T) {
 	if h := resp.Header.Get("some"); h != "value" {
 		t.Fatalf("unexpected header value %s", h)
 	}
-	r, err := ioutil.ReadAll(resp.Body)
+	r, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +293,7 @@ func TestTLSServerConfig(t *testing.T) {
 	if h := resp.Header.Get("some"); h != "value" {
 		t.Fatalf("unexpected header value %s", h)
 	}
-	r, err := ioutil.ReadAll(resp.Body)
+	r, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestBodyReadError(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code %d", resp.StatusCode)
 	}
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err == nil {
 		t.Fatal("unexpected nil error reading response body")
 	}

--- a/sdk/internal/perf/recording.go
+++ b/sdk/internal/perf/recording.go
@@ -9,7 +9,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -37,7 +37,7 @@ func init() {
 			panic(err)
 		}
 	}
-	cert, err := ioutil.ReadFile(localFile)
+	cert, err := os.ReadFile(localFile)
 	if err != nil {
 		log.Printf("could not read file set in PROXY_CERT variable at %s.\n", localFile)
 	}
@@ -182,7 +182,7 @@ func (c *RecordingHTTPClient) start() error {
 
 	recID := resp.Header.Get(idHeader)
 	if recID == "" {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		if err != nil {
 			return fmt.Errorf("there was an error reading the body: %s", err.Error())
@@ -209,7 +209,7 @@ func (c *RecordingHTTPClient) stop() error {
 	req.Header.Set("x-recording-id", c.recID) //recTest)
 	resp, err := defaultHTTPClient.Do(req)
 	if resp.StatusCode != 200 {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		if err == nil {
 			return fmt.Errorf("proxy did not stop the recording properly: %s", string(b))

--- a/sdk/internal/recording/matchers.go
+++ b/sdk/internal/recording/matchers.go
@@ -9,7 +9,7 @@ package recording
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -104,7 +104,7 @@ func SetDefaultMatcher(t *testing.T, options *SetDefaultMatcherOptions) error {
 		return err
 	}
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 	req.ContentLength = int64(len(marshalled))
 
 	return handleProxyResponse(client.Do(req))

--- a/sdk/internal/recording/recording.go
+++ b/sdk/internal/recording/recording.go
@@ -13,7 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -415,7 +415,7 @@ func (r *Recording) createVariablesFileIfNotExists() (*os.File, error) {
 }
 
 func (r *Recording) unmarshalVariablesFile(out interface{}) error {
-	data, err := ioutil.ReadFile(r.VariablesFile)
+	data, err := os.ReadFile(r.VariablesFile)
 	if err != nil {
 		// If the file or dir do not exist, this is not an error to report
 		if os.IsNotExist(err) {
@@ -468,7 +468,7 @@ func init() {
 			log.Panicf(err.Error())
 		}
 	}
-	cert, err := ioutil.ReadFile(localFile)
+	cert, err := os.ReadFile(localFile)
 	if err != nil {
 		log.Printf("could not read file set in PROXY_CERT variable at %s.\n", localFile)
 	}
@@ -598,7 +598,7 @@ func Start(t *testing.T, pathToRecordings string, options *RecordingOptions) err
 	if err != nil {
 		return err
 	}
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 	req.ContentLength = int64(len(marshalled))
 
 	resp, err := client.Do(req)
@@ -607,7 +607,7 @@ func Start(t *testing.T, pathToRecordings string, options *RecordingOptions) err
 	}
 	recId := resp.Header.Get(IDHeader)
 	if recId == "" {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		if err != nil {
 			return err
@@ -617,7 +617,7 @@ func Start(t *testing.T, pathToRecordings string, options *RecordingOptions) err
 
 	// Unmarshal any variables returned by the proxy
 	var m map[string]interface{}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err
@@ -670,7 +670,7 @@ func Stop(t *testing.T, options *RecordingOptions) error {
 		if err != nil {
 			return err
 		}
-		req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+		req.Body = io.NopCloser(bytes.NewReader(marshalled))
 		req.ContentLength = int64(len(marshalled))
 	}
 
@@ -682,7 +682,7 @@ func Stop(t *testing.T, options *RecordingOptions) error {
 	req.Header.Set(IDHeader, recTest.recordingId)
 	resp, err := client.Do(req)
 	if resp.StatusCode != 200 {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		if err == nil {
 			return fmt.Errorf("proxy did not stop the recording properly: %s", string(b))

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -9,7 +9,7 @@ package recording
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -57,7 +57,7 @@ func (s *recordingTests) TestStopDoesNotSaveVariablesWhenNoVariablesExist() {
 	err = target.Stop()
 	require.NoError(err)
 
-	_, err = ioutil.ReadFile(target.VariablesFile)
+	_, err = os.ReadFile(target.VariablesFile)
 	require.Equal(true, os.IsNotExist(err))
 }
 
@@ -468,7 +468,7 @@ func TestStartStopRecordingClient(t *testing.T) {
 	}()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)

--- a/sdk/internal/recording/request_matcher.go
+++ b/sdk/internal/recording/request_matcher.go
@@ -9,7 +9,7 @@ package recording
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 
@@ -112,7 +112,7 @@ func getBody(r *http.Request) string {
 		if err != nil {
 			return "could not parse body: " + err.Error()
 		}
-		r.Body = ioutil.NopCloser(&body)
+		r.Body = io.NopCloser(&body)
 	}
 	return body.String()
 }

--- a/sdk/internal/recording/request_matcher_test.go
+++ b/sdk/internal/recording/request_matcher_test.go
@@ -8,7 +8,6 @@ package recording
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -206,5 +205,5 @@ func (s *requestMatcherTests) TestCompareMethods() {
 }
 
 func closerFromString(content string) io.ReadCloser {
-	return ioutil.NopCloser(strings.NewReader(content))
+	return io.NopCloser(strings.NewReader(content))
 }

--- a/sdk/internal/recording/sanitizer.go
+++ b/sdk/internal/recording/sanitizer.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -101,7 +101,7 @@ func handleProxyResponse(resp *http.Response, err error) error {
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err
@@ -153,7 +153,7 @@ func AddBodyKeySanitizer(jsonPath, value, regex string, options *RecordingOption
 		return err
 	}
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 	req.ContentLength = int64(len(marshalled))
 	return handleProxyResponse(client.Do(req))
 }
@@ -189,7 +189,7 @@ func AddBodyRegexSanitizer(value, regex string, options *RecordingOptions) error
 		return err
 	}
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 	req.ContentLength = int64(len(marshalled))
 	return handleProxyResponse(client.Do(req))
 }
@@ -226,7 +226,7 @@ func AddContinuationSanitizer(key, method string, resetAfterFirst bool, options 
 		return err
 	}
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 	req.ContentLength = int64(len(marshalled))
 	return handleProxyResponse(client.Do(req))
 }
@@ -262,7 +262,7 @@ func AddGeneralRegexSanitizer(value, regex string, options *RecordingOptions) er
 		return err
 	}
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 	req.ContentLength = int64(len(marshalled))
 	return handleProxyResponse(client.Do(req))
 }
@@ -303,7 +303,7 @@ func AddHeaderRegexSanitizer(key, value, regex string, options *RecordingOptions
 		return err
 	}
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 	req.ContentLength = int64(len(marshalled))
 	return handleProxyResponse(client.Do(req))
 }
@@ -360,7 +360,7 @@ func AddRemoveHeaderSanitizer(headersForRemoval []string, options *RecordingOpti
 		return err
 	}
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 	req.ContentLength = int64(len(marshalled))
 	return handleProxyResponse(client.Do(req))
 }
@@ -393,7 +393,7 @@ func AddURISanitizer(value, regex string, options *RecordingOptions) error {
 		return err
 	}
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 	req.ContentLength = int64(len(marshalled))
 	return handleProxyResponse(client.Do(req))
 }
@@ -425,7 +425,7 @@ func AddURISubscriptionIDSanitizer(value string, options *RecordingOptions) erro
 			return err
 		}
 
-		req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+		req.Body = io.NopCloser(bytes.NewReader(marshalled))
 		req.ContentLength = int64(len(marshalled))
 	}
 	return handleProxyResponse(client.Do(req))

--- a/sdk/internal/recording/sanitizer_test.go
+++ b/sdk/internal/recording/sanitizer_test.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -230,7 +230,7 @@ func TestUriSanitizer(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -287,7 +287,7 @@ func TestHeaderRegexSanitizer(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -324,7 +324,7 @@ func TestBodyKeySanitizer(t *testing.T) {
 	marshalled, err := json.Marshal(bodyValue)
 	require.NoError(t, err)
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 
 	err = AddBodyKeySanitizer("$.Tag", "Sanitized", "", nil)
 	require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestBodyKeySanitizer(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -379,7 +379,7 @@ func TestBodyRegexSanitizer(t *testing.T) {
 	marshalled, err := json.Marshal(bodyValue)
 	require.NoError(t, err)
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 
 	err = AddBodyRegexSanitizer("Sanitized", "Value", nil)
 	require.NoError(t, err)
@@ -401,7 +401,7 @@ func TestBodyRegexSanitizer(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -451,7 +451,7 @@ func TestRemoveHeaderSanitizer(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -487,7 +487,7 @@ func TestContinuationSanitizer(t *testing.T) {
 	marshalled, err := json.Marshal(bodyValue)
 	require.NoError(t, err)
 
-	req.Body = ioutil.NopCloser(bytes.NewReader(marshalled))
+	req.Body = io.NopCloser(bytes.NewReader(marshalled))
 
 	err = AddContinuationSanitizer("Location", "Sanitized", true, nil)
 	require.NoError(t, err)
@@ -515,7 +515,7 @@ func TestContinuationSanitizer(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -562,7 +562,7 @@ func TestGeneralRegexSanitizer(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -608,7 +608,7 @@ func TestOAuthResponseSanitizer(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -651,7 +651,7 @@ func TestUriSubscriptionIdSanitizer(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -704,7 +704,7 @@ func TestResetSanitizers(t *testing.T) {
 	defer jsonFile.Close()
 
 	var data RecordingFileStruct
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
@@ -755,7 +755,7 @@ func TestSingleTestSanitizer(t *testing.T) {
 			defer jsonFile.Close()
 
 			var data RecordingFileStruct
-			byteValue, err := ioutil.ReadAll(jsonFile)
+			byteValue, err := io.ReadAll(jsonFile)
 			require.NoError(t, err)
 			err = json.Unmarshal(byteValue, &data)
 			require.NoError(t, err)

--- a/sdk/internal/recording/testdata/mockserver/main_test.go
+++ b/sdk/internal/recording/testdata/mockserver/main_test.go
@@ -10,7 +10,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,7 +26,7 @@ func TestMain(t *testing.T) {
 	res := w.Result()
 	defer res.Body.Close()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	var unmarshalled map[string]string


### PR DESCRIPTION
Update to latest golangci-lint to support Go 1.19.
Update Go 1.18 to latest patch version.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
