### PR TITLE
set MaxIdleConnsPerHost to 100 instead of 2 in defaultTransport

### DIFF
--- a/sdk/azcore/runtime/transport_default_http_client.go
+++ b/sdk/azcore/runtime/transport_default_http_client.go
@@ -22,8 +22,13 @@ func init() {
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
+		ForceAttemptHTTP2: true,
+		MaxIdleConns:      100,
+		//https://pkg.go.dev/net/http#Transport
+		// MaxIdleConnsPerHost, if non-zero, controls the maximum idle
+		// (keep-alive) connections to keep per-host. If zero,
+		// DefaultMaxIdleConnsPerHost(2) is used.
+		MaxIdleConnsPerHost:   100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
