### PR TITLE
[azservicebus] Make it so retry sleeps can be cancelled.

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 - AcceptNextSessionForQueue and AcceptNextSessionForSubscription now return an azservicebus.Error with 
   Code set to CodeTimeout when they fail due to no sessions being available. Examples for this have 
-  been added for `AcceptNextSessionForQueue`. PR#TBD.
+  been added for `AcceptNextSessionForQueue`. PR#19113.
+- Retries now respect cancellation when they're in the "delay before next try" phase.
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/internal/utils/retrier.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier.go
@@ -52,12 +52,10 @@ func Retry(ctx context.Context, eventName log.Event, operation string, fn func(c
 			sleep := calcDelay(ro, i)
 			log.Writef(eventName, "(%s) Retry attempt %d sleeping for %s", operation, i, sleep)
 
-			sleepCtx, cancelSleep := context.WithTimeout(ctx, sleep)
-			<-sleepCtx.Done()
-			cancelSleep()
-
-			if ctx.Err() != nil {
+			select {
+			case <-ctx.Done():
 				return ctx.Err()
+			case <-time.After(sleep):
 			}
 		}
 


### PR DESCRIPTION
The sleep between retries was not cancellable but it should have been. This changes it to use a context.WithTimeout() instead.