### PR TITLE
[azservicebus] Idle timer

### DIFF
--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -44,6 +44,8 @@ type FakeAMQPLinks struct {
 	Closed              int
 	CloseIfNeededCalled int
 
+	GetFn func(ctx context.Context) (*LinksWithID, error)
+
 	// values to be returned for each `Get` call
 	Revision LinkID
 	Receiver AMQPReceiver
@@ -188,6 +190,10 @@ func (l *FakeAMQPLinks) Get(ctx context.Context) (*LinksWithID, error) {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
+		if l.GetFn != nil {
+			return l.GetFn(ctx)
+		}
+
 		return &LinksWithID{
 			Sender:   l.Sender,
 			Receiver: l.Receiver,

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -17,6 +17,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/go-amqp"
 )
 
+var IdleError = errors.New("link was idle, detaching (will be reattached).")
+
 type errNonRetriable struct {
 	Message string
 }
@@ -167,6 +169,10 @@ func GetRecoveryKind(err error) RecoveryKind {
 
 	if IsCancelError(err) {
 		return RecoveryKindFatal
+	}
+
+	if errors.Is(err, IdleError) {
+		return RecoveryKindLink
 	}
 
 	var netErr net.Error

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -286,3 +286,7 @@ func Test_TransformError(t *testing.T) {
 	// and it's okay, for convenience, to pass a nil.
 	require.Nil(t, TransformError(nil))
 }
+
+func Test_IdleError(t *testing.T) {
+	require.Equal(t, RecoveryKindLink, GetRecoveryKind(IdleError))
+}

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -215,6 +215,7 @@ func TestReceiverCancellationUnitTests(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		r := &Receiver{
+			idleDuration:             5 * time.Minute,
 			defaultTimeAfterFirstMsg: time.Second,
 			defaultDrainTimeout:      time.Second,
 			amqpLinks: &internal.FakeAMQPLinks{


### PR DESCRIPTION
We seem to have some customers that can reproduce an issue where the receiver is "active" but no longer receiving any messages.

Currently, our keep-alive check is only checking things at the connection level, including our keep-alive. However, if our link were to be disconnected on the service side, and we somehow missed the detach notification, there'd be no confirmation on our end that the link is actually alive since we don't re-issue credits unless something changes (and nothing will).

This change makes it so we give it a max 5 minutes of pure-idle time on the client. If we don't receive anything for that time we'll just restart the link, which is a pretty cheap operation and it will guarantee that the link is active. I've also added in some error messages specifically around this behavior, which should give us something to narrow down on in our stress testing as well.