### PR TITLE
Add constants for azidentity environment variables

### DIFF
--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -25,9 +25,15 @@ import (
 )
 
 const (
-	azureAuthorityHost         = "AZURE_AUTHORITY_HOST"
-	azureClientID              = "AZURE_CLIENT_ID"
-	azureRegionalAuthorityName = "AZURE_REGIONAL_AUTHORITY_NAME"
+	azureAuthorityHost             = "AZURE_AUTHORITY_HOST"
+	azureClientCertificatePassword = "AZURE_CLIENT_CERTIFICATE_PASSWORD"
+	azureClientCertificatePath     = "AZURE_CLIENT_CERTIFICATE_PATH"
+	azureClientID                  = "AZURE_CLIENT_ID"
+	azureClientSecret              = "AZURE_CLIENT_SECRET"
+	azurePassword                  = "AZURE_PASSWORD"
+	azureRegionalAuthorityName     = "AZURE_REGIONAL_AUTHORITY_NAME"
+	azureTenantID                  = "AZURE_TENANT_ID"
+	azureUsername                  = "AZURE_USERNAME"
 
 	organizationsTenantID   = "organizations"
 	developerSignOnClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestDefaultAzureCredential_GetTokenSuccess(t *testing.T) {
-	env := map[string]string{"AZURE_TENANT_ID": fakeTenantID, azureClientID: fakeClientID, "AZURE_CLIENT_SECRET": secret}
+	env := map[string]string{azureTenantID: fakeTenantID, azureClientID: fakeClientID, azureClientSecret: secret}
 	setEnvironmentVariables(t, env)
 	cred, err := NewDefaultAzureCredential(nil)
 	if err != nil {

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -64,7 +64,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 	if options == nil {
 		options = &EnvironmentCredentialOptions{}
 	}
-	tenantID := os.Getenv("AZURE_TENANT_ID")
+	tenantID := os.Getenv(azureTenantID)
 	if tenantID == "" {
 		return nil, errors.New("missing environment variable AZURE_TENANT_ID")
 	}
@@ -72,7 +72,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 	if clientID == "" {
 		return nil, errors.New("missing environment variable " + azureClientID)
 	}
-	if clientSecret := os.Getenv("AZURE_CLIENT_SECRET"); clientSecret != "" {
+	if clientSecret := os.Getenv(azureClientSecret); clientSecret != "" {
 		log.Write(EventAuthentication, "EnvironmentCredential will authenticate with ClientSecretCredential")
 		o := &ClientSecretCredentialOptions{ClientOptions: options.ClientOptions}
 		cred, err := NewClientSecretCredential(tenantID, clientID, clientSecret, o)
@@ -81,14 +81,14 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 		}
 		return &EnvironmentCredential{cred: cred}, nil
 	}
-	if certPath := os.Getenv("AZURE_CLIENT_CERTIFICATE_PATH"); certPath != "" {
+	if certPath := os.Getenv(azureClientCertificatePath); certPath != "" {
 		log.Write(EventAuthentication, "EnvironmentCredential will authenticate with ClientCertificateCredential")
 		certData, err := os.ReadFile(certPath)
 		if err != nil {
 			return nil, fmt.Errorf(`failed to read certificate file "%s": %v`, certPath, err)
 		}
 		var password []byte
-		if v := os.Getenv("AZURE_CLIENT_CERTIFICATE_PASSWORD"); v != "" {
+		if v := os.Getenv(azureClientCertificatePassword); v != "" {
 			password = []byte(v)
 		}
 		certs, key, err := ParseCertificates(certData, password)
@@ -105,8 +105,8 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 		}
 		return &EnvironmentCredential{cred: cred}, nil
 	}
-	if username := os.Getenv("AZURE_USERNAME"); username != "" {
-		if password := os.Getenv("AZURE_PASSWORD"); password != "" {
+	if username := os.Getenv(azureUsername); username != "" {
+		if password := os.Getenv(azurePassword); password != "" {
 			log.Write(EventAuthentication, "EnvironmentCredential will authenticate with UsernamePasswordCredential")
 			o := &UsernamePasswordCredentialOptions{ClientOptions: options.ClientOptions}
 			cred, err := NewUsernamePasswordCredential(tenantID, clientID, username, password, o)

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func resetEnvironmentVarsForTest() {
-	clearEnvVars("AZURE_TENANT_ID", azureClientID, "AZURE_CLIENT_SECRET", "AZURE_CLIENT_CERTIFICATE_PATH", "AZURE_USERNAME", "AZURE_PASSWORD")
+	clearEnvVars(azureTenantID, azureClientID, azureClientSecret, azureClientCertificatePath, azureUsername, azurePassword)
 }
 
 func TestEnvironmentCredential_TenantIDNotSet(t *testing.T) {
@@ -29,7 +29,7 @@ func TestEnvironmentCredential_TenantIDNotSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_CLIENT_SECRET", secret)
+	err = os.Setenv(azureClientSecret, secret)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -41,11 +41,11 @@ func TestEnvironmentCredential_TenantIDNotSet(t *testing.T) {
 
 func TestEnvironmentCredential_ClientIDNotSet(t *testing.T) {
 	resetEnvironmentVarsForTest()
-	err := os.Setenv("AZURE_TENANT_ID", fakeTenantID)
+	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_CLIENT_SECRET", secret)
+	err = os.Setenv(azureClientSecret, secret)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestEnvironmentCredential_ClientIDNotSet(t *testing.T) {
 
 func TestEnvironmentCredential_ClientSecretNotSet(t *testing.T) {
 	resetEnvironmentVarsForTest()
-	err := os.Setenv("AZURE_TENANT_ID", fakeTenantID)
+	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestEnvironmentCredential_ClientSecretNotSet(t *testing.T) {
 
 func TestEnvironmentCredential_ClientSecretSet(t *testing.T) {
 	resetEnvironmentVarsForTest()
-	err := os.Setenv("AZURE_TENANT_ID", fakeTenantID)
+	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestEnvironmentCredential_ClientSecretSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_CLIENT_SECRET", secret)
+	err = os.Setenv(azureClientSecret, secret)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestEnvironmentCredential_ClientSecretSet(t *testing.T) {
 
 func TestEnvironmentCredential_ClientCertificatePathSet(t *testing.T) {
 	resetEnvironmentVarsForTest()
-	err := os.Setenv("AZURE_TENANT_ID", fakeTenantID)
+	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestEnvironmentCredential_ClientCertificatePathSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "testdata/certificate.pem")
+	err = os.Setenv(azureClientCertificatePath, "testdata/certificate.pem")
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -119,9 +119,9 @@ func TestEnvironmentCredential_ClientCertificatePathSet(t *testing.T) {
 
 func TestEnvironmentCredential_ClientCertificatePassword(t *testing.T) {
 	for key, value := range map[string]string{
-		"AZURE_TENANT_ID":               fakeTenantID,
-		azureClientID:                   fakeClientID,
-		"AZURE_CLIENT_CERTIFICATE_PATH": "testdata/certificate_encrypted_key.pfx",
+		azureTenantID:              fakeTenantID,
+		azureClientID:              fakeClientID,
+		azureClientCertificatePath: "testdata/certificate_encrypted_key.pfx",
 	} {
 		t.Setenv(key, value)
 	}
@@ -131,7 +131,7 @@ func TestEnvironmentCredential_ClientCertificatePassword(t *testing.T) {
 			if correctPassword {
 				password = "password"
 			}
-			t.Setenv("AZURE_CLIENT_CERTIFICATE_PASSWORD", password)
+			t.Setenv(azureClientCertificatePassword, password)
 			cred, err := NewEnvironmentCredential(nil)
 			if correctPassword {
 				if err != nil {
@@ -149,7 +149,7 @@ func TestEnvironmentCredential_ClientCertificatePassword(t *testing.T) {
 
 func TestEnvironmentCredential_UsernameOnlySet(t *testing.T) {
 	resetEnvironmentVarsForTest()
-	err := os.Setenv("AZURE_TENANT_ID", fakeTenantID)
+	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestEnvironmentCredential_UsernameOnlySet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_USERNAME", "username")
+	err = os.Setenv(azureUsername, "username")
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestEnvironmentCredential_UsernameOnlySet(t *testing.T) {
 
 func TestEnvironmentCredential_UsernamePasswordSet(t *testing.T) {
 	resetEnvironmentVarsForTest()
-	err := os.Setenv("AZURE_TENANT_ID", fakeTenantID)
+	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -177,11 +177,11 @@ func TestEnvironmentCredential_UsernamePasswordSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_USERNAME", "username")
+	err = os.Setenv(azureUsername, "username")
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
-	err = os.Setenv("AZURE_PASSWORD", "password")
+	err = os.Setenv(azurePassword, "password")
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
 	}
@@ -212,10 +212,10 @@ func TestEnvironmentCredential_SendCertificateChain(t *testing.T) {
 	srv.AppendResponse()
 
 	vars := map[string]string{
-		azureClientID:                   liveSP.clientID,
-		"AZURE_CLIENT_CERTIFICATE_PATH": liveSP.pfxPath,
-		"AZURE_TENANT_ID":               liveSP.tenantID,
-		envVarSendCertChain:             "true",
+		azureClientID:              liveSP.clientID,
+		azureClientCertificatePath: liveSP.pfxPath,
+		azureTenantID:              liveSP.tenantID,
+		envVarSendCertChain:        "true",
 	}
 	setEnvironmentVariables(t, vars)
 	cred, err := NewEnvironmentCredential(&EnvironmentCredentialOptions{ClientOptions: azcore.ClientOptions{Transport: srv}})
@@ -233,9 +233,9 @@ func TestEnvironmentCredential_SendCertificateChain(t *testing.T) {
 
 func TestEnvironmentCredential_ClientSecretLive(t *testing.T) {
 	vars := map[string]string{
-		azureClientID:         liveSP.clientID,
-		"AZURE_CLIENT_SECRET": liveSP.secret,
-		"AZURE_TENANT_ID":     liveSP.tenantID,
+		azureClientID:     liveSP.clientID,
+		azureClientSecret: liveSP.secret,
+		azureTenantID:     liveSP.tenantID,
 	}
 	setEnvironmentVariables(t, vars)
 	opts, stop := initRecording(t)
@@ -249,9 +249,9 @@ func TestEnvironmentCredential_ClientSecretLive(t *testing.T) {
 
 func TestEnvironmentCredential_InvalidClientSecretLive(t *testing.T) {
 	vars := map[string]string{
-		azureClientID:         liveSP.clientID,
-		"AZURE_CLIENT_SECRET": "invalid secret",
-		"AZURE_TENANT_ID":     liveSP.tenantID,
+		azureClientID:     liveSP.clientID,
+		azureClientSecret: "invalid secret",
+		azureTenantID:     liveSP.tenantID,
 	}
 	setEnvironmentVariables(t, vars)
 	opts, stop := initRecording(t)
@@ -278,10 +278,10 @@ func TestEnvironmentCredential_InvalidClientSecretLive(t *testing.T) {
 
 func TestEnvironmentCredential_UserPasswordLive(t *testing.T) {
 	vars := map[string]string{
-		azureClientID:     developerSignOnClientID,
-		"AZURE_TENANT_ID": liveUser.tenantID,
-		"AZURE_USERNAME":  liveUser.username,
-		"AZURE_PASSWORD":  liveUser.password,
+		azureClientID: developerSignOnClientID,
+		azureTenantID: liveUser.tenantID,
+		azureUsername: liveUser.username,
+		azurePassword: liveUser.password,
 	}
 	setEnvironmentVariables(t, vars)
 	opts, stop := initRecording(t)
@@ -295,10 +295,10 @@ func TestEnvironmentCredential_UserPasswordLive(t *testing.T) {
 
 func TestEnvironmentCredential_InvalidPasswordLive(t *testing.T) {
 	vars := map[string]string{
-		azureClientID:     developerSignOnClientID,
-		"AZURE_TENANT_ID": liveUser.tenantID,
-		"AZURE_USERNAME":  liveUser.username,
-		"AZURE_PASSWORD":  "invalid password",
+		azureClientID: developerSignOnClientID,
+		azureTenantID: liveUser.tenantID,
+		azureUsername: liveUser.username,
+		azurePassword: "invalid password",
 	}
 	setEnvironmentVariables(t, vars)
 	opts, stop := initRecording(t)


### PR DESCRIPTION
A future PR will add more references to these strings, and we can tidy them up now to make that PR less noisy.