### PR TITLE
Remove duplicate definition of client options

### DIFF
--- a/sdk/storage/azblob/appendblob/client.go
+++ b/sdk/storage/azblob/appendblob/client.go
@@ -8,6 +8,9 @@ package appendblob
 
 import (
 	"context"
+	"io"
+	"os"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -15,8 +18,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
-	"io"
-	"os"
 )
 
 // Client represents a client to an Azure Storage append blob;
@@ -25,17 +26,17 @@ type Client base.CompositeClient[generated.BlobClient, generated.AppendBlobClien
 // NewClient creates an AppendBlobClient with the specified URL, Azure AD credential, and options.
 func NewClient(blobURL string, cred azcore.TokenCredential, o *blob.ClientOptions) (*Client, error) {
 	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{shared.TokenScope}, nil)
-	conOptions := exported.GetConnectionOptions(o)
+	conOptions := exported.GetClientOptions(o)
 	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, authPolicy)
-	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, conOptions)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
 
 	return (*Client)(base.NewAppendBlobClient(blobURL, pl, nil)), nil
 }
 
 // NewClientWithNoCredential creates an AppendBlobClient with the specified URL and options.
 func NewClientWithNoCredential(blobURL string, o *blob.ClientOptions) (*Client, error) {
-	conOptions := exported.GetConnectionOptions(o)
-	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, conOptions)
+	conOptions := exported.GetClientOptions(o)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
 
 	return (*Client)(base.NewAppendBlobClient(blobURL, pl, nil)), nil
 }
@@ -43,9 +44,9 @@ func NewClientWithNoCredential(blobURL string, o *blob.ClientOptions) (*Client, 
 // NewClientWithSharedKey creates an AppendBlobClient with the specified URL, shared key, and options.
 func NewClientWithSharedKey(blobURL string, cred *blob.SharedKeyCredential, o *blob.ClientOptions) (*Client, error) {
 	authPolicy := exported.NewSharedKeyCredPolicy(cred)
-	conOptions := exported.GetConnectionOptions(o)
+	conOptions := exported.GetClientOptions(o)
 	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, authPolicy)
-	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, conOptions)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
 
 	return (*Client)(base.NewAppendBlobClient(blobURL, pl, cred)), nil
 }

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -7,12 +7,13 @@
 package blob
 
 import (
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
-	"time"
 )
 
 // Type Declarations ---------------------------------------------------------------------
@@ -28,9 +29,6 @@ type ModifiedAccessConditions = exported.ModifiedAccessConditions
 
 // AccessTier defines values for Blob Access Tier
 type AccessTier = generated.AccessTier
-
-// ClientOptions adds additional client options while constructing connection
-type ClientOptions = exported.ClientOptions
 
 // CpkInfo contains a group of parameters for client provided encryption key.
 type CpkInfo = generated.CpkInfo

--- a/sdk/storage/azblob/client.go
+++ b/sdk/storage/azblob/client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
 )
 
-// ClientOptions adds additional client options while constructing connection
+// ClientOptions contains the optional parameters when creating a Client.
 type ClientOptions = exported.ClientOptions
 
 // Client represents a URL to an Azure Storage blob; the blob may be a block blob, append blob, or page blob.

--- a/sdk/storage/azblob/container/models.go
+++ b/sdk/storage/azblob/container/models.go
@@ -13,9 +13,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
 )
 
-// ClientOptions adds additional client options while constructing connection
-type ClientOptions = exported.ClientOptions
-
 // SharedKeyCredential contains an account's name and its primary or secondary key.
 type SharedKeyCredential = exported.SharedKeyCredential
 

--- a/sdk/storage/azblob/internal/exported/clients_utils.go
+++ b/sdk/storage/azblob/internal/exported/clients_utils.go
@@ -7,53 +7,18 @@
 package exported
 
 import (
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-// ClientOptions adds additional client options while constructing connection
+// ClientOptions contains the optional parameters when creating a Client.
+// NOTE: all clients use this options type.
 type ClientOptions struct {
-	// Cloud specifies a cloud for the client. The default is Azure Public Cloud.
-	Cloud cloud.Configuration
-
-	// Logging configures the built-in logging policy.
-	Logging policy.LogOptions
-
-	// Retry configures the built-in retry policy.
-	Retry policy.RetryOptions
-
-	// Telemetry configures the built-in telemetry policy.
-	Telemetry policy.TelemetryOptions
-
-	// Transport sets the transport for HTTP requests.
-	Transport policy.Transporter
-
-	// PerCallPolicies contains custom policies to inject into the pipeline.
-	// Each policy is executed once per request.
-	PerCallPolicies []policy.Policy
-
-	// PerRetryPolicies contains custom policies to inject into the pipeline.
-	// Each policy is executed once per request, and for each retry of that request.
-	PerRetryPolicies []policy.Policy
+	azcore.ClientOptions
 }
 
-func (c *ClientOptions) toPolicyOptions() *policy.ClientOptions {
-	return &policy.ClientOptions{
-		Cloud:            c.Cloud,
-		Logging:          c.Logging,
-		Retry:            c.Retry,
-		Telemetry:        c.Telemetry,
-		Transport:        c.Transport,
-		PerCallPolicies:  c.PerCallPolicies,
-		PerRetryPolicies: c.PerRetryPolicies,
-	}
-}
-
-// ---------------------------------------------------------------------------------------------------------------------
-
-func GetConnectionOptions(options *ClientOptions) *policy.ClientOptions {
+func GetClientOptions(options *ClientOptions) *ClientOptions {
 	if options == nil {
 		options = &ClientOptions{}
 	}
-	return options.toPolicyOptions()
+	return options
 }

--- a/sdk/storage/azblob/pageblob/client.go
+++ b/sdk/storage/azblob/pageblob/client.go
@@ -8,6 +8,11 @@ package pageblob
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -16,10 +21,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
-	"io"
-	"net/http"
-	"net/url"
-	"os"
 )
 
 // Client represents a client to an Azure Storage page blob;
@@ -29,9 +30,9 @@ type Client base.CompositeClient[generated.BlobClient, generated.PageBlobClient]
 // Example of serviceURL: https://<your_storage_account>.blob.core.windows.net
 func NewClient(blobURL string, cred azcore.TokenCredential, options *blob.ClientOptions) (*Client, error) {
 	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{shared.TokenScope}, nil)
-	conOptions := exported.GetConnectionOptions(options)
+	conOptions := exported.GetClientOptions(options)
 	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, authPolicy)
-	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, conOptions)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
 
 	return (*Client)(base.NewPageBlobClient(blobURL, pl, nil)), nil
 }
@@ -39,8 +40,8 @@ func NewClient(blobURL string, cred azcore.TokenCredential, options *blob.Client
 // NewClientWithNoCredential creates a ServiceClient object using the specified URL and options.
 // Example of serviceURL: https://<your_storage_account>.blob.core.windows.net?<SAS token>
 func NewClientWithNoCredential(blobURL string, options *blob.ClientOptions) (*Client, error) {
-	conOptions := exported.GetConnectionOptions(options)
-	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, conOptions)
+	conOptions := exported.GetClientOptions(options)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
 
 	return (*Client)(base.NewPageBlobClient(blobURL, pl, nil)), nil
 }
@@ -49,9 +50,9 @@ func NewClientWithNoCredential(blobURL string, options *blob.ClientOptions) (*Cl
 // Example of serviceURL: https://<your_storage_account>.blob.core.windows.net
 func NewClientWithSharedKey(blobURL string, cred *blob.SharedKeyCredential, options *blob.ClientOptions) (*Client, error) {
 	authPolicy := exported.NewSharedKeyCredPolicy(cred)
-	conOptions := exported.GetConnectionOptions(options)
+	conOptions := exported.GetClientOptions(options)
 	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, authPolicy)
-	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, conOptions)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
 
 	return (*Client)(base.NewPageBlobClient(blobURL, pl, cred)), nil
 }

--- a/sdk/storage/azblob/service/models.go
+++ b/sdk/storage/azblob/service/models.go
@@ -12,9 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
 )
 
-// ClientOptions adds additional client options while constructing connection
-type ClientOptions = exported.ClientOptions
-
 // SharedKeyCredential contains an account's name and its primary or secondary key.
 type SharedKeyCredential = exported.SharedKeyCredential
 

--- a/sdk/storage/azblob/testdata/perf/download_blob.go
+++ b/sdk/storage/azblob/testdata/perf/download_blob.go
@@ -8,10 +8,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"io"
 	"os"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/perf"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -106,7 +108,9 @@ func (g *downloadTestGlobal) NewPerfTest(ctx context.Context, options *perf.Perf
 	}
 
 	containerClient, err := container.NewClientFromConnectionString(connStr, d.downloadTestGlobal.containerName, &azblob.ClientOptions{
-		Transport: d.PerfTestOptions.Transporter,
+		ClientOptions: azcore.ClientOptions{
+			Transport: d.PerfTestOptions.Transporter,
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/storage/azblob/testdata/perf/go.mod
+++ b/sdk/storage/azblob/testdata/perf/go.mod
@@ -3,12 +3,12 @@ module github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/testdata/perf
 go 1.18
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.0
 )
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/sdk/storage/azblob/testdata/perf/go.sum
+++ b/sdk/storage/azblob/testdata/perf/go.sum
@@ -1,9 +1,9 @@
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.0.0 h1:Yoicul8bnVdQrhDMTHxdEckRGX01XvwXDHUT9zYZ3k0=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0 h1:QkAcEIAKbNL4KoFr4SathZPhDhF4mVwpBMFlYjyAqy8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
-github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0 h1:WVsrXCnHlDDX8ls+tootqRE87/hL9S/g4ewig9RsD/c=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1 h1:BWe8a+f/t+7KY7zH2mqygeUD0t8hNFXe08p1Pb3/jKE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=
 github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=

--- a/sdk/storage/azblob/testdata/perf/list_blobs.go
+++ b/sdk/storage/azblob/testdata/perf/list_blobs.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"os"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/perf"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -105,7 +107,9 @@ func (g *listTestGlobal) NewPerfTest(ctx context.Context, options *perf.PerfTest
 		connStr,
 		u.listTestGlobal.containerName,
 		&azblob.ClientOptions{
-			Transport: u.PerfTestOptions.Transporter,
+			ClientOptions: azcore.ClientOptions{
+				Transport: g.PerfTestOptions.Transporter,
+			},
 		},
 	)
 	if err != nil {

--- a/sdk/storage/azblob/testdata/perf/upload_blob.go
+++ b/sdk/storage/azblob/testdata/perf/upload_blob.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"io"
 	"os"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/perf"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -88,7 +90,9 @@ func (g *uploadTestGlobal) NewPerfTest(ctx context.Context, options *perf.PerfTe
 		connStr,
 		u.uploadTestGlobal.containerName,
 		&azblob.ClientOptions{
-			Transport: u.PerfTestOptions.Transporter,
+			ClientOptions: azcore.ClientOptions{
+				Transport: u.PerfTestOptions.Transporter,
+			},
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Use the one from azcore instead.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
