### PR TITLE
[azservicebus] Disable the idle link tracking on session links

### DIFF
--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -167,9 +167,10 @@ func (client *Client) NewReceiverForQueue(queueName string, options *ReceiverOpt
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	receiver, err := newReceiver(newReceiverArgs{
 		cleanupOnClose:      cleanupOnClose,
-		ns:                  client.namespace,
 		entity:              entity{Queue: queueName},
 		getRecoveryKindFunc: internal.GetRecoveryKind,
+		idleTimeout:         0,
+		ns:                  client.namespace,
 		retryOptions:        client.retryOptions,
 	}, options)
 
@@ -186,9 +187,10 @@ func (client *Client) NewReceiverForSubscription(topicName string, subscriptionN
 	id, cleanupOnClose := client.getCleanupForCloseable()
 	receiver, err := newReceiver(newReceiverArgs{
 		cleanupOnClose:      cleanupOnClose,
-		ns:                  client.namespace,
 		entity:              entity{Topic: topicName, Subscription: subscriptionName},
 		getRecoveryKindFunc: internal.GetRecoveryKind,
+		idleTimeout:         0,
+		ns:                  client.namespace,
 		retryOptions:        client.retryOptions,
 	}, options)
 

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -33,7 +33,7 @@ func TestReceiverCancel(t *testing.T) {
 	require.Empty(t, messages)
 }
 
-func TestReceiverSendFiveReceiveFive(t *testing.T) {
+func TestReceiverSendFiveReceiveFive_Queue(t *testing.T) {
 	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()
 
@@ -50,6 +50,48 @@ func TestReceiverSendFiveReceiveFive(t *testing.T) {
 
 	receiver, err := serviceBusClient.NewReceiverForQueue(queueName, nil)
 	require.NoError(t, err)
+
+	// just some sanity checking for the local idle checker.
+	require.NotNil(t, receiver.idleTracker)
+	require.Equal(t, receiver.idleTracker.MaxDuration, defaultReceiverIdleTime)
+
+	messages, err := receiver.ReceiveMessages(context.Background(), 5, nil)
+	require.NoError(t, err)
+
+	sort.Sort(receivedMessageSlice(messages))
+
+	require.EqualValues(t, 5, len(messages))
+
+	for i := 0; i < 5; i++ {
+		require.EqualValues(t,
+			fmt.Sprintf("[%d]: send five, receive five", i),
+			string(messages[i].Body))
+
+		require.NoError(t, receiver.CompleteMessage(context.Background(), messages[i], nil))
+	}
+}
+
+func TestReceiverSendFiveReceiveFive_Subscription(t *testing.T) {
+	serviceBusClient, cleanup, topicName, subscriptionName := setupLiveTestWithSubscription(t, &liveTestOptionsWithSubscription{})
+	defer cleanup()
+
+	sender, err := serviceBusClient.NewSender(topicName, nil)
+	require.NoError(t, err)
+	defer sender.Close(context.Background())
+
+	for i := 0; i < 5; i++ {
+		err = sender.SendMessage(context.Background(), &Message{
+			Body: []byte(fmt.Sprintf("[%d]: send five, receive five", i)),
+		}, nil)
+		require.NoError(t, err)
+	}
+
+	receiver, err := serviceBusClient.NewReceiverForSubscription(topicName, subscriptionName, nil)
+	require.NoError(t, err)
+
+	// just some sanity checking for the local idle checker.
+	require.NotNil(t, receiver.idleTracker)
+	require.Equal(t, receiver.idleTracker.MaxDuration, defaultReceiverIdleTime)
 
 	messages, err := receiver.ReceiveMessages(context.Background(), 5, nil)
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -55,12 +55,7 @@ func TestReceiverSendFiveReceiveFive_Queue(t *testing.T) {
 	require.NotNil(t, receiver.idleTracker)
 	require.Equal(t, receiver.idleTracker.MaxDuration, defaultReceiverIdleTime)
 
-	messages, err := receiver.ReceiveMessages(context.Background(), 5, nil)
-	require.NoError(t, err)
-
-	sort.Sort(receivedMessageSlice(messages))
-
-	require.EqualValues(t, 5, len(messages))
+	messages := mustReceiveMessages(t, receiver, 5, time.Minute)
 
 	for i := 0; i < 5; i++ {
 		require.EqualValues(t,
@@ -93,12 +88,7 @@ func TestReceiverSendFiveReceiveFive_Subscription(t *testing.T) {
 	require.NotNil(t, receiver.idleTracker)
 	require.Equal(t, receiver.idleTracker.MaxDuration, defaultReceiverIdleTime)
 
-	messages, err := receiver.ReceiveMessages(context.Background(), 5, nil)
-	require.NoError(t, err)
-
-	sort.Sort(receivedMessageSlice(messages))
-
-	require.EqualValues(t, 5, len(messages))
+	messages := mustReceiveMessages(t, receiver, 5, time.Minute)
 
 	for i := 0; i < 5; i++ {
 		require.EqualValues(t,

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -66,12 +66,16 @@ func newSessionReceiver(ctx context.Context, args newSessionReceiverArgs, option
 	}
 
 	r, err := newReceiver(newReceiverArgs{
-		ns:                  args.ns,
-		entity:              args.entity,
 		cleanupOnClose:      args.cleanupOnClose,
-		newLinkFn:           sessionReceiver.newLink,
+		entity:              args.entity,
 		getRecoveryKindFunc: internal.GetRecoveryKindForSession,
-		retryOptions:        args.retryOptions,
+		// It's a bit more complicated to do an idle timeout for sessions
+		// and there's limited gain - the renewing the session lock provides
+		// a guarantee that the link is still alive.
+		idleTimeout:  -1,
+		newLinkFn:    sessionReceiver.newLink,
+		ns:           args.ns,
+		retryOptions: args.retryOptions,
 	}, options)
 
 	if err != nil {


### PR DESCRIPTION
Session links, unlike non-session links, have a lock renewal method that will affirm that the link is alive. Doing our own client-side link checking just complicates things and, in some cases, makes it so you lose the lock for a session you once owned.

Fixes #19566