### PR TITLE
Test cleanup

### DIFF
--- a/sdk/storage/azblob/zt_append_blob_client_test.go
+++ b/sdk/storage/azblob/zt_append_blob_client_test.go
@@ -9,12 +9,14 @@ package azblob_test
 import (
 	"bytes"
 	"crypto/md5"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/stretchr/testify/require"
-	"strings"
 )
 
 // nolint
@@ -84,7 +86,7 @@ func (s *azblobUnrecordedTestSuite) TestAppendBlockWithMD5() {
 	appendBlockOptions := appendblob.AppendBlockOptions{
 		TransactionalContentMD5: contentMD5,
 	}
-	appendResp, err := abClient.AppendBlock(ctx, NopCloser(readerToBody), &appendBlockOptions)
+	appendResp, err := abClient.AppendBlock(ctx, streaming.NopCloser(readerToBody), &appendBlockOptions)
 	_require.Nil(err)
 	// _require.Equal(appendResp.RawResponse.StatusCode, 201)
 	_require.Equal(*appendResp.BlobAppendOffset, "0")
@@ -105,7 +107,7 @@ func (s *azblobUnrecordedTestSuite) TestAppendBlockWithMD5() {
 	appendBlockOptions = appendblob.AppendBlockOptions{
 		TransactionalContentMD5: badMD5,
 	}
-	appendResp, err = abClient.AppendBlock(ctx, NopCloser(readerToBody), &appendBlockOptions)
+	appendResp, err = abClient.AppendBlock(ctx, streaming.NopCloser(readerToBody), &appendBlockOptions)
 	_require.NotNil(err)
 
 	validateBlobErrorCode(_require, err, bloberror.MD5Mismatch)
@@ -136,7 +138,7 @@ func (s *azblobUnrecordedTestSuite) TestAppendBlockWithMD5() {
 //	_require.Nil(err)
 //	//_require.Equal(cResp1.RawResponse.StatusCode, 201)
 //
-//	appendResp, err := srcBlob.AppendBlock(ctx, NopCloser(r), nil)
+//	appendResp, err := srcBlob.AppendBlock(ctx, streaming.NopCloser(r), nil)
 //	_require.Nil(err)
 //	_require.Nil(err)
 //	// _require.Equal(appendResp.RawResponse.StatusCode, 201)
@@ -232,7 +234,7 @@ func (s *azblobUnrecordedTestSuite) TestAppendBlockWithMD5() {
 //	_require.Nil(err)
 //	//_require.Equal(cResp1.RawResponse.StatusCode, 201)
 //
-//	appendResp, err := srcBlob.AppendBlock(ctx, NopCloser(r), nil)
+//	appendResp, err := srcBlob.AppendBlock(ctx, streaming.NopCloser(r), nil)
 //	_require.Nil(err)
 //	// _require.Equal(appendResp.RawResponse.StatusCode, 201)
 //	_require.Equal(*appendResp.BlobAppendOffset, "0")
@@ -724,7 +726,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockNilBody() {
 	abName := generateBlobName(testName)
 	abClient := createNewAppendBlob(_require, abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(bytes.NewReader(nil)), nil)
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(bytes.NewReader(nil)), nil)
 	_require.NotNil(err)
 
 	validateBlobErrorCode(_require, err, bloberror.InvalidHeaderValue)
@@ -746,7 +748,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockEmptyBody() {
 	abName := generateBlobName(testName)
 	abClient := createNewAppendBlob(_require, abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader("")), nil)
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader("")), nil)
 	_require.NotNil(err)
 
 	validateBlobErrorCode(_require, err, bloberror.InvalidHeaderValue)
@@ -768,7 +770,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockNonExistentBlob() {
 	abName := generateBlobName(testName)
 	abClient := getAppendBlobClient(abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), nil)
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), nil)
 	_require.NotNil(err)
 
 	validateBlobErrorCode(_require, err, bloberror.BlobNotFound)
@@ -810,7 +812,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfModifiedSinceTrue() {
 			},
 		},
 	}
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
 	_require.Nil(err)
 
 	validateBlockAppended(_require, abClient, len(blockBlobDefaultData))
@@ -846,7 +848,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfModifiedSinceFalse() {
 			},
 		},
 	}
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
 	_require.NotNil(err)
 
 	validateBlobErrorCode(_require, err, bloberror.ConditionNotMet)
@@ -882,7 +884,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfUnmodifiedSinceTrue() {
 			},
 		},
 	}
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
 	_require.Nil(err)
 
 	validateBlockAppended(_require, abClient, len(blockBlobDefaultData))
@@ -918,7 +920,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfUnmodifiedSinceFalse() {
 			},
 		},
 	}
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
 	_require.NotNil(err)
 
 	validateBlobErrorCode(_require, err, bloberror.ConditionNotMet)
@@ -942,7 +944,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfMatchTrue() {
 
 	resp, _ := abClient.GetProperties(ctx, nil)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
 		AccessConditions: &blob.AccessConditions{
 			ModifiedAccessConditions: &blob.ModifiedAccessConditions{
 				IfMatch: resp.ETag,
@@ -970,7 +972,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfMatchFalse() {
 	abName := generateBlobName(testName)
 	abClient := createNewAppendBlob(_require, abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
 		AccessConditions: &blob.AccessConditions{
 			ModifiedAccessConditions: &blob.ModifiedAccessConditions{
 				IfMatch: to.Ptr("garbage"),
@@ -997,7 +999,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfNoneMatchTrue() {
 	abName := generateBlobName(testName)
 	abClient := createNewAppendBlob(_require, abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
 		AccessConditions: &blob.AccessConditions{
 			ModifiedAccessConditions: &blob.ModifiedAccessConditions{
 				IfNoneMatch: to.Ptr("garbage"),
@@ -1026,7 +1028,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfNoneMatchFalse() {
 
 	resp, _ := abClient.GetProperties(ctx, nil)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
 		AccessConditions: &blob.AccessConditions{
 			ModifiedAccessConditions: &blob.ModifiedAccessConditions{
 				IfNoneMatch: resp.ETag,
@@ -1050,7 +1052,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfNoneMatchFalse() {
 ////			AppendPosition: &appendPosition,
 ////		},
 ////	}
-////	_, err := abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions) // This will cause the library to set the value of the header to 0
+////	_, err := abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions) // This will cause the library to set the value of the header to 0
 ////	_require.NotNil(err)
 ////
 ////	validateBlockAppended(c, abClient, len(blockBlobDefaultData))
@@ -1062,7 +1064,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfNoneMatchFalse() {
 ////	defer deleteContainer(_require, containerClient)
 ////	abClient, _ := createNewAppendBlob(c, containerClient)
 ////
-////	_, err := abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), nil) // The position will not match, but the condition should be ignored
+////	_, err := abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), nil) // The position will not match, but the condition should be ignored
 ////	_require.Nil(err)
 ////
 ////	appendPosition := int64(0)
@@ -1071,7 +1073,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfNoneMatchFalse() {
 ////			AppendPosition: &appendPosition,
 ////		},
 ////	}
-////	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
+////	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendBlockOptions)
 ////	_require.Nil(err)
 ////
 ////	validateBlockAppended(c, abClient, 2*len(blockBlobDefaultData))
@@ -1093,10 +1095,10 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfAppendPositionMatchTrueNonZero() 
 	abName := generateBlobName(testName)
 	abClient := createNewAppendBlob(_require, abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), nil)
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), nil)
 	_require.Nil(err)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
 		AppendPositionAccessConditions: &appendblob.AppendPositionAccessConditions{
 			AppendPosition: to.Ptr(int64(len(blockBlobDefaultData))),
 		},
@@ -1122,10 +1124,10 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfAppendPositionMatchFalseNegOne() 
 	abName := generateBlobName(testName)
 	abClient := createNewAppendBlob(_require, abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), nil)
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), nil)
 	_require.Nil(err)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
 		AppendPositionAccessConditions: &appendblob.AppendPositionAccessConditions{
 			AppendPosition: to.Ptr[int64](-1),
 		},
@@ -1150,7 +1152,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfAppendPositionMatchFalseNonZero()
 	abName := generateBlobName(testName)
 	abClient := createNewAppendBlob(_require, abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
 		AppendPositionAccessConditions: &appendblob.AppendPositionAccessConditions{
 			AppendPosition: to.Ptr[int64](12),
 		},
@@ -1175,7 +1177,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfMaxSizeTrue() {
 	abName := generateBlobName(testName)
 	abClient := createNewAppendBlob(_require, abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
 		AppendPositionAccessConditions: &appendblob.AppendPositionAccessConditions{
 			MaxSize: to.Ptr(int64(len(blockBlobDefaultData) + 1)),
 		},
@@ -1200,7 +1202,7 @@ func (s *azblobTestSuite) TestBlobAppendBlockIfMaxSizeFalse() {
 	abName := generateBlobName(testName)
 	abClient := createNewAppendBlob(_require, abName, containerClient)
 
-	_, err = abClient.AppendBlock(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
+	_, err = abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &appendblob.AppendBlockOptions{
 		AppendPositionAccessConditions: &appendblob.AppendPositionAccessConditions{
 			MaxSize: to.Ptr(int64(len(blockBlobDefaultData) - 1)),
 		},

--- a/sdk/storage/azblob/zt_blob_tags_test.go
+++ b/sdk/storage/azblob/zt_blob_tags_test.go
@@ -8,6 +8,10 @@ package azblob_test
 
 import (
 	"bytes"
+	"io"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -15,8 +19,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob"
 	"github.com/stretchr/testify/require"
-	"io"
-	"strings"
 )
 
 // nolint
@@ -79,12 +81,12 @@ func (s *azblobUnrecordedTestSuite) TestSetBlobTagsWithVID() {
 		"Javascript": "Android",
 	}
 
-	blockBlobUploadResp, err := bbClient.Upload(ctx, NopCloser(bytes.NewReader([]byte("data"))), nil)
+	blockBlobUploadResp, err := bbClient.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("data"))), nil)
 	_require.Nil(err)
 	// _require.Equal(blockBlobUploadResp.RawResponse.StatusCode, 201)
 	versionId1 := blockBlobUploadResp.VersionID
 
-	blockBlobUploadResp, err = bbClient.Upload(ctx, NopCloser(bytes.NewReader([]byte("updated_data"))), nil)
+	blockBlobUploadResp, err = bbClient.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("updated_data"))), nil)
 	_require.Nil(err)
 	// _require.Equal(blockBlobUploadResp.RawResponse.StatusCode, 201)
 	versionId2 := blockBlobUploadResp.VersionID
@@ -143,7 +145,7 @@ func (s *azblobUnrecordedTestSuite) TestUploadBlockBlobWithSpecialCharactersInTa
 		HTTPHeaders: &basicHeaders,
 		Tags:        blobTagsMap,
 	}
-	_, err = bbClient.Upload(ctx, NopCloser(bytes.NewReader([]byte("data"))), &uploadBlockBlobOptions)
+	_, err = bbClient.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("data"))), &uploadBlockBlobOptions)
 	_require.Nil(err)
 	// TODO: Check for metadata and header
 	// _require.Equal(blockBlobUploadResp.RawResponse.StatusCode, 201)
@@ -178,7 +180,7 @@ func (s *azblobUnrecordedTestSuite) TestStageBlockWithTags() {
 
 	for index, d := range data {
 		base64BlockIDs[index] = blockIDIntToBase64(index)
-		resp, err := bbClient.StageBlock(ctx, base64BlockIDs[index], NopCloser(strings.NewReader(d)), nil)
+		resp, err := bbClient.StageBlock(ctx, base64BlockIDs[index], streaming.NopCloser(strings.NewReader(d)), nil)
 		_require.Nil(err)
 		// _require.Equal(resp.RawResponse.StatusCode, 201)
 		_require.NotEqual(*resp.Version, "")
@@ -442,7 +444,7 @@ func (s *azblobUnrecordedTestSuite) TestGetPropertiesReturnsTagsCount() {
 		HTTPHeaders: &basicHeaders,
 		Metadata:    basicMetadata,
 	}
-	_, err = bbClient.Upload(ctx, NopCloser(bytes.NewReader([]byte("data"))), &uploadBlockBlobOptions)
+	_, err = bbClient.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("data"))), &uploadBlockBlobOptions)
 	_require.Nil(err)
 
 	getPropertiesResponse, err := bbClient.GetProperties(ctx, nil)

--- a/sdk/storage/azblob/zt_blob_versioning_test.go
+++ b/sdk/storage/azblob/zt_blob_versioning_test.go
@@ -8,6 +8,11 @@ package azblob_test
 
 import (
 	"bytes"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -15,9 +20,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob"
 	"github.com/stretchr/testify/require"
-	"io"
-	"strconv"
-	"strings"
 )
 
 func (s *azblobTestSuite) TestBlockBlobGetPropertiesUsingVID() {
@@ -144,7 +146,7 @@ func (s *azblobTestSuite) TestCreateAndDownloadBlobSpecialCharactersWithVID() {
 	for i := 0; i < len(data); i++ {
 		blobName := "abc" + string(data[i])
 		blobClient := containerClient.NewBlockBlobClient(blobName)
-		resp, err := blobClient.Upload(ctx, NopCloser(strings.NewReader(string(data[i]))), nil)
+		resp, err := blobClient.Upload(ctx, streaming.NopCloser(strings.NewReader(string(data[i]))), nil)
 		_require.Nil(err)
 		_require.NotNil(resp.VersionID)
 
@@ -175,12 +177,12 @@ func (s *azblobTestSuite) TestCreateAndDownloadBlobSpecialCharactersWithVID() {
 //	defer deleteContainer(_require, containerClient)
 //	blobClient := getBlockBlobClient(generateBlobName(testName), containerClient)
 //
-//	resp, err := blobClient.Upload(ctx, NopCloser(bytes.NewReader([]byte("data"))), &blockblob.UploadOptions{Metadata: basicMetadata})
+//	resp, err := blobClient.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("data"))), &blockblob.UploadOptions{Metadata: basicMetadata})
 //	_require.Nil(err)
 //	versionId := resp.VersionID
 //	_require.NotNil(versionId)
 //
-//	resp, err = blobClient.Upload(ctx, NopCloser(bytes.NewReader([]byte("updated_data"))), &blockblob.UploadOptions{Metadata: basicMetadata})
+//	resp, err = blobClient.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("updated_data"))), &blockblob.UploadOptions{Metadata: basicMetadata})
 //	_require.Nil(err)
 //	_require.NotNil(resp.VersionID)
 //
@@ -234,7 +236,7 @@ func (s *azblobTestSuite) TestDeleteSpecificBlobVersion() {
 
 	versions := make([]string, 0)
 	for i := 0; i < 5; i++ {
-		uploadResp, err := bbClient.Upload(ctx, NopCloser(bytes.NewReader([]byte("data"+strconv.Itoa(i)))), &blockblob.UploadOptions{
+		uploadResp, err := bbClient.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("data"+strconv.Itoa(i)))), &blockblob.UploadOptions{
 			Metadata: basicMetadata,
 		})
 		_require.Nil(err)
@@ -435,7 +437,7 @@ func (s *azblobTestSuite) TestPutBlockListReturnsVID() {
 
 	for index, d := range data {
 		base64BlockIDs[index] = blockIDIntToBase64(index)
-		resp, err := bbClient.StageBlock(ctx, base64BlockIDs[index], NopCloser(strings.NewReader(d)), nil)
+		resp, err := bbClient.StageBlock(ctx, base64BlockIDs[index], streaming.NopCloser(strings.NewReader(d)), nil)
 		_require.Nil(err)
 		// _require.Equal(resp.RawResponse.StatusCode, 201)
 		_require.NotNil(resp.Version)
@@ -473,7 +475,7 @@ func (s *azblobUnrecordedTestSuite) TestCreateBlockBlobReturnsVID() {
 	bbClient := containerClient.NewBlockBlobClient(generateBlobName(testName))
 
 	// Prepare source blob for copy.
-	uploadResp, err := bbClient.Upload(ctx, NopCloser(r), nil)
+	uploadResp, err := bbClient.Upload(ctx, streaming.NopCloser(r), nil)
 	_require.Nil(err)
 	// _require.Equal(uploadResp.RawResponse.StatusCode, 201)
 	_require.NotNil(uploadResp.VersionID)

--- a/sdk/storage/azblob/zt_client_provided_key_test.go
+++ b/sdk/storage/azblob/zt_client_provided_key_test.go
@@ -9,15 +9,17 @@ package azblob_test
 import (
 	"bytes"
 	"crypto/md5"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob"
 	"github.com/stretchr/testify/require"
-	"io"
-	"strconv"
-	"strings"
 )
 
 /*
@@ -73,7 +75,7 @@ func (s *azblobTestSuite) TestPutBlockAndPutBlockListWithCPK() {
 		stageBlockOptions := blockblob.StageBlockOptions{
 			CpkInfo: &testCPKByValue,
 		}
-		_, err := bbClient.StageBlock(ctx, base64BlockIDs[index], NopCloser(strings.NewReader(word)), &stageBlockOptions)
+		_, err := bbClient.StageBlock(ctx, base64BlockIDs[index], streaming.NopCloser(strings.NewReader(word)), &stageBlockOptions)
 		_require.Nil(err)
 	}
 
@@ -127,7 +129,7 @@ func (s *azblobTestSuite) TestPutBlockAndPutBlockListWithCPKByScope() {
 		stageBlockOptions := blockblob.StageBlockOptions{
 			CpkScopeInfo: &testCPKByScope,
 		}
-		_, err := bbClient.StageBlock(ctx, base64BlockIDs[index], NopCloser(strings.NewReader(word)), &stageBlockOptions)
+		_, err := bbClient.StageBlock(ctx, base64BlockIDs[index], streaming.NopCloser(strings.NewReader(word)), &stageBlockOptions)
 		_require.Nil(err)
 	}
 
@@ -505,7 +507,7 @@ func (s *azblobTestSuite) TestAppendBlockWithCPK() {
 		appendBlockOptions := appendblob.AppendBlockOptions{
 			CpkInfo: &testCPKByValue,
 		}
-		resp, err := abClient.AppendBlock(ctx, NopCloser(strings.NewReader(word)), &appendBlockOptions)
+		resp, err := abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(word)), &appendBlockOptions)
 		_require.Nil(err)
 		// _require.Equal(resp.RawResponse.StatusCode, 201)
 		_require.Equal(*resp.BlobAppendOffset, strconv.Itoa(index*4))
@@ -564,7 +566,7 @@ func (s *azblobTestSuite) TestAppendBlockWithCPKScope() {
 		appendBlockOptions := appendblob.AppendBlockOptions{
 			CpkScopeInfo: &testCPKByScope,
 		}
-		resp, err := abClient.AppendBlock(ctx, NopCloser(strings.NewReader(word)), &appendBlockOptions)
+		resp, err := abClient.AppendBlock(ctx, streaming.NopCloser(strings.NewReader(word)), &appendBlockOptions)
 		_require.Nil(err)
 		// _require.Equal(resp.RawResponse.StatusCode, 201)
 		_require.Equal(*resp.BlobAppendOffset, strconv.Itoa(index*4))
@@ -617,7 +619,7 @@ func (s *azblobTestSuite) TestAppendBlockWithCPKScope() {
 //	_require.Nil(err)
 //	//_require.Equal(cResp1.RawResponse.StatusCode, 201)
 //
-//	resp, err := srcABClient.AppendBlock(ctx, NopCloser(r), nil)
+//	resp, err := srcABClient.AppendBlock(ctx, streaming.NopCloser(r), nil)
 //	_require.Nil(err)
 //	// _require.Equal(resp.RawResponse.StatusCode, 201)
 //	_require.Equal(*resp.BlobAppendOffset, "0")
@@ -727,7 +729,7 @@ func (s *azblobTestSuite) TestAppendBlockWithCPKScope() {
 //	_require.Nil(err)
 //	//_require.Equal(cResp1.RawResponse.StatusCode, 201)
 //
-//	resp, err := srcClient.AppendBlock(ctx, NopCloser(r), nil)
+//	resp, err := srcClient.AppendBlock(ctx, streaming.NopCloser(r), nil)
 //	_require.Nil(err)
 //	// _require.Equal(resp.RawResponse.StatusCode, 201)
 //	_require.Equal(*resp.BlobAppendOffset, "0")
@@ -943,7 +945,7 @@ func (s *azblobUnrecordedTestSuite) TestPageBlockWithCPKScope() {
 //	uploadPagesOptions := pageblob.UploadPagesOptions{
 //		Offset: to.Ptr(offset), Count: to.Ptr(count),
 //	}
-//	_, err = bbClient.UploadPages(ctx, NopCloser(r), &uploadPagesOptions)
+//	_, err = bbClient.UploadPages(ctx, streaming.NopCloser(r), &uploadPagesOptions)
 //	_require.Nil(err)
 //	// _require.Equal(uploadResp.RawResponse.StatusCode, 201)
 //	srcBlobParts, _ := NewBlobURLParts(bbClient.URL())
@@ -1028,7 +1030,7 @@ func (s *azblobUnrecordedTestSuite) TestPageBlockWithCPKScope() {
 //	uploadPagesOptions := pageblob.UploadPagesOptions{
 //		Offset: to.Ptr(offset), Count: to.Ptr(count),
 //	}
-//	_, err = srcPBClient.UploadPages(ctx, NopCloser(r), &uploadPagesOptions)
+//	_, err = srcPBClient.UploadPages(ctx, streaming.NopCloser(r), &uploadPagesOptions)
 //	_require.Nil(err)
 //	// _require.Equal(uploadResp.RawResponse.StatusCode, 201)
 //	srcBlobParts, _ := NewBlobURLParts(srcPBClient.URL())
@@ -1101,7 +1103,7 @@ func (s *azblobUnrecordedTestSuite) TestPageBlockWithCPKScope() {
 //	uploadPagesOptions := pageblob.UploadPagesOptions{
 //		Offset: to.Ptr(offset), Count: to.Ptr(count),
 //	}
-//	_, err = srcBlob.UploadPages(ctx, NopCloser(r), &uploadPagesOptions)
+//	_, err = srcBlob.UploadPages(ctx, streaming.NopCloser(r), &uploadPagesOptions)
 //	_require.Nil(err)
 //	// _require.Equal(uploadResp.RawResponse.StatusCode, 201)
 //

--- a/sdk/storage/azblob/zt_container_client_test.go
+++ b/sdk/storage/azblob/zt_container_client_test.go
@@ -8,13 +8,15 @@ package azblob_test
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/stretchr/testify/require"
-	"strconv"
-	"strings"
 )
 
 //nolint
@@ -304,7 +306,7 @@ func (s *azblobTestSuite) TestContainerCreateAccessNone() {
 	uploadBlockBlobOptions := blockblob.UploadOptions{
 		Metadata: basicMetadata,
 	}
-	_, err = bbClient.Upload(ctx, NopCloser(strings.NewReader("Content")), &uploadBlockBlobOptions)
+	_, err = bbClient.Upload(ctx, streaming.NopCloser(strings.NewReader("Content")), &uploadBlockBlobOptions)
 	_require.Nil(err)
 
 	// Reference the same container URL but with anonymous credentials
@@ -1282,7 +1284,7 @@ func (s *azblobTestSuite) TestListBlobIncludeMetadata() {
 	blobName := generateBlobName(testName)
 	for i := 0; i < 6; i++ {
 		bbClient := getBlockBlobClient(blobName+strconv.Itoa(i), containerClient)
-		_, err = bbClient.Upload(ctx, NopCloser(strings.NewReader(blockBlobDefaultData)), &blockblob.UploadOptions{Metadata: basicMetadata})
+		_, err = bbClient.Upload(ctx, streaming.NopCloser(strings.NewReader(blockBlobDefaultData)), &blockblob.UploadOptions{Metadata: basicMetadata})
 		_require.Nil(err)
 		// _require.Equal(cResp.RawResponse.StatusCode, 201)
 	}

--- a/sdk/storage/azblob/zt_page_blob_client_test.go
+++ b/sdk/storage/azblob/zt_page_blob_client_test.go
@@ -8,6 +8,9 @@ package azblob_test
 
 import (
 	"bytes"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	testframework "github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -15,7 +18,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 func (s *azblobTestSuite) TestPutGetPages() {
@@ -98,7 +100,7 @@ func (s *azblobTestSuite) TestPutGetPages() {
 //	destBlob := createNewPageBlobWithSize(_require, "dstblob", containerClient, int64(contentSize))
 //
 //	offset, _, count := int64(0), int64(contentSize-1), int64(contentSize)
-//	uploadSrcResp1, err := srcBlob.UploadPages(ctx, NopCloser(r), &pageblob.UploadPagesOptions{
+//	uploadSrcResp1, err := srcBlob.UploadPages(ctx, streaming.NopCloser(r), &pageblob.UploadPagesOptions{
 //		Offset: to.Ptr(offset),
 //		Count: to.Ptr(count),
 //	}
@@ -175,7 +177,7 @@ func (s *azblobTestSuite) TestPutGetPages() {
 //	// Prepare source pbClient for copy.
 //	offset, _, count := int64(0), int64(contentSize-1), int64(contentSize)
 //	uploadPagesOptions := pageblob.UploadPagesOptions{Offset: to.Ptr(int64(offset)), Count: to.Ptr(int64(count)),}
-//	_, err = srcBlob.UploadPages(ctx, NopCloser(r), &uploadPagesOptions)
+//	_, err = srcBlob.UploadPages(ctx, streaming.NopCloser(r), &uploadPagesOptions)
 //	_require.Nil(err)
 //	// _require.Equal(uploadSrcResp1.RawResponse.StatusCode, 201)
 //
@@ -465,7 +467,7 @@ func (s *azblobTestSuite) TestPageSequenceNumbers() {
 //	_ = body
 //	contentMD5 := md5Value[:]
 //
-//	putResp, err := pbClient.UploadPages(ctx, NopCloser(readerToBody), &pageblob.UploadPagesOptions{
+//	putResp, err := pbClient.UploadPages(ctx, streaming.NopCloser(readerToBody), &pageblob.UploadPagesOptions{
 //		Offset:                  to.Ptr(offset),
 //		Count:                   to.Ptr(count),
 //		TransactionalContentMD5: contentMD5,
@@ -487,7 +489,7 @@ func (s *azblobTestSuite) TestPageSequenceNumbers() {
 //	readerToBody, _ = getRandomDataAndReader(1024)
 //	_, badMD5 := getRandomDataAndReader(16)
 //	basContentMD5 := badMD5[:]
-//	putResp, err = pbClient.UploadPages(ctx, NopCloser(readerToBody), &pageblob.UploadPagesOptions{
+//	putResp, err = pbClient.UploadPages(ctx, streaming.NopCloser(readerToBody), &pageblob.UploadPagesOptions{
 //		Offset:                  to.Ptr(offset),
 //		Count:                   to.Ptr(count),
 //		TransactionalContentMD5: basContentMD5,
@@ -1016,7 +1018,7 @@ func (s *azblobTestSuite) TestBlobPutPagesEmptyBody() {
 	r := bytes.NewReader([]byte{})
 	offset, count := int64(0), int64(0)
 	uploadPagesOptions := pageblob.UploadPagesOptions{Offset: to.Ptr(int64(offset)), Count: to.Ptr(int64(count))}
-	_, err = pbClient.UploadPages(ctx, NopCloser(r), &uploadPagesOptions)
+	_, err = pbClient.UploadPages(ctx, streaming.NopCloser(r), &uploadPagesOptions)
 	_require.NotNil(err)
 }
 

--- a/sdk/storage/azblob/zt_test.go
+++ b/sdk/storage/azblob/zt_test.go
@@ -9,17 +9,18 @@ package azblob_test
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
-	"github.com/stretchr/testify/require"
 	"io"
 	"log"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+	"github.com/stretchr/testify/require"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	testframework "github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
@@ -112,19 +113,6 @@ func (s *azblobUnrecordedTestSuite) BeforeTest(suite string, test string) {
 // nolint
 func (s *azblobUnrecordedTestSuite) AfterTest(suite string, test string) {
 
-}
-
-type nopCloser struct {
-	io.ReadSeeker
-}
-
-func (n nopCloser) Close() error {
-	return nil
-}
-
-// NopCloser returns a ReadSeekCloser with a no-op close method wrapping the provided io.ReadSeeker.
-func NopCloser(rs io.ReadSeeker) io.ReadSeekCloser {
-	return nopCloser{rs}
 }
 
 // Some tests require setting service properties. It can take up to 30 seconds for the new properties to be reflected across all FEs.


### PR DESCRIPTION
Removed duplicate definition of NopCloser.
Import blocks are properly formatted.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
