### PR TITLE
Fix live test after MMF change

### DIFF
--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -3450,7 +3450,10 @@ func (s *BlockBlobUnrecordedTestsSuite) TestUploadStreamToBlobProperties() {
 	_require.NoError(err)
 	_require.EqualValues(getPropertiesResp.Metadata, testcommon.BasicMetadata)
 	_require.Equal(*getPropertiesResp.TagCount, int64(len(testcommon.BasicBlobTagsMap)))
-	_require.Equal(blob.ParseHTTPHeaders(getPropertiesResp), testcommon.BasicHeaders)
+	respHeaders := testcommon.BasicHeaders
+	calcMD5 := md5.Sum(blobData)
+	respHeaders.BlobContentMD5 = calcMD5[:]
+	_require.Equal(respHeaders, blob.ParseHTTPHeaders(getPropertiesResp))
 
 	getTagsResp, err := bbClient.GetTags(context.Background(), nil)
 	_require.NoError(err)

--- a/sdk/storage/azblob/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azblob/internal/testcommon/clients_auth.go
@@ -11,12 +11,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
@@ -87,7 +87,7 @@ var SpecialCharBlobTagsMap = map[string]string{
 }
 
 func setClientOptions(t *testing.T, opts *azcore.ClientOptions) {
-	opts.Logging.AllowedHeaders = []string{"X-Request-Mismatch", "X-Request-Mismatch-Error"}
+	opts.Logging.AllowedHeaders = append(opts.Logging.AllowedHeaders, "X-Request-Mismatch", "X-Request-Mismatch-Error")
 
 	transport, err := recording.NewRecordingHTTPClient(t, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
The MMF change introduced a change to UploadStream that would internally switch to Upload if the source size was smaller than one block.  When this happens, the MD5 is calculated and returned which the test didn't expect to happen.

Introduced in https://github.com/Azure/azure-sdk-for-go/pull/19635