### PR TITLE
Constrain legacy CI to main and legacy branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,10 @@
 # This builds only track 1 SDKs. See eng\pipelines\templates\steps\build.yml for track 2.
 
 trigger:
+  branches:
+    include:
+    - main
+    - legacy
   paths:
     exclude:
     - sdk/
@@ -8,6 +12,10 @@ trigger:
     - eng/config.json
 
 pr:
+  branches:
+    include:
+    - main
+    - legacy
   paths:
     exclude:
     - sdk/


### PR DESCRIPTION
This should hopefully also prevent the legacy CI from triggering when
changes to eng/config.json are made.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
