### PR TITLE
Check HTTP status code before looking for LRO status

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs Fixed
 * Fixed an issue in `runtime.SetMultipartFormData` to properly handle slices of `io.ReadSeekCloser`.
 * Fixed the MaxRetryDelay default to be 60s.
+* Failure to poll the state of an LRO will now return an `*azcore.ResponseError` for poller types that require this behavior.
 
 ### Other Changes
 * Retain contents of read-only fields when sending requests.

--- a/sdk/azcore/internal/pollers/async/async.go
+++ b/sdk/azcore/internal/pollers/async/async.go
@@ -99,6 +99,10 @@ func (p *Poller[T]) Done() bool {
 // Poll retrieves the current state of the LRO.
 func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 	err := pollers.PollHelper(ctx, p.AsyncURL, p.pl, func(resp *http.Response) (string, error) {
+		if !pollers.StatusCodeValid(resp) {
+			p.resp = resp
+			return "", exported.NewResponseError(resp)
+		}
 		state, err := pollers.GetStatus(resp)
 		if err != nil {
 			return "", err

--- a/sdk/azcore/internal/pollers/async/async_test.go
+++ b/sdk/azcore/internal/pollers/async/async_test.go
@@ -213,7 +213,7 @@ func TestPollFailed(t *testing.T) {
 	resp.Header.Set(shared.HeaderAzureAsync, fakePollingURL)
 	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
-			StatusCode: http.StatusBadRequest,
+			StatusCode: http.StatusOK,
 			Header:     http.Header{},
 			Body:       io.NopCloser(strings.NewReader(`{ "status": "failed" }`)),
 		}, nil
@@ -222,11 +222,36 @@ func TestPollFailed(t *testing.T) {
 	require.False(t, poller.Done())
 	resp, err = poller.Poll(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, poller.Done())
 	var result widget
 	err = poller.Result(context.Background(), &result)
 	var respErr *exported.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	require.Empty(t, result)
+}
+
+func TestPollError(t *testing.T) {
+	resp := initialResponse(http.MethodPatch, http.NoBody)
+	resp.Header.Set(shared.HeaderAzureAsync, fakePollingURL)
+	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(`{ "error": { "code": "NotFound", "message": "the item doesn't exist" } }`)),
+		}, nil
+	})), resp, "")
+	require.NoError(t, err)
+	require.False(t, poller.Done())
+	resp, err = poller.Poll(context.Background())
+	require.Error(t, err)
+	require.Nil(t, resp)
+	var respErr *exported.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	require.Equal(t, http.StatusNotFound, respErr.StatusCode)
+	require.False(t, poller.Done())
+	var result widget
+	err = poller.Result(context.Background(), &result)
 	require.ErrorAs(t, err, &respErr)
 	require.Empty(t, result)
 }

--- a/sdk/azcore/internal/pollers/body/body.go
+++ b/sdk/azcore/internal/pollers/body/body.go
@@ -100,6 +100,10 @@ func (p *Poller[T]) Done() bool {
 
 func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 	err := pollers.PollHelper(ctx, p.PollURL, p.pl, func(resp *http.Response) (string, error) {
+		if !pollers.StatusCodeValid(resp) {
+			p.resp = resp
+			return "", exported.NewResponseError(resp)
+		}
 		if resp.StatusCode == http.StatusNoContent {
 			p.resp = resp
 			p.CurState = pollers.StatusSucceeded

--- a/sdk/azcore/internal/pollers/op/op.go
+++ b/sdk/azcore/internal/pollers/op/op.go
@@ -91,6 +91,10 @@ func (p *Poller[T]) Done() bool {
 
 func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 	err := pollers.PollHelper(ctx, p.OpLocURL, p.pl, func(resp *http.Response) (string, error) {
+		if !pollers.StatusCodeValid(resp) {
+			p.resp = resp
+			return "", exported.NewResponseError(resp)
+		}
 		state, err := pollers.GetStatus(resp)
 		if err != nil {
 			return "", err

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -233,7 +233,10 @@ func TestPollHelper(t *testing.T) {
 
 	require.Error(t, err)
 	pl = exported.NewPipeline(shared.TransportFunc(func(*http.Request) (*http.Response, error) {
-		return &http.Response{}, nil
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       http.NoBody,
+		}, nil
 	}))
 	err = PollHelper(context.Background(), fakeEndpoint, pl, func(*http.Response) (string, error) {
 		return "", errors.New("failed")
@@ -242,7 +245,10 @@ func TestPollHelper(t *testing.T) {
 
 	require.Error(t, err)
 	pl = exported.NewPipeline(shared.TransportFunc(func(*http.Request) (*http.Response, error) {
-		return &http.Response{}, nil
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+		}, nil
 	}))
 	err = PollHelper(context.Background(), fakeEndpoint, pl, func(*http.Response) (string, error) {
 		return "inProgress", nil


### PR DESCRIPTION
Per LRO guidelines, operation/RELO must return a success HTTP status code when checking the status regardless of the operation's state. If polling on an LRO returns an unsuccessful HTTP status code, it should be surfaced as an *azcore.ResponseError.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/19330
