### PR TITLE
Various bug fixes for azcore and internal

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Adjusted the initial retry delay to 800ms per the Azure SDK guidelines.
 
 ### Other Changes
 

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -38,7 +38,7 @@ func setDefaults(o *policy.RetryOptions) {
 		o.MaxRetryDelay = math.MaxInt64
 	}
 	if o.RetryDelay == 0 {
-		o.RetryDelay = 4 * time.Second
+		o.RetryDelay = 800 * time.Millisecond
 	} else if o.RetryDelay < 0 {
 		o.RetryDelay = 0
 	}

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -333,7 +333,7 @@ func TestRetryPolicyRequestTimedOut(t *testing.T) {
 	defer close()
 	srv.SetError(errors.New("bogus error"))
 	pl := exported.NewPipeline(srv, NewRetryPolicy(nil))
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
 	defer cancel()
 	req, err := NewRequest(ctx, http.MethodPost, srv.URL())
 	if err != nil {

--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Don't modify the original *http.Request during recording/perf as it causes failures during retries.
 
 ### Other Changes
 

--- a/sdk/internal/perf/recording.go
+++ b/sdk/internal/perf/recording.go
@@ -131,8 +131,8 @@ func NewProxyTransport(options *TransportOptions) *RecordingHTTPClient {
 
 func (c RecordingHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if c.mode != liveMode {
-		err := c.replaceAuthority(req)
-		if err != nil {
+		var err error
+		if req, err = c.replaceAuthority(req); err != nil {
 			return nil, err
 		}
 	}
@@ -144,22 +144,29 @@ func (c *RecordingHTTPClient) SetMode(mode string) {
 	c.mode = mode
 }
 
-func (c *RecordingHTTPClient) replaceAuthority(rawReq *http.Request) error {
+func (c *RecordingHTTPClient) replaceAuthority(rawReq *http.Request) (*http.Request, error) {
 	parsedProxyURL, err := url.Parse(c.options.proxyURL)
 	if err != nil {
-		return fmt.Errorf("there was an error parsing url '%s': %s", c.options.proxyURL, err.Error())
+		return nil, fmt.Errorf("there was an error parsing url '%s': %s", c.options.proxyURL, err.Error())
 	}
 	originalURLHost := rawReq.URL.Host
 	originalURLScheme := rawReq.URL.Scheme
-	rawReq.URL.Scheme = parsedProxyURL.Scheme
-	rawReq.URL.Host = parsedProxyURL.Host
-	rawReq.Host = parsedProxyURL.Host
 
-	rawReq.Header.Set(upstreamURIHeader, fmt.Sprintf("%v://%v", originalURLScheme, originalURLHost))
-	rawReq.Header.Set(modeHeader, c.mode)
-	rawReq.Header.Set(idHeader, c.recID)
-	rawReq.Header.Set("x-recording-remove", "false")
-	return nil
+	// don't modify the original request
+	cp := *rawReq
+	cpURL := *cp.URL
+	cp.URL = &cpURL
+	cp.Header = rawReq.Header.Clone()
+
+	cp.URL.Scheme = parsedProxyURL.Scheme
+	cp.URL.Host = parsedProxyURL.Host
+	cp.Host = parsedProxyURL.Host
+
+	cp.Header.Set(upstreamURIHeader, fmt.Sprintf("%v://%v", originalURLScheme, originalURLHost))
+	cp.Header.Set(modeHeader, c.mode)
+	cp.Header.Set(idHeader, c.recID)
+	cp.Header.Set("x-recording-remove", "false")
+	return &cp, nil
 }
 
 // start tells the test proxy to begin accepting requests for a given test

--- a/sdk/internal/perf/recording_test.go
+++ b/sdk/internal/perf/recording_test.go
@@ -33,9 +33,9 @@ func TestRecordingHTTPClient_Do(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, "https://localhost:5001", resp.Request.URL.String())
-	require.Contains(t, req.Header.Get(upstreamURIHeader), "https://www.bing.com")
-	require.Equal(t, req.Header.Get(modeHeader), "record")
-	require.Equal(t, req.Header.Get(idHeader), client.recID)
+	require.Contains(t, resp.Request.Header.Get(upstreamURIHeader), "https://www.bing.com")
+	require.Equal(t, resp.Request.Header.Get(modeHeader), "record")
+	require.Equal(t, resp.Request.Header.Get(idHeader), client.recID)
 
 	proxyTransportsSuite[t.Name()].SetMode("playback")
 	req, err = http.NewRequest("POST", "https://www.bing.com", nil)
@@ -43,7 +43,7 @@ func TestRecordingHTTPClient_Do(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, "https://localhost:5001", resp.Request.URL.String())
-	require.Contains(t, req.Header.Get(upstreamURIHeader), "https://www.bing.com")
-	require.Equal(t, req.Header.Get(modeHeader), "playback")
-	require.Equal(t, req.Header.Get(idHeader), client.recID)
+	require.Contains(t, resp.Request.Header.Get(upstreamURIHeader), "https://www.bing.com")
+	require.Equal(t, resp.Request.Header.Get(modeHeader), "playback")
+	require.Equal(t, resp.Request.Header.Get(idHeader), client.recID)
 }

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -473,7 +473,7 @@ func TestStartStopRecordingClient(t *testing.T) {
 	err = json.Unmarshal(byteValue, &data)
 	require.NoError(t, err)
 	require.Equal(t, "https://azsdkengsys.azurecr.io/acr/v1/some_registry/_tags", data.Entries[0].RequestURI)
-	require.Equal(t, req.URL.String(), "https://localhost:5001/acr/v1/some_registry/_tags")
+	require.Equal(t, resp.Request.URL.String(), "https://localhost:5001/acr/v1/some_registry/_tags")
 }
 
 func TestStopRecordingNoStart(t *testing.T) {


### PR DESCRIPTION
Adjusted the initial retry delay to align with the design guidelines.
Fixed an issue with modifying the original *http.Request that breaks
retries during recording playback.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
