### PR TITLE
Set correct Key Vault scope when challenge verification disabled

### DIFF
--- a/sdk/keyvault/internal/CHANGELOG.md
+++ b/sdk/keyvault/internal/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 0.7.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.7.1 (2022-11-14)
 
 ### Bugs Fixed
-
-### Other Changes
+* `KeyVaultChallengePolicy` uses incorrect authentication scope when challenge verification is disabled
 
 ## 0.7.0 (2022-09-20)
 

--- a/sdk/keyvault/internal/challenge_policy.go
+++ b/sdk/keyvault/internal/challenge_policy.go
@@ -203,9 +203,9 @@ func (k *KeyVaultChallengePolicy) findScopeAndTenant(resp *http.Response, req *h
 		if !strings.HasSuffix(req.URL.Host, "."+parsed.Host) {
 			return &challengePolicyError{err: fmt.Errorf(challengeMatchError, scope)}
 		}
-		if !strings.HasSuffix(scope, "/.default") {
-			scope += "/.default"
-		}
+	}
+	if !strings.HasSuffix(scope, "/.default") {
+		scope += "/.default"
 	}
 	k.scope = &scope
 	return nil


### PR DESCRIPTION
Oops, looks like I introduced a bug in #19123 by misplacing a closing brace. We must add the scope `/.default` to AADv1 resource strings like `https://vault.azure.net` regardless of whether challenge resource verification is enabled.