### PR TITLE
Enable custom IMDS timeout value

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 * `ManagedIdentityCredential` caches tokens in memory
+* Added `ManagedIdentityCredentialOptions.IMDSTimeout` to configure the IMDS endpoint probe timeout.
 
 ### Bugs Fixed
 * `ClientCertificateCredential` sends only the leaf cert for SNI authentication

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -67,7 +66,6 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 	msiCred, err := NewManagedIdentityCredential(o)
 	if err == nil {
 		creds = append(creds, msiCred)
-		msiCred.mic.imdsTimeout = time.Second
 	} else {
 		errorMessages = append(errorMessages, credNameManagedIdentity+": "+err.Error())
 		creds = append(creds, &defaultCredentialErrorReporter{credType: credNameManagedIdentity, err: err})

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -114,6 +114,10 @@ func newManagedIdentityClient(options *ManagedIdentityCredentialOptions) (*manag
 	if options == nil {
 		options = &ManagedIdentityCredentialOptions{}
 	}
+	if options.IMDSTimeout == 0 {
+		options.IMDSTimeout = time.Second
+	}
+
 	cp := options.ClientOptions
 	c := managedIdentityClient{id: options.ID, endpoint: imdsEndpoint, msiType: msiTypeIMDS}
 	env := "IMDS"

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -67,7 +67,8 @@ type ManagedIdentityCredentialOptions struct {
 	ID ManagedIDKind
 
 	// IMDSTimeout is the timeout used during initial discoverability of the IMDS endpoint.
-	// The default is one second.
+	// Once the endpoint has been discovered, the timeout is discarded.
+	// The default value is one second.
 	IMDSTimeout time.Duration
 }
 

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -64,6 +65,10 @@ type ManagedIdentityCredentialOptions struct {
 	// instead of the hosting environment's default. The value may be the identity's client ID or resource ID, but note that
 	// some platforms don't accept resource IDs.
 	ID ManagedIDKind
+
+	// IMDSTimeout is the timeout used during initial discoverability of the IMDS endpoint.
+	// The default is one second.
+	IMDSTimeout time.Duration
 }
 
 // ManagedIdentityCredential authenticates an Azure managed identity in any hosting environment supporting managed identities.


### PR DESCRIPTION
Provide an option for ManagedIdentityCredential to configure the IMDS endpoint probe timeout.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
