### PR TITLE
[azeventhubs] More bugs with ownership/epoch levels

### DIFF
--- a/sdk/messaging/azeventhubs/internal/eh/stress/stress.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/stress.go
@@ -5,12 +5,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"sort"
 	"time"
 
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/eh/stress/tests"
 )
 
@@ -44,19 +44,10 @@ func main() {
 
 	for _, test := range tests {
 		if test.name == testName {
-			// azlog.SetEvents(azeventhubs.EventAuth, azeventhubs.EventConn, azeventhubs.EventConsumer)
-			// azlog.SetListener(func(e azlog.Event, s string) {
-			// 	log.Printf("[%s] %s", e, s)
-			// })
-
-			defer func() {
-				err := recover()
-
-				if err != nil {
-					log.Printf("FATAL ERROR: %s", err)
-				}
-			}()
-
+			//azlog.SetEvents(azeventhubs.EventAuth, azeventhubs.EventConn, azeventhubs.EventConsumer)
+			azlog.SetListener(func(e azlog.Event, s string) {
+				//log.Printf("[%s] %s", e, s)
+			})
 			rand.Seed(time.Now().UnixNano())
 
 			if err := test.fn(context.Background()); err != nil {

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/tracking_data.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/tracking_data.go
@@ -1,0 +1,53 @@
+package tests
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type trackingData struct {
+	PartitionID string
+
+	// atomically updated number, from the sender, telling us how many messages have been sent.
+	SentCount *int64
+
+	// tracks the received sequence numbers, with the idea that there could be duplicates
+	// as partitions are stolen/rearranged. Mostly we care about # of unique events received
+	// but in the near future we'll also start checking duplication as well.
+	mu                      *sync.Mutex
+	receivedSequenceNumbers *map[int64]int
+}
+
+type trackedCounts struct {
+	Received int64
+	Sent     int64
+}
+
+func newTrackingData(partitionID string) trackingData {
+	var sentCount int64
+
+	return trackingData{
+		PartitionID:             partitionID,
+		SentCount:               &sentCount,
+		mu:                      &sync.Mutex{},
+		receivedSequenceNumbers: &map[int64]int{},
+	}
+}
+
+func (td trackingData) Inc(seqNumber int64) {
+	td.mu.Lock()
+	defer td.mu.Unlock()
+
+	(*td.receivedSequenceNumbers)[seqNumber]++
+}
+
+func (td trackingData) Stats() trackedCounts {
+	// not transactional...
+	sent := atomic.LoadInt64(td.SentCount)
+	received := int64(len(*td.receivedSequenceNumbers))
+
+	return trackedCounts{
+		Received: received,
+		Sent:     sent,
+	}
+}

--- a/sdk/messaging/azeventhubs/internal/errors_test.go
+++ b/sdk/messaging/azeventhubs/internal/errors_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOwnershipLost(t *testing.T) {
+	detachErr := &amqp.DetachError{
+		RemoteError: &amqp.Error{
+			Condition: amqp.ErrorCondition("amqp:link:stolen"),
+		},
+	}
+
+	require.Equal(t, RecoveryKindFatal, GetRecoveryKind(detachErr))
+	require.False(t, IsQuickRecoveryError(detachErr))
+
+	transformedErr := TransformError(detachErr)
+
+	var err *exported.Error
+	require.ErrorAs(t, transformedErr, &err)
+	require.Equal(t, exported.CodeOwnershipLost, err.Code)
+}

--- a/sdk/messaging/azeventhubs/internal/exported/error.go
+++ b/sdk/messaging/azeventhubs/internal/exported/error.go
@@ -17,7 +17,7 @@ const (
 
 	// CodeOwnershipLost means that a partition that you were reading from was opened
 	// by another link with a higher epoch/owner level.
-	CodeOwnershipLost = "ownershiplost"
+	CodeOwnershipLost Code = "ownershiplost"
 )
 
 // Error represents an Event Hub specific error.

--- a/sdk/messaging/azeventhubs/internal/links.go
+++ b/sdk/messaging/azeventhubs/internal/links.go
@@ -121,7 +121,7 @@ func (l *Links[LinkT]) Retry(ctx context.Context, eventName log.Event, operation
 		prevLinkWithID = linkWithID
 
 		if err := fn(ctx, *linkWithID); err != nil {
-			if args.I == 0 && !didQuickRetry && IsDetachError(err) {
+			if args.I == 0 && !didQuickRetry && IsQuickRecoveryError(err) {
 				// go-amqp will asynchronously handle detaches. This means errors that you get
 				// back from Send(), for instance, can actually be from much earlier in time
 				// depending on the last time you called into Send().

--- a/sdk/messaging/azeventhubs/processor.go
+++ b/sdk/messaging/azeventhubs/processor.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	azlog "github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
@@ -291,6 +292,7 @@ func (p *Processor) addPartitionClient(ctx context.Context, ownership Ownership,
 
 	partClient, err := p.consumerClient.NewPartitionClient(ownership.PartitionID, &NewPartitionClientOptions{
 		StartPosition: sp,
+		OwnerLevel:    to.Ptr[int64](0),
 	})
 
 	if err != nil {


### PR DESCRIPTION
Fixes some more bugs, revamps the processor test to use multiple processors

- When running the processor our owner level should default to zero if none is chosen (otherwise exclusive ownership doesn't kick in on the Event Hubs side)
- CodeConditionLost was typed as a string, instead of a Code
- The ownership lost error is actually two errors - an outer amqp.DetachError, with an inner RemoteError that's actually the error with the condition we need to check. So that's fixed, and it's also marked as a fatal error, so we don't get weird contention for no reason.

