### PR TITLE
Fix race condition when fetching expiring resource

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.1 (unreleased)
+## 1.1.1 (2022-11-09)
 
 ### Bugs Fixed
 * Fixed a race condition in `temporal.Resource[TResource, TState].Get`.

--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.1.1 (unreleased)
+
+### Bugs Fixed
+* Fixed a race condition in `temporal.Resource[TResource, TState].Get`.
+
 ## 1.1.0 (2022-10-20)
 
 ### Features Added

--- a/sdk/internal/temporal/resource.go
+++ b/sdk/internal/temporal/resource.go
@@ -49,9 +49,12 @@ func (er *Resource[TResource, TState]) Get(state TState) (TResource, error) {
 	const window = 5 * time.Minute   // This example updates the resource 5 minutes prior to expiration
 	const backoff = 30 * time.Second // Minimum wait time between eager update attempts
 
-	now, acquire, expired, resource := time.Now(), false, false, er.resource
+	now, acquire, expired := time.Now(), false, false
+
 	// acquire exclusive lock
 	er.cond.L.Lock()
+	resource := er.resource
+
 	for {
 		expired = er.expiration.IsZero() || er.expiration.Before(now)
 		if expired {

--- a/sdk/internal/version.go
+++ b/sdk/internal/version.go
@@ -11,5 +11,5 @@ const (
 	Module = "internal"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.1.0"
+	Version = "v1.1.1"
 )


### PR DESCRIPTION
Read from shared state when the lock is held.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/19528