### PR TITLE
Fixed bug when combining pipeline and client allow lists

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed an issue in `runtime.SetMultipartFormData` to properly handle slices of `io.ReadSeekCloser`.
 * Fixed the MaxRetryDelay default to be 60s.
 * Failure to poll the state of an LRO will now return an `*azcore.ResponseError` for poller types that require this behavior.
+* Fixed a bug in `runtime.NewPipeline` that would cause pipeline-specified allowed headers and query parameters to be lost.
 
 ### Other Changes
 * Retain contents of read-only fields when sending requests.

--- a/sdk/azcore/internal/shared/shared_test.go
+++ b/sdk/azcore/internal/shared/shared_test.go
@@ -13,6 +13,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelay(t *testing.T) {
@@ -54,6 +56,10 @@ func TestRetryAfter(t *testing.T) {
 	if s := d / time.Second; s < 598 || s > 602 {
 		t.Fatalf("expected ~600 seconds, got %d", s)
 	}
+	resp.Header.Set(HeaderRetryAfter, "invalid")
+	if d = RetryAfter(resp); d != 0 {
+		t.Fatalf("expected zero for invalid value, got %d", d)
+	}
 }
 
 func TestTypeOfT(t *testing.T) {
@@ -67,7 +73,10 @@ func TestTypeOfT(t *testing.T) {
 
 func TestNopClosingBytesReader(t *testing.T) {
 	const val1 = "the data"
-	ncbr := &NopClosingBytesReader{s: []byte(val1)}
+	ncbr := NewNopClosingBytesReader([]byte(val1))
+	if ncbr.Bytes() == nil {
+		t.Fatal("unexpected nil value")
+	}
 	b, err := io.ReadAll(ncbr)
 	if err != nil {
 		t.Fatal(err)
@@ -122,4 +131,12 @@ func TestNopClosingBytesReader(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
+}
+
+func TestTransportFunc(t *testing.T) {
+	resp, err := TransportFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, nil
+	}).Do(nil)
+	require.Nil(t, resp)
+	require.NoError(t, err)
 }

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -34,13 +34,13 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 		cp = *options
 	}
 	if len(plOpts.AllowedHeaders) > 0 {
-		headers := make([]string, 0, len(plOpts.AllowedHeaders)+len(cp.Logging.AllowedHeaders))
+		headers := make([]string, len(plOpts.AllowedHeaders)+len(cp.Logging.AllowedHeaders))
 		copy(headers, plOpts.AllowedHeaders)
 		headers = append(headers, cp.Logging.AllowedHeaders...)
 		cp.Logging.AllowedHeaders = headers
 	}
 	if len(plOpts.AllowedQueryParameters) > 0 {
-		qp := make([]string, 0, len(plOpts.AllowedQueryParameters)+len(cp.Logging.AllowedQueryParams))
+		qp := make([]string, len(plOpts.AllowedQueryParameters)+len(cp.Logging.AllowedQueryParams))
 		copy(qp, plOpts.AllowedQueryParameters)
 		qp = append(qp, cp.Logging.AllowedQueryParams...)
 		cp.Logging.AllowedQueryParams = qp

--- a/sdk/azcore/runtime/policy_body_download_test.go
+++ b/sdk/azcore/runtime/policy_body_download_test.go
@@ -8,6 +8,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"testing"
@@ -243,6 +244,9 @@ func TestDownloadBodyWithRetryPost(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
+	if s := err.Error(); s != "body download policy: mock read failure" {
+		t.Fatalf("unexpected error message: %s", s)
+	}
 	payload, err := Payload(resp)
 	if err == nil {
 		t.Fatalf("expected an error")
@@ -331,5 +335,12 @@ func TestReadBodyAfterSeek(t *testing.T) {
 	}
 	if i != 10 {
 		t.Fatalf("did not seek correctly")
+	}
+}
+
+func TestBodyDownloadError(t *testing.T) {
+	bde := &bodyDownloadError{err: io.EOF}
+	if !errors.Is(bde, io.EOF) {
+		t.Fatal("unwrap should provide inner error")
 	}
 }


### PR DESCRIPTION
Specify slice length when creating destination for copy operation.
Added additional tests to improve code coverage.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/15755
