### PR TITLE
[azeventhubs] Bug fixes: send to 'any' partition, also offset position strings were incorrect.

### DIFF
--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -5,6 +5,7 @@ package azeventhubs
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -181,11 +182,7 @@ func (cc *ConsumerClient) ReceiveEvents(ctx context.Context, count int, options 
 		return nil, internal.TransformError(err)
 	}
 
-	cc.offsetExpression = getOffsetExpression(StartPosition{
-		SequenceNumber: to.Ptr(events[len(events)-1].SequenceNumber),
-		Inclusive:      false,
-	})
-
+	cc.offsetExpression = formatOffsetExpressionForSequence(">", events[len(events)-1].SequenceNumber)
 	return events, nil
 }
 
@@ -220,34 +217,66 @@ func (cc *ConsumerClient) Close(ctx context.Context) error {
 	return cc.namespace.Close(ctx, true)
 }
 
-func getOffsetExpression(startPosition StartPosition) string {
+func getOffsetExpression(startPosition StartPosition) (string, error) {
 	lt := ">"
 
 	if startPosition.Inclusive {
 		lt = ">="
 	}
 
+	var errMultipleFieldsSet = errors.New("Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+
+	offsetExpr := ""
+
 	if startPosition.EnqueuedTime != nil {
 		// time-based, non-inclusive
-		return fmt.Sprintf("amqp.annotation.x-opt-enqueued-time %s '%v'", lt, startPosition.EnqueuedTime.UnixNano()/int64(time.Millisecond))
+		offsetExpr = fmt.Sprintf("amqp.annotation.x-opt-enqueued-time %s '%d'", lt, startPosition.EnqueuedTime.UnixMilli())
 	}
 
 	if startPosition.Offset != nil {
 		// offset-based, non-inclusive
 		// ex: amqp.annotation.x-opt-enqueued-time %s '165805323000'
-		return fmt.Sprintf("amqp.annotation.x-opt-offset %s '%v'", lt, startPosition.Offset)
+		if offsetExpr != "" {
+			return "", errMultipleFieldsSet
+		}
+
+		offsetExpr = fmt.Sprintf("amqp.annotation.x-opt-offset %s '%d'", lt, *startPosition.Offset)
 	}
 
 	if startPosition.Latest != nil && *startPosition.Latest {
-		return "amqp.annotation.x-opt-offset > '@latest'"
+		if offsetExpr != "" {
+			return "", errMultipleFieldsSet
+		}
+
+		offsetExpr = "amqp.annotation.x-opt-offset > '@latest'"
 	}
 
 	if startPosition.SequenceNumber != nil {
-		return fmt.Sprintf("amqp.annotation.x-opt-sequence-number %s '%d", lt, *startPosition.SequenceNumber)
+		if offsetExpr != "" {
+			return "", errMultipleFieldsSet
+		}
+
+		offsetExpr = formatOffsetExpressionForSequence(lt, *startPosition.SequenceNumber)
+	}
+
+	if startPosition.Earliest != nil && *startPosition.Earliest {
+		if offsetExpr != "" {
+			return "", errMultipleFieldsSet
+		}
+
+		return "amqp.annotation.x-opt-offset > '-1'", nil
+	}
+
+	if offsetExpr != "" {
+		return offsetExpr, nil
 	}
 
 	// default to the start
-	return "amqp.annotation.x-opt-offset > '-1'"
+	return "amqp.annotation.x-opt-offset > '-1'", nil
+}
+
+func formatOffsetExpressionForSequence(op string, sequenceNumber int64) string {
+	return fmt.Sprintf("amqp.annotation.x-opt-sequence-number %s '%d'", op, sequenceNumber)
 }
 
 func (cc *ConsumerClient) getEntityPath(partitionID string) string {
@@ -295,15 +324,20 @@ func newConsumerClientImpl(args consumerClientArgs, options *ConsumerClientOptio
 		options = &ConsumerClientOptions{}
 	}
 
+	offsetExpr, err := getOffsetExpression(options.StartPosition)
+
+	if err != nil {
+		return nil, err
+	}
+
 	client := &ConsumerClient{
 		eventHub:         args.eventHub,
 		partitionID:      args.partitionID,
 		ownerLevel:       options.OwnerLevel,
 		consumerGroup:    args.consumerGroup,
-		offsetExpression: getOffsetExpression(options.StartPosition),
+		offsetExpression: offsetExpr,
 	}
 
-	var err error
 	var nsOptions []internal.NamespaceOption
 
 	if args.connectionString != "" {

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -224,7 +224,7 @@ func getOffsetExpression(startPosition StartPosition) (string, error) {
 		lt = ">="
 	}
 
-	var errMultipleFieldsSet = errors.New("Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+	var errMultipleFieldsSet = errors.New("only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
 
 	offsetExpr := ""
 

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -56,7 +56,7 @@ type StartPosition struct {
 	// or inclusive, based on the Inclusive property.
 	// NOTE: offsets are not stable values, and might refer to different events over time
 	// as the Event Hub events reach their age limit and are discarded.
-	Offset *uint64
+	Offset *int64
 
 	// SequenceNumber will start the consumer after the specified sequence number. Can be exclusive
 	// or inclusive, based on the Inclusive property.

--- a/sdk/messaging/azeventhubs/consumer_client_unit_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_unit_test.go
@@ -4,8 +4,10 @@ package azeventhubs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,6 +44,82 @@ func TestUnitNewConsumerClient(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 		require.Equal(t, "eventHubName", client.eventHub)
+	})
+}
+
+func TestUnit_getOffsetExpression(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		expr, err := getOffsetExpression(StartPosition{})
+		require.NoError(t, err)
+		require.Equal(t, "amqp.annotation.x-opt-offset > '-1'", expr)
+
+		expr, err = getOffsetExpression(StartPosition{Earliest: to.Ptr(true)})
+		require.NoError(t, err)
+		require.Equal(t, "amqp.annotation.x-opt-offset > '-1'", expr)
+
+		expr, err = getOffsetExpression(StartPosition{Latest: to.Ptr(true)})
+		require.NoError(t, err)
+		require.Equal(t, "amqp.annotation.x-opt-offset > '@latest'", expr)
+
+		expr, err = getOffsetExpression(StartPosition{Offset: to.Ptr(uint64(101))})
+		require.NoError(t, err)
+		require.Equal(t, "amqp.annotation.x-opt-offset > '101'", expr)
+
+		expr, err = getOffsetExpression(StartPosition{Offset: to.Ptr(uint64(101)), Inclusive: true})
+		require.NoError(t, err)
+		require.Equal(t, "amqp.annotation.x-opt-offset >= '101'", expr)
+
+		expr, err = getOffsetExpression(StartPosition{SequenceNumber: to.Ptr(int64(202))})
+		require.NoError(t, err)
+		require.Equal(t, "amqp.annotation.x-opt-sequence-number > '202'", expr)
+
+		expr, err = getOffsetExpression(StartPosition{SequenceNumber: to.Ptr(int64(202)), Inclusive: true})
+		require.NoError(t, err)
+		require.Equal(t, "amqp.annotation.x-opt-sequence-number >= '202'", expr)
+
+		enqueueTime, err := time.Parse(time.RFC3339, "2020-01-01T01:02:03Z")
+		require.NoError(t, err)
+
+		expr, err = getOffsetExpression(StartPosition{EnqueuedTime: &enqueueTime})
+		require.NoError(t, err)
+		require.Equal(t, "amqp.annotation.x-opt-enqueued-time > '1577840523000'", expr)
+
+		expr, err = getOffsetExpression(StartPosition{EnqueuedTime: &enqueueTime, Inclusive: true})
+		require.NoError(t, err)
+		require.Equal(t, "amqp.annotation.x-opt-enqueued-time >= '1577840523000'", expr)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		enqueueTime, err := time.Parse(time.RFC3339, "2020-01-01T01:02:03Z")
+		require.NoError(t, err)
+
+		expr, err := getOffsetExpression(StartPosition{
+			EnqueuedTime: &enqueueTime,
+			Offset:       to.Ptr[uint64](101),
+		})
+		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+		require.Empty(t, expr)
+
+		expr, err = getOffsetExpression(StartPosition{
+			Offset: to.Ptr[uint64](202),
+			Latest: to.Ptr(true),
+		})
+		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+		require.Empty(t, expr)
+
+		expr, err = getOffsetExpression(StartPosition{
+			Latest:         to.Ptr(true),
+			SequenceNumber: to.Ptr[int64](202),
+		})
+		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+		require.Empty(t, expr)
+
+		expr, err = getOffsetExpression(StartPosition{
+			SequenceNumber: to.Ptr[int64](202),
+			Earliest:       to.Ptr(true),
+		})
+		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+		require.Empty(t, expr)
 	})
 }
 

--- a/sdk/messaging/azeventhubs/consumer_client_unit_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_unit_test.go
@@ -61,11 +61,11 @@ func TestUnit_getOffsetExpression(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "amqp.annotation.x-opt-offset > '@latest'", expr)
 
-		expr, err = getOffsetExpression(StartPosition{Offset: to.Ptr(uint64(101))})
+		expr, err = getOffsetExpression(StartPosition{Offset: to.Ptr(int64(101))})
 		require.NoError(t, err)
 		require.Equal(t, "amqp.annotation.x-opt-offset > '101'", expr)
 
-		expr, err = getOffsetExpression(StartPosition{Offset: to.Ptr(uint64(101)), Inclusive: true})
+		expr, err = getOffsetExpression(StartPosition{Offset: to.Ptr(int64(101)), Inclusive: true})
 		require.NoError(t, err)
 		require.Equal(t, "amqp.annotation.x-opt-offset >= '101'", expr)
 
@@ -95,13 +95,13 @@ func TestUnit_getOffsetExpression(t *testing.T) {
 
 		expr, err := getOffsetExpression(StartPosition{
 			EnqueuedTime: &enqueueTime,
-			Offset:       to.Ptr[uint64](101),
+			Offset:       to.Ptr[int64](101),
 		})
 		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
 		require.Empty(t, expr)
 
 		expr, err = getOffsetExpression(StartPosition{
-			Offset: to.Ptr[uint64](202),
+			Offset: to.Ptr[int64](202),
 			Latest: to.Ptr(true),
 		})
 		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")

--- a/sdk/messaging/azeventhubs/consumer_client_unit_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_unit_test.go
@@ -97,28 +97,28 @@ func TestUnit_getOffsetExpression(t *testing.T) {
 			EnqueuedTime: &enqueueTime,
 			Offset:       to.Ptr[int64](101),
 		})
-		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+		require.EqualError(t, err, "only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
 		require.Empty(t, expr)
 
 		expr, err = getOffsetExpression(StartPosition{
 			Offset: to.Ptr[int64](202),
 			Latest: to.Ptr(true),
 		})
-		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+		require.EqualError(t, err, "only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
 		require.Empty(t, expr)
 
 		expr, err = getOffsetExpression(StartPosition{
 			Latest:         to.Ptr(true),
 			SequenceNumber: to.Ptr[int64](202),
 		})
-		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+		require.EqualError(t, err, "only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
 		require.Empty(t, expr)
 
 		expr, err = getOffsetExpression(StartPosition{
 			SequenceNumber: to.Ptr[int64](202),
 			Earliest:       to.Ptr(true),
 		})
-		require.EqualError(t, err, "Only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
+		require.EqualError(t, err, "only a single start point can be set: Earliest, EnqueuedTime, Latest, Offset, or SequenceNumber")
 		require.Empty(t, expr)
 	})
 }


### PR DESCRIPTION
Fixing two bugs and adding in some tests:
- When you send a batch of events you can choose to send it to any available partition. I missed a nil check, added in and added a test.
- The offset position filter strings were being incorrectly formatted. It appears that the sequence number one was accepted _anyways_, but I've now fixed it so they're aligned with what JS does.