### PR TITLE
Retry-After delay shouldn't exceed MaxRetryDelay

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Don't retry a request if the `Retry-After` delay is greater than the configured `RetryOptions.MaxRetryDelay`.
 
 ### Other Changes
 

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -676,7 +676,7 @@ func TestPipelineNoRetryOn429(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	// initial response is throttling with a long retry-after delay, it should not trigger a retry
-	srv.AppendResponse(mock.WithStatusCode(http.StatusTooManyRequests), mock.WithHeader("Retry-After", "300"))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusTooManyRequests), mock.WithHeader(shared.HeaderRetryAfter, "300"))
 	perRetryPolicy := countingPolicy{}
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	require.NoError(t, err)
@@ -685,6 +685,23 @@ func TestPipelineNoRetryOn429(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 	require.Equal(t, 1, perRetryPolicy.count)
+}
+
+func TestPipelineRetryOn429(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusTooManyRequests), mock.WithHeader(shared.HeaderRetryAfter, "1"))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusTooManyRequests), mock.WithHeader(shared.HeaderRetryAfter, "1"))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+	perRetryPolicy := countingPolicy{}
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	require.NoError(t, err)
+	opt := testRetryOptions()
+	pl := exported.NewPipeline(srv, NewRetryPolicy(opt), &perRetryPolicy)
+	resp, err := pl.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 3, perRetryPolicy.count)
 }
 
 func newRewindTrackingBody(s string) *rewindTrackingBody {


### PR DESCRIPTION
Don't retry when Retry-After has a delay greater than the configured
MaxRetryDelay value.