### PR TITLE
Enable users to override client default API versions

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.1.5 (Unreleased)
+## 1.2.0 (Unreleased)
 
 ### Features Added
+* Added `ClientOptions.APIVersion` field, which overrides the default version a client
+  requests of the service, if the client supports this (all ARM clients do).
 
 ### Breaking Changes
 

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -18,8 +18,6 @@ import (
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-const apiVersion = azruntime.APIVersionQueryParamName("api-version")
-
 // NewPipeline creates a pipeline from connection options. Policies from ClientOptions are
 // placed after policies from PipelineOptions. The telemetry policy, when enabled, will
 // use the specified module and version info.
@@ -45,8 +43,8 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 		copy(perCall, plOpts.PerCall)
 		plOpts.PerCall = append(perCall, regPolicy)
 	}
-	if plOpts.APIVersionName == nil {
-		plOpts.APIVersionName = apiVersion
+	if plOpts.APIVersionName == "" {
+		plOpts.APIVersionName = "api-version"
 	}
 	return azruntime.NewPipeline(module, version, plOpts, &options.ClientOptions), nil
 }

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -18,6 +18,8 @@ import (
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
+const apiVersion = azruntime.APIVersionQueryParamName("api-version")
+
 // NewPipeline creates a pipeline from connection options. Policies from ClientOptions are
 // placed after policies from PipelineOptions. The telemetry policy, when enabled, will
 // use the specified module and version info.
@@ -42,6 +44,9 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 		perCall := make([]azpolicy.Policy, 0, len(plOpts.PerCall)+1)
 		copy(perCall, plOpts.PerCall)
 		plOpts.PerCall = append(perCall, regPolicy)
+	}
+	if plOpts.APIVersionName == nil {
+		plOpts.APIVersionName = apiVersion
 	}
 	return azruntime.NewPipeline(module, version, plOpts, &options.ClientOptions), nil
 }

--- a/sdk/azcore/arm/runtime/pipeline_test.go
+++ b/sdk/azcore/arm/runtime/pipeline_test.go
@@ -38,7 +38,7 @@ func TestNewPipelineWithAPIVersion(t *testing.T) {
 	require.NoError(t, err)
 	res, err := pl.Do(req)
 	require.NoError(t, err)
-	require.Equal(t, version, res.Request.URL.Query().Get(string(apiVersion)))
+	require.Equal(t, version, res.Request.URL.Query().Get(string("api-version")))
 }
 
 func TestNewPipelineWithOptions(t *testing.T) {

--- a/sdk/azcore/arm/runtime/pipeline_test.go
+++ b/sdk/azcore/arm/runtime/pipeline_test.go
@@ -20,7 +20,26 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/stretchr/testify/require"
 )
+
+func TestNewPipelineWithAPIVersion(t *testing.T) {
+	version := "42"
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse()
+	pl, err := NewPipeline("...", "...", mockCredential{}, azruntime.PipelineOptions{}, &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			APIVersion: version,
+		},
+	})
+	require.NoError(t, err)
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	require.NoError(t, err)
+	res, err := pl.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, version, res.Request.URL.Query().Get(string(apiVersion)))
+}
 
 func TestNewPipelineWithOptions(t *testing.T) {
 	srv, close := mock.NewServer()

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -30,5 +30,5 @@ const (
 	Module = "azcore"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.1.5"
+	Version = "v1.2.0"
 )

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -27,7 +27,7 @@ type Request = exported.Request
 // ClientOptions contains optional settings for a client's pipeline.
 // All zero-value fields will be initialized with default values.
 type ClientOptions struct {
-	// APIVersion overrides the client's default service version.
+	// APIVersion overrides the default version requested of the service. Set with caution as this package version has not been tested with arbitrary service versions.
 	APIVersion string
 
 	// Cloud specifies a cloud for the client. The default is Azure Public Cloud.

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -27,6 +27,9 @@ type Request = exported.Request
 // ClientOptions contains optional settings for a client's pipeline.
 // All zero-value fields will be initialized with default values.
 type ClientOptions struct {
+	// APIVersion overrides the client's default service version.
+	APIVersion string
+
 	// Cloud specifies a cloud for the client. The default is Azure Public Cloud.
 	Cloud cloud.Configuration
 

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -16,9 +16,9 @@ import (
 // PipelineOptions contains Pipeline options for SDK developers
 type PipelineOptions struct {
 	AllowedHeaders, AllowedQueryParameters []string
-	// APIVersionName is the name of the query parameter or header the service reads for an API version value
-	APIVersionName    APIVersionName
-	PerCall, PerRetry []policy.Policy
+	APIVersionLocation                     APIVersionLocation
+	APIVersionName                         string
+	PerCall, PerRetry                      []policy.Policy
 }
 
 // Pipeline represents a primitive for sending HTTP requests and receiving responses.
@@ -51,8 +51,8 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 	if !cp.Telemetry.Disabled {
 		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))
 	}
-	if plOpts.APIVersionName != nil && cp.APIVersion != "" {
-		policies = append(policies, NewAPIVersionPolicy(plOpts.APIVersionName, cp.APIVersion))
+	if cp.APIVersion != "" {
+		policies = append(policies, NewAPIVersionPolicy(plOpts.APIVersionLocation, plOpts.APIVersionName, cp.APIVersion))
 	}
 	policies = append(policies, plOpts.PerCall...)
 	policies = append(policies, cp.PerCallPolicies...)

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -48,11 +48,11 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 	// we put the includeResponsePolicy at the very beginning so that the raw response
 	// is populated with the final response (some policies might mutate the response)
 	policies := []policy.Policy{policyFunc(includeResponsePolicy)}
-	if !cp.Telemetry.Disabled {
-		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))
-	}
 	if cp.APIVersion != "" {
 		policies = append(policies, NewAPIVersionPolicy(plOpts.APIVersionLocation, plOpts.APIVersionName, cp.APIVersion))
+	}
+	if !cp.Telemetry.Disabled {
+		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))
 	}
 	policies = append(policies, plOpts.PerCall...)
 	policies = append(policies, cp.PerCallPolicies...)

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -16,7 +16,9 @@ import (
 // PipelineOptions contains Pipeline options for SDK developers
 type PipelineOptions struct {
 	AllowedHeaders, AllowedQueryParameters []string
-	PerCall, PerRetry                      []policy.Policy
+	// APIVersionName is the name of the query parameter or header the service reads for an API version value
+	APIVersionName    APIVersionName
+	PerCall, PerRetry []policy.Policy
 }
 
 // Pipeline represents a primitive for sending HTTP requests and receiving responses.
@@ -48,6 +50,9 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 	policies := []policy.Policy{policyFunc(includeResponsePolicy)}
 	if !cp.Telemetry.Disabled {
 		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))
+	}
+	if plOpts.APIVersionName != nil && cp.APIVersion != "" {
+		policies = append(policies, NewAPIVersionPolicy(plOpts.APIVersionName, cp.APIVersion))
 	}
 	policies = append(policies, plOpts.PerCall...)
 	policies = append(policies, cp.PerCallPolicies...)

--- a/sdk/azcore/runtime/policy_api_version.go
+++ b/sdk/azcore/runtime/policy_api_version.go
@@ -1,0 +1,80 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+const (
+	apiVersionHeaderName = iota
+	apiVersionQueryParamName
+)
+
+// APIVersionName is the name of an API version query parameter or header.
+type APIVersionName interface {
+	fmt.Stringer
+	kind() int
+}
+
+// APIVersionHeaderName names the header a client should set with a request's API version.
+type APIVersionHeaderName string
+
+func (h APIVersionHeaderName) kind() int {
+	return apiVersionHeaderName
+}
+
+func (h APIVersionHeaderName) String() string {
+	return string(h)
+}
+
+// APIVersionQueryParamName names the query parameter a client should set with a request's API version.
+type APIVersionQueryParamName string
+
+func (q APIVersionQueryParamName) kind() int {
+	return apiVersionQueryParamName
+}
+
+func (q APIVersionQueryParamName) String() string {
+	return string(q)
+}
+
+// APIVersionPolicy enables users to set the API version of every request a client sends.
+type APIVersionPolicy struct {
+	// name of the query param or header to set. Should be provided by the client.
+	name APIVersionName
+	// version value. Should be provided by the user.
+	version string
+}
+
+// NewAPIVersionPolicy constructs an APIVersionPolicy. If version is "", Do will be a no-op.
+func NewAPIVersionPolicy(name APIVersionName, version string) *APIVersionPolicy {
+	return &APIVersionPolicy{name, version}
+}
+
+// Do sets the request's API version, if the policy is configured to do so, replacing any prior value.
+func (a *APIVersionPolicy) Do(req *policy.Request) (*http.Response, error) {
+	if a.version != "" {
+		if a.name == nil {
+			// user set ClientOptions.APIVersion but the client ctor didn't set PipelineOptions.APIVersionName
+			return nil, errors.New("this client doesn't support overriding its API version")
+		}
+		switch a.name.kind() {
+		case apiVersionHeaderName:
+			req.Raw().Header.Set(a.name.String(), a.version)
+		case apiVersionQueryParamName:
+			q := req.Raw().URL.Query()
+			q.Set(a.name.String(), a.version)
+			req.Raw().URL.RawQuery = q.Encode()
+		}
+	}
+	return req.Next()
+}

--- a/sdk/azcore/runtime/policy_api_version.go
+++ b/sdk/azcore/runtime/policy_api_version.go
@@ -8,6 +8,7 @@ package runtime
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -56,6 +57,8 @@ func (a *APIVersionPolicy) Do(req *policy.Request) (*http.Response, error) {
 			q := req.Raw().URL.Query()
 			q.Set(a.name, a.version)
 			req.Raw().URL.RawQuery = q.Encode()
+		default:
+			return nil, fmt.Errorf("unknown APIVersionLocation %d", a.location)
 		}
 	}
 	return req.Next()

--- a/sdk/azcore/runtime/policy_api_version_test.go
+++ b/sdk/azcore/runtime/policy_api_version_test.go
@@ -80,6 +80,7 @@ func TestAPIVersionPolicy(t *testing.T) {
 		// ctor via NewPipeline(). The policy should return an error when the user specifies a version
 		// the policy can't set because the service client didn't identify the header/query param.
 		{version: version, err: true},
+		{location: 2, version: version, err: true},
 	} {
 		t.Run("no-op", func(t *testing.T) {
 			p := NewAPIVersionPolicy(test.location, test.name, test.version)

--- a/sdk/azcore/runtime/policy_api_version_test.go
+++ b/sdk/azcore/runtime/policy_api_version_test.go
@@ -41,9 +41,9 @@ func TestAPIVersionPolicy(t *testing.T) {
 			res, err := pl.Do(req)
 			require.NoError(t, err)
 			if header {
-				require.Equal(t, version, res.Request.Header.Get(s))
+				require.Equal(t, version, res.Request.Header.Get(name))
 			} else {
-				require.Equal(t, version, res.Request.URL.Query().Get(s))
+				require.Equal(t, version, res.Request.URL.Query().Get(name))
 			}
 
 			// the policy should override an existing value
@@ -59,9 +59,9 @@ func TestAPIVersionPolicy(t *testing.T) {
 			res, err = pl.Do(req)
 			require.NoError(t, err)
 			if header {
-				require.Equal(t, version, res.Request.Header.Get(s))
+				require.Equal(t, version, res.Request.Header.Get(name))
 			} else {
-				require.Equal(t, version, res.Request.URL.Query().Get(s))
+				require.Equal(t, version, res.Request.URL.Query().Get(name))
 			}
 		})
 	}

--- a/sdk/azcore/runtime/policy_api_version_test.go
+++ b/sdk/azcore/runtime/policy_api_version_test.go
@@ -1,0 +1,107 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIVersionPolicy(t *testing.T) {
+	name, version := "api-version", "42"
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse()
+
+	for _, header := range []bool{true, false} {
+		name := "query param"
+		if header {
+			name = "header"
+		}
+		t.Run(name, func(t *testing.T) {
+			var v APIVersionName
+			if header {
+				v = APIVersionHeaderName(name)
+			} else {
+				v = APIVersionQueryParamName(name)
+			}
+			p := NewAPIVersionPolicy(v, version)
+			pl := newTestPipeline(&policy.ClientOptions{Transport: srv, PerCallPolicies: []policy.Policy{p}})
+
+			// when the value isn't set, the policy should set it
+			req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+			require.NoError(t, err)
+			res, err := pl.Do(req)
+			require.NoError(t, err)
+			if header {
+				require.Equal(t, version, res.Request.Header.Get(name))
+			} else {
+				require.Equal(t, version, res.Request.URL.Query().Get(name))
+			}
+
+			// the policy should override an existing value
+			req, err = NewRequest(context.Background(), http.MethodGet, srv.URL())
+			require.NoError(t, err)
+			if header {
+				req.Raw().Header.Set(name, "not-"+version)
+			} else {
+				q := req.Raw().URL.Query()
+				q.Set(name, "not-"+version)
+				req.Raw().URL.RawQuery = q.Encode()
+			}
+			res, err = pl.Do(req)
+			require.NoError(t, err)
+			if header {
+				require.Equal(t, version, res.Request.Header.Get(name))
+			} else {
+				require.Equal(t, version, res.Request.URL.Query().Get(name))
+			}
+		})
+	}
+
+	for _, test := range []struct {
+		err     bool
+		name    APIVersionName
+		version string
+	}{
+		// the policy should modify the request only when given both a version and parameter name
+		{},
+		{name: APIVersionHeaderName(name), version: ""},
+		{name: APIVersionQueryParamName(name), version: ""},
+
+		// The policy must know which header/query param to set. This should come from the service client
+		// ctor via NewPipeline(). The policy should return an error when the user specifies a version
+		// the policy can't set because the service client didn't identify the header/query param.
+		{name: nil, version: version, err: true},
+	} {
+		t.Run("no-op", func(t *testing.T) {
+			p := NewAPIVersionPolicy(test.name, test.version)
+			pl := newTestPipeline(&policy.ClientOptions{Transport: srv, PerCallPolicies: []policy.Policy{p}})
+			req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+			require.NoError(t, err)
+			res, err := pl.Do(req)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			for _, p := range res.Request.URL.Query() {
+				require.NotEqual(t, name, p)
+				require.NotContains(t, p, version)
+			}
+			for _, h := range res.Request.Header {
+				require.NotEqual(t, name, h)
+				require.NotContains(t, h, version)
+			}
+		})
+	}
+}


### PR DESCRIPTION
...with code like this:
```go
armsubscription.NewSubscriptionsClient(cred, &arm.ClientOptions{
	ClientOptions: azcore.ClientOptions{
		APIVersion: "42",
	}
})
```
To get this API for ARM clients, users can simply upgrade `azcore`--no code gen required. For data plane clients, we'll need to release new versions that tell the new pipeline policy which header/query param to set. It's therefore possible for a user to upgrade `azcore` and set the new option for a data plane client that won't respect it. In this case I have the policy's `Do()` return an error (a constructor error isn't possible). That's bad, but I like it better than silently ignoring configuration. Let me know if you see a better alternative.