### PR TITLE
[azeventhubs] Default start position is supposed to be latest, not earliest

### DIFF
--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -51,6 +51,7 @@ type ConsumerClientOptions struct {
 }
 
 // StartPosition indicates the position to start receiving events within a partition.
+// The default position is Latest.
 type StartPosition struct {
 	// Offset will start the consumer after the specified offset. Can be exclusive
 	// or inclusive, based on the Inclusive property.
@@ -272,7 +273,7 @@ func getOffsetExpression(startPosition StartPosition) (string, error) {
 	}
 
 	// default to the start
-	return "amqp.annotation.x-opt-offset > '-1'", nil
+	return "amqp.annotation.x-opt-offset > '@latest'", nil
 }
 
 func formatOffsetExpressionForSequence(op string, sequenceNumber int64) string {

--- a/sdk/messaging/azeventhubs/consumer_client_unit_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_unit_test.go
@@ -51,7 +51,7 @@ func TestUnit_getOffsetExpression(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		expr, err := getOffsetExpression(StartPosition{})
 		require.NoError(t, err)
-		require.Equal(t, "amqp.annotation.x-opt-offset > '-1'", expr)
+		require.Equal(t, "amqp.annotation.x-opt-offset > '@latest'", expr)
 
 		expr, err = getOffsetExpression(StartPosition{Earliest: to.Ptr(true)})
 		require.NoError(t, err)


### PR DESCRIPTION
This matches what we've done in other track 2 libraries.