### PR TITLE
[azeventhubs] Updating the documentation and API surface based on arch board feedback

### DIFF
--- a/sdk/messaging/azeventhubs/checkpoint_store.go
+++ b/sdk/messaging/azeventhubs/checkpoint_store.go
@@ -26,39 +26,25 @@ type CheckpointStore interface {
 
 // Ownership tracks which consumer owns a particular partition.
 type Ownership struct {
-	CheckpointStoreAddress
-	OwnershipData
-}
-
-// OwnershipData is data specific to ownership, like the
-// current owner, by ID, and the last time the ownership was
-// updated, which is used to calculate if ownership has expired.
-type OwnershipData struct {
-	OwnerID          string
-	LastModifiedTime time.Time
-	ETag             string
-}
-
-// Checkpoint tracks the last succesfully processed event in a partition.
-type Checkpoint struct {
-	CheckpointStoreAddress
-	CheckpointData
-}
-
-// CheckpointStoreAddress contains the properties needed to uniquely address checkpoints
-// or ownership.
-type CheckpointStoreAddress struct {
 	ConsumerGroup           string
 	EventHubName            string
 	FullyQualifiedNamespace string
 	PartitionID             string
+
+	OwnerID          string    // the owner ID of the Processor
+	LastModifiedTime time.Time // used when calculating if ownership has expired
+	ETag             string    // the ETag, used when attempting to claim or update ownership of a partition.
 }
 
-// CheckpointData tracks latest offset and sequence number that have been
-// processed by the client.
-type CheckpointData struct {
-	Offset         *int64
-	SequenceNumber *int64
+// Checkpoint tracks the last succesfully processed event in a partition.
+type Checkpoint struct {
+	ConsumerGroup           string
+	EventHubName            string
+	FullyQualifiedNamespace string
+	PartitionID             string
+
+	Offset         *int64 // the last succesfully processed Offset.
+	SequenceNumber *int64 // the last succesfully processed SequenceNumber.
 }
 
 // ListCheckpointsOptions contains optional parameters for the ListCheckpoints function

--- a/sdk/messaging/azeventhubs/checkpoints/blob_store.go
+++ b/sdk/messaging/azeventhubs/checkpoints/blob_store.go
@@ -68,7 +68,7 @@ func (b *BlobStore) ClaimOwnership(ctx context.Context, partitionOwnership []aze
 
 	// TODO: in parallel?
 	for _, po := range partitionOwnership {
-		blobName, err := nameForOwnershipBlob(po.CheckpointStoreAddress)
+		blobName, err := nameForOwnershipBlob(po)
 
 		if err != nil {
 			return nil, err
@@ -80,7 +80,7 @@ func (b *BlobStore) ClaimOwnership(ctx context.Context, partitionOwnership []aze
 			expectedETag = &po.ETag
 		}
 
-		lastModified, etag, err := b.setMetadata(ctx, blobName, newOwnershipBlobMetadata(po.OwnershipData), expectedETag)
+		lastModified, etag, err := b.setMetadata(ctx, blobName, newOwnershipBlobMetadata(po), expectedETag)
 
 		if err != nil {
 			var storageErr *blob.StorageError
@@ -95,14 +95,11 @@ func (b *BlobStore) ClaimOwnership(ctx context.Context, partitionOwnership []aze
 			return nil, err
 		}
 
-		ownerships = append(ownerships, azeventhubs.Ownership{
-			CheckpointStoreAddress: po.CheckpointStoreAddress,
-			OwnershipData: azeventhubs.OwnershipData{
-				ETag:             etag,
-				OwnerID:          po.OwnershipData.OwnerID,
-				LastModifiedTime: *lastModified,
-			},
-		})
+		newOwnership := po
+		newOwnership.ETag = etag
+		newOwnership.LastModifiedTime = *lastModified
+
+		ownerships = append(ownerships, newOwnership)
 	}
 
 	return ownerships, nil
@@ -110,7 +107,7 @@ func (b *BlobStore) ClaimOwnership(ctx context.Context, partitionOwnership []aze
 
 // ListCheckpoints lists all the available checkpoints.
 func (b *BlobStore) ListCheckpoints(ctx context.Context, fullyQualifiedNamespace string, eventHubName string, consumerGroup string, options *azeventhubs.ListCheckpointsOptions) ([]azeventhubs.Checkpoint, error) {
-	prefix, err := prefixForCheckpointBlobs(azeventhubs.CheckpointStoreAddress{
+	prefix, err := prefixForCheckpointBlobs(azeventhubs.Checkpoint{
 		FullyQualifiedNamespace: fullyQualifiedNamespace,
 		EventHubName:            eventHubName,
 		ConsumerGroup:           consumerGroup,
@@ -134,21 +131,19 @@ func (b *BlobStore) ListCheckpoints(ctx context.Context, fullyQualifiedNamespace
 
 		for _, blob := range resp.Segment.BlobItems {
 			partitionID := partitionIDRegexp.FindString(*blob.Name)
-			cpdata, err := newCheckpointData(blob.Metadata)
 
-			if err != nil {
+			cp := azeventhubs.Checkpoint{
+				FullyQualifiedNamespace: fullyQualifiedNamespace,
+				EventHubName:            eventHubName,
+				ConsumerGroup:           consumerGroup,
+				PartitionID:             partitionID,
+			}
+
+			if err := updateCheckpoint(blob.Metadata, &cp); err != nil {
 				return nil, err
 			}
 
-			checkpoints = append(checkpoints, azeventhubs.Checkpoint{
-				CheckpointStoreAddress: azeventhubs.CheckpointStoreAddress{
-					FullyQualifiedNamespace: fullyQualifiedNamespace,
-					EventHubName:            eventHubName,
-					ConsumerGroup:           consumerGroup,
-					PartitionID:             partitionID,
-				},
-				CheckpointData: cpdata,
-			})
+			checkpoints = append(checkpoints, cp)
 		}
 	}
 
@@ -163,10 +158,11 @@ var partitionIDRegexp = regexp.MustCompile("[^/]+?$")
 
 // ListOwnership lists all ownerships.
 func (b *BlobStore) ListOwnership(ctx context.Context, fullyQualifiedNamespace string, eventHubName string, consumerGroup string, options *azeventhubs.ListOwnershipOptions) ([]azeventhubs.Ownership, error) {
-	prefix, err := prefixForOwnershipBlobs(azeventhubs.CheckpointStoreAddress{
+	prefix, err := prefixForOwnershipBlobs(azeventhubs.Ownership{
 		FullyQualifiedNamespace: fullyQualifiedNamespace,
 		EventHubName:            eventHubName,
 		ConsumerGroup:           consumerGroup,
+		// ignore partition ID as this is wildcarded.
 	})
 
 	if err != nil {
@@ -187,21 +183,19 @@ func (b *BlobStore) ListOwnership(ctx context.Context, fullyQualifiedNamespace s
 
 		for _, blob := range resp.Segment.BlobItems {
 			partitionID := partitionIDRegexp.FindString(*blob.Name)
-			ownershipData, err := newOwnershipData(blob)
 
-			if err != nil {
+			o := azeventhubs.Ownership{
+				FullyQualifiedNamespace: fullyQualifiedNamespace,
+				EventHubName:            eventHubName,
+				ConsumerGroup:           consumerGroup,
+				PartitionID:             partitionID,
+			}
+
+			if err := updateOwnership(blob, &o); err != nil {
 				return nil, err
 			}
 
-			ownerships = append(ownerships, azeventhubs.Ownership{
-				CheckpointStoreAddress: azeventhubs.CheckpointStoreAddress{
-					FullyQualifiedNamespace: fullyQualifiedNamespace,
-					EventHubName:            eventHubName,
-					ConsumerGroup:           consumerGroup,
-					PartitionID:             partitionID,
-				},
-				OwnershipData: ownershipData,
-			})
+			ownerships = append(ownerships, o)
 		}
 	}
 
@@ -214,13 +208,13 @@ func (b *BlobStore) ListOwnership(ctx context.Context, fullyQualifiedNamespace s
 
 // UpdateCheckpoint updates a specific checkpoint with a sequence and offset.
 func (b *BlobStore) UpdateCheckpoint(ctx context.Context, checkpoint azeventhubs.Checkpoint, options *azeventhubs.UpdateCheckpointOptions) error {
-	blobName, err := nameForCheckpointBlob(checkpoint.CheckpointStoreAddress)
+	blobName, err := nameForCheckpointBlob(checkpoint)
 
 	if err != nil {
 		return err
 	}
 
-	_, _, err = b.setMetadata(ctx, blobName, newCheckpointBlobMetadata(checkpoint.CheckpointData), nil)
+	_, _, err = b.setMetadata(ctx, blobName, newCheckpointBlobMetadata(checkpoint), nil)
 	return err
 }
 
@@ -273,7 +267,7 @@ func (b *BlobStore) setMetadata(ctx context.Context, blobName string, blobMetada
 	}
 }
 
-func nameForCheckpointBlob(a azeventhubs.CheckpointStoreAddress) (string, error) {
+func nameForCheckpointBlob(a azeventhubs.Checkpoint) (string, error) {
 	if a.FullyQualifiedNamespace == "" || a.EventHubName == "" || a.ConsumerGroup == "" || a.PartitionID == "" {
 		return "", errors.New("missing fields for blob name")
 	}
@@ -282,7 +276,7 @@ func nameForCheckpointBlob(a azeventhubs.CheckpointStoreAddress) (string, error)
 	return fmt.Sprintf("%s/%s/%s/checkpoint/%s", a.FullyQualifiedNamespace, a.EventHubName, a.ConsumerGroup, a.PartitionID), nil
 }
 
-func prefixForCheckpointBlobs(a azeventhubs.CheckpointStoreAddress) (string, error) {
+func prefixForCheckpointBlobs(a azeventhubs.Checkpoint) (string, error) {
 	if a.FullyQualifiedNamespace == "" || a.EventHubName == "" || a.ConsumerGroup == "" {
 		return "", errors.New("missing fields for blob prefix")
 	}
@@ -291,7 +285,7 @@ func prefixForCheckpointBlobs(a azeventhubs.CheckpointStoreAddress) (string, err
 	return fmt.Sprintf("%s/%s/%s/checkpoint/", a.FullyQualifiedNamespace, a.EventHubName, a.ConsumerGroup), nil
 }
 
-func nameForOwnershipBlob(a azeventhubs.CheckpointStoreAddress) (string, error) {
+func nameForOwnershipBlob(a azeventhubs.Ownership) (string, error) {
 	if a.FullyQualifiedNamespace == "" || a.EventHubName == "" || a.ConsumerGroup == "" || a.PartitionID == "" {
 		return "", errors.New("missing fields for blob name")
 	}
@@ -300,7 +294,7 @@ func nameForOwnershipBlob(a azeventhubs.CheckpointStoreAddress) (string, error) 
 	return fmt.Sprintf("%s/%s/%s/ownership/%s", a.FullyQualifiedNamespace, a.EventHubName, a.ConsumerGroup, a.PartitionID), nil
 }
 
-func prefixForOwnershipBlobs(a azeventhubs.CheckpointStoreAddress) (string, error) {
+func prefixForOwnershipBlobs(a azeventhubs.Ownership) (string, error) {
 	if a.FullyQualifiedNamespace == "" || a.EventHubName == "" || a.ConsumerGroup == "" {
 		return "", errors.New("missing fields for blob prefix")
 	}
@@ -309,42 +303,41 @@ func prefixForOwnershipBlobs(a azeventhubs.CheckpointStoreAddress) (string, erro
 	return fmt.Sprintf("%s/%s/%s/ownership/", a.FullyQualifiedNamespace, a.EventHubName, a.ConsumerGroup), nil
 }
 
-func newCheckpointData(metadata map[string]*string) (azeventhubs.CheckpointData, error) {
+func updateCheckpoint(metadata map[string]*string, destCheckpoint *azeventhubs.Checkpoint) error {
 	if metadata == nil {
-		return azeventhubs.CheckpointData{}, fmt.Errorf("no checkpoint metadata for blob")
+		return fmt.Errorf("no checkpoint metadata for blob")
 	}
 
 	sequenceNumberStr, ok := metadata["sequencenumber"]
 
 	if !ok || sequenceNumberStr == nil {
-		return azeventhubs.CheckpointData{}, errors.New("sequencenumber is missing from metadata")
+		return errors.New("sequencenumber is missing from metadata")
 	}
 
 	sequenceNumber, err := strconv.ParseInt(*sequenceNumberStr, 10, 64)
 
 	if err != nil {
-		return azeventhubs.CheckpointData{}, fmt.Errorf("sequencenumber could not be parsed as an int64: %s", err.Error())
+		return fmt.Errorf("sequencenumber could not be parsed as an int64: %s", err.Error())
 	}
 
 	offsetStr, ok := metadata["offset"]
 
 	if !ok || offsetStr == nil {
-		return azeventhubs.CheckpointData{}, errors.New("offset is missing from metadata")
+		return errors.New("offset is missing from metadata")
 	}
 
 	offset, err := strconv.ParseInt(*offsetStr, 10, 64)
 
 	if err != nil {
-		return azeventhubs.CheckpointData{}, fmt.Errorf("offset could not be parsed as an int64: %s", err.Error())
+		return fmt.Errorf("offset could not be parsed as an int64: %s", err.Error())
 	}
 
-	return azeventhubs.CheckpointData{
-		Offset:         &offset,
-		SequenceNumber: &sequenceNumber,
-	}, nil
+	destCheckpoint.Offset = &offset
+	destCheckpoint.SequenceNumber = &sequenceNumber
+	return nil
 }
 
-func newCheckpointBlobMetadata(cpd azeventhubs.CheckpointData) map[string]string {
+func newCheckpointBlobMetadata(cpd azeventhubs.Checkpoint) map[string]string {
 	m := map[string]string{}
 
 	if cpd.SequenceNumber != nil {
@@ -358,25 +351,24 @@ func newCheckpointBlobMetadata(cpd azeventhubs.CheckpointData) map[string]string
 	return m
 }
 
-func newOwnershipData(b *blob.BlobItemInternal) (azeventhubs.OwnershipData, error) {
+func updateOwnership(b *blob.BlobItemInternal, destOwnership *azeventhubs.Ownership) error {
 	if b == nil || b.Metadata == nil || b.Properties == nil {
-		return azeventhubs.OwnershipData{}, fmt.Errorf("no ownership metadata for blob")
+		return fmt.Errorf("no ownership metadata for blob")
 	}
 
 	ownerID, ok := b.Metadata["ownerid"]
 
 	if !ok || ownerID == nil {
-		return azeventhubs.OwnershipData{}, errors.New("ownerid is missing from metadata")
+		return errors.New("ownerid is missing from metadata")
 	}
 
-	return azeventhubs.OwnershipData{
-		OwnerID:          *ownerID,
-		LastModifiedTime: *b.Properties.LastModified,
-		ETag:             *b.Properties.Etag,
-	}, nil
+	destOwnership.OwnerID = *ownerID
+	destOwnership.LastModifiedTime = *b.Properties.LastModified
+	destOwnership.ETag = *b.Properties.Etag
+	return nil
 }
 
-func newOwnershipBlobMetadata(od azeventhubs.OwnershipData) map[string]string {
+func newOwnershipBlobMetadata(od azeventhubs.Ownership) map[string]string {
 	return map[string]string{
 		"ownerid": od.OwnerID,
 	}

--- a/sdk/messaging/azeventhubs/checkpoints/blob_store.go
+++ b/sdk/messaging/azeventhubs/checkpoints/blob_store.go
@@ -24,16 +24,16 @@ type BlobStore struct {
 	cc *blob.ContainerClient
 }
 
-// NewBlobStoreOptions contains optional parameters for the New, NewFromConnectionString and NewWithSharedKey
+// BlobStoreOptions contains optional parameters for the New, NewFromConnectionString and NewWithSharedKey
 // functions
-type NewBlobStoreOptions struct {
+type BlobStoreOptions struct {
 	azcore.ClientOptions
 }
 
 // NewBlobStore creates a checkpoint store that stores ownership and checkpoints in
 // Azure Blob storage, using a container URL and a TokenCredential.
 // NOTE: the container must exist before the checkpoint store can be used.
-func NewBlobStore(containerURL string, cred azcore.TokenCredential, options *NewBlobStoreOptions) (*BlobStore, error) {
+func NewBlobStore(containerURL string, cred azcore.TokenCredential, options *BlobStoreOptions) (*BlobStore, error) {
 	cc, err := blob.NewContainerClient(containerURL, cred, toContainerClientOptions(options))
 
 	if err != nil {
@@ -49,7 +49,7 @@ func NewBlobStore(containerURL string, cred azcore.TokenCredential, options *New
 // ownership and checkpoints in Azure Blob storage, using a storage account
 // connection string.
 // NOTE: the container must exist before the checkpoint store can be used.
-func NewBlobStoreFromConnectionString(connectionString string, containerName string, options *NewBlobStoreOptions) (azeventhubs.CheckpointStore, error) {
+func NewBlobStoreFromConnectionString(connectionString string, containerName string, options *BlobStoreOptions) (azeventhubs.CheckpointStore, error) {
 	cc, err := blob.NewContainerClientFromConnectionString(connectionString, containerName, toContainerClientOptions(options))
 
 	if err != nil {
@@ -374,7 +374,7 @@ func newOwnershipBlobMetadata(od azeventhubs.Ownership) map[string]string {
 	}
 }
 
-func toContainerClientOptions(opts *NewBlobStoreOptions) *blob.ClientOptions {
+func toContainerClientOptions(opts *BlobStoreOptions) *blob.ClientOptions {
 	if opts == nil {
 		return nil
 	}

--- a/sdk/messaging/azeventhubs/checkpoints/blob_store_test.go
+++ b/sdk/messaging/azeventhubs/checkpoints/blob_store_test.go
@@ -29,16 +29,12 @@ func TestBlobStore_Checkpoints(t *testing.T) {
 	require.Empty(t, checkpoints)
 
 	err = store.UpdateCheckpoint(context.Background(), azeventhubs.Checkpoint{
-		CheckpointStoreAddress: azeventhubs.CheckpointStoreAddress{
-			ConsumerGroup:           "$Default",
-			EventHubName:            "event-hub-name",
-			FullyQualifiedNamespace: "ns.servicebus.windows.net",
-			PartitionID:             "partition-id",
-		},
-		CheckpointData: azeventhubs.CheckpointData{
-			Offset:         to.Ptr[int64](101),
-			SequenceNumber: to.Ptr[int64](202),
-		},
+		ConsumerGroup:           "$Default",
+		EventHubName:            "event-hub-name",
+		FullyQualifiedNamespace: "ns.servicebus.windows.net",
+		PartitionID:             "partition-id",
+		Offset:                  to.Ptr[int64](101),
+		SequenceNumber:          to.Ptr[int64](202),
 	}, nil)
 	require.NoError(t, err)
 
@@ -46,16 +42,12 @@ func TestBlobStore_Checkpoints(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, azeventhubs.Checkpoint{
-		CheckpointStoreAddress: azeventhubs.CheckpointStoreAddress{
-			ConsumerGroup:           "$Default",
-			EventHubName:            "event-hub-name",
-			FullyQualifiedNamespace: "ns.servicebus.windows.net",
-			PartitionID:             "partition-id",
-		},
-		CheckpointData: azeventhubs.CheckpointData{
-			Offset:         to.Ptr[int64](101),
-			SequenceNumber: to.Ptr[int64](202),
-		},
+		ConsumerGroup:           "$Default",
+		EventHubName:            "event-hub-name",
+		FullyQualifiedNamespace: "ns.servicebus.windows.net",
+		PartitionID:             "partition-id",
+		Offset:                  to.Ptr[int64](101),
+		SequenceNumber:          to.Ptr[int64](202),
 	}, checkpoints[0])
 }
 
@@ -78,19 +70,13 @@ func TestBlobStore_Ownership(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, ownerships)
 
-	address := azeventhubs.CheckpointStoreAddress{
-		ConsumerGroup:           "$Default",
-		EventHubName:            "event-hub-name",
-		FullyQualifiedNamespace: "ns.servicebus.windows.net",
-		PartitionID:             "partition-id",
-	}
-
 	ownerships, err = store.ClaimOwnership(context.Background(), []azeventhubs.Ownership{
 		{
-			CheckpointStoreAddress: address,
-			OwnershipData: azeventhubs.OwnershipData{
-				OwnerID: "owner-id",
-			},
+			ConsumerGroup:           "$Default",
+			EventHubName:            "event-hub-name",
+			FullyQualifiedNamespace: "ns.servicebus.windows.net",
+			PartitionID:             "partition-id",
+			OwnerID:                 "owner-id",
 		},
 	}, nil)
 	require.NoError(t, err)
@@ -100,23 +86,25 @@ func TestBlobStore_Ownership(t *testing.T) {
 	require.NotZero(t, ownerships[0].LastModifiedTime)
 
 	require.Equal(t, azeventhubs.Ownership{
-		CheckpointStoreAddress: address,
-		OwnershipData: azeventhubs.OwnershipData{
-			OwnerID:          "owner-id",
-			ETag:             ownerships[0].ETag,
-			LastModifiedTime: ownerships[0].LastModifiedTime,
-		},
+		ConsumerGroup:           "$Default",
+		EventHubName:            "event-hub-name",
+		FullyQualifiedNamespace: "ns.servicebus.windows.net",
+		PartitionID:             "partition-id",
+		OwnerID:                 "owner-id",
+		ETag:                    ownerships[0].ETag,
+		LastModifiedTime:        ownerships[0].LastModifiedTime,
 	}, ownerships[0])
 
 	// if we attempt to claim it with a non-matching etag it will fail to claim
 	// but not fail the call.
 	ownerships, err = store.ClaimOwnership(context.Background(), []azeventhubs.Ownership{
 		{
-			CheckpointStoreAddress: address,
-			OwnershipData: azeventhubs.OwnershipData{
-				OwnerID: "owner-id",
-				ETag:    "non-matching-etag",
-			},
+			ConsumerGroup:           "$Default",
+			EventHubName:            "event-hub-name",
+			FullyQualifiedNamespace: "ns.servicebus.windows.net",
+			PartitionID:             "partition-id",
+			OwnerID:                 "owner-id",
+			ETag:                    "non-matching-etag",
 		},
 	}, nil)
 	require.NoError(t, err)
@@ -125,22 +113,24 @@ func TestBlobStore_Ownership(t *testing.T) {
 	// now we'll use the actual etag
 	ownerships, err = store.ClaimOwnership(context.Background(), []azeventhubs.Ownership{
 		{
-			CheckpointStoreAddress: address,
-			OwnershipData: azeventhubs.OwnershipData{
-				OwnerID: "owner-id",
-				ETag:    etagAfterFirstClaim,
-			},
+			ConsumerGroup:           "$Default",
+			EventHubName:            "event-hub-name",
+			FullyQualifiedNamespace: "ns.servicebus.windows.net",
+			PartitionID:             "partition-id",
+			OwnerID:                 "owner-id",
+			ETag:                    etagAfterFirstClaim,
 		},
 	}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, azeventhubs.Ownership{
-		CheckpointStoreAddress: address,
-		OwnershipData: azeventhubs.OwnershipData{
-			OwnerID:          "owner-id",
-			ETag:             ownerships[0].ETag,
-			LastModifiedTime: ownerships[0].LastModifiedTime,
-		},
+		ConsumerGroup:           "$Default",
+		EventHubName:            "event-hub-name",
+		FullyQualifiedNamespace: "ns.servicebus.windows.net",
+		PartitionID:             "partition-id",
+		OwnerID:                 "owner-id",
+		ETag:                    ownerships[0].ETag,
+		LastModifiedTime:        ownerships[0].LastModifiedTime,
 	}, ownerships[0])
 
 	// etag definitely got updated.
@@ -156,31 +146,29 @@ func TestBlobStore_ListAndClaim(t *testing.T) {
 	store, err := checkpoints.NewBlobStoreFromConnectionString(testData.ConnectionString, testData.ContainerName, nil)
 	require.NoError(t, err)
 
-	address := azeventhubs.CheckpointStoreAddress{
-		ConsumerGroup:           "$Default",
-		EventHubName:            "event-hub-name",
-		FullyQualifiedNamespace: "ns.servicebus.windows.net",
-		PartitionID:             "partition-id",
-	}
-
 	claimedOwnerships, err := store.ClaimOwnership(context.Background(), []azeventhubs.Ownership{
 		{
-			CheckpointStoreAddress: address,
-			OwnershipData: azeventhubs.OwnershipData{
-				OwnerID: "first-client",
-			},
+			ConsumerGroup:           "$Default",
+			EventHubName:            "event-hub-name",
+			FullyQualifiedNamespace: "ns.servicebus.windows.net",
+			PartitionID:             "partition-id",
+			OwnerID:                 "first-client",
 		},
 	}, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, claimedOwnerships)
 
-	listedOwnerships, err := store.ListOwnership(context.Background(), address.FullyQualifiedNamespace, address.EventHubName, address.ConsumerGroup, nil)
+	listedOwnerships, err := store.ListOwnership(context.Background(), "ns.servicebus.windows.net", "event-hub-name", "$Default", nil)
 	require.NoError(t, err)
 
 	require.Equal(t, "first-client", listedOwnerships[0].OwnerID)
 	require.NotEmpty(t, listedOwnerships[0].ETag)
 	require.NotZero(t, listedOwnerships[0].LastModifiedTime)
-	require.Equal(t, address, listedOwnerships[0].CheckpointStoreAddress)
+
+	require.Equal(t, "$Default", listedOwnerships[0].ConsumerGroup)
+	require.Equal(t, "event-hub-name", listedOwnerships[0].EventHubName)
+	require.Equal(t, "ns.servicebus.windows.net", listedOwnerships[0].FullyQualifiedNamespace)
+	require.Equal(t, "partition-id", listedOwnerships[0].PartitionID)
 
 	// update using the etag
 	claimedOwnerships, err = store.ClaimOwnership(context.Background(), listedOwnerships, nil)

--- a/sdk/messaging/azeventhubs/checkpoints/doc.go
+++ b/sdk/messaging/azeventhubs/checkpoints/doc.go
@@ -4,7 +4,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Package checkpoints provides a CheckpointStore that uses Azure Blob Storage.
-// This checkpoint store can be used with the azeventhubs.Processor type to
-// coordinate distributed consumption of events from an event hub.
+// Package checkpoints provides a CheckpointStore using Azure Blob Storage.
+//
+// CheckpointStore's are generally not used on their own and will be created so they
+// can be passed to a [Processor] to coordinate distributed consumption of events from an event hub.
+//
+// See [example_processor_test.go] for an example that uses the [checkpoints.BlobStore] with
+// a [Processor].
+//
+// [Processor]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs#Processor
+// [example_processor_test.go]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/example_processor_test.go
 package checkpoints

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -78,8 +78,9 @@ type ConsumerClient struct {
 }
 
 // NewConsumerClient creates a ConsumerClient which uses an azcore.TokenCredential for authentication.
+//
 // The fullyQualifiedNamespace is the Event Hubs namespace name (ex: myeventhub.servicebus.windows.net)
-// The credential is one of the credentials in the `github.com/Azure/azure-sdk-for-go/sdk/azidentity` package.
+// The credential is one of the credentials in the [github.com/Azure/azure-sdk-for-go/sdk/azidentity] package.
 func NewConsumerClient(fullyQualifiedNamespace string, eventHub string, consumerGroup string, credential azcore.TokenCredential, options *ConsumerClientOptions) (*ConsumerClient, error) {
 	return newConsumerClient(consumerClientArgs{
 		consumerGroup:           consumerGroup,
@@ -92,12 +93,10 @@ func NewConsumerClient(fullyQualifiedNamespace string, eventHub string, consumer
 // NewConsumerClientFromConnectionString creates a ConsumerClient from a connection string.
 //
 // connectionString can be one of the following formats:
-//
-// Connection string, no EntityPath. In this case eventHub cannot be empty.
-// ex: Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
-//
-// Connection string, has EntityPath. In this case eventHub must be empty.
-// ex: Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<entity path>
+//   - Connection string, no EntityPath. In this case eventHub cannot be empty.
+//     ex: Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
+//   - Connection string, has EntityPath. In this case eventHub must be empty.
+//     ex: Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<entity path>
 func NewConsumerClientFromConnectionString(connectionString string, eventHub string, consumerGroup string, options *ConsumerClientOptions) (*ConsumerClient, error) {
 	parsedConn, err := parseConn(connectionString, eventHub)
 
@@ -126,7 +125,8 @@ type PartitionClientOptions struct {
 	OwnerLevel *int64
 }
 
-// NewPartitionClient creates a client that can receive events from a partition.
+// NewPartitionClient creates a client that can receive events from a partition. By default it starts
+// at the latest point in the partition, which can be changed using the options parameter.
 func (cc *ConsumerClient) NewPartitionClient(partitionID string, options *PartitionClientOptions) (*PartitionClient, error) {
 	return newPartitionClient(partitionClientArgs{
 		namespace:     cc.namespace,
@@ -148,8 +148,9 @@ func (cc *ConsumerClient) GetEventHubProperties(ctx context.Context, options *Ge
 	return getEventHubProperties(ctx, cc.namespace, rpcLink.Link, cc.eventHub, options)
 }
 
-// GetPartitionProperties gets properties for a specific partition. This includes data like the last enqueued sequence number, the first sequence
-// number and when an event was last enqueued to the partition.
+// GetPartitionProperties gets properties for a specific partition. This includes data like the
+// last enqueued sequence number, the first sequence number and when an event was last enqueued
+// to the partition.
 func (cc *ConsumerClient) GetPartitionProperties(ctx context.Context, partitionID string, options *GetPartitionPropertiesOptions) (PartitionProperties, error) {
 	rpcLink, err := cc.links.GetManagementLink(ctx)
 

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -77,10 +77,13 @@ type ConsumerClient struct {
 	clientID string
 }
 
-// NewConsumerClient creates a ConsumerClient which uses an azcore.TokenCredential for authentication.
+// NewConsumerClient creates a ConsumerClient which uses an azcore.TokenCredential for authentication. You
+// MUST call [azeventhubs.ConsumerClient.Close] on this client to avoid leaking resources.
 //
 // The fullyQualifiedNamespace is the Event Hubs namespace name (ex: myeventhub.servicebus.windows.net)
-// The credential is one of the credentials in the [github.com/Azure/azure-sdk-for-go/sdk/azidentity] package.
+// The credential is one of the credentials in the [azidentity] package.
+//
+// [azidentity]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity
 func NewConsumerClient(fullyQualifiedNamespace string, eventHub string, consumerGroup string, credential azcore.TokenCredential, options *ConsumerClientOptions) (*ConsumerClient, error) {
 	return newConsumerClient(consumerClientArgs{
 		consumerGroup:           consumerGroup,
@@ -90,17 +93,19 @@ func NewConsumerClient(fullyQualifiedNamespace string, eventHub string, consumer
 	}, options)
 }
 
-// NewConsumerClientFromConnectionString creates a ConsumerClient from a connection string.
+// NewConsumerClientFromConnectionString creates a ConsumerClient from a connection string. You
+// MUST call [azeventhubs.ConsumerClient.Close] on this client to avoid leaking resources.
 //
-// connectionString can be one of the following formats:
+// connectionString can be one of two formats - with or without an EntityPath key.
 //
-// Connection string, no EntityPath. In this case eventHub cannot be empty
+// When the connection string does not have an entity path, as shown below, the eventHub parameter cannot
+// be empty and should contain the name of your event hub.
 //
 //	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
 //
-// Connection string, has EntityPath. In this case eventHub must be empty.
+// When the connection string DOES have an entity path, as shown below, the eventHub parameter must be empty.
 //
-//	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;
+//	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<entity path>;
 func NewConsumerClientFromConnectionString(connectionString string, eventHub string, consumerGroup string, options *ConsumerClientOptions) (*ConsumerClient, error) {
 	parsedConn, err := parseConn(connectionString, eventHub)
 
@@ -131,6 +136,7 @@ type PartitionClientOptions struct {
 
 // NewPartitionClient creates a client that can receive events from a partition. By default it starts
 // at the latest point in the partition. This can be changed using the options parameter.
+// You MUST call [azeventhubs.PartitionClient.Close] on the returned client to avoid leaking resources.
 func (cc *ConsumerClient) NewPartitionClient(partitionID string, options *PartitionClientOptions) (*PartitionClient, error) {
 	return newPartitionClient(partitionClientArgs{
 		namespace:     cc.namespace,
@@ -181,7 +187,7 @@ func (cc *ConsumerClient) getDetails() consumerClientDetails {
 	}
 }
 
-// Close closes the connection for this client.
+// Close releases resources for this client.
 func (cc *ConsumerClient) Close(ctx context.Context) error {
 	return cc.namespace.Close(ctx, true)
 }

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -93,10 +93,14 @@ func NewConsumerClient(fullyQualifiedNamespace string, eventHub string, consumer
 // NewConsumerClientFromConnectionString creates a ConsumerClient from a connection string.
 //
 // connectionString can be one of the following formats:
-//   - Connection string, no EntityPath. In this case eventHub cannot be empty.
-//     ex: Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
-//   - Connection string, has EntityPath. In this case eventHub must be empty.
-//     ex: Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<entity path>
+//
+// Connection string, no EntityPath. In this case eventHub cannot be empty
+//
+//	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
+//
+// Connection string, has EntityPath. In this case eventHub must be empty.
+//
+//	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;
 func NewConsumerClientFromConnectionString(connectionString string, eventHub string, consumerGroup string, options *ConsumerClientOptions) (*ConsumerClient, error) {
 	parsedConn, err := parseConn(connectionString, eventHub)
 
@@ -111,7 +115,7 @@ func NewConsumerClientFromConnectionString(connectionString string, eventHub str
 	}, options)
 }
 
-// PartitionClientOptions provides options for the Subscribe function.
+// PartitionClientOptions provides options for the NewPartitionClient function.
 type PartitionClientOptions struct {
 	// StartPosition is the position we will start receiving events from,
 	// either an offset (inclusive) with Offset, or receiving events received
@@ -126,7 +130,7 @@ type PartitionClientOptions struct {
 }
 
 // NewPartitionClient creates a client that can receive events from a partition. By default it starts
-// at the latest point in the partition, which can be changed using the options parameter.
+// at the latest point in the partition. This can be changed using the options parameter.
 func (cc *ConsumerClient) NewPartitionClient(partitionID string, options *PartitionClientOptions) (*PartitionClient, error) {
 	return newPartitionClient(partitionClientArgs{
 		namespace:     cc.namespace,

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -52,17 +52,6 @@ type ConsumerClientOptions struct {
 	// RetryOptions controls how often operations are retried from this client and any
 	// Receivers and Senders created from this client.
 	RetryOptions RetryOptions
-
-	// StartPosition is the position we will start receiving events from,
-	// either an offset (inclusive) with Offset, or receiving events received
-	// after a specific time using EnqueuedTime.
-	StartPosition StartPosition
-
-	// OwnerLevel is the priority for this consumer, also known as the 'epoch' level.
-	// When used, a consumer with a higher OwnerLevel will take ownership of a partition
-	// from consumers with a lower OwnerLevel.
-	// Default is off.
-	OwnerLevel *uint64
 }
 
 // ConsumerClient can create PartitionClient instances, which can read events from

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -47,7 +47,7 @@ type ConsumerClientOptions struct {
 
 	// NewWebSocketConn is a function that can create a net.Conn for use with websockets.
 	// For an example, see ExampleNewClient_usingWebsockets() function in example_client_test.go.
-	NewWebSocketConn func(ctx context.Context, args NewWebSocketConnArgs) (net.Conn, error)
+	NewWebSocketConn func(ctx context.Context, args WebSocketConnArgs) (net.Conn, error)
 
 	// RetryOptions controls how often operations are retried from this client and any
 	// Receivers and Senders created from this client.
@@ -112,8 +112,8 @@ func NewConsumerClientFromConnectionString(connectionString string, eventHub str
 	}, options)
 }
 
-// NewPartitionClientOptions provides options for the Subscribe function.
-type NewPartitionClientOptions struct {
+// PartitionClientOptions provides options for the Subscribe function.
+type PartitionClientOptions struct {
 	// StartPosition is the position we will start receiving events from,
 	// either an offset (inclusive) with Offset, or receiving events received
 	// after a specific time using EnqueuedTime.
@@ -127,7 +127,7 @@ type NewPartitionClientOptions struct {
 }
 
 // NewPartitionClient creates a client that can receive events from a partition.
-func (cc *ConsumerClient) NewPartitionClient(partitionID string, options *NewPartitionClientOptions) (*PartitionClient, error) {
+func (cc *ConsumerClient) NewPartitionClient(partitionID string, options *PartitionClientOptions) (*PartitionClient, error) {
 	return newPartitionClient(partitionClientArgs{
 		namespace:     cc.namespace,
 		eventHub:      cc.eventHub,

--- a/sdk/messaging/azeventhubs/consumer_client_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_test.go
@@ -75,7 +75,7 @@ func TestConsumerClient_DefaultAzureCredential(t *testing.T) {
 			require.NoError(t, err)
 		}()
 
-		eventDataBatch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.NewEventDataBatchOptions{
+		eventDataBatch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
 			PartitionID: to.Ptr(firstPartition.PartitionID),
 		})
 		require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestConsumerClient_DefaultAzureCredential(t *testing.T) {
 		err = producerClient.SendEventBatch(context.Background(), eventDataBatch, nil)
 		require.NoError(t, err)
 
-		subscription, err := consumerClient.NewPartitionClient(firstPartition.PartitionID, &azeventhubs.NewPartitionClientOptions{
+		subscription, err := consumerClient.NewPartitionClient(firstPartition.PartitionID, &azeventhubs.PartitionClientOptions{
 			StartPosition: getStartPosition(firstPartition),
 		})
 		require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestConsumerClient_Concurrent_NoEpoch(t *testing.T) {
 			require.NoError(t, err)
 		}()
 
-		partitionClient, err := client.NewPartitionClient(partitions[0].PartitionID, &azeventhubs.NewPartitionClientOptions{
+		partitionClient, err := client.NewPartitionClient(partitions[0].PartitionID, &azeventhubs.PartitionClientOptions{
 			StartPosition: getStartPosition(partitions[0]),
 		})
 		require.NoError(t, err)
@@ -220,7 +220,7 @@ func TestConsumerClient_SameEpoch_StealsLink(t *testing.T) {
 
 	ownerLevel := int64(2)
 
-	origPartClient, cleanup := newPartitionClientForTest(t, partitions[0].PartitionID, azeventhubs.NewPartitionClientOptions{
+	origPartClient, cleanup := newPartitionClientForTest(t, partitions[0].PartitionID, azeventhubs.PartitionClientOptions{
 		StartPosition: getStartPosition(partitions[0]),
 		OwnerLevel:    &ownerLevel,
 	})
@@ -236,7 +236,7 @@ func TestConsumerClient_SameEpoch_StealsLink(t *testing.T) {
 
 	// link with owner level of 2 is alive, so now we'll steal it.
 
-	thiefPartClient, cleanup := newPartitionClientForTest(t, partitions[0].PartitionID, azeventhubs.NewPartitionClientOptions{
+	thiefPartClient, cleanup := newPartitionClientForTest(t, partitions[0].PartitionID, azeventhubs.PartitionClientOptions{
 		StartPosition: getStartPosition(partitions[0]),
 		OwnerLevel:    &ownerLevel,
 	})
@@ -269,7 +269,7 @@ func TestConsumerClient_LowerEpochsAreRejected(t *testing.T) {
 
 	highestOwnerLevel := int64(2)
 
-	origPartClient, cleanup := newPartitionClientForTest(t, partitions[0].PartitionID, azeventhubs.NewPartitionClientOptions{
+	origPartClient, cleanup := newPartitionClientForTest(t, partitions[0].PartitionID, azeventhubs.PartitionClientOptions{
 		StartPosition: getStartPosition(partitions[0]),
 		OwnerLevel:    &highestOwnerLevel,
 	})
@@ -288,7 +288,7 @@ func TestConsumerClient_LowerEpochsAreRejected(t *testing.T) {
 	}
 
 	for _, ownerLevel := range lowerOwnerLevels {
-		origPartClient, cleanup := newPartitionClientForTest(t, partitions[0].PartitionID, azeventhubs.NewPartitionClientOptions{
+		origPartClient, cleanup := newPartitionClientForTest(t, partitions[0].PartitionID, azeventhubs.PartitionClientOptions{
 			StartPosition: getStartPosition(partitions[0]),
 			OwnerLevel:    ownerLevel,
 		})
@@ -312,7 +312,7 @@ func TestConsumerClient_LowerEpochsAreRejected(t *testing.T) {
 	require.NotEmpty(t, events)
 }
 
-func newPartitionClientForTest(t *testing.T, partitionID string, subscribeOptions azeventhubs.NewPartitionClientOptions) (*azeventhubs.PartitionClient, func()) {
+func newPartitionClientForTest(t *testing.T, partitionID string, subscribeOptions azeventhubs.PartitionClientOptions) (*azeventhubs.PartitionClient, func()) {
 	testParams := test.GetConnectionParamsForTest(t)
 
 	origClient, err := azeventhubs.NewConsumerClientFromConnectionString(testParams.ConnectionString, testParams.EventHubName, "$Default", &azeventhubs.ConsumerClientOptions{
@@ -348,7 +348,7 @@ func TestConsumerClient_StartPositions(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	batch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.NewEventDataBatchOptions{
+	batch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
 		PartitionID: to.Ptr("0"),
 	})
 	require.NoError(t, err)
@@ -379,7 +379,7 @@ func TestConsumerClient_StartPositions(t *testing.T) {
 			require.NoError(t, err)
 		}()
 
-		subscription, err := consumerClient.NewPartitionClient("0", &azeventhubs.NewPartitionClientOptions{
+		subscription, err := consumerClient.NewPartitionClient("0", &azeventhubs.PartitionClientOptions{
 			StartPosition: azeventhubs.StartPosition{
 				Offset: &origPartProps.LastEnqueuedOffset,
 			},
@@ -408,7 +408,7 @@ func TestConsumerClient_StartPositions(t *testing.T) {
 			require.NoError(t, err)
 		}()
 
-		subscription, err := consumerClient.NewPartitionClient("0", &azeventhubs.NewPartitionClientOptions{
+		subscription, err := consumerClient.NewPartitionClient("0", &azeventhubs.PartitionClientOptions{
 			StartPosition: azeventhubs.StartPosition{
 				EnqueuedTime: &origPartProps.LastEnqueuedOn,
 			},
@@ -432,7 +432,7 @@ func TestConsumerClient_StartPositions(t *testing.T) {
 			require.NoError(t, err)
 		}()
 
-		subscription, err := consumerClient.NewPartitionClient("0", &azeventhubs.NewPartitionClientOptions{
+		subscription, err := consumerClient.NewPartitionClient("0", &azeventhubs.PartitionClientOptions{
 			StartPosition: azeventhubs.StartPosition{
 				Earliest: to.Ptr(true),
 			},
@@ -471,7 +471,7 @@ func TestConsumerClient_StartPosition_Latest(t *testing.T) {
 	latestEventsCh := make(chan []*azeventhubs.ReceivedEventData, 1)
 
 	go func() {
-		subscription, err := consumerClient.NewPartitionClient("0", &azeventhubs.NewPartitionClientOptions{
+		subscription, err := consumerClient.NewPartitionClient("0", &azeventhubs.PartitionClientOptions{
 			StartPosition: azeventhubs.StartPosition{
 				Latest: to.Ptr(true),
 			},
@@ -499,7 +499,7 @@ func TestConsumerClient_StartPosition_Latest(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	batch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.NewEventDataBatchOptions{
+	batch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
 		PartitionID: to.Ptr("0"),
 	})
 	require.NoError(t, err)
@@ -558,7 +558,7 @@ func mustSendEventsToAllPartitions(t *testing.T, events []*azeventhubs.EventData
 			partitionsCh <- partProps
 
 			// send the message to the partition.
-			batch, err := producer.NewEventDataBatch(context.Background(), &azeventhubs.NewEventDataBatchOptions{
+			batch, err := producer.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
 				PartitionID: &partitionID,
 			})
 			require.NoError(t, err)

--- a/sdk/messaging/azeventhubs/doc.go
+++ b/sdk/messaging/azeventhubs/doc.go
@@ -4,6 +4,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Package azeventhubs provides clients for sending events, using the ConsumerClient type or
-// the Processor, and receiving using the ProducerClient type.
+// Package azeventhubs provides clients for sending events and consuming events.
+//
+// For sending events, use the [azeventhubs.ProducerClient].
+//
+// There are two clients for consuming events:
+//   - [azeventhubs.Processor], which handles checkpointing and load balancing using durable storage.
+//   - [azeventhubs.ConsumerClient], which is fully manual, but provides full control.
 package azeventhubs

--- a/sdk/messaging/azeventhubs/event_data_batch.go
+++ b/sdk/messaging/azeventhubs/event_data_batch.go
@@ -177,9 +177,9 @@ func calcActualSizeForPayload(payload []byte) uint64 {
 	return uint64(vbin32Overhead + len(payload))
 }
 
-func newEventDataBatch(sender amqpwrap.AMQPSenderCloser, options *NewEventDataBatchOptions) (*EventDataBatch, error) {
+func newEventDataBatch(sender amqpwrap.AMQPSenderCloser, options *EventDataBatchOptions) (*EventDataBatch, error) {
 	if options == nil {
-		options = &NewEventDataBatchOptions{}
+		options = &EventDataBatchOptions{}
 	}
 
 	if options.PartitionID != nil && options.PartitionKey != nil {

--- a/sdk/messaging/azeventhubs/event_data_batch.go
+++ b/sdk/messaging/azeventhubs/event_data_batch.go
@@ -14,11 +14,14 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
 )
 
-// ErrEventDataTooLarge is returned when a message cannot fit into a batch when using EventDataBatch.AddEventData()
+// ErrEventDataTooLarge is returned when a message cannot fit into a batch when using the [azeventhubs.EventDataBatch.AddEventData] function.
 var ErrEventDataTooLarge = errors.New("the EventData could not be added because it is too large for the batch")
 
 type (
-	// EventDataBatch represents a batch of messages to send to Event Hubs in a single message
+	// EventDataBatch is used to efficiently pack up EventData before sending it to Event Hubs.
+	//
+	// EventDataBatch's are not meant to be created directly. Use [azeventhubs.ProducerClient.NewEventDataBatch],
+	// which will create them with the proper size limit for your Event Hub.
 	EventDataBatch struct {
 		mu sync.RWMutex
 
@@ -42,16 +45,20 @@ type AddEventDataOptions struct {
 	// For future expansion
 }
 
-// AddEventData adds an EventData to the batch if the message will not exceed the max size of the batch
-// Returns:
-// - ErrMessageTooLarge if the message cannot fit
-// - a non-nil error for other failures
-// - nil, otherwise
+// AddEventData adds an EventData to the batch, failing if the EventData would
+// cause the EventDataBatch to be too large to send.
+//
+// This size limit was set when the EventDataBatch was created, in options to
+// [azeventhubs.ProducerClient.NewEventDataBatch], or (by default) from Event
+// Hubs itself.
+//
+// Returns ErrMessageTooLarge if the message cannot fit, or a non-nil error for
+// other failures.
 func (mb *EventDataBatch) AddEventData(ed *EventData, options *AddEventDataOptions) error {
 	return mb.addAMQPMessage(ed.toAMQPMessage())
 }
 
-// NumBytes is the number of bytes in the message batch
+// NumBytes is the number of bytes in the batch.
 func (mb *EventDataBatch) NumBytes() uint64 {
 	mb.mu.RLock()
 	defer mb.mu.RUnlock()
@@ -59,7 +66,7 @@ func (mb *EventDataBatch) NumBytes() uint64 {
 	return mb.currentSize
 }
 
-// NumEvents returns the # of events in the batch.
+// NumEvents returns the number of events in the batch.
 func (mb *EventDataBatch) NumEvents() int32 {
 	mb.mu.RLock()
 	defer mb.mu.RUnlock()

--- a/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
+++ b/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
@@ -42,7 +42,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 	link := eventBatchLinkForTest{maxMessageSize: 10000}
 
 	t.Run("default: uses link size", func(t *testing.T) {
-		batch, err := newEventDataBatch(link, &NewEventDataBatchOptions{})
+		batch, err := newEventDataBatch(link, &EventDataBatchOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, batch)
 		require.Equal(t, link.MaxMessageSize(), batch.maxBytes)
@@ -58,7 +58,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 	})
 
 	t.Run("custom size", func(t *testing.T) {
-		batch, err := newEventDataBatch(link, &NewEventDataBatchOptions{
+		batch, err := newEventDataBatch(link, &EventDataBatchOptions{
 			MaxBytes: 9,
 		})
 		require.NoError(t, err)
@@ -67,13 +67,13 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 	})
 
 	t.Run("requested size is bigger than allowed size", func(t *testing.T) {
-		batch, err := newEventDataBatch(link, &NewEventDataBatchOptions{MaxBytes: link.maxMessageSize + 1})
+		batch, err := newEventDataBatch(link, &EventDataBatchOptions{MaxBytes: link.maxMessageSize + 1})
 		require.EqualError(t, err, fmt.Sprintf("maximum message size for batch was set to %d bytes, which is larger than the maximum size allowed by link (%d)", link.maxMessageSize+1, link.MaxMessageSize()))
 		require.Nil(t, batch)
 	})
 
 	t.Run("partition key", func(t *testing.T) {
-		batch, err := newEventDataBatch(link, &NewEventDataBatchOptions{
+		batch, err := newEventDataBatch(link, &EventDataBatchOptions{
 			PartitionKey: to.Ptr("hello-partition-key"),
 		})
 		require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 	})
 
 	t.Run("partition ID", func(t *testing.T) {
-		batch, err := newEventDataBatch(link, &NewEventDataBatchOptions{
+		batch, err := newEventDataBatch(link, &EventDataBatchOptions{
 			PartitionID: to.Ptr("101"),
 		})
 		require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 	as2k := [2048]byte{'A'}
 
 	t.Run("sizeCalculationsAreCorrectVBin8", func(t *testing.T) {
-		mb, err := newEventDataBatch(link, &NewEventDataBatchOptions{MaxBytes: 8000})
+		mb, err := newEventDataBatch(link, &EventDataBatchOptions{MaxBytes: 8000})
 		require.NoError(t, err)
 
 		err = mb.AddEventData(&EventData{
@@ -118,7 +118,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 	})
 
 	t.Run("sizeCalculationsAreCorrectVBin32", func(t *testing.T) {
-		mb, err := newEventDataBatch(link, &NewEventDataBatchOptions{MaxBytes: 8000})
+		mb, err := newEventDataBatch(link, &EventDataBatchOptions{MaxBytes: 8000})
 		require.NoError(t, err)
 
 		err = mb.AddEventData(&EventData{
@@ -144,7 +144,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 	// the first message gets special treatment since it gets used as the actual
 	// batch message's envelope.
 	t.Run("firstMessageTooLarge", func(t *testing.T) {
-		mb, err := newEventDataBatch(link, &NewEventDataBatchOptions{MaxBytes: 1})
+		mb, err := newEventDataBatch(link, &EventDataBatchOptions{MaxBytes: 1})
 		require.NoError(t, err)
 
 		err = mb.AddEventData(&EventData{
@@ -158,7 +158,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 	})
 
 	t.Run("addTooManyMessages", func(t *testing.T) {
-		mb, err := newEventDataBatch(link, &NewEventDataBatchOptions{MaxBytes: 200})
+		mb, err := newEventDataBatch(link, &EventDataBatchOptions{MaxBytes: 200})
 		require.NoError(t, err)
 
 		require.EqualValues(t, 0, mb.currentSize)
@@ -181,7 +181,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 	})
 
 	t.Run("addConcurrently", func(t *testing.T) {
-		mb, err := newEventDataBatch(link, &NewEventDataBatchOptions{MaxBytes: 10000})
+		mb, err := newEventDataBatch(link, &EventDataBatchOptions{MaxBytes: 10000})
 		require.NoError(t, err)
 
 		wg := sync.WaitGroup{}

--- a/sdk/messaging/azeventhubs/example_consuming_events_test.go
+++ b/sdk/messaging/azeventhubs/example_consuming_events_test.go
@@ -36,20 +36,20 @@ func Example_consuming_events() {
 
 	defer consumerClient.Close(context.TODO())
 
-	subscription, err := consumerClient.NewPartitionClient(eventHubPartitionID, nil)
+	partitionClient, err := consumerClient.NewPartitionClient(eventHubPartitionID, nil)
 
 	if err != nil {
 		panic(err)
 	}
 
-	defer subscription.Close(context.TODO())
+	defer partitionClient.Close(context.TODO())
 
 	for {
 		// ReceiveEvents will wait until it either receives the # of events requested (100, in this call)
 		// or if the context is cancelled, in which case it'll return any messages it has received.
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 
-		events, err := subscription.ReceiveEvents(ctx, 100, nil)
+		events, err := partitionClient.ReceiveEvents(ctx, 100, nil)
 		cancel()
 
 		if err != nil {

--- a/sdk/messaging/azeventhubs/example_consuming_events_test.go
+++ b/sdk/messaging/azeventhubs/example_consuming_events_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 )
 
-func Example_consumingEvents() {
+func Example_consumingEventsUsingConsumerClient() {
 	eventHubNamespace := os.Getenv("EVENTHUB_NAMESPACE") // <ex: myeventhubnamespace.servicebus.windows.net>
 	eventHubName := os.Getenv("EVENTHUB_NAME")
 	eventHubPartitionID := os.Getenv("EVENTHUB_PARTITION")

--- a/sdk/messaging/azeventhubs/example_consuming_events_test.go
+++ b/sdk/messaging/azeventhubs/example_consuming_events_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 )
 
-func Example_consuming_events() {
+func Example_consumingEvents() {
 	eventHubNamespace := os.Getenv("EVENTHUB_NAMESPACE") // <ex: myeventhubnamespace.servicebus.windows.net>
 	eventHubName := os.Getenv("EVENTHUB_NAME")
 	eventHubPartitionID := os.Getenv("EVENTHUB_PARTITION")

--- a/sdk/messaging/azeventhubs/example_processor_test.go
+++ b/sdk/messaging/azeventhubs/example_processor_test.go
@@ -43,6 +43,8 @@ func Example_consuming_events_using_processor() {
 		panic(err)
 	}
 
+	defer consumerClient.Close(context.TODO())
+
 	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, nil)
 
 	if err != nil {

--- a/sdk/messaging/azeventhubs/example_processor_test.go
+++ b/sdk/messaging/azeventhubs/example_processor_test.go
@@ -52,7 +52,7 @@ func Example_consumingEventsUsingProcessor() {
 
 	// Create the Processor
 	//
-	// The Processor is will handle load balancing with other Processor instances, running in separate
+	// The Processor handles load balancing with other Processor instances, running in separate
 	// processes or even on separate machines. Each one will use the checkpointStore to coordinate
 	// state and ownership, dynamically.
 	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, nil)
@@ -61,12 +61,12 @@ func Example_consumingEventsUsingProcessor() {
 		panic(err)
 	}
 
-	// this will be launched in a goroutine and will just continue to loop
-	// and process partitions.
+	// This function will be launched in a goroutine and will loop and launch
+	// processing of partitions, in parallel.
 	dispatchPartitionClients := func() {
-		// This loop will run and eventually terminate when either:
-		// 1. You cancel the passed in context
-		// 2. The Processor.Run() call is cancelled or terminates.
+		// Our loop will terminate when:
+		// - You cancel the passed in context
+		// - The Processor.Run() call is cancelled or terminates.
 		for {
 			partitionClient := processor.NextPartitionClient(context.TODO())
 
@@ -96,8 +96,8 @@ func Example_consumingEventsUsingProcessor() {
 	processorCtx, processorCancel := context.WithCancel(context.TODO())
 	defer processorCancel()
 
-	// Run the load balancer. The dispatchPartitionClient goroutine, launched
-	// above, will continually receive ProcessorPartitionClients as partitions
+	// Run the load balancer. The dispatchPartitionClients goroutine, launched
+	// above, will continually get new ProcessorPartitionClient's as partitions
 	// are allocated.
 	//
 	// Stopping the processor is as simple as canceling the context that you passed

--- a/sdk/messaging/azeventhubs/example_processor_test.go
+++ b/sdk/messaging/azeventhubs/example_processor_test.go
@@ -122,7 +122,7 @@ func processEvents(partitionClient *azeventhubs.ProcessorPartitionClient) error 
 	defer closePartitionResources(partitionClient)
 
 	// [BEGIN] Initialize any resources needed to process the partition
-	if err := initializePartitionResources(); err != nil {
+	if err := initializePartitionResources(partitionClient.PartitionID()); err != nil {
 		return err
 	}
 

--- a/sdk/messaging/azeventhubs/example_processor_test.go
+++ b/sdk/messaging/azeventhubs/example_processor_test.go
@@ -30,6 +30,7 @@ func Example_consuming_events_using_processor() {
 	containerName := os.Getenv("CHECKPOINTSTORE_STORAGE_CONTAINER_NAME")
 
 	// Create the checkpoint store
+	//
 	// NOTE: the Blob container must exist before the checkpoint store can be used.
 	checkpointStore, err := checkpoints.NewBlobStoreFromConnectionString(storageCS, containerName, nil)
 
@@ -37,6 +38,10 @@ func Example_consuming_events_using_processor() {
 		panic(err)
 	}
 
+	// Create a ConsumerClient
+	//
+	// The Processor (created below) will use this to create any PartitionClient instances, as ownership
+	// is assigned.
 	consumerClient, err := azeventhubs.NewConsumerClientFromConnectionString(ehCS, eventHubName, azeventhubs.DefaultConsumerGroup, nil)
 
 	if err != nil {
@@ -45,22 +50,36 @@ func Example_consuming_events_using_processor() {
 
 	defer consumerClient.Close(context.TODO())
 
+	// Create the Processor
+	//
+	// The Processor is will handle load balancing with other Processor instances, running in separate
+	// processes or even on separate machines. Each one will use the checkpointStore to coordinate
+	// state and ownership, dynamically.
 	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, nil)
 
 	if err != nil {
 		panic(err)
 	}
 
-	dispatchProcessors := func() {
-		// Loop continually - each time we acquire a new partition NextPartitionClient() will
-		// return it.
+	// this will be launched in a goroutine and will just continue to loop
+	// and process partitions.
+	dispatchPartitionClients := func() {
+		// This loop will run and eventually terminate when either:
+		// 1. You cancel the passed in context
+		// 2. The Processor.Run() call is cancelled or terminates.
 		for {
 			partitionClient := processor.NextPartitionClient(context.TODO())
 
 			if partitionClient == nil {
+				// this happens if Processor.Run terminates or if you cancel
+				// the passed in context.
 				break
 			}
 
+			// Each time you get a ProcessorPartitionClient, you are the
+			// exclusive owner. The previous owner (if there was one) will get an
+			// *azeventhubs.Error from their next call to PartitionClient.ReceiveEvents()
+			// with a Code of CodeOwnershipLost.
 			go func() {
 				if err := processEvents(partitionClient); err != nil {
 					panic(err)
@@ -69,44 +88,59 @@ func Example_consuming_events_using_processor() {
 		}
 	}
 
-	go dispatchProcessors()
+	go dispatchPartitionClients()
 
+	// This context will control the lifetime of the Processor.Run call.
+	// When it is cancelled the processor will stop running and also close
+	// any ProcessorPartitionClient's it opened while running.
 	processorCtx, processorCancel := context.WithCancel(context.TODO())
 	defer processorCancel()
 
-	// Launch the load balancer. The dispatchProcessors() goroutine, launched
+	// Run the load balancer. The dispatchPartitionClient goroutine, launched
 	// above, will continually receive ProcessorPartitionClients as partitions
 	// are allocated.
 	//
-	// To stop the processor cancel the context that you passed in to Run().
+	// Stopping the processor is as simple as canceling the context that you passed
+	// in to Run.
 	if err := processor.Run(processorCtx); err != nil {
 		panic(err)
 	}
 }
 
 func processEvents(partitionClient *azeventhubs.ProcessorPartitionClient) error {
-	// initialize any resources needed to process the partition
-	// This is the equivalent to PartitionOpen
+	// In other models of the Processor we have broken up the partition
+	// lifecycle model.
+	//
+	// In Go, we model this as a function call with a loop, using this structure:
+	//
+	// 1. [BEGIN] Initialize any partition specific resources.
+	// 2. [CONTINUOUS] Run a loop, calling ReceiveEvents() and UpdateCheckpoint().
+	// 3. [END] Close any resources associated with the processor.
 
-	defer func() {
-		// Do cleanup here, like shutting down database connections
-		// or other resources used for processing this partition.
-		partitionClient.Close(context.TODO())
-	}()
+	// [END] Do cleanup here, like shutting down database connections
+	// or other resources used for processing this partition.
+	defer closePartitionResources(partitionClient)
 
+	// [BEGIN] Initialize any resources needed to process the partition
+	if err := initializePartitionResources(); err != nil {
+		return err
+	}
+
+	// [CONTINUOUS] loop until you lose ownership or your own criteria, checkpointing
+	// as needed using UpdateCheckpoint.
 	for {
-		// wait for a minute for up to 100 events to arrive.
+		// Wait for a minute (controlled by the receiveCtx) or for 100 events to arrive.
 		receiveCtx, receiveCtxCancel := context.WithTimeout(context.TODO(), time.Minute)
 		events, err := partitionClient.ReceiveEvents(receiveCtx, 100, nil)
 		receiveCtxCancel()
 
+		// Timing out (context.DeadlineExceeded) is fine. We didn't receive our 100 events
+		// but we might have received _some_ events.
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 			if eventHubError := (*azeventhubs.Error)(nil); errors.As(err, &eventHubError) && eventHubError.Code == exported.CodeOwnershipLost {
 				// This means that the partition was "stolen" - this can happen as partitions are balanced between
-				// consumers.
-
-				// the 'defer'd function we did above will take of any resource cleanup so we'll just exit the
-				// function at this point.
+				// consumers. We'll exit here and just let our "defer closePartitionResources" handle closing
+				// resources, including the ProcessorPartitionClient.
 				return nil
 			}
 
@@ -120,12 +154,26 @@ func processEvents(partitionClient *azeventhubs.ProcessorPartitionClient) error 
 			fmt.Printf("Event received with body %v\n", event.Body)
 		}
 
+		// it's possible to get zero events if the partition is empty, or if no new events have arrived
+		// since your last receive.
 		if len(events) != 0 {
-			// Update the checkpoint with the last event received. If the processor is restarted
-			// it will resume from this point in the partition.
+			// Update the checkpoint with the last event received. If we lose ownership of this partition or
+			// have to restart the next owner will start from this point.
 			if err := partitionClient.UpdateCheckpoint(context.TODO(), events[len(events)-1]); err != nil {
 				return err
 			}
 		}
 	}
+}
+
+func initializePartitionResources(partitionID string) error {
+	// initialize things that might be partition specific, like a
+	// database connection.
+	return nil
+}
+
+func closePartitionResources(partitionClient *azeventhubs.ProcessorPartitionClient) {
+	// Each PartitionClient holds onto an external resource and should be closed if you're
+	// not processing them anymore.
+	defer partitionClient.Close(context.TODO())
 }

--- a/sdk/messaging/azeventhubs/example_processor_test.go
+++ b/sdk/messaging/azeventhubs/example_processor_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/exported"
 )
 
-func Example_consuming_events_using_processor() {
+func Example_consumingEventsUsingProcessor() {
 	// The Processor makes it simpler to do distributed consumption of an Event Hub.
 	// It automatically coordinates with other Processor instances to ensure balanced
 	// allocation of partitions and tracks status, durably, in a CheckpointStore.

--- a/sdk/messaging/azeventhubs/example_producing_events_test.go
+++ b/sdk/messaging/azeventhubs/example_producing_events_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 )
 
-func Example_producingEvents() {
+func Example_producingEventsUsingProducerClient() {
 	eventHubNamespace := os.Getenv("EVENTHUB_NAMESPACE") // <ex: myeventhubnamespace.servicebus.windows.net>
 	eventHubName := os.Getenv("EVENTHUB_NAME")
 

--- a/sdk/messaging/azeventhubs/example_producing_events_test.go
+++ b/sdk/messaging/azeventhubs/example_producing_events_test.go
@@ -47,7 +47,7 @@ func Example_producing() {
 	// batch, err := producerClient.NewEventDataBatch(context.TODO(), &azeventhubs.NewEventDataBatchOptions{
 	// 	PartitionKey: to.Ptr("partition key"),
 	// })
-	newBatchOptions := &azeventhubs.NewEventDataBatchOptions{}
+	newBatchOptions := &azeventhubs.EventDataBatchOptions{}
 
 	batch, err := producerClient.NewEventDataBatch(context.TODO(), newBatchOptions)
 

--- a/sdk/messaging/azeventhubs/example_producing_events_test.go
+++ b/sdk/messaging/azeventhubs/example_producing_events_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 )
 
-func Example_producing() {
+func Example_producingEvents() {
 	eventHubNamespace := os.Getenv("EVENTHUB_NAMESPACE") // <ex: myeventhubnamespace.servicebus.windows.net>
 	eventHubName := os.Getenv("EVENTHUB_NAME")
 

--- a/sdk/messaging/azeventhubs/example_producing_events_test.go
+++ b/sdk/messaging/azeventhubs/example_producing_events_test.go
@@ -36,14 +36,16 @@ func Example_producingEvents() {
 
 	events := createEventsForSample()
 
-	// Other examples:
+	// Other options you might consider:
 	//
-	// sending a batch to a specific partition:
+	// Targeting a batch to a specific partition
+	//
 	// batch, err := producerClient.NewEventDataBatch(context.TODO(), &azeventhubs.NewEventDataBatchOptions{
 	// 	PartitionID: to.Ptr("0"),
 	// })
 	//
-	// targeting a batch using a partition key
+	// Targeting a batch using a partition key
+	//
 	// batch, err := producerClient.NewEventDataBatch(context.TODO(), &azeventhubs.NewEventDataBatchOptions{
 	// 	PartitionKey: to.Ptr("partition key"),
 	// })

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/finite_processor_stress.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/finite_processor_stress.go
@@ -93,7 +93,7 @@ func FiniteProcessorTest(ctx context.Context) error {
 		return err
 	}
 
-	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.NewProcessorOptions{
+	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.ProcessorOptions{
 		LoadBalancingStrategy: azeventhubs.ProcessorStrategyGreedy,
 	})
 

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/finite_processor_stress.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/finite_processor_stress.go
@@ -73,7 +73,7 @@ func FiniteProcessorTest(ctx context.Context) error {
 
 	defer producerClient.Close(ctx)
 
-	err = initCheckpointStore(ctx, producerClient, azeventhubs.CheckpointStoreAddress{
+	err = initCheckpointStore(ctx, producerClient, azeventhubs.Checkpoint{
 		ConsumerGroup:           azeventhubs.DefaultConsumerGroup,
 		FullyQualifiedNamespace: testData.Namespace,
 		EventHubName:            testData.HubName,

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/finite_send_and_receive.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/finite_send_and_receive.go
@@ -104,7 +104,7 @@ func consumeEventsFromPartition(ctx context.Context, consumerClient *azeventhubs
 	// read in 10 second chunks. If we ever end a 10 second chunk with no messages
 	// then we've probably just failed.
 
-	partitionClient, err := consumerClient.NewPartitionClient(partitionID, &azeventhubs.NewPartitionClientOptions{
+	partitionClient, err := consumerClient.NewPartitionClient(partitionID, &azeventhubs.PartitionClientOptions{
 		StartPosition: startPosition,
 	})
 

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/infinite_processor.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/infinite_processor.go
@@ -104,7 +104,7 @@ func InfiniteProcessorTest(ctx context.Context) error {
 
 			defer consumerClient.Close(ctx)
 
-			processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.NewProcessorOptions{
+			processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.ProcessorOptions{
 				LoadBalancingStrategy: azeventhubs.ProcessorStrategyGreedy,
 			})
 
@@ -184,7 +184,7 @@ func continuallySendEvents(ctx context.Context, producerClient *azeventhubs.Prod
 		default:
 		}
 
-		batch, err := producerClient.NewEventDataBatch(ctx, &azeventhubs.NewEventDataBatchOptions{
+		batch, err := producerClient.NewEventDataBatch(ctx, &azeventhubs.EventDataBatchOptions{
 			PartitionID: &partitionID,
 		})
 

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/infinite_processor.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/infinite_processor.go
@@ -261,7 +261,7 @@ func testInitialize(ctx context.Context, testData *stressTestData, containerName
 
 	defer producerClient.Close(ctx)
 
-	err = initCheckpointStore(ctx, producerClient, azeventhubs.CheckpointStoreAddress{
+	err = initCheckpointStore(ctx, producerClient, azeventhubs.Checkpoint{
 		ConsumerGroup:           azeventhubs.DefaultConsumerGroup,
 		FullyQualifiedNamespace: testData.Namespace,
 		EventHubName:            testData.HubName,

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
@@ -119,7 +119,7 @@ func sendEventsToPartition(ctx context.Context, producerClient *azeventhubs.Prod
 
 	extraBytes := make([]byte, numExtraBytes)
 
-	batch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.NewEventDataBatchOptions{
+	batch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
 		PartitionID: &partitionID,
 	})
 
@@ -152,7 +152,7 @@ func sendEventsToPartition(ctx context.Context, producerClient *azeventhubs.Prod
 				return azeventhubs.StartPosition{}, err
 			}
 
-			tempBatch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.NewEventDataBatchOptions{
+			tempBatch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
 				PartitionID: &partitionID,
 			})
 

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
@@ -197,7 +197,7 @@ func sendEventsToPartition(ctx context.Context, producerClient *azeventhubs.Prod
 	return sp, nil
 }
 
-func initCheckpointStore(ctx context.Context, client propertiesClient, baseAddress azeventhubs.CheckpointStoreAddress, cps azeventhubs.CheckpointStore) error {
+func initCheckpointStore(ctx context.Context, client propertiesClient, baseCheckpoint azeventhubs.Checkpoint, cps azeventhubs.CheckpointStore) error {
 	hubProps, err := client.GetEventHubProperties(ctx, nil)
 
 	if err != nil {
@@ -211,23 +211,18 @@ func initCheckpointStore(ctx context.Context, client propertiesClient, baseAddre
 			return err
 		}
 
-		newAddress := baseAddress
-		newAddress.PartitionID = partitionID
-
-		var checkpointData azeventhubs.CheckpointData
+		newCheckpoint := baseCheckpoint
+		newCheckpoint.PartitionID = partitionID
 
 		if partProps.IsEmpty {
-			checkpointData.Offset = to.Ptr[int64](-1)
-			checkpointData.SequenceNumber = to.Ptr[int64](0)
+			newCheckpoint.Offset = to.Ptr[int64](-1)
+			newCheckpoint.SequenceNumber = to.Ptr[int64](0)
 		} else {
-			checkpointData.Offset = &partProps.LastEnqueuedOffset
-			checkpointData.SequenceNumber = &partProps.LastEnqueuedSequenceNumber
+			newCheckpoint.Offset = &partProps.LastEnqueuedOffset
+			newCheckpoint.SequenceNumber = &partProps.LastEnqueuedSequenceNumber
 		}
 
-		err = cps.UpdateCheckpoint(ctx, azeventhubs.Checkpoint{
-			CheckpointStoreAddress: newAddress,
-			CheckpointData:         checkpointData,
-		}, nil)
+		err = cps.UpdateCheckpoint(ctx, newCheckpoint, nil)
 
 		if err != nil {
 			return err

--- a/sdk/messaging/azeventhubs/internal/exported/new_websocket_conn_args.go
+++ b/sdk/messaging/azeventhubs/internal/exported/new_websocket_conn_args.go
@@ -5,9 +5,9 @@ package exported
 
 // NOTE: this struct is exported via client.go:NewWebSocketConnArgs
 
-// NewWebSocketConnArgs are the arguments to the NewWebSocketConn function you pass if you want
+// WebSocketConnArgs are the arguments to the NewWebSocketConn function you pass if you want
 // to enable websockets.
-type NewWebSocketConnArgs struct {
+type WebSocketConnArgs struct {
 	// Host is the the `wss://<host>` to connect to
 	Host string
 }

--- a/sdk/messaging/azeventhubs/internal/namespace.go
+++ b/sdk/messaging/azeventhubs/internal/namespace.go
@@ -43,7 +43,7 @@ type (
 		tlsConfig     *tls.Config
 		userAgent     string
 
-		newWebSocketConn func(ctx context.Context, args exported.NewWebSocketConnArgs) (net.Conn, error)
+		newWebSocketConn func(ctx context.Context, args exported.WebSocketConnArgs) (net.Conn, error)
 
 		// NOTE: exported only so it can be checked in a test
 		RetryOptions exported.RetryOptions
@@ -117,7 +117,7 @@ func NamespaceWithUserAgent(userAgent string) NamespaceOption {
 }
 
 // NamespaceWithWebSocket configures the namespace and all entities to use wss:// rather than amqps://
-func NamespaceWithWebSocket(newWebSocketConn func(ctx context.Context, args exported.NewWebSocketConnArgs) (net.Conn, error)) NamespaceOption {
+func NamespaceWithWebSocket(newWebSocketConn func(ctx context.Context, args exported.WebSocketConnArgs) (net.Conn, error)) NamespaceOption {
 	return func(ns *Namespace) error {
 		ns.newWebSocketConn = newWebSocketConn
 		return nil
@@ -175,7 +175,7 @@ func (ns *Namespace) newClientImpl(ctx context.Context) (amqpwrap.AMQPClient, er
 	}
 
 	if ns.newWebSocketConn != nil {
-		nConn, err := ns.newWebSocketConn(ctx, exported.NewWebSocketConnArgs{
+		nConn, err := ns.newWebSocketConn(ctx, exported.WebSocketConnArgs{
 			Host: ns.getWSSHostURI() + "$servicebus/websocket",
 		})
 

--- a/sdk/messaging/azeventhubs/partition_client.go
+++ b/sdk/messaging/azeventhubs/partition_client.go
@@ -132,7 +132,7 @@ func (cc *PartitionClient) ReceiveEvents(ctx context.Context, count int, options
 	return events, nil
 }
 
-// Close closes the consumer's link and the underlying AMQP connection.
+// Close releases resources for this client.
 func (cc *PartitionClient) Close(ctx context.Context) error {
 	if cc.links != nil {
 		return cc.links.Close(ctx)

--- a/sdk/messaging/azeventhubs/partition_client.go
+++ b/sdk/messaging/azeventhubs/partition_client.go
@@ -21,6 +21,8 @@ const DefaultConsumerGroup = "$Default"
 
 // StartPosition indicates the position to start receiving events within a partition.
 // The default position is Latest.
+//
+// You can set this in the options for ConsumerClient.
 type StartPosition struct {
 	// Offset will start the consumer after the specified offset. Can be exclusive
 	// or inclusive, based on the Inclusive property.
@@ -48,6 +50,8 @@ type StartPosition struct {
 }
 
 // PartitionClient is used to receive events from an Event Hub partition.
+//
+// This type is instantiated from the [ConsumerClient] type, using [ConsumerClient.NewPartitionClient].
 type PartitionClient struct {
 	retryOptions  RetryOptions
 	eventHub      string

--- a/sdk/messaging/azeventhubs/partition_client.go
+++ b/sdk/messaging/azeventhubs/partition_client.go
@@ -186,9 +186,9 @@ type partitionClientArgs struct {
 	retryOptions RetryOptions
 }
 
-func newPartitionClient(args partitionClientArgs, options *NewPartitionClientOptions) (*PartitionClient, error) {
+func newPartitionClient(args partitionClientArgs, options *PartitionClientOptions) (*PartitionClient, error) {
 	if options == nil {
-		options = &NewPartitionClientOptions{}
+		options = &PartitionClientOptions{}
 	}
 
 	offsetExpr, err := getOffsetExpression(options.StartPosition)

--- a/sdk/messaging/azeventhubs/processor.go
+++ b/sdk/messaging/azeventhubs/processor.go
@@ -27,9 +27,9 @@ const (
 	ProcessorStrategyGreedy ProcessorStrategy = "greedy"
 )
 
-// NewProcessorOptions are the options for the NewProcessor
+// ProcessorOptions are the options for the NewProcessor
 // function.
-type NewProcessorOptions struct {
+type ProcessorOptions struct {
 	// LoadBalancingStrategy dictates how concurrent Processor instances distribute
 	// ownership of partitions between them.
 	// The default strategy is ProcessorStrategyBalanced.
@@ -90,18 +90,18 @@ type Processor struct {
 
 type consumerClientForProcessor interface {
 	GetEventHubProperties(ctx context.Context, options *GetEventHubPropertiesOptions) (EventHubProperties, error)
-	NewPartitionClient(partitionID string, options *NewPartitionClientOptions) (*PartitionClient, error)
+	NewPartitionClient(partitionID string, options *PartitionClientOptions) (*PartitionClient, error)
 	getDetails() consumerClientDetails
 }
 
 // NewProcessor creates a Processor.
-func NewProcessor(consumerClient *ConsumerClient, checkpointStore CheckpointStore, options *NewProcessorOptions) (*Processor, error) {
+func NewProcessor(consumerClient *ConsumerClient, checkpointStore CheckpointStore, options *ProcessorOptions) (*Processor, error) {
 	return newProcessorImpl(consumerClient, checkpointStore, options)
 }
 
-func newProcessorImpl(consumerClient consumerClientForProcessor, checkpointStore CheckpointStore, options *NewProcessorOptions) (*Processor, error) {
+func newProcessorImpl(consumerClient consumerClientForProcessor, checkpointStore CheckpointStore, options *ProcessorOptions) (*Processor, error) {
 	if options == nil {
-		options = &NewProcessorOptions{}
+		options = &ProcessorOptions{}
 	}
 
 	updateInterval := 10 * time.Second
@@ -299,7 +299,7 @@ func (p *Processor) addPartitionClient(ctx context.Context, ownership Ownership,
 		return err
 	}
 
-	partClient, err := p.consumerClient.NewPartitionClient(ownership.PartitionID, &NewPartitionClientOptions{
+	partClient, err := p.consumerClient.NewPartitionClient(ownership.PartitionID, &PartitionClientOptions{
 		StartPosition: sp,
 		OwnerLevel:    &p.ownerLevel,
 	})

--- a/sdk/messaging/azeventhubs/processor.go
+++ b/sdk/messaging/azeventhubs/processor.go
@@ -183,27 +183,12 @@ func (p *Processor) NextPartitionClient(ctx context.Context) *ProcessorPartition
 	}
 }
 
-// Run handles the load balancing loop, blocking until it encounters fatal errors or the
-// passed in context is cancelled.
+// Run handles the load balancing loop, blocking until the passed in context is cancelled
+// or it encounters an unrecoverable error. On cancellation, it will return a nil error.
 //
-// Run continually checks the passed in CheckpointStore, attempting to distribute partitions
-// fairly between itself and any other active consumers. New [ProcessorPartitionClient] instances
-// are created and will be returned from [Processor.NextPartitionClient] as they are available.
-//
-// When partition ownership is lost [ProcessorPartitionClient]'s will return an errors.
-//
-// Callers will typically create a goroutine, continually calling
-// [Processor.NextPartitionClient] in a loop to get [ProcessorPartitionClient]
-// instances, and then process those in parallel.
-//
-// The main thread will call [Processor.Run], blocking until the context passed
-// to Run is cancelled.
-//
-
-// Run will exit when the passed in context has been cancelled or if there are unrecoverable
-// or persistent errors in load balancing.
-//
-// On cancellation, it will return a nil error.
+// As partitions are claimed new [ProcessorPartitionClient] instances will be returned from
+// [Processor.NextPartitionClient]. This can happen at any time, based on new Processor instances
+// coming online, as well as other Processors exiting.
 //
 // See [example_processor_test.go] for an example of typical usage.
 //

--- a/sdk/messaging/azeventhubs/processor.go
+++ b/sdk/messaging/azeventhubs/processor.go
@@ -75,6 +75,8 @@ type StartPositions struct {
 //
 // See [example_processor_test.go] for an example of typical usage or Run
 // for a more detailed description of how load balancing works.
+//
+// [example_processor_test.go]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/example_processor_test.go
 type Processor struct {
 	ownershipUpdateInterval time.Duration
 	defaultStartPositions   StartPositions
@@ -100,7 +102,9 @@ type consumerClientForProcessor interface {
 
 // NewProcessor creates a Processor.
 //
-// See [Processor] for more information or the [example_processor_test.go] for an example.
+// More general information can be found on the documentation for the [azeventhubs.Processor] type or the [example_processor_test.go] for an example.
+//
+// [example_processor_test.go]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/example_processor_test.go
 func NewProcessor(consumerClient *ConsumerClient, checkpointStore CheckpointStore, options *ProcessorOptions) (*Processor, error) {
 	return newProcessorImpl(consumerClient, checkpointStore, options)
 }
@@ -166,6 +170,8 @@ func newProcessorImpl(consumerClient consumerClientForProcessor, checkpointStore
 // be executed in a goroutine in a loop.
 //
 // See [example_processor_test.go] for an example of typical usage.
+//
+// [example_processor_test.go]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/example_processor_test.go
 func (p *Processor) NextPartitionClient(ctx context.Context) *ProcessorPartitionClient {
 	<-p.runCalled
 
@@ -200,6 +206,8 @@ func (p *Processor) NextPartitionClient(ctx context.Context) *ProcessorPartition
 // On cancellation, it will return a nil error.
 //
 // See [example_processor_test.go] for an example of typical usage.
+//
+// [example_processor_test.go]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/example_processor_test.go
 func (p *Processor) Run(ctx context.Context) error {
 	err := p.runImpl(ctx)
 

--- a/sdk/messaging/azeventhubs/processor.go
+++ b/sdk/messaging/azeventhubs/processor.go
@@ -102,7 +102,8 @@ type consumerClientForProcessor interface {
 
 // NewProcessor creates a Processor.
 //
-// More general information can be found on the documentation for the [azeventhubs.Processor] type or the [example_processor_test.go] for an example.
+// More information can be found in the documentation for the [azeventhubs.Processor]
+// type or the [example_processor_test.go] for an example.
 //
 // [example_processor_test.go]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/example_processor_test.go
 func NewProcessor(consumerClient *ConsumerClient, checkpointStore CheckpointStore, options *ProcessorOptions) (*Processor, error) {

--- a/sdk/messaging/azeventhubs/processor.go
+++ b/sdk/messaging/azeventhubs/processor.go
@@ -164,7 +164,7 @@ func newProcessorImpl(consumerClient consumerClientForProcessor, checkpointStore
 }
 
 // NextPartitionClient will get the next owned [PartitionProcessorClient] if one is acquired
-// or will block until a new one arrives or [processor.Run] is cancelled.
+// or will block until a new one arrives or [processor.Run] is cancelled. You MUST call [azeventhubs.ProcessorPartitionClient.Close] on the returned client to avoid leaking resources.
 //
 // This function is safe to call before [processor.Run] has been called and will typically
 // be executed in a goroutine in a loop.

--- a/sdk/messaging/azeventhubs/processor_load_balancer.go
+++ b/sdk/messaging/azeventhubs/processor_load_balancer.go
@@ -139,17 +139,13 @@ func (lb *processorLoadBalancer) getAvailablePartitions(ctx context.Context, par
 		}
 
 		unownedOrExpired = append(unownedOrExpired, Ownership{
-			CheckpointStoreAddress: CheckpointStoreAddress{
-				FullyQualifiedNamespace: lb.details.FullyQualifiedNamespace,
-				ConsumerGroup:           lb.details.ConsumerGroup,
-				EventHubName:            lb.details.EventHubName,
-				PartitionID:             partID,
-			},
-			OwnershipData: OwnershipData{
-				OwnerID: lb.details.ClientID,
-				// note that we don't have etag info here since nobody has
-				// ever owned this partition.
-			},
+			FullyQualifiedNamespace: lb.details.FullyQualifiedNamespace,
+			ConsumerGroup:           lb.details.ConsumerGroup,
+			EventHubName:            lb.details.EventHubName,
+			PartitionID:             partID,
+			OwnerID:                 lb.details.ClientID,
+			// note that we don't have etag info here since nobody has
+			// ever owned this partition.
 		})
 	}
 

--- a/sdk/messaging/azeventhubs/processor_load_balancers_test.go
+++ b/sdk/messaging/azeventhubs/processor_load_balancers_test.go
@@ -311,15 +311,11 @@ const testEventHubName = "event-hub"
 
 func newTestOwnership(partitionID string, ownerID string) Ownership {
 	return Ownership{
-		OwnershipData: OwnershipData{
-			OwnerID: ownerID,
-		},
-		CheckpointStoreAddress: CheckpointStoreAddress{
-			PartitionID:             partitionID,
-			ConsumerGroup:           testConsumerGroup,
-			EventHubName:            testEventHubName,
-			FullyQualifiedNamespace: testEventHubFQDN,
-		},
+		OwnerID:                 ownerID,
+		PartitionID:             partitionID,
+		ConsumerGroup:           testConsumerGroup,
+		EventHubName:            testEventHubName,
+		FullyQualifiedNamespace: testEventHubFQDN,
 	}
 }
 

--- a/sdk/messaging/azeventhubs/processor_partition_client.go
+++ b/sdk/messaging/azeventhubs/processor_partition_client.go
@@ -7,7 +7,13 @@ import "context"
 
 // ProcessorPartitionClient allows you to receive events, similar to a PartitionClient, with
 // integration into a checkpoint store for tracking progress.
-// NOTE: This type is instantiated using the Processor type, which handles dynamic load balancing.
+//
+// This type is instantiated from the Processor type, which handles dynamic load balancing.
+//
+// See [example_processor_test.go] for an example of typical usage.
+//
+// NOTE: If you do NOT want to use dynamic load balancing, and would prefer to track state and ownership
+// manually, use the [ConsumerClient] type instead.
 type ProcessorPartitionClient struct {
 	partitionID           string
 	innerClient           *PartitionClient // *azeventhubs.PartitionClient
@@ -22,8 +28,8 @@ func (c *ProcessorPartitionClient) ReceiveEvents(ctx context.Context, count int,
 	return c.innerClient.ReceiveEvents(ctx, count, options)
 }
 
-// UpdateCheckpoint updates the checkpoint store.
-// The next time a client loads, using the checkpoint store, it will start from the event _after_ the latestEvent.
+// UpdateCheckpoint updates the checkpoint store. This ensure that if the Processor is restarted it will
+// start from after this point.
 func (p *ProcessorPartitionClient) UpdateCheckpoint(ctx context.Context, latestEvent *ReceivedEventData) error {
 	return p.checkpointStore.UpdateCheckpoint(ctx, Checkpoint{
 		CheckpointStoreAddress: CheckpointStoreAddress{
@@ -40,7 +46,7 @@ func (p *ProcessorPartitionClient) UpdateCheckpoint(ctx context.Context, latestE
 }
 
 // PartitionID is the partition ID of the partition we're receiving from.
-// This will not change.
+// This will not change during the lifetime of this ProcessorPartitionClient.
 func (p *ProcessorPartitionClient) PartitionID() string {
 	return p.partitionID
 }

--- a/sdk/messaging/azeventhubs/processor_partition_client.go
+++ b/sdk/messaging/azeventhubs/processor_partition_client.go
@@ -34,16 +34,12 @@ func (c *ProcessorPartitionClient) ReceiveEvents(ctx context.Context, count int,
 // start from after this point.
 func (p *ProcessorPartitionClient) UpdateCheckpoint(ctx context.Context, latestEvent *ReceivedEventData) error {
 	return p.checkpointStore.UpdateCheckpoint(ctx, Checkpoint{
-		CheckpointStoreAddress: CheckpointStoreAddress{
-			ConsumerGroup:           p.consumerClientDetails.ConsumerGroup,
-			EventHubName:            p.consumerClientDetails.EventHubName,
-			FullyQualifiedNamespace: p.consumerClientDetails.FullyQualifiedNamespace,
-			PartitionID:             p.partitionID,
-		},
-		CheckpointData: CheckpointData{
-			SequenceNumber: &latestEvent.SequenceNumber,
-			Offset:         latestEvent.Offset,
-		},
+		ConsumerGroup:           p.consumerClientDetails.ConsumerGroup,
+		EventHubName:            p.consumerClientDetails.EventHubName,
+		FullyQualifiedNamespace: p.consumerClientDetails.FullyQualifiedNamespace,
+		PartitionID:             p.partitionID,
+		SequenceNumber:          &latestEvent.SequenceNumber,
+		Offset:                  latestEvent.Offset,
 	}, nil)
 }
 

--- a/sdk/messaging/azeventhubs/processor_partition_client.go
+++ b/sdk/messaging/azeventhubs/processor_partition_client.go
@@ -53,7 +53,7 @@ func (p *ProcessorPartitionClient) PartitionID() string {
 	return p.partitionID
 }
 
-// Close closes the partition client.
+// Close releases resources for the partition client.
 // This does not close the ConsumerClient that the Processor was started with.
 func (c *ProcessorPartitionClient) Close(ctx context.Context) error {
 	c.cleanupFn()

--- a/sdk/messaging/azeventhubs/processor_partition_client.go
+++ b/sdk/messaging/azeventhubs/processor_partition_client.go
@@ -14,6 +14,8 @@ import "context"
 //
 // NOTE: If you do NOT want to use dynamic load balancing, and would prefer to track state and ownership
 // manually, use the [ConsumerClient] type instead.
+//
+// [example_processor_test.go]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/example_processor_test.go
 type ProcessorPartitionClient struct {
 	partitionID           string
 	innerClient           *PartitionClient // *azeventhubs.PartitionClient

--- a/sdk/messaging/azeventhubs/processor_test.go
+++ b/sdk/messaging/azeventhubs/processor_test.go
@@ -95,7 +95,7 @@ func TestProcessor_Contention(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.NewProcessorOptions{
+		processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.ProcessorOptions{
 			UpdateInterval: 10 * time.Second,
 		})
 		require.NoError(t, err)
@@ -219,7 +219,7 @@ func testPartitionAcquisition(t *testing.T, loadBalancerStrategy azeventhubs.Pro
 	require.NoError(t, err)
 
 	t.Logf("Processor created")
-	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.NewProcessorOptions{
+	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.ProcessorOptions{
 		UpdateInterval:        time.Millisecond,
 		LoadBalancingStrategy: loadBalancerStrategy,
 	})
@@ -288,7 +288,7 @@ func testWithLoadBalancer(t *testing.T, loadBalancerStrategy azeventhubs.Process
 	require.NoError(t, err)
 
 	t.Logf("Processor created")
-	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.NewProcessorOptions{
+	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, &azeventhubs.ProcessorOptions{
 		UpdateInterval:        time.Millisecond,
 		LoadBalancingStrategy: loadBalancerStrategy,
 	})
@@ -360,7 +360,7 @@ func processEventsForTest(t *testing.T, producerClient *azeventhubs.ProducerClie
 
 		for i := 0; i < expectedEventsCount/batchSize; i++ {
 			pid := partitionClient.PartitionID()
-			batch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.NewEventDataBatchOptions{
+			batch, err := producerClient.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
 				PartitionID: &pid,
 			})
 			require.NoError(t, err)

--- a/sdk/messaging/azeventhubs/processor_unit_test.go
+++ b/sdk/messaging/azeventhubs/processor_unit_test.go
@@ -29,6 +29,7 @@ func TestUnit_Processor_loadBalancing(t *testing.T) {
 			PartitionID:             partitionID,
 		}
 	}
+
 	require.Equal(t, ProcessorStrategyBalanced, firstProcessor.lb.strategy)
 
 	allPartitionIDs := []string{"1", "100", "1001"}

--- a/sdk/messaging/azeventhubs/processor_unit_test.go
+++ b/sdk/messaging/azeventhubs/processor_unit_test.go
@@ -141,7 +141,7 @@ func TestUnit_Processor_loadBalancing(t *testing.T) {
 func TestUnit_Processor_Run(t *testing.T) {
 	cps := newCheckpointStoreForTest()
 
-	processor, err := newProcessorImpl(simpleFakeConsumerClient(), cps, &NewProcessorOptions{
+	processor, err := newProcessorImpl(simpleFakeConsumerClient(), cps, &ProcessorOptions{
 		PartitionExpirationDuration: time.Hour,
 	})
 
@@ -182,13 +182,13 @@ func TestUnit_Processor_Run_singleConsumerPerPartition(t *testing.T) {
 			ClientID:                "my-client-id",
 		},
 		getEventHubPropertiesResult: ehProps,
-		newPartitionClientFn: func(partitionID string, options *NewPartitionClientOptions) (*PartitionClient, error) {
+		newPartitionClientFn: func(partitionID string, options *PartitionClientOptions) (*PartitionClient, error) {
 			partitionClientsCreated++
 			return newFakePartitionClient(partitionID, ""), nil
 		},
 	}
 
-	processor, err := newProcessorImpl(cc, cps, &NewProcessorOptions{
+	processor, err := newProcessorImpl(cc, cps, &ProcessorOptions{
 		PartitionExpirationDuration: time.Hour,
 	})
 	require.NoError(t, err)
@@ -247,14 +247,14 @@ func TestUnit_Processor_Run_startPosition(t *testing.T) {
 
 	fakeConsumerClient := simpleFakeConsumerClient()
 
-	fakeConsumerClient.newPartitionClientFn = func(partitionID string, options *NewPartitionClientOptions) (*PartitionClient, error) {
+	fakeConsumerClient.newPartitionClientFn = func(partitionID string, options *PartitionClientOptions) (*PartitionClient, error) {
 		offsetExpr, err := getOffsetExpression(options.StartPosition)
 		require.NoError(t, err)
 
 		return newFakePartitionClient(partitionID, offsetExpr), nil
 	}
 
-	processor, err := newProcessorImpl(fakeConsumerClient, cps, &NewProcessorOptions{
+	processor, err := newProcessorImpl(fakeConsumerClient, cps, &ProcessorOptions{
 		PartitionExpirationDuration: time.Hour,
 	})
 	require.NoError(t, err)
@@ -310,7 +310,7 @@ func TestUnit_Processor_Run_cancellation(t *testing.T) {
 			FullyQualifiedNamespace: "fqdn",
 			ClientID:                "my-client-id",
 		},
-	}, cps, &NewProcessorOptions{
+	}, cps, &ProcessorOptions{
 		PartitionExpirationDuration: time.Hour,
 	})
 
@@ -349,7 +349,7 @@ func newProcessorForTest(t *testing.T, clientID string, cps CheckpointStore) *Pr
 			FullyQualifiedNamespace: "fqdn",
 			ClientID:                clientID,
 		},
-	}, cps, &NewProcessorOptions{
+	}, cps, &ProcessorOptions{
 		PartitionExpirationDuration: time.Hour,
 	})
 	require.NoError(t, err)
@@ -363,7 +363,7 @@ type fakeConsumerClient struct {
 	getEventHubPropertiesErr    error
 
 	partitionClients     map[string]newMockPartitionClientResult
-	newPartitionClientFn func(partitionID string, options *NewPartitionClientOptions) (*PartitionClient, error)
+	newPartitionClientFn func(partitionID string, options *PartitionClientOptions) (*PartitionClient, error)
 }
 
 type newMockPartitionClientResult struct {
@@ -375,7 +375,7 @@ func (cc *fakeConsumerClient) GetEventHubProperties(ctx context.Context, options
 	return cc.getEventHubPropertiesResult, cc.getEventHubPropertiesErr
 }
 
-func (cc *fakeConsumerClient) NewPartitionClient(partitionID string, options *NewPartitionClientOptions) (*PartitionClient, error) {
+func (cc *fakeConsumerClient) NewPartitionClient(partitionID string, options *PartitionClientOptions) (*PartitionClient, error) {
 	if cc.newPartitionClientFn != nil {
 		return cc.newPartitionClientFn(partitionID, options)
 	}

--- a/sdk/messaging/azeventhubs/producer_client.go
+++ b/sdk/messaging/azeventhubs/producer_client.go
@@ -111,6 +111,11 @@ type EventDataBatchOptions struct {
 }
 
 // NewEventDataBatch can be used to create a batch that contain multiple events.
+//
+// This batch contains logic to make sure that the it doesn't exceed the maximum size
+// for the Event Hubs link, using it's [azeventhubs.EventDataBatch.AddEventData] function.
+// A lower size limit can also be configured using the options.
+//
 // If the operation fails it can return an *azeventhubs.Error type if the failure is actionable.
 func (pc *ProducerClient) NewEventDataBatch(ctx context.Context, options *EventDataBatchOptions) (*EventDataBatch, error) {
 	var batch *EventDataBatch

--- a/sdk/messaging/azeventhubs/producer_client.go
+++ b/sdk/messaging/azeventhubs/producer_client.go
@@ -59,6 +59,7 @@ type ProducerClient struct {
 const anyPartitionID = ""
 
 // NewProducerClient creates a ProducerClient which uses an azcore.TokenCredential for authentication.
+//
 // The fullyQualifiedNamespace is the Event Hubs namespace name (ex: myeventhub.servicebus.windows.net)
 // The credential is one of the credentials in the `github.com/Azure/azure-sdk-for-go/sdk/azidentity` package.
 func NewProducerClient(fullyQualifiedNamespace string, eventHub string, credential azcore.TokenCredential, options *ProducerClientOptions) (*ProducerClient, error) {
@@ -73,11 +74,13 @@ func NewProducerClient(fullyQualifiedNamespace string, eventHub string, credenti
 //
 // connectionString can be one of the following formats:
 //
-// Connection string, no EntityPath. In this case eventHub cannot be empty.
-// ex: Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
+// Connection string, no EntityPath. In this case eventHub cannot be empty
+//
+//	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
 //
 // Connection string, has EntityPath. In this case eventHub must be empty.
-// ex: Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<entity path>
+//
+//	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;
 func NewProducerClientFromConnectionString(connectionString string, eventHub string, options *ProducerClientOptions) (*ProducerClient, error) {
 	parsedConn, err := parseConn(connectionString, eventHub)
 

--- a/sdk/messaging/azeventhubs/producer_client.go
+++ b/sdk/messaging/azeventhubs/producer_client.go
@@ -20,8 +20,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
 )
 
-// NewWebSocketConnArgs are passed to your web socket creation function (ClientOptions.NewWebSocketConn)
-type NewWebSocketConnArgs = exported.NewWebSocketConnArgs
+// WebSocketConnArgs are passed to your web socket creation function (ClientOptions.NewWebSocketConn)
+type WebSocketConnArgs = exported.WebSocketConnArgs
 
 // RetryOptions represent the options for retries.
 type RetryOptions = exported.RetryOptions
@@ -37,7 +37,7 @@ type ProducerClientOptions struct {
 
 	// NewWebSocketConn is a function that can create a net.Conn for use with websockets.
 	// For an example, see ExampleNewClient_usingWebsockets() function in example_client_test.go.
-	NewWebSocketConn func(ctx context.Context, args NewWebSocketConnArgs) (net.Conn, error)
+	NewWebSocketConn func(ctx context.Context, args WebSocketConnArgs) (net.Conn, error)
 
 	// RetryOptions controls how often operations are retried from this client and any
 	// Receivers and Senders created from this client.
@@ -91,8 +91,8 @@ func NewProducerClientFromConnectionString(connectionString string, eventHub str
 	}, options)
 }
 
-// NewEventDataBatchOptions contains optional parameters for the NewEventDataBatch function
-type NewEventDataBatchOptions struct {
+// EventDataBatchOptions contains optional parameters for the NewEventDataBatch function
+type EventDataBatchOptions struct {
 	// MaxBytes overrides the max size (in bytes) for a batch.
 	// By default NewMessageBatch will use the max message size provided by the service.
 	MaxBytes uint64
@@ -109,7 +109,7 @@ type NewEventDataBatchOptions struct {
 
 // NewEventDataBatch can be used to create a batch that contain multiple events.
 // If the operation fails it can return an *azeventhubs.Error type if the failure is actionable.
-func (pc *ProducerClient) NewEventDataBatch(ctx context.Context, options *NewEventDataBatchOptions) (*EventDataBatch, error) {
+func (pc *ProducerClient) NewEventDataBatch(ctx context.Context, options *EventDataBatchOptions) (*EventDataBatch, error) {
 	var batch *EventDataBatch
 
 	partitionID := anyPartitionID

--- a/sdk/messaging/azeventhubs/producer_client.go
+++ b/sdk/messaging/azeventhubs/producer_client.go
@@ -58,10 +58,13 @@ type ProducerClient struct {
 // to get event hub properties or partition properties.
 const anyPartitionID = ""
 
-// NewProducerClient creates a ProducerClient which uses an azcore.TokenCredential for authentication.
+// NewProducerClient creates a ProducerClient which uses an azcore.TokenCredential for authentication. You
+// MUST call [azeventhubs.ProducerClient.Close] on this client to avoid leaking resources.
 //
 // The fullyQualifiedNamespace is the Event Hubs namespace name (ex: myeventhub.servicebus.windows.net)
-// The credential is one of the credentials in the `github.com/Azure/azure-sdk-for-go/sdk/azidentity` package.
+// The credential is one of the credentials in the [azidentity] package.
+//
+// [azidentity]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity
 func NewProducerClient(fullyQualifiedNamespace string, eventHub string, credential azcore.TokenCredential, options *ProducerClientOptions) (*ProducerClient, error) {
 	return newProducerClientImpl(producerClientCreds{
 		fullyQualifiedNamespace: fullyQualifiedNamespace,
@@ -70,17 +73,19 @@ func NewProducerClient(fullyQualifiedNamespace string, eventHub string, credenti
 	}, options)
 }
 
-// NewProducerClientFromConnectionString creates a ProducerClient from a connection string.
+// NewProducerClientFromConnectionString creates a ProducerClient from a connection string. You
+// MUST call [azeventhubs.ProducerClient.Close] on this client to avoid leaking resources.
 //
-// connectionString can be one of the following formats:
+// connectionString can be one of two formats - with or without an EntityPath key.
 //
-// Connection string, no EntityPath. In this case eventHub cannot be empty
+// When the connection string does not have an entity path, as shown below, the eventHub parameter cannot
+// be empty and should contain the name of your event hub.
 //
 //	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
 //
-// Connection string, has EntityPath. In this case eventHub must be empty.
+// When the connection string DOES have an entity path, as shown below, the eventHub parameter must be empty.
 //
-//	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;
+//	Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<entity path>;
 func NewProducerClientFromConnectionString(connectionString string, eventHub string, options *ProducerClientOptions) (*ProducerClient, error) {
 	parsedConn, err := parseConn(connectionString, eventHub)
 
@@ -97,7 +102,7 @@ func NewProducerClientFromConnectionString(connectionString string, eventHub str
 // EventDataBatchOptions contains optional parameters for the NewEventDataBatch function
 type EventDataBatchOptions struct {
 	// MaxBytes overrides the max size (in bytes) for a batch.
-	// By default NewMessageBatch will use the max message size provided by the service.
+	// By default NewEventDataBatch will use the max message size provided by the service.
 	MaxBytes uint64
 
 	// PartitionKey is hashed to calculate the partition assignment. Messages and message
@@ -110,13 +115,14 @@ type EventDataBatchOptions struct {
 	PartitionID *string
 }
 
-// NewEventDataBatch can be used to create a batch that contain multiple events.
+// NewEventDataBatch can be used to create an EventDataBatch, which can contain multiple
+// events.
 //
-// This batch contains logic to make sure that the it doesn't exceed the maximum size
+// EventDataBatch contains logic to make sure that the it doesn't exceed the maximum size
 // for the Event Hubs link, using it's [azeventhubs.EventDataBatch.AddEventData] function.
-// A lower size limit can also be configured using the options.
+// A lower size limit can also be configured through the options.
 //
-// If the operation fails it can return an *azeventhubs.Error type if the failure is actionable.
+// If the operation fails it can return an azeventhubs.Error type if the failure is actionable.
 func (pc *ProducerClient) NewEventDataBatch(ctx context.Context, options *EventDataBatchOptions) (*EventDataBatch, error) {
 	var batch *EventDataBatch
 
@@ -180,7 +186,7 @@ func (pc *ProducerClient) GetEventHubProperties(ctx context.Context, options *Ge
 	return getEventHubProperties(ctx, pc.namespace, rpcLink.Link, pc.eventHub, options)
 }
 
-// Close closes the producer's AMQP links and the underlying AMQP connection.
+// Close releases resources for this client.
 func (pc *ProducerClient) Close(ctx context.Context) error {
 	if err := pc.links.Close(ctx); err != nil {
 		azlog.Writef(EventProducer, "Failed when closing links while shutting down producer client: %s", err.Error())

--- a/sdk/messaging/azeventhubs/producer_client_test.go
+++ b/sdk/messaging/azeventhubs/producer_client_test.go
@@ -95,7 +95,7 @@ func TestNewProducerClient_SendToAny(t *testing.T) {
 			producer, err := azeventhubs.NewProducerClientFromConnectionString(testParams.ConnectionString, testParams.EventHubName, nil)
 			require.NoError(t, err)
 
-			batch, err := producer.NewEventDataBatch(context.Background(), &azeventhubs.NewEventDataBatchOptions{
+			batch, err := producer.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
 				PartitionKey: partitionKey,
 			})
 			require.NoError(t, err)
@@ -169,7 +169,7 @@ func TestProducerClient_SendBatchExample(t *testing.T) {
 
 	// this is a replicate of the code we use in the example "example_producer_events.go"
 	// just testing to make sure it works the way we expect it to.
-	newBatchOptions := &azeventhubs.NewEventDataBatchOptions{
+	newBatchOptions := &azeventhubs.EventDataBatchOptions{
 		MaxBytes:    300,
 		PartitionID: to.Ptr("0"),
 	}
@@ -255,7 +255,7 @@ func TestProducerClient_SendBatchExample(t *testing.T) {
 
 	defer consumerClient.Close(context.Background())
 
-	partitionClient, err := consumerClient.NewPartitionClient("0", &azeventhubs.NewPartitionClientOptions{
+	partitionClient, err := consumerClient.NewPartitionClient("0", &azeventhubs.PartitionClientOptions{
 		StartPosition: getStartPosition(beforeSend),
 	})
 	require.NoError(t, err)
@@ -284,7 +284,7 @@ func receiveEventFromAnyPartition(ctx context.Context, t *testing.T, consumer *a
 
 	for _, partProps := range allPartitions {
 		go func(partProps azeventhubs.PartitionProperties) {
-			partClient, err := consumer.NewPartitionClient(partProps.PartitionID, &azeventhubs.NewPartitionClientOptions{
+			partClient, err := consumer.NewPartitionClient(partProps.PartitionID, &azeventhubs.PartitionClientOptions{
 				StartPosition: getStartPosition(partProps),
 			})
 			require.NoError(t, err)
@@ -367,7 +367,7 @@ func sendAndReceiveToPartitionTest(t *testing.T, cs string, eventHubName string,
 		require.NoError(t, err)
 	}()
 
-	batch, err := producer.NewEventDataBatch(context.Background(), &azeventhubs.NewEventDataBatchOptions{
+	batch, err := producer.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
 		PartitionID: &partitionID,
 	})
 	require.NoError(t, err)
@@ -399,7 +399,7 @@ func sendAndReceiveToPartitionTest(t *testing.T, cs string, eventHubName string,
 
 	var actualBodies []string
 
-	subscription, err := consumer.NewPartitionClient(partitionID, &azeventhubs.NewPartitionClientOptions{
+	subscription, err := consumer.NewPartitionClient(partitionID, &azeventhubs.PartitionClientOptions{
 		StartPosition: getStartPosition(partProps),
 	})
 	require.NoError(t, err)

--- a/sdk/messaging/azeventhubs/test_checkpoint_store_test.go
+++ b/sdk/messaging/azeventhubs/test_checkpoint_store_test.go
@@ -23,16 +23,12 @@ func Test_InMemoryCheckpointStore_Checkpoints(t *testing.T) {
 
 	for i := int64(0); i < 5; i++ {
 		err = store.UpdateCheckpoint(context.Background(), Checkpoint{
-			CheckpointStoreAddress: CheckpointStoreAddress{
-				FullyQualifiedNamespace: "ns",
-				EventHubName:            "eh",
-				ConsumerGroup:           "cg",
-				PartitionID:             "100",
-			},
-			CheckpointData: CheckpointData{
-				Offset:         to.Ptr(i),
-				SequenceNumber: to.Ptr(i + 1),
-			},
+			FullyQualifiedNamespace: "ns",
+			EventHubName:            "eh",
+			ConsumerGroup:           "cg",
+			PartitionID:             "100",
+			Offset:                  to.Ptr(i),
+			SequenceNumber:          to.Ptr(i + 1),
 		}, nil)
 		require.NoError(t, err)
 
@@ -41,16 +37,12 @@ func Test_InMemoryCheckpointStore_Checkpoints(t *testing.T) {
 
 		require.Equal(t, []Checkpoint{
 			{
-				CheckpointStoreAddress: CheckpointStoreAddress{
-					FullyQualifiedNamespace: "ns",
-					EventHubName:            "eh",
-					ConsumerGroup:           "cg",
-					PartitionID:             "100",
-				},
-				CheckpointData: CheckpointData{
-					Offset:         to.Ptr(i),
-					SequenceNumber: to.Ptr(i + 1),
-				},
+				FullyQualifiedNamespace: "ns",
+				EventHubName:            "eh",
+				ConsumerGroup:           "cg",
+				PartitionID:             "100",
+				Offset:                  to.Ptr(i),
+				SequenceNumber:          to.Ptr(i + 1),
 			},
 		}, checkpoints)
 	}
@@ -68,34 +60,26 @@ func Test_InMemoryCheckpointStore_Ownership(t *testing.T) {
 	for i := int64(0); i < 5; i++ {
 		ownerships, err = store.ClaimOwnership(context.Background(), []Ownership{
 			{
-				CheckpointStoreAddress: CheckpointStoreAddress{
-					FullyQualifiedNamespace: "ns",
-					EventHubName:            "eh",
-					ConsumerGroup:           "cg",
-					PartitionID:             "100",
-				},
-				OwnershipData: OwnershipData{
-					OwnerID:          "owner-id",
-					LastModifiedTime: time.Time{},
-					ETag:             previousETag,
-				},
-			}}, nil)
-		require.NoError(t, err)
-
-		expectedOwnership := Ownership{
-			CheckpointStoreAddress: CheckpointStoreAddress{
 				FullyQualifiedNamespace: "ns",
 				EventHubName:            "eh",
 				ConsumerGroup:           "cg",
 				PartitionID:             "100",
-			},
-			OwnershipData: OwnershipData{
-				OwnerID: "owner-id",
-				// these fields are dynamically generated, so we just make sure
-				// they do get filled out
-				LastModifiedTime: ownerships[0].LastModifiedTime,
-				ETag:             ownerships[0].ETag,
-			},
+				OwnerID:                 "owner-id",
+				LastModifiedTime:        time.Time{},
+				ETag:                    previousETag,
+			}}, nil)
+		require.NoError(t, err)
+
+		expectedOwnership := Ownership{
+			FullyQualifiedNamespace: "ns",
+			EventHubName:            "eh",
+			ConsumerGroup:           "cg",
+			PartitionID:             "100",
+			OwnerID:                 "owner-id",
+			// these fields are dynamically generated, so we just make sure
+			// they do get filled out
+			LastModifiedTime: ownerships[0].LastModifiedTime,
+			ETag:             ownerships[0].ETag,
 		}
 
 		require.NotEqual(t, previousETag, ownerships[0].ETag)
@@ -123,16 +107,12 @@ func Test_InMemoryCheckpointStore_OwnershipLoss(t *testing.T) {
 	// If you don't specify an etag (ie, it's blank) then you always win ownership.
 	ownerships, err = store.ClaimOwnership(context.Background(), []Ownership{
 		{
-			CheckpointStoreAddress: CheckpointStoreAddress{
-				FullyQualifiedNamespace: "ns",
-				EventHubName:            "eh",
-				ConsumerGroup:           "cg",
-				PartitionID:             "100",
-			},
-			OwnershipData: OwnershipData{
-				OwnerID:          "owner-id",
-				LastModifiedTime: time.Time{},
-			},
+			FullyQualifiedNamespace: "ns",
+			EventHubName:            "eh",
+			ConsumerGroup:           "cg",
+			PartitionID:             "100",
+			OwnerID:                 "owner-id",
+			LastModifiedTime:        time.Time{},
 		}}, nil)
 	require.NoError(t, err)
 
@@ -142,17 +122,13 @@ func Test_InMemoryCheckpointStore_OwnershipLoss(t *testing.T) {
 	// the current one.
 	ownerships, err = store.ClaimOwnership(context.Background(), []Ownership{
 		{
-			CheckpointStoreAddress: CheckpointStoreAddress{
-				FullyQualifiedNamespace: "ns",
-				EventHubName:            "eh",
-				ConsumerGroup:           "cg",
-				PartitionID:             "100",
-			},
-			OwnershipData: OwnershipData{
-				OwnerID:          "new-owner-id",
-				LastModifiedTime: time.Time{},
-				ETag:             "non-matching-etag",
-			},
+			FullyQualifiedNamespace: "ns",
+			EventHubName:            "eh",
+			ConsumerGroup:           "cg",
+			PartitionID:             "100",
+			OwnerID:                 "new-owner-id",
+			LastModifiedTime:        time.Time{},
+			ETag:                    "non-matching-etag",
 		}}, nil)
 	require.NoError(t, err)
 	require.Empty(t, ownerships, "we weren't able to claim any partitions because our etag didn't match")
@@ -168,17 +144,13 @@ func Test_InMemoryCheckpointStore_OwnershipLoss(t *testing.T) {
 	// okay, let's claim the partition properly (with a matching etag)
 	ownerships, err = store.ClaimOwnership(context.Background(), []Ownership{
 		{
-			CheckpointStoreAddress: CheckpointStoreAddress{
-				FullyQualifiedNamespace: "ns",
-				EventHubName:            "eh",
-				ConsumerGroup:           "cg",
-				PartitionID:             "100",
-			},
-			OwnershipData: OwnershipData{
-				OwnerID:          "new-owner-id",
-				LastModifiedTime: time.Time{},
-				ETag:             previousETag,
-			},
+			FullyQualifiedNamespace: "ns",
+			EventHubName:            "eh",
+			ConsumerGroup:           "cg",
+			PartitionID:             "100",
+			OwnerID:                 "new-owner-id",
+			LastModifiedTime:        time.Time{},
+			ETag:                    previousETag,
 		}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, "new-owner-id", ownerships[0].OwnerID)
@@ -204,7 +176,7 @@ func newCheckpointStoreForTest() *testCheckpointStore {
 }
 
 func (cps *testCheckpointStore) ExpireOwnership(o Ownership) {
-	key := strings.Join([]string{o.CheckpointStoreAddress.FullyQualifiedNamespace, o.CheckpointStoreAddress.EventHubName, o.CheckpointStoreAddress.ConsumerGroup, o.CheckpointStoreAddress.PartitionID}, "/")
+	key := strings.Join([]string{o.FullyQualifiedNamespace, o.EventHubName, o.ConsumerGroup, o.PartitionID}, "/")
 
 	cps.ownershipMu.Lock()
 	defer cps.ownershipMu.Unlock()
@@ -222,14 +194,14 @@ func (cps *testCheckpointStore) ClaimOwnership(ctx context.Context, partitionOwn
 			cps.ownershipMu.Lock()
 			defer cps.ownershipMu.Unlock()
 
-			if po.CheckpointStoreAddress.ConsumerGroup == "" ||
-				po.CheckpointStoreAddress.EventHubName == "" ||
-				po.CheckpointStoreAddress.FullyQualifiedNamespace == "" ||
-				po.CheckpointStoreAddress.PartitionID == "" {
+			if po.ConsumerGroup == "" ||
+				po.EventHubName == "" ||
+				po.FullyQualifiedNamespace == "" ||
+				po.PartitionID == "" {
 				panic("bad test, not all required fields were filled out for ownership data")
 			}
 
-			key := strings.Join([]string{po.CheckpointStoreAddress.FullyQualifiedNamespace, po.CheckpointStoreAddress.EventHubName, po.CheckpointStoreAddress.ConsumerGroup, po.CheckpointStoreAddress.PartitionID}, "/")
+			key := strings.Join([]string{po.FullyQualifiedNamespace, po.EventHubName, po.ConsumerGroup, po.PartitionID}, "/")
 
 			current, exists := cps.ownerships[key]
 
@@ -246,8 +218,8 @@ func (cps *testCheckpointStore) ClaimOwnership(ctx context.Context, partitionOwn
 				return nil, err
 			}
 
-			newOwnership.OwnershipData.ETag = uuid.String()
-			newOwnership.OwnershipData.LastModifiedTime = time.Now().UTC()
+			newOwnership.ETag = uuid.String()
+			newOwnership.LastModifiedTime = time.Now().UTC()
 			cps.ownerships[key] = newOwnership
 
 			return &newOwnership, nil
@@ -295,19 +267,19 @@ func (cps *testCheckpointStore) UpdateCheckpoint(ctx context.Context, checkpoint
 	cps.checkpointsMu.Lock()
 	defer cps.checkpointsMu.Unlock()
 
-	if checkpoint.CheckpointStoreAddress.ConsumerGroup == "" ||
-		checkpoint.CheckpointStoreAddress.EventHubName == "" ||
-		checkpoint.CheckpointStoreAddress.FullyQualifiedNamespace == "" ||
-		checkpoint.CheckpointStoreAddress.PartitionID == "" {
+	if checkpoint.ConsumerGroup == "" ||
+		checkpoint.EventHubName == "" ||
+		checkpoint.FullyQualifiedNamespace == "" ||
+		checkpoint.PartitionID == "" {
 		panic("bad test, not all required fields were filled out for checkpoint data")
 	}
 
-	key := toInMemoryKey(checkpoint.CheckpointStoreAddress)
+	key := toInMemoryKey(checkpoint)
 	cps.checkpoints[key] = checkpoint
 
 	return nil
 }
 
-func toInMemoryKey(a CheckpointStoreAddress) string {
+func toInMemoryKey(a Checkpoint) string {
 	return strings.Join([]string{a.FullyQualifiedNamespace, a.EventHubName, a.ConsumerGroup, a.PartitionID}, "/")
 }


### PR DESCRIPTION
Some great discussion in the archboard. There are still some bigger issues that need to be discussed, but these were some of the discussion that are easily resolveable:

- Added a lot of documentation to areas, making it clear which types require Closing, and added a bunch of self-referential docs as well between the type descriptions to get to examples, from sub-types to show which types actually instantiate them (ie: PartitionClient, ProcessorPartitionClient both mention their parent types and which function you use to create them).
- All types that used to say 'New*Options' types are properly renamed to just be *Options instead, avoiding 'New' clutter at the package level.
- Flatten the CheckpointStore's Ownership and Checkpoint types. This removed 3 extra clutter types (OwnershipData, CheckpointData and CheckpointStoreAddress). 

There were some other things that were wrong as well that I've fixed now:

- If your whole-file example function has more than one underscore in it it doesn't get listed in pkg.go.dev. So I fixed some of those - your naming convention needs to match Example_camelCaseOnly)
- Removed StartPosition and OwnerLevel fields from the ConsumerClientOptions (they are only supposed to be in the PartitionClientOptions).

Fixes #19152