### PR TITLE
[azeventhubs] Fixing some issues with docs and samples

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- EventDataBatch.NumMessages() renamed to EventDataBatch.NumEvents()
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/messaging/azeventhubs/checkpoint_store.go
+++ b/sdk/messaging/azeventhubs/checkpoint_store.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs
 
 import (

--- a/sdk/messaging/azeventhubs/checkpoints/blob_store.go
+++ b/sdk/messaging/azeventhubs/checkpoints/blob_store.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package checkpoints
 
 import (

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs
 
 import (

--- a/sdk/messaging/azeventhubs/event_data.go
+++ b/sdk/messaging/azeventhubs/event_data.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs
 
 import (

--- a/sdk/messaging/azeventhubs/event_data_batch.go
+++ b/sdk/messaging/azeventhubs/event_data_batch.go
@@ -59,8 +59,8 @@ func (mb *EventDataBatch) NumBytes() uint64 {
 	return mb.currentSize
 }
 
-// NumMessages returns the # of messages in the batch.
-func (mb *EventDataBatch) NumMessages() int32 {
+// NumEvents returns the # of events in the batch.
+func (mb *EventDataBatch) NumEvents() int32 {
 	mb.mu.RLock()
 	defer mb.mu.RUnlock()
 

--- a/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
+++ b/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
@@ -108,7 +108,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 		}, nil)
 
 		require.NoError(t, err)
-		require.EqualValues(t, 1, mb.NumMessages())
+		require.EqualValues(t, 1, mb.NumEvents())
 		require.EqualValues(t, 172, mb.NumBytes())
 
 		actualBytes, err := mb.toAMQPMessage().MarshalBinary()
@@ -132,7 +132,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 		}, nil)
 
 		require.NoError(t, err)
-		require.EqualValues(t, 1, mb.NumMessages())
+		require.EqualValues(t, 1, mb.NumEvents())
 		require.EqualValues(t, 4357, mb.NumBytes())
 
 		actualBytes, err := mb.toAMQPMessage().MarshalBinary()
@@ -169,7 +169,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 		require.EqualValues(t, 121, mb.currentSize)
 
 		sizeBefore := mb.NumBytes()
-		countBefore := mb.NumMessages()
+		countBefore := mb.NumEvents()
 
 		err = mb.AddEventData(&EventData{
 			Body: as2k[:],
@@ -177,7 +177,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 		require.EqualError(t, err, ErrEventDataTooLarge.Error())
 
 		require.Equal(t, sizeBefore, mb.NumBytes(), "size is unchanged when a message fails to get added")
-		require.Equal(t, countBefore, mb.NumMessages(), "count is unchanged when a message fails to get added")
+		require.Equal(t, countBefore, mb.NumEvents(), "count is unchanged when a message fails to get added")
 	})
 
 	t.Run("addConcurrently", func(t *testing.T) {
@@ -200,7 +200,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 		}
 
 		wg.Wait()
-		require.EqualValues(t, 100, mb.NumMessages())
+		require.EqualValues(t, 100, mb.NumEvents())
 	})
 }
 

--- a/sdk/messaging/azeventhubs/example_consuming_events_test.go
+++ b/sdk/messaging/azeventhubs/example_consuming_events_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs_test
 
 import (
@@ -12,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 )
 
-func Example_consuming() {
+func Example_consuming_events() {
 	eventHubNamespace := os.Getenv("EVENTHUB_NAMESPACE") // <ex: myeventhubnamespace.servicebus.windows.net>
 	eventHubName := os.Getenv("EVENTHUB_NAME")
 	eventHubPartitionID := os.Getenv("EVENTHUB_PARTITION")
@@ -55,9 +56,13 @@ func Example_consuming() {
 			panic(err)
 		}
 
-		for _, event := range events {
-			// process the event in some way
-			fmt.Printf("Event received with body %v\n", event.Body)
-		}
+		processConsumedEvents(events)
+	}
+}
+
+func processConsumedEvents(events []*azeventhubs.ReceivedEventData) {
+	for _, event := range events {
+		// process the event in some way
+		fmt.Printf("Event received with body %v\n", event.Body)
 	}
 }

--- a/sdk/messaging/azeventhubs/example_enabling_logging_test.go
+++ b/sdk/messaging/azeventhubs/example_enabling_logging_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs_test
 
 import (
@@ -11,9 +12,7 @@ import (
 
 func Example_enableLogging() {
 	// print log output to stdout
-	azlog.SetListener(func(event azlog.Event, s string) {
-		fmt.Printf("[%s] %s\n", event, s)
-	})
+	azlog.SetListener(printLoggedEvent)
 
 	// pick the set of events to log
 	azlog.SetEvents(
@@ -28,4 +27,8 @@ func Example_enableLogging() {
 	// Output:
 	// Logging enabled
 	//
+}
+
+func printLoggedEvent(event azlog.Event, s string) {
+	fmt.Printf("[%s] %s\n", event, s)
 }

--- a/sdk/messaging/azeventhubs/example_producing_events_test.go
+++ b/sdk/messaging/azeventhubs/example_producing_events_test.go
@@ -34,6 +34,8 @@ func Example_producing() {
 
 	defer producerClient.Close(context.TODO())
 
+	events := createEventsForSample()
+
 	// Other examples:
 	//
 	// sending a batch to a specific partition:
@@ -52,8 +54,6 @@ func Example_producing() {
 	if err != nil {
 		panic(err)
 	}
-
-	events := createEventsForSample()
 
 	for i := 0; i < len(events); i++ {
 		err = batch.AddEventData(events[i], nil)

--- a/sdk/messaging/azeventhubs/example_producing_events_test.go
+++ b/sdk/messaging/azeventhubs/example_producing_events_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs_test
 
 import (
@@ -44,33 +45,62 @@ func Example_producing() {
 	// batch, err := producerClient.NewEventDataBatch(context.TODO(), &azeventhubs.NewEventDataBatchOptions{
 	// 	PartitionKey: to.Ptr("partition key"),
 	// })
-	batch, err := producerClient.NewEventDataBatch(context.TODO(), nil)
+	newBatchOptions := &azeventhubs.NewEventDataBatchOptions{}
+
+	batch, err := producerClient.NewEventDataBatch(context.TODO(), newBatchOptions)
 
 	if err != nil {
 		panic(err)
 	}
 
-	eventData := &azeventhubs.EventData{
-		Body: []byte("hello"),
+	events := createEventsForSample()
+
+	for i := 0; i < len(events); i++ {
+		err = batch.AddEventData(events[i], nil)
+
+		if errors.Is(err, azeventhubs.ErrEventDataTooLarge) {
+			if batch.NumEvents() == 0 {
+				// This one event is too large for this batch, even on its own. No matter what we do it
+				// will not be sendable at its current size.
+				panic(err)
+			}
+
+			// This batch is full - we can send it and create a new one and continue
+			// packaging and sending events.
+			if err := producerClient.SendEventBatch(context.TODO(), batch, nil); err != nil {
+				panic(err)
+			}
+
+			tmpBatch, err := producerClient.NewEventDataBatch(context.TODO(), newBatchOptions)
+
+			if err != nil {
+				panic(err)
+			}
+
+			batch = tmpBatch
+
+			// rewind so we can retry adding this event to a batch
+			i--
+		} else if err != nil {
+			panic(err)
+		}
 	}
 
-	err = batch.AddEventData(eventData, nil)
-
-	if errors.Is(err, azeventhubs.ErrEventDataTooLarge) {
-		// EventData is too large for this batch.
-		//
-		// If the batch is empty and this happens then the event will never be sendable at it's current
-		// size as it exceeds what the link allows.
-		//
-		// Otherwise, it's simplest to send this batch and create a new one, starting with this event.
-		panic(err)
-	} else if err != nil {
-		panic(err)
+	// if we have any events in the last batch, send it
+	if batch.NumEvents() > 0 {
+		if err := producerClient.SendEventBatch(context.TODO(), batch, nil); err != nil {
+			panic(err)
+		}
 	}
+}
 
-	err = producerClient.SendEventBatch(context.TODO(), batch, nil)
-
-	if err != nil {
-		panic(err)
+func createEventsForSample() []*azeventhubs.EventData {
+	return []*azeventhubs.EventData{
+		{
+			Body: []byte("hello"),
+		},
+		{
+			Body: []byte("world"),
+		},
 	}
 }

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
@@ -143,11 +143,11 @@ func sendEventsToPartition(ctx context.Context, producerClient *azeventhubs.Prod
 		err := batch.AddEventData(ed, nil)
 
 		if errors.Is(err, azeventhubs.ErrEventDataTooLarge) {
-			if batch.NumMessages() == 0 {
+			if batch.NumEvents() == 0 {
 				return azeventhubs.StartPosition{}, errors.New("single event was too large to fit into batch")
 			}
 
-			log.Printf("[%s] Sending batch with %d messages", partitionID, batch.NumMessages())
+			log.Printf("[%s] Sending batch with %d messages", partitionID, batch.NumEvents())
 			if err := producerClient.SendEventBatch(context.Background(), batch, nil); err != nil {
 				return azeventhubs.StartPosition{}, err
 			}
@@ -167,8 +167,8 @@ func sendEventsToPartition(ctx context.Context, producerClient *azeventhubs.Prod
 		}
 	}
 
-	if batch.NumMessages() > 0 {
-		log.Printf("[%s] Sending last batch with %d messages", partitionID, batch.NumMessages())
+	if batch.NumEvents() > 0 {
+		log.Printf("[%s] Sending last batch with %d messages", partitionID, batch.NumEvents())
 		if err := producerClient.SendEventBatch(ctx, batch, nil); err != nil {
 			return azeventhubs.StartPosition{}, err
 		}

--- a/sdk/messaging/azeventhubs/mgmt.go
+++ b/sdk/messaging/azeventhubs/mgmt.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs
 
 import (

--- a/sdk/messaging/azeventhubs/partition_client.go
+++ b/sdk/messaging/azeventhubs/partition_client.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs
 
 import (

--- a/sdk/messaging/azeventhubs/processor.go
+++ b/sdk/messaging/azeventhubs/processor.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs
 
 import (

--- a/sdk/messaging/azeventhubs/processor_load_balancer.go
+++ b/sdk/messaging/azeventhubs/processor_load_balancer.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs
 
 import (

--- a/sdk/messaging/azeventhubs/processor_partition_client.go
+++ b/sdk/messaging/azeventhubs/processor_partition_client.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs
 
 import "context"

--- a/sdk/messaging/azeventhubs/producer_client.go
+++ b/sdk/messaging/azeventhubs/producer_client.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package azeventhubs
 
 import (


### PR DESCRIPTION
The pkg.go.dev for this package looks pretty bad because of some simple conventions I accidentally violated:

1. Any comment that's directly above the `package` declaration will be included as the package comment, which resulted in a bunch of "Copyright Microsoft"'s being inserted into the Overview. Fixed that by just adding in a blank line.
2. Whole-file examples will not display the full file unless there's at least one other `package level` declaration in the file. I've introduced some that I think aren't too artificial.

I also found an inconsistency in the batch naming - it really should be NumEvents(), rather than NumMessages(), since we're going with the Events terminology rather than Messages (EventData, ReceivedEventData, SendEventDataBatch).