### PR TITLE
[Event Hubs] Example fix

### DIFF
--- a/sdk/messaging/azeventhubs/example_producing_events_test.go
+++ b/sdk/messaging/azeventhubs/example_producing_events_test.go
@@ -24,9 +24,9 @@ func Example_producingEventsUsingProducerClient() {
 
 	// Can also use a connection string:
 	//
-	// producerClient, err = azeventhubs.NewProducerClientFromConnectionString(connectionString, eventHubName, nil)
+	// producerClient, err := azeventhubs.NewProducerClientFromConnectionString(connectionString, eventHubName, nil)
 	//
-	producerClient, err = azeventhubs.NewProducerClient(eventHubNamespace, eventHubName, defaultAzureCred, nil)
+	producerClient, err := azeventhubs.NewProducerClient(eventHubNamespace, eventHubName, defaultAzureCred, nil)
 
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
While testing out some of the Go Event Hubs examples I go an error. Changing the following lines to use the declaration and assignment operator seems to fix it. 

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
