### PR TITLE
[azservicebus] Do a sleep in our azidentity test if it initially reports that we don't have Send claims

### DIFF
--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -5,7 +5,6 @@ package azservicebus
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -39,7 +38,7 @@ func TestNewClientWithAzureIdentity(t *testing.T) {
 	envCred, err := azidentity.NewEnvironmentCredential(nil)
 
 	if err == nil {
-		fmt.Printf("Env cred works, being added to our chained token credential")
+		t.Logf("Env cred works, being added to our chained token credential")
 		credsToAdd = append(credsToAdd, envCred)
 	}
 
@@ -60,18 +59,16 @@ func TestNewClientWithAzureIdentity(t *testing.T) {
 
 	err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")}, nil)
 
-	if err != nil {
-		if strings.Contains(err.Error(), "'Send' claim(s) are required to perform this operation") {
-			const sleepDuration = time.Minute
-			// it's possible we're just dealing with a propagation delay for our
-			// configured identity and the newly created resource. We'll sleep
-			// a bit to give it some time and try again.
-			t.Logf("Enacting CI workaround to deal with RBAC propagation delays. Sleeping for %s...", sleepDuration)
-			time.Sleep(sleepDuration)
-			t.Logf("Done sleeping for %s", sleepDuration)
+	if err != nil && strings.Contains(err.Error(), "'Send' claim(s) are required to perform this operation") {
+		const sleepDuration = time.Minute
+		// it's possible we're just dealing with a propagation delay for our
+		// configured identity and the newly created resource. We'll sleep
+		// a bit to give it some time and try again.
+		t.Logf("Enacting CI workaround to deal with RBAC propagation delays. Sleeping for %s...", sleepDuration)
+		time.Sleep(sleepDuration)
+		t.Logf("Done sleeping for %s", sleepDuration)
 
-			err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")}, nil)
-		}
+		err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")}, nil)
 	}
 
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,6 +59,21 @@ func TestNewClientWithAzureIdentity(t *testing.T) {
 	require.NoError(t, err)
 
 	err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")}, nil)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "'Send' claim(s) are required to perform this operation") {
+			const sleepDuration = time.Minute
+			// it's possible we're just dealing with a propagation delay for our
+			// configured identity and the newly created resource. We'll sleep
+			// a bit to give it some time and try again.
+			t.Logf("Enacting CI workaround to deal with RBAC propagation delays. Sleeping for %s...", sleepDuration)
+			time.Sleep(sleepDuration)
+			t.Logf("Done sleeping for %s", sleepDuration)
+
+			err = sender.SendMessage(context.TODO(), &Message{Body: []byte("hello - authenticating with a TokenCredential")}, nil)
+		}
+	}
+
 	require.NoError(t, err)
 
 	receiver, err := client.NewReceiverForQueue(queue, nil)


### PR DESCRIPTION
Adding in a workaround for the annoying "send claims" bug that manifests in CI. 

Fixes #19609