### PR TITLE
[azservicebus/azeventhubs] Fix "$cbs node has already been opened" issue

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 0.2.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.2.1 (2022-11-08)
 
 ### Bugs Fixed
 
-### Other Changes
+- $cbs link is properly closed, even on cancellation (#19492)
 
 ## 0.2.0 (2022-10-17)
 

--- a/sdk/messaging/azeventhubs/internal/eh/stress/Chart.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Chart.yaml
@@ -8,5 +8,5 @@ annotations:
   namespace: 'go'
 dependencies:
 - name: stress-test-addons
-  version: ~2.0.0
+  version: ~0.2.0
   repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/sdk/messaging/azeventhubs/internal/eh/stress/Chart.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Chart.yaml
@@ -8,5 +8,5 @@ annotations:
   namespace: 'go'
 dependencies:
 - name: stress-test-addons
-  version: ~0.1.20
+  version: ~2.0.0
   repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/sdk/messaging/azeventhubs/internal/links.go
+++ b/sdk/messaging/azeventhubs/internal/links.go
@@ -310,7 +310,11 @@ func (l *Links[LinkT]) Close(ctx context.Context) error {
 	return l.closeLinks(ctx, true)
 }
 
-func (l *Links[LinkT]) closeLinks(ctx context.Context, permanent bool) error {
+func (l *Links[LinkT]) closeLinks(_ context.Context, permanent bool) error {
+	// we're finding, in practice, that allowing cancellations when cleaning up state
+	// just results in inconsistencies. We'll cut cancellation off here for now.
+	ctx := context.Background()
+
 	if err := l.closeManagementLink(ctx); err != nil {
 		azlog.Writef(exported.EventConn, "Error while cleaning up management link while doing connection recovery: %s", err.Error())
 	}

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.1.2 (2022-11-08)
 
 ### Bugs Fixed
 
-### Other Changes
+- $cbs link is properly closed, even on cancellation (#19492)
 
 ## 1.1.1 (2022-10-11)
 

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -468,7 +468,9 @@ func (l *AMQPLinksImpl) initWithoutLocking(ctx context.Context) error {
 
 // close closes the link.
 // NOTE: No locking is done in this function, call `Close` if you require locking.
-func (l *AMQPLinksImpl) closeWithoutLocking(ctx context.Context, permanent bool) error {
+func (l *AMQPLinksImpl) closeWithoutLocking(_ context.Context, permanent bool) error {
+	ctx := context.Background()
+
 	if l.closedPermanently {
 		return nil
 	}

--- a/sdk/messaging/azservicebus/internal/stress/Chart.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.yaml
@@ -8,5 +8,5 @@ annotations:
   namespace: 'go'
 dependencies:
 - name: stress-test-addons
-  version: ~2.0.0
+  version: ~0.2.0
   repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/sdk/messaging/azservicebus/internal/stress/Chart.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.yaml
@@ -8,5 +8,5 @@ annotations:
   namespace: 'go'
 dependencies:
 - name: stress-test-addons
-  version: ~0.1.20
+  version: ~2.0.0
   repository: https://stresstestcharts.blob.core.windows.net/helm/


### PR DESCRIPTION
When looking for leaks in negotiateClaim I missed the most "obvious" one - if you cancel the function we still need to close the link we opened. If we don't we leak it, and the service will then start failing future negotiations to open it.

This showed up in https://github.com/Azure/azure-sdk-for-go/issues/19347, originally, but a fix I made recently in SB to test attaching/detaching links made it even more obvious.

Fixes #19347