### PR TITLE
Fix panic due to nil map

### DIFF
--- a/sdk/data/azappconfig/policy_sync_token.go
+++ b/sdk/data/azappconfig/policy_sync_token.go
@@ -26,7 +26,7 @@ type syncTokenPolicy struct {
 }
 
 func newSyncTokenPolicy() *syncTokenPolicy {
-	return &syncTokenPolicy{}
+	return &syncTokenPolicy{syncTokens: map[string]syncToken{}}
 }
 
 func parseToken(tok string) (syncToken, error) {

--- a/sdk/data/azappconfig/policy_sync_token_test.go
+++ b/sdk/data/azappconfig/policy_sync_token_test.go
@@ -48,7 +48,7 @@ func TestSyncTokenPolicy(t *testing.T) {
 		}),
 	})
 
-	req, err := runtime.NewRequest(context.Background(), http.MethodGet, "http://fake.endpoint.org")
+	req, err := runtime.NewRequest(context.Background(), http.MethodGet, "http://test.contoso.com")
 	require.NoError(t, err)
 
 	resp, err := pl.Do(req)
@@ -71,7 +71,7 @@ func TestSyncTokenPolicyError(t *testing.T) {
 		}),
 	})
 
-	req, err := runtime.NewRequest(context.Background(), http.MethodGet, "http://fake.endpoint.org")
+	req, err := runtime.NewRequest(context.Background(), http.MethodGet, "http://test.contoso.com")
 	require.NoError(t, err)
 
 	resp, err := pl.Do(req)

--- a/sdk/data/azappconfig/policy_sync_token_test.go
+++ b/sdk/data/azappconfig/policy_sync_token_test.go
@@ -1,0 +1,80 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azappconfig
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/internal/generated"
+	"github.com/stretchr/testify/require"
+)
+
+// TransportFunc is a helper to use a first-class func to satisfy the Transporter interface.
+type TransportFunc func(*http.Request) (*http.Response, error)
+
+// Do implements the Transporter interface for the TransportFunc type.
+func (pf TransportFunc) Do(req *http.Request) (*http.Response, error) {
+	return pf(req)
+}
+
+type nonRetriableError struct {
+	error
+}
+
+func (nonRetriableError) NonRetriable() {}
+
+func TestSyncTokenPolicy(t *testing.T) {
+	stp := newSyncTokenPolicy()
+	require.NotNil(t, stp)
+
+	pl := runtime.NewPipeline("TestSyncTokenPolicy", generated.ModuleVersion, runtime.PipelineOptions{PerRetry: []policy.Policy{stp}}, &policy.ClientOptions{
+		Transport: TransportFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+				Header: http.Header{
+					"Sync-Token": []string{"jtqGc1I4=MDoyOA==;sn=28"},
+				},
+			}, nil
+		}),
+	})
+
+	req, err := runtime.NewRequest(context.Background(), http.MethodGet, "http://fake.endpoint.org")
+	require.NoError(t, err)
+
+	resp, err := pl.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	st := stp.syncTokens["jtqGc1I4"]
+	require.NotZero(t, st)
+	require.Equal(t, "jtqGc1I4", st.id)
+	require.Equal(t, int64(28), st.seqNo)
+	require.Equal(t, "MDoyOA==", st.value)
+}
+
+func TestSyncTokenPolicyError(t *testing.T) {
+	stp := newSyncTokenPolicy()
+	require.NotNil(t, stp)
+
+	pl := runtime.NewPipeline("TestSyncTokenPolicy", generated.ModuleVersion, runtime.PipelineOptions{PerRetry: []policy.Policy{stp}}, &policy.ClientOptions{
+		Transport: TransportFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, nonRetriableError{errors.New("failed")}
+		}),
+	})
+
+	req, err := runtime.NewRequest(context.Background(), http.MethodGet, "http://fake.endpoint.org")
+	require.NoError(t, err)
+
+	resp, err := pl.Do(req)
+	require.Error(t, err)
+	require.Nil(t, resp)
+}


### PR DESCRIPTION
For bug caught during live testing in the release pipeline.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1933645&view=logs&j=5ec87896-d90a-5d4a-c9b7-f77bbdb1fe36&t=fe393d95-4d2a-5621-96a7-be5b73339968

```
2022-10-20T19:13:31.2559466Z --- FAIL: TestClient (0.06s)
2022-10-20T19:13:31.2560888Z panic: assignment to entry in nil map [recovered]
2022-10-20T19:13:31.2562284Z 	panic: assignment to entry in nil map
2022-10-20T19:13:31.2562956Z 
2022-10-20T19:13:31.2563992Z goroutine 6 [running]:
2022-10-20T19:13:31.2565241Z testing.tRunner.func1.2({0x6e54c0, 0x7b9440})
2022-10-20T19:13:31.2566792Z 	/opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1389 +0x24e
2022-10-20T19:13:31.2568219Z testing.tRunner.func1()
2022-10-20T19:13:31.2569571Z 	/opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1392 +0x39f
2022-10-20T19:13:31.2571091Z panic({0x6e54c0, 0x7b9440})
2022-10-20T19:13:31.2572465Z 	/opt/hostedtoolcache/go/1.18.2/x64/src/runtime/panic.go:838 +0x207
2022-10-20T19:13:31.2574760Z github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig.(*syncTokenPolicy).addToken(0xc000010068, {0xc000208030?, 0x732899?})
2022-10-20T19:13:31.2576532Z 	/mnt/vss/_work/1/s/sdk/data/azappconfig/policy_sync_token.go:81 +0x192
2022-10-20T19:13:31.2578558Z github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig.(*syncTokenPolicy).Do(0xc000010068, 0xc000072e00)
2022-10-20T19:13:31.2580195Z 	/mnt/vss/_work/1/s/sdk/data/azappconfig/policy_sync_token.go:100 +0x2cb
2022-10-20T19:13:31.2582310Z github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported.(*Request).Next(0xc000072dc0)
2022-10-20T19:13:31.2584474Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/internal/exported/request.go:84 +0xf2
2022-10-20T19:13:31.2586687Z github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig.(*hmacAuthenticationPolicy).Do(0xc000122200?, 0xc000072dc0)
2022-10-20T19:13:31.2588407Z 	/mnt/vss/_work/1/s/sdk/data/azappconfig/policy_hmac_auth.go:75 +0x7a8
2022-10-20T19:13:31.2590946Z github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported.(*Request).Next(0xc000072d80)
2022-10-20T19:13:31.2593229Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/internal/exported/request.go:84 +0xf2
2022-10-20T19:13:31.2595970Z github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime.(*retryPolicy).Do(0xd399f7b28f21d0e?, 0xc000072d80)
2022-10-20T19:13:31.2598395Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/runtime/policy_retry.go:124 +0x67b
2022-10-20T19:13:31.2600611Z github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported.(*Request).Next(0xc000072d40)
2022-10-20T19:13:31.2602851Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/internal/exported/request.go:84 +0xf2
2022-10-20T19:13:31.2605153Z github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime.telemetryPolicy.Do({{0xc00001ae70?, 0x70e6a0?}}, 0xc000072d40)
2022-10-20T19:13:31.2607445Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/runtime/policy_telemetry.go:66 +0x1c5
2022-10-20T19:13:31.2610055Z github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported.(*Request).Next(0xc000072d00)
2022-10-20T19:13:31.2612759Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/internal/exported/request.go:84 +0xf2
2022-10-20T19:13:31.2614972Z github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime.includeResponsePolicy(0xc000072d00)
2022-10-20T19:13:31.2617369Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/runtime/policy_include_response.go:19 +0x25
2022-10-20T19:13:31.2619634Z github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime.policyFunc.Do(0xc00007f7d0?, 0xc000160bd0?)
2022-10-20T19:13:31.2621829Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/runtime/pipeline.go:72 +0x1f
2022-10-20T19:13:31.2624020Z github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported.(*Request).Next(0xc000072bc0)
2022-10-20T19:13:31.2626370Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/internal/exported/request.go:84 +0xf2
2022-10-20T19:13:31.2628962Z github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported.Pipeline.Do({{0xc00019a000?, 0x7bc2a8?, 0xc000020100?}}, 0xc000072bc0)
2022-10-20T19:13:31.2631155Z 	/mnt/vss/_work/1/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/internal/exported/pipeline.go:96 +0x199
2022-10-20T19:13:31.2633558Z github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/internal/generated.(*AzureAppConfigurationClient).PutKeyValue(0xc00007f740, {0x7bc2a8?, 0xc000020100?}, {0x730716?, 0x0?}, 0x0?)
2022-10-20T19:13:31.2635593Z 	/mnt/vss/_work/1/s/sdk/data/azappconfig/internal/generated/azureappconfiguration_client.go:846 +0xa8
2022-10-20T19:13:31.2638179Z github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig.(*Client).AddSetting(0xc00005f0d0, {0x7bc2a8, 0xc000020100}, {0x730716, 0x3}, 0xc00005f040, 0xc000137988)
2022-10-20T19:13:31.2640541Z 	/mnt/vss/_work/1/s/sdk/data/azappconfig/client.go:157 +0x211
2022-10-20T19:13:31.2642607Z github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig.TestClient(0xc000115380)
2022-10-20T19:13:31.2644323Z 	/mnt/vss/_work/1/s/sdk/data/azappconfig/client_test.go:32 +0x1dd
2022-10-20T19:13:31.2645745Z testing.tRunner(0xc000115380, 0x762dd8)
2022-10-20T19:13:31.2647143Z 	/opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1439 +0x102
2022-10-20T19:13:31.2648523Z created by testing.(*T).Run
2022-10-20T19:13:31.2649965Z 	/opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x35f
```