### PR TITLE
Don't touch resp when err is non nil

### DIFF
--- a/sdk/data/azappconfig/CHANGELOG.md
+++ b/sdk/data/azappconfig/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed a bug in `syncTokenPolicy` that could cause a panic in some conditions.
 
 ### Other Changes
 

--- a/sdk/data/azappconfig/CHANGELOG.md
+++ b/sdk/data/azappconfig/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Release History
 
-## 0.4.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.4.2 (2022-10-20)
 
 ### Bugs Fixed
 * Fixed a bug in `syncTokenPolicy` that could cause a panic in some conditions.
-
-### Other Changes
 
 ## 0.4.1 (2022-09-22)
 

--- a/sdk/data/azappconfig/policy_sync_token.go
+++ b/sdk/data/azappconfig/policy_sync_token.go
@@ -95,7 +95,7 @@ func (policy *syncTokenPolicy) Do(req *policy.Request) (*http.Response, error) {
 
 	resp, err := req.Next()
 
-	if err != nil {
+	if err == nil {
 		for _, st := range resp.Header[syncTokenHeaderName] {
 			policy.addToken(st)
 		}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-go/issues/19223