### PR TITLE
Clean up RetryReader

### DIFF
--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -306,7 +306,7 @@ func (b *Client) download(ctx context.Context, writer io.WriterAt, o downloadOpt
 			if err != nil {
 				return err
 			}
-			body := dr.BodyReader(&o.RetryReaderOptionsPerBlock)
+			var body io.ReadCloser = dr.NewRetryReader(ctx, &o.RetryReaderOptionsPerBlock)
 			if o.Progress != nil {
 				rangeProgress := int64(0)
 				body = streaming.NewResponseProgress(
@@ -360,10 +360,12 @@ func (b *Client) DownloadStream(ctx context.Context, o *DownloadStreamOptions) (
 		eTag = *dr.ETag
 	}
 	return DownloadStreamResponse{
-		b:                          b,
+		client:                     b,
 		BlobClientDownloadResponse: dr,
-		getInfo:                    HTTPGetterInfo{Offset: offset, Count: count, ETag: eTag},
+		getInfo:                    httpGetterInfo{Offset: offset, Count: count, ETag: eTag},
 		ObjectReplicationRules:     deserializeORSPolicies(dr.ObjectReplicationRules),
+		cpkInfo:                    o.CpkInfo,
+		cpkScope:                   o.CpkScopeInfo,
 	}, err
 }
 

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -338,6 +338,9 @@ func (b *Client) download(ctx context.Context, writer io.WriterAt, o downloadOpt
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/get-blob.
 func (b *Client) DownloadStream(ctx context.Context, o *DownloadStreamOptions) (DownloadStreamResponse, error) {
 	downloadOptions, leaseAccessConditions, cpkInfo, modifiedAccessConditions := o.format()
+	if o == nil {
+		o = &DownloadStreamOptions{}
+	}
 
 	dr, err := b.generated().Download(ctx, downloadOptions, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
@@ -347,11 +350,11 @@ func (b *Client) DownloadStream(ctx context.Context, o *DownloadStreamOptions) (
 	offset := int64(0)
 	count := int64(CountToEnd)
 
-	if o != nil && o.Offset != nil {
+	if o.Offset != nil {
 		offset = *o.Offset
 	}
 
-	if o != nil && o.Count != nil {
+	if o.Count != nil {
 		count = *o.Count
 	}
 

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -178,8 +178,10 @@ type DownloadBufferOptions struct {
 	// BlobAccessConditions indicates the access conditions used when making HTTP GET requests against the blob.
 	AccessConditions *AccessConditions
 
-	// ClientProvidedKeyOptions indicates the client provided key by name and/or by value to encrypt/decrypt data.
-	CpkInfo      *CpkInfo
+	// CpkInfo contains a group of parameters for client provided encryption key.
+	CpkInfo *CpkInfo
+
+	// CpkScopeInfo contains a group of parameters for client provided encryption scope.
 	CpkScopeInfo *CpkScopeInfo
 
 	// Parallelism indicates the maximum number of blocks to download in parallel (0=default)

--- a/sdk/storage/azblob/testdata/perf/download_blob.go
+++ b/sdk/storage/azblob/testdata/perf/download_blob.go
@@ -130,12 +130,9 @@ func (d *downloadPerfTest) Run(ctx context.Context) error {
 		return err
 	}
 	downloadedData := &bytes.Buffer{}
-	reader := get.BodyReader(nil)
-	_, err = downloadedData.ReadFrom(reader)
-	if err != nil {
-		return err
-	}
-	return reader.Close()
+	defer get.Body.Close()
+	_, err = downloadedData.ReadFrom(get.Body)
+	return err
 }
 
 func (*downloadPerfTest) Cleanup(ctx context.Context) error {

--- a/sdk/storage/azblob/zt_blob_client_test.go
+++ b/sdk/storage/azblob/zt_blob_client_test.go
@@ -178,11 +178,11 @@ func (s *azblobTestSuite) TestBlobStartCopyDestEmpty() {
 	_require.Nil(err)
 
 	// Read the blob data to verify the copy
-	data, err := io.ReadAll(resp.BodyReader(nil))
+	data, err := io.ReadAll(resp.Body)
 	_require.Nil(err)
 	_require.Equal(*resp.ContentLength, int64(len(blockBlobDefaultData)))
 	_require.Equal(string(data), blockBlobDefaultData)
-	_ = resp.BodyReader(nil).Close()
+	_ = resp.Body.Close()
 }
 
 func (s *azblobTestSuite) TestBlobStartCopyMetadata() {
@@ -1497,7 +1497,7 @@ func (s *azblobTestSuite) TestBlobDownloadDataCountZero() {
 	_require.Nil(err)
 
 	// Specifying a count of 0 results in the value being ignored
-	data, err := io.ReadAll(resp.BodyReader(nil))
+	data, err := io.ReadAll(resp.Body)
 	_require.Nil(err)
 	_require.Equal(string(data), blockBlobDefaultData)
 }
@@ -1522,7 +1522,7 @@ func (s *azblobTestSuite) TestBlobDownloadDataCountExact() {
 	resp, err := bbClient.DownloadStream(ctx, &options)
 	_require.Nil(err)
 
-	data, err := io.ReadAll(resp.BodyReader(nil))
+	data, err := io.ReadAll(resp.Body)
 	_require.Nil(err)
 	_require.Equal(string(data), blockBlobDefaultData)
 }
@@ -1546,7 +1546,7 @@ func (s *azblobTestSuite) TestBlobDownloadDataCountOutOfRange() {
 	resp, err := bbClient.DownloadStream(ctx, &options)
 	_require.Nil(err)
 
-	data, err := io.ReadAll(resp.BodyReader(nil))
+	data, err := io.ReadAll(resp.Body)
 	_require.Nil(err)
 	_require.Equal(string(data), blockBlobDefaultData)
 }
@@ -1571,7 +1571,7 @@ func (s *azblobTestSuite) TestBlobDownloadDataEmptyRangeStruct() {
 	resp, err := bbClient.DownloadStream(ctx, &options)
 	_require.Nil(err)
 
-	data, err := io.ReadAll(resp.BodyReader(nil))
+	data, err := io.ReadAll(resp.Body)
 	_require.Nil(err)
 	_require.Equal(string(data), blockBlobDefaultData)
 }

--- a/sdk/storage/azblob/zt_blob_tags_test.go
+++ b/sdk/storage/azblob/zt_blob_tags_test.go
@@ -194,7 +194,7 @@ func (s *azblobUnrecordedTestSuite) TestStageBlockWithTags() {
 
 	contentResp, err := bbClient.DownloadStream(ctx, nil)
 	_require.Nil(err)
-	contentData, err := io.ReadAll(contentResp.BodyReader(nil))
+	contentData, err := io.ReadAll(contentResp.Body)
 	_require.Nil(err)
 	_require.EqualValues(contentData, []uint8(strings.Join(data, "")))
 

--- a/sdk/storage/azblob/zt_blob_versioning_test.go
+++ b/sdk/storage/azblob/zt_blob_versioning_test.go
@@ -143,7 +143,7 @@ func (s *azblobTestSuite) TestCreateAndDownloadBlobSpecialCharactersWithVID() {
 		_require.Nil(err)
 		dResp, err := blobClientWithVersionID.DownloadStream(ctx, nil)
 		_require.Nil(err)
-		d1, err := io.ReadAll(dResp.BodyReader(nil))
+		d1, err := io.ReadAll(dResp.Body)
 		_require.Nil(err)
 		_require.NotEqual(*dResp.Version, "")
 		_require.EqualValues(string(d1), string(data[i]))
@@ -274,7 +274,7 @@ func (s *azblobTestSuite) TestDeleteSpecificBlobVersion() {
 		_require.Nil(err)
 		downloadResp, err := bbClientWithVersionID.DownloadStream(ctx, nil)
 		_require.Nil(err)
-		destData, err := io.ReadAll(downloadResp.BodyReader(nil))
+		destData, err := io.ReadAll(downloadResp.Body)
 		_require.Nil(err)
 		_require.EqualValues(destData, "data"+strconv.Itoa(i))
 	}
@@ -431,7 +431,7 @@ func (s *azblobTestSuite) TestPutBlockListReturnsVID() {
 
 	contentResp, err := bbClient.DownloadStream(ctx, nil)
 	_require.Nil(err)
-	contentData, err := io.ReadAll(contentResp.BodyReader(nil))
+	contentData, err := io.ReadAll(contentResp.Body)
 	_require.Nil(err)
 	_require.EqualValues(contentData, []uint8(strings.Join(data, "")))
 }

--- a/sdk/storage/azblob/zt_block_blob_client_test.go
+++ b/sdk/storage/azblob/zt_block_blob_client_test.go
@@ -1000,7 +1000,7 @@ func (s *azblobTestSuite) TestBlobPutBlockListValidateData() {
 
 	resp, err := bbClient.DownloadStream(ctx, nil)
 	_require.Nil(err)
-	data, err := io.ReadAll(resp.BodyReader(nil))
+	data, err := io.ReadAll(resp.Body)
 	_require.Nil(err)
 	_require.Equal(string(data), blockBlobDefaultData)
 }

--- a/sdk/storage/azblob/zt_client_provided_key_test.go
+++ b/sdk/storage/azblob/zt_client_provided_key_test.go
@@ -98,9 +98,10 @@ func (s *azblobTestSuite) TestPutBlockAndPutBlockListWithCPK() {
 	getResp, err := bbClient.DownloadStream(ctx, &downloadBlobOptions)
 	_require.Nil(err)
 	b := bytes.Buffer{}
-	reader := getResp.BodyReader(&blob.RetryReaderOptions{CpkInfo: &testCPKByValue})
-	_, _ = b.ReadFrom(reader)
-	_ = reader.Close()
+	_, err = b.ReadFrom(getResp.Body)
+	_require.NoError(err)
+	err = getResp.Body.Close()
+	_require.NoError(err)
 	_require.Equal(b.String(), "AAA BBB CCC ")
 	_require.EqualValues(*getResp.ETag, *resp.ETag)
 	_require.EqualValues(*getResp.LastModified, *resp.LastModified)
@@ -149,7 +150,7 @@ func (s *azblobTestSuite) TestPutBlockAndPutBlockListWithCPKByScope() {
 	getResp, err := bbClient.DownloadStream(ctx, &downloadBlobOptions)
 	_require.Nil(err)
 	b := bytes.Buffer{}
-	reader := getResp.BodyReader(nil)
+	reader := getResp.Body
 	_, err = b.ReadFrom(reader)
 	_require.Nil(err)
 	_ = reader.Close() // The client must close the response body when finished with it
@@ -273,7 +274,7 @@ func (s *azblobTestSuite) TestPutBlockAndPutBlockListWithCPKByScope() {
 //	}
 //	downloadResp, err := destBlob.BlobClient.DownloadStream(ctx, &downloadBlobOptions)
 //	_require.Nil(err)
-//	destData, err := io.ReadAll(downloadResp.BodyReader(nil))
+//	destData, err := io.ReadAll(downloadResp.Body)
 //	_require.Nil(err)
 //	_require.EqualValues(destData, content)
 //	_require.EqualValues(*downloadResp.EncryptionKeySHA256, *testCPKByValue.EncryptionKeySHA256)
@@ -386,7 +387,7 @@ func (s *azblobTestSuite) TestPutBlockAndPutBlockListWithCPKByScope() {
 //	}
 //	downloadResp, err := destBlob.BlobClient.DownloadStream(ctx, &downloadBlobOptions)
 //	_require.Nil(err)
-//	destData, err := io.ReadAll(downloadResp.BodyReader(nil))
+//	destData, err := io.ReadAll(downloadResp.Body)
 //	_require.Nil(err)
 //	_require.EqualValues(destData, content)
 //	_require.EqualValues(*downloadResp.EncryptionScope, *testCPKByScope.EncryptionScope)
@@ -430,7 +431,7 @@ func (s *azblobUnrecordedTestSuite) TestUploadBlobWithMD5WithCPK() {
 	})
 	_require.Nil(err)
 	_require.EqualValues(downloadResp.ContentMD5, md5Val[:])
-	destData, err := io.ReadAll(downloadResp.BodyReader(&blob.RetryReaderOptions{CpkInfo: &testCPKByValue}))
+	destData, err := io.ReadAll(downloadResp.Body)
 	_require.Nil(err)
 	_require.EqualValues(destData, srcData)
 	_require.EqualValues(downloadResp.EncryptionKeySHA256, testCPKByValue.EncryptionKeySHA256)
@@ -460,13 +461,14 @@ func (s *azblobTestSuite) TestUploadBlobWithMD5WithCPKScope() {
 
 	// Download blob to do data integrity check.
 	downloadBlobOptions := blob.DownloadStreamOptions{
+		CpkInfo:      &testCPKByValue,
 		CpkScopeInfo: &testCPKByScope,
 	}
 	downloadResp, err := bbClient.DownloadStream(ctx, &downloadBlobOptions)
 	_require.Nil(err)
 	_require.EqualValues(downloadResp.ContentMD5, md5Val[:])
-	destData, err := io.ReadAll(downloadResp.BodyReader(&blob.RetryReaderOptions{CpkInfo: &testCPKByValue}))
-	_require.Nil(err)
+	destData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
 	_require.EqualValues(destData, srcData)
 	_require.EqualValues(*downloadResp.EncryptionScope, *testCPKByScope.EncryptionScope)
 }
@@ -521,7 +523,7 @@ func (s *azblobTestSuite) TestAppendBlockWithCPK() {
 	downloadResp, err := abClient.DownloadStream(ctx, &downloadBlobOptions)
 	_require.Nil(err)
 
-	data, err := io.ReadAll(downloadResp.BodyReader(nil))
+	data, err := io.ReadAll(downloadResp.Body)
 	_require.Nil(err)
 	_require.EqualValues(string(data), "AAA BBB CCC ")
 	_require.EqualValues(*downloadResp.EncryptionKeySHA256, *testCPKByValue.EncryptionKeySHA256)
@@ -573,7 +575,7 @@ func (s *azblobTestSuite) TestAppendBlockWithCPKScope() {
 	downloadResp, err := abClient.DownloadStream(ctx, &downloadBlobOptions)
 	_require.Nil(err)
 
-	data, err := io.ReadAll(downloadResp.BodyReader(nil))
+	data, err := io.ReadAll(downloadResp.Body)
 	_require.Nil(err)
 	_require.EqualValues(string(data), "AAA BBB CCC ")
 	_require.EqualValues(*downloadResp.EncryptionScope, *testCPKByScope.EncryptionScope)
@@ -851,7 +853,7 @@ func (s *azblobUnrecordedTestSuite) TestPageBlockWithCPK() {
 	downloadResp, err := pbClient.DownloadStream(ctx, &downloadBlobOptions)
 	_require.Nil(err)
 
-	destData, err := io.ReadAll(downloadResp.BodyReader(nil))
+	destData, err := io.ReadAll(downloadResp.Body)
 	_require.Nil(err)
 	_require.EqualValues(destData, srcData)
 	_require.EqualValues(*downloadResp.EncryptionKeySHA256, *testCPKByValue.EncryptionKeySHA256)
@@ -903,7 +905,7 @@ func (s *azblobUnrecordedTestSuite) TestPageBlockWithCPKScope() {
 	downloadResp, err := pbClient.DownloadStream(ctx, &downloadBlobOptions)
 	_require.Nil(err)
 
-	destData, err := io.ReadAll(downloadResp.BodyReader(nil))
+	destData, err := io.ReadAll(downloadResp.Body)
 	_require.Nil(err)
 	_require.EqualValues(destData, srcData)
 	_require.EqualValues(*downloadResp.EncryptionScope, *testCPKByScope.EncryptionScope)

--- a/sdk/storage/azblob/zt_client_provided_key_test.go
+++ b/sdk/storage/azblob/zt_client_provided_key_test.go
@@ -461,7 +461,6 @@ func (s *azblobTestSuite) TestUploadBlobWithMD5WithCPKScope() {
 
 	// Download blob to do data integrity check.
 	downloadBlobOptions := blob.DownloadStreamOptions{
-		CpkInfo:      &testCPKByValue,
 		CpkScopeInfo: &testCPKByScope,
 	}
 	downloadResp, err := bbClient.DownloadStream(ctx, &downloadBlobOptions)

--- a/sdk/storage/azblob/zt_examples_test.go
+++ b/sdk/storage/azblob/zt_examples_test.go
@@ -96,7 +96,7 @@ func Example() {
 
 	// Use the bytes.Buffer object to read the downloaded data.
 	// RetryReaderOptions has a lot of in-depth tuning abilities, but for the sake of simplicity, we'll omit those here.
-	reader := blobDownloadResponse.BodyReader(nil)
+	reader := blobDownloadResponse.Body
 	downloadData, err := io.ReadAll(reader)
 	handleError(err)
 	if string(downloadData) != uploadData {
@@ -761,7 +761,7 @@ func Example_blockblob_Client() {
 	handleError(err)
 
 	blobData := &bytes.Buffer{}
-	reader := blobDownloadResponse.BodyReader(nil)
+	reader := blobDownloadResponse.Body
 	_, err = blobData.ReadFrom(reader)
 	if err != nil {
 		return
@@ -804,7 +804,7 @@ func Example_appendblob_Client() {
 	get, err := appendBlobClient.DownloadStream(context.TODO(), nil)
 	handleError(err)
 	b := bytes.Buffer{}
-	reader := get.BodyReader(nil)
+	reader := get.Body
 	_, err = b.ReadFrom(reader)
 	if err != nil {
 		return
@@ -885,7 +885,7 @@ func Example_pageblob_Client() {
 	get, err := pageBlobClient.DownloadStream(context.TODO(), nil)
 	handleError(err)
 	blobData := &bytes.Buffer{}
-	reader := get.BodyReader(nil)
+	reader := get.Body
 	_, err = blobData.ReadFrom(reader)
 	if err != nil {
 		return
@@ -1063,7 +1063,7 @@ func Example_blob_AccessConditions() {
 		if err != nil {
 			log.Fatalf("Failure: %s\n", err.Error())
 		} else {
-			err := response.BodyReader(nil).Close()
+			err := response.Body.Close()
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -1260,7 +1260,7 @@ func Example_blob_Client_CreateSnapshot() {
 	get, err := baseBlobClient.DownloadStream(context.TODO(), nil)
 	handleError(err)
 	b := bytes.Buffer{}
-	reader := get.BodyReader(nil)
+	reader := get.Body
 	_, err = b.ReadFrom(reader)
 	if err != nil {
 		return
@@ -1276,7 +1276,7 @@ func Example_blob_Client_CreateSnapshot() {
 	get, err = snapshotBlobClient.DownloadStream(context.TODO(), nil)
 	handleError(err)
 	b.Reset()
-	reader = get.BodyReader(nil)
+	reader = get.Body
 	_, err = b.ReadFrom(reader)
 	if err != nil {
 		return
@@ -1358,7 +1358,7 @@ func Example_progressUploadDownload() {
 
 	// Wrap the response body in a ResponseBodyProgress and pass a callback function for progress reporting.
 	responseBody := streaming.NewResponseProgress(
-		get.BodyReader(nil),
+		get.Body,
 		func(bytesTransferred int64) {
 			fmt.Printf("Read %d of %d bytes.", bytesTransferred, *get.ContentLength)
 		},
@@ -1491,7 +1491,7 @@ func Example_blob_Client_Download() {
 	// Download returns an intelligent retryable stream around a blob; it returns an io.ReadCloser.
 	dr, err := blobClient.DownloadStream(context.TODO(), nil)
 	handleError(err)
-	rs := dr.BodyReader(nil)
+	rs := dr.Body
 
 	// NewResponseBodyProgress wraps the GetRetryStream with progress reporting; it returns an io.ReadCloser.
 	stream := streaming.NewResponseProgress(

--- a/sdk/storage/azblob/zt_highlevel_test.go
+++ b/sdk/storage/azblob/zt_highlevel_test.go
@@ -61,7 +61,7 @@ func performUploadStreamToBlockBlobTest(t *testing.T, _require *require.Assertio
 	_require.Nil(err)
 
 	// Assert that the content is correct
-	actualBlobData, err := io.ReadAll(downloadResponse.BodyReader(nil))
+	actualBlobData, err := io.ReadAll(downloadResponse.Body)
 	_require.Nil(err)
 	_require.Equal(len(actualBlobData), blobSize)
 	_require.EqualValues(actualBlobData, blobData)
@@ -583,7 +583,7 @@ func (s *azblobUnrecordedTestSuite) TestUploadStreamToBlobProperties() {
 	_require.NoError(err)
 
 	// Assert that the content is correct
-	actualBlobData, err := io.ReadAll(downloadResponse.BodyReader(nil))
+	actualBlobData, err := io.ReadAll(downloadResponse.Body)
 	_require.NoError(err)
 	_require.Equal(len(actualBlobData), blobSize)
 	_require.EqualValues(actualBlobData, blobData)

--- a/sdk/storage/azblob/zt_test.go
+++ b/sdk/storage/azblob/zt_test.go
@@ -116,7 +116,7 @@ func disableSoftDelete(_require *require.Assertions, client *service.Client) {
 func validateUpload(_require *require.Assertions, blobClient *blockblob.Client) {
 	resp, err := blobClient.DownloadStream(ctx, nil)
 	_require.Nil(err)
-	data, err := io.ReadAll(resp.BodyReader(nil))
+	data, err := io.ReadAll(resp.Body)
 	_require.Nil(err)
 	_require.Len(data, 0)
 }


### PR DESCRIPTION
Removed method RetryReader.BodyReader as it's redundant.
Removed duplicate CPK options from RetryReaderOptions.  We now cache the
values used in the DownloadStream API call.
Renamed the fields in RetryReaderOptions to shorten them.
Stop exporting various helper types.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
