### PR TITLE
Fix sub-test case not getting recording variables

### DIFF
--- a/sdk/internal/recording/recording.go
+++ b/sdk/internal/recording/recording.go
@@ -807,7 +807,8 @@ func IsLiveOnly(t *testing.T) bool {
 
 // GetVariables returns access to the variables stored by the test proxy for a specific test
 func GetVariables(t *testing.T) map[string]interface{} {
-	if s, ok := testSuite[t.Name()]; ok {
+	name := strings.Split(t.Name(),"/")[0]
+	if s, ok := testSuite[name]; ok {
 		return s.variables
 	}
 	return nil

--- a/sdk/internal/recording/recording.go
+++ b/sdk/internal/recording/recording.go
@@ -807,7 +807,7 @@ func IsLiveOnly(t *testing.T) bool {
 
 // GetVariables returns access to the variables stored by the test proxy for a specific test
 func GetVariables(t *testing.T) map[string]interface{} {
-	name := strings.Split(t.Name(),"/")[0]
+	name := strings.Split(t.Name(), "/")[0]
 	if s, ok := testSuite[name]; ok {
 		return s.variables
 	}


### PR DESCRIPTION
example：
  test name： ScheduledqueryrulesTestSuite
  sub-test name：ScheduledqueryrulesTestSuite/TestScheduledqueryrule

monitor live test: https://github.com/Azure/azure-sdk-for-go/pull/19117