### PR TITLE
Add tracing package

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 * Added `ClientOptions.APIVersion` field, which overrides the default version a client
   requests of the service, if the client supports this (all ARM clients do).
+* Added package `tracing` that contains the building blocks for distributed tracing.
+* Added field `TracingProvider` to type `policy.ClientOptions` that will be used to set the per-client tracing implementation.
 
 ### Breaking Changes
 

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 )
 
 // Policy represents an extensibility point for the Pipeline that can mutate the specified
@@ -41,6 +42,10 @@ type ClientOptions struct {
 
 	// Telemetry configures the built-in telemetry policy.
 	Telemetry TelemetryOptions
+
+	// TracingProvider configures the tracing provider.
+	// It defaults to a no-op tracer.
+	TracingProvider tracing.Provider
 
 	// Transport sets the transport for HTTP requests.
 	Transport Transporter

--- a/sdk/azcore/tracing/constants.go
+++ b/sdk/azcore/tracing/constants.go
@@ -1,0 +1,41 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tracing
+
+// SpanKind represents the role of a Span inside a Trace. Often, this defines how a Span will be processed and visualized by various backends.
+type SpanKind int
+
+const (
+	// SpanKindInternal indicates the span represents an interal operation within an application.  This is the default value.
+	SpanKindInternal SpanKind = 1
+
+	// SpanKindServer indicates the span covers server-side handling of a request.
+	SpanKindServer SpanKind = 2
+
+	// SpanKindClient indicates the span describes a request to a remote service.
+	SpanKindClient SpanKind = 3
+
+	// SpanKindProducer indicates the span was created by a messaging producer.
+	SpanKindProducer SpanKind = 4
+
+	// SpanKindConsumer indicates the span was created by a messaging consumer.
+	SpanKindConsumer SpanKind = 5
+)
+
+// SpanStatus represents the status of a span.
+type SpanStatus int
+
+const (
+	// SpanStatusUnset is the default status code.
+	SpanStatusUnset SpanStatus = 0
+
+	// SpanStatusError indicates the operation contains an error.
+	SpanStatusError SpanStatus = 1
+
+	// SpanStatusOK indicates the operation completed successfully.
+	SpanStatusOK SpanStatus = 2
+)

--- a/sdk/azcore/tracing/constants.go
+++ b/sdk/azcore/tracing/constants.go
@@ -10,7 +10,7 @@ package tracing
 type SpanKind int
 
 const (
-	// SpanKindInternal indicates the span represents an interal operation within an application.  This is the default value.
+	// SpanKindInternal indicates the span represents an internal operation within an application.  This is the default value.
 	SpanKindInternal SpanKind = 1
 
 	// SpanKindServer indicates the span covers server-side handling of a request.

--- a/sdk/azcore/tracing/constants.go
+++ b/sdk/azcore/tracing/constants.go
@@ -10,7 +10,7 @@ package tracing
 type SpanKind int
 
 const (
-	// SpanKindInternal indicates the span represents an internal operation within an application.  This is the default value.
+	// SpanKindInternal indicates the span represents an internal operation within an application.
 	SpanKindInternal SpanKind = 1
 
 	// SpanKindServer indicates the span covers server-side handling of a request.

--- a/sdk/azcore/tracing/tracing.go
+++ b/sdk/azcore/tracing/tracing.go
@@ -17,26 +17,26 @@ type ProviderOptions struct {
 }
 
 // NewProvider creates a new Provider with the specified values.
-//   - impl is the underlying implementation for creating Tracer instances
+//   - newTracerFn is the underlying implementation for creating Tracer instances
 //   - options contains optional values; pass nil to accept the default value
-func NewProvider(impl func(name, version string) Tracer, options *ProviderOptions) Provider {
+func NewProvider(newTracerFn func(name, version string) Tracer, options *ProviderOptions) Provider {
 	return Provider{
-		impl: impl,
+		newTracerFn: newTracerFn,
 	}
 }
 
 // Provider is the factory that creates Tracer instances.
 // It defaults to a no-op provider.
 type Provider struct {
-	impl func(name, version string) Tracer
+	newTracerFn func(name, version string) Tracer
 }
 
 // NewTracer creates a new Tracer for the specified name and version.
 //   - name - the name of the tracer object, typically the fully qualified name of the service client
 //   - version - the version of the module in which the service client resides
 func (p Provider) NewTracer(name, version string) (tracer Tracer) {
-	if p.impl != nil {
-		tracer = p.impl(name, version)
+	if p.newTracerFn != nil {
+		tracer = p.newTracerFn(name, version)
 	}
 	return
 }
@@ -49,17 +49,17 @@ type TracerOptions struct {
 }
 
 // NewTracer creates a Tracer with the specified values.
-//   - impl is the underlying implementation for creating Span instances
+//   - newSpanFn is the underlying implementation for creating Span instances
 //   - options contains optional values; pass nil to accept the default value
-func NewTracer(impl func(ctx context.Context, spanName string, options *SpanOptions) (context.Context, Span), options *TracerOptions) Tracer {
+func NewTracer(newSpanFn func(ctx context.Context, spanName string, options *SpanOptions) (context.Context, Span), options *TracerOptions) Tracer {
 	return Tracer{
-		impl: impl,
+		newSpanFn: newSpanFn,
 	}
 }
 
 // Tracer is the factory that creates Span instances.
 type Tracer struct {
-	impl func(ctx context.Context, spanName string, options *SpanOptions) (context.Context, Span)
+	newSpanFn func(ctx context.Context, spanName string, options *SpanOptions) (context.Context, Span)
 }
 
 // Start creates a new span and a context.Context that contains it.
@@ -67,8 +67,8 @@ type Tracer struct {
 //   - spanName identifies the span within a trace, it's typically the fully qualified API name
 //   - options contains optional values for the span, pass nil to accept any defaults
 func (t Tracer) Start(ctx context.Context, spanName string, options *SpanOptions) (context.Context, Span) {
-	if t.impl != nil {
-		return t.impl(ctx, spanName, options)
+	if t.newSpanFn != nil {
+		return t.newSpanFn(ctx, spanName, options)
 	}
 	return ctx, Span{}
 }

--- a/sdk/azcore/tracing/tracing.go
+++ b/sdk/azcore/tracing/tracing.go
@@ -1,0 +1,168 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package tracing contains the definitions needed to support distributed tracing.
+package tracing
+
+import (
+	"context"
+)
+
+// ProviderOptions contains the optional values when creating a Provider.
+type ProviderOptions struct {
+	// for future expansion
+}
+
+// NewProvider creates a new Provider with the specified values.
+//   - impl is the underlying implementation for creating Tracer instances
+//   - options contains optional values; pass nil to accept the default value
+func NewProvider(impl func(name, version string) Tracer, options *ProviderOptions) Provider {
+	return Provider{
+		impl: impl,
+	}
+}
+
+// Provider is the factory that creates Tracer instances.
+// It defaults to a no-op provider.
+type Provider struct {
+	impl func(name, version string) Tracer
+}
+
+// NewTracer creates a new Tracer for the specified name and version.
+//   - name - the name of the tracer object, typically the fully qualified name of the service client
+//   - version - the version of the module in which the service client resides
+func (p Provider) NewTracer(name, version string) (tracer Tracer) {
+	if p.impl != nil {
+		tracer = p.impl(name, version)
+	}
+	return
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// TracerOptions contains the optional values when creating a Tracer.
+type TracerOptions struct {
+	// for future expansion
+}
+
+// NewTracer creates a Tracer with the specified values.
+//   - impl is the underlying implementation for creating Span instances
+//   - options contains optional values; pass nil to accept the default value
+func NewTracer(impl func(ctx context.Context, spanName string, options *SpanOptions) (context.Context, Span), options *TracerOptions) Tracer {
+	return Tracer{
+		impl: impl,
+	}
+}
+
+// Tracer is the factory that creates Span instances.
+type Tracer struct {
+	impl func(ctx context.Context, spanName string, options *SpanOptions) (context.Context, Span)
+}
+
+// Start creates a new span and a context.Context that contains it.
+//   - ctx is the parent context for this span. If it contains a Span, the newly created span will be a child of that span, else it will be a root span
+//   - spanName identifies the span within a trace, it's typically the fully qualified API name
+//   - options contains optional values for the span, pass nil to accept any defaults
+func (t Tracer) Start(ctx context.Context, spanName string, options *SpanOptions) (context.Context, Span) {
+	if t.impl != nil {
+		return t.impl(ctx, spanName, options)
+	}
+	return ctx, Span{}
+}
+
+// SpanOptions contains optional settings for creating a span.
+type SpanOptions struct {
+	// Kind indicates the kind of Span.
+	Kind SpanKind
+
+	// Attributes contains key-value pairs of attributes for the span.
+	Attributes []Attribute
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// SpanImpl abstracts the underlying implementation for Span,
+// allowing it to work with various tracing implementations.
+// Any zero-values will have their default, no-op behavior.
+type SpanImpl struct {
+	// End contains the implementation for the Span.End method.
+	End func()
+
+	// SetAttributes contains the implementation for the Span.SetAttributes method.
+	SetAttributes func(...Attribute)
+
+	// AddEvent contains the implementation for the Span.AddEvent method.
+	AddEvent func(string, ...Attribute)
+
+	// AddError contains the implementation for the Span.AddError method.
+	AddError func(err error)
+
+	// SetStatus contains the implementation for the Span.SetStatus method.
+	SetStatus func(SpanStatus, string)
+}
+
+// NewSpan creates a Span with the specified implementation.
+func NewSpan(impl SpanImpl) Span {
+	return Span{
+		impl: impl,
+	}
+}
+
+// Span is a single unit of a trace.  A trace can contain multiple spans.
+// A zero-value Span provides a no-op implementation.
+type Span struct {
+	impl SpanImpl
+}
+
+// End terminates the span and MUST be called before the span leaves scope.
+// Any further updates to the span will be ignored after End is called.
+func (s Span) End() {
+	if s.impl.End != nil {
+		s.impl.End()
+	}
+}
+
+// SetAttributes sets the specified attributes on the Span.
+// Any existing attributes with the same keys will have their values overwritten.
+func (s Span) SetAttributes(attrs ...Attribute) {
+	if s.impl.SetAttributes != nil {
+		s.impl.SetAttributes(attrs...)
+	}
+}
+
+// AddEvent adds a named event with an optional set of attributes to the span.
+func (s Span) AddEvent(name string, attrs ...Attribute) {
+	if s.impl.AddEvent != nil {
+		s.impl.AddEvent(name, attrs...)
+	}
+}
+
+// AddError adds the specified error event to the span.
+func (s Span) AddError(err error) {
+	if s.impl.AddError != nil {
+		s.impl.AddError(err)
+	}
+}
+
+// SetStatus sets the status on the span along with a description.
+func (s Span) SetStatus(code SpanStatus, desc string) {
+	if s.impl.SetStatus != nil {
+		s.impl.SetStatus(code, desc)
+	}
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Attribute is a key-value pair.
+type Attribute struct {
+	// Key is the name of the attribute.
+	Key string
+
+	// Value is the attribute's value.
+	// Types that are natively supported include int64, float64, int, bool, string.
+	// Any other type will be formatted per rules of fmt.Sprintf("%v").
+	Value any
+}

--- a/sdk/azcore/tracing/tracing_test.go
+++ b/sdk/azcore/tracing/tracing_test.go
@@ -1,0 +1,65 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderZeroValues(t *testing.T) {
+	pr := Provider{}
+	tr := pr.NewTracer("name", "version")
+	require.Zero(t, tr)
+	ctx, sp := tr.Start(context.Background(), "spanName", nil)
+	require.Equal(t, context.Background(), ctx)
+	require.Zero(t, sp)
+	sp.AddError(nil)
+	sp.AddEvent("event")
+	sp.End()
+	sp.SetAttributes(Attribute{})
+	sp.SetStatus(SpanStatusError, "boom")
+}
+
+func TestProvider(t *testing.T) {
+	var addErrorCalled bool
+	var addEventCalled bool
+	var endCalled bool
+	var setAttributesCalled bool
+	var setStatusCalled bool
+
+	pr := NewProvider(func(name, version string) Tracer {
+		return NewTracer(func(context.Context, string, *SpanOptions) (context.Context, Span) {
+			return nil, NewSpan(SpanImpl{
+				AddError:      func(error) { addErrorCalled = true },
+				AddEvent:      func(string, ...Attribute) { addEventCalled = true },
+				End:           func() { endCalled = true },
+				SetAttributes: func(...Attribute) { setAttributesCalled = true },
+				SetStatus:     func(SpanStatus, string) { setStatusCalled = true },
+			})
+		}, nil)
+	}, nil)
+	tr := pr.NewTracer("name", "version")
+	require.NotZero(t, tr)
+
+	ctx, sp := tr.Start(context.Background(), "name", nil)
+	require.NotEqual(t, context.Background(), ctx)
+	require.NotZero(t, sp)
+
+	sp.AddError(nil)
+	sp.AddEvent("event")
+	sp.End()
+	sp.SetAttributes()
+	sp.SetStatus(SpanStatusError, "desc")
+	require.True(t, addErrorCalled)
+	require.True(t, addEventCalled)
+	require.True(t, endCalled)
+	require.True(t, setAttributesCalled)
+	require.True(t, setStatusCalled)
+}


### PR DESCRIPTION
This package contains the definitions needed to implement distributed tracing in SDKs and client-side providers.

https://apiview.dev/Assemblies/Review/4bc716d2a1de445ea75a731f427dec52#azcore/tracing

Fixes
- https://github.com/Azure/azure-sdk-for-go/issues/7358
- https://github.com/Azure/azure-sdk-for-go/issues/19280