### PR TITLE
Making the recovery logic for connections simpler by having them only…

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Bugs Fixed
 
 - Retries now respect cancellation when they're in the "delay before next try" phase. (PR#19295)
-- Fixed a potential leak which could cause us to open and leak a $cbs link connection, resulting in errors. (PR#TBD)
+- Fixed a potential leak which could cause us to open and leak a $cbs link connection, resulting in errors. (PR#19326)
 
 ### Other Changes
 

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -23,8 +23,6 @@
 - Retries now respect cancellation when they're in the "delay before next try" phase. (PR#19295)
 - Fixed a potential leak which could cause us to open and leak a $cbs link connection, resulting in errors. (PR#19326)
 
-### Other Changes
-
 ## 0.1.1 (2022-09-08)
 
 ### Features Added

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.0 (Unreleased)
+## 0.2.0 (2022-10-13)
 
 ### Features Added
 
@@ -20,7 +20,8 @@
 
 ### Bugs Fixed
 
-- Retries now respect cancellation when they're in the "delay before next try" phase. (PR#TBD)
+- Retries now respect cancellation when they're in the "delay before next try" phase. (PR#19295)
+- Fixed a potential leak which could cause us to open and leak a $cbs link connection, resulting in errors. (PR#TBD)
 
 ### Other Changes
 

--- a/sdk/messaging/azeventhubs/internal/amqp_fakes.go
+++ b/sdk/messaging/azeventhubs/internal/amqp_fakes.go
@@ -12,14 +12,22 @@ import (
 
 type FakeNSForPartClient struct {
 	NamespaceForAMQPLinks
-	Receiver *FakeAMQPReceiver
+
+	Receiver          *FakeAMQPReceiver
+	NewReceiverErr    error
+	NewReceiverCalled int
+
+	Sender          *FakeAMQPSender
+	NewSenderErr    error
+	NewSenderCalled int
 
 	RecoverFn func(ctx context.Context, clientRevision uint64) error
 }
 
 type FakeAMQPSession struct {
 	amqpwrap.AMQPSession
-	NS *FakeNSForPartClient
+	NS          *FakeNSForPartClient
+	CloseCalled int
 }
 
 type FakeAMQPReceiver struct {
@@ -43,6 +51,7 @@ type FakeAMQPReceiver struct {
 	NameForLink string
 
 	CloseCalled int
+	CloseError  error
 }
 
 func (ns *FakeNSForPartClient) Recover(ctx context.Context, clientRevision uint64) error {
@@ -61,6 +70,7 @@ func (ns *FakeNSForPartClient) NewAMQPSession(ctx context.Context) (amqpwrap.AMQ
 }
 
 func (sess *FakeAMQPSession) NewReceiver(ctx context.Context, source string, opts *amqp.ReceiverOptions) (amqpwrap.AMQPReceiverCloser, error) {
+	sess.NS.NewReceiverCalled++
 	sess.NS.Receiver.ManualCreditsSetFromOptions = opts.ManualCredits
 	sess.NS.Receiver.CreditsSetFromOptions = opts.Credit
 
@@ -68,7 +78,17 @@ func (sess *FakeAMQPSession) NewReceiver(ctx context.Context, source string, opt
 		sess.NS.Receiver.ActiveCredits = opts.Credit
 	}
 
-	return sess.NS.Receiver, nil
+	return sess.NS.Receiver, sess.NS.NewReceiverErr
+}
+
+func (sess *FakeAMQPSession) NewSender(ctx context.Context, target string, opts *amqp.SenderOptions) (AMQPSenderCloser, error) {
+	sess.NS.NewSenderCalled++
+	return sess.NS.Sender, sess.NS.NewSenderErr
+}
+
+func (sess *FakeAMQPSession) Close(ctx context.Context) error {
+	sess.CloseCalled++
+	return nil
 }
 
 func (r *FakeAMQPReceiver) Credits() uint32 {
@@ -98,5 +118,31 @@ func (r *FakeAMQPReceiver) Receive(ctx context.Context) (*amqp.Message, error) {
 
 func (r *FakeAMQPReceiver) Close(ctx context.Context) error {
 	r.CloseCalled++
+	return r.CloseError
+}
+
+type FakeAMQPSender struct {
+	amqpwrap.AMQPSenderCloser
+	CloseCalled int
+	CloseError  error
+}
+
+func (s *FakeAMQPSender) Close(ctx context.Context) error {
+	s.CloseCalled++
+	return s.CloseError
+}
+
+type fakeAMQPClient struct {
+	amqpwrap.AMQPClient
+	closeCalled int
+	session     *FakeAMQPSession
+}
+
+func (f *fakeAMQPClient) NewSession(ctx context.Context, opts *amqp.SessionOptions) (amqpwrap.AMQPSession, error) {
+	return f.session, nil
+}
+
+func (f *fakeAMQPClient) Close() error {
+	f.closeCalled++
 	return nil
 }

--- a/sdk/messaging/azeventhubs/internal/eh/stress/stress-test-resources.json
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/stress-test-resources.json
@@ -64,7 +64,7 @@
       "location": "[variables('location')]",
       "dependsOn": ["[resourceId('Microsoft.EventHub/namespaces', variables('namespaceName'))]"],
       "properties": {
-        "messageRetentionInDays": 1,
+        "messageRetentionInDays": 7,
         "partitionCount": 32
       }
     },

--- a/sdk/messaging/azeventhubs/internal/eh/stress/templates/deploy-job.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/templates/deploy-job.yaml
@@ -3,6 +3,7 @@
 metadata:
   labels:
     testName: "go-eventhubs"
+    Skip.RemoveTestResources: "true"
 spec:
   # uncomment to deploy to the southeastasia region.
   # nodeSelector:
@@ -21,30 +22,36 @@ spec:
       - batch
       - "-rounds"
       - "100"
+      - "-verbose"
       {{ else if (eq .Stress.Scenario "batchprefetchoff") }}
       - batch
       - "-rounds"
       - "100"
       - "-prefetch"
       - "-1"
+      - "-verbose"
       {{ else if (eq .Stress.Scenario "batchinfinite") }}
       - batch
       - "-rounds"
       - "-1"      
+      - "-verbose"
       {{ else if (eq .Stress.Scenario "processor") }}
       - processor
       - "-rounds"
       - "100"
+      - "-verbose"
       {{ else if (eq .Stress.Scenario "processorprefetchoff") }}
       - processor
       - "-rounds"
       - "100"
       - "-prefetch"
       - "-1"
+      - "-verbose"
       {{ else if (eq .Stress.Scenario "processorinfinite") }}
       - processor
       - "-rounds"
       - "-1"
+      - "-verbose"
       {{- end -}}
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/batch_stress_tester.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/batch_stress_tester.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 package tests
 
 import (
@@ -174,12 +175,19 @@ func consumeForBatchTester(ctx context.Context, round int64, cc *azeventhubs.Con
 	defer log.Printf("[r:%d/%d,p:%s] Done receiving messages from partition", round, params.rounds, params.partitionID)
 
 	total := 0
+	numCancels := 0
+	const cancelLimit = 5
 
 	analyzeErrorFn := func(err error) error {
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 				// track these, we can use it as a proxy for "network was slow" or similar.
 				testData.TC.TrackMetric(MetricDeadlineExceeded, float64(1), nil)
+				numCancels++
+
+				if numCancels >= cancelLimit {
+					return fmt.Errorf("cancellation errors were received %d times in a row. Stopping test as this indicates a problem", numCancels)
+				}
 			} else {
 				return fmt.Errorf("received %d/%d, but then got err: %w", total, params.numToSend, err)
 			}
@@ -193,8 +201,8 @@ func consumeForBatchTester(ctx context.Context, round int64, cc *azeventhubs.Con
 		events, err := partClient.ReceiveEvents(ctx, params.batchSize, nil)
 		cancel()
 
-		if analyzeErrorFn(err) != nil {
-			panic(analyzeErrorFn(err))
+		if err := analyzeErrorFn(err); err != nil {
+			panic(err)
 		}
 
 		testData.TC.TrackMetric(MetricReceived, float64(len(events)), nil)

--- a/sdk/messaging/azeventhubs/internal/links_unit_test.go
+++ b/sdk/messaging/azeventhubs/internal/links_unit_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/amqpwrap"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinks_NoOp(t *testing.T) {
+	fakeNS := &FakeNSForPartClient{}
+	links := NewLinks(fakeNS, "managementPath", func(partitionID string) string {
+		return fmt.Sprintf("part:%s", partitionID)
+	},
+		func(ctx context.Context, session amqpwrap.AMQPSession, entityPath string) (*FakeAMQPReceiver, error) {
+			panic("Nothing should be created for a nil error")
+		})
+
+	// no error just no-ops
+	err := links.RecoverIfNeeded(context.Background(), "0", nil, nil)
+	require.NoError(t, err)
+}
+
+func TestLinks_LinkStale(t *testing.T) {
+	fakeNS := &FakeNSForPartClient{}
+
+	var nextID int
+	var receivers []*FakeAMQPReceiver
+
+	links := NewLinks(fakeNS, "managementPath", func(partitionID string) string {
+		return fmt.Sprintf("part:%s", partitionID)
+	},
+		func(ctx context.Context, session amqpwrap.AMQPSession, entityPath string) (*FakeAMQPReceiver, error) {
+			nextID++
+			receivers = append(receivers, &FakeAMQPReceiver{
+				NameForLink: fmt.Sprintf("Link%d", nextID),
+			})
+			return receivers[len(receivers)-1], nil
+		})
+
+	staleLWID, err := links.GetLink(context.Background(), "0")
+	require.NoError(t, err)
+	require.NotNil(t, staleLWID)
+	require.NotNil(t, links.links["0"], "cache contains the newly created link for partition 0")
+
+	// we'll recover first, but our lwid (after this recovery) is stale since
+	// the link cache will be updated after this is done.
+	err = links.RecoverIfNeeded(context.Background(), "0", staleLWID, &amqp.DetachError{})
+	require.NoError(t, err)
+	require.Nil(t, links.links["0"], "closed link is removed from the cache")
+	require.Equal(t, 1, receivers[0].CloseCalled, "original receiver is closed, and replaced")
+
+	// trying to recover again is a no-op (if nothing is in the cache)
+	err = links.RecoverIfNeeded(context.Background(), "0", staleLWID, &amqp.DetachError{})
+	require.NoError(t, err)
+	require.Nil(t, links.links["0"], "closed link is removed from the cache")
+	require.Equal(t, 1, receivers[0].CloseCalled, "original receiver is closed, and replaced")
+
+	receivers = nil
+
+	// now let's create a new link, and attempt using the old stale lwid
+	// it'll no-op then too - we don't need to do anything, they should just call GetLink() again.
+	newLWID, err := links.GetLink(context.Background(), "0")
+	require.NoError(t, err)
+	require.NotNil(t, newLWID)
+	require.Equal(t, (*links.links["0"].Link).LinkName(), newLWID.Link.LinkName(), "cache contains the newly created link for partition 0")
+
+	err = links.RecoverIfNeeded(context.Background(), "0", staleLWID, &amqp.DetachError{})
+	require.NoError(t, err)
+	require.Equal(t, 0, receivers[0].CloseCalled, "receiver is NOT closed - we didn't need to replace it since the lwid with the error was stale")
+}
+
+func TestLinks_LinkRecoveryOnly(t *testing.T) {
+	fakeNS := &FakeNSForPartClient{}
+
+	var nextID int
+	var receivers []*FakeAMQPReceiver
+
+	links := NewLinks(fakeNS, "managementPath", func(partitionID string) string {
+		return fmt.Sprintf("part:%s", partitionID)
+	},
+		func(ctx context.Context, session amqpwrap.AMQPSession, entityPath string) (*FakeAMQPReceiver, error) {
+			nextID++
+			receivers = append(receivers, &FakeAMQPReceiver{
+				NameForLink: fmt.Sprintf("Link%d", nextID),
+			})
+			return receivers[len(receivers)-1], nil
+		})
+
+	lwid, err := links.GetLink(context.Background(), "0")
+	require.NoError(t, err)
+	require.NotNil(t, lwid)
+	require.NotNil(t, links.links["0"], "cache contains the newly created link for partition 0")
+
+	err = links.RecoverIfNeeded(context.Background(), "0", lwid, &amqp.DetachError{})
+	require.NoError(t, err)
+	require.Nil(t, links.links["0"], "cache will no longer a link for partition 0")
+
+	// no new links are create - we'll need to do something that requires a link
+	// to cause it to come back.
+	require.Equal(t, 1, len(receivers))
+	require.Equal(t, 1, receivers[0].CloseCalled)
+
+	receivers = nil
+
+	// cause a new link to get created to replace the old one.
+	newLWID, err := links.GetLink(context.Background(), "0")
+	require.NoError(t, err)
+	require.NotEqual(t, lwid, newLWID, "new link gets a new ID")
+	require.NotNil(t, links.links["0"], "cache contains the newly created link for partition 0")
+
+	require.Equal(t, 1, len(receivers))
+	require.Equal(t, 0, receivers[0].CloseCalled)
+}
+
+func TestLinks_ConnectionRecovery(t *testing.T) {
+	recoverClientCalled := 0
+
+	fakeNS := &FakeNSForPartClient{
+		RecoverFn: func(ctx context.Context, clientRevision uint64) error {
+			// we'll just always recover for our test.
+			recoverClientCalled++
+			return nil
+		},
+	}
+
+	var nextID int
+	var receivers []*FakeAMQPReceiver
+
+	links := NewLinks(fakeNS, "managementPath", func(partitionID string) string {
+		return fmt.Sprintf("part:%s", partitionID)
+	},
+		func(ctx context.Context, session amqpwrap.AMQPSession, entityPath string) (*FakeAMQPReceiver, error) {
+			nextID++
+			receivers = append(receivers, &FakeAMQPReceiver{
+				NameForLink: fmt.Sprintf("Link%d", nextID),
+			})
+			return receivers[len(receivers)-1], nil
+		})
+
+	lwid, err := links.GetLink(context.Background(), "0")
+	require.NoError(t, err)
+	require.NotNil(t, lwid)
+	require.NotNil(t, links.links["0"], "cache contains the newly created link for partition 0")
+
+	require.Equal(t, recoverClientCalled, 0)
+
+	err = links.RecoverIfNeeded(context.Background(), "0", lwid, &amqp.ConnectionError{})
+	require.NoError(t, err)
+	require.Nil(t, links.links["0"], "cache will no longer a link for partition 0")
+
+	require.Equal(t, recoverClientCalled, 1, "client was recovered")
+
+	// no new links are create - we'll need to do something that requires a link
+	// to cause it to come back.
+	require.Equal(t, 1, len(receivers))
+	require.Equal(t, 1, receivers[0].CloseCalled)
+
+	// cause a new link to get created to replace the old one.
+	receivers = nil
+
+	newLWID, err := links.GetLink(context.Background(), "0")
+	require.NoError(t, err)
+	require.NotEqual(t, lwid, newLWID, "new link gets a new ID")
+	require.NotNil(t, links.links["0"], "cache contains the newly created link for partition 0")
+
+	require.Equal(t, 1, len(receivers))
+	require.Equal(t, 0, receivers[0].CloseCalled)
+}

--- a/sdk/messaging/azeventhubs/internal/namespace_test.go
+++ b/sdk/messaging/azeventhubs/internal/namespace_test.go
@@ -341,61 +341,74 @@ func TestNamespaceUpdateClientWithoutLock(t *testing.T) {
 	require.Same(t, origClient, client)
 }
 
-// TODO: will fix in the next PR
-// func TestNamespaceConnectionRecovery(t *testing.T) {
-// 	newClientCount := 0
-// 	var fakeClientErr error
+func TestNamespaceConnectionRecovery(t *testing.T) {
+	type testData struct {
+		NS              *Namespace
+		NewClientCount  int
+		FakeClientError error
+	}
 
-// 	ns := &Namespace{
-// 		connID: 2,
-// 		newClientFn: func(ctx context.Context) (amqpwrap.AMQPClient, error) {
-// 			newClientCount++
-// 			return nil, fakeClientErr
-// 		},
-// 	}
+	init := func() *testData {
+		td := &testData{}
+		td.NS = &Namespace{
+			connID: 2,
+			newClientFn: func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+				td.NewClientCount++
+				return nil, td.FakeClientError
+			},
+		}
+		return td
+	}
 
-// 	// ie, my connection is stale (it doesn't actually matter if the connID is >, although that's impossible
-// 	// since it means their connection came from the future)
-// 	origConnID := ns.connID
+	t.Run("stale connection ID", func(t *testing.T) {
+		testData := init()
 
-// 	shouldRecreate, err := ns.Recover(context.Background(), ns.connID-1)
-// 	require.True(t, shouldRecreate, "connection we used for our links was stale (connID: 1 != connID: 2), so links should be recreated")
-// 	require.Zero(t, newClientCount, "existing client is re-used")
-// 	require.Equal(t, origConnID, ns.connID, "no new client created, connID is unchanged")
-// 	require.NoError(t, err)
+		// ie, my connection is stale (it doesn't actually matter if the connID is >, although that's impossible
+		// since it means their connection came from the future)
+		origConnID := testData.NS.connID
 
-// 	// this time the connection must be having errors AND it matches our current ID
-// 	origConnID = ns.connID
-// 	origClient := &fakeAMQPClient{}
-// 	ns.client = origClient
+		err := testData.NS.Recover(context.Background(), testData.NS.connID-1)
+		require.Zero(t, testData.NewClientCount, "existing client is re-used")
+		require.Equal(t, origConnID, testData.NS.connID, "no new client created, connID is unchanged")
+		require.NoError(t, err)
+	})
 
-// 	shouldRecreate, err = ns.Recover(context.Background(), ns.connID)
-// 	require.True(t, shouldRecreate, "new client was created so we have to recreate links")
-// 	require.Equal(t, 1, newClientCount, "new client is created (assumption is if it matches then our current connection is returning errors)")
-// 	require.Equal(t, origConnID+1, ns.connID, "new client created, connID increments")
-// 	require.NoError(t, err)
-// 	require.Equal(t, 1, origClient.closeCalled, "old client is closed")
-// 	require.NotSame(t, origClient, ns.client, "new client instance created")
+	t.Run("connection matches", func(t *testing.T) {
+		testData := init()
 
-// 	// and the last outcome - we did try to recover, but failed. We will end up in a state
-// 	// where the client will be nil, so the next attempt to get the client will create
-// 	// a new one.
-// 	fakeClientErr = errors.New("we failed to create the connection!")
-// 	origConnID = ns.connID
-// 	newClientCount = 0
+		// this time the connection must be having errors AND it matches our current ID
+		origConnID := testData.NS.connID
+		origClient := &fakeAMQPClient{}
+		testData.NS.client = origClient
 
-// 	shouldRecreate, err = ns.Recover(context.Background(), origConnID)
-// 	require.Equal(t, fakeClientErr, err)
-// 	require.False(t, shouldRecreate)
-// 	require.Equal(t, 1, newClientCount, "we did attempt to create a new client, it just failed.")
-// 	require.Equal(t, origConnID, ns.connID, "new client failed to be created so the conn ID is unchanged")
+		err := testData.NS.Recover(context.Background(), testData.NS.connID)
+		require.Equal(t, 1, testData.NewClientCount, "new client is created (assumption is if it matches then our current connection is returning errors)")
+		require.Equal(t, origConnID+1, testData.NS.connID, "new client created, connID increments")
+		require.NoError(t, err)
+		require.Equal(t, 1, origClient.closeCalled, "old client is closed")
+		require.NotSame(t, origClient, testData.NS.client, "new client instance created")
+	})
 
-// 	// if the namespace is closed then this function fails.
-// 	ns.Close(context.Background(), true)
-// 	shouldRecreate, err = ns.Recover(context.Background(), origConnID)
-// 	require.ErrorIs(t, err, ErrClientClosed)
-// 	require.False(t, shouldRecreate)
-// }
+	t.Run("recover but failed", func(t *testing.T) {
+		testData := init()
+
+		// and the last outcome - we did try to recover, but failed. We will end up in a state
+		// where the client will be nil, so the next attempt to get the client will create
+		// a new one.
+		testData.FakeClientError = errors.New("we failed to create the connection!")
+		origConnID := testData.NS.connID
+
+		err := testData.NS.Recover(context.Background(), origConnID)
+		require.Equal(t, testData.FakeClientError, err)
+		require.Equal(t, 1, testData.NewClientCount, "we did attempt to create a new client, it just failed.")
+		require.Equal(t, origConnID, testData.NS.connID, "new client failed to be created so the conn ID is unchanged")
+
+		// if the namespace is closed then this function fails.
+		testData.NS.Close(context.Background(), true)
+		err = testData.NS.Recover(context.Background(), origConnID)
+		require.ErrorIs(t, err, ErrClientClosed)
+	})
+}
 
 type fakeAMQPClient struct {
 	amqpwrap.AMQPClient

--- a/sdk/messaging/azeventhubs/internal/namespace_test.go
+++ b/sdk/messaging/azeventhubs/internal/namespace_test.go
@@ -409,13 +409,3 @@ func TestNamespaceConnectionRecovery(t *testing.T) {
 		require.ErrorIs(t, err, ErrClientClosed)
 	})
 }
-
-type fakeAMQPClient struct {
-	amqpwrap.AMQPClient
-	closeCalled int
-}
-
-func (f *fakeAMQPClient) Close() error {
-	f.closeCalled++
-	return nil
-}

--- a/sdk/messaging/azeventhubs/internal/rpc_test.go
+++ b/sdk/messaging/azeventhubs/internal/rpc_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRPCLink(t *testing.T) {
+	initFn := func() *fakeAMQPClient {
+		return &fakeAMQPClient{
+			session: &FakeAMQPSession{
+				NS: &FakeNSForPartClient{
+					Receiver: &FakeAMQPReceiver{},
+					Sender:   &FakeAMQPSender{},
+				},
+			},
+		}
+	}
+
+	t.Run("everything works, RPCLink is created", func(t *testing.T) {
+		fakeClient := initFn()
+
+		rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+			Client:   fakeClient,
+			Address:  "fake-address",
+			LogEvent: log.Event("testing"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, rpcLink)
+
+		require.Zero(t, fakeClient.session.CloseCalled)
+		require.Zero(t, fakeClient.session.NS.Receiver.CloseCalled)
+		require.Zero(t, fakeClient.session.NS.Sender.CloseCalled)
+	})
+
+	t.Run("session created, sender fails", func(t *testing.T) {
+		fakeClient := initFn()
+
+		fakeClient.session.NS.NewSenderErr = errors.New("test error")
+
+		rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+			Client:   fakeClient,
+			Address:  "fake-address",
+			LogEvent: log.Event("testing"),
+		})
+		require.EqualError(t, err, "test error")
+		require.Nil(t, rpcLink)
+
+		require.Equal(t, 1, fakeClient.session.CloseCalled, "session closed as part of cleanup")
+		require.Equal(t, 1, fakeClient.session.NS.NewSenderCalled, "sender creation failed, but was called")
+		require.Zero(t, fakeClient.session.NS.NewReceiverCalled, "receiver was never created")
+	})
+
+	t.Run("receiver fails to be created", func(t *testing.T) {
+		// receiver is last in the list, so we'll have to close out sender and session.
+		fakeClient := initFn()
+
+		fakeClient.session.NS.NewReceiverErr = errors.New("test error")
+
+		rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+			Client:   fakeClient,
+			Address:  "fake-address",
+			LogEvent: log.Event("testing"),
+		})
+		require.EqualError(t, err, "test error")
+		require.Nil(t, rpcLink)
+
+		require.Equal(t, 1, fakeClient.session.NS.NewSenderCalled, "sender creation failed, but was called")
+		require.Equal(t, 1, fakeClient.session.CloseCalled, "session closed as part of cleanup")
+		require.Equal(t, 1, fakeClient.session.NS.Sender.CloseCalled, "sender was closed")
+		require.Equal(t, 1, fakeClient.session.NS.NewReceiverCalled, "attempted to create receiver but will fail")
+	})
+
+	t.Run("close failures are logged", func(t *testing.T) {
+		logsFn := test.CaptureLogsForTest()
+
+		// receiver is last in the list, so we'll have to close out sender and session.
+		fakeClient := initFn()
+
+		fakeClient.session.NS.NewReceiverErr = errors.New("test error")
+		// we want this failure to be logged, in case it's responsible for our "multiple $cbs links are open" error.
+		fakeClient.session.NS.Sender.CloseError = errors.New("sender close failure")
+
+		rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+			Client:   fakeClient,
+			Address:  "fake-address",
+			LogEvent: log.Event("testing"),
+		})
+		require.EqualError(t, err, "test error")
+		require.Nil(t, rpcLink)
+
+		require.Equal(t, 1, fakeClient.session.NS.NewSenderCalled, "sender creation failed, but was called")
+		require.Equal(t, 1, fakeClient.session.CloseCalled, "session closed as part of cleanup")
+		require.Equal(t, 1, fakeClient.session.NS.Sender.CloseCalled, "sender was closed")
+		require.Equal(t, 1, fakeClient.session.NS.NewReceiverCalled, "attempted to create receiver but will fail")
+
+		logMessages := logsFn()
+		require.Equal(t, []string{
+			"[azeh.Auth] Failed closing sender for RPC Link: sender close failure",
+		}, logMessages)
+	})
+}


### PR DESCRIPTION
Making the recovery logic for connections simpler by having them only be responsible for recovering themselves, not all other links.

Prior to this we'd do a blanket CloseLinks() for the first recovery that happened to reboot the connection. Since each of these recoveries has to happen for each link anyways it's a bit simpler to let them each recover individually. This also preps us for the receiver redirect feature, where we can't assume that all the links are actually part of the same connection.
    
And added a bunch of tests for both parts of this (Namespace.Recover and Links.Recover).