### PR TITLE
[azblob] fix pager nextpage endless loop

### DIFF
--- a/sdk/storage/azblob/service/client.go
+++ b/sdk/storage/azblob/service/client.go
@@ -186,7 +186,7 @@ func (s *Client) NewListContainersPager(o *ListContainersOptions) *runtime.Pager
 			if page == nil {
 				req, err = s.generated().ListContainersSegmentCreateRequest(ctx, &listOptions)
 			} else {
-				listOptions.Marker = page.Marker
+				listOptions.Marker = page.NextMarker
 				req, err = s.generated().ListContainersSegmentCreateRequest(ctx, &listOptions)
 			}
 			if err != nil {


### PR DESCRIPTION
This problem appears if MaxResults < numContainers. Since MaxResults=5000 by default, in most cases everything will be ok, but we also found this problem after performed point in time restore on one of containers:
`az storage blob restore --account-name $storage_account --time-to-restore "$formatted_date" --blob-range $container ${container}-0 $sub_conf $rg_conf`
After PITR, for some reason, pager.NextPage starts returning 10 containers each request (which is less than we have) despite the MaxResults=5000 set and we get into an infinite loop since after the first request page.Marker=nil [here](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/storage/azblob/service/client.go#L189)