### PR TITLE
Export constants required by other exported types

### DIFF
--- a/sdk/storage/azblob/appendblob/models.go
+++ b/sdk/storage/azblob/appendblob/models.go
@@ -7,11 +7,12 @@
 package appendblob
 
 import (
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
-	"time"
 )
 
 // AppendPositionAccessConditions contains a group of parameters for the Client.AppendBlock method.
@@ -25,7 +26,7 @@ type CreateOptions struct {
 	ImmutabilityPolicyExpiry *time.Time
 
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *blob.ImmutabilityPolicyMode
+	ImmutabilityPolicyMode *blob.ImmutabilityPolicySetting
 
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool

--- a/sdk/storage/azblob/autorest.md
+++ b/sdk/storage/azblob/autorest.md
@@ -1,7 +1,5 @@
 # Code Generation - Azure Blob SDK for Golang
 
-<!-- autorest --use=@autorest/go@4.0.0-preview.35 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-10-02/blob.json --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --output-folder=generated/ --module=azblob --openapi-type="data-plane" --credential-scope=none -->
-
 ```bash
 autorest autorest.md
 gofmt -w internal/generated/*
@@ -14,7 +12,7 @@ go: true
 clear-output-folder: false
 version: "^3.0.0"
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-10-02/blob.json"
+input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/e515b6251fdc21015282d2e84b85beec7c091763/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-10-02/blob.json"
 credential-scope: "https://storage.azure.com/.default"
 output-folder: internal/generated
 file-prefix: "zz_"
@@ -191,4 +189,58 @@ directive:
   transform: >
     $.BlobItemInternal.properties["OrMetadata"] = $.BlobItemInternal.properties["ObjectReplicationMetadata"];
     delete $.BlobItemInternal.properties["ObjectReplicationMetadata"];
+```
+
+# Export various createRequest/HandleResponse methods
+
+``` yaml
+directive:
+- from: zz_container_client.go
+  where: $
+  transform: >-
+    return $.
+      replace(/listBlobHierarchySegmentCreateRequest/g, function(_, s) { return `ListBlobHierarchySegmentCreateRequest` }).
+      replace(/listBlobHierarchySegmentHandleResponse/g, function(_, s) { return `ListBlobHierarchySegmentHandleResponse` });
+
+- from: zz_pageblob_client.go
+  where: $
+  transform: >-
+    return $.
+      replace(/getPageRanges(Diff)?CreateRequest/g, function(_, s) { if (s === undefined) { s = '' }; return `GetPageRanges${s}CreateRequest` }).
+      replace(/getPageRanges(Diff)?HandleResponse/g, function(_, s) { if (s === undefined) { s = '' }; return `GetPageRanges${s}HandleResponse` });
+```
+
+### Clean up some const type names so they don't stutter
+
+``` yaml
+directive:
+- from: swagger-document
+  where: $.parameters['BlobDeleteType']
+  transform: >
+    $["x-ms-enum"].name = "DeleteType";
+    $["x-ms-client-name"] = "DeleteType";
+
+- from: swagger-document
+  where: $.parameters['BlobExpiryOptions']
+  transform: >
+    $["x-ms-enum"].name = "ExpiryOptions";
+    $["x-ms-client-name"].name = "ExpiryOptions";
+
+- from: swagger-document
+  where: $["x-ms-paths"][*].*.responses[*].headers["x-ms-immutability-policy-mode"]
+  transform: >
+    $["x-ms-client-name"].name = "ImmutabilityPolicyMode";
+    $.enum = [ "Mutable", "Unlocked", "Locked"];
+    $["x-ms-enum"] = { "name": "ImmutabilityPolicyMode", "modelAsString": false };
+
+- from: swagger-document
+  where: $.parameters['ImmutabilityPolicyMode']
+  transform: >
+    $["x-ms-enum"].name = "ImmutabilityPolicySetting";
+    $["x-ms-client-name"].name = "ImmutabilityPolicySetting";
+
+- from: swagger-document
+  where: $.definitions['BlobPropertiesInternal']
+  transform: >
+    $.properties.ImmutabilityPolicyMode["x-ms-enum"].name = "ImmutabilityPolicyMode";
 ```

--- a/sdk/storage/azblob/blob/constants.go
+++ b/sdk/storage/azblob/blob/constants.go
@@ -17,6 +17,20 @@ const (
 	DefaultDownloadBlockSize = int64(4 * 1024 * 1024) // 4MB
 )
 
+// BlobType defines values for BlobType
+type BlobType = generated.BlobType
+
+const (
+	BlobTypeBlockBlob  BlobType = generated.BlobTypeBlockBlob
+	BlobTypePageBlob   BlobType = generated.BlobTypePageBlob
+	BlobTypeAppendBlob BlobType = generated.BlobTypeAppendBlob
+)
+
+// PossibleBlobTypeValues returns the possible values for the BlobType const type.
+func PossibleBlobTypeValues() []BlobType {
+	return generated.PossibleBlobTypeValues()
+}
+
 // DeleteSnapshotsOptionType defines values for DeleteSnapshotsOptionType
 type DeleteSnapshotsOptionType = generated.DeleteSnapshotsOptionType
 
@@ -70,18 +84,31 @@ func PossibleRehydratePriorityValues() []RehydratePriority {
 	return generated.PossibleRehydratePriorityValues()
 }
 
-// ImmutabilityPolicyMode defines values for BlobImmutabilityPolicyMode
-type ImmutabilityPolicyMode = generated.BlobImmutabilityPolicyMode
+// ImmutabilityPolicyMode defines values for ImmutabilityPolicyMode
+type ImmutabilityPolicyMode = generated.ImmutabilityPolicyMode
 
 const (
-	ImmutabilityPolicyModeMutable  ImmutabilityPolicyMode = generated.BlobImmutabilityPolicyModeMutable
-	ImmutabilityPolicyModeUnlocked ImmutabilityPolicyMode = generated.BlobImmutabilityPolicyModeUnlocked
-	ImmutabilityPolicyModeLocked   ImmutabilityPolicyMode = generated.BlobImmutabilityPolicyModeLocked
+	ImmutabilityPolicyModeMutable  ImmutabilityPolicyMode = generated.ImmutabilityPolicyModeMutable
+	ImmutabilityPolicyModeUnlocked ImmutabilityPolicyMode = generated.ImmutabilityPolicyModeUnlocked
+	ImmutabilityPolicyModeLocked   ImmutabilityPolicyMode = generated.ImmutabilityPolicyModeLocked
 )
 
-// PossibleBlobImmutabilityPolicyModeValues returns the possible values for the BlobImmutabilityPolicyMode const type.
-func PossibleBlobImmutabilityPolicyModeValues() []ImmutabilityPolicyMode {
-	return generated.PossibleBlobImmutabilityPolicyModeValues()
+// PossibleImmutabilityPolicyModeValues returns the possible values for the ImmutabilityPolicyMode const type.
+func PossibleImmutabilityPolicyModeValues() []ImmutabilityPolicyMode {
+	return generated.PossibleImmutabilityPolicyModeValues()
+}
+
+// ImmutabilityPolicySetting returns the possible values for the ImmutabilityPolicySetting const type.
+type ImmutabilityPolicySetting = generated.ImmutabilityPolicySetting
+
+const (
+	ImmutabilityPolicySettingUnlocked ImmutabilityPolicySetting = generated.ImmutabilityPolicySettingUnlocked
+	ImmutabilityPolicySettingLocked   ImmutabilityPolicySetting = generated.ImmutabilityPolicySettingLocked
+)
+
+// PossibleImmutabilityPolicySettingValues returns the possible values for the ImmutabilityPolicySetting const type.
+func PossibleImmutabilityPolicySettingValues() []ImmutabilityPolicySetting {
+	return generated.PossibleImmutabilityPolicySettingValues()
 }
 
 // CopyStatusType defines values for CopyStatusType
@@ -125,32 +152,32 @@ func PossibleArchiveStatusValues() []ArchiveStatus {
 	return generated.PossibleArchiveStatusValues()
 }
 
-// DeleteType defines values for BlobDeleteType
-type DeleteType = generated.BlobDeleteType
+// DeleteType defines values for DeleteType
+type DeleteType = generated.DeleteType
 
 const (
-	DeleteTypeNone      DeleteType = generated.BlobDeleteTypeNone
-	DeleteTypePermanent DeleteType = generated.BlobDeleteTypePermanent
+	DeleteTypeNone      DeleteType = generated.DeleteTypeNone
+	DeleteTypePermanent DeleteType = generated.DeleteTypePermanent
 )
 
-// PossibleBlobDeleteTypeValues returns the possible values for the BlobDeleteType const type.
-func PossibleBlobDeleteTypeValues() []DeleteType {
-	return generated.PossibleBlobDeleteTypeValues()
+// PossibleDeleteTypeValues returns the possible values for the DeleteType const type.
+func PossibleDeleteTypeValues() []DeleteType {
+	return generated.PossibleDeleteTypeValues()
 }
 
-// ExpiryOptions defines values for BlobExpiryOptions
-type ExpiryOptions = generated.BlobExpiryOptions
+// ExpiryOptions defines values for ExpiryOptions
+type ExpiryOptions = generated.ExpiryOptions
 
 const (
-	ExpiryOptionsAbsolute           ExpiryOptions = generated.BlobExpiryOptionsAbsolute
-	ExpiryOptionsNeverExpire        ExpiryOptions = generated.BlobExpiryOptionsNeverExpire
-	ExpiryOptionsRelativeToCreation ExpiryOptions = generated.BlobExpiryOptionsRelativeToCreation
-	ExpiryOptionsRelativeToNow      ExpiryOptions = generated.BlobExpiryOptionsRelativeToNow
+	ExpiryOptionsAbsolute           ExpiryOptions = generated.ExpiryOptionsAbsolute
+	ExpiryOptionsNeverExpire        ExpiryOptions = generated.ExpiryOptionsNeverExpire
+	ExpiryOptionsRelativeToCreation ExpiryOptions = generated.ExpiryOptionsRelativeToCreation
+	ExpiryOptionsRelativeToNow      ExpiryOptions = generated.ExpiryOptionsRelativeToNow
 )
 
-// PossibleBlobExpiryOptionsValues returns the possible values for the BlobExpiryOptions const type.
-func PossibleBlobExpiryOptionsValues() []ExpiryOptions {
-	return generated.PossibleBlobExpiryOptionsValues()
+// PossibleExpiryOptionsValues returns the possible values for the ExpiryOptions const type.
+func PossibleExpiryOptionsValues() []ExpiryOptions {
+	return generated.PossibleExpiryOptionsValues()
 }
 
 // QueryFormatType - The quick query format type.

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -291,7 +291,7 @@ type StartCopyFromURLOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *ImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicySetting
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
 	// Optional. Used to set blob tags in various blob operations.
@@ -417,7 +417,7 @@ type CopyFromURLOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *ImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicySetting
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the

--- a/sdk/storage/azblob/blob/utils.go
+++ b/sdk/storage/azblob/blob/utils.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
 )
 
 // ObjectReplicationRules struct
@@ -60,7 +59,14 @@ func deserializeORSPolicies(policies map[string]string) (objectReplicationPolici
 
 // ParseHTTPHeaders parses GetPropertiesResponse and returns HTTPHeaders
 func ParseHTTPHeaders(resp GetPropertiesResponse) HTTPHeaders {
-	return generated.ParseHTTPHeaders(resp)
+	return HTTPHeaders{
+		BlobContentType:        resp.ContentType,
+		BlobContentEncoding:    resp.ContentEncoding,
+		BlobContentLanguage:    resp.ContentLanguage,
+		BlobContentDisposition: resp.ContentDisposition,
+		BlobCacheControl:       resp.CacheControl,
+		BlobContentMD5:         resp.ContentMD5,
+	}
 }
 
 // ParseSASTimeString try to parse sas time string.

--- a/sdk/storage/azblob/constants.go
+++ b/sdk/storage/azblob/constants.go
@@ -1,0 +1,35 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azblob
+
+import "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
+
+// PublicAccessType defines values for AccessType - private (default) or blob or container
+type PublicAccessType = generated.PublicAccessType
+
+const (
+	PublicAccessTypeBlob      PublicAccessType = generated.PublicAccessTypeBlob
+	PublicAccessTypeContainer PublicAccessType = generated.PublicAccessTypeContainer
+)
+
+// PossiblePublicAccessTypeValues returns the possible values for the PublicAccessType const type.
+func PossiblePublicAccessTypeValues() []PublicAccessType {
+	return generated.PossiblePublicAccessTypeValues()
+}
+
+// DeleteSnapshotsOptionType defines values for DeleteSnapshotsOptionType
+type DeleteSnapshotsOptionType = generated.DeleteSnapshotsOptionType
+
+const (
+	DeleteSnapshotsOptionTypeInclude DeleteSnapshotsOptionType = generated.DeleteSnapshotsOptionTypeInclude
+	DeleteSnapshotsOptionTypeOnly    DeleteSnapshotsOptionType = generated.DeleteSnapshotsOptionTypeOnly
+)
+
+// PossibleDeleteSnapshotsOptionTypeValues returns the possible values for the DeleteSnapshotsOptionType const type.
+func PossibleDeleteSnapshotsOptionTypeValues() []DeleteSnapshotsOptionType {
+	return generated.PossibleDeleteSnapshotsOptionTypeValues()
+}

--- a/sdk/storage/azblob/internal/generated/zz_blob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blob_client.go
@@ -729,8 +729,8 @@ func (client *BlobClient) deleteCreateRequest(ctx context.Context, options *Blob
 	if options != nil && options.Timeout != nil {
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
-	if options != nil && options.BlobDeleteType != nil {
-		reqQP.Set("deletetype", string(*options.BlobDeleteType))
+	if options != nil && options.DeleteType != nil {
+		reqQP.Set("deletetype", string(*options.DeleteType))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
@@ -1122,7 +1122,7 @@ func (client *BlobClient) downloadHandleResponse(resp *http.Response) (BlobClien
 		result.ImmutabilityPolicyExpiresOn = &immutabilityPolicyExpiresOn
 	}
 	if val := resp.Header.Get("x-ms-immutability-policy-mode"); val != "" {
-		result.ImmutabilityPolicyMode = (*BlobImmutabilityPolicyMode)(&val)
+		result.ImmutabilityPolicyMode = (*ImmutabilityPolicyMode)(&val)
 	}
 	if val := resp.Header.Get("x-ms-legal-hold"); val != "" {
 		legalHold, err := strconv.ParseBool(val)
@@ -1509,7 +1509,7 @@ func (client *BlobClient) getPropertiesHandleResponse(resp *http.Response) (Blob
 		result.ImmutabilityPolicyExpiresOn = &immutabilityPolicyExpiresOn
 	}
 	if val := resp.Header.Get("x-ms-immutability-policy-mode"); val != "" {
-		result.ImmutabilityPolicyMode = (*BlobImmutabilityPolicyMode)(&val)
+		result.ImmutabilityPolicyMode = (*ImmutabilityPolicyMode)(&val)
 	}
 	if val := resp.Header.Get("x-ms-legal-hold"); val != "" {
 		legalHold, err := strconv.ParseBool(val)
@@ -2014,7 +2014,7 @@ func (client *BlobClient) renewLeaseHandleResponse(resp *http.Response) (BlobCli
 // Generated from API version 2020-10-02
 // expiryOptions - Required. Indicates mode of the expiry time
 // options - BlobClientSetExpiryOptions contains the optional parameters for the BlobClient.SetExpiry method.
-func (client *BlobClient) SetExpiry(ctx context.Context, expiryOptions BlobExpiryOptions, options *BlobClientSetExpiryOptions) (BlobClientSetExpiryResponse, error) {
+func (client *BlobClient) SetExpiry(ctx context.Context, expiryOptions ExpiryOptions, options *BlobClientSetExpiryOptions) (BlobClientSetExpiryResponse, error) {
 	req, err := client.setExpiryCreateRequest(ctx, expiryOptions, options)
 	if err != nil {
 		return BlobClientSetExpiryResponse{}, err
@@ -2030,7 +2030,7 @@ func (client *BlobClient) SetExpiry(ctx context.Context, expiryOptions BlobExpir
 }
 
 // setExpiryCreateRequest creates the SetExpiry request.
-func (client *BlobClient) setExpiryCreateRequest(ctx context.Context, expiryOptions BlobExpiryOptions, options *BlobClientSetExpiryOptions) (*policy.Request, error) {
+func (client *BlobClient) setExpiryCreateRequest(ctx context.Context, expiryOptions ExpiryOptions, options *BlobClientSetExpiryOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2279,7 +2279,7 @@ func (client *BlobClient) setImmutabilityPolicyHandleResponse(resp *http.Respons
 		result.ImmutabilityPolicyExpiry = &immutabilityPolicyExpiry
 	}
 	if val := resp.Header.Get("x-ms-immutability-policy-mode"); val != "" {
-		result.ImmutabilityPolicyMode = (*BlobImmutabilityPolicyMode)(&val)
+		result.ImmutabilityPolicyMode = (*ImmutabilityPolicyMode)(&val)
 	}
 	return result, nil
 }
@@ -2484,6 +2484,7 @@ func (client *BlobClient) setMetadataHandleResponse(resp *http.Response) (BlobCl
 // SetTags - The Set Tags operation enables users to set tags on a blob.
 // If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-10-02
+// tags - Blob tags
 // options - BlobClientSetTagsOptions contains the optional parameters for the BlobClient.SetTags method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.

--- a/sdk/storage/azblob/internal/generated/zz_constants.go
+++ b/sdk/storage/azblob/internal/generated/zz_constants.go
@@ -9,7 +9,6 @@
 
 package generated
 
-// AccessTier defines values for Blob Access Tier
 type AccessTier string
 
 const (
@@ -51,7 +50,6 @@ func PossibleAccessTierValues() []AccessTier {
 	}
 }
 
-// AccountKind defines values for AccountKind
 type AccountKind string
 
 const (
@@ -73,7 +71,6 @@ func PossibleAccountKindValues() []AccountKind {
 	}
 }
 
-// ArchiveStatus defines values for ArchiveStatus
 type ArchiveStatus string
 
 const (
@@ -86,42 +83,6 @@ func PossibleArchiveStatusValues() []ArchiveStatus {
 	return []ArchiveStatus{
 		ArchiveStatusRehydratePendingToCool,
 		ArchiveStatusRehydratePendingToHot,
-	}
-}
-
-// BlobDeleteType defines values for BlobDeleteType
-type BlobDeleteType string
-
-const (
-	BlobDeleteTypeNone      BlobDeleteType = "None"
-	BlobDeleteTypePermanent BlobDeleteType = "Permanent"
-)
-
-// PossibleBlobDeleteTypeValues returns the possible values for the BlobDeleteType const type.
-func PossibleBlobDeleteTypeValues() []BlobDeleteType {
-	return []BlobDeleteType{
-		BlobDeleteTypeNone,
-		BlobDeleteTypePermanent,
-	}
-}
-
-// BlobExpiryOptions defines values for BlobExpiryOptions
-type BlobExpiryOptions string
-
-const (
-	BlobExpiryOptionsAbsolute           BlobExpiryOptions = "Absolute"
-	BlobExpiryOptionsNeverExpire        BlobExpiryOptions = "NeverExpire"
-	BlobExpiryOptionsRelativeToCreation BlobExpiryOptions = "RelativeToCreation"
-	BlobExpiryOptionsRelativeToNow      BlobExpiryOptions = "RelativeToNow"
-)
-
-// PossibleBlobExpiryOptionsValues returns the possible values for the BlobExpiryOptions const type.
-func PossibleBlobExpiryOptionsValues() []BlobExpiryOptions {
-	return []BlobExpiryOptions{
-		BlobExpiryOptionsAbsolute,
-		BlobExpiryOptionsNeverExpire,
-		BlobExpiryOptionsRelativeToCreation,
-		BlobExpiryOptionsRelativeToNow,
 	}
 }
 
@@ -143,25 +104,6 @@ func PossibleBlobGeoReplicationStatusValues() []BlobGeoReplicationStatus {
 	}
 }
 
-// BlobImmutabilityPolicyMode defines values for BlobImmutabilityPolicyMode
-type BlobImmutabilityPolicyMode string
-
-const (
-	BlobImmutabilityPolicyModeMutable  BlobImmutabilityPolicyMode = "Mutable"
-	BlobImmutabilityPolicyModeUnlocked BlobImmutabilityPolicyMode = "Unlocked"
-	BlobImmutabilityPolicyModeLocked   BlobImmutabilityPolicyMode = "Locked"
-)
-
-// PossibleBlobImmutabilityPolicyModeValues returns the possible values for the BlobImmutabilityPolicyMode const type.
-func PossibleBlobImmutabilityPolicyModeValues() []BlobImmutabilityPolicyMode {
-	return []BlobImmutabilityPolicyMode{
-		BlobImmutabilityPolicyModeMutable,
-		BlobImmutabilityPolicyModeUnlocked,
-		BlobImmutabilityPolicyModeLocked,
-	}
-}
-
-// BlobType defines values for BlobType
 type BlobType string
 
 const (
@@ -179,7 +121,6 @@ func PossibleBlobTypeValues() []BlobType {
 	}
 }
 
-// BlockListType defines values for BlockListType
 type BlockListType string
 
 const (
@@ -197,7 +138,6 @@ func PossibleBlockListTypeValues() []BlockListType {
 	}
 }
 
-// CopyStatusType defines values for CopyStatusType
 type CopyStatusType string
 
 const (
@@ -217,7 +157,6 @@ func PossibleCopyStatusTypeValues() []CopyStatusType {
 	}
 }
 
-// DeleteSnapshotsOptionType defines values for DeleteSnapshotsOptionType
 type DeleteSnapshotsOptionType string
 
 const (
@@ -233,7 +172,21 @@ func PossibleDeleteSnapshotsOptionTypeValues() []DeleteSnapshotsOptionType {
 	}
 }
 
-// EncryptionAlgorithmType defines values for EncryptionAlgorithmType
+type DeleteType string
+
+const (
+	DeleteTypeNone      DeleteType = "None"
+	DeleteTypePermanent DeleteType = "Permanent"
+)
+
+// PossibleDeleteTypeValues returns the possible values for the DeleteType const type.
+func PossibleDeleteTypeValues() []DeleteType {
+	return []DeleteType{
+		DeleteTypeNone,
+		DeleteTypePermanent,
+	}
+}
+
 type EncryptionAlgorithmType string
 
 const (
@@ -249,7 +202,57 @@ func PossibleEncryptionAlgorithmTypeValues() []EncryptionAlgorithmType {
 	}
 }
 
-// LeaseDurationType defines values for LeaseDurationType
+type ExpiryOptions string
+
+const (
+	ExpiryOptionsAbsolute           ExpiryOptions = "Absolute"
+	ExpiryOptionsNeverExpire        ExpiryOptions = "NeverExpire"
+	ExpiryOptionsRelativeToCreation ExpiryOptions = "RelativeToCreation"
+	ExpiryOptionsRelativeToNow      ExpiryOptions = "RelativeToNow"
+)
+
+// PossibleExpiryOptionsValues returns the possible values for the ExpiryOptions const type.
+func PossibleExpiryOptionsValues() []ExpiryOptions {
+	return []ExpiryOptions{
+		ExpiryOptionsAbsolute,
+		ExpiryOptionsNeverExpire,
+		ExpiryOptionsRelativeToCreation,
+		ExpiryOptionsRelativeToNow,
+	}
+}
+
+type ImmutabilityPolicyMode string
+
+const (
+	ImmutabilityPolicyModeMutable  ImmutabilityPolicyMode = "Mutable"
+	ImmutabilityPolicyModeUnlocked ImmutabilityPolicyMode = "Unlocked"
+	ImmutabilityPolicyModeLocked   ImmutabilityPolicyMode = "Locked"
+)
+
+// PossibleImmutabilityPolicyModeValues returns the possible values for the ImmutabilityPolicyMode const type.
+func PossibleImmutabilityPolicyModeValues() []ImmutabilityPolicyMode {
+	return []ImmutabilityPolicyMode{
+		ImmutabilityPolicyModeMutable,
+		ImmutabilityPolicyModeUnlocked,
+		ImmutabilityPolicyModeLocked,
+	}
+}
+
+type ImmutabilityPolicySetting string
+
+const (
+	ImmutabilityPolicySettingUnlocked ImmutabilityPolicySetting = "Unlocked"
+	ImmutabilityPolicySettingLocked   ImmutabilityPolicySetting = "Locked"
+)
+
+// PossibleImmutabilityPolicySettingValues returns the possible values for the ImmutabilityPolicySetting const type.
+func PossibleImmutabilityPolicySettingValues() []ImmutabilityPolicySetting {
+	return []ImmutabilityPolicySetting{
+		ImmutabilityPolicySettingUnlocked,
+		ImmutabilityPolicySettingLocked,
+	}
+}
+
 type LeaseDurationType string
 
 const (
@@ -265,7 +268,6 @@ func PossibleLeaseDurationTypeValues() []LeaseDurationType {
 	}
 }
 
-// LeaseStateType defines values for LeaseStateType
 type LeaseStateType string
 
 const (
@@ -287,7 +289,6 @@ func PossibleLeaseStateTypeValues() []LeaseStateType {
 	}
 }
 
-// LeaseStatusType defines values for LeaseStatusType
 type LeaseStatusType string
 
 const (
@@ -303,7 +304,6 @@ func PossibleLeaseStatusTypeValues() []LeaseStatusType {
 	}
 }
 
-// ListBlobsIncludeItem defines values for ListBlobsIncludeItem
 type ListBlobsIncludeItem string
 
 const (
@@ -335,7 +335,6 @@ func PossibleListBlobsIncludeItemValues() []ListBlobsIncludeItem {
 	}
 }
 
-// ListContainersIncludeType defines values for ListContainersIncludeType
 type ListContainersIncludeType string
 
 const (
@@ -353,7 +352,6 @@ func PossibleListContainersIncludeTypeValues() []ListContainersIncludeType {
 	}
 }
 
-// PremiumPageBlobAccessTier defines values for Premium PageBlob's AccessTier
 type PremiumPageBlobAccessTier string
 
 const (
@@ -387,7 +385,6 @@ func PossiblePremiumPageBlobAccessTierValues() []PremiumPageBlobAccessTier {
 	}
 }
 
-// PublicAccessType defines values for AccessType - private (default) or blob or container
 type PublicAccessType string
 
 const (
@@ -440,7 +437,6 @@ func PossibleRehydratePriorityValues() []RehydratePriority {
 	}
 }
 
-// SKUName defines values for SkuName - LRS, GRS, RAGRS, ZRS, Premium LRS
 type SKUName string
 
 const (
@@ -462,7 +458,6 @@ func PossibleSKUNameValues() []SKUName {
 	}
 }
 
-// SequenceNumberActionType defines values for SequenceNumberActionType
 type SequenceNumberActionType string
 
 const (

--- a/sdk/storage/azblob/internal/generated/zz_container_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_container_client.go
@@ -784,7 +784,7 @@ func (client *ContainerClient) ListBlobFlatSegmentCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// ListBlobFlatSegmentHandleResponse handles the ListBlobFlatSegment response.
+// listBlobFlatSegmentHandleResponse handles the ListBlobFlatSegment response.
 func (client *ContainerClient) ListBlobFlatSegmentHandleResponse(resp *http.Response) (ContainerClientListBlobFlatSegmentResponse, error) {
 	result := ContainerClientListBlobFlatSegmentResponse{}
 	if val := resp.Header.Get("Content-Type"); val != "" {

--- a/sdk/storage/azblob/internal/generated/zz_models.go
+++ b/sdk/storage/azblob/internal/generated/zz_models.go
@@ -65,7 +65,7 @@ type AppendBlobClientCreateOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicySetting
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
@@ -185,7 +185,7 @@ type BlobClientCopyFromURLOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicySetting
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
@@ -237,12 +237,12 @@ type BlobClientDeleteImmutabilityPolicyOptions struct {
 
 // BlobClientDeleteOptions contains the optional parameters for the BlobClient.Delete method.
 type BlobClientDeleteOptions struct {
-	// Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled.
-	BlobDeleteType *BlobDeleteType
 	// Required if the blob has associated snapshots. Specify one of the following two options: include: Delete the base blob
 	// and all of its snapshots. only: Delete only the blob's snapshots and not the blob
 	// itself
 	DeleteSnapshots *DeleteSnapshotsOptionType
+	// Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled.
+	DeleteType *DeleteType
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
@@ -385,7 +385,7 @@ type BlobClientSetImmutabilityPolicyOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicySetting
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
@@ -464,7 +464,7 @@ type BlobClientStartCopyFromURLOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicySetting
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
@@ -594,17 +594,17 @@ type BlobPropertiesInternal struct {
 	DestinationSnapshot       *string         `xml:"DestinationSnapshot"`
 
 	// The name of the encryption scope under which the blob is encrypted.
-	EncryptionScope             *string                     `xml:"EncryptionScope"`
-	ExpiresOn                   *time.Time                  `xml:"Expiry-Time"`
-	ImmutabilityPolicyExpiresOn *time.Time                  `xml:"ImmutabilityPolicyUntilDate"`
-	ImmutabilityPolicyMode      *BlobImmutabilityPolicyMode `xml:"ImmutabilityPolicyMode"`
-	IncrementalCopy             *bool                       `xml:"IncrementalCopy"`
-	IsSealed                    *bool                       `xml:"Sealed"`
-	LastAccessedOn              *time.Time                  `xml:"LastAccessTime"`
-	LeaseDuration               *LeaseDurationType          `xml:"LeaseDuration"`
-	LeaseState                  *LeaseStateType             `xml:"LeaseState"`
-	LeaseStatus                 *LeaseStatusType            `xml:"LeaseStatus"`
-	LegalHold                   *bool                       `xml:"LegalHold"`
+	EncryptionScope             *string                 `xml:"EncryptionScope"`
+	ExpiresOn                   *time.Time              `xml:"Expiry-Time"`
+	ImmutabilityPolicyExpiresOn *time.Time              `xml:"ImmutabilityPolicyUntilDate"`
+	ImmutabilityPolicyMode      *ImmutabilityPolicyMode `xml:"ImmutabilityPolicyMode"`
+	IncrementalCopy             *bool                   `xml:"IncrementalCopy"`
+	IsSealed                    *bool                   `xml:"Sealed"`
+	LastAccessedOn              *time.Time              `xml:"LastAccessTime"`
+	LeaseDuration               *LeaseDurationType      `xml:"LeaseDuration"`
+	LeaseState                  *LeaseStateType         `xml:"LeaseState"`
+	LeaseStatus                 *LeaseStatusType        `xml:"LeaseStatus"`
+	LegalHold                   *bool                   `xml:"LegalHold"`
 
 	// If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
 	// and Standard.
@@ -644,7 +644,7 @@ type BlockBlobClientCommitBlockListOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicySetting
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
@@ -750,7 +750,7 @@ type BlockBlobClientUploadOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicySetting
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
@@ -1321,7 +1321,7 @@ type PageBlobClientCreateOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicySetting
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
@@ -1476,17 +1476,6 @@ type PageRange struct {
 
 	// REQUIRED
 	Start *int64 `xml:"Start"`
-}
-
-// Raw converts PageRange into primitive start, end integers of type int64
-func (pr *PageRange) Raw() (start, end int64) {
-	if pr.Start != nil {
-		start = *pr.Start
-	}
-	if pr.End != nil {
-		end = *pr.End
-	}
-	return
 }
 
 type QueryFormat struct {

--- a/sdk/storage/azblob/internal/generated/zz_response_types.go
+++ b/sdk/storage/azblob/internal/generated/zz_response_types.go
@@ -425,7 +425,7 @@ type BlobClientDownloadResponse struct {
 	ImmutabilityPolicyExpiresOn *time.Time
 
 	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicyMode
 
 	// IsCurrentVersion contains the information returned from the x-ms-is-current-version header response.
 	IsCurrentVersion *bool
@@ -590,7 +590,7 @@ type BlobClientGetPropertiesResponse struct {
 	ImmutabilityPolicyExpiresOn *time.Time
 
 	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicyMode
 
 	// IsCurrentVersion contains the information returned from the x-ms-is-current-version header response.
 	IsCurrentVersion *bool
@@ -645,17 +645,6 @@ type BlobClientGetPropertiesResponse struct {
 
 	// VersionID contains the information returned from the x-ms-version-id header response.
 	VersionID *string
-}
-
-func ParseHTTPHeaders(r BlobClientGetPropertiesResponse) BlobHTTPHeaders {
-	return BlobHTTPHeaders{
-		BlobContentType:        r.ContentType,
-		BlobContentEncoding:    r.ContentEncoding,
-		BlobContentLanguage:    r.ContentLanguage,
-		BlobContentDisposition: r.ContentDisposition,
-		BlobCacheControl:       r.CacheControl,
-		BlobContentMD5:         r.ContentMD5,
-	}
 }
 
 // BlobClientGetTagsResponse contains the response from method BlobClient.GetTags.
@@ -881,7 +870,7 @@ type BlobClientSetImmutabilityPolicyResponse struct {
 	ImmutabilityPolicyExpiry *time.Time
 
 	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+	ImmutabilityPolicyMode *ImmutabilityPolicyMode
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string

--- a/sdk/storage/azblob/pageblob/constants.go
+++ b/sdk/storage/azblob/pageblob/constants.go
@@ -13,6 +13,21 @@ const (
 	PageBytes = 512
 )
 
+// CopyStatusType defines values for CopyStatusType
+type CopyStatusType = generated.CopyStatusType
+
+const (
+	CopyStatusTypePending CopyStatusType = generated.CopyStatusTypePending
+	CopyStatusTypeSuccess CopyStatusType = generated.CopyStatusTypeSuccess
+	CopyStatusTypeAborted CopyStatusType = generated.CopyStatusTypeAborted
+	CopyStatusTypeFailed  CopyStatusType = generated.CopyStatusTypeFailed
+)
+
+// PossibleCopyStatusTypeValues returns the possible values for the CopyStatusType const type.
+func PossibleCopyStatusTypeValues() []CopyStatusType {
+	return generated.PossibleCopyStatusTypeValues()
+}
+
 // PremiumPageBlobAccessTier defines values for Premium PageBlob's AccessTier
 type PremiumPageBlobAccessTier = generated.PremiumPageBlobAccessTier
 

--- a/sdk/storage/azblob/pageblob/models.go
+++ b/sdk/storage/azblob/pageblob/models.go
@@ -19,6 +19,9 @@ import (
 // PageList - the list of pages
 type PageList = generated.PageList
 
+// PageRange defines a range of pages.
+type PageRange = generated.PageRange
+
 // SequenceNumberAccessConditions contains a group of parameters for the Client.UploadPages method.
 type SequenceNumberAccessConditions = generated.SequenceNumberAccessConditions
 

--- a/sdk/storage/azblob/service/constants.go
+++ b/sdk/storage/azblob/service/constants.go
@@ -75,3 +75,16 @@ const (
 func PossibleBlobGeoReplicationStatusValues() []BlobGeoReplicationStatus {
 	return generated.PossibleBlobGeoReplicationStatusValues()
 }
+
+// PublicAccessType defines values for AccessType - private (default) or blob or container
+type PublicAccessType = generated.PublicAccessType
+
+const (
+	PublicAccessTypeBlob      PublicAccessType = generated.PublicAccessTypeBlob
+	PublicAccessTypeContainer PublicAccessType = generated.PublicAccessTypeContainer
+)
+
+// PossiblePublicAccessTypeValues returns the possible values for the PublicAccessType const type.
+func PossiblePublicAccessTypeValues() []PublicAccessType {
+	return generated.PossiblePublicAccessTypeValues()
+}

--- a/sdk/storage/azblob/zt_client_provided_key_test.go
+++ b/sdk/storage/azblob/zt_client_provided_key_test.go
@@ -786,6 +786,16 @@ func (s *azblobTestSuite) TestAppendBlockWithCPKScope() {
 //	_require.EqualValues(destData, srcData)
 //}
 
+func rawPageRange(pr *pageblob.PageRange) (start, end int64) {
+	if pr.Start != nil {
+		start = *pr.Start
+	}
+	if pr.End != nil {
+		end = *pr.End
+	}
+	return
+}
+
 // nolint
 func (s *azblobUnrecordedTestSuite) TestPageBlockWithCPK() {
 	_require := require.New(s.T())
@@ -816,7 +826,7 @@ func (s *azblobUnrecordedTestSuite) TestPageBlockWithCPK() {
 		_require.Nil(err)
 		pageListResp := resp.PageList.PageRange
 		start, end := int64(0), int64(contentSize-1)
-		rawStart, rawEnd := pageListResp[0].Raw()
+		rawStart, rawEnd := rawPageRange(pageListResp[0])
 		_require.Equal(rawStart, start)
 		_require.Equal(rawEnd, end)
 		if err != nil {
@@ -878,7 +888,7 @@ func (s *azblobUnrecordedTestSuite) TestPageBlockWithCPKScope() {
 		_require.Nil(err)
 		pageListResp := resp.PageList.PageRange
 		start, end := int64(0), int64(contentSize-1)
-		rawStart, rawEnd := pageListResp[0].Raw()
+		rawStart, rawEnd := rawPageRange(pageListResp[0])
 		_require.Equal(rawStart, start)
 		_require.Equal(rawEnd, end)
 		if err != nil {

--- a/sdk/storage/azblob/zt_page_blob_client_test.go
+++ b/sdk/storage/azblob/zt_page_blob_client_test.go
@@ -69,7 +69,7 @@ func (s *azblobTestSuite) TestPutGetPages() {
 		_require.NotNil(pageListResp.PageList)
 		pageRangeResp := pageListResp.PageList.PageRange
 		_require.Len(pageRangeResp, 1)
-		rawStart, rawEnd := (pageRangeResp)[0].Raw()
+		rawStart, rawEnd := rawPageRange((pageRangeResp)[0])
 		_require.Equal(rawStart, offset)
 		_require.Equal(rawEnd, count-1)
 		if err != nil {
@@ -274,7 +274,7 @@ func (s *azblobUnrecordedTestSuite) TestClearDiffPages() {
 		pageRangeResp := pageListResp.PageList.PageRange
 		_require.NotNil(pageRangeResp)
 		_require.Len(pageRangeResp, 1)
-		rawStart, rawEnd := (pageRangeResp)[0].Raw()
+		rawStart, rawEnd := rawPageRange((pageRangeResp)[0])
 		_require.Equal(rawStart, int64(2048))
 		_require.Equal(rawEnd, int64(4095))
 		if err != nil {
@@ -2002,7 +2002,7 @@ func validateBasicGetPageRanges(_require *require.Assertions, resp pageblob.Page
 	_require.NotNil(resp.PageRange)
 	_require.Len(resp.PageRange, 1)
 	start, end := int64(0), int64(pageblob.PageBytes-1)
-	rawStart, rawEnd := (resp.PageRange)[0].Raw()
+	rawStart, rawEnd := rawPageRange((resp.PageRange)[0])
 	_require.Equal(rawStart, start)
 	_require.Equal(rawEnd, end)
 }
@@ -2090,12 +2090,12 @@ func (s *azblobTestSuite) TestBlobGetPageRangesNonContiguousRanges() {
 		_require.Len(pageListResp, 2)
 
 		start, end := int64(0), int64(pageblob.PageBytes-1)
-		rawStart, rawEnd := pageListResp[0].Raw()
+		rawStart, rawEnd := rawPageRange(pageListResp[0])
 		_require.Equal(rawStart, start)
 		_require.Equal(rawEnd, end)
 
 		start, end = int64(pageblob.PageBytes*2), int64((pageblob.PageBytes*3)-1)
-		rawStart, rawEnd = pageListResp[1].Raw()
+		rawStart, rawEnd = rawPageRange(pageListResp[1])
 		_require.Equal(rawStart, start)
 		_require.Equal(rawEnd, end)
 		if err != nil {
@@ -2383,7 +2383,7 @@ func validateDiffPageRanges(_require *require.Assertions, resp pageblob.PageList
 	_require.Nil(err)
 	_require.NotNil(resp.PageRange)
 	_require.Len(resp.PageRange, 1)
-	rawStart, rawEnd := resp.PageRange[0].Raw()
+	rawStart, rawEnd := rawPageRange(resp.PageRange[0])
 	_require.EqualValues(rawStart, int64(0))
 	_require.EqualValues(rawEnd, int64(pageblob.PageBytes-1))
 }


### PR DESCRIPTION
Removed stuttering of some constant type names.
Pinned codegen to a specific commit for reproducible builds.
Added directives to export some generated, internal, methods.
Moved hand-edits of generated code elsewhere.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
