### PR TITLE
remove duplicate manifest publish in pipeline

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -90,7 +90,6 @@ stages:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
             go.version: '1.18.5'
-            generate.bom: true
           Linux_Go119:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04

--- a/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
@@ -33,7 +33,6 @@ stages:
             pool.name: azsdk-pool-mms-win-2019-general
             image.name: MMS2019
             go.version: '1.18.5'
-            generate.bom: true
           Linux_Go119:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04


### PR DESCRIPTION
Remove duplicate manifest publish in pipeline (minor fix for https://github.com/Azure/azure-sdk-for-go/pull/18805) to resolve pipeline failure.