### PR TITLE
[azservicebus] If the links instance has an old connection ID, recover the links (not the connection)

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -7,7 +7,9 @@
 - AcceptNextSessionForQueue and AcceptNextSessionForSubscription now return an azservicebus.Error with 
   Code set to CodeTimeout when they fail due to no sessions being available. Examples for this have 
   been added for `AcceptNextSessionForQueue`. PR#19113.
-- Retries now respect cancellation when they're in the "delay before next try" phase.
+- Retries now respect cancellation when they're in the "delay before next try" phase. (PR#19216)
+- An error in connection recovery logic could waste retries, resulting in errors related to losing
+  a connection (connlost). (PR#19281)
 
 ## 1.1.0 (2022-08-09)
 

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -218,7 +218,7 @@ func (links *AMQPLinksImpl) recoverConnection(ctx context.Context, theirID LinkI
 	links.mu.Lock()
 	defer links.mu.Unlock()
 
-	created, err := links.ns.Recover(ctx, uint64(theirID.Conn))
+	shouldRecreate, err := links.ns.Recover(ctx, uint64(theirID.Conn))
 
 	if err != nil {
 		log.Writef(exported.EventConn, "Recover connection failure: %s", err)
@@ -230,8 +230,8 @@ func (links *AMQPLinksImpl) recoverConnection(ctx context.Context, theirID LinkI
 	// - the link they received an error on is our current link, so it needs to be recreated.
 	//   (if it wasn't the same then we've already recovered and created a new link,
 	//    so no recovery would be needed)
-	if created || theirID.Link == links.id.Link {
-		log.Writef(exported.EventConn, "recreating link: c: %v, current:%v, old:%v", created, links.id, theirID)
+	if shouldRecreate || theirID.Link == links.id.Link {
+		log.Writef(exported.EventConn, "recreating link: c: %v, current:%v, old:%v", shouldRecreate, links.id, theirID)
 		if err := links.initWithoutLocking(ctx); err != nil {
 			return err
 		}

--- a/sdk/messaging/azservicebus/internal/namespace_test.go
+++ b/sdk/messaging/azservicebus/internal/namespace_test.go
@@ -336,6 +336,61 @@ func TestNamespaceUpdateClientWithoutLock(t *testing.T) {
 	require.Same(t, origClient, client)
 }
 
+func TestNamespaceConnectionRecovery(t *testing.T) {
+	newClientCount := 0
+	var fakeClientErr error
+
+	ns := &Namespace{
+		connID: 2,
+		newClientFn: func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+			newClientCount++
+			return nil, fakeClientErr
+		},
+	}
+
+	// ie, my connection is stale (it doesn't actually matter if the connID is >, although that's impossible
+	// since it means their connection came from the future)
+	origConnID := ns.connID
+
+	shouldRecreate, err := ns.Recover(context.Background(), ns.connID-1)
+	require.True(t, shouldRecreate, "connection we used for our links was stale (connID: 1 != connID: 2), so links should be recreated")
+	require.Zero(t, newClientCount, "existing client is re-used")
+	require.Equal(t, origConnID, ns.connID, "no new client created, connID is unchanged")
+	require.NoError(t, err)
+
+	// this time the connection must be having errors AND it matches our current ID
+	origConnID = ns.connID
+	origClient := &fakeAMQPClient{}
+	ns.client = origClient
+
+	shouldRecreate, err = ns.Recover(context.Background(), ns.connID)
+	require.True(t, shouldRecreate, "new client was created so we have to recreate links")
+	require.Equal(t, 1, newClientCount, "new client is created (assumption is if it matches then our current connection is returning errors)")
+	require.Equal(t, origConnID+1, ns.connID, "new client created, connID increments")
+	require.NoError(t, err)
+	require.Equal(t, 1, origClient.closeCalled, "old client is closed")
+	require.NotSame(t, origClient, ns.client, "new client instance created")
+
+	// and the last outcome - we did try to recover, but failed. We will end up in a state
+	// where the client will be nil, so the next attempt to get the client will create
+	// a new one.
+	fakeClientErr = errors.New("we failed to create the connection!")
+	origConnID = ns.connID
+	newClientCount = 0
+
+	shouldRecreate, err = ns.Recover(context.Background(), origConnID)
+	require.Equal(t, fakeClientErr, err)
+	require.False(t, shouldRecreate)
+	require.Equal(t, 1, newClientCount, "we did attempt to create a new client, it just failed.")
+	require.Equal(t, origConnID, ns.connID, "new client failed to be created so the conn ID is unchanged")
+
+	// if the namespace is closed then this function fails.
+	ns.Close(context.Background(), true)
+	shouldRecreate, err = ns.Recover(context.Background(), origConnID)
+	require.ErrorIs(t, err, ErrClientClosed)
+	require.False(t, shouldRecreate)
+}
+
 type fakeAMQPClient struct {
 	amqpwrap.AMQPClient
 	closeCalled int


### PR DESCRIPTION
(Found this while running tests (and some simulations) for azeventhubs in PR#19281

AMQPLinks relies on Namespace to determine if it should recover links. I had code in there that would return true if the connection was recreated, but missed the case where the connection was NOT recreated but the user's connection ID was outdated. 

The odds of this happening increase the more Receivers or Senders you have on a single Client instance.