### PR TITLE
AzureCLICredential reports token expiration time in UTC

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* `AzureCLICredential` reports token expiration in local time (should be UTC)
 
 ### Other Changes
 * `AzureCLICredential` imposes its default timeout only when the `Context`

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -162,15 +162,15 @@ func (c *AzureCLICredential) createAccessToken(tk []byte) (azcore.AccessToken, e
 		return azcore.AccessToken{}, err
 	}
 
-	// note the Azure CLI's "expiresOn" field is local time
-	tokenExpirationDate, err := time.ParseInLocation("2006-01-02 15:04:05.999999", t.ExpiresOn, time.Local)
+	// the Azure CLI's "expiresOn" is local time
+	exp, err := time.ParseInLocation("2006-01-02 15:04:05.999999", t.ExpiresOn, time.Local)
 	if err != nil {
 		return azcore.AccessToken{}, fmt.Errorf("Error parsing token expiration time %q: %v", t.ExpiresOn, err)
 	}
 
 	converted := azcore.AccessToken{
 		Token:     t.AccessToken,
-		ExpiresOn: tokenExpirationDate,
+		ExpiresOn: exp.UTC(),
 	}
 	return converted, nil
 }

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -162,32 +162,17 @@ func (c *AzureCLICredential) createAccessToken(tk []byte) (azcore.AccessToken, e
 		return azcore.AccessToken{}, err
 	}
 
-	tokenExpirationDate, err := parseExpirationDate(t.ExpiresOn)
+	// note the Azure CLI's "expiresOn" field is local time
+	tokenExpirationDate, err := time.ParseInLocation("2006-01-02 15:04:05.999999", t.ExpiresOn, time.Local)
 	if err != nil {
-		return azcore.AccessToken{}, fmt.Errorf("Error parsing Token Expiration Date %q: %+v", t.ExpiresOn, err)
+		return azcore.AccessToken{}, fmt.Errorf("Error parsing token expiration time %q: %v", t.ExpiresOn, err)
 	}
 
 	converted := azcore.AccessToken{
 		Token:     t.AccessToken,
-		ExpiresOn: *tokenExpirationDate,
+		ExpiresOn: tokenExpirationDate,
 	}
 	return converted, nil
-}
-
-// parseExpirationDate parses either a Azure CLI or CloudShell date into a time object
-func parseExpirationDate(input string) (*time.Time, error) {
-	// CloudShell (and potentially the Azure CLI in future)
-	expirationDate, cloudShellErr := time.Parse(time.RFC3339, input)
-	if cloudShellErr != nil {
-		// Azure CLI (Python) e.g. 2017-08-31 19:48:57.998857 (plus the local timezone)
-		const cliFormat = "2006-01-02 15:04:05.999999"
-		expirationDate, cliErr := time.ParseInLocation(cliFormat, input, time.Local)
-		if cliErr != nil {
-			return nil, fmt.Errorf("Error parsing expiration date %q.\n\nCloudShell Error: \n%+v\n\nCLI Error:\n%+v", input, cloudShellErr, cliErr)
-		}
-		return &expirationDate, nil
-	}
-	return &expirationDate, nil
 }
 
 var _ azcore.TokenCredential = (*AzureCLICredential)(nil)


### PR DESCRIPTION
Currently it does so in local time, unlike all other credential types. This change doesn't affect comparisons through the `time` API because those are location-aware, however it is a breaking change for anyone who took a dependency on this value's specific location. I can't imagine why anyone would have done that.