### PR TITLE
Retain contents of read-only fields when sending requests

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed an issue in `runtime.SetMultipartFormData` to properly handle slices of `io.ReadSeekCloser`.
 
 ### Other Changes
+* Retain contents of read-only fields when sending requests.
 
 ## 1.1.4 (2022-10-06)
 

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -95,7 +95,7 @@ func MarshalAsByteArray(req *policy.Request, v []byte, format Base64Encoding) er
 
 // MarshalAsJSON calls json.Marshal() to get the JSON encoding of v then calls SetBody.
 func MarshalAsJSON(req *policy.Request, v interface{}) error {
-	if omit := os.Getenv("AZURE_SDK_GO_OMIT_READONLY"); omit != "" {
+	if omit := os.Getenv("AZURE_SDK_GO_OMIT_READONLY"); omit == "true" {
 		v = cloneWithoutReadOnlyFields(v)
 	}
 	b, err := json.Marshal(v)

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -94,7 +95,9 @@ func MarshalAsByteArray(req *policy.Request, v []byte, format Base64Encoding) er
 
 // MarshalAsJSON calls json.Marshal() to get the JSON encoding of v then calls SetBody.
 func MarshalAsJSON(req *policy.Request, v interface{}) error {
-	v = cloneWithoutReadOnlyFields(v)
+	if omit := os.Getenv("AZURE_SDK_GO_OMIT_READONLY"); omit != "" {
+		v = cloneWithoutReadOnlyFields(v)
+	}
 	b, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Errorf("error marshalling type %T: %s", v, err)

--- a/sdk/azcore/runtime/request_test.go
+++ b/sdk/azcore/runtime/request_test.go
@@ -14,7 +14,6 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -343,8 +342,7 @@ func TestCloneWithoutReadOnlyFieldsEndToEnd(t *testing.T) {
 		Name: &name,
 	}
 
-	os.Setenv("AZURE_SDK_GO_OMIT_READONLY", "true")
-	defer os.Unsetenv("AZURE_SDK_GO_OMIT_READONLY")
+	t.Setenv("AZURE_SDK_GO_OMIT_READONLY", "true")
 
 	err = MarshalAsJSON(req, nro)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.go/issues/843