### PR TITLE
[azservicebus] Adding in a session manager test - create and receive on sessions repeatedly.

### DIFF
--- a/sdk/messaging/azservicebus/internal/stress/Chart.lock
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.21
-digest: sha256:ac7f0861fd54ebba0e3fec92c1fecc058e96f58df9094641605dd4250a7a423f
-generated: "2022-10-29T01:11:52.71900634Z"
+  version: 0.2.0
+digest: sha256:59fff3930e78c4ca9f9c0120433c7695d31db63f36ac61d50abcc91b1f1835a0
+generated: "2022-11-19T01:30:02.403917379Z"

--- a/sdk/messaging/azservicebus/internal/stress/scenarios-matrix.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/scenarios-matrix.yaml
@@ -1,3 +1,9 @@
+displayNames:
+  # this makes it so these don't show up in the scenario names, 
+  # since they're just clutter.
+  1.5Gi": ""
+  4Gi": ""
+  image: ""
 matrix:
   images:
     go18:
@@ -6,23 +12,37 @@ matrix:
   scenarios:
     constantDetach:
       testTarget: constantDetach
+      memory: "1.5Gi"
     constantDetachmentSender:
       testTarget: constantDetachmentSender
+      memory: "1.5Gi"
     finitePeeks:
       testTarget: finitePeeks
+      memory: "1.5Gi"
     finiteSendAndReceive:
-      testTarget: finiteSendAndReceive
+      testTarget: finiteSendAndReceive    
+      memory: "1.5Gi"
+    finiteSessions:
+      testTarget: finiteSessions
+      memory: "4Gi"
     idleFastReconnect:
       testTarget: idleFastReconnect
+      memory: "1.5Gi"
     infiniteSendAndReceive:
       testTarget: infiniteSendAndReceive
+      memory: "1.5Gi"
     longRunningRenewLock:
       testTarget: longRunningRenewLock
+      memory: "1.5Gi"
     mostlyIdleReceiver:
       testTarget: mostlyIdleReceiver
+      memory: "1.5Gi"
     rapidOpenClose:
       testTarget: rapidOpenClose
+      memory: "1.5Gi"      
     receiveCancellation:
       testTarget: receiveCancellation
+      memory: "1.5Gi"
     sendAndReceiveDrain:
       testTarget: sendAndReceiveDrain
+      memory: "1.5Gi"

--- a/sdk/messaging/azservicebus/internal/stress/scenarios-matrix.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/scenarios-matrix.yaml
@@ -16,6 +16,9 @@ matrix:
     constantDetachmentSender:
       testTarget: constantDetachmentSender
       memory: "1.5Gi"
+    emptySessions:
+      testTarget: emptySessions
+      memory: "1.0Gi"
     finitePeeks:
       testTarget: finitePeeks
       memory: "1.5Gi"

--- a/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
@@ -65,7 +65,7 @@ func MustCreateStressContext(testName string) *StressContext {
 
 	ctx, cancel := NewCtrlCContext()
 
-	azlog.SetEvents(azservicebus.EventSender, azservicebus.EventReceiver, azservicebus.EventConn, azservicebus.EventAuth)
+	azlog.SetEvents(azservicebus.EventSender, azservicebus.EventReceiver, azservicebus.EventConn)
 
 	logMessages := make(chan string, 10000)
 
@@ -158,11 +158,36 @@ func (tracker *StressContext) Failf(format string, args ...any) {
 	panic(err)
 }
 
+func (tracker *StressContext) NoError(err error) {
+	if err == nil {
+		return
+	}
+
+	tracker.LogIfFailed(err.Error(), err, nil)
+	panic(err)
+}
+
+func (tracker *StressContext) NoErrorf(err error, format string, args ...any) {
+	if err == nil {
+		return
+	}
+
+	msg := fmt.Sprintf(format, args...)
+	tracker.LogIfFailed(fmt.Sprintf("%s: %s", msg, err.Error()), err, nil)
+	panic(err)
+}
+
 func (tracker *StressContext) Assert(condition bool, message string) {
 	tracker.LogIfFailed(message, nil, nil)
 
 	if !condition {
 		panic(message)
+	}
+}
+
+func (tracker *StressContext) Equal(val1 any, val2 any) {
+	if val1 != val2 {
+		panic(fmt.Errorf("Expected %v, got %v", val1, val2))
 	}
 }
 

--- a/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
@@ -191,6 +191,12 @@ func (tracker *StressContext) Equal(val1 any, val2 any) {
 	}
 }
 
+func (tracker *StressContext) Nil(val1 any) {
+	if val1 == nil {
+		panic("value was not nil")
+	}
+}
+
 func (sc *StressContext) LogIfFailed(message string, err error, stats *Stats) {
 	if err != nil {
 		log.Printf("Error: %s: %#v, %T", message, err, err)

--- a/sdk/messaging/azservicebus/internal/stress/templates/deploy-job.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/templates/deploy-job.yaml
@@ -22,7 +22,7 @@ spec:
       # just uses 'limits' for both.
       resources:
         limits:
-          memory: "1.5Gi"
+          memory: {{.Stress.memory}}
           cpu: "1"
       args: 
       - "tests"

--- a/sdk/messaging/azservicebus/internal/stress/tests/empty_sessions.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/empty_sessions.go
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/stress/shared"
+)
+
+func EmptySessions(remainingArgs []string) {
+	params := struct {
+		numAttempts int
+		rounds      int
+	}{}
+
+	fs := flag.NewFlagSet("emptysessions", flag.PanicOnError)
+
+	fs.IntVar(&params.numAttempts, "sessions", 2000, "Number of attempts to get a session")
+	fs.IntVar(&params.rounds, "rounds", 100, "Number of rounds to run with these parameters. -1 means math.MaxInt64")
+
+	topicName := strings.ToLower(fmt.Sprintf("topic-%X", time.Now().UnixNano()))
+	log.Printf("Creating topic %s", topicName)
+
+	sc := shared.MustCreateStressContext("emptysessions")
+	defer sc.End()
+
+	cleanup := shared.MustCreateSubscriptions(sc, topicName, []string{"sub1"}, &shared.MustCreateSubscriptionsOptions{
+		Subscription: &admin.CreateSubscriptionOptions{
+			Properties: &admin.SubscriptionProperties{
+				RequiresSession: to.Ptr(true),
+			},
+		},
+	})
+	defer cleanup()
+
+	client, err := azservicebus.NewClientFromConnectionString(sc.ConnectionString, &azservicebus.ClientOptions{
+		RetryOptions: azservicebus.RetryOptions{
+			// barrel through retryable failures - we're specifically trying to see if we ever stop
+			// receiving the standard "no session within time limit" error.
+			MaxRetries: 10,
+		},
+	})
+	sc.NoError(err)
+
+	defer func() {
+		sc.NoError(client.Close(context.Background()))
+	}()
+
+	for round := 0; round < params.rounds; round++ {
+		for i := 0; i < params.numAttempts; i++ {
+			// the default "wait for next session" timeout is basically a minute. If we exceed that then something is broken.
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			sessionReceiver, err := client.AcceptNextSessionForSubscription(ctx, topicName, "sub1", nil)
+			cancel()
+			sc.Nil(sessionReceiver)
+
+			// the error should indicate that we timed out waiting for a new session
+			if sbErr := (*azservicebus.Error)(nil); errors.As(err, &sbErr) {
+				sc.Equal(azservicebus.CodeTimeout, sbErr.Code)
+			} else if err != nil {
+				sc.PanicOnError("A non-timeout error occurred", err)
+			}
+		}
+	}
+}

--- a/sdk/messaging/azservicebus/internal/stress/tests/finite_sessions.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/finite_sessions.go
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tests
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/stress/shared"
+)
+
+type finiteSessionsArgs struct {
+	numSessions          int
+	rounds               int
+	enableVerboseLogging bool
+}
+
+func FiniteSessions(remainingArgs []string) {
+	// NOTE: these values aren't particularly special, but they do try to create a reasonable default
+	// test just to make sure everything is working.
+	//
+	// Look in ../templates/deploy-job.yaml for some of the other parameter variations we use in stress/longevity
+	// testing.
+	fs := flag.NewFlagSet("FiniteSessions", flag.ContinueOnError)
+
+	params := finiteSessionsArgs{}
+
+	fs.IntVar(&params.numSessions, "sessions", 2000, "Number of sessions to test")
+	fs.IntVar(&params.rounds, "rounds", 100, "Number of rounds to run with these parameters. -1 means math.MaxInt64")
+	fs.BoolVar(&params.enableVerboseLogging, "verbose", false, "enable verbose azure sdk logging")
+
+	sc := shared.MustCreateStressContext("FiniteSessions")
+	defer sc.End()
+
+	topicName := strings.ToLower(fmt.Sprintf("topic-%X", time.Now().UnixNano()))
+
+	log.Printf("Creating topic %s", topicName)
+
+	cleanup := shared.MustCreateSubscriptions(sc, topicName, []string{"sub1"}, &shared.MustCreateSubscriptionsOptions{
+		Subscription: &admin.CreateSubscriptionOptions{
+			Properties: &admin.SubscriptionProperties{
+				RequiresSession: to.Ptr(true),
+			},
+		},
+	})
+	defer cleanup()
+
+	client, err := azservicebus.NewClientFromConnectionString(sc.ConnectionString, nil)
+	sc.NoError(err)
+
+	sender, err := client.NewSender(topicName, nil)
+	sc.NoError(err)
+
+	defer sender.Close(sc.Context)
+
+	for round := 0; round < int(params.rounds); round++ {
+		var sessionReceivers []*azservicebus.SessionReceiver
+		wg := sync.WaitGroup{}
+
+		for i := 0; i < params.numSessions; i++ {
+			sessionID := fmt.Sprintf("%d:%d", round, i)
+
+			err = sender.SendMessage(sc.Context, &azservicebus.Message{
+				SessionID: &sessionID,
+			}, nil)
+			sc.NoError(err)
+
+			sessionReceiver, err := client.AcceptNextSessionForSubscription(sc.Context, topicName, "sub1", nil)
+			sc.NoError(err)
+
+			// one of the things mentioned in the customer issue - they keep the session receivers
+			// alive for a long time.
+			sessionReceivers = append(sessionReceivers, sessionReceiver)
+
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				ctx, cancel := context.WithTimeout(sc.Context, time.Minute)
+				messages, err := sessionReceiver.ReceiveMessages(ctx, 2, nil)
+				cancel()
+
+				sc.NoError(err)
+				sc.Equal(1, len(messages))
+				sc.Equal(sessionID, *messages[0].SessionID)
+
+				sc.NoError(sessionReceiver.CompleteMessage(sc.Context, messages[0], nil))
+			}()
+		}
+
+		wg.Wait()
+
+		for _, receiver := range sessionReceivers {
+			err = receiver.Close(sc.Context)
+			sc.NoErrorf(err, "No errors when session receiver is closed")
+		}
+	}
+}

--- a/sdk/messaging/azservicebus/internal/stress/tests/finite_sessions.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/finite_sessions.go
@@ -19,9 +19,8 @@ import (
 )
 
 type finiteSessionsArgs struct {
-	numSessions          int
-	rounds               int
-	enableVerboseLogging bool
+	numSessions int
+	rounds      int
 }
 
 func FiniteSessions(remainingArgs []string) {
@@ -36,7 +35,6 @@ func FiniteSessions(remainingArgs []string) {
 
 	fs.IntVar(&params.numSessions, "sessions", 2000, "Number of sessions to test")
 	fs.IntVar(&params.rounds, "rounds", 100, "Number of rounds to run with these parameters. -1 means math.MaxInt64")
-	fs.BoolVar(&params.enableVerboseLogging, "verbose", false, "enable verbose azure sdk logging")
 
 	sc := shared.MustCreateStressContext("FiniteSessions")
 	defer sc.End()

--- a/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
@@ -24,7 +24,7 @@ func IdleFastReconnect(remainingArgs []string) {
 	sc.Track(startEvent)
 	defer sc.End()
 
-	cleanup := shared.MustCreateSubscriptions(sc, topicName, []string{"subscriptionA"})
+	cleanup := shared.MustCreateSubscriptions(sc, topicName, []string{"subscriptionA"}, nil)
 	defer cleanup()
 
 	client, err := azservicebus.NewClientFromConnectionString(sc.ConnectionString, &azservicebus.ClientOptions{

--- a/sdk/messaging/azservicebus/internal/stress/tests/infinite_send_and_receive.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/infinite_send_and_receive.go
@@ -29,7 +29,7 @@ func InfiniteSendAndReceiveRun(remainingArgs []string) {
 
 	stats := sc.NewStat("infinite")
 
-	cleanup := shared.MustCreateSubscriptions(sc, topicName, []string{"batch"})
+	cleanup := shared.MustCreateSubscriptions(sc, topicName, []string{"batch"}, nil)
 	defer cleanup()
 
 	time.AfterFunc(5*24*time.Hour, func() {

--- a/sdk/messaging/azservicebus/internal/stress/tests/tests.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/tests.go
@@ -34,6 +34,7 @@ func Run(remainingArgs []string) {
 	allTests := map[string]func(args []string){
 		"constantDetach":           ConstantDetachment,
 		"constantDetachmentSender": ConstantDetachmentSender,
+		"emptySessions":            EmptySessions,
 		"finitePeeks":              FinitePeeks,
 		"finiteSendAndReceive":     FiniteSendAndReceiveTest,
 		"finiteSessions":           FiniteSessions,

--- a/sdk/messaging/azservicebus/internal/stress/tests/tests.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/tests.go
@@ -36,6 +36,7 @@ func Run(remainingArgs []string) {
 		"constantDetachmentSender": ConstantDetachmentSender,
 		"finitePeeks":              FinitePeeks,
 		"finiteSendAndReceive":     FiniteSendAndReceiveTest,
+		"finiteSessions":           FiniteSessions,
 		"idleFastReconnect":        IdleFastReconnect,
 		"infiniteSendAndReceive":   InfiniteSendAndReceiveRun,
 		"longRunningRenewLock":     LongRunningRenewLockTest,

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -249,7 +249,7 @@ type RenewSessionLockOptions struct {
 // using `LockedUntil`.
 // If the operation fails it can return an *azservicebus.Error type if the failure is actionable.
 func (sr *SessionReceiver) RenewSessionLock(ctx context.Context, options *RenewSessionLockOptions) error {
-	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
+	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "RenewSessionLock", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		newLockedUntil, err := internal.RenewSessionLock(ctx, lwv.RPC, lwv.Receiver.LinkName(), *sr.sessionID)
 
 		if err != nil {


### PR DESCRIPTION
Adding in a test that lets us test sessions by repeatedly creating them (ie, sending a message with a session ID) and then receiving on it. 

The session tests (since it holds open more receivers) uses more memory, so we account for that now by specifying a memory limit for each test.

Part of the fix for #19511.