### PR TITLE
Request.SetBody() allows overwriting with an empty body

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Other Changes
 * Updated `internal` module to latest version.
+* `policy/Request.SetBody()` allows replacing a request's body with an empty one
 
 ## 1.2.0 (2022-11-04)
 

--- a/sdk/azcore/internal/exported/request.go
+++ b/sdk/azcore/internal/exported/request.go
@@ -101,7 +101,8 @@ func (req *Request) OperationValue(value interface{}) bool {
 }
 
 // SetBody sets the specified ReadSeekCloser as the HTTP request body, and sets Content-Type and Content-Length
-// accordingly. If the ReadSeekCloser is nil or empty, Content-Length won't be set.
+// accordingly. If the ReadSeekCloser is nil or empty, Content-Length won't be set. If contentType is "",
+// Content-Type won't be set.
 func (req *Request) SetBody(body io.ReadSeekCloser, contentType string) error {
 	var err error
 	var size int64
@@ -115,14 +116,14 @@ func (req *Request) SetBody(body io.ReadSeekCloser, contentType string) error {
 		// treat an empty stream the same as a nil one: assign req a nil body
 		body = nil
 		// RFC 9110 specifies a client shouldn't set Content-Length on a request containing no content
-		// (Del is a no-op when the header isn't set already)
+		// (Del is a no-op when the header has no value)
 		req.req.Header.Del(shared.HeaderContentLength)
 	} else {
-		req.req.Header.Set(shared.HeaderContentLength, strconv.FormatInt(size, 10))
 		_, err = body.Seek(0, io.SeekStart)
 		if err != nil {
 			return err
 		}
+		req.req.Header.Set(shared.HeaderContentLength, strconv.FormatInt(size, 10))
 		req.Raw().GetBody = func() (io.ReadCloser, error) {
 			_, err := body.Seek(0, io.SeekStart) // Seek back to the beginning of the stream
 			return body, err
@@ -133,7 +134,12 @@ func (req *Request) SetBody(body io.ReadSeekCloser, contentType string) error {
 	req.body = body
 	req.req.Body = body
 	req.req.ContentLength = size
-	req.req.Header.Set(shared.HeaderContentType, contentType)
+	if contentType == "" {
+		// Del is a no-op when the header has no value
+		req.req.Header.Del(shared.HeaderContentType)
+	} else {
+		req.req.Header.Set(shared.HeaderContentType, contentType)
+	}
 	return nil
 }
 

--- a/sdk/azcore/internal/exported/request_test.go
+++ b/sdk/azcore/internal/exported/request_test.go
@@ -133,6 +133,7 @@ func TestRequestEmptyBody(t *testing.T) {
 	require.NoError(t, req.SetBody(nil, ""))
 	require.Nil(t, req.Body())
 	require.NotContains(t, req.Raw().Header, shared.HeaderContentLength)
+	require.NotContains(t, req.Raw().Header, shared.HeaderContentType)
 
 	// SetBody should allow replacing a previously set body with an empty one
 	req, err = NewRequest(context.Background(), http.MethodPost, testURL)

--- a/sdk/azcore/internal/exported/request_test.go
+++ b/sdk/azcore/internal/exported/request_test.go
@@ -124,7 +124,7 @@ func TestRequestEmptyBody(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, req.SetBody(NopCloser(strings.NewReader("")), "application/text"))
 	require.Nil(t, req.Body())
-	require.Equal(t, []string{"0"}, req.Raw().Header[shared.HeaderContentLength])
+	require.NotContains(t, req.Raw().Header, shared.HeaderContentLength)
 	require.Equal(t, []string{"application/text"}, req.Raw().Header[shared.HeaderContentType])
 
 	// SetBody should treat a nil ReadSeekCloser the same as one having no content
@@ -132,6 +132,7 @@ func TestRequestEmptyBody(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, req.SetBody(nil, ""))
 	require.Nil(t, req.Body())
+	require.NotContains(t, req.Raw().Header, shared.HeaderContentLength)
 
 	// SetBody should allow replacing a previously set body with an empty one
 	req, err = NewRequest(context.Background(), http.MethodPost, testURL)
@@ -139,7 +140,7 @@ func TestRequestEmptyBody(t *testing.T) {
 	require.NoError(t, req.SetBody(NopCloser(strings.NewReader("content")), "application/text"))
 	require.NoError(t, req.SetBody(nil, "application/json"))
 	require.Nil(t, req.Body())
-	require.Equal(t, []string{"0"}, req.Raw().Header[shared.HeaderContentLength])
+	require.NotContains(t, req.Raw().Header, shared.HeaderContentLength)
 	require.Equal(t, []string{"application/json"}, req.Raw().Header[shared.HeaderContentType])
 }
 


### PR DESCRIPTION
Today, sending a `Request` without its body (Key Vault clients do this) requires copying it and/or modifying the underlying `http.Request` because `Request.SetBody()` won't overwrite a non-empty body with an empty one. This is apparently an oversight--`SetBody` will overwrite a non-empty body or set an empty body, but it won't do both at once.