### PR TITLE
[azeventhubs] Adding in prefetch value for the Processor, updating stress tests

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Features Added
 
-- Adds ProcessorOptions.Prefetch field, allowing configuration of Prefetch values for PartitionClients
-  created using the Processor.
+- Adds ProcessorOptions.Prefetch field, allowing configuration of Prefetch values for PartitionClients created using the Processor. (PR#19786)
 
 ### Breaking Changes
 

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Adds ProcessorOptions.Prefetch field, allowing configuration of Prefetch values for PartitionClients
+  created using the Processor.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.21
-digest: sha256:ac7f0861fd54ebba0e3fec92c1fecc058e96f58df9094641605dd4250a7a423f
-generated: "2022-10-26T23:28:36.470982569Z"
+  version: 0.2.0
+digest: sha256:59fff3930e78c4ca9f9c0120433c7695d31db63f36ac61d50abcc91b1f1835a0
+generated: "2023-01-06T23:57:35.96426915Z"

--- a/sdk/messaging/azeventhubs/internal/eh/stress/scenarios-matrix.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/scenarios-matrix.yaml
@@ -6,13 +6,39 @@ matrix:
   scenarios:
     batch:
       testTarget: batch
+      type: "batch"
+      rounds: 100
+      prefetch: 0
+      verbose: ""
+      sleepAfter: "5m"
     batchprefetchoff:
-      testTarget: batchprefetchoff
+      testTarget: batch
+      rounds: 100
+      prefetch: -1
+      verbose: ""
+      sleepAfter: "5m"
     batchinfinite:
-      testTarget: batchinfinite
+      testTarget: batch
+      type: "batch"
+      rounds: 100
+      prefetch: 0
+      verbose: ""
+      sleepAfter: "5m"
     processor:
       testTarget: processor
+      rounds: 100
+      prefetch: 0
+      verbose: ""
+      sleepAfter: "5m"
     processorprefetchoff:
-      testTarget: processorprefetchoff
+      testTarget: processor
+      rounds: 100
+      prefetch: -1
+      verbose: ""
+      sleepAfter: "5m"
     processorinfinite:
-      testTarget: processorinfinite
+      testTarget: processor
+      rounds: 100
+      prefetch: 0
+      verbose: ""
+      sleepAfter: "5m"

--- a/sdk/messaging/azeventhubs/internal/eh/stress/templates/deploy-job.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/templates/deploy-job.yaml
@@ -29,37 +29,14 @@ spec:
       # NOTE: -verbose activates _all_ the Azure internal logging, which can get quite large.
       # so it's not enabled for every target in here. We also have an issue filed to whittle it
       # down (https://github.com/Azure/azure-sdk-for-go/issues/19459)
-      {{ if (eq .Stress.testTarget "batch") }}
-      - batch
+      - "{{.Stress.testTarget}}"
       - "-rounds"
-      - "100"
-      - "-verbose"
-      {{ else if (eq .Stress.testTarget "batchprefetchoff") }}
-      - batch
-      - "-rounds"
-      - "100"
+      - "{{.Stress.rounds}}"
       - "-prefetch"
-      - "-1"
-      - "-verbose"
-      {{ else if (eq .Stress.testTarget "batchinfinite") }}
-      - batch
-      - "-rounds"
-      - "-1"      
-      {{ else if (eq .Stress.testTarget "processor") }}
-      - processor
-      - "-rounds"
-      - "100"
-      {{ else if (eq .Stress.testTarget "processorprefetchoff") }}
-      - processor
-      - "-rounds"
-      - "100"
-      - "-prefetch"
-      - "-1"
-      {{ else if (eq .Stress.testTarget "processorinfinite") }}
-      - processor
-      - "-rounds"
-      - "-1"
-      {{- end -}}
+      - "{{.Stress.prefetch}}"
+      - "{{.Stress.verbose}}"
+      - "-sleepAfter"
+      - "{{.Stress.sleepAfter}}"
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}
 

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
@@ -5,6 +5,7 @@ package tests
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -380,4 +381,24 @@ func enableVerboseLogging() {
 	azlog.SetListener(func(e azlog.Event, s string) {
 		log.Printf("[%s] %s", e, s)
 	})
+}
+
+func addSleepAfterFlag(fs *flag.FlagSet) func() {
+	var durationStr string
+	fs.StringVar(&durationStr, "sleepAfter", "0m", "Time to sleep after test completes")
+
+	return func() {
+		sleepAfter, err := time.ParseDuration(durationStr)
+
+		if err != nil {
+			log.Printf("Invalid sleepAfter duration given: %s", sleepAfter)
+			return
+		}
+
+		if sleepAfter > 0 {
+			log.Printf("Sleeping for %s", sleepAfter)
+			time.Sleep(sleepAfter)
+			log.Printf("Done sleeping for %s", sleepAfter)
+		}
+	}
 }


### PR DESCRIPTION
- Added the option to configure prefetch count for ProcessorPartitionClient's created from the Processor
- Fixed some issues with the stress tests. Batch tests were using a really large batch size, which was too large for the amount of memory we're using in our test containers.
- Processor tests weren't configuring a prefetch value (prior to this PR the setting wasn't exposed)
    
Also, just generally made the stress tests a bit cleaner, leveragin the scenario-matrix more for configuring values.

Fixes #19770