### PR TITLE
Cosmos DB - Add PatchItem support

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.3 (Unreleased)
 
 ### Features Added
+* Added `PatchItem` function to patch documents
 
 ### Breaking Changes
 

--- a/sdk/data/azcosmos/README.md
+++ b/sdk/data/azcosmos/README.md
@@ -143,6 +143,27 @@ if err != nil {
 itemResponse, err = container.ReplaceItem(context, pk, id, marshalledReplace, nil)
 handle(err)
 
+// Patch an item
+patchItem := map[string]any{
+		"operations": []struct {
+			Op    string      `json:"op"`
+			Path  string      `json:"path"`
+			Value interface{} `json:"value"`
+		}{
+			{
+				Op:    "replace",
+				Path:  "/value",
+				Value: 5,
+			},
+		},
+	}
+marshalledPatch, err = json.Marshal(patchItem)
+if err != nil {
+    log.Fatal(err)
+}
+itemResponse, err = container.PatchItem(context, pk, id, marshalledPatch, nil)
+handle(err)
+
 // Delete an item
 itemResponse, err = container.DeleteItem(context, pk, id, nil)
 handle(err)

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -248,6 +248,26 @@ func (c *Client) sendPutRequest(
 	return c.executeAndEnsureSuccessResponse(req)
 }
 
+func (c *Client) sendPatchRequest(
+	path string,
+	ctx context.Context,
+	content interface{},
+	operationContext pipelineRequestOptions,
+	requestOptions cosmosRequestOptions,
+	requestEnricher func(*policy.Request)) (*http.Response, error) {
+	req, err := c.createRequest(path, ctx, http.MethodPatch, operationContext, requestOptions, requestEnricher)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.attachContent(content, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.executeAndEnsureSuccessResponse(req)
+}
+
 func (c *Client) sendGetRequest(
 	path string,
 	ctx context.Context,

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -5,7 +5,6 @@ package azcosmos
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -369,7 +368,7 @@ func (c *ContainerClient) PatchItem(
 	ctx context.Context,
 	partitionKey PartitionKey,
 	itemId string,
-	item []byte,
+	item *PatchOptions,
 	o *ItemOptions) (ItemResponse, error) {
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -401,182 +400,6 @@ func (c *ContainerClient) PatchItem(
 	}
 
 	return newItemResponse(azResponse)
-}
-
-// PatchIncrementItem increments a value at the target path within an item in a Cosmos container.
-// ctx - The context for the request.
-// partitionKey - The partition key for the item.
-// itemId - The id of the item to patch.
-// path - The path within the item.
-// value - The value which will be incremented.
-// o - Options for the operation.
-func (c *ContainerClient) PatchIncrementItem(
-	ctx context.Context,
-	partitionKey PartitionKey,
-	itemId string,
-	path string,
-	value interface{},
-	o *ItemOptions) (ItemResponse, error) {
-
-	patchItem := map[string]any{
-		"operations": []struct {
-			Op    string      `json:"op"`
-			Path  string      `json:"path"`
-			Value interface{} `json:"value"`
-		}{
-			{
-				Op:    "increment",
-				Path:  path,
-				Value: value,
-			},
-		},
-	}
-
-	marshalledPatch, err := json.Marshal(patchItem)
-	if err != nil {
-		return ItemResponse{}, err
-	}
-	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
-}
-
-// PatchSetItem sets a value at the target path within an item in a Cosmos container.
-// ctx - The context for the request.
-// partitionKey - The partition key for the item.
-// itemId - The id of the item to patch.
-// path - The path within the item.
-// value - The value which will be incremented.
-// o - Options for the operation.
-func (c *ContainerClient) PatchSetItem(
-	ctx context.Context,
-	partitionKey PartitionKey,
-	itemId string,
-	path string,
-	value interface{},
-	o *ItemOptions) (ItemResponse, error) {
-
-	patchItem := map[string]any{
-		"operations": []struct {
-			Op    string      `json:"op"`
-			Path  string      `json:"path"`
-			Value interface{} `json:"value"`
-		}{
-			{
-				Op:    "set",
-				Path:  path,
-				Value: value,
-			},
-		},
-	}
-
-	marshalledPatch, err := json.Marshal(patchItem)
-	if err != nil {
-		return ItemResponse{}, err
-	}
-	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
-}
-
-// PatchReplaceItem replaces the current value with a specified value at the target path within an item in a Cosmos container.
-// ctx - The context for the request.
-// partitionKey - The partition key for the item.
-// itemId - The id of the item to patch.
-// path - The path within the item.
-// value - The value which will be incremented.
-// o - Options for the operation.
-func (c *ContainerClient) PatchReplaceItem(
-	ctx context.Context,
-	partitionKey PartitionKey,
-	itemId string,
-	path string,
-	value interface{},
-	o *ItemOptions) (ItemResponse, error) {
-
-	patchItem := map[string]any{
-		"operations": []struct {
-			Op    string      `json:"op"`
-			Path  string      `json:"path"`
-			Value interface{} `json:"value"`
-		}{
-			{
-				Op:    "replace",
-				Path:  path,
-				Value: value,
-			},
-		},
-	}
-
-	marshalledPatch, err := json.Marshal(patchItem)
-	if err != nil {
-		return ItemResponse{}, err
-	}
-	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
-}
-
-// PatchAddItem adds a new object member or inserts value into array item at the target path within an item in a Cosmos container.
-// ctx - The context for the request.
-// partitionKey - The partition key for the item.
-// itemId - The id of the item to patch.
-// path - The path within the item.
-// value - The value which will be incremented.
-// o - Options for the operation.
-func (c *ContainerClient) PatchAddItem(
-	ctx context.Context,
-	partitionKey PartitionKey,
-	itemId string,
-	path string,
-	value interface{},
-	o *ItemOptions) (ItemResponse, error) {
-
-	patchItem := map[string]any{
-		"operations": []struct {
-			Op    string      `json:"op"`
-			Path  string      `json:"path"`
-			Value interface{} `json:"value"`
-		}{
-			{
-				Op:    "add",
-				Path:  path,
-				Value: value,
-			},
-		},
-	}
-
-	marshalledPatch, err := json.Marshal(patchItem)
-	if err != nil {
-		return ItemResponse{}, err
-	}
-	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
-}
-
-// PatchRemoveItem removes the specified path from an item in a Cosmos container.
-// ctx - The context for the request.
-// partitionKey - The partition key for the item.
-// itemId - The id of the item to patch.
-// path - The path within the item.
-// o - Options for the operation.
-func (c *ContainerClient) PatchRemoveItem(
-	ctx context.Context,
-	partitionKey PartitionKey,
-	itemId string,
-	path string,
-	o *ItemOptions) (ItemResponse, error) {
-
-	patchItem := map[string]any{
-		"operations": []struct {
-			Op   string `json:"op"`
-			Path string `json:"path"`
-		}{
-			{
-				Op:   "remove",
-				Path: path,
-			},
-		},
-	}
-
-	marshalledPatch, err := json.Marshal(patchItem)
-	if err != nil {
-		return ItemResponse{}, err
-	}
-	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
 }
 
 // DeleteItem deletes an item in a Cosmos container.

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -5,6 +5,7 @@ package azcosmos
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -356,6 +357,226 @@ func (c *ContainerClient) ReadItem(
 	}
 
 	return newItemResponse(azResponse)
+}
+
+// PatchItem patches an item in a Cosmos container.
+// ctx - The context for the request.
+// partitionKey - The partition key for the item.
+// itemId - The id of the item to patch.
+// item - The content to be used to patch.
+// o - Options for the operation.
+func (c *ContainerClient) PatchItem(
+	ctx context.Context,
+	partitionKey PartitionKey,
+	itemId string,
+	item []byte,
+	o *ItemOptions) (ItemResponse, error) {
+	h := headerOptionsOverride{
+		partitionKey: &partitionKey,
+	}
+
+	if o == nil {
+		o = &ItemOptions{}
+	}
+
+	operationContext := pipelineRequestOptions{
+		resourceType:          resourceTypeDocument,
+		resourceAddress:       createLink(c.link, pathSegmentDocument, itemId),
+		headerOptionsOverride: &h}
+
+	path, err := generatePathForNameBased(resourceTypeDocument, operationContext.resourceAddress, false)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+
+	azResponse, err := c.database.client.sendPatchRequest(
+		path,
+		ctx,
+		item,
+		operationContext,
+		o,
+		nil)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+
+	return newItemResponse(azResponse)
+}
+
+// PatchIncrementItem increments a value at the target path within an item in a Cosmos container.
+// ctx - The context for the request.
+// partitionKey - The partition key for the item.
+// itemId - The id of the item to patch.
+// path - The path within the item.
+// value - The value which will be incremented.
+// o - Options for the operation.
+func (c *ContainerClient) PatchIncrementItem(
+	ctx context.Context,
+	partitionKey PartitionKey,
+	itemId string,
+	path string,
+	value interface{},
+	o *ItemOptions) (ItemResponse, error) {
+
+	patchItem := map[string]any{
+		"operations": []struct {
+			Op    string      `json:"op"`
+			Path  string      `json:"path"`
+			Value interface{} `json:"value"`
+		}{
+			{
+				Op:    "increment",
+				Path:  path,
+				Value: value,
+			},
+		},
+	}
+
+	marshalledPatch, err := json.Marshal(patchItem)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
+}
+
+// PatchSetItem sets a value at the target path within an item in a Cosmos container.
+// ctx - The context for the request.
+// partitionKey - The partition key for the item.
+// itemId - The id of the item to patch.
+// path - The path within the item.
+// value - The value which will be incremented.
+// o - Options for the operation.
+func (c *ContainerClient) PatchSetItem(
+	ctx context.Context,
+	partitionKey PartitionKey,
+	itemId string,
+	path string,
+	value interface{},
+	o *ItemOptions) (ItemResponse, error) {
+
+	patchItem := map[string]any{
+		"operations": []struct {
+			Op    string      `json:"op"`
+			Path  string      `json:"path"`
+			Value interface{} `json:"value"`
+		}{
+			{
+				Op:    "set",
+				Path:  path,
+				Value: value,
+			},
+		},
+	}
+
+	marshalledPatch, err := json.Marshal(patchItem)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
+}
+
+// PatchReplaceItem replaces the current value with a specified value at the target path within an item in a Cosmos container.
+// ctx - The context for the request.
+// partitionKey - The partition key for the item.
+// itemId - The id of the item to patch.
+// path - The path within the item.
+// value - The value which will be incremented.
+// o - Options for the operation.
+func (c *ContainerClient) PatchReplaceItem(
+	ctx context.Context,
+	partitionKey PartitionKey,
+	itemId string,
+	path string,
+	value interface{},
+	o *ItemOptions) (ItemResponse, error) {
+
+	patchItem := map[string]any{
+		"operations": []struct {
+			Op    string      `json:"op"`
+			Path  string      `json:"path"`
+			Value interface{} `json:"value"`
+		}{
+			{
+				Op:    "replace",
+				Path:  path,
+				Value: value,
+			},
+		},
+	}
+
+	marshalledPatch, err := json.Marshal(patchItem)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
+}
+
+// PatchAddItem adds a new object member or inserts value into array item at the target path within an item in a Cosmos container.
+// ctx - The context for the request.
+// partitionKey - The partition key for the item.
+// itemId - The id of the item to patch.
+// path - The path within the item.
+// value - The value which will be incremented.
+// o - Options for the operation.
+func (c *ContainerClient) PatchAddItem(
+	ctx context.Context,
+	partitionKey PartitionKey,
+	itemId string,
+	path string,
+	value interface{},
+	o *ItemOptions) (ItemResponse, error) {
+
+	patchItem := map[string]any{
+		"operations": []struct {
+			Op    string      `json:"op"`
+			Path  string      `json:"path"`
+			Value interface{} `json:"value"`
+		}{
+			{
+				Op:    "add",
+				Path:  path,
+				Value: value,
+			},
+		},
+	}
+
+	marshalledPatch, err := json.Marshal(patchItem)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
+}
+
+// PatchRemoveItem removes the specified path from an item in a Cosmos container.
+// ctx - The context for the request.
+// partitionKey - The partition key for the item.
+// itemId - The id of the item to patch.
+// path - The path within the item.
+// o - Options for the operation.
+func (c *ContainerClient) PatchRemoveItem(
+	ctx context.Context,
+	partitionKey PartitionKey,
+	itemId string,
+	path string,
+	o *ItemOptions) (ItemResponse, error) {
+
+	patchItem := map[string]any{
+		"operations": []struct {
+			Op    string      `json:"op"`
+			Path  string      `json:"path"`
+		}{
+			{
+				Op:    "remove",
+				Path:  path,
+			},
+		},
+	}
+
+	marshalledPatch, err := json.Marshal(patchItem)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	return c.PatchItem(ctx, partitionKey, itemId, marshalledPatch, o)
 }
 
 // DeleteItem deletes an item in a Cosmos container.

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -562,12 +562,12 @@ func (c *ContainerClient) PatchRemoveItem(
 
 	patchItem := map[string]any{
 		"operations": []struct {
-			Op    string      `json:"op"`
-			Path  string      `json:"path"`
+			Op   string `json:"op"`
+			Path string `json:"path"`
 		}{
 			{
-				Op:    "remove",
-				Path:  path,
+				Op:   "remove",
+				Path: path,
 			},
 		},
 	}

--- a/sdk/data/azcosmos/cosmos_container_test.go
+++ b/sdk/data/azcosmos/cosmos_container_test.go
@@ -592,7 +592,9 @@ func TestContainerExecuteBatch(t *testing.T) {
 
 func TestContainerPatchItem(t *testing.T) {
 	jsonString := []byte(`{"id":"doc1","foo":"bar","hello":"world"}`)
-	patchJsonString := []byte(`{"operations":[{"op":"set","path":"/hello","value":"world"}]}`)
+	patchOpt := CreatePatchOptions()
+	patchOpt.Set("/hello", "world")
+
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(
@@ -610,7 +612,7 @@ func TestContainerPatchItem(t *testing.T) {
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
 
-	resp, err := container.PatchItem(context.TODO(), NewPartitionKeyString("1"), "doc1", patchJsonString, nil)
+	resp, err := container.PatchItem(context.TODO(), NewPartitionKeyString("1"), "doc1", patchOpt, nil)
 	if err != nil {
 		t.Fatalf("Failed to patch item: %v", err)
 	}

--- a/sdk/data/azcosmos/cosmos_container_test.go
+++ b/sdk/data/azcosmos/cosmos_container_test.go
@@ -589,3 +589,61 @@ func TestContainerExecuteBatch(t *testing.T) {
 		t.Errorf("Expected %v, but got %v", string(marshalledOperations), request.body)
 	}
 }
+
+func TestContainerPatchItem(t *testing.T) {
+	jsonString := []byte(`{"id":"doc1","foo":"bar","hello":"world"}`)
+	patchJsonString := []byte(`{"operations":[{"op":"set","path":"/hello","value":"world"}]}`)
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithBody(jsonString),
+		mock.WithHeader(cosmosHeaderEtag, "someEtag"),
+		mock.WithHeader(cosmosHeaderActivityId, "someActivityId"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "13.42"),
+		mock.WithStatusCode(200))
+
+	verifier := pipelineVerifier{}
+
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	client := &Client{endpoint: srv.URL(), pipeline: pl}
+
+	database, _ := newDatabase("databaseId", client)
+	container, _ := newContainer("containerId", database)
+
+	resp, err := container.PatchItem(context.TODO(), NewPartitionKeyString("1"), "doc1", patchJsonString, nil)
+	if err != nil {
+		t.Fatalf("Failed to patch item: %v", err)
+	}
+
+	if string(resp.Value) != string(jsonString) {
+		t.Errorf("Expected value to be %s, but got %s", string(jsonString), string(resp.Value))
+	}
+
+	if resp.RawResponse == nil {
+		t.Fatal("RawResponse is nil")
+	}
+
+	if resp.ActivityID == "" {
+		t.Fatal("Activity id was not returned")
+	}
+
+	if resp.RequestCharge == 0 {
+		t.Fatal("Request charge was not returned")
+	}
+
+	if resp.RequestCharge != 13.42 {
+		t.Errorf("Expected RequestCharge to be %f, but got %f", 13.42, resp.RequestCharge)
+	}
+
+	if resp.ETag != "someEtag" {
+		t.Errorf("Expected ETag to be %s, but got %s", "someEtag", resp.ETag)
+	}
+
+	if verifier.requests[0].method != http.MethodPatch {
+		t.Errorf("Expected method to be %s, but got %s", http.MethodPatch, verifier.requests[0].method)
+	}
+
+	if verifier.requests[0].url.RequestURI() != "/dbs/databaseId/colls/containerId/docs/doc1" {
+		t.Errorf("Expected url to be %s, but got %s", "/dbs/databaseId/colls/containerId/docs/doc1", verifier.requests[0].url.RequestURI())
+	}
+}

--- a/sdk/data/azcosmos/cosmos_item_request_patch_options.go
+++ b/sdk/data/azcosmos/cosmos_item_request_patch_options.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azcosmos
 
 // PatchOperationType defines supported values for operation types in Patch Document.
@@ -51,7 +54,7 @@ func (p *PatchOptions) Replace(path string, value interface{}) {
 	})
 }
 
-// Replace appends an add operation to the patch request.
+// Add appends an add operation to the patch request.
 func (p *PatchOptions) Add(path string, value interface{}) {
 	p.Operations = append(p.Operations, PatchOperation{
 		Op:    PatchOperationTypeAdd,
@@ -60,7 +63,7 @@ func (p *PatchOptions) Add(path string, value interface{}) {
 	})
 }
 
-// Replace appends a set operation to the patch request.
+// Set appends a set operation to the patch request.
 func (p *PatchOptions) Set(path string, value interface{}) {
 	p.Operations = append(p.Operations, PatchOperation{
 		Op:    PatchOperationTypeSet,
@@ -69,7 +72,7 @@ func (p *PatchOptions) Set(path string, value interface{}) {
 	})
 }
 
-// Replace appends a remove operation to the patch request.
+// Remove appends a remove operation to the patch request.
 func (p *PatchOptions) Remove(path string) {
 	p.Operations = append(p.Operations, PatchOperation{
 		Op:   PatchOperationTypeRemove,
@@ -77,7 +80,7 @@ func (p *PatchOptions) Remove(path string) {
 	})
 }
 
-// Replace appends an increment operation to the patch request.
+// Increment appends an increment operation to the patch request.
 func (p *PatchOptions) Increment(path string, value interface{}) {
 	p.Operations = append(p.Operations, PatchOperation{
 		Op:    PatchOperationTypeIncrement,

--- a/sdk/data/azcosmos/cosmos_item_request_patch_options.go
+++ b/sdk/data/azcosmos/cosmos_item_request_patch_options.go
@@ -1,0 +1,87 @@
+package azcosmos
+
+// PatchOperationType defines supported values for operation types in Patch Document.
+type PatchOperationType string
+
+const (
+	// Represents a patch operation Add.
+	PatchOperationTypeAdd PatchOperationType = "add"
+	// Represents a patch operation Replace.
+	PatchOperationTypeReplace PatchOperationType = "replace"
+	// Represents a patch operation Remove.
+	PatchOperationTypeRemove PatchOperationType = "remove"
+	// Represents a patch operation Set.
+	PatchOperationTypeSet PatchOperationType = "set"
+	// Represents a patch operation Increment.
+	PatchOperationTypeIncrement PatchOperationType = "incr"
+)
+
+// PatchOperation represents individual patch operation.
+type PatchOperation struct {
+	Op    PatchOperationType `json:"op"`
+	Path  string             `json:"path"`
+	Value interface{}        `json:"value,omitempty"`
+}
+
+// PatchOptions represents the patch request.
+type PatchOptions struct {
+	Condition  *string          `json:"condition,omitempty"`
+	Operations []PatchOperation `json:"operations"`
+}
+
+// CreatePatchOptions returns a struct that represents the patch request.
+func CreatePatchOptions() *PatchOptions {
+	return &PatchOptions{
+		Condition:  nil,
+		Operations: make([]PatchOperation, 0),
+	}
+}
+
+// SetCondition sets condition for the patch request.
+func (p *PatchOptions) SetCondition(condition string) {
+	p.Condition = &condition
+}
+
+// Replace appends a replace operation to the patch request.
+func (p *PatchOptions) Replace(path string, value interface{}) {
+	p.Operations = append(p.Operations, PatchOperation{
+		Op:    PatchOperationTypeReplace,
+		Path:  path,
+		Value: value,
+	})
+}
+
+// Replace appends an add operation to the patch request.
+func (p *PatchOptions) Add(path string, value interface{}) {
+	p.Operations = append(p.Operations, PatchOperation{
+		Op:    PatchOperationTypeAdd,
+		Path:  path,
+		Value: value,
+	})
+}
+
+// Replace appends a set operation to the patch request.
+func (p *PatchOptions) Set(path string, value interface{}) {
+	p.Operations = append(p.Operations, PatchOperation{
+		Op:    PatchOperationTypeSet,
+		Path:  path,
+		Value: value,
+	})
+}
+
+// Replace appends a remove operation to the patch request.
+func (p *PatchOptions) Remove(path string) {
+	p.Operations = append(p.Operations, PatchOperation{
+		Op:   PatchOperationTypeRemove,
+		Path: path,
+	})
+}
+
+// Replace appends an increment operation to the patch request.
+func (p *PatchOptions) Increment(path string, value interface{}) {
+	p.Operations = append(p.Operations, PatchOperation{
+		Op:    PatchOperationTypeIncrement,
+		Path:  path,
+		Value: value,
+	})
+}

--- a/sdk/data/azcosmos/emulator_cosmos_item_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_item_test.go
@@ -132,25 +132,15 @@ func TestItemCRUD(t *testing.T) {
 		t.Fatalf("Expected value to be 4, got %v", itemResponseBody["value"])
 	}
 
-	patchItem := map[string]any{
-		"operations": []struct {
-			Op    string `json:"op"`
-			Path  string `json:"path"`
-			Value int    `json:"value"`
-		}{
-			{
-				Op:    "replace",
-				Path:  "/value",
-				Value: 5,
-			},
-		},
-	}
-	marshalled, err = json.Marshal(patchItem)
-	if err != nil {
-		t.Fatal(err)
-	}
+	patchItem := CreatePatchOptions()
+	patchItem.SetCondition("from c where c.id = 1")
+	patchItem.Replace("/value", 5)
+	patchItem.Set("/hello", "world")
+	patchItem.Add("/foo", "bar")
+	patchItem.Remove("/value")
+	patchItem.Increment("/count", 1)
 
-	itemResponse, err = container.PatchItem(context.TODO(), pk, "1", marshalled, nil)
+	itemResponse, err = container.PatchItem(context.TODO(), pk, "1", patchItem, nil)
 	if err != nil {
 		t.Fatalf("Failed to patch item: %v", err)
 	}

--- a/sdk/data/azcosmos/emulator_cosmos_item_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_item_test.go
@@ -133,7 +133,7 @@ func TestItemCRUD(t *testing.T) {
 	}
 
 	patchItem := CreatePatchOptions()
-	patchItem.SetCondition("from c where c.id = 1")
+	patchItem.SetCondition("from c where c.id = '1'")
 	patchItem.Replace("/value", 5)
 	patchItem.Set("/hello", "world")
 	patchItem.Add("/foo", "bar")

--- a/sdk/data/azcosmos/emulator_cosmos_item_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_item_test.go
@@ -132,6 +132,29 @@ func TestItemCRUD(t *testing.T) {
 		t.Fatalf("Expected value to be 4, got %v", itemResponseBody["value"])
 	}
 
+	patchItem := map[string]any{
+		"operations": []struct {
+			Op    string `json:"op"`
+			Path  string `json:"path"`
+			Value int    `json:"value"`
+		}{
+			{
+				Op:    "replace",
+				Path:  "/value",
+				Value: 5,
+			},
+		},
+	}
+	marshalled, err = json.Marshal(patchItem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	itemResponse, err = container.PatchItem(context.TODO(), pk, "1", marshalled, nil)
+	if err != nil {
+		t.Fatalf("Failed to patch item: %v", err)
+	}
+
 	itemResponse, err = container.DeleteItem(context.TODO(), pk, "1", nil)
 	if err != nil {
 		t.Fatalf("Failed to replace item: %v", err)

--- a/sdk/data/azcosmos/go.mod
+++ b/sdk/data/azcosmos/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
 go 1.18
 
 require (
-	github.com/Azure/azure-sdk-for-go v63.2.0+incompatible
+	github.com/Azure/azure-sdk-for-go v67.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0

--- a/sdk/data/azcosmos/go.sum
+++ b/sdk/data/azcosmos/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go v63.2.0+incompatible h1:OIqkK/zTGqVUuzpEvY0B1YSYDRAFC/j+y0w2GovCggI=
-github.com/Azure/azure-sdk-for-go v63.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v67.0.0+incompatible h1:SVBwznSETB0Sipd0uyGJr7khLhJOFRUEUb+0JgkCvDo=
+github.com/Azure/azure-sdk-for-go v67.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.0.0 h1:Yoicul8bnVdQrhDMTHxdEckRGX01XvwXDHUT9zYZ3k0=


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

Hi, first time contributing.

This PR addresses https://github.com/Azure/azure-sdk-for-go/issues/18682

Implemented PatchItem method based on existing PUT/POST methods.
This also includes Patch{Add, Replace, Set, Increment}Item wrapper methods of PatchItem per requested in the issue.

The choice of theses wrapper methods are based on the [Java SDK reference](https://learn.microsoft.com/en-us/java/api/com.azure.cosmos.models.cosmospatchoperations?view=azure-java-stable#method-summary)

Tested PatchItem in my personal project with CosmosDB emulator and worked fine. Other wrapper methods are calling PatchItem internally so should work as well.

Sorry, unsure how to version this in azcosmos/CHANGELOG.md

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
