### PR TITLE
[azservicebus] Ignore the leading XMLNS for properties in subscription rules

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -19,6 +19,7 @@
     not being delivered, but still incrementing their delivery count and requiring the message lock 
     timeout to expire.
   - Link detach could result in messages being ignored, requiring the message lock timeout to expire.
+- Subscription rules weren't deserializing properly when created from the portal (PR#18813)
 
 ## 1.0.2-beta.0 (2022-07-07)
 

--- a/sdk/messaging/azservicebus/admin/admin_client.go
+++ b/sdk/messaging/azservicebus/admin/admin_client.go
@@ -34,9 +34,12 @@ type ClientOptions struct {
 // NewClientFromConnectionString creates a Client authenticating using a connection string.
 // connectionString can be a Service Bus connection string for the namespace or for an entity, which contains a
 // SharedAccessKeyName and SharedAccessKey properties (for instance, from the Azure Portal):
-//   Endpoint=sb://<sb>.servicebus.windows.net/;SharedAccessKeyName=<key name>;SharedAccessKey=<key value>
+//
+//	Endpoint=sb://<sb>.servicebus.windows.net/;SharedAccessKeyName=<key name>;SharedAccessKey=<key value>
+//
 // Or it can be a connection string with a SharedAccessSignature:
-//   Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>
+//
+//	Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>
 func NewClientFromConnectionString(connectionString string, options *ClientOptions) (*Client, error) {
 	var clientOptions *azcore.ClientOptions
 

--- a/sdk/messaging/azservicebus/admin/testdata/emptyrulefeed.json
+++ b/sdk/messaging/azservicebus/admin/testdata/emptyrulefeed.json
@@ -1,0 +1,9 @@
+{
+    "XMLName": {
+      "Space": "",
+      "Local": ""
+    },
+    "ID": "https://fakeservicebus/csharp/Subscriptions/subwithfilter/Rules/?%24skip=2\u0026api-version=2021-05",
+    "Title": "Rules",
+    "Entries": null
+  }

--- a/sdk/messaging/azservicebus/admin/testdata/rulefeed.json
+++ b/sdk/messaging/azservicebus/admin/testdata/rulefeed.json
@@ -1,0 +1,182 @@
+
+{
+    "XMLName": {
+      "Space": "",
+      "Local": ""
+    },
+    "ID": "https://fakeservicebus/csharp/Subscriptions/subwithfilter/Rules/?api-version=2021-05",
+    "Title": "Rules",
+    "Entries": [
+      {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
+        "ID": "https://fakeservicebus/csharp/Subscriptions/subwithfilter/Rules/CorrelationFilter1?api-version=2021-05",
+        "Title": "CorrelationFilter1",
+        "Author": null,
+        "Link": {
+          "XMLName": {
+            "Space": "http://www.w3.org/2005/Atom",
+            "Local": "link"
+          },
+          "Rel": "self",
+          "HREF": "CorrelationFilter1?api-version=2021-05"
+        },
+        "DataServiceSchema": "",
+        "DataServiceMetadataSchema": "",
+        "AtomSchema": "",
+        "Content": {
+          "XMLName": {
+            "Space": "http://www.w3.org/2005/Atom",
+            "Local": "content"
+          },
+          "Type": "application/xml",
+          "RuleDescription": {
+            "XMLName": {
+              "Space": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+              "Local": "RuleDescription"
+            },
+            "XMLNS": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+            "XMLNSI": "",
+            "InstanceMetadataSchema": null,
+            "ServiceBusSchema": null,
+            "CreatedAt": "2022-08-08T22:23:20.3432504Z",
+            "Filter": {
+              "XMLName": {
+                "Space": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+                "Local": "Filter"
+              },
+              "RawXML": "PENvcnJlbGF0aW9uSWQ+MTE8L0NvcnJlbGF0aW9uSWQ+PFByb3BlcnRpZXM+PEtleVZhbHVlT2ZzdHJpbmdhbnlUeXBlPjxLZXk+aGVsbG88L0tleT48VmFsdWUgaTp0eXBlPSJkNXAxOnN0cmluZyIgeG1sbnM6ZDVwMT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiPndvcmxkPC9WYWx1ZT48L0tleVZhbHVlT2ZzdHJpbmdhbnlUeXBlPjwvUHJvcGVydGllcz4=",
+              "RawAttrs": null,
+              "CorrelationID": "11",
+              "MessageID": null,
+              "To": null,
+              "ReplyTo": null,
+              "Label": null,
+              "SessionID": null,
+              "ReplyToSessionID": null,
+              "ContentType": null,
+              "Properties": {
+                "KeyValues": [
+                  {
+                    "Key": "hello",
+                    "Value": {
+                      "Type": "d5p1:string",
+                      "L28NS": "",
+                      "Text": "world"
+                    }
+                  },
+                  {
+                    "Key": "helloint",
+                    "Value": {
+                      "Type": "doesnotmatter:int",
+                      "L28NS": "",
+                      "Text": "101"
+                    }
+                  },
+                  {
+                    "Key": "hellodouble",
+                    "Value": {
+                      "Type": "d5p1:double",
+                      "L28NS": "",
+                      "Text": "1.1"
+                    }
+                  },
+                  {
+                    "Key": "hellodatetime",
+                    "Value": {
+                      "Type": "d6p1:dateTime",
+                      "L28NS": "",
+                      "Text": "2020-01-01T01:02:03Z"
+                    }
+                  }
+                ]
+              },
+              "Type": "CorrelationFilter",
+              "SQLExpression": null,
+              "CompatibilityLevel": 0,
+              "Parameters": null
+            },
+            "Action": {
+              "Type": "EmptyRuleAction",
+              "SQLExpression": "",
+              "Parameters": null,
+              "RawXML": null,
+              "RawAttrs": null
+            },
+            "Name": "CorrelationFilter1"
+          }
+        }
+      },
+      {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
+        "ID": "https://fakeservicebus/csharp/Subscriptions/subwithfilter/Rules/SQLFilter1?api-version=2021-05",
+        "Title": "SQLFilter1",
+        "Author": null,
+        "Link": {
+          "XMLName": {
+            "Space": "http://www.w3.org/2005/Atom",
+            "Local": "link"
+          },
+          "Rel": "self",
+          "HREF": "SQLFilter1?api-version=2021-05"
+        },
+        "DataServiceSchema": "",
+        "DataServiceMetadataSchema": "",
+        "AtomSchema": "",
+        "Content": {
+          "XMLName": {
+            "Space": "http://www.w3.org/2005/Atom",
+            "Local": "content"
+          },
+          "Type": "application/xml",
+          "RuleDescription": {
+            "XMLName": {
+              "Space": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+              "Local": "RuleDescription"
+            },
+            "XMLNS": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+            "XMLNSI": "",
+            "InstanceMetadataSchema": null,
+            "ServiceBusSchema": null,
+            "CreatedAt": "2022-08-08T22:47:21.5507406Z",
+            "Filter": {
+              "XMLName": {
+                "Space": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect",
+                "Local": "Filter"
+              },
+              "RawXML": "PFNxbEV4cHJlc3Npb24+MT0xPC9TcWxFeHByZXNzaW9uPjxDb21wYXRpYmlsaXR5TGV2ZWw+MjA8L0NvbXBhdGliaWxpdHlMZXZlbD48UGFyYW1ldGVycy8+",
+              "RawAttrs": null,
+              "CorrelationID": null,
+              "MessageID": null,
+              "To": null,
+              "ReplyTo": null,
+              "Label": null,
+              "SessionID": null,
+              "ReplyToSessionID": null,
+              "ContentType": null,
+              "Properties": null,
+              "Type": "SqlFilter",
+              "SQLExpression": "1=1",
+              "CompatibilityLevel": 20,
+              "Parameters": {
+                "KeyValues": null
+              }
+            },
+            "Action": {
+              "Type": "EmptyRuleAction",
+              "SQLExpression": "",
+              "Parameters": null,
+              "RawXML": null,
+              "RawAttrs": null
+            },
+            "Name": "SQLFilter1"
+          }
+        }
+      }
+    ]
+  }

--- a/sdk/messaging/azservicebus/amqp_message.go
+++ b/sdk/messaging/azservicebus/amqp_message.go
@@ -11,7 +11,8 @@ import (
 
 // AMQPAnnotatedMessage represents the AMQP message, as received from Service Bus.
 // For details about these properties, refer to the AMQP specification:
-//   https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
+//
+//	https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
 //
 // Some fields in this struct are typed 'any', which means they will accept AMQP primitives, or in some
 // cases slices and maps.

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -87,9 +87,12 @@ func NewClient(fullyQualifiedNamespace string, credential azcore.TokenCredential
 // A Client allows you create receivers (for queues or subscriptions) and senders (for queues and topics).
 // connectionString can be a Service Bus connection string for the namespace or for an entity, which contains a
 // SharedAccessKeyName and SharedAccessKey properties (for instance, from the Azure Portal):
-//   Endpoint=sb://<sb>.servicebus.windows.net/;SharedAccessKeyName=<key name>;SharedAccessKey=<key value>
+//
+//	Endpoint=sb://<sb>.servicebus.windows.net/;SharedAccessKeyName=<key name>;SharedAccessKey=<key value>
+//
 // Or it can be a connection string with a SharedAccessSignature:
-//   Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>
+//
+//	Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>
 func NewClientFromConnectionString(connectionString string, options *ClientOptions) (*Client, error) {
 	if connectionString == "" {
 		return nil, errors.New("connectionString must not be empty")

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -56,7 +56,9 @@ type AMQPLinks interface {
 }
 
 // AMQPLinksImpl manages the set of AMQP links (and detritus) typically needed to work
-//  within Service Bus:
+//
+//	within Service Bus:
+//
 // - An *goamqp.Sender or *goamqp.Receiver AMQP link (could also be 'both' if needed)
 // - A `$management` link
 // - an *goamqp.Session

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -214,7 +213,7 @@ var ErrFeedEmpty = errors.New("entity does not exist")
 // (similar to xml.Unmarshal, which this func is calling).
 // If an empty feed is found, it returns nil.
 func deserializeBody(resp *http.Response, respObj interface{}) (*http.Response, error) {
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return resp, err

--- a/sdk/messaging/azservicebus/internal/atom/manager_common.go
+++ b/sdk/messaging/azservicebus/internal/atom/manager_common.go
@@ -6,7 +6,6 @@ package atom
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -16,6 +15,6 @@ func CloseRes(ctx context.Context, res *http.Response) {
 		return
 	}
 
-	_, _ = io.Copy(ioutil.Discard, res.Body)
+	_, _ = io.Copy(io.Discard, res.Body)
 	_ = res.Body.Close()
 }

--- a/sdk/messaging/azservicebus/internal/go-amqp/client.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/client.go
@@ -173,7 +173,9 @@ func randString(n int) string {
 // linkKey uniquely identifies a link on a connection by name and direction.
 //
 // A link can be identified uniquely by the ordered tuple
-//     (source-container-id, target-container-id, name)
+//
+//	(source-container-id, target-container-id, name)
+//
 // On a single connection the container ID pairs can be abbreviated
 // to a boolean flag indicating the direction of the link.
 type linkKey struct {

--- a/sdk/messaging/azservicebus/internal/go-amqp/internal/frames/frames.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/internal/frames/frames.go
@@ -14,18 +14,20 @@ import (
 
 /*
 <type name="source" class="composite" source="list" provides="source">
-    <descriptor name="amqp:source:list" code="0x00000000:0x00000028"/>
-    <field name="address" type="*" requires="address"/>
-    <field name="durable" type="terminus-durability" default="none"/>
-    <field name="expiry-policy" type="terminus-expiry-policy" default="session-end"/>
-    <field name="timeout" type="seconds" default="0"/>
-    <field name="dynamic" type="boolean" default="false"/>
-    <field name="dynamic-node-properties" type="node-properties"/>
-    <field name="distribution-mode" type="symbol" requires="distribution-mode"/>
-    <field name="filter" type="filter-set"/>
-    <field name="default-outcome" type="*" requires="outcome"/>
-    <field name="outcomes" type="symbol" multiple="true"/>
-    <field name="capabilities" type="symbol" multiple="true"/>
+
+	<descriptor name="amqp:source:list" code="0x00000000:0x00000028"/>
+	<field name="address" type="*" requires="address"/>
+	<field name="durable" type="terminus-durability" default="none"/>
+	<field name="expiry-policy" type="terminus-expiry-policy" default="session-end"/>
+	<field name="timeout" type="seconds" default="0"/>
+	<field name="dynamic" type="boolean" default="false"/>
+	<field name="dynamic-node-properties" type="node-properties"/>
+	<field name="distribution-mode" type="symbol" requires="distribution-mode"/>
+	<field name="filter" type="filter-set"/>
+	<field name="default-outcome" type="*" requires="outcome"/>
+	<field name="outcomes" type="symbol" multiple="true"/>
+	<field name="capabilities" type="symbol" multiple="true"/>
+
 </type>
 */
 type Source struct {
@@ -198,14 +200,16 @@ func (s Source) String() string {
 
 /*
 <type name="target" class="composite" source="list" provides="target">
-    <descriptor name="amqp:target:list" code="0x00000000:0x00000029"/>
-    <field name="address" type="*" requires="address"/>
-    <field name="durable" type="terminus-durability" default="none"/>
-    <field name="expiry-policy" type="terminus-expiry-policy" default="session-end"/>
-    <field name="timeout" type="seconds" default="0"/>
-    <field name="dynamic" type="boolean" default="false"/>
-    <field name="dynamic-node-properties" type="node-properties"/>
-    <field name="capabilities" type="symbol" multiple="true"/>
+
+	<descriptor name="amqp:target:list" code="0x00000000:0x00000029"/>
+	<field name="address" type="*" requires="address"/>
+	<field name="durable" type="terminus-durability" default="none"/>
+	<field name="expiry-policy" type="terminus-expiry-policy" default="session-end"/>
+	<field name="timeout" type="seconds" default="0"/>
+	<field name="dynamic" type="boolean" default="false"/>
+	<field name="dynamic-node-properties" type="node-properties"/>
+	<field name="capabilities" type="symbol" multiple="true"/>
+
 </type>
 */
 type Target struct {
@@ -427,15 +431,17 @@ func (o *PerformOpen) String() string {
 
 /*
 <type name="begin" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:begin:list" code="0x00000000:0x00000011"/>
-    <field name="remote-channel" type="ushort"/>
-    <field name="next-outgoing-id" type="transfer-number" mandatory="true"/>
-    <field name="incoming-window" type="uint" mandatory="true"/>
-    <field name="outgoing-window" type="uint" mandatory="true"/>
-    <field name="handle-max" type="handle" default="4294967295"/>
-    <field name="offered-capabilities" type="symbol" multiple="true"/>
-    <field name="desired-capabilities" type="symbol" multiple="true"/>
-    <field name="properties" type="fields"/>
+
+	<descriptor name="amqp:begin:list" code="0x00000000:0x00000011"/>
+	<field name="remote-channel" type="ushort"/>
+	<field name="next-outgoing-id" type="transfer-number" mandatory="true"/>
+	<field name="incoming-window" type="uint" mandatory="true"/>
+	<field name="outgoing-window" type="uint" mandatory="true"/>
+	<field name="handle-max" type="handle" default="4294967295"/>
+	<field name="offered-capabilities" type="symbol" multiple="true"/>
+	<field name="desired-capabilities" type="symbol" multiple="true"/>
+	<field name="properties" type="fields"/>
+
 </type>
 */
 type PerformBegin struct {
@@ -528,21 +534,23 @@ func (b *PerformBegin) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="attach" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:attach:list" code="0x00000000:0x00000012"/>
-    <field name="name" type="string" mandatory="true"/>
-    <field name="handle" type="handle" mandatory="true"/>
-    <field name="role" type="role" mandatory="true"/>
-    <field name="snd-settle-mode" type="sender-settle-mode" default="mixed"/>
-    <field name="rcv-settle-mode" type="receiver-settle-mode" default="first"/>
-    <field name="source" type="*" requires="source"/>
-    <field name="target" type="*" requires="target"/>
-    <field name="unsettled" type="map"/>
-    <field name="incomplete-unsettled" type="boolean" default="false"/>
-    <field name="initial-delivery-count" type="sequence-no"/>
-    <field name="max-message-size" type="ulong"/>
-    <field name="offered-capabilities" type="symbol" multiple="true"/>
-    <field name="desired-capabilities" type="symbol" multiple="true"/>
-    <field name="properties" type="fields"/>
+
+	<descriptor name="amqp:attach:list" code="0x00000000:0x00000012"/>
+	<field name="name" type="string" mandatory="true"/>
+	<field name="handle" type="handle" mandatory="true"/>
+	<field name="role" type="role" mandatory="true"/>
+	<field name="snd-settle-mode" type="sender-settle-mode" default="mixed"/>
+	<field name="rcv-settle-mode" type="receiver-settle-mode" default="first"/>
+	<field name="source" type="*" requires="source"/>
+	<field name="target" type="*" requires="target"/>
+	<field name="unsettled" type="map"/>
+	<field name="incomplete-unsettled" type="boolean" default="false"/>
+	<field name="initial-delivery-count" type="sequence-no"/>
+	<field name="max-message-size" type="ulong"/>
+	<field name="offered-capabilities" type="symbol" multiple="true"/>
+	<field name="desired-capabilities" type="symbol" multiple="true"/>
+	<field name="properties" type="fields"/>
+
 </type>
 */
 type PerformAttach struct {
@@ -739,18 +747,20 @@ func (a *PerformAttach) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="flow" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:flow:list" code="0x00000000:0x00000013"/>
-    <field name="next-incoming-id" type="transfer-number"/>
-    <field name="incoming-window" type="uint" mandatory="true"/>
-    <field name="next-outgoing-id" type="transfer-number" mandatory="true"/>
-    <field name="outgoing-window" type="uint" mandatory="true"/>
-    <field name="handle" type="handle"/>
-    <field name="delivery-count" type="sequence-no"/>
-    <field name="link-credit" type="uint"/>
-    <field name="available" type="uint"/>
-    <field name="drain" type="boolean" default="false"/>
-    <field name="echo" type="boolean" default="false"/>
-    <field name="properties" type="fields"/>
+
+	<descriptor name="amqp:flow:list" code="0x00000000:0x00000013"/>
+	<field name="next-incoming-id" type="transfer-number"/>
+	<field name="incoming-window" type="uint" mandatory="true"/>
+	<field name="next-outgoing-id" type="transfer-number" mandatory="true"/>
+	<field name="outgoing-window" type="uint" mandatory="true"/>
+	<field name="handle" type="handle"/>
+	<field name="delivery-count" type="sequence-no"/>
+	<field name="link-credit" type="uint"/>
+	<field name="available" type="uint"/>
+	<field name="drain" type="boolean" default="false"/>
+	<field name="echo" type="boolean" default="false"/>
+	<field name="properties" type="fields"/>
+
 </type>
 */
 type PerformFlow struct {
@@ -912,18 +922,20 @@ func (f *PerformFlow) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="transfer" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:transfer:list" code="0x00000000:0x00000014"/>
-    <field name="handle" type="handle" mandatory="true"/>
-    <field name="delivery-id" type="delivery-number"/>
-    <field name="delivery-tag" type="delivery-tag"/>
-    <field name="message-format" type="message-format"/>
-    <field name="settled" type="boolean"/>
-    <field name="more" type="boolean" default="false"/>
-    <field name="rcv-settle-mode" type="receiver-settle-mode"/>
-    <field name="state" type="*" requires="delivery-state"/>
-    <field name="resume" type="boolean" default="false"/>
-    <field name="aborted" type="boolean" default="false"/>
-    <field name="batchable" type="boolean" default="false"/>
+
+	<descriptor name="amqp:transfer:list" code="0x00000000:0x00000014"/>
+	<field name="handle" type="handle" mandatory="true"/>
+	<field name="delivery-id" type="delivery-number"/>
+	<field name="delivery-tag" type="delivery-tag"/>
+	<field name="message-format" type="message-format"/>
+	<field name="settled" type="boolean"/>
+	<field name="more" type="boolean" default="false"/>
+	<field name="rcv-settle-mode" type="receiver-settle-mode"/>
+	<field name="state" type="*" requires="delivery-state"/>
+	<field name="resume" type="boolean" default="false"/>
+	<field name="aborted" type="boolean" default="false"/>
+	<field name="batchable" type="boolean" default="false"/>
+
 </type>
 */
 type PerformTransfer struct {
@@ -1143,13 +1155,15 @@ func (t *PerformTransfer) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="disposition" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:disposition:list" code="0x00000000:0x00000015"/>
-    <field name="role" type="role" mandatory="true"/>
-    <field name="first" type="delivery-number" mandatory="true"/>
-    <field name="last" type="delivery-number"/>
-    <field name="settled" type="boolean" default="false"/>
-    <field name="state" type="*" requires="delivery-state"/>
-    <field name="batchable" type="boolean" default="false"/>
+
+	<descriptor name="amqp:disposition:list" code="0x00000000:0x00000015"/>
+	<field name="role" type="role" mandatory="true"/>
+	<field name="first" type="delivery-number" mandatory="true"/>
+	<field name="last" type="delivery-number"/>
+	<field name="settled" type="boolean" default="false"/>
+	<field name="state" type="*" requires="delivery-state"/>
+	<field name="batchable" type="boolean" default="false"/>
+
 </type>
 */
 type PerformDisposition struct {
@@ -1227,10 +1241,12 @@ func (d *PerformDisposition) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="detach" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:detach:list" code="0x00000000:0x00000016"/>
-    <field name="handle" type="handle" mandatory="true"/>
-    <field name="closed" type="boolean" default="false"/>
-    <field name="error" type="error"/>
+
+	<descriptor name="amqp:detach:list" code="0x00000000:0x00000016"/>
+	<field name="handle" type="handle" mandatory="true"/>
+	<field name="closed" type="boolean" default="false"/>
+	<field name="error" type="error"/>
+
 </type>
 */
 type PerformDetach struct {
@@ -1275,8 +1291,10 @@ func (d *PerformDetach) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="end" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:end:list" code="0x00000000:0x00000017"/>
-    <field name="error" type="error"/>
+
+	<descriptor name="amqp:end:list" code="0x00000000:0x00000017"/>
+	<field name="error" type="error"/>
+
 </type>
 */
 type PerformEnd struct {
@@ -1303,8 +1321,10 @@ func (e *PerformEnd) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="close" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:close:list" code="0x00000000:0x00000018"/>
-    <field name="error" type="error"/>
+
+	<descriptor name="amqp:close:list" code="0x00000000:0x00000018"/>
+	<field name="error" type="error"/>
+
 </type>
 */
 type PerformClose struct {

--- a/sdk/messaging/azservicebus/internal/go-amqp/link_options.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/link_options.go
@@ -177,14 +177,18 @@ type ReceiverOptions struct {
 // Example:
 //
 // The standard selector-filter is defined as:
-//  <descriptor name="apache.org:selector-filter:string" code="0x0000468C:0x00000004"/>
+//
+//	<descriptor name="apache.org:selector-filter:string" code="0x0000468C:0x00000004"/>
+//
 // In this case the name is "apache.org:selector-filter:string" and the code is
 // 0x0000468C00000004.
-//  LinkSourceFilter("apache.org:selector-filter:string", 0x0000468C00000004, exampleValue)
+//
+//	LinkSourceFilter("apache.org:selector-filter:string", 0x0000468C00000004, exampleValue)
 //
 // References:
-//  http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set
-//  http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#section-descriptor-values
+//
+//	http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set
+//	http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#section-descriptor-values
 type LinkFilter func(encoding.Filter)
 
 // LinkFilterSource creates or updates the named filter for this LinkFilter.

--- a/sdk/messaging/azservicebus/internal/go-amqp/manualCreditor.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/manualCreditor.go
@@ -36,9 +36,10 @@ func (mc *manualCreditor) EndDrain() {
 // FlowBits gets gets the proper values for the next flow frame
 // and resets the internal state.
 // Returns:
-//   (drain: true, credits: 0) if a flow is needed (drain)
-//   (drain: false, credits > 0) if a flow is needed (issue credit)
-//   (drain: false, credits == 0) if no flow needed.
+//
+//	(drain: true, credits: 0) if a flow is needed (drain)
+//	(drain: false, credits > 0) if a flow is needed (issue credit)
+//	(drain: false, credits == 0) if no flow needed.
 func (mc *manualCreditor) FlowBits(currentCredits uint32) (bool, uint32) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()

--- a/sdk/messaging/azservicebus/internal/test/test_helpers.go
+++ b/sdk/messaging/azservicebus/internal/test/test_helpers.go
@@ -99,14 +99,13 @@ func CreateExpiringQueue(t *testing.T, qd *atom.QueueDescription) (string, func(
 // Returns a function that ends log capturing and returns any captured messages.
 // It's safe to call endCapture() multiple times, so a simple call pattern is:
 //
-//   endCapture := CaptureLogsForTest()
-//   defer endCapture()				// ensure cleanup in case of test assert failures
+//	endCapture := CaptureLogsForTest()
+//	defer endCapture()				// ensure cleanup in case of test assert failures
 //
-//   /* some test code */
+//	/* some test code */
 //
-//   messages := endCapture()
-//   /* do inspection of log messages */
-//
+//	messages := endCapture()
+//	/* do inspection of log messages */
 func CaptureLogsForTest() func() []string {
 	messagesCh := make(chan string, 10000)
 	return CaptureLogsForTestWithChannel(messagesCh)


### PR DESCRIPTION
The individual properties for a rule in Service Bus come with an XML ns prefix. We don't actually care about this as we're just trying to figure out what the assigned type is (string, int, etc..) so this just strips out the prefix.

Fixes #18785