### PR TITLE
[azservicebus] Add in a simple "clearing of session state" test

### DIFF
--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -231,6 +231,7 @@ type SetSessionStateOptions struct {
 }
 
 // SetSessionState sets the state associated with the session.
+// Passing nil for state will clear the session state.
 // If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (sr *SessionReceiver) SetSessionState(ctx context.Context, state []byte, options *SetSessionStateOptions) error {
 	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -231,7 +231,7 @@ type SetSessionStateOptions struct {
 }
 
 // SetSessionState sets the state associated with the session.
-// Passing nil for state will clear the session state.
+// Pass nil for the state parameter to clear the stored session state.
 // If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (sr *SessionReceiver) SetSessionState(ctx context.Context, state []byte, options *SetSessionStateOptions) error {
 	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {

--- a/sdk/messaging/azservicebus/session_receiver_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_test.go
@@ -58,6 +58,12 @@ func TestSessionReceiver_acceptSession(t *testing.T) {
 	sessionState, err = receiver.GetSessionState(ctx, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, "hello", string(sessionState))
+
+	// sanity check that we can clear out session state as well.
+	require.NoError(t, receiver.SetSessionState(ctx, nil, nil))
+	sessionState, err = receiver.GetSessionState(ctx, nil)
+	require.NoError(t, err)
+	require.Nil(t, sessionState)
 }
 
 func TestSessionReceiver_blankSessionIDs(t *testing.T) {


### PR DESCRIPTION
The functionality was always there but it wasn't documented and there wasn't a test for it.