### PR TITLE
Remove ioutil usage

### DIFF
--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -94,7 +93,7 @@ func (p pipelineAdapter) Do(r *http.Request) (*http.Response, error) {
 		if rsc, ok := r.Body.(io.ReadSeekCloser); ok {
 			body = rsc
 		} else {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				return nil, err
 			}

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -107,7 +107,7 @@ const (
 
 func validateJWTRequestContainsHeader(t *testing.T, headerName string) mock.ResponsePredicate {
 	return func(req *http.Request) bool {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			t.Fatal("Expected a request with the JWT in the body.")
 		}

--- a/sdk/azidentity/errors_test.go
+++ b/sdk/azidentity/errors_test.go
@@ -9,7 +9,7 @@ package azidentity
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -28,7 +28,7 @@ func TestAuthenticationFailedErrorInterface(t *testing.T) {
 	res := &http.Response{
 		Status:     "400 Bad Request",
 		StatusCode: 400,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(resBodyString)),
+		Body:       io.NopCloser(bytes.NewBufferString(resBodyString)),
 		Request:    req,
 	}
 	err = newAuthenticationFailedError(credNameAzureCLI, "error message", res)

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -338,7 +337,7 @@ func (c *managedIdentityClient) getAzureArcSecretKey(ctx context.Context, resour
 	if pos == -1 {
 		return "", fmt.Errorf("did not receive a correct value from WWW-Authenticate header: %s", header)
 	}
-	key, err := ioutil.ReadFile(header[pos+1:])
+	key, err := os.ReadFile(header[pos+1:])
 	if err != nil {
 		return "", fmt.Errorf("could not read file (%s) contents: %v", header[pos+1:], err)
 	}

--- a/sdk/data/azappconfig/policy_hmac_auth.go
+++ b/sdk/data/azappconfig/policy_hmac_auth.go
@@ -13,7 +13,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -48,11 +48,11 @@ func (policy *hmacAuthenticationPolicy) Do(request *policy.Request) (*http.Respo
 	var content []byte
 	if req.Body != nil {
 		var err error
-		if content, err = ioutil.ReadAll(req.Body); err != nil {
+		if content, err = io.ReadAll(req.Body); err != nil {
 			return nil, err
 		}
 	}
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(content))
+	req.Body = io.NopCloser(bytes.NewBuffer(content))
 
 	timestamp := time.Now().UTC().Format(http.TimeFormat)
 

--- a/sdk/data/azcosmos/cosmos_client_test.go
+++ b/sdk/data/azcosmos/cosmos_client_test.go
@@ -6,7 +6,7 @@ package azcosmos
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -202,7 +202,7 @@ func TestAttachContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	readBody, _ := ioutil.ReadAll(req.Body())
+	readBody, _ := io.ReadAll(req.Body())
 
 	if string(readBody) != string(marshalled) {
 		t.Errorf("Expected %v, but got %v", string(marshalled), string(readBody))
@@ -219,7 +219,7 @@ func TestAttachContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	readBody, _ = ioutil.ReadAll(req.Body())
+	readBody, _ = io.ReadAll(req.Body())
 
 	if string(readBody) != string(marshalled) {
 		t.Errorf("Expected %v, but got %v", string(marshalled), string(readBody))
@@ -530,7 +530,7 @@ func (p *pipelineVerifier) Do(req *policy.Request) (*http.Response, error) {
 	pr.method = req.Raw().Method
 	pr.url = req.Raw().URL
 	if req.Body() != nil {
-		readBody, _ := ioutil.ReadAll(req.Body())
+		readBody, _ := io.ReadAll(req.Body())
 		pr.body = string(readBody)
 	}
 	pr.contentType = req.Raw().Header.Get(headerContentType)

--- a/sdk/data/aztables/example_test.go
+++ b/sdk/data/aztables/example_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -166,7 +166,7 @@ func ExampleClient_SubmitTransaction() {
 	if err != nil {
 		var httpErr *azcore.ResponseError
 		if errors.As(err, &httpErr) {
-			body, err := ioutil.ReadAll(httpErr.RawResponse.Body)
+			body, err := io.ReadAll(httpErr.RawResponse.Body)
 			if err != nil {
 				panic(err)
 			}

--- a/sdk/data/aztables/transactional_batch.go
+++ b/sdk/data/aztables/transactional_batch.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -139,7 +138,7 @@ func (t *Client) submitTransactionInternal(ctx context.Context, transactionActio
 
 // create the transaction response. This will read the inner responses
 func buildTransactionResponse(req *policy.Request, resp *http.Response, itemCount int) (TransactionResponse, error) {
-	bytesBody, err := ioutil.ReadAll(resp.Body)
+	bytesBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return TransactionResponse{}, err
 	}
@@ -156,7 +155,7 @@ func buildTransactionResponse(req *policy.Request, resp *http.Response, itemCoun
 		return TransactionResponse{}, err
 	}
 
-	innerBytes, err := ioutil.ReadAll(outerPart)
+	innerBytes, err := io.ReadAll(outerPart)
 	if err != nil && err != io.ErrUnexpectedEOF { // Cosmos specific error handling
 		return TransactionResponse{}, err
 	}
@@ -166,7 +165,7 @@ func buildTransactionResponse(req *policy.Request, resp *http.Response, itemCoun
 	i := 0
 	innerPart, err := mpReader.NextPart()
 	for ; err == nil; innerPart, err = mpReader.NextPart() {
-		part, err := ioutil.ReadAll(innerPart)
+		part, err := io.ReadAll(innerPart)
 		if err != nil {
 			break
 		}

--- a/sdk/keyvault/azcertificates/client_test.go
+++ b/sdk/keyvault/azcertificates/client_test.go
@@ -15,8 +15,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -457,14 +457,14 @@ func TestMergeCertificate(t *testing.T) {
 	certOpResp, err := client.GetCertificateOperation(ctx, certName, nil)
 	require.NoError(t, err)
 
-	data, err := ioutil.ReadFile("testdata/ca.crt")
+	data, err := os.ReadFile("testdata/ca.crt")
 	require.NoError(t, err)
 	block, _ := pem.Decode(data)
 	require.NotNil(t, block)
 	caCert, err := x509.ParseCertificate(block.Bytes)
 	require.NoError(t, err)
 
-	data, err = ioutil.ReadFile("testdata/ca.key")
+	data, err = os.ReadFile("testdata/ca.key")
 	require.NoError(t, err)
 	pkeyBlock, _ := pem.Decode(data)
 	require.NotNil(t, pkeyBlock)

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -214,7 +213,7 @@ var ErrFeedEmpty = errors.New("entity does not exist")
 // (similar to xml.Unmarshal, which this func is calling).
 // If an empty feed is found, it returns nil.
 func deserializeBody(resp *http.Response, respObj interface{}) (*http.Response, error) {
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return resp, err

--- a/sdk/messaging/azservicebus/internal/atom/manager_common.go
+++ b/sdk/messaging/azservicebus/internal/atom/manager_common.go
@@ -6,7 +6,6 @@ package atom
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -16,6 +15,6 @@ func CloseRes(ctx context.Context, res *http.Response) {
 		return
 	}
 
-	_, _ = io.Copy(ioutil.Discard, res.Body)
+	_, _ = io.Copy(io.Discard, res.Body)
 	_ = res.Body.Close()
 }


### PR DESCRIPTION
`io/ioutil` was deprecated in 1.16 and golangci-lint now warns about it. I left `azblob` alone to avoid causing merge conflicts.