### PR TITLE
Add logs to dump calculate block size and count during upload

### DIFF
--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -412,14 +412,17 @@ func (bb *Client) uploadFromReader(ctx context.Context, reader io.ReaderAt, actu
 		return uploadFromReaderResponse{}, errors.New("block limit exceeded")
 	}
 
-	log.Writef(exported.EventUpload, "=====> actual size %v, block-size %v, block-count %v",
-		actualSize, o.BlockSize, numBlocks)
+	urlparts, err := blob.ParseURL(bb.generated().Endpoint())
+	if err == nil {
+		log.Writef(exported.EventUpload, "blob name %s actual size %v block-size %v block-count %v",
+			urlparts.BlobName, actualSize, o.BlockSize, numBlocks)
+	}
 
 	blockIDList := make([]string, numBlocks) // Base-64 encoded block IDs
 	progress := int64(0)
 	progressLock := &sync.Mutex{}
 
-	err := shared.DoBatchTransfer(ctx, &shared.BatchTransferOptions{
+	err = shared.DoBatchTransfer(ctx, &shared.BatchTransferOptions{
 		OperationName: "uploadFromReader",
 		TransferSize:  readerSize,
 		ChunkSize:     o.BlockSize,

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -391,7 +391,6 @@ func (bb *Client) uploadFromReader(ctx context.Context, reader io.ReaderAt, actu
 			}
 			// StageBlock will be called with blockSize blocks and a Concurrency of (BufferSize / BlockSize).
 		}
-		log.Writef(exported.EventUpload, "=====> computed block-size %v", o.BlockSize)
 	}
 
 	if readerSize <= MaxUploadBlobBytes {
@@ -412,7 +411,9 @@ func (bb *Client) uploadFromReader(ctx context.Context, reader io.ReaderAt, actu
 		// prevent any math bugs from attempting to upload too many blocks which will always fail
 		return uploadFromReaderResponse{}, errors.New("block limit exceeded")
 	}
-	log.Writef(exported.EventUpload, "=====> computed block-count %v", numBlocks)
+
+	log.Writef(exported.EventUpload, "=====> actual size %v, block-size %v, block-count %v",
+		actualSize, o.BlockSize, numBlocks)
 
 	blockIDList := make([]string, numBlocks) // Base-64 encoded block IDs
 	progress := int64(0)

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -412,17 +412,19 @@ func (bb *Client) uploadFromReader(ctx context.Context, reader io.ReaderAt, actu
 		return uploadFromReaderResponse{}, errors.New("block limit exceeded")
 	}
 
-	urlparts, err := blob.ParseURL(bb.generated().Endpoint())
-	if err == nil {
-		log.Writef(exported.EventUpload, "blob name %s actual size %v block-size %v block-count %v",
-			urlparts.BlobName, actualSize, o.BlockSize, numBlocks)
+	if log.Should(exported.EventUpload) {
+		urlparts, err := blob.ParseURL(bb.generated().Endpoint())
+		if err == nil {
+			log.Writef(exported.EventUpload, "blob name %s actual size %v block-size %v block-count %v",
+				urlparts.BlobName, actualSize, o.BlockSize, numBlocks)
+		}
 	}
 
 	blockIDList := make([]string, numBlocks) // Base-64 encoded block IDs
 	progress := int64(0)
 	progressLock := &sync.Mutex{}
 
-	err = shared.DoBatchTransfer(ctx, &shared.BatchTransferOptions{
+	err := shared.DoBatchTransfer(ctx, &shared.BatchTransferOptions{
 		OperationName: "uploadFromReader",
 		TransferSize:  readerSize,
 		ChunkSize:     o.BlockSize,

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/base"
@@ -390,6 +391,7 @@ func (bb *Client) uploadFromReader(ctx context.Context, reader io.ReaderAt, actu
 			}
 			// StageBlock will be called with blockSize blocks and a Concurrency of (BufferSize / BlockSize).
 		}
+		log.Writef(exported.EventUpload, "=====> computed block-size %v", o.BlockSize)
 	}
 
 	if readerSize <= MaxUploadBlobBytes {
@@ -410,6 +412,7 @@ func (bb *Client) uploadFromReader(ctx context.Context, reader io.ReaderAt, actu
 		// prevent any math bugs from attempting to upload too many blocks which will always fail
 		return uploadFromReaderResponse{}, errors.New("block limit exceeded")
 	}
+	log.Writef(exported.EventUpload, "=====> computed block-count %v", numBlocks)
 
 	blockIDList := make([]string, numBlocks) // Base-64 encoded block IDs
 	progress := int64(0)

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -3983,11 +3983,14 @@ func TestUploadLogEvent(t *testing.T) {
 	log.SetEvents(azblob.EventUpload, log.EventRequest, log.EventResponse)
 	log.SetListener(func(cls log.Event, msg string) {
 		t.Logf("%s: %s\n", cls, msg)
-		listnercalled = true
+		if cls == azblob.EventUpload {
+			listnercalled = true
+			require.Equal(t, msg, "blob name path1/path2 actual size 270000000 block-size 4194304 block-count 65")
+		}
 	})
 
 	fbb := &fakeBlockBlob{}
-	client, err := blockblob.NewClientWithNoCredential("https://fake/blob/path", &blockblob.ClientOptions{
+	client, err := blockblob.NewClientWithNoCredential("https://fake/blob/path1/path2", &blockblob.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			Transport: fbb,
 			Telemetry: policy.TelemetryOptions{ApplicationID: "testApp/1.0.0-preview.2"},

--- a/sdk/storage/azblob/blockblob/examples_test.go
+++ b/sdk/storage/azblob/blockblob/examples_test.go
@@ -215,7 +215,7 @@ func Example_blockblob_uploadLogs() {
 	azlog.SetEvents(azblob.EventUpload, azlog.EventRequest, azlog.EventResponse)
 	azlog.SetListener(func(cls azlog.Event, msg string) {
 		if cls == azblob.EventUpload {
-			fmt.Printf(msg)
+			fmt.Println(msg)
 		}
 	})
 

--- a/sdk/storage/azblob/internal/exported/log_events.go
+++ b/sdk/storage/azblob/internal/exported/log_events.go
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package exported
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
+)
+
+// NOTE: these are publicly exported via type-aliasing in azblob/log.go
+const (
+	// EventUpload is used when we compute number of blocks to upload and size of each block.
+	EventUpload log.Event = "azblob.Upload"
+)

--- a/sdk/storage/azblob/log.go
+++ b/sdk/storage/azblob/log.go
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azblob
+
+import "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
+
+const (
+	// EventUpload is used when we compute number of blocks to upload and size of each block.
+	EventUpload = exported.EventUpload
+)

--- a/sdk/storage/azblob/log.go
+++ b/sdk/storage/azblob/log.go
@@ -6,6 +6,6 @@ package azblob
 import "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
 
 const (
-	// EventUpload is used when we compute number of blocks to upload and size of each block.
+	// EventUpload is used for logging events related to upload operation.
 	EventUpload = exported.EventUpload
 )


### PR DESCRIPTION
- Create a new logging event to track number of blocks and size of each block calculated during upload.

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
