### PR TITLE
Add optional auth challenge handling to BearerTokenPolicy

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.2.1 (Unreleased)
+## 1.3.0 (Unreleased)
 
 ### Features Added
+* Added `BearerTokenOptions.AuthorizationHandler` to enable extending `BearerTokenPolicy`
+  with custom authorization logic
 
 ### Breaking Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.3.0 (Unreleased)
 
 ### Features Added
-* Added `BearerTokenOptions.AuthorizationHandler` to enable extending `BearerTokenPolicy`
+* Added `BearerTokenOptions.AuthorizationHandler` to enable extending `runtime.BearerTokenPolicy`
   with custom authorization logic
 
 ### Breaking Changes

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -30,5 +30,5 @@ const (
 	Module = "azcore"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.2.1"
+	Version = "v1.3.0"
 )

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -140,8 +140,6 @@ type BearerTokenOptions struct {
 }
 
 // AuthorizationHandler allows SDK developers to insert custom logic that runs when BearerTokenPolicy must authorize a request.
-// Errors returned by its functions should be have a NonRetriable() marker method to prevent [runtime.RetryPolicy] retrying
-// requests the AuthorizationHandler can't authorize.
 type AuthorizationHandler struct {
 	// OnRequest is called each time the policy receives a request. Its func parameter authorizes the request with a token
 	// from the policy's given credential. Implementations that need to perform I/O should use the Request's context,

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -7,6 +7,7 @@
 package policy
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -132,5 +133,28 @@ type TokenRequestOptions struct {
 
 // BearerTokenOptions configures the bearer token policy's behavior.
 type BearerTokenOptions struct {
-	// placeholder for future options
+	// AuthorizationHandler allows SDK developers to run client-specific logic when BearerTokenPolicy must authorize a request.
+	// When this field isn't set, the policy follows its default behavior of authorizing every request with a bearer token from
+	// its given credential.
+	AuthorizationHandler AuthorizationHandler
+}
+
+// AuthorizationHandler allows SDK developers to insert custom logic that runs when BearerTokenPolicy must authorize a request.
+// Errors returned by its functions should be have a NonRetriable() marker method to prevent [runtime.RetryPolicy] retrying
+// requests the AuthorizationHandler can't authorize.
+type AuthorizationHandler struct {
+	// OnRequest is called each time the policy receives a request. Its func parameter authorizes the request with a token
+	// from the policy's given credential. Implementations that need to perform I/O should use the Request's context,
+	// available from Request.Raw().Context(). When OnRequest returns an error, the policy propagates that error and doesn't
+	// send the request. When OnRequest is nil, the policy follows its default behavior, authorizing the request with a
+	// token from its credential according to its configuration.
+	OnRequest func(*Request, func(TokenRequestOptions) error) error
+
+	// OnChallenge is called when the policy receives a 401 response, allowing the AuthorizationHandler to re-authorize the
+	// request according to an authentication challenge (the Response's WWW-Authenticate header). OnChallenge is responsible
+	// for parsing parameters from the challenge. Its func parameter will authorize the request with a token from the policy's
+	// given credential. Implementations that need to perform I/O should use the Request's context, available from
+	// Request.Raw().Context(). When OnChallenge returns nil, the policy will send the request again. When OnChallenge is nil,
+	// the policy will return any 401 response to the client.
+	OnChallenge func(*Request, *http.Response, func(TokenRequestOptions) error) error
 }


### PR DESCRIPTION
Closes #17554 by adding a couple of extension points SDK developers can use to insert custom logic around BearerTokenPolicy's default behavior. These allow clients to elicit challenges (to discover auth parameters) and to handle them, without having to copy and tweak BearerTokenPolicy, as we've done for Key Vault and ARM. This will simplify supporting CAE and ARM cross-tenant authentication. #19447 has a draft implementation for Key Vault showing this new API in use.