### PR TITLE
Deploy live test MHSMs to higher capacity region

### DIFF
--- a/sdk/keyvault/azkeys/test-resources.json
+++ b/sdk/keyvault/azkeys/test-resources.json
@@ -37,7 +37,7 @@
         },
         "hsmLocation": {
             "type": "string",
-            "defaultValue": "westus3",
+            "defaultValue": "uksouth",
             "allowedValues": [
                 "australiacentral",
                 "australiaeast",
@@ -66,7 +66,7 @@
                 "westus3"
             ],
             "metadata": {
-                "description": "The location of the Managed HSM. By default, this is 'westus3'."
+                "description": "The location of the Managed HSM."
             }
         },
         "enableHsm": {


### PR DESCRIPTION
We've seen a string of deployment failures in live tests due to low MHSM capacity in westus3. The MHSM team has suggested uksouth as a higher capacity region, so let's give that a try.