### PR TITLE
Remove empty path segments when joining paths

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 * Don't retry a request if the `Retry-After` delay is greater than the configured `RetryOptions.MaxRetryDelay`.
+* Remove empty path segments in `runtime.JoinPaths()`.
 
 ### Other Changes
 

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -59,6 +59,10 @@ func JoinPaths(root string, paths ...string) string {
 	for i := 0; i < len(paths); i++ {
 		root = strings.TrimRight(root, "/")
 		paths[i] = strings.TrimLeft(paths[i], "/")
+		// remove any empty path segments. this can happen when an
+		// optional path param is unspecified so its placeholder is
+		// replaced with the empty string.
+		paths[i] = strings.Replace(paths[i], "//", "/", -1)
 		root += "/" + paths[i]
 	}
 

--- a/sdk/azcore/runtime/request_test.go
+++ b/sdk/azcore/runtime/request_test.go
@@ -553,7 +553,12 @@ func TestJoinPaths(t *testing.T) {
 	}
 
 	expected = "http://test.contoso.com/path/one/path/two/?qp1=abc&qp2=def"
-	if path := JoinPaths("http://test.contoso.com/?qp1=abc&qp2=def", "/path/one", "path/two"); path != expected {
+	if path := JoinPaths("http://test.contoso.com/?qp1=abc&qp2=def", "path/one", "path/two"); path != expected {
+		t.Fatalf("got %s, expected %s", path, expected)
+	}
+
+	expected = "http://test.contoso.com/path/one/clean/path/two/clean/path/three"
+	if path := JoinPaths("http://test.contoso.com", "/path/one//clean", "path/two/clean//", "//path//three"); path != expected {
 		t.Fatalf("got %s, expected %s", path, expected)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
