### PR TITLE
Remove dead code in managed_identity_credentials.go 

### DIFF
--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -85,9 +85,7 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 		return nil, err
 	}
 	cred := confidential.NewCredFromTokenProvider(mic.provideToken)
-	if err != nil {
-		return nil, err
-	}
+
 	// It's okay to give MSAL an invalid client ID because MSAL will use it only as part of a cache key.
 	// ManagedIdentityClient handles all the details of authentication and won't receive this value from MSAL.
 	clientID := "SYSTEM-ASSIGNED-MANAGED-IDENTITY"


### PR DESCRIPTION
This dead code was causing compile errors under go1.20.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [N/A] Tests are included and/or updated for code changes.
- [N/A] Updates to [CHANGELOG.md][] are included.
- [N/A] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
