### PR TITLE
ManagedIdentityCredential caches tokens

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -1,15 +1,12 @@
 # Release History
 
-## 1.2.0-beta.3 (Unreleased)
+## 1.2.0-beta.3 (2022-09-06)
 
 ### Features Added
-
-### Breaking Changes
+* `ManagedIdentityCredential` caches tokens in-memory
 
 ### Bugs Fixed
 * `ClientCertificateCredential` sends only the leaf cert for SNI authentication
-
-### Other Changes
 
 ## 1.2.0-beta.2 (2022-08-10)
 

--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Release History
 
-## 1.2.0-beta.3 (2022-09-06)
+## 1.2.0-beta.3 (Unreleased)
 
 ### Features Added
-* `ManagedIdentityCredential` caches tokens in-memory
+* `ManagedIdentityCredential` caches tokens in memory
 
 ### Bugs Fixed
 * `ClientCertificateCredential` sends only the leaf cert for SNI authentication

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -28,7 +28,6 @@ import (
 
 // constants used throughout this package
 const (
-	accessTokenRespSuccess   = `{"access_token": "` + tokenValue + `", "expires_in": 3600}`
 	accessTokenRespMalformed = `{"access_token": 0, "expires_in": 3600}`
 	badTenantID              = "bad_tenant"
 	tenantDiscoveryResponse  = `{
@@ -98,10 +97,13 @@ const (
 		"msgraph_host": "graph.microsoft.com",
 		"rbac_url": "https://pas.windows.net"
 		}`
-	tokenValue = "new_token"
+	tokenExpiresIn = 3600
+	tokenValue     = "new_token"
 )
 
-var instanceDiscoveryResponse = []byte(`{
+var (
+	accessTokenRespSuccess    = fmt.Sprintf(`{"access_token": "%s", "expires_in": %d}`, tokenValue, tokenExpiresIn)
+	instanceDiscoveryResponse = []byte(`{
 	"tenant_discovery_endpoint": "https://login.microsoftonline.com/tenant/v2.0/.well-known/openid-configuration",
 	"api-version": "1.1",
 	"metadata": [
@@ -117,6 +119,7 @@ var instanceDiscoveryResponse = []byte(`{
 		}
 	]
 }`)
+)
 
 // constants for this file
 const (

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -67,7 +67,7 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 	msiCred, err := NewManagedIdentityCredential(o)
 	if err == nil {
 		creds = append(creds, msiCred)
-		msiCred.client.imdsTimeout = time.Second
+		msiCred.mic.imdsTimeout = time.Second
 	} else {
 		errorMessages = append(errorMessages, credNameManagedIdentity+": "+err.Error())
 		creds = append(creds, &defaultCredentialErrorReporter{credType: credNameManagedIdentity, err: err})

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -80,7 +80,7 @@ func TestDefaultAzureCredential_UserAssignedIdentity(t *testing.T) {
 			for _, c := range cred.chain.sources {
 				if m, ok := c.(*ManagedIdentityCredential); ok {
 					if actual := m.mic.id; actual != ID {
-						t.Fatalf(`expected "%v", got "%v"`, ID.String(), actual)
+						t.Fatalf(`expected "%s", got "%v"`, ID, actual)
 					}
 					return
 				}

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -78,9 +78,9 @@ func TestDefaultAzureCredential_UserAssignedIdentity(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, c := range cred.chain.sources {
-				if mic, ok := c.(*ManagedIdentityCredential); ok {
-					if mic.id != ID {
-						t.Fatalf(`expected %v, got "%v"`, ID, mic.id)
+				if m, ok := c.(*ManagedIdentityCredential); ok {
+					if actual := m.mic.id; actual != ID {
+						t.Fatalf(`expected "%v", got "%v"`, ID.String(), actual)
 					}
 					return
 				}

--- a/sdk/azidentity/go.mod
+++ b/sdk/azidentity/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0
-	github.com/AzureAD/microsoft-authentication-library-for-go v0.6.1-0.20220829173503-20bee33c4933
+	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0
 	github.com/golang-jwt/jwt/v4 v4.4.2
 	golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88
 )

--- a/sdk/azidentity/go.mod
+++ b/sdk/azidentity/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0
-	github.com/AzureAD/microsoft-authentication-library-for-go v0.6.0
+	github.com/AzureAD/microsoft-authentication-library-for-go v0.6.1-0.20220829173503-20bee33c4933
 	github.com/golang-jwt/jwt/v4 v4.4.2
 	golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88
 )

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -2,8 +2,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
-github.com/AzureAD/microsoft-authentication-library-for-go v0.6.1-0.20220829173503-20bee33c4933 h1:SaOe5jUpk/a3E17eaA6eVUQB4HsdzKr59E/if1RP42k=
-github.com/AzureAD/microsoft-authentication-library-for-go v0.6.1-0.20220829173503-20bee33c4933/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 h1:VgSJlZH5u0k2qxSpqyghcFQKmvYckj46uymKK5XzkBM=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -2,8 +2,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
-github.com/AzureAD/microsoft-authentication-library-for-go v0.6.0 h1:XMEdVDFxgulDDl0lQmAZS6j8gRQ/0pJ+ZpXH2FHVtDc=
-github.com/AzureAD/microsoft-authentication-library-for-go v0.6.0/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.6.1-0.20220829173503-20bee33c4933 h1:SaOe5jUpk/a3E17eaA6eVUQB4HsdzKr59E/if1RP42k=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.6.1-0.20220829173503-20bee33c4933/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=

--- a/sdk/azidentity/live_test.go
+++ b/sdk/azidentity/live_test.go
@@ -200,19 +200,17 @@ func testGetTokenSuccess(t *testing.T, cred azcore.TokenCredential) {
 	if tk.Token == "" {
 		t.Fatal("GetToken returned an invalid token")
 	}
-	if tk.ExpiresOn.Before(time.Now().UTC()) {
+	if tk.ExpiresOn.Before(time.Now()) {
 		t.Fatal("GetToken returned an invalid expiration time")
 	}
-	_, actual := tk.ExpiresOn.Zone()
-	_, expected := time.Now().UTC().Zone()
-	if actual != expected {
+	if tk.ExpiresOn.Location() != time.UTC {
 		t.Fatal("ExpiresOn isn't UTC")
 	}
 	tk2, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tk2.Token != tk.Token || tk2.ExpiresOn.After(tk.ExpiresOn) {
+	if tk2.Token != tk.Token || tk2.ExpiresOn != tk.ExpiresOn {
 		t.Fatal("expected a cached token")
 	}
 }


### PR DESCRIPTION
Internal changes that add token caching to `ManagedIdentityCredential` courtesy of MSAL. Draft pending the next MSAL release. Closes #16765.