### PR TITLE
Add completed as teminal state in sdk/azcore

### DIFF
--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -23,7 +23,7 @@ import (
 
 // the well-known set of LRO status/provisioning state values.
 const (
-	StatusCompleteed = "Completed"
+	StatusCompleted  = "Completed"
 	StatusSucceeded  = "Succeeded"
 	StatusCanceled   = "Canceled"
 	StatusFailed     = "Failed"
@@ -32,7 +32,7 @@ const (
 
 // IsTerminalState returns true if the LRO's state is terminal.
 func IsTerminalState(s string) bool {
-	return strings.EqualFold(s, StatusSucceeded) || strings.EqualFold(s, StatusFailed) || strings.EqualFold(s, StatusCanceled) || strings.EqualFold(s, StatusCompleteed)
+	return strings.EqualFold(s, StatusSucceeded) || strings.EqualFold(s, StatusFailed) || strings.EqualFold(s, StatusCanceled) || strings.EqualFold(s, StatusCompleted)
 }
 
 // Failed returns true if the LRO's state is terminal failure.
@@ -47,7 +47,7 @@ func Succeeded(s string) bool {
 
 // Completed return true if is terminal completed
 func Completed(s string) bool {
-	return strings.EqualFold(s, StatusCompleteed)
+	return strings.EqualFold(s, StatusCompleted)
 }
 
 // returns true if the LRO response contains a valid HTTP status code

--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -23,6 +23,7 @@ import (
 
 // the well-known set of LRO status/provisioning state values.
 const (
+	StatusCompleteed = "Completed"
 	StatusSucceeded  = "Succeeded"
 	StatusCanceled   = "Canceled"
 	StatusFailed     = "Failed"
@@ -31,7 +32,7 @@ const (
 
 // IsTerminalState returns true if the LRO's state is terminal.
 func IsTerminalState(s string) bool {
-	return strings.EqualFold(s, StatusSucceeded) || strings.EqualFold(s, StatusFailed) || strings.EqualFold(s, StatusCanceled)
+	return strings.EqualFold(s, StatusSucceeded) || strings.EqualFold(s, StatusFailed) || strings.EqualFold(s, StatusCanceled) || strings.EqualFold(s, StatusCompleteed)
 }
 
 // Failed returns true if the LRO's state is terminal failure.
@@ -42,6 +43,11 @@ func Failed(s string) bool {
 // Succeeded returns true if the LRO's state is terminal success.
 func Succeeded(s string) bool {
 	return strings.EqualFold(s, StatusSucceeded)
+}
+
+// Completed return true if is terminal completed
+func Completed(s string) bool {
+	return strings.EqualFold(s, StatusCompleteed)
 }
 
 // returns true if the LRO response contains a valid HTTP status code

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -24,6 +24,7 @@ func TestIsTerminalState(t *testing.T) {
 	require.True(t, IsTerminalState("Succeeded"), "Succeeded is a terminal state")
 	require.True(t, IsTerminalState("failed"), "failed is a terminal state")
 	require.True(t, IsTerminalState("canceled"), "canceled is a terminal state")
+	require.True(t, IsTerminalState("Completed"), "Completed is a terminal state")
 }
 
 func TestStatusCodeValid(t *testing.T) {
@@ -90,6 +91,7 @@ func TestIsValidURL(t *testing.T) {
 func TestFailed(t *testing.T) {
 	require.False(t, Failed("Succeeded"))
 	require.False(t, Failed("Updating"))
+	require.False(t, Failed("Completed"))
 	require.True(t, Failed("failed"))
 }
 


### PR DESCRIPTION
When working with the sdk/resourcemanager/costmanagement/armcostmanagement v1.0.0 package I encountered a bug when polling the result of NewGenerateDetailedCostReportClient.BeginCreateOperation.

When the report is succesfully generated by this function, it returns a status of 'Completed', however, 'Completed is not recognized as a terminal state in the underlying sdk/azcore package. This leads to an infinite loop in the PollUntilDone function. The bug can be replicated by taking the example of NewGenerateDetailedCostReportClient.BeginCreateOperation from [docs](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement#GenerateDetailedCostReportClient.BeginCreateOperation)

This PR adds 'Completed' as a recognized terminal state.

```
package main

import (
	"context"
	"log"

	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement"
)

func main() {
	cred, err := azidentity.NewDefaultAzureCredential(nil)
	if err != nil {
		log.Fatalf("failed to obtain a credential: %v", err)
	}
	ctx := context.Background()
	client, err := armcostmanagement.NewGenerateDetailedCostReportClient(cred, nil)
	if err != nil {
		log.Fatalf("failed to create client: %v", err)
	}
	poller, err := client.BeginCreateOperation(ctx,
		"providers/Microsoft.Billing/billingAccounts/12345",
		armcostmanagement.GenerateDetailedCostReportDefinition{
			BillingPeriod: to.Ptr("202008"),
			Metric:        to.Ptr(armcostmanagement.GenerateDetailedCostReportMetricTypeActualCost),
		},
		nil)
	if err != nil {
		log.Fatalf("failed to finish the request: %v", err)
	}
	res, err := poller.PollUntilDone(ctx, nil) // INFINITE LOOP HERE
	if err != nil {
		log.Fatalf("failed to pull the result: %v", err)
	}
	// TODO: use response item
	_ = res
}
```


- [ x] The purpose of this PR is explained in this or a referenced issue.
- [ x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
