### PR TITLE
Expose tracing provider from the pipeline

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,7 @@
   requests of the service, if the client supports this (all ARM clients do).
 * Added package `tracing` that contains the building blocks for distributed tracing.
 * Added field `TracingProvider` to type `policy.ClientOptions` that will be used to set the per-client tracing implementation.
+* Added method `TracingProvider` to type `runtime.Pipeline` that exposes the tracing provider for a pipeline.
 
 ### Breaking Changes
 

--- a/sdk/azcore/internal/pollers/async/async.go
+++ b/sdk/azcore/internal/pollers/async/async.go
@@ -33,7 +33,7 @@ func CanResume(token map[string]interface{}) bool {
 
 // Poller is an LRO poller that uses the Azure-AsyncOperation pattern.
 type Poller[T any] struct {
-	pl exported.Pipeline
+	pl exported.Policy
 
 	resp *http.Response
 
@@ -58,7 +58,7 @@ type Poller[T any] struct {
 
 // New creates a new Poller from the provided initial response and final-state type.
 // Pass nil for response to create an empty Poller for rehydration.
-func New[T any](pl exported.Pipeline, resp *http.Response, finalState pollers.FinalStateVia) (*Poller[T], error) {
+func New[T any](pl exported.Policy, resp *http.Response, finalState pollers.FinalStateVia) (*Poller[T], error) {
 	if resp == nil {
 		log.Write(log.EventLRO, "Resuming Azure-AsyncOperation poller.")
 		return &Poller[T]{pl: pl}, nil

--- a/sdk/azcore/internal/pollers/body/body.go
+++ b/sdk/azcore/internal/pollers/body/body.go
@@ -42,7 +42,7 @@ func CanResume(token map[string]interface{}) bool {
 
 // Poller is an LRO poller that uses the Body pattern.
 type Poller[T any] struct {
-	pl exported.Pipeline
+	pl exported.Policy
 
 	resp *http.Response
 
@@ -58,7 +58,7 @@ type Poller[T any] struct {
 
 // New creates a new Poller from the provided initial response.
 // Pass nil for response to create an empty Poller for rehydration.
-func New[T any](pl exported.Pipeline, resp *http.Response) (*Poller[T], error) {
+func New[T any](pl exported.Policy, resp *http.Response) (*Poller[T], error) {
 	if resp == nil {
 		log.Write(log.EventLRO, "Resuming Body poller.")
 		return &Poller[T]{pl: pl}, nil

--- a/sdk/azcore/internal/pollers/loc/loc.go
+++ b/sdk/azcore/internal/pollers/loc/loc.go
@@ -41,7 +41,7 @@ func CanResume(token map[string]interface{}) bool {
 
 // Poller is an LRO poller that uses the Location pattern.
 type Poller[T any] struct {
-	pl   exported.Pipeline
+	pl   exported.Policy
 	resp *http.Response
 
 	Type     string `json:"type"`
@@ -51,7 +51,7 @@ type Poller[T any] struct {
 
 // New creates a new Poller from the provided initial response.
 // Pass nil for response to create an empty Poller for rehydration.
-func New[T any](pl exported.Pipeline, resp *http.Response) (*Poller[T], error) {
+func New[T any](pl exported.Policy, resp *http.Response) (*Poller[T], error) {
 	if resp == nil {
 		log.Write(log.EventLRO, "Resuming Location poller.")
 		return &Poller[T]{pl: pl}, nil

--- a/sdk/azcore/internal/pollers/op/op.go
+++ b/sdk/azcore/internal/pollers/op/op.go
@@ -31,7 +31,7 @@ func CanResume(token map[string]interface{}) bool {
 
 // Poller is an LRO poller that uses the Operation-Location pattern.
 type Poller[T any] struct {
-	pl   exported.Pipeline
+	pl   exported.Policy
 	resp *http.Response
 
 	OpLocURL   string                `json:"oplocURL"`
@@ -44,7 +44,7 @@ type Poller[T any] struct {
 
 // New creates a new Poller from the provided initial response.
 // Pass nil for response to create an empty Poller for rehydration.
-func New[T any](pl exported.Pipeline, resp *http.Response, finalState pollers.FinalStateVia) (*Poller[T], error) {
+func New[T any](pl exported.Policy, resp *http.Response, finalState pollers.FinalStateVia) (*Poller[T], error) {
 	if resp == nil {
 		log.Write(log.EventLRO, "Resuming Operation-Location poller.")
 		return &Poller[T]{pl: pl}, nil

--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -269,7 +269,7 @@ func (p *NopPoller[T]) Result(ctx context.Context, out *T) error {
 // If the request fails, the update func is not called.
 // The update func returns the state of the operation for logging purposes or an error
 // if it fails to extract the required state from the response.
-func PollHelper(ctx context.Context, endpoint string, pl exported.Pipeline, update func(resp *http.Response) (string, error)) error {
+func PollHelper(ctx context.Context, endpoint string, pl exported.Policy, update func(resp *http.Response) (string, error)) error {
 	req, err := exported.NewRequest(ctx, http.MethodGet, endpoint)
 	if err != nil {
 		return err

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -23,7 +23,7 @@ type PageResponse struct {
 	NextPage bool  `json:"next"`
 }
 
-func pageResponseFetcher(ctx context.Context, pl Pipeline, endpoint string) (PageResponse, error) {
+func pageResponseFetcher(ctx context.Context, pl exported.Pipeline, endpoint string) (PageResponse, error) {
 	req, err := NewRequest(ctx, http.MethodGet, endpoint)
 	if err != nil {
 		return PageResponse{}, err

--- a/sdk/azcore/runtime/pipeline_test.go
+++ b/sdk/azcore/runtime/pipeline_test.go
@@ -126,4 +126,5 @@ func TestNewPipelineCustomPolicies(t *testing.T) {
 	require.Equal(t, 1, customPerCallPolicy.count)
 	require.Equal(t, 2, defaultPerRetryPolicy.count)
 	require.Equal(t, 2, customPerRetryPolicy.count)
+	require.Zero(t, pl.TracingProvider())
 }

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -56,7 +56,7 @@ type NewPollerOptions[T any] struct {
 }
 
 // NewPoller creates a Poller based on the provided initial response.
-func NewPoller[T any](resp *http.Response, pl exported.Pipeline, options *NewPollerOptions[T]) (*Poller[T], error) {
+func NewPoller[T any](resp *http.Response, pl Pipeline, options *NewPollerOptions[T]) (*Poller[T], error) {
 	if options == nil {
 		options = &NewPollerOptions[T]{}
 	}
@@ -123,7 +123,7 @@ type NewPollerFromResumeTokenOptions[T any] struct {
 }
 
 // NewPollerFromResumeToken creates a Poller from a resume token string.
-func NewPollerFromResumeToken[T any](token string, pl exported.Pipeline, options *NewPollerFromResumeTokenOptions[T]) (*Poller[T], error) {
+func NewPollerFromResumeToken[T any](token string, pl Pipeline, options *NewPollerFromResumeTokenOptions[T]) (*Poller[T], error) {
 	if options == nil {
 		options = &NewPollerFromResumeTokenOptions[T]{}
 	}


### PR DESCRIPTION
This simplifies client access to the configured tracing provider. The Pipeline type is no longer an alias, however its definition is identical to the internal version.

Example usage.
```go
func NewLRORetrysClient(moduleName, moduleVersion string, options *LRORetrysClientOptions) *LRORetrysClient {
	cp := LRORetrysClientOptions{}
	if options != nil {
		cp = *options
	}
	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &cp.ClientOptions)
	client := &LRORetrysClient{
		pl: pl,
	}
	client.tracer = pl.TracingProvider().NewTracer(reflect.TypeOf(client).Elem().PkgPath(), moduleVersion)
	return client
}
```