### PR TITLE
Add support for making recordings external to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ vendor/
 
 # api view file
 *.gosource
+
+# Default Test Proxy Assets restore directory
+.assets

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -3,7 +3,7 @@
 Param(
     [Parameter(Mandatory = $true)]
     [string] $serviceDirectory,
-    [string] $testTimeout = "1s"
+    [string] $testTimeout = "10s"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -1,8 +1,9 @@
 #Requires -Version 7.0
 
 Param(
+    [Parameter(Mandatory = $true)]
     [string] $serviceDirectory,
-    [string] $testTimeout
+    [string] $testTimeout = "1s"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -5,6 +5,8 @@ Param(
     [string] $testTimeout
 )
 
+$ErrorActionPreference = 'Stop'
+
 Push-Location sdk/$serviceDirectory
 Write-Host "##[command] Executing 'go test -timeout $testTimeout -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
 
@@ -12,7 +14,7 @@ go test -timeout $testTimeout -v -coverprofile coverage.txt ./... | Tee-Object -
 # go test will return a non-zero exit code on test failures so don't skip generating the report in this case
 $GOTESTEXITCODE = $LASTEXITCODE
 
-Get-Content outfile.txt | go-junit-report > report.xml
+Get-Content -Raw outfile.txt | go-junit-report > report.xml
 
 # if no tests were actually run (e.g. examples) delete the coverage file so it's omitted from the coverage report
 if (Select-String -path ./report.xml -pattern '<testsuites></testsuites>' -simplematch -quiet) {
@@ -32,8 +34,8 @@ if (Select-String -path ./report.xml -pattern '<testsuites></testsuites>' -simpl
     Get-Content ./coverage.json | gocov-xml > ./coverage.xml
     Get-Content ./coverage.json | gocov-html > ./coverage.html
 
-    Move-Item ./coverage.xml $repoRoot
-    Move-Item ./coverage.html $repoRoot
+    Move-Item -Force ./coverage.xml $repoRoot
+    Move-Item -Force ./coverage.html $repoRoot
 
     # use internal tool to fail if coverage is too low
     Pop-Location

--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+Support test recording assets external to repository
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.1.0 (2022-10-20)
 
 ### Features Added
 
-Support test recording assets external to repository
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+* Support test recording assets external to repository
 
 ## 1.0.1 (2022-08-22)
 

--- a/sdk/internal/recording/recording.go
+++ b/sdk/internal/recording/recording.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -576,7 +575,7 @@ func (r RecordingOptions) baseURL() string {
 }
 
 func getTestId(pathToRecordings string, t *testing.T) string {
-	return path.Join(pathToRecordings, "recordings", t.Name()+".json")
+	return filepath.Join(pathToRecordings, "recordings", t.Name()+".json")
 }
 
 func getGitRoot(fromPath string) (string, error) {
@@ -591,7 +590,9 @@ func getGitRoot(fromPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Unable to find git root for path '%s'", absPath)
 	}
-	return strings.TrimSpace(bytes.NewBuffer(root).String()), nil
+
+	// Wrap with Abs() to get os-specific path separators to support sub-path matching
+	return filepath.Abs(strings.TrimSpace(bytes.NewBuffer(root).String()))
 }
 
 // Traverse up from a recording path until an asset config file is found.
@@ -601,8 +602,8 @@ func findAssetsConfigFile(fromPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	assetConfigPath := path.Join(absPath, recordingAssetConfigName)
-	gitDirectoryPath := path.Join(absPath, ".git")
+	assetConfigPath := filepath.Join(absPath, recordingAssetConfigName)
+	gitDirectoryPath := filepath.Join(absPath, ".git")
 
 	if _, err := os.Stat(assetConfigPath); err == nil {
 		return assetConfigPath, nil
@@ -637,7 +638,7 @@ func getAssetsConfigLocation(pathToRecordings string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	abs, err := findAssetsConfigFile(path.Join(gitRoot, pathToRecordings))
+	abs, err := findAssetsConfigFile(filepath.Join(gitRoot, pathToRecordings))
 	if err != nil {
 		return "", "", err
 	}

--- a/sdk/internal/recording/recording.go
+++ b/sdk/internal/recording/recording.go
@@ -592,7 +592,7 @@ func getGitRoot(fromPath string) (string, error) {
 	}
 
 	// Wrap with Abs() to get os-specific path separators to support sub-path matching
-	return filepath.Abs(strings.TrimSpace(bytes.NewBuffer(root).String()))
+	return filepath.Abs(strings.TrimSpace(string(root)))
 }
 
 // Traverse up from a recording path until an asset config file is found.

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -596,14 +595,16 @@ func TestRecordingAssetConfig(t *testing.T) {
 		o.Close()
 
 		absPath, relPath, err := getAssetsConfigLocation(c.searchDirectory)
+		// Clean up first in case of an assertion panic
+		require.NoError(t, os.Remove(c.testFileLocation))
 		require.NoError(t, err)
-		expected := c.expectedDirectory + "/" + recordingAssetConfigName
-		absPathExpected := path.Join(gitRoot, expected)
-		require.Equal(t, absPathExpected, absPath)
+
+		expected := c.expectedDirectory + string(os.PathSeparator) + recordingAssetConfigName
+		expected = strings.ReplaceAll(expected, "/", string(os.PathSeparator))
 		require.Equal(t, expected, relPath)
 
-		err = os.Remove(c.testFileLocation)
-		require.NoError(t, err)
+		absPathExpected := filepath.Join(gitRoot, expected)
+		require.Equal(t, absPathExpected, absPath)
 	}
 }
 

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -551,15 +551,14 @@ func TestHostAndScheme(t *testing.T) {
 	require.Equal(t, r.host(), "localhost:5000")
 }
 
-func TestGitRoot(t *testing.T) {
+func TestGitRootDetection(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	_, err = getGitRoot(cwd)
+	gitRoot, err := getGitRoot(cwd)
 	require.NoError(t, err)
-}
 
-func TestGitRootNotFound(t *testing.T) {
-	_, err := getGitRoot("../../../../")
+	parentDir, _ := filepath.Split(gitRoot)
+	_, err = getGitRoot(parentDir)
 	require.Error(t, err)
 }
 

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -550,42 +551,75 @@ func TestHostAndScheme(t *testing.T) {
 	require.Equal(t, r.host(), "localhost:5000")
 }
 
-func TestRecordingAssetConfigNotExist(t *testing.T) {
-	assetPath, err := getAssetsConfigPath(".", 0)
+func TestGitRoot(t *testing.T) {
+	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	require.Equal(t, assetPath, "")
+	_, err = getGitRoot(cwd)
+	require.NoError(t, err)
 }
 
-func TestRecordingAssetConfigNoGitRepo(t *testing.T) {
-	_, err := getAssetsConfigPath("../../../../", 0)
+func TestGitRootNotFound(t *testing.T) {
+	_, err := getGitRoot("../../../../")
 	require.Error(t, err)
 }
 
-func TestRecordingAssetConfigInCwd(t *testing.T) {
-	_ = os.Remove(recordingAssetConfigName)
-	defer os.Remove(recordingAssetConfigName)
+func TestRecordingAssetConfigNotExist(t *testing.T) {
+	assetPath, err := getAssetsConfigLocation(".")
+	require.NoError(t, err)
+	require.Equal(t, "", assetPath)
+}
 
-	_, err := os.Create(recordingAssetConfigName)
+func TestRecordingAssetConfigOutOfBounds(t *testing.T) {
+	assetPath, err := getAssetsConfigLocation("../../../../")
+	require.NoError(t, err)
+	require.Equal(t, "", assetPath)
+}
+
+func TestRecordingAssetConfigInCwd(t *testing.T) {
+	recordingPath := "sdk/internal/recording"
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	gitRoot, err := getGitRoot(cwd)
+	require.NoError(t, err)
+
+	assetConfigPath := path.Join(gitRoot, recordingPath, recordingAssetConfigName)
+	_ = os.Remove(assetConfigPath)
+	defer func() {
+		err := os.Remove(assetConfigPath)
+		require.NoError(t, err)
+	}()
+
+	o, err := os.Create(assetConfigPath)
+	o.Close()
 	require.NoError(t, err)
 	expected, err := filepath.Abs(recordingAssetConfigName)
 	require.NoError(t, err)
 
-	assetPath, err := getAssetsConfigPath(".", 0)
-	require.Equal(t, assetPath, expected)
+	assetPath, err := getAssetsConfigLocation(recordingPath)
+	require.NoError(t, err)
+	require.Equal(t, expected, assetPath)
+	assetPath, err = getAssetsConfigLocation(recordingPath + "/")
+	require.NoError(t, err)
+	require.Equal(t, expected, assetPath)
 }
 
 func TestRecordingAssetConfigInParent(t *testing.T) {
 	parentAssetPath := "../" + recordingAssetConfigName
 	_ = os.Remove(parentAssetPath)
-	defer os.Remove(parentAssetPath)
+	defer func() {
+		err := os.Remove(parentAssetPath)
+		require.NoError(t, err)
+	}()
 
-	_, err := os.Create(parentAssetPath)
+	o, err := os.Create(parentAssetPath)
+	o.Close()
 	require.NoError(t, err)
 	expected, err := filepath.Abs(parentAssetPath)
 	require.NoError(t, err)
 
-	assetPath, err := getAssetsConfigPath(".", 0)
-	require.Equal(t, assetPath, expected)
+	assetPath, err := getAssetsConfigLocation("sdk/internal/recording")
+	require.NoError(t, err)
+	require.Equal(t, expected, assetPath)
 }
 
 func TestFindProxyCertLocation(t *testing.T) {

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -556,7 +556,7 @@ func TestGitRootDetection(t *testing.T) {
 	gitRoot, err := getGitRoot(cwd)
 	require.NoError(t, err)
 
-	parentDir, _ := filepath.Split(gitRoot)
+	parentDir := filepath.Dir(gitRoot)
 	_, err = getGitRoot(parentDir)
 	require.Error(t, err)
 }
@@ -569,10 +569,15 @@ func TestRecordingAssetConfigNotExist(t *testing.T) {
 }
 
 func TestRecordingAssetConfigOutOfBounds(t *testing.T) {
-	absPath, relPath, err := getAssetsConfigLocation("../../../../")
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	gitRoot, err := getGitRoot(cwd)
+	require.NoError(t, err)
+	parentDir := filepath.Dir(gitRoot)
+
+	absPath, err := findAssetsConfigFile(parentDir, gitRoot)
 	require.NoError(t, err)
 	require.Equal(t, "", absPath)
-	require.Equal(t, "", relPath)
 }
 
 func TestRecordingAssetConfig(t *testing.T) {

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -550,6 +550,44 @@ func TestHostAndScheme(t *testing.T) {
 	require.Equal(t, r.host(), "localhost:5000")
 }
 
+func TestRecordingAssetConfigNotExist(t *testing.T) {
+	assetPath, err := getAssetsConfigPath(".", 0)
+	require.NoError(t, err)
+	require.Equal(t, assetPath, "")
+}
+
+func TestRecordingAssetConfigNoGitRepo(t *testing.T) {
+	_, err := getAssetsConfigPath("../../../../", 0)
+	require.Error(t, err)
+}
+
+func TestRecordingAssetConfigInCwd(t *testing.T) {
+	_ = os.Remove(recordingAssetConfigName)
+	defer os.Remove(recordingAssetConfigName)
+
+	_, err := os.Create(recordingAssetConfigName)
+	require.NoError(t, err)
+	expected, err := filepath.Abs(recordingAssetConfigName)
+	require.NoError(t, err)
+
+	assetPath, err := getAssetsConfigPath(".", 0)
+	require.Equal(t, assetPath, expected)
+}
+
+func TestRecordingAssetConfigInParent(t *testing.T) {
+	parentAssetPath := "../" + recordingAssetConfigName
+	_ = os.Remove(parentAssetPath)
+	defer os.Remove(parentAssetPath)
+
+	_, err := os.Create(parentAssetPath)
+	require.NoError(t, err)
+	expected, err := filepath.Abs(parentAssetPath)
+	require.NoError(t, err)
+
+	assetPath, err := getAssetsConfigPath(".", 0)
+	require.Equal(t, assetPath, expected)
+}
+
 func TestFindProxyCertLocation(t *testing.T) {
 	savedValue, ok := os.LookupEnv("PROXY_CERT")
 	if ok {

--- a/sdk/internal/version.go
+++ b/sdk/internal/version.go
@@ -11,5 +11,5 @@ const (
 	Module = "internal"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.0.2"
+	Version = "v1.1.0"
 )


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/4257

This adds support to the recording package to work with [test proxy asset sync](https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/documentation/asset-sync/README.md), which will allow the test recordings to be moved out of the go repository into https://github.com/Azure/azure-sdk-assets.

The primary behavior change is: if an `assets.json` file is found in the current test service directory or any parent, the recording framework will request external assets via the test proxy during test setup. If there is no `assets.json`, then pre-existing recordings will be used instead. This change should support running tests via `run_tests.ps1` or invoking `go test` directly.

I also added some minor improvements to the testing scripts.

- Improve error and pipeline handling in run_tests.ps1
- Add test proxy default assets directory to gitignore
- Support test proxy external asset mode for test recordings