### PR TITLE
Export types needed by BlobURLParts

### DIFF
--- a/sdk/storage/azblob/common.go
+++ b/sdk/storage/azblob/common.go
@@ -42,3 +42,16 @@ type BlobURLParts = exported.BlobURLParts
 func ParseBlobURL(u string) (BlobURLParts, error) {
 	return exported.ParseBlobURL(u)
 }
+
+// SASQueryParameters object represents the components that make up an Azure Storage SAS' query parameters.
+// You parse a map of query parameters into its fields by calling NewSASQueryParameters(). You add the components
+// to a query parameter map by calling AddToValues().
+// NOTE: Changing any field requires computing a new SAS signature using a XxxSASSignatureValues type.
+// https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
+type SASQueryParameters = exported.SASQueryParameters
+
+// SASProtocol indicates the protocal in use for the SAS URL (http/https).
+type SASProtocol = exported.SASProtocol
+
+// IPRange represents a SAS IP range's start IP and (optionally) end IP.
+type IPRange = exported.IPRange


### PR DESCRIPTION
Added SASQueryParameters and its dependent types so that callers can
create a BlobURLParts type.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
