### PR TITLE
AzureCLICredential respects application deadlines

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+* `AzureCLICredential` imposes its default timeout only when the `Context`
+  passed to `GetToken()` has no deadline
 
 ## 1.3.0-beta.1 (2022-12-13)
 

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -100,8 +100,12 @@ func defaultTokenProvider() func(ctx context.Context, resource string, tenantID 
 			return nil, fmt.Errorf(`%s: unexpected scope "%s". Only alphanumeric characters and ".", ";", "-", and "/" are allowed`, credNameAzureCLI, resource)
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, timeoutCLIRequest)
-		defer cancel()
+		// set a default timeout for this authentication iff the application hasn't done so already
+		var cancel context.CancelFunc
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			ctx, cancel = context.WithTimeout(ctx, timeoutCLIRequest)
+			defer cancel()
+		}
 
 		commandLine := "az account get-access-token -o json --resource " + resource
 		if tenantID != "" {


### PR DESCRIPTION
It isn't possible today for an application to allow more than the credential's default 10 seconds for authentication because the credential indiscriminately calls `context.WithTimeout(..., 10*time.Second)`, which will shorten any longer deadline the application may have set. With this change, the credential imposes its default timeout only when the application hasn't already set a deadline. Closes #19575