### PR TITLE
Revert change for URL encoding query params

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-* URL-encode request query parameters when creating the request.
 
 ### Other Changes
 * Fixed various doc bugs.

--- a/sdk/azcore/internal/exported/request.go
+++ b/sdk/azcore/internal/exported/request.go
@@ -12,10 +12,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"reflect"
 	"strconv"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 )
@@ -59,14 +57,6 @@ func NewRequest(ctx context.Context, httpMethod string, endpoint string) (*Reque
 	if !(req.URL.Scheme == "http" || req.URL.Scheme == "https") {
 		return nil, fmt.Errorf("unsupported protocol scheme %s", req.URL.Scheme)
 	}
-	// some services will return query param values that include a semi-colon.
-	// we must encode it before parsing the raw query as it's considered invalid otherwise.
-	req.URL.RawQuery = strings.Replace(req.URL.RawQuery, ";", "%3B", -1)
-	qp, err := url.ParseQuery(req.URL.RawQuery)
-	if err != nil {
-		return nil, err
-	}
-	req.URL.RawQuery = qp.Encode()
 	return &Request{req: req}, nil
 }
 

--- a/sdk/azcore/internal/exported/request_test.go
+++ b/sdk/azcore/internal/exported/request_test.go
@@ -11,8 +11,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 const testURL = "http://test.contoso.com/"
@@ -142,16 +140,4 @@ func TestNewRequestFail(t *testing.T) {
 	if req != nil {
 		t.Fatal("unexpected request")
 	}
-}
-
-func TestNewRequestURLEncoded(t *testing.T) {
-	req, err := NewRequest(context.Background(), http.MethodOptions, `https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/usageDetails?$expand=meterDetails&$filter=properties/usageStart ge '2021-07-01' and properties/usageEnd lt '2022-07-02'&$top=2&api-version=2021-10-01&sessiontoken=&$skiptoken=ABC;123&skiptokenver=v1&id=00000000-0000-0000-0000-000000000000`)
-	require.NoError(t, err)
-	require.Equal(t, "%24expand=meterDetails&%24filter=properties%2FusageStart+ge+%272021-07-01%27+and+properties%2FusageEnd+lt+%272022-07-02%27&%24skiptoken=ABC%3B123&%24top=2&api-version=2021-10-01&id=00000000-0000-0000-0000-000000000000&sessiontoken=&skiptokenver=v1", req.req.URL.RawQuery)
-}
-
-func TestNewRequestURLEncodedFailed(t *testing.T) {
-	req, err := NewRequest(context.Background(), http.MethodOptions, `http://test.contoso.com/?invalid=%1`)
-	require.Error(t, err)
-	require.Nil(t, req)
 }

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -37,6 +37,7 @@ const (
 )
 
 // NewRequest creates a new policy.Request with the specified input.
+// The endpoint MUST be properly encoded before calling this function.
 func NewRequest(ctx context.Context, httpMethod string, endpoint string) (*policy.Request, error) {
 	return exported.NewRequest(ctx, httpMethod, endpoint)
 }


### PR DESCRIPTION
Services are expected to return properly encoded URLs in payloads.
Updated doc comment for NewRequest stating the encoding requirement.

Reverts fix made for https://github.com/Azure/azure-sdk-for-go/issues/18809