### PR TITLE
[azeventhubs] stress: We can't commit this much logging to the forward thrusters.

### DIFF
--- a/sdk/messaging/azeventhubs/internal/eh/stress/templates/deploy-job.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/templates/deploy-job.yaml
@@ -59,7 +59,6 @@ spec:
       - processor
       - "-rounds"
       - "-1"
-      - "-verbose"
       {{- end -}}
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}


### PR DESCRIPTION
This is really the only test that runs for long enough to really impact our budget. It's done pretty well so, for the most part, we'll leave logging off and figure out a better solution soon.