### PR TITLE
Use HTTPRange for specifying a range of bytes

### DIFF
--- a/sdk/storage/azblob/appendblob/models.go
+++ b/sdk/storage/azblob/appendblob/models.go
@@ -121,10 +121,9 @@ type AppendBlockFromURLOptions struct {
 	SourceModifiedAccessConditions *blob.SourceModifiedAccessConditions
 
 	AccessConditions *blob.AccessConditions
-	// Optional, you can specify whether a particular range of the blob is read
-	Offset *int64
 
-	Count *int64
+	// Range specifies a range of bytes.  The default value is all bytes.
+	Range blob.HTTPRange
 }
 
 func (o *AppendBlockFromURLOptions) format() (*generated.AppendBlobClientAppendBlockFromURLOptions, *generated.CpkInfo,
@@ -135,7 +134,7 @@ func (o *AppendBlockFromURLOptions) format() (*generated.AppendBlobClientAppendB
 	}
 
 	options := &generated.AppendBlobClientAppendBlockFromURLOptions{
-		SourceRange:             shared.GetSourceRange(o.Offset, o.Count),
+		SourceRange:             exported.FormatHTTPRange(o.Range),
 		SourceContentMD5:        o.SourceContentMD5,
 		SourceContentcrc64:      o.SourceContentCRC64,
 		TransactionalContentMD5: o.TransactionalContentMD5,

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -1513,7 +1513,7 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataCountNegative() {
 
 	options := blob.DownloadStreamOptions{
 		Range: blob.HTTPRange{
-			Offset: -2,
+			Count: -2,
 		},
 	}
 	_, err = bbClient.DownloadStream(context.Background(), &options)

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -1467,7 +1467,9 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataNegativeOffset() {
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 
 	options := blob.DownloadStreamOptions{
-		Offset: to.Ptr[int64](-1),
+		Range: blob.HTTPRange{
+			Offset: -1,
+		},
 	}
 	_, err = bbClient.DownloadStream(context.Background(), &options)
 	_require.Nil(err)
@@ -1487,7 +1489,9 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataOffsetOutOfRange() {
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 
 	options := blob.DownloadStreamOptions{
-		Offset: to.Ptr(int64(len(testcommon.BlockBlobDefaultData))),
+		Range: blob.HTTPRange{
+			Offset: int64(len(testcommon.BlockBlobDefaultData)),
+		},
 	}
 	_, err = bbClient.DownloadStream(context.Background(), &options)
 	_require.NotNil(err)
@@ -1508,7 +1512,9 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataCountNegative() {
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 
 	options := blob.DownloadStreamOptions{
-		Count: to.Ptr[int64](-2),
+		Range: blob.HTTPRange{
+			Offset: -2,
+		},
 	}
 	_, err = bbClient.DownloadStream(context.Background(), &options)
 	_require.Nil(err)
@@ -1527,9 +1533,7 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataCountZero() {
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 
-	options := blob.DownloadStreamOptions{
-		Count: to.Ptr[int64](0),
-	}
+	options := blob.DownloadStreamOptions{}
 	resp, err := bbClient.DownloadStream(context.Background(), &options)
 	_require.Nil(err)
 
@@ -1552,9 +1556,10 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataCountExact() {
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 
-	count := int64(len(testcommon.BlockBlobDefaultData))
 	options := blob.DownloadStreamOptions{
-		Count: &count,
+		Range: blob.HTTPRange{
+			Count: int64(len(testcommon.BlockBlobDefaultData)),
+		},
 	}
 	resp, err := bbClient.DownloadStream(context.Background(), &options)
 	_require.Nil(err)
@@ -1578,7 +1583,9 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataCountOutOfRange() {
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 
 	options := blob.DownloadStreamOptions{
-		Count: to.Ptr(int64((len(testcommon.BlockBlobDefaultData)) * 2)),
+		Range: blob.HTTPRange{
+			Count: int64((len(testcommon.BlockBlobDefaultData)) * 2),
+		},
 	}
 	resp, err := bbClient.DownloadStream(context.Background(), &options)
 	_require.Nil(err)
@@ -1601,10 +1608,7 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataEmptyRangeStruct() {
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 
-	options := blob.DownloadStreamOptions{
-		Count:  to.Ptr[int64](0),
-		Offset: to.Ptr[int64](0),
-	}
+	options := blob.DownloadStreamOptions{}
 	resp, err := bbClient.DownloadStream(context.Background(), &options)
 	_require.Nil(err)
 
@@ -1627,8 +1631,10 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataContentMD5() {
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 
 	options := blob.DownloadStreamOptions{
-		Count:              to.Ptr[int64](3),
-		Offset:             to.Ptr[int64](10),
+		Range: blob.HTTPRange{
+			Count:  3,
+			Offset: 10,
+		},
 		RangeGetContentMD5: to.Ptr(true),
 	}
 	resp, err := bbClient.DownloadStream(context.Background(), &options)

--- a/sdk/storage/azblob/blob/responses.go
+++ b/sdk/storage/azblob/blob/responses.go
@@ -39,8 +39,7 @@ func (r *DownloadStreamResponse) NewRetryReader(ctx context.Context, options *Re
 			ModifiedAccessConditions: &ModifiedAccessConditions{IfMatch: getInfo.ETag},
 		}
 		options := DownloadStreamOptions{
-			Offset:           &getInfo.Offset,
-			Count:            &getInfo.Count,
+			Range:            getInfo.Range,
 			AccessConditions: accessConditions,
 			CpkInfo:          r.cpkInfo,
 			CpkScopeInfo:     r.cpkScope,

--- a/sdk/storage/azblob/blob/retry_reader.go
+++ b/sdk/storage/azblob/blob/retry_reader.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
 )
 
 // HTTPGetter is a function type that refers to a method that performs an HTTP GET operation.
@@ -23,13 +22,7 @@ type httpGetter func(ctx context.Context, i httpGetterInfo) (io.ReadCloser, erro
 // HTTPGetterInfo is passed to an HTTPGetter function passing it parameters
 // that should be used to make an HTTP GET request.
 type httpGetterInfo struct {
-	// Offset specifies the start offset that should be used when
-	// creating the HTTP GET request's Range header
-	Offset int64
-
-	// Count specifies the count of bytes that should be used to calculate
-	// the end offset when creating the HTTP GET request's Range header
-	Count int64
+	Range HTTPRange
 
 	// ETag specifies the resource's etag that should be used when creating
 	// the HTTP GET request's If-Match header
@@ -46,7 +39,7 @@ type RetryReaderOptions struct {
 	MaxRetries int32
 
 	// OnFailedRead, when non-nil, is called after any failure to read. Expected usage is diagnostic logging.
-	OnFailedRead func(failureCount int32, lastError error, offset int64, count int64, willRetry bool)
+	OnFailedRead func(failureCount int32, lastError error, rnge HTTPRange, willRetry bool)
 
 	// EarlyCloseAsError can be set to true to prevent retries after "read on closed response body". By default,
 	// retryReader has the following special behaviour: closing the response body before it is all read is treated as a
@@ -91,7 +84,7 @@ func newRetryReader(ctx context.Context, initialResponse io.ReadCloser, info htt
 		ctx:                ctx,
 		getter:             getter,
 		info:               info,
-		countWasBounded:    info.Count != shared.CountToEnd,
+		countWasBounded:    info.Range.Count != CountToEnd,
 		response:           initialResponse,
 		responseMu:         &sync.Mutex{},
 		retryReaderOptions: o,
@@ -109,7 +102,7 @@ func (s *RetryReader) setResponse(r io.ReadCloser) {
 func (s *RetryReader) Read(p []byte) (n int, err error) {
 	for try := int32(0); ; try++ {
 		//fmt.Println(try)       // Comment out for debugging.
-		if s.countWasBounded && s.info.Count == shared.CountToEnd {
+		if s.countWasBounded && s.info.Range.Count == CountToEnd {
 			// User specified an original count and the remaining bytes are 0, return 0, EOF
 			return 0, io.EOF
 		}
@@ -139,9 +132,9 @@ func (s *RetryReader) Read(p []byte) (n int, err error) {
 
 		// We successfully read data or end EOF.
 		if err == nil || err == io.EOF {
-			s.info.Offset += int64(n) // Increments the start offset in case we need to make a new HTTP request in the future
-			if s.info.Count != shared.CountToEnd {
-				s.info.Count -= int64(n) // Decrement the count in case we need to make a new HTTP request in the future
+			s.info.Range.Offset += int64(n) // Increments the start offset in case we need to make a new HTTP request in the future
+			if s.info.Range.Count != CountToEnd {
+				s.info.Range.Count -= int64(n) // Decrement the count in case we need to make a new HTTP request in the future
 			}
 			return n, err // Return the return to the caller
 		}
@@ -158,7 +151,7 @@ func (s *RetryReader) Read(p []byte) (n int, err error) {
 		// Notify, for logging purposes, of any failures
 		if s.retryReaderOptions.OnFailedRead != nil {
 			failureCount := try + 1 // because try is zero-based
-			s.retryReaderOptions.OnFailedRead(failureCount, err, s.info.Offset, s.info.Count, willRetry)
+			s.retryReaderOptions.OnFailedRead(failureCount, err, s.info.Range, willRetry)
 		}
 
 		if willRetry {

--- a/sdk/storage/azblob/blockblob/models.go
+++ b/sdk/storage/azblob/blockblob/models.go
@@ -106,9 +106,8 @@ type StageBlockFromURLOptions struct {
 	// Specify the crc64 calculated for the range of bytes that must be read from the copy source.
 	SourceContentCRC64 []byte
 
-	Offset *int64
-
-	Count *int64
+	// Range specifies a range of bytes.  The default value is all bytes.
+	Range blob.HTTPRange
 
 	CpkInfo *blob.CpkInfo
 
@@ -124,7 +123,7 @@ func (o *StageBlockFromURLOptions) format() (*generated.BlockBlobClientStageBloc
 		CopySourceAuthorization: o.CopySourceAuthorization,
 		SourceContentMD5:        o.SourceContentMD5,
 		SourceContentcrc64:      o.SourceContentCRC64,
-		SourceRange:             shared.GetSourceRange(o.Offset, o.Count),
+		SourceRange:             exported.FormatHTTPRange(o.Range),
 	}
 
 	return options, o.CpkInfo, o.CpkScopeInfo, o.LeaseAccessConditions, o.SourceModifiedAccessConditions

--- a/sdk/storage/azblob/client_test.go
+++ b/sdk/storage/azblob/client_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
@@ -220,8 +221,10 @@ func performUploadAndDownloadFileTest(t *testing.T, _require *require.Assertions
 		blobName,
 		destFile,
 		&blob.DownloadFileOptions{
-			Count:       int64(downloadCount),
-			Offset:      int64(downloadOffset),
+			Range: azblob.HTTPRange{
+				Count:  int64(downloadCount),
+				Offset: int64(downloadOffset),
+			},
 			BlockSize:   int64(blockSize),
 			Parallelism: uint16(parallelism),
 			// If Progress is non-nil, this function is called periodically as bytes are uploaded.
@@ -378,8 +381,10 @@ func performUploadAndDownloadBufferTest(t *testing.T, _require *require.Assertio
 		containerName,
 		blobName,
 		destBuffer, &blob.DownloadBufferOptions{
-			Count:       int64(downloadCount),
-			Offset:      int64(downloadOffset),
+			Range: azblob.HTTPRange{
+				Count:  int64(downloadCount),
+				Offset: int64(downloadOffset),
+			},
 			BlockSize:   int64(blockSize),
 			Parallelism: uint16(parallelism),
 			// If Progress is non-nil, this function is called periodically as bytes are uploaded.

--- a/sdk/storage/azblob/common.go
+++ b/sdk/storage/azblob/common.go
@@ -31,6 +31,6 @@ func ParseURL(u string) (URLParts, error) {
 }
 
 // HTTPRange defines a range of bytes within an HTTP resource, starting at offset and
-// ending at offset+count. A zero-value HttpRange indicates the entire resource. An HttpRange
-// which has an offset but na zero value count indicates from the offset to the resource's end.
+// ending at offset+count. A zero-value HTTPRange indicates the entire resource. An HTTPRange
+// which has an offset but no zero value count indicates from the offset to the resource's end.
 type HTTPRange = exported.HTTPRange

--- a/sdk/storage/azblob/common.go
+++ b/sdk/storage/azblob/common.go
@@ -29,3 +29,8 @@ type URLParts = sas.URLParts
 func ParseURL(u string) (URLParts, error) {
 	return sas.ParseURL(u)
 }
+
+// HTTPRange defines a range of bytes within an HTTP resource, starting at offset and
+// ending at offset+count. A zero-value HttpRange indicates the entire resource. An HttpRange
+// which has an offset but na zero value count indicates from the offset to the resource's end.
+type HTTPRange = exported.HTTPRange

--- a/sdk/storage/azblob/internal/exported/exported.go
+++ b/sdk/storage/azblob/internal/exported/exported.go
@@ -1,0 +1,33 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package exported
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// HTTPRange defines a range of bytes within an HTTP resource, starting at offset and
+// ending at offset+count. A zero-value HTTPRange indicates the entire resource. An HTTPRange
+// which has an offset but no zero value count indicates from the offset to the resource's end.
+type HTTPRange struct {
+	Offset int64
+	Count  int64
+}
+
+// FormatHTTPRange converts an HTTPRange to its string format.
+func FormatHTTPRange(r HTTPRange) *string {
+	if r.Offset == 0 && r.Count == 0 {
+		return nil // No specified range
+	}
+	endOffset := "" // if count == CountToEnd (0)
+	if r.Count > 0 {
+		endOffset = strconv.FormatInt((r.Offset+r.Count)-1, 10)
+	}
+	dataRange := fmt.Sprintf("bytes=%v-%s", r.Offset, endOffset)
+	return &dataRange
+}

--- a/sdk/storage/azblob/internal/shared/shared.go
+++ b/sdk/storage/azblob/internal/shared/shared.go
@@ -39,46 +39,6 @@ const (
 	HeaderRange             = "Range"
 )
 
-const CountToEnd = 0
-
-// HTTPRange defines a range of bytes within an HTTP resource, starting at offset and
-// ending at offset+count. A zero-value HttpRange indicates the entire resource. An HttpRange
-// which has an offset but na zero value count indicates from the offset to the resource's end.
-type HTTPRange struct {
-	Offset int64
-	Count  int64
-}
-
-func (r HTTPRange) Format() *string {
-	if r.Offset == 0 && r.Count == 0 { // Do common case first for performance
-		return nil // No specified range
-	}
-	endOffset := "" // if count == CountToEnd (0)
-	if r.Count > 0 {
-		endOffset = strconv.FormatInt((r.Offset+r.Count)-1, 10)
-	}
-	dataRange := fmt.Sprintf("bytes=%v-%s", r.Offset, endOffset)
-	return &dataRange
-}
-
-func GetSourceRange(offset, count *int64) *string {
-	if offset == nil && count == nil {
-		return nil
-	}
-	newOffset := int64(0)
-	newCount := int64(CountToEnd)
-
-	if offset != nil {
-		newOffset = *offset
-	}
-
-	if count != nil {
-		newCount = *count
-	}
-
-	return (&HTTPRange{Offset: newOffset, Count: newCount}).Format()
-}
-
 // CopyOptions returns a zero-value T if opts is nil.
 // If opts is not nil, a copy is made and its address returned.
 func CopyOptions[T any](opts *T) *T {

--- a/sdk/storage/azblob/pageblob/client.go
+++ b/sdk/storage/azblob/pageblob/client.go
@@ -174,9 +174,9 @@ func (pb *Client) UploadPagesFromURL(ctx context.Context, source string, sourceO
 
 // ClearPages frees the specified pages from the page blob.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-page.
-func (pb *Client) ClearPages(ctx context.Context, offset, count int64, options *ClearPagesOptions) (ClearPagesResponse, error) {
+func (pb *Client) ClearPages(ctx context.Context, rnge blob.HTTPRange, options *ClearPagesOptions) (ClearPagesResponse, error) {
 	clearOptions := &generated.PageBlobClientClearPagesOptions{
-		Range: shared.HTTPRange{Offset: offset, Count: count}.Format(),
+		Range: exported.FormatHTTPRange(rnge),
 	}
 
 	leaseAccessConditions, cpkInfo, cpkScopeInfo, sequenceNumberAccessConditions, modifiedAccessConditions := options.format()

--- a/sdk/storage/azblob/pageblob/examples_test.go
+++ b/sdk/storage/azblob/pageblob/examples_test.go
@@ -14,8 +14,8 @@ import (
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob"
 )
 
@@ -54,12 +54,17 @@ func Example_pageblob_Client() {
 	_, err = pageBlobClient.UploadPages(
 		context.TODO(),
 		streaming.NopCloser(bytes.NewReader(page)),
-		&pageblob.UploadPagesOptions{Offset: to.Ptr(int64(0)), Count: to.Ptr(int64(2 * pageblob.PageBytes))},
-	)
+		&pageblob.UploadPagesOptions{
+			Range: blob.HTTPRange{
+				Count: int64(2 * pageblob.PageBytes),
+			},
+		})
 	handleError(err)
 
 	pager := pageBlobClient.NewGetPageRangesPager(&pageblob.GetPageRangesOptions{
-		Offset: to.Ptr(int64(0)), Count: to.Ptr(int64(10 * pageblob.PageBytes)),
+		Range: blob.HTTPRange{
+			Count: int64(10 * pageblob.PageBytes),
+		},
 	})
 
 	for pager.More() {
@@ -72,11 +77,13 @@ func Example_pageblob_Client() {
 		}
 	}
 
-	_, err = pageBlobClient.ClearPages(context.TODO(), 0, 1*pageblob.PageBytes, nil)
+	_, err = pageBlobClient.ClearPages(context.TODO(), blob.HTTPRange{Count: 1 * pageblob.PageBytes}, nil)
 	handleError(err)
 
 	pager = pageBlobClient.NewGetPageRangesPager(&pageblob.GetPageRangesOptions{
-		Offset: to.Ptr(int64(0)), Count: to.Ptr(int64(10 * pageblob.PageBytes)),
+		Range: blob.HTTPRange{
+			Count: int64(10 * pageblob.PageBytes),
+		},
 	})
 
 	for pager.More() {

--- a/sdk/storage/azblob/pageblob/models.go
+++ b/sdk/storage/azblob/pageblob/models.go
@@ -86,9 +86,8 @@ func (o *CreateOptions) format() (*generated.PageBlobClientCreateOptions, *gener
 
 // UploadPagesOptions contains the optional parameters for the Client.UploadPages method.
 type UploadPagesOptions struct {
-	// Specify the transactional crc64 for the body, to be validated by the service.
-	Offset *int64
-	Count  *int64
+	// Range specifies a range of bytes.  The default value is all bytes.
+	Range blob.HTTPRange
 
 	TransactionalContentCRC64 []byte
 	// Specify the transactional md5 for the body, to be validated by the service.
@@ -109,7 +108,7 @@ func (o *UploadPagesOptions) format() (*generated.PageBlobClientUploadPagesOptio
 	options := &generated.PageBlobClientUploadPagesOptions{
 		TransactionalContentCRC64: o.TransactionalContentCRC64,
 		TransactionalContentMD5:   o.TransactionalContentMD5,
-		Range:                     shared.GetSourceRange(o.Offset, o.Count),
+		Range:                     exported.FormatHTTPRange(o.Range),
 	}
 
 	leaseAccessConditions, modifiedAccessConditions := exported.FormatBlobAccessConditions(o.AccessConditions)
@@ -195,9 +194,8 @@ type GetPageRangesOptions struct {
 	// specified by prevsnapshot is the older of the two. Note that incremental
 	// snapshots are currently supported only for blobs created on or after January 1, 2016.
 	PrevSnapshot *string
-	// Optional, you can specify whether a particular range of the blob is read
-	Offset *int64
-	Count  *int64
+	// Range specifies a range of bytes.  The default value is all bytes.
+	Range blob.HTTPRange
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
@@ -215,7 +213,7 @@ func (o *GetPageRangesOptions) format() (*generated.PageBlobClientGetPageRangesO
 	return &generated.PageBlobClientGetPageRangesOptions{
 		Marker:     o.Marker,
 		Maxresults: o.MaxResults,
-		Range:      shared.GetSourceRange(o.Offset, o.Count),
+		Range:      exported.FormatHTTPRange(o.Range),
 		Snapshot:   o.Snapshot,
 	}, leaseAccessConditions, modifiedAccessConditions
 }
@@ -246,9 +244,8 @@ type GetPageRangesDiffOptions struct {
 	// specified by prevsnapshot is the older of the two. Note that incremental
 	// snapshots are currently supported only for blobs created on or after January 1, 2016.
 	PrevSnapshot *string
-	// Optional, you can specify whether a particular range of the blob is read
-	Offset *int64
-	Count  *int64
+	// Range specifies a range of bytes.  The default value is all bytes.
+	Range blob.HTTPRange
 
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
@@ -269,7 +266,7 @@ func (o *GetPageRangesDiffOptions) format() (*generated.PageBlobClientGetPageRan
 		Maxresults:      o.MaxResults,
 		PrevSnapshotURL: o.PrevSnapshotURL,
 		Prevsnapshot:    o.PrevSnapshot,
-		Range:           shared.GetSourceRange(o.Offset, o.Count),
+		Range:           exported.FormatHTTPRange(o.Range),
 		Snapshot:        o.Snapshot,
 	}, leaseAccessConditions, modifiedAccessConditions
 


### PR DESCRIPTION
Replaced Offset and Count int64 pairs with HTTPRange.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
