### PR TITLE
[azquery] renaming

### DIFF
--- a/sdk/monitor/azquery/CHANGELOG.md
+++ b/sdk/monitor/azquery/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Breaking Changes
 * Added error return values to `NewLogsClient` and `NewMetricsClient`
+* Rename `Batch` to `QueryBatch`
+* Rename `NewListMetricDefinitionsPager` to `NewListDefinitionsPager`
+* Rename `NewListMetricNamespacesPager` to `NewListNamespacesPager`
+* Changed type of `Render` and `Statistics` from interface{} to []byte
 
 ### Bugs Fixed
 

--- a/sdk/monitor/azquery/README.md
+++ b/sdk/monitor/azquery/README.md
@@ -47,7 +47,10 @@ func main() {
 		//TODO: handle error
 	}
 
-	client := azquery.NewLogsClient(cred, nil)
+	client, error := azquery.NewLogsClient(cred, nil)
+	if err != nil {
+		//TODO: handle error
+	}
 }
 ```
 
@@ -65,7 +68,10 @@ func main() {
 		//TODO: handle error
 	}
 
-	client := azquery.NewMetricsClient(cred, nil)
+	client, err := azquery.NewMetricsClient(cred, nil)
+	if err != nil {
+		//TODO: handle error
+	}
 }
 ```
 
@@ -150,15 +156,16 @@ Results
 		|---Name *string
 		|---Type *LogsColumnType
 	|---Name *string
-	|---Rows [][]interface{}
+	|---Rows []Row
+	|---ColumnIndexLookup map[string]int
 |---Error *ErrorInfo
 	|---Code *string // custom error type
-|---Render interface{}
-|---Statistics interface{}
+|---Render []byte
+|---Statistics []byte
 ```
 
 ### Batch query
-`Batch` is an advanced method allowing users to execute multiple logs queries in a single request. It takes in a [BatchRequest](#batch-query-request-structure) and returns a [BatchResponse](#batch-query-result-structure). `Batch` can return results in any order (usually in order of completion/success). Please use the `ID` attribute to identify the correct response. 
+`QueryBatch` is an advanced method allowing users to execute multiple logs queries in a single request. It takes in a [BatchRequest](#batch-query-request-structure) and returns a [BatchResponse](#batch-query-result-structure). `QueryBatch` can return results in any order (usually in order of completion/success). Please use the `ID` attribute to identify the correct response. 
 ```go
 timespan := "2022-08-30/2022-08-31" // ISO8601 Standard Timespan
 batchRequest := azquery.BatchRequest{[]*azquery.BatchQueryRequest{
@@ -167,7 +174,7 @@ batchRequest := azquery.BatchRequest{[]*azquery.BatchQueryRequest{
 	{Body: &azquery.Body{Query: to.Ptr(kustoQuery3), Timespan: to.Ptr(timespan)}, ID: to.Ptr("3"), Workspace: to.Ptr(workspaceID)},
 }}
 
-res, err := client.Batch(context.TODO(), batchRequest, nil)
+res, err := client.QueryBatch(context.TODO(), batchRequest, nil)
 if err != nil {
 	//TODO: handle error
 }
@@ -198,14 +205,15 @@ BatchResponse
 	|---Body *BatchQueryResults
 		|---Error *ErrorInfo // custom error type
 			|---Code *string
-		|---Render interface{}
-		|---Statistics interface{}
+		|---Render []byte
+		|---Statistics []byte
 		|---Tables []*Table
 			|---Columns []*Column
 				|---Name *string
 				|---Type *LogsColumnType
 			|---Name *string
-			|---Rows [][]interface{}
+			|---Rows []Row
+			|---ColumnIndexLookup map[string]int
 	|---Headers map[string]*string
 	|---ID *string
 	|---Status *int32

--- a/sdk/monitor/azquery/autorest.md
+++ b/sdk/monitor/azquery/autorest.md
@@ -138,3 +138,22 @@ directive:
   - from: constants.go
     where: $
     transform: return $.replace(/const host = "(.*?)"/, "");
+
+  # change render and statistics type to []byte
+  - from: models.go
+    where: $
+    transform: return $.replace(/interface{}/g, "[]byte");
+  - from: models_serde.go
+    where: $
+    transform: return 
+      $.replace(/err(.*)r\.Statistics\)/, "r.Statistics = val") 
+  - from: models_serde.go
+    where: $
+    transform: return $.replace(/err(.*)r\.Render\)/, "r.Render = val");
+  - from: models_serde.go
+    where: $
+    transform: return 
+      $.replace(/err(.*)b\.Statistics\)/, "b.Statistics = val") 
+  - from: models_serde.go
+    where: $
+    transform: return $.replace(/err(.*)b\.Render\)/, "b.Render = val");

--- a/sdk/monitor/azquery/autorest.md
+++ b/sdk/monitor/azquery/autorest.md
@@ -50,10 +50,10 @@ directive:
  # rename log queries
   - rename-operation:
       from: Query_Execute
-      to: QueryWorkspace
+      to: Logs_QueryWorkspace
   - rename-operation:
       from: Query_Batch
-      to: Batch
+      to: Logs_QueryBatch
 
   # rename metric list to QueryResource
   - rename-operation:
@@ -63,10 +63,10 @@ directive:
  # rename ListMetricDefinitions and ListMetricNamespaces to generate in metrics_client.go
   - rename-operation:
       from: MetricDefinitions_List
-      to: Metrics_ListMetricDefinitions
+      to: Metrics_ListDefinitions
   - rename-operation:
       from: MetricNamespaces_List
-      to: Metrics_ListMetricNamespaces
+      to: Metrics_ListNamespaces
 
   # add default values for batch request path and method attributes
   - from: swagger-document

--- a/sdk/monitor/azquery/example_test.go
+++ b/sdk/monitor/azquery/example_test.go
@@ -127,7 +127,7 @@ func ExampleLogsClient_QueryWorkspace_second() {
 	fmt.Println(QueryResults)
 }
 
-func ExampleLogsClient_Batch() {
+func ExampleLogsClient_QueryBatch() {
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		//TODO: handle error

--- a/sdk/monitor/azquery/example_test.go
+++ b/sdk/monitor/azquery/example_test.go
@@ -146,7 +146,7 @@ func ExampleLogsClient_Batch() {
 		{Body: &azquery.Body{Query: to.Ptr(kustoQuery3), Timespan: to.Ptr(timespan)}, ID: to.Ptr("3"), Workspace: to.Ptr(workspaceID)},
 	}}
 
-	res, err := client.Batch(context.TODO(), batchRequest, nil)
+	res, err := client.QueryBatch(context.TODO(), batchRequest, nil)
 	if err != nil {
 		//TODO: handle error
 	}

--- a/sdk/monitor/azquery/logs_client.go
+++ b/sdk/monitor/azquery/logs_client.go
@@ -19,29 +19,29 @@ import (
 	"strings"
 )
 
-// Batch - Executes a batch of Analytics queries for data. Here [https://dev.loganalytics.io/documentation/Using-the-API]
+// QueryBatch - Executes a batch of Analytics queries for data. Here [https://dev.loganalytics.io/documentation/Using-the-API]
 // is an example for using POST with an Analytics query.
 // If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-05-19_Preview
 // body - The batch request body
-// options - LogsClientBatchOptions contains the optional parameters for the LogsClient.Batch method.
-func (client *LogsClient) Batch(ctx context.Context, body BatchRequest, options *LogsClientBatchOptions) (LogsClientBatchResponse, error) {
-	req, err := client.batchCreateRequest(ctx, body, options)
+// options - LogsClientQueryBatchOptions contains the optional parameters for the LogsClient.QueryBatch method.
+func (client *LogsClient) QueryBatch(ctx context.Context, body BatchRequest, options *LogsClientQueryBatchOptions) (LogsClientQueryBatchResponse, error) {
+	req, err := client.queryBatchCreateRequest(ctx, body, options)
 	if err != nil {
-		return LogsClientBatchResponse{}, err
+		return LogsClientQueryBatchResponse{}, err
 	}
 	resp, err := client.pl.Do(req)
 	if err != nil {
-		return LogsClientBatchResponse{}, err
+		return LogsClientQueryBatchResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return LogsClientBatchResponse{}, runtime.NewResponseError(resp)
+		return LogsClientQueryBatchResponse{}, runtime.NewResponseError(resp)
 	}
-	return client.batchHandleResponse(resp)
+	return client.queryBatchHandleResponse(resp)
 }
 
-// batchCreateRequest creates the Batch request.
-func (client *LogsClient) batchCreateRequest(ctx context.Context, body BatchRequest, options *LogsClientBatchOptions) (*policy.Request, error) {
+// queryBatchCreateRequest creates the QueryBatch request.
+func (client *LogsClient) queryBatchCreateRequest(ctx context.Context, body BatchRequest, options *LogsClientQueryBatchOptions) (*policy.Request, error) {
 	urlPath := "/$batch"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
@@ -51,11 +51,11 @@ func (client *LogsClient) batchCreateRequest(ctx context.Context, body BatchRequ
 	return req, runtime.MarshalAsJSON(req, body)
 }
 
-// batchHandleResponse handles the Batch response.
-func (client *LogsClient) batchHandleResponse(resp *http.Response) (LogsClientBatchResponse, error) {
-	result := LogsClientBatchResponse{}
+// queryBatchHandleResponse handles the QueryBatch response.
+func (client *LogsClient) queryBatchHandleResponse(resp *http.Response) (LogsClientQueryBatchResponse, error) {
+	result := LogsClientQueryBatchResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BatchResponse); err != nil {
-		return LogsClientBatchResponse{}, err
+		return LogsClientQueryBatchResponse{}, err
 	}
 	return result, nil
 }

--- a/sdk/monitor/azquery/logs_client_test.go
+++ b/sdk/monitor/azquery/logs_client_test.go
@@ -194,7 +194,7 @@ func TestBatch_QuerySuccess(t *testing.T) {
 	}}
 	testSerde(t, &batchRequest)
 
-	res, err := client.Batch(context.Background(), batchRequest, nil)
+	res, err := client.QueryBatch(context.Background(), batchRequest, nil)
 	if err != nil {
 		t.Fatalf("error with query, %s", err)
 	}
@@ -226,7 +226,7 @@ func TestBatch_PartialError(t *testing.T) {
 		{Body: &azquery.Body{Query: to.Ptr(query)}, ID: to.Ptr("2"), Workspace: to.Ptr(workspaceID)},
 	}}
 
-	res, err := client.Batch(context.Background(), batchRequest, nil)
+	res, err := client.QueryBatch(context.Background(), batchRequest, nil)
 	if err != nil {
 		t.Fatalf("error with query, %s", err)
 	}

--- a/sdk/monitor/azquery/metrics_client.go
+++ b/sdk/monitor/azquery/metrics_client.go
@@ -18,35 +18,34 @@ import (
 	"strings"
 )
 
-// NewListMetricDefinitionsPager - Lists the metric definitions for the resource.
+// NewListDefinitionsPager - Lists the metric definitions for the resource.
 // Generated from API version 2018-01-01
 // resourceURI - The identifier of the resource.
-// options - MetricsClientListMetricDefinitionsOptions contains the optional parameters for the MetricsClient.ListMetricDefinitions
-// method.
-func (client *MetricsClient) NewListMetricDefinitionsPager(resourceURI string, options *MetricsClientListMetricDefinitionsOptions) *runtime.Pager[MetricsClientListMetricDefinitionsResponse] {
-	return runtime.NewPager(runtime.PagingHandler[MetricsClientListMetricDefinitionsResponse]{
-		More: func(page MetricsClientListMetricDefinitionsResponse) bool {
+// options - MetricsClientListDefinitionsOptions contains the optional parameters for the MetricsClient.ListDefinitions method.
+func (client *MetricsClient) NewListDefinitionsPager(resourceURI string, options *MetricsClientListDefinitionsOptions) *runtime.Pager[MetricsClientListDefinitionsResponse] {
+	return runtime.NewPager(runtime.PagingHandler[MetricsClientListDefinitionsResponse]{
+		More: func(page MetricsClientListDefinitionsResponse) bool {
 			return false
 		},
-		Fetcher: func(ctx context.Context, page *MetricsClientListMetricDefinitionsResponse) (MetricsClientListMetricDefinitionsResponse, error) {
-			req, err := client.listMetricDefinitionsCreateRequest(ctx, resourceURI, options)
+		Fetcher: func(ctx context.Context, page *MetricsClientListDefinitionsResponse) (MetricsClientListDefinitionsResponse, error) {
+			req, err := client.listDefinitionsCreateRequest(ctx, resourceURI, options)
 			if err != nil {
-				return MetricsClientListMetricDefinitionsResponse{}, err
+				return MetricsClientListDefinitionsResponse{}, err
 			}
 			resp, err := client.pl.Do(req)
 			if err != nil {
-				return MetricsClientListMetricDefinitionsResponse{}, err
+				return MetricsClientListDefinitionsResponse{}, err
 			}
 			if !runtime.HasStatusCode(resp, http.StatusOK) {
-				return MetricsClientListMetricDefinitionsResponse{}, runtime.NewResponseError(resp)
+				return MetricsClientListDefinitionsResponse{}, runtime.NewResponseError(resp)
 			}
-			return client.listMetricDefinitionsHandleResponse(resp)
+			return client.listDefinitionsHandleResponse(resp)
 		},
 	})
 }
 
-// listMetricDefinitionsCreateRequest creates the ListMetricDefinitions request.
-func (client *MetricsClient) listMetricDefinitionsCreateRequest(ctx context.Context, resourceURI string, options *MetricsClientListMetricDefinitionsOptions) (*policy.Request, error) {
+// listDefinitionsCreateRequest creates the ListDefinitions request.
+func (client *MetricsClient) listDefinitionsCreateRequest(ctx context.Context, resourceURI string, options *MetricsClientListDefinitionsOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.Insights/metricDefinitions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
@@ -63,44 +62,43 @@ func (client *MetricsClient) listMetricDefinitionsCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// listMetricDefinitionsHandleResponse handles the ListMetricDefinitions response.
-func (client *MetricsClient) listMetricDefinitionsHandleResponse(resp *http.Response) (MetricsClientListMetricDefinitionsResponse, error) {
-	result := MetricsClientListMetricDefinitionsResponse{}
+// listDefinitionsHandleResponse handles the ListDefinitions response.
+func (client *MetricsClient) listDefinitionsHandleResponse(resp *http.Response) (MetricsClientListDefinitionsResponse, error) {
+	result := MetricsClientListDefinitionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MetricDefinitionCollection); err != nil {
-		return MetricsClientListMetricDefinitionsResponse{}, err
+		return MetricsClientListDefinitionsResponse{}, err
 	}
 	return result, nil
 }
 
-// NewListMetricNamespacesPager - Lists the metric namespaces for the resource.
+// NewListNamespacesPager - Lists the metric namespaces for the resource.
 // Generated from API version 2017-12-01-preview
 // resourceURI - The identifier of the resource.
-// options - MetricsClientListMetricNamespacesOptions contains the optional parameters for the MetricsClient.ListMetricNamespaces
-// method.
-func (client *MetricsClient) NewListMetricNamespacesPager(resourceURI string, options *MetricsClientListMetricNamespacesOptions) *runtime.Pager[MetricsClientListMetricNamespacesResponse] {
-	return runtime.NewPager(runtime.PagingHandler[MetricsClientListMetricNamespacesResponse]{
-		More: func(page MetricsClientListMetricNamespacesResponse) bool {
+// options - MetricsClientListNamespacesOptions contains the optional parameters for the MetricsClient.ListNamespaces method.
+func (client *MetricsClient) NewListNamespacesPager(resourceURI string, options *MetricsClientListNamespacesOptions) *runtime.Pager[MetricsClientListNamespacesResponse] {
+	return runtime.NewPager(runtime.PagingHandler[MetricsClientListNamespacesResponse]{
+		More: func(page MetricsClientListNamespacesResponse) bool {
 			return false
 		},
-		Fetcher: func(ctx context.Context, page *MetricsClientListMetricNamespacesResponse) (MetricsClientListMetricNamespacesResponse, error) {
-			req, err := client.listMetricNamespacesCreateRequest(ctx, resourceURI, options)
+		Fetcher: func(ctx context.Context, page *MetricsClientListNamespacesResponse) (MetricsClientListNamespacesResponse, error) {
+			req, err := client.listNamespacesCreateRequest(ctx, resourceURI, options)
 			if err != nil {
-				return MetricsClientListMetricNamespacesResponse{}, err
+				return MetricsClientListNamespacesResponse{}, err
 			}
 			resp, err := client.pl.Do(req)
 			if err != nil {
-				return MetricsClientListMetricNamespacesResponse{}, err
+				return MetricsClientListNamespacesResponse{}, err
 			}
 			if !runtime.HasStatusCode(resp, http.StatusOK) {
-				return MetricsClientListMetricNamespacesResponse{}, runtime.NewResponseError(resp)
+				return MetricsClientListNamespacesResponse{}, runtime.NewResponseError(resp)
 			}
-			return client.listMetricNamespacesHandleResponse(resp)
+			return client.listNamespacesHandleResponse(resp)
 		},
 	})
 }
 
-// listMetricNamespacesCreateRequest creates the ListMetricNamespaces request.
-func (client *MetricsClient) listMetricNamespacesCreateRequest(ctx context.Context, resourceURI string, options *MetricsClientListMetricNamespacesOptions) (*policy.Request, error) {
+// listNamespacesCreateRequest creates the ListNamespaces request.
+func (client *MetricsClient) listNamespacesCreateRequest(ctx context.Context, resourceURI string, options *MetricsClientListNamespacesOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/microsoft.insights/metricNamespaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
@@ -117,11 +115,11 @@ func (client *MetricsClient) listMetricNamespacesCreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// listMetricNamespacesHandleResponse handles the ListMetricNamespaces response.
-func (client *MetricsClient) listMetricNamespacesHandleResponse(resp *http.Response) (MetricsClientListMetricNamespacesResponse, error) {
-	result := MetricsClientListMetricNamespacesResponse{}
+// listNamespacesHandleResponse handles the ListNamespaces response.
+func (client *MetricsClient) listNamespacesHandleResponse(resp *http.Response) (MetricsClientListNamespacesResponse, error) {
+	result := MetricsClientListNamespacesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MetricNamespaceCollection); err != nil {
-		return MetricsClientListMetricNamespacesResponse{}, err
+		return MetricsClientListNamespacesResponse{}, err
 	}
 	return result, nil
 }

--- a/sdk/monitor/azquery/metrics_client_test.go
+++ b/sdk/monitor/azquery/metrics_client_test.go
@@ -45,7 +45,7 @@ func TestQueryResource_BasicQuerySuccess(t *testing.T) {
 func TestNewListMetricDefinitionsPager_Success(t *testing.T) {
 	client := startMetricsTest(t)
 
-	pager := client.NewListMetricDefinitionsPager(resourceURI, nil)
+	pager := client.NewListDefinitionsPager(resourceURI, nil)
 
 	// test if first page is valid
 	if pager.More() {
@@ -66,7 +66,7 @@ func TestNewListMetricDefinitionsPager_Success(t *testing.T) {
 func TestNewListMetricNamespacesPager_Success(t *testing.T) {
 	client := startMetricsTest(t)
 
-	pager := client.NewListMetricNamespacesPager(resourceURI, nil)
+	pager := client.NewListNamespacesPager(resourceURI, nil)
 
 	// test if first page is valid
 	if pager.More() {

--- a/sdk/monitor/azquery/models.go
+++ b/sdk/monitor/azquery/models.go
@@ -49,10 +49,10 @@ type BatchQueryResults struct {
 	Error *ErrorInfo `json:"error,omitempty"`
 
 	// Visualization data in JSON format.
-	Render interface{} `json:"render,omitempty"`
+	Render []byte `json:"render,omitempty"`
 
 	// Statistics represented in JSON format.
-	Statistics interface{} `json:"statistics,omitempty"`
+	Statistics []byte `json:"statistics,omitempty"`
 
 	// The list of tables, columns and rows.
 	Tables []*Table `json:"tables,omitempty"`
@@ -338,10 +338,10 @@ type Results struct {
 	Error *ErrorInfo `json:"error,omitempty"`
 
 	// Visualization data in JSON format.
-	Render interface{} `json:"render,omitempty"`
+	Render []byte `json:"render,omitempty"`
 
 	// Statistics represented in JSON format.
-	Statistics interface{} `json:"statistics,omitempty"`
+	Statistics []byte `json:"statistics,omitempty"`
 }
 
 // TimeSeriesElement - A time series result type. The discriminator value is always TimeSeries in this case.

--- a/sdk/monitor/azquery/models.go
+++ b/sdk/monitor/azquery/models.go
@@ -101,8 +101,8 @@ type LocalizableString struct {
 	LocalizedValue *string `json:"localizedValue,omitempty"`
 }
 
-// LogsClientBatchOptions contains the optional parameters for the LogsClient.Batch method.
-type LogsClientBatchOptions struct {
+// LogsClientQueryBatchOptions contains the optional parameters for the LogsClient.QueryBatch method.
+type LogsClientQueryBatchOptions struct {
 	// placeholder for future optional parameters
 }
 
@@ -258,15 +258,14 @@ type MetricValue struct {
 	Total *float64 `json:"total,omitempty"`
 }
 
-// MetricsClientListMetricDefinitionsOptions contains the optional parameters for the MetricsClient.ListMetricDefinitions
-// method.
-type MetricsClientListMetricDefinitionsOptions struct {
+// MetricsClientListDefinitionsOptions contains the optional parameters for the MetricsClient.ListDefinitions method.
+type MetricsClientListDefinitionsOptions struct {
 	// Metric namespace to query metric definitions for.
 	Metricnamespace *string
 }
 
-// MetricsClientListMetricNamespacesOptions contains the optional parameters for the MetricsClient.ListMetricNamespaces method.
-type MetricsClientListMetricNamespacesOptions struct {
+// MetricsClientListNamespacesOptions contains the optional parameters for the MetricsClient.ListNamespaces method.
+type MetricsClientListNamespacesOptions struct {
 	// The ISO 8601 conform Date start time from which to query for metric namespaces.
 	StartTime *string
 }

--- a/sdk/monitor/azquery/models_serde.go
+++ b/sdk/monitor/azquery/models_serde.go
@@ -132,10 +132,10 @@ func (b *BatchQueryResults) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "Error", &b.Error)
 			delete(rawMsg, key)
 		case "render":
-			err = unpopulate(val, "Render", &b.Render)
+			b.Render = val
 			delete(rawMsg, key)
 		case "statistics":
-			err = unpopulate(val, "Statistics", &b.Statistics)
+			b.Statistics = val
 			delete(rawMsg, key)
 		case "tables":
 			err = unpopulate(val, "Tables", &b.Tables)
@@ -732,10 +732,10 @@ func (r *Results) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "Error", &r.Error)
 			delete(rawMsg, key)
 		case "render":
-			err = unpopulate(val, "Render", &r.Render)
+			r.Render = val
 			delete(rawMsg, key)
 		case "statistics":
-			err = unpopulate(val, "Statistics", &r.Statistics)
+			r.Statistics = val
 			delete(rawMsg, key)
 		case "tables":
 			err = unpopulate(val, "Tables", &r.Tables)

--- a/sdk/monitor/azquery/response_types.go
+++ b/sdk/monitor/azquery/response_types.go
@@ -9,8 +9,8 @@
 
 package azquery
 
-// LogsClientBatchResponse contains the response from method LogsClient.Batch.
-type LogsClientBatchResponse struct {
+// LogsClientQueryBatchResponse contains the response from method LogsClient.QueryBatch.
+type LogsClientQueryBatchResponse struct {
 	BatchResponse
 }
 
@@ -19,13 +19,13 @@ type LogsClientQueryWorkspaceResponse struct {
 	Results
 }
 
-// MetricsClientListMetricDefinitionsResponse contains the response from method MetricsClient.ListMetricDefinitions.
-type MetricsClientListMetricDefinitionsResponse struct {
+// MetricsClientListDefinitionsResponse contains the response from method MetricsClient.ListDefinitions.
+type MetricsClientListDefinitionsResponse struct {
 	MetricDefinitionCollection
 }
 
-// MetricsClientListMetricNamespacesResponse contains the response from method MetricsClient.ListMetricNamespaces.
-type MetricsClientListMetricNamespacesResponse struct {
+// MetricsClientListNamespacesResponse contains the response from method MetricsClient.ListNamespaces.
+type MetricsClientListNamespacesResponse struct {
 	MetricNamespaceCollection
 }
 

--- a/sdk/monitor/azquery/utils_test.go
+++ b/sdk/monitor/azquery/utils_test.go
@@ -67,12 +67,10 @@ func TestMain(m *testing.M) {
 	if recording.GetRecordMode() == recording.PlaybackMode {
 		credential = &FakeCredential{}
 	} else {
-		/*tenantID := lookupEnvVar("AZQUERY_TENANT_ID")
+		tenantID := lookupEnvVar("AZQUERY_TENANT_ID")
 		clientID := lookupEnvVar("AZQUERY_CLIENT_ID")
 		secret := lookupEnvVar("AZQUERY_CLIENT_SECRET")
 		credential, err = azidentity.NewClientSecretCredential(tenantID, clientID, secret, nil)
-		*/
-		credential, err = azidentity.NewDefaultAzureCredential(nil)
 		if err != nil {
 			panic(err)
 		}

--- a/sdk/monitor/azquery/utils_test.go
+++ b/sdk/monitor/azquery/utils_test.go
@@ -67,10 +67,12 @@ func TestMain(m *testing.M) {
 	if recording.GetRecordMode() == recording.PlaybackMode {
 		credential = &FakeCredential{}
 	} else {
-		tenantID := lookupEnvVar("AZQUERY_TENANT_ID")
+		/*tenantID := lookupEnvVar("AZQUERY_TENANT_ID")
 		clientID := lookupEnvVar("AZQUERY_CLIENT_ID")
 		secret := lookupEnvVar("AZQUERY_CLIENT_SECRET")
 		credential, err = azidentity.NewClientSecretCredential(tenantID, clientID, secret, nil)
+		*/
+		credential, err = azidentity.NewDefaultAzureCredential(nil)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Renaming and type updates to make the library clearer and more in line with the other Monitor Query language libraries.

Method Name Updates:
1. NewListMetricDefinitionsPager -> NewListDefinitionsPager
2. NewListMetricNamespacesPager -> NewListNamespacesPager
3. Batch -> QueryBatch

Type Update:
Render and Statistics field would go from being of type interface{} to []byte