### PR TITLE
Consolidate common MSAL options

### DIFF
--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
@@ -79,17 +78,7 @@ func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeC
 		cp = *options
 	}
 	cp.init()
-	if !validTenantID(cp.TenantID) {
-		return nil, errors.New(tenantIDValidationErr)
-	}
-	authorityHost, err := setAuthorityHost(cp.Cloud)
-	if err != nil {
-		return nil, err
-	}
-	c, err := public.New(cp.ClientID,
-		public.WithAuthority(runtime.JoinPaths(authorityHost, cp.TenantID)),
-		public.WithHTTPClient(newPipelineAdapter(&cp.ClientOptions)),
-	)
+	c, err := getPublicClient(cp.ClientID, cp.TenantID, &cp.ClientOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
@@ -56,17 +55,7 @@ func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOption
 		cp = *options
 	}
 	cp.init()
-	if !validTenantID(cp.TenantID) {
-		return nil, errors.New(tenantIDValidationErr)
-	}
-	authorityHost, err := setAuthorityHost(cp.Cloud)
-	if err != nil {
-		return nil, err
-	}
-	c, err := public.New(cp.ClientID,
-		public.WithAuthority(runtime.JoinPaths(authorityHost, cp.TenantID)),
-		public.WithHTTPClient(newPipelineAdapter(&cp.ClientOptions)),
-	)
+	c, err := getPublicClient(cp.ClientID, cp.TenantID, &cp.ClientOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
@@ -37,20 +36,10 @@ type UsernamePasswordCredential struct {
 // NewUsernamePasswordCredential creates a UsernamePasswordCredential. clientID is the ID of the application the user
 // will authenticate to. Pass nil for options to accept defaults.
 func NewUsernamePasswordCredential(tenantID string, clientID string, username string, password string, options *UsernamePasswordCredentialOptions) (*UsernamePasswordCredential, error) {
-	if !validTenantID(tenantID) {
-		return nil, errors.New(tenantIDValidationErr)
-	}
 	if options == nil {
 		options = &UsernamePasswordCredentialOptions{}
 	}
-	authorityHost, err := setAuthorityHost(options.Cloud)
-	if err != nil {
-		return nil, err
-	}
-	c, err := public.New(clientID,
-		public.WithAuthority(runtime.JoinPaths(authorityHost, tenantID)),
-		public.WithHTTPClient(newPipelineAdapter(&options.ClientOptions)),
-	)
+	c, err := getPublicClient(clientID, tenantID, &options.ClientOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This consolidates setting the core MSAL options required by all credential types into a couple of helpers.