### PR TITLE
[azservicebus] Create a programmatically useful code for when a session is not available

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bugs Fixed
 
+- AcceptNextSessionForQueue and AcceptNextSessionForSubscription now return an azservicebus.Error with 
+  Code set to CodeTimeout when they fail due to no sessions being available. Examples for this have 
+  been added for `AcceptNextSessionForQueue`. PR#TBD.
+
 ### Other Changes
 
 ## 1.1.0 (2022-08-09)

--- a/sdk/messaging/azservicebus/error.go
+++ b/sdk/messaging/azservicebus/error.go
@@ -21,6 +21,12 @@ const (
 	// This message will be available again after the lock period expires, or, potentially
 	// go to the dead letter queue if delivery attempts have been exceeded.
 	CodeLockLost = exported.CodeLockLost
+
+	// CodeTimeout means the service timed out during an operation.
+	// For instance, if you use ServiceBusClient.AcceptNextSessionForQueue() and there aren't
+	// any available sessions it will eventually time out and return an *azservicebus.Error
+	// with this code.
+	CodeTimeout = exported.CodeTimeout
 )
 
 // Error represents a Service Bus specific error.

--- a/sdk/messaging/azservicebus/example_session_receiver_test.go
+++ b/sdk/messaging/azservicebus/example_session_receiver_test.go
@@ -5,28 +5,111 @@ package azservicebus_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 )
 
 func ExampleClient_AcceptSessionForQueue() {
-	sessionReceiver, err := client.AcceptSessionForQueue(context.TODO(), "exampleSessionQueue", "Example Session ID", nil)
-	exitOnError("Failed to create session receiver", err)
+	sessionReceiver, err := client.AcceptSessionForQueue(context.TODO(), "exampleSessionQueue", "exampleSessionId", nil)
 
-	// session receivers function the same as any other receiver
+	if err != nil {
+		panic(err)
+	}
+
+	defer sessionReceiver.Close(context.TODO())
+
+	// session receivers work just like non-session receivers
+	// with one difference - instead of a lock per message there is a lock
+	// for the session itself.
+
+	// Like a message lock, you'll want to periodically renew your session lock.
+	err = sessionReceiver.RenewSessionLock(context.TODO(), nil)
+
+	if err != nil {
+		panic(err)
+	}
+
 	messages, err := sessionReceiver.ReceiveMessages(context.TODO(), 5, nil)
-	exitOnError("Failed to receive a message", err)
+
+	if err != nil {
+		panic(err)
+	}
 
 	for _, message := range messages {
 		err = sessionReceiver.CompleteMessage(context.TODO(), message, nil)
-		exitOnError("Failed to complete message", err)
+
+		if err != nil {
+			panic(err)
+		}
 
 		fmt.Printf("Received message from session ID \"%s\" and completed it", *message.SessionID)
 	}
 }
 
-func ExampleClient_AcceptNextSessionForQueue() {
-	sessionReceiver, err := client.AcceptNextSessionForQueue(context.TODO(), "exampleSessionQueue", nil)
-	exitOnError("Failed to create session receiver", err)
+func ExampleClient_AcceptSessionForSubscription() {
+	sessionReceiver, err := client.AcceptSessionForSubscription(context.TODO(), "exampleTopic", "exampleSubscription", "exampleSessionId", nil)
 
-	fmt.Printf("Session receiver was assigned session ID \"%s\"", sessionReceiver.SessionID())
+	if err != nil {
+		panic(err)
+	}
+
+	defer sessionReceiver.Close(context.TODO())
+
+	// see ExampleClient_AcceptSessionForQueue() for usage of the SessionReceiver.
+}
+
+func ExampleClient_AcceptNextSessionForQueue() {
+	for {
+		func() {
+			sessionReceiver, err := client.AcceptNextSessionForQueue(context.TODO(), "exampleSessionQueue", nil)
+
+			if err != nil {
+				var sbErr *azservicebus.Error
+
+				if errors.As(err, &sbErr) && sbErr.Code == azservicebus.CodeTimeout {
+					// there are no sessions available. This isn't fatal - we can use the client and
+					// try to AcceptNextSessionForQueue() again.
+					fmt.Printf("No session available\n")
+					return
+				} else {
+					panic(err)
+				}
+			}
+
+			defer sessionReceiver.Close(context.TODO())
+
+			fmt.Printf("Session receiver was assigned session ID \"%s\"", sessionReceiver.SessionID())
+
+			// see ExampleClient_AcceptSessionForQueue() for usage of the SessionReceiver.
+		}()
+	}
+}
+
+func ExampleClient_AcceptNextSessionForSubscription() {
+	for {
+		func() {
+			sessionReceiver, err := client.AcceptNextSessionForSubscription(context.TODO(), "exampleTopicName", "exampleSubscriptionName", nil)
+
+			if err != nil {
+				var sbErr *azservicebus.Error
+
+				if errors.As(err, &sbErr) && sbErr.Code == azservicebus.CodeTimeout {
+					// there are no sessions available. This isn't fatal - we can use the client and
+					// try to AcceptNextSessionForSubscription() again.
+					fmt.Printf("No session available\n")
+					return
+				} else {
+					panic(err)
+				}
+			}
+
+			defer sessionReceiver.Close(context.TODO())
+
+			fmt.Printf("Session receiver was assigned session ID \"%s\"", sessionReceiver.SessionID())
+
+			// see AcceptSessionForSubscription() for some usage of the SessionReceiver itself.
+		}()
+	}
 }

--- a/sdk/messaging/azservicebus/example_session_roundrobin_test.go
+++ b/sdk/messaging/azservicebus/example_session_roundrobin_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azservicebus_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+)
+
+func ExampleClient_AcceptNextSessionForQueue_roundrobin() {
+	var sessionEnabledQueueName = "exampleSessionQueue"
+
+	for {
+		// You can have multiple active session receivers, provided they're each receiving
+		// from different sessions.
+		//
+		// AcceptNextSessionForQueue (or AcceptNextSessionForSubscription) makes it simple to implement
+		// this pattern, consuming multiple session receivers in parallel.
+		sessionReceiver, err := client.AcceptNextSessionForQueue(context.TODO(), sessionEnabledQueueName, nil)
+
+		if err != nil {
+			var sbErr *azservicebus.Error
+
+			if errors.As(err, &sbErr) && sbErr.Code == azservicebus.CodeTimeout {
+				fmt.Printf("No sessions available\n")
+
+				// NOTE: you could also continue here, which will block and wait again for a
+				// session to become available.
+				break
+			}
+
+			panic(err)
+		}
+
+		fmt.Printf("Got receiving for session '%s'\n", sessionReceiver.SessionID())
+
+		// consume the session
+		go func() {
+			defer func() {
+				fmt.Printf("Closing receiver for session '%s'\n", sessionReceiver.SessionID())
+				err := sessionReceiver.Close(context.TODO())
+
+				if err != nil {
+					panic(err)
+				}
+			}()
+
+			// we're only reading a few messages here, but you can also receive in a loop
+			messages, err := sessionReceiver.ReceiveMessages(context.TODO(), 10, nil)
+
+			if err != nil {
+				panic(err)
+			}
+
+			fmt.Printf("Received %d messages from session '%s'\n", len(messages), sessionReceiver.SessionID())
+
+			for _, m := range messages {
+				if err := processMessageFromSession(context.TODO(), sessionReceiver, m); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+}
+
+func processMessageFromSession(ctx context.Context, receiver *azservicebus.SessionReceiver, receivedMsg *azservicebus.ReceivedMessage) error {
+	fmt.Printf("Received message for session %s, message ID %s\n", *receivedMsg.SessionID, receivedMsg.MessageID)
+	return receiver.CompleteMessage(ctx, receivedMsg, nil)
+}

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -65,7 +65,7 @@ func TransformError(err error) error {
 
 	if isMicrosoftTimeoutError(err) {
 		// one scenario where this error pops up is if you're waiting for an available
-		// session and there are non available. It waits, up to one minute, and then
+		// session and there are none available. It waits, up to one minute, and then
 		// returns this error.
 		return exported.NewError(exported.CodeTimeout, err)
 	}

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -63,6 +63,13 @@ func TransformError(err error) error {
 		return exported.NewError(exported.CodeLockLost, err)
 	}
 
+	if isMicrosoftTimeoutError(err) {
+		// one scenario where this error pops up is if you're waiting for an available
+		// session and there are non available. It waits, up to one minute, and then
+		// returns this error.
+		return exported.NewError(exported.CodeTimeout, err)
+	}
+
 	rk := GetRecoveryKind(err)
 
 	switch rk {
@@ -77,6 +84,16 @@ func TransformError(err error) error {
 		// isn't one of our specifically called out cases so we'll just return it.
 		return err
 	}
+}
+
+func isMicrosoftTimeoutError(err error) bool {
+	var amqpErr *amqp.Error
+
+	if errors.As(err, &amqpErr) && amqpErr.Condition == amqp.ErrorCondition("com.microsoft:timeout") {
+		return true
+	}
+
+	return false
 }
 
 func IsDetachError(err error) bool {

--- a/sdk/messaging/azservicebus/internal/exported/error.go
+++ b/sdk/messaging/azservicebus/internal/exported/error.go
@@ -19,6 +19,12 @@ const (
 	// This message will be available again after the lock period expires, or, potentially
 	// go to the dead letter queue if delivery attempts have been exceeded.
 	CodeLockLost Code = "locklost"
+
+	// CodeTimeout means the service timed out during an operation.
+	// For instance, if you use ServiceBusClient.AcceptNextSessionForQueue() and there aren't
+	// any available sessions it will eventually time out and return an *azservicebus.Error
+	// with this code.
+	CodeTimeout Code = "timeout"
 )
 
 // Error represents a Service Bus specific error.

--- a/sdk/messaging/azservicebus/liveTestHelpers_test.go
+++ b/sdk/messaging/azservicebus/liveTestHelpers_test.go
@@ -107,7 +107,8 @@ func createQueue(t *testing.T, connectionString string, queueProperties *admin.Q
 	}
 }
 
-// createSubscription creates a queue, automatically setting it to delete on idle in 5 minutes.
+// createSubscription creates a topic, automatically setting it to delete on idle in 5 minutes.
+// It also creates a subscription named 'sub'.
 func createSubscription(t *testing.T, connectionString string, topicProperties *admin.TopicProperties, subscriptionProperties *admin.SubscriptionProperties) (string, func()) {
 	nanoSeconds := time.Now().UnixNano()
 	topicName := fmt.Sprintf("topic-%X", nanoSeconds)

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -716,9 +716,10 @@ func TestReceiverMultiTopic(t *testing.T) {
 }
 
 func TestReceiverMessageLockExpires(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		LockDuration: to.Ptr("PT5S"),
-	})
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			LockDuration: to.Ptr("PT5S"),
+		}})
 	defer cleanup()
 
 	sender, err := client.NewSender(queueName, nil)

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 func Test_Sender_MessageID(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		EnablePartitioning: to.Ptr(true),
-	})
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			EnablePartitioning: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	sender, err := client.NewSender(queueName, nil)
@@ -119,9 +120,10 @@ func receiveAll(t *testing.T, receiver *Receiver, expected int) []*ReceivedMessa
 }
 
 func Test_Sender_UsingPartitionedQueue(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		EnablePartitioning: to.Ptr(true),
-	})
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			EnablePartitioning: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	sender, err := client.NewSender(queueName, nil)

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -16,9 +16,10 @@ import (
 
 // SessionReceiver is a Receiver that handles sessions.
 type SessionReceiver struct {
-	inner       *Receiver
-	sessionID   *string
-	lockedUntil time.Time
+	inner             *Receiver
+	sessionID         *string
+	acceptNextTimeout time.Duration
+	lockedUntil       time.Time
 }
 
 // SessionReceiverOptions contains options for the `Client.AcceptSessionForQueue/Subscription` or `Client.AcceptNextSessionForQueue/Subscription`
@@ -50,11 +51,12 @@ func toReceiverOptions(sropts *SessionReceiverOptions) *ReceiverOptions {
 }
 
 type newSessionReceiverArgs struct {
-	sessionID      *string
-	ns             internal.NamespaceWithNewAMQPLinks
-	entity         entity
-	cleanupOnClose func()
-	retryOptions   RetryOptions
+	sessionID         *string
+	ns                internal.NamespaceWithNewAMQPLinks
+	entity            entity
+	cleanupOnClose    func()
+	retryOptions      RetryOptions
+	acceptNextTimeout time.Duration
 }
 
 func newSessionReceiver(ctx context.Context, args newSessionReceiverArgs, options *ReceiverOptions) (*SessionReceiver, error) {
@@ -76,6 +78,7 @@ func newSessionReceiver(ctx context.Context, args newSessionReceiverArgs, option
 		return nil, err
 	}
 
+	sessionReceiver.acceptNextTimeout = args.acceptNextTimeout
 	sessionReceiver.inner = r
 
 	// temp workaround until we expose the session expiration time from the receiver in go-amqp
@@ -97,6 +100,16 @@ func (r *SessionReceiver) newLink(ctx context.Context, session amqpwrap.AMQPSess
 		linkOptions.Filters = append(linkOptions.Filters, amqp.LinkFilterSource(sessionFilterName, code, nil))
 	} else {
 		linkOptions.Filters = append(linkOptions.Filters, amqp.LinkFilterSource(sessionFilterName, code, r.sessionID))
+	}
+
+	if r.acceptNextTimeout > 0 {
+		if linkOptions.Properties == nil {
+			linkOptions.Properties = map[string]any{}
+		}
+
+		// the remote side of this seems _very_ picky that the type not be larger than 32-bits.
+		timeoutInMS := uint32(r.acceptNextTimeout / time.Millisecond)
+		linkOptions.Properties["com.microsoft:timeout"] = timeoutInMS
 	}
 
 	link, err := session.NewReceiver(ctx, r.inner.amqpLinks.EntityPath(), linkOptions)

--- a/sdk/messaging/azservicebus/session_receiver_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_test.go
@@ -20,9 +20,10 @@ import (
 )
 
 func TestSessionReceiver_acceptSession(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		RequiresSession: to.Ptr(true),
-	})
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			RequiresSession: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	ctx := context.Background()
@@ -60,9 +61,10 @@ func TestSessionReceiver_acceptSession(t *testing.T) {
 }
 
 func TestSessionReceiver_blankSessionIDs(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		RequiresSession: to.Ptr(true),
-	})
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			RequiresSession: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	ctx := context.Background()
@@ -115,9 +117,10 @@ func TestSessionReceiver_blankSessionIDs(t *testing.T) {
 }
 
 func TestSessionReceiver_acceptSessionButAlreadyLocked(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		RequiresSession: to.Ptr(true),
-	})
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			RequiresSession: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	ctx := context.Background()
@@ -134,10 +137,11 @@ func TestSessionReceiver_acceptSessionButAlreadyLocked(t *testing.T) {
 	require.Nil(t, receiver)
 }
 
-func TestSessionReceiver_acceptNextSession(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		RequiresSession: to.Ptr(true),
-	})
+func TestSessionReceiver_acceptNextSession_sessionExists(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			RequiresSession: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	ctx := context.Background()
@@ -175,35 +179,37 @@ func TestSessionReceiver_acceptNextSession(t *testing.T) {
 	require.EqualValues(t, "hello", string(sessionState))
 }
 
-func TestSessionReceiver_noSessionsAvailable(t *testing.T) {
-	t.Skip("Really slow test (since it has to wait for a timeout from the service)")
-
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		RequiresSession: to.Ptr(true),
-	})
+func TestSessionReceiver_acceptNextSession_noSessionsExist(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		ClientOptions: &ClientOptions{
+			RetryOptions: RetryOptions{
+				MaxRetryDelay: time.Millisecond,
+			},
+		},
+		QueueProperties: &admin.QueueProperties{
+			RequiresSession: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	ctx := context.Background()
 
-	// now try again (there are no sessions available with messages so we expect a failure
+	// This adds an extra property to our link that sets a shorter scanning interval on the
+	// service side. If you comment this out it will let the service determine the timeout,
+	// which is 1 minute.
+	client.acceptNextTimeout = time.Second
+
 	receiver, err := client.AcceptNextSessionForQueue(ctx, queueName, nil)
-
-	var amqpError *amqp.Error
-	require.True(t, errors.As(err, &amqpError))
-
-	// just documenting this for now - if this is consistent enough we'll want to provide some guidance as this is a normal condition but
-	// it looks like it's an error instead.
-	// (actual error)
-	// *Error{Condition: com.microsoft:timeout, Description: The operation did not complete within the allotted timeout of 00:01:04.9800000. The time allotted to this operation may have been a portion of a longer timeout.
-	require.EqualValues(t, amqpError.Condition, "com.microsoft:timeout")
-
+	var sbErr *Error
+	require.ErrorAs(t, err, &sbErr)
+	require.Equal(t, CodeTimeout, sbErr.Code, "CodeTimeout since no sessions are available")
 	require.Nil(t, receiver)
 }
 
 func TestSessionReceiver_nonSessionReceiver(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		RequiresSession: to.Ptr(true),
-	})
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			RequiresSession: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	// opening a non-session full receiver fails and it's at least understandable
@@ -229,9 +235,10 @@ func TestSessionReceiver_nonSessionReceiver(t *testing.T) {
 }
 
 func TestSessionReceiver_RenewSessionLock(t *testing.T) {
-	client, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		RequiresSession: to.Ptr(true),
-	})
+	client, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			RequiresSession: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	sessionReceiver, err := client.AcceptSessionForQueue(context.Background(), queueName, "session-1", nil)
@@ -256,9 +263,10 @@ func TestSessionReceiver_RenewSessionLock(t *testing.T) {
 }
 
 func TestSessionReceiver_Detach(t *testing.T) {
-	serviceBusClient, cleanup, queueName := setupLiveTest(t, &admin.QueueProperties{
-		RequiresSession: to.Ptr(true),
-	})
+	serviceBusClient, cleanup, queueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			RequiresSession: to.Ptr(true),
+		}})
 	defer cleanup()
 
 	azlog.SetListener(func(e azlog.Event, s string) {
@@ -309,6 +317,122 @@ func TestSessionReceiver_Detach(t *testing.T) {
 
 	require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0], nil))
 	require.NoError(t, receiver.Close(context.Background()))
+}
+
+func TestSessionReceiver_roundRobin(t *testing.T) {
+	client, cleanup, sessionEnabledQueueName := setupLiveTest(t, &liveTestOptions{
+		QueueProperties: &admin.QueueProperties{
+			RequiresSession: to.Ptr(true),
+		},
+		ClientOptions: &ClientOptions{
+			RetryOptions: RetryOptions{
+				MaxRetries: -1,
+			},
+		}})
+	defer cleanup()
+
+	sender, err := client.NewSender(sessionEnabledQueueName, nil)
+	require.NoError(t, err)
+
+	defer func() {
+		err := sender.Close(context.Background())
+		require.NoError(t, err)
+	}()
+
+	const maxSessions = 5
+
+	for i := 0; i < maxSessions; i++ {
+		sessionID := fmt.Sprintf("session%d", i)
+
+		err = sender.SendMessage(context.Background(), &Message{
+			Body:      []byte(sessionID),
+			SessionID: to.Ptr(sessionID),
+		}, nil)
+		require.NoError(t, err)
+	}
+
+	receivedSessions := make(chan string, maxSessions)
+
+	processMessageFromSession := func(ctx context.Context, receiver *SessionReceiver, message *ReceivedMessage) error {
+		fmt.Printf("Completing messages for '%s'\n", *message.SessionID)
+		err := receiver.CompleteMessage(ctx, message, nil)
+		fmt.Printf("Completed messages for '%s'\n", *message.SessionID)
+
+		require.Equal(t, receiver.SessionID(), *message.SessionID)
+		receivedSessions <- *message.SessionID
+		return err
+	}
+
+	client.acceptNextTimeout = time.Second
+
+	// NOTE: this code is intentionally similar to `ExampleClient_AcceptNextSessionForQueue_roundrobin` so we can
+	// test it.
+	// BEGIN
+	for {
+		// You can have multiple active session receivers, provided they're each receiving
+		// from different sessions.
+		//
+		// AcceptNextSessionForQueue (or AcceptNextSessionForSubscription) makes it simple to implement
+		// this pattern, consuming multiple session receivers in parallel.
+		sessionReceiver, err := client.AcceptNextSessionForQueue(context.TODO(), sessionEnabledQueueName, nil)
+
+		if err != nil {
+			var sbErr *Error
+
+			if errors.As(err, &sbErr) && sbErr.Code == CodeTimeout {
+				fmt.Printf("No sessions available\n")
+
+				// NOTE: you could also continue here, which will block and wait again for a
+				// session to become available.
+				break
+			}
+
+			panic(err)
+		}
+
+		fmt.Printf("Got receiving for session '%s'\n", sessionReceiver.SessionID())
+
+		// consume the session
+		go func() {
+			defer func() {
+				fmt.Printf("Closing receiver for session '%s'\n", sessionReceiver.SessionID())
+				err := sessionReceiver.Close(context.TODO())
+
+				if err != nil {
+					panic(err)
+				}
+			}()
+
+			// we're only reading a few messages here, but you can also receive in a loop
+			messages, err := sessionReceiver.ReceiveMessages(context.TODO(), 10, nil)
+
+			if err != nil {
+				panic(err)
+			}
+
+			fmt.Printf("Received %d messages from session '%s'\n", len(messages), sessionReceiver.SessionID())
+
+			for _, m := range messages {
+				if err := processMessageFromSession(context.TODO(), sessionReceiver, m); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+
+	// END
+
+	t.Logf("Waiting for all sessions to complete")
+
+	all := map[string]bool{}
+
+	for i := 0; i < maxSessions; i++ {
+		sessionID := <-receivedSessions
+		t.Logf("Got %s's message", sessionID)
+		all[sessionID] = true
+	}
+
+	require.Equal(t, maxSessions, len(all))
 }
 
 func Test_toReceiverOptions(t *testing.T) {


### PR DESCRIPTION
Adding a new error Code (`CodeTimeout`) for when we get back a `com.microsoft:timeout` error from Service Bus. The primary use is if we are doing an `AcceptNextSessionFor<Entity>()` and there aren't any available sessions.
    
This should allow customers to figure out if there's a genuine failure or if their session-enabled queue/subscription is simply "empty".

This also improves the tests and adds in some more customer exposed examples for reading through a a queue of sessions.
    
Fixes #19039