### PR TITLE
Add GenerateAlphaNumericID feature to testutil of mgmt. plane interal.

### DIFF
--- a/sdk/resourcemanager/internal/CHANGELOG.md
+++ b/sdk/resourcemanager/internal/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.1.0 (2022-08-24)
 
 ### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+* Add `GenerateAlphaNumericID` to testutil
 
 ## 1.0.1 (2022-06-23)
 

--- a/sdk/resourcemanager/internal/testdata/recordings/TestGenerateAlphaNumericID.json
+++ b/sdk/resourcemanager/internal/testdata/recordings/TestGenerateAlphaNumericID.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "recordingRandomSeed": "1661246628"
+  }
+}

--- a/sdk/resourcemanager/internal/testutil/recording_test.go
+++ b/sdk/resourcemanager/internal/testutil/recording_test.go
@@ -35,3 +35,11 @@ func TestStartStopRecording(t *testing.T) {
 	stop := StartRecording(t, pathToPackage)
 	defer stop()
 }
+
+func TestGenerateAlphaNumericID(t *testing.T) {
+	stop := StartRecording(t, pathToPackage)
+	first := GenerateAlphaNumericID(t, "test", 6)
+	second := GenerateAlphaNumericID(t, "test", 6)
+	require.Equal(t, first, second)
+	defer stop()
+}

--- a/sdk/resourcemanager/internal/version.go
+++ b/sdk/resourcemanager/internal/version.go
@@ -11,5 +11,5 @@ const (
 	Module = "internal"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.0.2"
+	Version = "v1.1.0"
 )


### PR DESCRIPTION
In order to support generate random ID for `prefix` string in api scenario, introduce this help function to `testutil` in resourcemanager/internal.