### PR TITLE
comment api view export temporary

### DIFF
--- a/eng/tools/generator/cmd/v2/automation/automationCmd.go
+++ b/eng/tools/generator/cmd/v2/automation/automationCmd.go
@@ -154,8 +154,8 @@ func (ctx *automationContext) generate(input *pipeline.GenerateInput) (*pipeline
 					HasBreakingChange:   &breaking,
 					BreakingChangeItems: &breakingChangeItems,
 				},
-				APIViewArtifact: fmt.Sprintf("sdk/resourcemanager/%s/%s", namespaceResult.RPName, namespaceResult.PackageName+".gosource"),
-				Language:        "Go",
+				// APIViewArtifact: fmt.Sprintf("sdk/resourcemanager/%s/%s", namespaceResult.RPName, namespaceResult.PackageName+".gosource"),
+				// Language:        "Go",
 			})
 		}
 		log.Printf("Finish to process readme file: %s", readme)


### PR DESCRIPTION
There is some issue for the api view rest api for go. Wait for fix and revert temporarily.