### PR TITLE
[azeventhubs, azservicebus] stress eng script requires a specific version, not ~version's

### DIFF
--- a/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.21
-digest: sha256:ac7f0861fd54ebba0e3fec92c1fecc058e96f58df9094641605dd4250a7a423f
-generated: "2022-10-26T23:28:36.470982569Z"
+  version: 0.2.0
+digest: sha256:53cbe4c0fed047f6c611523bd34181b21a310e7a3a21cb14f649bb09e4a77648
+generated: "2022-11-02T01:52:46.0968979Z"

--- a/sdk/messaging/azeventhubs/internal/eh/stress/Chart.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Chart.yaml
@@ -8,5 +8,5 @@ annotations:
   namespace: 'go'
 dependencies:
 - name: stress-test-addons
-  version: ~0.1.20
+  version: 0.2.0
   repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/sdk/messaging/azservicebus/internal/stress/Chart.lock
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.21
-digest: sha256:ac7f0861fd54ebba0e3fec92c1fecc058e96f58df9094641605dd4250a7a423f
-generated: "2022-10-29T01:11:52.71900634Z"
+  version: 0.2.0
+digest: sha256:53cbe4c0fed047f6c611523bd34181b21a310e7a3a21cb14f649bb09e4a77648
+generated: "2022-11-02T02:01:59.10112386Z"

--- a/sdk/messaging/azservicebus/internal/stress/Chart.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.yaml
@@ -8,5 +8,5 @@ annotations:
   namespace: 'go'
 dependencies:
 - name: stress-test-addons
-  version: ~0.1.20
+  version: 0.2.0
   repository: https://stresstestcharts.blob.core.windows.net/helm/


### PR DESCRIPTION
The stress deploy script is doing version checking, but it doesn't handle versions with `~` as the matcher, which I use exclusively.

Changing for now, issue filed for the stress script itself at https://github.com/Azure/azure-sdk-tools/issues/4590.