### PR TITLE
Consolidate API version policy options

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0 (2022-11-03)
+## 1.2.0 (2022-11-04)
 
 ### Features Added
 * Added `ClientOptions.APIVersion` field, which overrides the default version a client

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -43,8 +43,8 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 		copy(perCall, plOpts.PerCall)
 		plOpts.PerCall = append(perCall, regPolicy)
 	}
-	if plOpts.APIVersionName == "" {
-		plOpts.APIVersionName = "api-version"
+	if plOpts.APIVersion.Name == "" {
+		plOpts.APIVersion.Name = "api-version"
 	}
 	return azruntime.NewPipeline(module, version, plOpts, &options.ClientOptions), nil
 }

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -16,8 +16,7 @@ import (
 // PipelineOptions contains Pipeline options for SDK developers
 type PipelineOptions struct {
 	AllowedHeaders, AllowedQueryParameters []string
-	APIVersionLocation                     APIVersionLocation
-	APIVersionName                         string
+	APIVersion                             APIVersionOptions
 	PerCall, PerRetry                      []policy.Policy
 }
 
@@ -49,7 +48,7 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 	// is populated with the final response (some policies might mutate the response)
 	policies := []policy.Policy{policyFunc(includeResponsePolicy)}
 	if cp.APIVersion != "" {
-		policies = append(policies, newAPIVersionPolicy(plOpts.APIVersionLocation, plOpts.APIVersionName, cp.APIVersion))
+		policies = append(policies, newAPIVersionPolicy(cp.APIVersion, &plOpts.APIVersion))
 	}
 	if !cp.Telemetry.Disabled {
 		policies = append(policies, NewTelemetryPolicy(module, version, &cp.Telemetry))

--- a/sdk/azcore/runtime/policy_api_version.go
+++ b/sdk/azcore/runtime/policy_api_version.go
@@ -14,6 +14,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
+// APIVersionOptions contains options for API versions
+type APIVersionOptions struct {
+	Location APIVersionLocation
+	Name     string
+}
+
 // APIVersionLocation indicates which part of a request identifies the service version
 type APIVersionLocation int
 
@@ -27,8 +33,11 @@ const (
 // newAPIVersionPolicy constructs an APIVersionPolicy. name is the name of the query parameter or header and
 // version is its value. If version is "", Do will be a no-op. If version isn't empty and name is empty,
 // Do will return an error.
-func newAPIVersionPolicy(location APIVersionLocation, name, version string) *apiVersionPolicy {
-	return &apiVersionPolicy{location: location, name: name, version: version}
+func newAPIVersionPolicy(version string, opts *APIVersionOptions) *apiVersionPolicy {
+	if opts == nil {
+		opts = &APIVersionOptions{}
+	}
+	return &apiVersionPolicy{location: opts.Location, name: opts.Name, version: version}
 }
 
 // apiVersionPolicy enables users to set the API version of every request a client sends.
@@ -47,7 +56,7 @@ type apiVersionPolicy struct {
 func (a *apiVersionPolicy) Do(req *policy.Request) (*http.Response, error) {
 	if a.version != "" {
 		if a.name == "" {
-			// user set ClientOptions.APIVersion but the client ctor didn't set PipelineOptions.APIVersionLocation
+			// user set ClientOptions.APIVersion but the client ctor didn't set PipelineOptions.APIVersionOptions
 			return nil, errors.New("this client doesn't support overriding its API version")
 		}
 		switch a.location {

--- a/sdk/azcore/runtime/policy_api_version.go
+++ b/sdk/azcore/runtime/policy_api_version.go
@@ -16,7 +16,9 @@ import (
 
 // APIVersionOptions contains options for API versions
 type APIVersionOptions struct {
+	// Location indicates where to set the version on a request, for example in a header or query param
 	Location APIVersionLocation
+	// Name is the name of the header or query parameter, for example "api-version"
 	Name     string
 }
 

--- a/sdk/azcore/runtime/policy_api_version.go
+++ b/sdk/azcore/runtime/policy_api_version.go
@@ -32,9 +32,8 @@ const (
 	APIVersionLocationHeader = 1
 )
 
-// newAPIVersionPolicy constructs an APIVersionPolicy. name is the name of the query parameter or header and
-// version is its value. If version is "", Do will be a no-op. If version isn't empty and name is empty,
-// Do will return an error.
+// newAPIVersionPolicy constructs an APIVersionPolicy. If version is "", Do will be a no-op. If version
+// isn't empty and opts.Name is empty, Do will return an error.
 func newAPIVersionPolicy(version string, opts *APIVersionOptions) *apiVersionPolicy {
 	if opts == nil {
 		opts = &APIVersionOptions{}

--- a/sdk/azcore/runtime/policy_api_version.go
+++ b/sdk/azcore/runtime/policy_api_version.go
@@ -19,7 +19,7 @@ type APIVersionOptions struct {
 	// Location indicates where to set the version on a request, for example in a header or query param
 	Location APIVersionLocation
 	// Name is the name of the header or query parameter, for example "api-version"
-	Name     string
+	Name string
 }
 
 // APIVersionLocation indicates which part of a request identifies the service version

--- a/sdk/azcore/runtime/policy_api_version_test.go
+++ b/sdk/azcore/runtime/policy_api_version_test.go
@@ -32,7 +32,7 @@ func TestAPIVersionPolicy(t *testing.T) {
 			if header {
 				location = APIVersionLocationHeader
 			}
-			p := newAPIVersionPolicy(location, name, version)
+			p := newAPIVersionPolicy(version, &APIVersionOptions{Location: location, Name: name})
 			pl := newTestPipeline(&policy.ClientOptions{Transport: srv, PerCallPolicies: []policy.Policy{p}})
 
 			// when the value isn't set, the policy should set it
@@ -83,7 +83,7 @@ func TestAPIVersionPolicy(t *testing.T) {
 		{location: 2, version: version, err: true},
 	} {
 		t.Run("no-op", func(t *testing.T) {
-			p := newAPIVersionPolicy(test.location, test.name, test.version)
+			p := newAPIVersionPolicy(test.version, &APIVersionOptions{Location: test.location, Name: test.name})
 			pl := newTestPipeline(&policy.ClientOptions{Transport: srv, PerCallPolicies: []policy.Policy{p}})
 			req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 			require.NoError(t, err)


### PR DESCRIPTION
Following from Joel's comment that it's awkward for `PipelineOptions` to have two fields for `APIVersionPolicy` options, and what if we later want to add a third, this PR consolidates them in a new type. The result is easier to extend but still awkward because although it seems best for the policy constructor to take this new type, its values are logically required. That is to say, it doesn't make sense to construct `APIVersionPolicy` without telling it where on to set the version on requests. Functionally speaking though, these values are optional because the policy is a no-op when they aren't set. (That's a workaround for `NewPipeline()` being unable to return an error.) So, please look it over and share your thoughts--maybe there's a tidier third way here.