### PR TITLE
Improve azidentity test constants

### DIFF
--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -30,95 +30,95 @@ import (
 const (
 	accessTokenRespMalformed = `{"access_token": 0, "expires_in": 3600}`
 	badTenantID              = "bad_tenant"
-	tenantDiscoveryResponse  = `{
-		"token_endpoint": "https://login.microsoftonline.com/3c631bb7-a9f7-4343-a5ba-a6159135f1fc/oauth2/v2.0/token",
+	tokenExpiresIn           = 3600
+	tokenValue               = "new_token"
+)
+
+var (
+	accessTokenRespSuccess    = []byte(fmt.Sprintf(`{"access_token": "%s", "expires_in": %d}`, tokenValue, tokenExpiresIn))
+	instanceDiscoveryResponse = []byte(strings.ReplaceAll(`{
+		"tenant_discovery_endpoint": "https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration",
+		"api-version": "1.1",
+		"metadata": [
+			{
+				"preferred_network": "login.microsoftonline.com",
+				"preferred_cache": "login.windows.net",
+				"aliases": [
+					"login.microsoftonline.com",
+					"login.windows.net",
+					"login.microsoft.com",
+					"sts.windows.net"
+				]
+			}
+		]
+	}`, "{tenant}", fakeTenantID))
+	tenantDiscoveryResponse = []byte(strings.ReplaceAll(`{
+		"token_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
 		"token_endpoint_auth_methods_supported": [
-		"client_secret_post",
-		"private_key_jwt",
-		"client_secret_basic"
+			"client_secret_post",
+			"private_key_jwt",
+			"client_secret_basic"
 		],
-		"jwks_uri": "https://login.microsoftonline.com/3c631bb7-a9f7-4343-a5ba-a6159135f1fc/discovery/v2.0/keys",
+		"jwks_uri": "https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys",
 		"response_modes_supported": [
-		"query",
-		"fragment",
-		"form_post"
+			"query",
+			"fragment",
+			"form_post"
 		],
 		"subject_types_supported": [
-		"pairwise"
+			"pairwise"
 		],
 		"id_token_signing_alg_values_supported": [
-		"RS256"
+			"RS256"
 		],
 		"response_types_supported": [
-		"code",
-		"id_token",
-		"code id_token",
-		"id_token token"
+			"code",
+			"id_token",
+			"code id_token",
+			"id_token token"
 		],
 		"scopes_supported": [
-		"openid",
-		"profile",
-		"email",
-		"offline_access"
+			"openid",
+			"profile",
+			"email",
+			"offline_access"
 		],
-		"issuer": "https://login.microsoftonline.com/3c631bb7-a9f7-4343-a5ba-a6159135f1fc/v2.0",
+		"issuer": "https://login.microsoftonline.com/{tenant}/v2.0",
 		"request_uri_parameter_supported": false,
 		"userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
-		"authorization_endpoint": "https://login.microsoftonline.com/3c631bb7-a9f7-4343-a5ba-a6159135f1fc/oauth2/v2.0/authorize",
-		"device_authorization_endpoint": "https://login.microsoftonline.com/3c631bb7-a9f7-4343-a5ba-a6159135f1fc/oauth2/v2.0/devicecode",
+		"authorization_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize",
+		"device_authorization_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/devicecode",
 		"http_logout_supported": true,
 		"frontchannel_logout_supported": true,
-		"end_session_endpoint": "https://login.microsoftonline.com/3c631bb7-a9f7-4343-a5ba-a6159135f1fc/oauth2/v2.0/logout",
+		"end_session_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/logout",
 		"claims_supported": [
-		"sub",
-		"iss",
-		"cloud_instance_name",
-		"cloud_instance_host_name",
-		"cloud_graph_host_name",
-		"msgraph_host",
-		"aud",
-		"exp",
-		"iat",
-		"auth_time",
-		"acr",
-		"nonce",
-		"preferred_username",
-		"name",
-		"tid",
-		"ver",
-		"at_hash",
-		"c_hash",
-		"email"
+			"sub",
+			"iss",
+			"cloud_instance_name",
+			"cloud_instance_host_name",
+			"cloud_graph_host_name",
+			"msgraph_host",
+			"aud",
+			"exp",
+			"iat",
+			"auth_time",
+			"acr",
+			"nonce",
+			"preferred_username",
+			"name",
+			"tid",
+			"ver",
+			"at_hash",
+			"c_hash",
+			"email"
 		],
-		"kerberos_endpoint": "https://login.microsoftonline.com/3c631bb7-a9f7-4343-a5ba-a6159135f1fc/kerberos",
+		"kerberos_endpoint": "https://login.microsoftonline.com/{tenant}/kerberos",
 		"tenant_region_scope": "NA",
 		"cloud_instance_name": "microsoftonline.com",
 		"cloud_graph_host_name": "graph.windows.net",
 		"msgraph_host": "graph.microsoft.com",
 		"rbac_url": "https://pas.windows.net"
-		}`
-	tokenExpiresIn = 3600
-	tokenValue     = "new_token"
-)
-
-var (
-	accessTokenRespSuccess    = fmt.Sprintf(`{"access_token": "%s", "expires_in": %d}`, tokenValue, tokenExpiresIn)
-	instanceDiscoveryResponse = []byte(`{
-	"tenant_discovery_endpoint": "https://login.microsoftonline.com/tenant/v2.0/.well-known/openid-configuration",
-	"api-version": "1.1",
-	"metadata": [
-		{
-			"preferred_network": "login.microsoftonline.com",
-			"preferred_cache": "login.windows.net",
-			"aliases": [
-				"login.microsoftonline.com",
-				"login.windows.net",
-				"login.microsoft.com",
-				"sts.windows.net"
-			]
-		}
-	]
-}`)
+	}`, "{tenant}", fakeTenantID))
 )
 
 // constants for this file

--- a/sdk/azidentity/client_assertion_credential_test.go
+++ b/sdk/azidentity/client_assertion_credential_test.go
@@ -21,8 +21,8 @@ func TestClientAssertionCredential(t *testing.T) {
 	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer close()
 	srv.AppendResponse(mock.WithBody(instanceDiscoveryResponse))
-	srv.AppendResponse(mock.WithBody([]byte(tenantDiscoveryResponse)))
-	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithBody(tenantDiscoveryResponse))
+	srv.AppendResponse(mock.WithBody(accessTokenRespSuccess))
 
 	key := struct{}{}
 	calls := 0
@@ -61,8 +61,8 @@ func TestClientAssertionCredentialCallbackError(t *testing.T) {
 	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer close()
 	srv.AppendResponse(mock.WithBody(instanceDiscoveryResponse))
-	srv.AppendResponse(mock.WithBody([]byte(tenantDiscoveryResponse)))
-	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithBody(tenantDiscoveryResponse))
+	srv.AppendResponse(mock.WithBody(accessTokenRespSuccess))
 
 	expectedError := errors.New("it didn't work")
 	getAssertion := func(c context.Context) (string, error) { return "", expectedError }

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -114,8 +114,8 @@ func TestClientCertificateCredential_SendCertificateChain(t *testing.T) {
 			srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 			defer close()
 			srv.AppendResponse(mock.WithBody(instanceDiscoveryResponse))
-			srv.AppendResponse(mock.WithBody([]byte(tenantDiscoveryResponse)))
-			srv.AppendResponse(mock.WithPredicate(validateX5C(t, test.certs)), mock.WithBody([]byte(accessTokenRespSuccess)))
+			srv.AppendResponse(mock.WithBody(tenantDiscoveryResponse))
+			srv.AppendResponse(mock.WithPredicate(validateX5C(t, test.certs)), mock.WithBody(accessTokenRespSuccess))
 			srv.AppendResponse()
 
 			options := ClientCertificateCredentialOptions{ClientOptions: azcore.ClientOptions{Transport: srv}, SendCertificateChain: true}
@@ -167,7 +167,7 @@ func TestClientCertificateCredential_NoPrivateKey(t *testing.T) {
 	test := allCertTests[0]
 	srv, close := mock.NewTLSServer()
 	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithBody(accessTokenRespSuccess))
 	options := ClientCertificateCredentialOptions{}
 	options.Cloud.ActiveDirectoryAuthorityHost = srv.URL()
 	options.Transport = srv

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -207,8 +207,8 @@ func TestEnvironmentCredential_SendCertificateChain(t *testing.T) {
 	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer close()
 	srv.AppendResponse(mock.WithBody(instanceDiscoveryResponse))
-	srv.AppendResponse(mock.WithBody([]byte(tenantDiscoveryResponse)))
-	srv.AppendResponse(mock.WithPredicate(validateX5C(t, certs)), mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithBody(tenantDiscoveryResponse))
+	srv.AppendResponse(mock.WithPredicate(validateX5C(t, certs)), mock.WithBody(accessTokenRespSuccess))
 	srv.AppendResponse()
 
 	vars := map[string]string{

--- a/sdk/azidentity/managed_identity_client_test.go
+++ b/sdk/azidentity/managed_identity_client_test.go
@@ -44,7 +44,7 @@ func TestIMDSEndpointParse(t *testing.T) {
 func TestManagedIdentityClient_UserAgent(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithBody(accessTokenRespSuccess))
 	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL()})
 	options := ManagedIdentityCredentialOptions{
 		ClientOptions: azcore.ClientOptions{
@@ -67,7 +67,7 @@ func TestManagedIdentityClient_UserAgent(t *testing.T) {
 func TestManagedIdentityClient_ApplicationID(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
-	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithBody(accessTokenRespSuccess))
 	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL()})
 	appID := "customvalue"
 	options := ManagedIdentityCredentialOptions{

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -81,7 +81,7 @@ func TestManagedIdentityCredential_AzureArc(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithHeader("WWW-Authenticate", "Basic realm="+file.Name()), mock.WithStatusCode(401))
-	srv.AppendResponse(mock.WithPredicate(validateReq), mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithPredicate(validateReq), mock.WithBody(accessTokenRespSuccess))
 	srv.AppendResponse()
 
 	setEnvironmentVariables(t, map[string]string{
@@ -112,7 +112,7 @@ func TestManagedIdentityCredential_CloudShell(t *testing.T) {
 	}
 	srv, close := mock.NewServer()
 	defer close()
-	srv.AppendResponse(mock.WithPredicate(validateReq), mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithPredicate(validateReq), mock.WithBody(accessTokenRespSuccess))
 	srv.AppendResponse()
 	setEnvironmentVariables(t, map[string]string{msiEndpoint: srv.URL()})
 	options := ManagedIdentityCredentialOptions{}
@@ -474,7 +474,7 @@ func TestManagedIdentityCredential_IMDSTimeoutSuccess(t *testing.T) {
 	resetEnvironmentVarsForTest()
 	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer close()
-	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody(accessTokenRespSuccess))
 	options := ManagedIdentityCredentialOptions{}
 	options.Transport = srv
 	cred, err := NewManagedIdentityCredential(&options)
@@ -514,7 +514,7 @@ func TestManagedIdentityCredential_ServiceFabric(t *testing.T) {
 	}
 	srv, close := mock.NewServer()
 	defer close()
-	srv.AppendResponse(mock.WithPredicate(pred), mock.WithBody([]byte(accessTokenRespSuccess)))
+	srv.AppendResponse(mock.WithPredicate(pred), mock.WithBody(accessTokenRespSuccess))
 	srv.AppendResponse()
 	setEnvironmentVariables(t, map[string]string{identityEndpoint: srv.URL(), identityHeader: expectedSecret, identityServerThumbprint: "..."})
 	cred, err := NewManagedIdentityCredential(nil)


### PR DESCRIPTION
Constants always cast to `[]byte` in use may as well be `[]byte` to begin with. Also removing magic constants from fake metadata (the tenant IDs).