### PR TITLE
Blob Batch

### DIFF
--- a/sdk/storage/azblob/blobbatch/blob_batch.go
+++ b/sdk/storage/azblob/blobbatch/blob_batch.go
@@ -1,0 +1,153 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package blobbatch
+
+import (
+	"context"
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/base"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
+)
+
+func getGeneratedBlobClient(b *blob.Client) *generated.BlobClient {
+	return base.InnerClient((*base.Client[generated.BlobClient])(b))
+}
+
+func NewBatchBuilder() *BatchBuilder {
+	return &BatchBuilder{}
+}
+
+func (b *BatchBuilder) AddBlobBatchDelete(blobPath string, o *DeleteOptions) {
+	b.batchDeleteList = append(b.batchDeleteList, &BatchDeleteOptions{
+		BlobPath:      &blobPath,
+		DeleteOptions: o,
+	})
+}
+
+func (b *BatchBuilder) AddBlobBatchSetTier(blobPath string, accessTier blob.AccessTier, o *SetTierOptions) {
+	b.batchSetTierList = append(b.batchSetTierList, &BatchSetTierOptions{
+		BlobPath:       &blobPath,
+		AccessTier:     accessTier,
+		SetTierOptions: o,
+	})
+}
+
+func (b *BatchBuilder) Reset() {
+	b.batchDeleteList = b.batchDeleteList[:0]
+	b.batchSetTierList = b.batchSetTierList[:0]
+}
+
+func (b *BatchBuilder) createBatchRequest(ctx context.Context, p policy.Policy, url *string, batchID *string) (string, error) {
+	urlParts, err := blob.ParseURL(*url)
+	if err != nil {
+		return "", err
+	}
+
+	contentID := 1
+	batchRequest := ""
+	for _, d := range b.batchDeleteList {
+		blobPath := d.getBlobPath(&urlParts)
+		blobURL := fmt.Sprintf("%s://%s%s", urlParts.Scheme, urlParts.Host, blobPath)
+		subReq, err := d.createDeleteRequest(ctx, p, batchID, &blobURL, &contentID)
+		if err != nil {
+			// handle error
+			continue
+		}
+		batchRequest += subReq
+		contentID++
+	}
+
+	// TODO: add for batch set tier
+	for _, b := range b.batchSetTierList {
+		blobPath := b.getBlobPath(&urlParts)
+		blobURL := fmt.Sprintf("%s://%s%s", urlParts.Scheme, urlParts.Host, blobPath)
+		subReq, err := b.createSetTierRequest(ctx, p, batchID, &blobURL, &contentID)
+		if err != nil {
+			// handle error
+			continue
+		}
+		batchRequest += subReq
+		contentID++
+	}
+	batchRequest += shared.GetBatchRequestDelimiter(*batchID, true, true) + shared.HttpNewline
+	return batchRequest, nil
+}
+
+// TODO: add query parameters
+func (d *BatchDeleteOptions) getBlobPath(urlParts *blob.URLParts) string {
+	urlPath := *d.BlobPath
+	if len(urlParts.ContainerName) != 0 {
+		urlPath = "/" + urlParts.ContainerName + "/" + urlPath
+	}
+
+	return urlPath
+}
+
+func (d *BatchDeleteOptions) createDeleteRequest(ctx context.Context, p policy.Policy, batchID *string, blobURL *string, contentID *int) (string, error) {
+	blobClient, err := blob.NewClientWithNoCredential(*blobURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req, err := getGeneratedBlobClient(blobClient).DeleteCreateRequest(ctx, nil, nil, nil)
+	if err != nil {
+		return "", err
+	}
+
+	shared.UpdateSubRequestHeaders(req)
+
+	// adding authorization header to the request by executing the policy
+	if p != nil {
+		resp, err := p.Do(req)
+		if resp != nil && err != nil {
+			return fmt.Sprintf("%v: %v", resp.StatusCode, resp.Status), err
+		}
+	}
+
+	batchSubRequest := shared.CreateSubReqHeader(*batchID, *contentID)
+	batchSubRequest += shared.BuildSubRequest(req)
+
+	return batchSubRequest, nil
+}
+
+// TODO: add query parameters
+func (b *BatchSetTierOptions) getBlobPath(urlParts *blob.URLParts) string {
+	urlPath := *b.BlobPath
+	if len(urlParts.ContainerName) != 0 {
+		urlPath = "/" + urlParts.ContainerName + "/" + urlPath
+	}
+
+	return urlPath
+}
+
+func (b *BatchSetTierOptions) createSetTierRequest(ctx context.Context, p policy.Policy, batchID *string, blobURL *string, contentID *int) (string, error) {
+	blobClient, err := blob.NewClientWithNoCredential(*blobURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req, err := getGeneratedBlobClient(blobClient).SetTierCreateRequest(ctx, b.AccessTier, nil, nil, nil)
+	if err != nil {
+		return "", err
+	}
+
+	shared.UpdateSubRequestHeaders(req)
+
+	// adding authorization header to the request by executing the policy
+	if p != nil {
+		resp, err := p.Do(req)
+		if resp != nil && err != nil {
+			return fmt.Sprintf("%v: %v", resp.StatusCode, resp.Status), err
+		}
+	}
+
+	batchSubRequest := shared.CreateSubReqHeader(*batchID, *contentID)
+	batchSubRequest += shared.BuildSubRequest(req)
+
+	return batchSubRequest, nil
+}

--- a/sdk/storage/azblob/blobbatch/blob_batch.go
+++ b/sdk/storage/azblob/blobbatch/blob_batch.go
@@ -33,7 +33,7 @@ func NewBatchBuilder() *BatchBuilder {
 //   - DeleteOptions - delete options; pass nil to accept default values
 func (b *BatchBuilder) AddBlobBatchDelete(blobPath string, o *DeleteOptions) {
 	b.batchDeleteList = append(b.batchDeleteList, &BatchDeleteOptions{
-		BlobPath:      &blobPath,
+		BlobPath:      blobPath,
 		DeleteOptions: o,
 	})
 }
@@ -46,7 +46,7 @@ func (b *BatchBuilder) AddBlobBatchDelete(blobPath string, o *DeleteOptions) {
 //   - SetTierOptions - set tier options; pass nil to accept default values
 func (b *BatchBuilder) AddBlobBatchSetTier(blobPath string, accessTier blob.AccessTier, o *SetTierOptions) {
 	b.batchSetTierList = append(b.batchSetTierList, &BatchSetTierOptions{
-		BlobPath:       &blobPath,
+		BlobPath:       blobPath,
 		AccessTier:     accessTier,
 		SetTierOptions: o,
 	})
@@ -118,7 +118,7 @@ func (b *BatchBuilder) createBatchRequest(ctx context.Context, p policy.Policy, 
 // e.g. /containerName/blobName?queryParams
 // TODO: add query parameters in the blob path, make this a common method for BatchDeleteOptions and BatchSetTierOptions
 func (d *BatchDeleteOptions) getBlobPath(urlParts *blob.URLParts) string {
-	urlPath := *d.BlobPath
+	urlPath := d.BlobPath
 	if len(urlParts.ContainerName) != 0 {
 		urlPath = "/" + urlParts.ContainerName + "/" + urlPath
 	}
@@ -162,7 +162,7 @@ func (d *BatchDeleteOptions) createDeleteRequest(ctx context.Context, p policy.P
 // e.g. /containerName/blobName?queryParams
 // TODO: add query parameters in the blob path, make this a common method for BatchDeleteOptions and BatchSetTierOptions
 func (b *BatchSetTierOptions) getBlobPath(urlParts *blob.URLParts) string {
-	urlPath := *b.BlobPath
+	urlPath := b.BlobPath
 	if len(urlParts.ContainerName) != 0 {
 		urlPath = "/" + urlParts.ContainerName + "/" + urlPath
 	}

--- a/sdk/storage/azblob/blobbatch/container_client.go
+++ b/sdk/storage/azblob/blobbatch/container_client.go
@@ -1,0 +1,131 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package blobbatch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/base"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
+)
+
+// ContainerBatchClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
+type ContainerBatchClient struct {
+	cnt    *container.Client
+	policy policy.Policy
+}
+
+// NewContainerBatchClient creates an instance of Client with the specified values.
+//   - containerURL - the URL of the container e.g. https://<account>.blob.core.windows.net/container
+//   - cred - an Azure AD credential, typically obtained via the azidentity module
+//   - options - client options; pass nil to accept the default values
+func NewContainerBatchClient(containerURL string, cred azcore.TokenCredential, options *ClientOptions) (*ContainerBatchClient, error) {
+	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{shared.TokenScope}, nil)
+	conOptions := shared.GetClientOptions(options)
+	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, authPolicy)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+
+	return &ContainerBatchClient{
+		cnt:    (*container.Client)(base.NewContainerClient(containerURL, pl, nil)),
+		policy: authPolicy,
+	}, nil
+}
+
+// NewContainerBatchClientWithNoCredential creates an instance of Client with the specified values.
+// This is used to anonymously access a container or with a shared access signature (SAS) token.
+//   - containerURL - the URL of the container e.g. https://<account>.blob.core.windows.net/container?<sas token>
+//   - options - client options; pass nil to accept the default values
+func NewContainerBatchClientWithNoCredential(containerURL string, options *ClientOptions) (*ContainerBatchClient, error) {
+	conOptions := shared.GetClientOptions(options)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+
+	return &ContainerBatchClient{
+		cnt: (*container.Client)(base.NewContainerClient(containerURL, pl, nil)),
+	}, nil
+}
+
+// NewContainerBatchClientWithSharedKeyCredential creates an instance of Client with the specified values.
+//   - containerURL - the URL of the container e.g. https://<account>.blob.core.windows.net/container
+//   - cred - a SharedKeyCredential created with the matching container's storage account and access key
+//   - options - client options; pass nil to accept the default values
+func NewContainerBatchClientWithSharedKeyCredential(containerURL string, cred *container.SharedKeyCredential, options *ClientOptions) (*ContainerBatchClient, error) {
+	authPolicy := exported.NewSharedKeyCredPolicy(cred)
+	conOptions := shared.GetClientOptions(options)
+	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, authPolicy)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+
+	return &ContainerBatchClient{
+		cnt:    (*container.Client)(base.NewContainerClient(containerURL, pl, nil)),
+		policy: authPolicy,
+	}, nil
+}
+
+// NewContainerBatchClientFromConnectionString creates an instance of Client with the specified values.
+//   - connectionString - a connection string for the desired storage account
+//   - containerName - the name of the container within the storage account
+//   - options - client options; pass nil to accept the default values
+func NewContainerBatchClientFromConnectionString(connectionString string, containerName string, options *ClientOptions) (*ContainerBatchClient, error) {
+	parsed, err := shared.ParseConnectionString(connectionString)
+	if err != nil {
+		return nil, err
+	}
+	parsed.ServiceURL = runtime.JoinPaths(parsed.ServiceURL, containerName)
+
+	if parsed.AccountKey != "" && parsed.AccountName != "" {
+		credential, err := exported.NewSharedKeyCredential(parsed.AccountName, parsed.AccountKey)
+		if err != nil {
+			return nil, err
+		}
+		return NewContainerBatchClientWithSharedKeyCredential(parsed.ServiceURL, credential, options)
+	}
+
+	return NewContainerBatchClientWithNoCredential(parsed.ServiceURL, options)
+}
+
+func (c *ContainerBatchClient) generated() *generated.ContainerClient {
+	return base.InnerClient((*base.Client[generated.ContainerClient])(c.cnt))
+}
+
+func (c *ContainerBatchClient) sharedKey() *container.SharedKeyCredential {
+	return base.SharedKey((*base.Client[generated.ContainerClient])(c.cnt))
+}
+
+// URL returns the URL endpoint used by the Client object.
+func (c *ContainerBatchClient) URL() string {
+	return c.generated().Endpoint()
+}
+
+func (c *ContainerBatchClient) SubmitBatch(ctx context.Context, bb *BatchBuilder) (ContainerClientSubmitBatchResponse, error) {
+	if bb == nil {
+		return ContainerClientSubmitBatchResponse{}, errors.New("batch builder is empty")
+	}
+
+	batchID, err := shared.CreateBatchID()
+	if err != nil {
+		return ContainerClientSubmitBatchResponse{}, err
+	}
+
+	batchReq, err := bb.createBatchRequest(ctx, c.policy, to.Ptr(c.URL()), &batchID)
+	if err != nil {
+		return ContainerClientSubmitBatchResponse{}, err
+	}
+
+	reader := bytes.NewReader([]byte(batchReq))
+	rsc := streaming.NopCloser(reader)
+	multipartContentType := "multipart/mixed; boundary=" + batchID
+	resp, err := c.generated().SubmitBatch(ctx, int64(len(batchReq)), multipartContentType, rsc, nil)
+	return resp, err
+}

--- a/sdk/storage/azblob/blobbatch/container_client.go
+++ b/sdk/storage/azblob/blobbatch/container_client.go
@@ -111,7 +111,8 @@ func (c *ContainerBatchClient) URL() string {
 }
 
 // SubmitBatch operation allows multiple API calls to be embedded into a single HTTP request.
-//   - BatchBuilder - contains the list of operations to be submitted. It supports up to 256 sub-requests in a single batch.
+// - BatchBuilder - contains the list of operations to be submitted. It supports up to 256 sub-requests in a single batch.
+// For more information, see https://docs.microsoft.com/rest/api/storageservices/blob-batch
 func (c *ContainerBatchClient) SubmitBatch(ctx context.Context, bb *BatchBuilder) (ContainerClientSubmitBatchResponse, error) {
 	if bb == nil {
 		return ContainerClientSubmitBatchResponse{}, errors.New("batch builder is empty")
@@ -135,4 +136,32 @@ func (c *ContainerBatchClient) SubmitBatch(ctx context.Context, bb *BatchBuilder
 
 	// TODO: parse the response body to map individual operations to their responses
 	return resp, err
+}
+
+// DeleteBlobs operation allows multiple delete blob API calls to be embedded into a single HTTP request.
+// - BatchDeleteOptions - contains the list of delete blob operations to be submitted. It supports up to 256 sub-requests in a single batch.
+// For more information, see https://docs.microsoft.com/rest/api/storageservices/blob-batch
+func (c *ContainerBatchClient) DeleteBlobs(ctx context.Context, blobs []*BatchDeleteOptions) (ContainerClientSubmitBatchResponse, error) {
+	if len(blobs) == 0 {
+		return ContainerClientSubmitBatchResponse{}, errors.New("delete batch list is empty")
+	}
+
+	bb := NewBatchBuilder()
+	bb.batchDeleteList = blobs
+
+	return c.SubmitBatch(ctx, bb)
+}
+
+// SetTiers operation allows multiple blob set tier API calls to be embedded into a single HTTP request.
+// - BatchSetTierOptions - contains the list of blob set tier operations to be submitted. It supports up to 256 sub-requests in a single batch.
+// For more information, see https://docs.microsoft.com/rest/api/storageservices/blob-batch
+func (c *ContainerBatchClient) SetTiers(ctx context.Context, blobs []*BatchSetTierOptions) (ContainerClientSubmitBatchResponse, error) {
+	if len(blobs) == 0 {
+		return ContainerClientSubmitBatchResponse{}, errors.New("set tier batch list is empty")
+	}
+
+	bb := NewBatchBuilder()
+	bb.batchSetTierList = blobs
+
+	return c.SubmitBatch(ctx, bb)
 }

--- a/sdk/storage/azblob/blobbatch/container_client.go
+++ b/sdk/storage/azblob/blobbatch/container_client.go
@@ -101,10 +101,6 @@ func (c *ContainerBatchClient) generated() *generated.ContainerClient {
 	return base.InnerClient((*base.Client[generated.ContainerClient])(c.cnt))
 }
 
-func (c *ContainerBatchClient) sharedKey() *container.SharedKeyCredential {
-	return base.SharedKey((*base.Client[generated.ContainerClient])(c.cnt))
-}
-
 // URL returns the URL endpoint used by the Client object.
 func (c *ContainerBatchClient) URL() string {
 	return c.generated().Endpoint()

--- a/sdk/storage/azblob/blobbatch/examples_test.go
+++ b/sdk/storage/azblob/blobbatch/examples_test.go
@@ -1,0 +1,131 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package blobbatch_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blobbatch"
+	"log"
+	"os"
+)
+
+func handleError(err error) {
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+// ExampleContainerBatchClient shows blob batch operations for delete and set tier using ContainerBatchClient
+func Example_containerBatchClient() {
+	accountName, accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME"), os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
+	const containerName = "testcontainer"
+
+	// create shared key credential
+	cred, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	handleError(err)
+
+	// create container batch client
+	containerURL := fmt.Sprintf("https://%s.blob.core.windows.net/%s", accountName, containerName)
+	cntBatchClient, err := blobbatch.NewContainerBatchClientWithSharedKeyCredential(containerURL, cred, nil)
+
+	// create new batch builder
+	bb := blobbatch.NewBatchBuilder()
+
+	// add operations to the batch builder
+	bb.AddBlobBatchDelete("testBlob0", nil)
+	bb.AddBlobBatchDelete("testBlob1", &blobbatch.DeleteOptions{
+		VersionID: to.Ptr("2023-01-03T11:57:25.4067017Z"), // version id for deletion
+	})
+	bb.AddBlobBatchDelete("testBlob2", &blobbatch.DeleteOptions{
+		Snapshot: to.Ptr("2023-01-03T11:57:25.6515618Z"), // snapshot for deletion
+	})
+	bb.AddBlobBatchDelete("testBlob3", &blobbatch.DeleteOptions{
+		BlobDeleteOptions: &blob.DeleteOptions{
+			DeleteSnapshots: to.Ptr(blob.DeleteSnapshotsOptionTypeOnly),
+			BlobDeleteType:  to.Ptr(blob.DeleteTypeNone),
+		},
+	})
+
+	bb.AddBlobBatchSetTier("testBlob4", blob.AccessTierHot, nil)
+	bb.AddBlobBatchSetTier("testBlob5", blob.AccessTierCool, &blobbatch.SetTierOptions{
+		VersionID: to.Ptr("2023-01-03T11:57:25.4067017Z"),
+	})
+
+	resp, err := cntBatchClient.SubmitBatch(context.TODO(), bb)
+	handleError(err)
+
+	// print response body
+	p := make([]byte, 10000)
+	_, err = resp.Body.Read(p)
+	handleError(err)
+	fmt.Println(string(p))
+}
+
+// ExampleServiceBatchClient shows blob batch operations for delete and set tier using ServiceBatchClient
+func Example_serviceBatchClient() {
+	accountName, ok := os.LookupEnv("AZURE_STORAGE_ACCOUNT_NAME")
+	if !ok {
+		panic("AZURE_STORAGE_ACCOUNT_NAME could not be found")
+	}
+	tenantID, ok := os.LookupEnv("AZURE_TENANT_ID")
+	if !ok {
+		panic("AZURE_TENANT_ID could not be found")
+	}
+	clientID, ok := os.LookupEnv("AZURE_CLIENT_ID")
+	if !ok {
+		panic("AZURE_CLIENT_ID could not be found")
+	}
+	clientSecret, ok := os.LookupEnv("AZURE_CLIENT_SECRET")
+	if !ok {
+		panic("AZURE_CLIENT_SECRET could not be found")
+	}
+
+	// create client secret credential
+	cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
+	handleError(err)
+
+	// create service batch client
+	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net/", accountName)
+	svcBatchClient, err := blobbatch.NewServiceBatchClient(serviceURL, cred, nil)
+
+	// create new batch builder
+	bb := blobbatch.NewBatchBuilder()
+
+	// add operations to the batch builder
+	bb.AddBlobBatchDelete("/container1/testBlob0", nil)
+	bb.AddBlobBatchDelete("/container2/testBlob1", &blobbatch.DeleteOptions{
+		VersionID: to.Ptr("2023-01-03T11:57:25.4067017Z"), // version id for deletion
+	})
+	bb.AddBlobBatchDelete("/container1/testBlob2", &blobbatch.DeleteOptions{
+		Snapshot: to.Ptr("2023-01-03T11:57:25.6515618Z"), // snapshot for deletion
+	})
+	bb.AddBlobBatchDelete("/container2/testBlob3", &blobbatch.DeleteOptions{
+		BlobDeleteOptions: &blob.DeleteOptions{
+			DeleteSnapshots: to.Ptr(blob.DeleteSnapshotsOptionTypeOnly),
+			BlobDeleteType:  to.Ptr(blob.DeleteTypeNone),
+		},
+	})
+
+	bb.AddBlobBatchSetTier("/container3/testBlob4", blob.AccessTierHot, nil)
+	bb.AddBlobBatchSetTier("/container4/testBlob5", blob.AccessTierCool, &blobbatch.SetTierOptions{
+		VersionID: to.Ptr("2023-01-03T11:57:25.4067017Z"),
+	})
+
+	resp, err := svcBatchClient.SubmitBatch(context.TODO(), bb)
+	handleError(err)
+
+	// print response body
+	p := make([]byte, 10000)
+	_, err = resp.Body.Read(p)
+	handleError(err)
+	fmt.Println(string(p))
+}

--- a/sdk/storage/azblob/blobbatch/examples_test.go
+++ b/sdk/storage/azblob/blobbatch/examples_test.go
@@ -36,6 +36,7 @@ func Example_containerBatchClient() {
 	// create container batch client
 	containerURL := fmt.Sprintf("https://%s.blob.core.windows.net/%s", accountName, containerName)
 	cntBatchClient, err := blobbatch.NewContainerBatchClientWithSharedKeyCredential(containerURL, cred, nil)
+	handleError(err)
 
 	// create new batch builder
 	bb := blobbatch.NewBatchBuilder()
@@ -96,6 +97,7 @@ func Example_serviceBatchClient() {
 	// create service batch client
 	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net/", accountName)
 	svcBatchClient, err := blobbatch.NewServiceBatchClient(serviceURL, cred, nil)
+	handleError(err)
 
 	// create new batch builder
 	bb := blobbatch.NewBatchBuilder()
@@ -143,6 +145,7 @@ func Example_containerBatchClientDeleteBlobs() {
 	// create container batch client
 	containerURL := fmt.Sprintf("https://%s.blob.core.windows.net/%s", accountName, containerName)
 	cntBatchClient, err := blobbatch.NewContainerBatchClientWithSharedKeyCredential(containerURL, cred, nil)
+	handleError(err)
 
 	var blobs []*blobbatch.BatchDeleteOptions
 	for i := 0; i < 10; i++ {
@@ -164,7 +167,6 @@ func Example_containerBatchClientDeleteBlobs() {
 // Example_serviceBatchClientSetTiers shows batch set tier operations using ServiceBatchClient
 func Example_serviceBatchClientSetTiers() {
 	accountName, accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME"), os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
-	const containerName = "testcontainer"
 	const blobName = "testBlob"
 
 	// create shared key credential
@@ -174,6 +176,7 @@ func Example_serviceBatchClientSetTiers() {
 	// create container batch client
 	svcURL := fmt.Sprintf("https://%s.blob.core.windows.net/", accountName)
 	svcBatchClient, err := blobbatch.NewServiceBatchClientWithSharedKeyCredential(svcURL, cred, nil)
+	handleError(err)
 
 	var blobs []*blobbatch.BatchSetTierOptions
 	for i := 0; i < 10; i++ {

--- a/sdk/storage/azblob/blobbatch/examples_test.go
+++ b/sdk/storage/azblob/blobbatch/examples_test.go
@@ -129,3 +129,66 @@ func Example_serviceBatchClient() {
 	handleError(err)
 	fmt.Println(string(p))
 }
+
+// ExampleContainerBatchClientDeleteBlobs shows batch delete operations using ContainerBatchClient
+func Example_containerBatchClientDeleteBlobs() {
+	accountName, accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME"), os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
+	const containerName = "testcontainer"
+	const blobName = "testBlob"
+
+	// create shared key credential
+	cred, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	handleError(err)
+
+	// create container batch client
+	containerURL := fmt.Sprintf("https://%s.blob.core.windows.net/%s", accountName, containerName)
+	cntBatchClient, err := blobbatch.NewContainerBatchClientWithSharedKeyCredential(containerURL, cred, nil)
+
+	var blobs []*blobbatch.BatchDeleteOptions
+	for i := 0; i < 10; i++ {
+		blobs = append(blobs, &blobbatch.BatchDeleteOptions{
+			BlobPath: fmt.Sprintf("%v%v", blobName, i),
+		})
+	}
+
+	resp, err := cntBatchClient.DeleteBlobs(context.TODO(), blobs)
+	handleError(err)
+
+	// print response body
+	p := make([]byte, 10000)
+	_, err = resp.Body.Read(p)
+	handleError(err)
+	fmt.Println(string(p))
+}
+
+// Example_serviceBatchClientSetTiers shows batch set tier operations using ServiceBatchClient
+func Example_serviceBatchClientSetTiers() {
+	accountName, accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME"), os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
+	const containerName = "testcontainer"
+	const blobName = "testBlob"
+
+	// create shared key credential
+	cred, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	handleError(err)
+
+	// create container batch client
+	svcURL := fmt.Sprintf("https://%s.blob.core.windows.net/", accountName)
+	svcBatchClient, err := blobbatch.NewServiceBatchClientWithSharedKeyCredential(svcURL, cred, nil)
+
+	var blobs []*blobbatch.BatchSetTierOptions
+	for i := 0; i < 10; i++ {
+		blobs = append(blobs, &blobbatch.BatchSetTierOptions{
+			BlobPath:   fmt.Sprintf("%v%v", blobName, i),
+			AccessTier: blob.AccessTierCool,
+		})
+	}
+
+	resp, err := svcBatchClient.SetTiers(context.TODO(), blobs)
+	handleError(err)
+
+	// print response body
+	p := make([]byte, 10000)
+	_, err = resp.Body.Read(p)
+	handleError(err)
+	fmt.Println(string(p))
+}

--- a/sdk/storage/azblob/blobbatch/models.go
+++ b/sdk/storage/azblob/blobbatch/models.go
@@ -41,7 +41,7 @@ type SetTierOptions struct {
 //   - /containerName/blobName when using ServiceBatchClient, e.g. /container/blob.txt
 //   - DeleteOptions - optional parameters for the BlobClient.Delete method.
 type BatchDeleteOptions struct {
-	BlobPath *string
+	BlobPath string
 	*DeleteOptions
 }
 
@@ -52,7 +52,7 @@ type BatchDeleteOptions struct {
 //   - AccessTier - defines values for Blob Access Tier
 //   - DeleteOptions - optional parameters for the BlobClient.Delete method.
 type BatchSetTierOptions struct {
-	BlobPath   *string
+	BlobPath   string
 	AccessTier blob.AccessTier
 	*SetTierOptions
 }

--- a/sdk/storage/azblob/blobbatch/models.go
+++ b/sdk/storage/azblob/blobbatch/models.go
@@ -21,34 +21,50 @@ type ClientOptions struct {
 // SharedKeyCredential contains an account's name and its primary or secondary key.
 type SharedKeyCredential = exported.SharedKeyCredential
 
+// DeleteOptions contains the optional parameters for the BlobClient.Delete method.
 type DeleteOptions struct {
 	VersionID         *string
 	Snapshot          *string
 	BlobDeleteOptions *blob.DeleteOptions
 }
 
+// SetTierOptions contains the optional parameters for the BlobClient.SetTier method.
 type SetTierOptions struct {
 	VersionID          *string
 	Snapshot           *string
 	BlobSetTierOptions *blob.SetTierOptions
 }
 
+// BatchDeleteOptions contains the options for batch delete operation
+//   - BlobPath: Must be in the following format.
+//   - blobName when using ContainerBatchClient, e.g. blob.txt
+//   - /containerName/blobName when using ServiceBatchClient, e.g. /container/blob.txt
+//   - DeleteOptions - optional parameters for the BlobClient.Delete method.
 type BatchDeleteOptions struct {
 	BlobPath *string
 	*DeleteOptions
 }
 
+// BatchSetTierOptions contains the options for batch set tier operation
+//   - BlobPath: Must be in the following format.
+//   - blobName when using ContainerBatchClient, e.g. blob.txt
+//   - /containerName/blobName when using ServiceBatchClient, e.g. /container/blob.txt
+//   - AccessTier - defines values for Blob Access Tier
+//   - DeleteOptions - optional parameters for the BlobClient.Delete method.
 type BatchSetTierOptions struct {
 	BlobPath   *string
 	AccessTier blob.AccessTier
 	*SetTierOptions
 }
 
+// BatchBuilder is used for creating the batch operations list. It contains delete and set tier lists for blobs.
 type BatchBuilder struct {
 	batchDeleteList  []*BatchDeleteOptions
 	batchSetTierList []*BatchSetTierOptions
 }
 
+// ContainerClientSubmitBatchResponse contains the response from method ContainerBatchClient.SubmitBatch.
 type ContainerClientSubmitBatchResponse = generated.ContainerClientSubmitBatchResponse
 
+// ServiceClientSubmitBatchResponse contains the response from method ServiceBatchClient.SubmitBatch.
 type ServiceClientSubmitBatchResponse = generated.ServiceClientSubmitBatchResponse

--- a/sdk/storage/azblob/blobbatch/models.go
+++ b/sdk/storage/azblob/blobbatch/models.go
@@ -1,0 +1,54 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package blobbatch
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
+)
+
+// ClientOptions contains the optional parameters when creating a Client.
+type ClientOptions struct {
+	azcore.ClientOptions
+}
+
+// SharedKeyCredential contains an account's name and its primary or secondary key.
+type SharedKeyCredential = exported.SharedKeyCredential
+
+type DeleteOptions struct {
+	VersionID         *string
+	Snapshot          *string
+	BlobDeleteOptions *blob.DeleteOptions
+}
+
+type SetTierOptions struct {
+	VersionID          *string
+	Snapshot           *string
+	BlobSetTierOptions *blob.SetTierOptions
+}
+
+type BatchDeleteOptions struct {
+	BlobPath *string
+	*DeleteOptions
+}
+
+type BatchSetTierOptions struct {
+	BlobPath   *string
+	AccessTier blob.AccessTier
+	*SetTierOptions
+}
+
+type BatchBuilder struct {
+	batchDeleteList  []*BatchDeleteOptions
+	batchSetTierList []*BatchSetTierOptions
+}
+
+type ContainerClientSubmitBatchResponse = generated.ContainerClientSubmitBatchResponse
+
+type ServiceClientSubmitBatchResponse = generated.ServiceClientSubmitBatchResponse

--- a/sdk/storage/azblob/blobbatch/service_client.go
+++ b/sdk/storage/azblob/blobbatch/service_client.go
@@ -99,10 +99,6 @@ func (s *ServiceBatchClient) generated() *generated.ServiceClient {
 	return base.InnerClient((*base.Client[generated.ServiceClient])(s.svc))
 }
 
-func (s *ServiceBatchClient) sharedKey() *SharedKeyCredential {
-	return base.SharedKey((*base.Client[generated.ServiceClient])(s.svc))
-}
-
 // URL returns the URL endpoint used by the Client object.
 func (s *ServiceBatchClient) URL() string {
 	return s.generated().Endpoint()

--- a/sdk/storage/azblob/blobbatch/service_client.go
+++ b/sdk/storage/azblob/blobbatch/service_client.go
@@ -109,7 +109,8 @@ func (s *ServiceBatchClient) URL() string {
 }
 
 // SubmitBatch operation allows multiple API calls to be embedded into a single HTTP request.
-//   - BatchBuilder - contains the list of operations to be submitted. It supports up to 256 sub-requests in a single batch.
+// - BatchBuilder - contains the list of operations to be submitted. It supports up to 256 sub-requests in a single batch.
+// For more information, see https://docs.microsoft.com/rest/api/storageservices/blob-batch
 func (s *ServiceBatchClient) SubmitBatch(ctx context.Context, bb *BatchBuilder) (ServiceClientSubmitBatchResponse, error) {
 	if bb == nil {
 		return ServiceClientSubmitBatchResponse{}, errors.New("batch builder is empty")
@@ -133,4 +134,32 @@ func (s *ServiceBatchClient) SubmitBatch(ctx context.Context, bb *BatchBuilder) 
 
 	// TODO: parse the response body to map individual operations to their responses
 	return resp, err
+}
+
+// DeleteBlobs operation allows multiple delete blob API calls to be embedded into a single HTTP request.
+// - BatchDeleteOptions - contains the list of delete blob operations to be submitted. It supports up to 256 sub-requests in a single batch.
+// For more information, see https://docs.microsoft.com/rest/api/storageservices/blob-batch
+func (s *ServiceBatchClient) DeleteBlobs(ctx context.Context, blobs []*BatchDeleteOptions) (ServiceClientSubmitBatchResponse, error) {
+	if len(blobs) == 0 {
+		return ServiceClientSubmitBatchResponse{}, errors.New("delete batch list is empty")
+	}
+
+	bb := NewBatchBuilder()
+	bb.batchDeleteList = blobs
+
+	return s.SubmitBatch(ctx, bb)
+}
+
+// SetTiers operation allows multiple blob set tier API calls to be embedded into a single HTTP request.
+// - BatchSetTierOptions - contains the list of blob set tier operations to be submitted. It supports up to 256 sub-requests in a single batch.
+// For more information, see https://docs.microsoft.com/rest/api/storageservices/blob-batch
+func (s *ServiceBatchClient) SetTiers(ctx context.Context, blobs []*BatchSetTierOptions) (ServiceClientSubmitBatchResponse, error) {
+	if len(blobs) == 0 {
+		return ServiceClientSubmitBatchResponse{}, errors.New("set tier batch list is empty")
+	}
+
+	bb := NewBatchBuilder()
+	bb.batchSetTierList = blobs
+
+	return s.SubmitBatch(ctx, bb)
 }

--- a/sdk/storage/azblob/blobbatch/service_client.go
+++ b/sdk/storage/azblob/blobbatch/service_client.go
@@ -1,0 +1,129 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package blobbatch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/base"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+)
+
+// ServiceBatchClient represents a URL to the Azure Blob Storage service allowing you to manipulate blob containers.
+type ServiceBatchClient struct {
+	svc    *service.Client
+	policy policy.Policy
+}
+
+// NewServiceBatchClient creates an instance of Client with the specified values.
+//   - serviceURL - the URL of the storage account e.g. https://<account>.blob.core.windows.net/
+//   - cred - an Azure AD credential, typically obtained via the azidentity module
+//   - options - client options; pass nil to accept the default values
+func NewServiceBatchClient(serviceURL string, cred azcore.TokenCredential, options *ClientOptions) (*ServiceBatchClient, error) {
+	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{shared.TokenScope}, nil)
+	conOptions := shared.GetClientOptions(options)
+	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, authPolicy)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+
+	return &ServiceBatchClient{
+		svc:    (*service.Client)(base.NewServiceClient(serviceURL, pl, nil)),
+		policy: authPolicy,
+	}, nil
+}
+
+// NewServiceBatchClientWithNoCredential creates an instance of Client with the specified values.
+// This is used to anonymously access a storage account or with a shared access signature (SAS) token.
+//   - serviceURL - the URL of the storage account e.g. https://<account>.blob.core.windows.net/?<sas token>
+//   - options - client options; pass nil to accept the default values
+func NewServiceBatchClientWithNoCredential(serviceURL string, options *ClientOptions) (*ServiceBatchClient, error) {
+	conOptions := shared.GetClientOptions(options)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+
+	return &ServiceBatchClient{
+		svc: (*service.Client)(base.NewServiceClient(serviceURL, pl, nil)),
+	}, nil
+}
+
+// NewServiceBatchClientWithSharedKeyCredential creates an instance of Client with the specified values.
+//   - serviceURL - the URL of the storage account e.g. https://<account>.blob.core.windows.net/
+//   - cred - a SharedKeyCredential created with the matching storage account and access key
+//   - options - client options; pass nil to accept the default values
+func NewServiceBatchClientWithSharedKeyCredential(serviceURL string, cred *SharedKeyCredential, options *ClientOptions) (*ServiceBatchClient, error) {
+	authPolicy := exported.NewSharedKeyCredPolicy(cred)
+	conOptions := shared.GetClientOptions(options)
+	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, authPolicy)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+
+	return &ServiceBatchClient{
+		svc:    (*service.Client)(base.NewServiceClient(serviceURL, pl, nil)),
+		policy: authPolicy,
+	}, nil
+}
+
+// NewServiceBatchClientFromConnectionString creates an instance of Client with the specified values.
+//   - connectionString - a connection string for the desired storage account
+//   - options - client options; pass nil to accept the default values
+func NewServiceBatchClientFromConnectionString(connectionString string, options *ClientOptions) (*ServiceBatchClient, error) {
+	parsed, err := shared.ParseConnectionString(connectionString)
+	if err != nil {
+		return nil, err
+	}
+
+	if parsed.AccountKey != "" && parsed.AccountName != "" {
+		credential, err := exported.NewSharedKeyCredential(parsed.AccountName, parsed.AccountKey)
+		if err != nil {
+			return nil, err
+		}
+		return NewServiceBatchClientWithSharedKeyCredential(parsed.ServiceURL, credential, options)
+	}
+
+	return NewServiceBatchClientWithNoCredential(parsed.ServiceURL, options)
+}
+
+func (s *ServiceBatchClient) generated() *generated.ServiceClient {
+	return base.InnerClient((*base.Client[generated.ServiceClient])(s.svc))
+}
+
+func (s *ServiceBatchClient) sharedKey() *SharedKeyCredential {
+	return base.SharedKey((*base.Client[generated.ServiceClient])(s.svc))
+}
+
+// URL returns the URL endpoint used by the Client object.
+func (s *ServiceBatchClient) URL() string {
+	return s.generated().Endpoint()
+}
+
+func (s *ServiceBatchClient) SubmitBatch(ctx context.Context, bb *BatchBuilder) (ServiceClientSubmitBatchResponse, error) {
+	if bb == nil {
+		return ServiceClientSubmitBatchResponse{}, errors.New("batch builder is empty")
+	}
+
+	batchID, err := shared.CreateBatchID()
+	if err != nil {
+		return ServiceClientSubmitBatchResponse{}, err
+	}
+
+	batchReq, err := bb.createBatchRequest(ctx, s.policy, to.Ptr(s.URL()), &batchID)
+	if err != nil {
+		return ServiceClientSubmitBatchResponse{}, err
+	}
+
+	reader := bytes.NewReader([]byte(batchReq))
+	rsc := streaming.NopCloser(reader)
+	multipartContentType := "multipart/mixed; boundary=" + batchID
+	resp, err := s.generated().SubmitBatch(ctx, int64(len(batchReq)), multipartContentType, rsc, nil)
+	return resp, err
+}

--- a/sdk/storage/azblob/internal/generated/blob_client.go
+++ b/sdk/storage/azblob/internal/generated/blob_client.go
@@ -6,7 +6,11 @@
 
 package generated
 
-import "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
 
 func (client *BlobClient) Endpoint() string {
 	return client.endpoint
@@ -14,4 +18,12 @@ func (client *BlobClient) Endpoint() string {
 
 func (client *BlobClient) Pipeline() runtime.Pipeline {
 	return client.pl
+}
+
+func (client *BlobClient) DeleteCreateRequest(ctx context.Context, options *BlobClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+	return client.deleteCreateRequest(ctx, options, leaseAccessConditions, modifiedAccessConditions)
+}
+
+func (client *BlobClient) SetTierCreateRequest(ctx context.Context, tier AccessTier, options *BlobClientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+	return client.setTierCreateRequest(ctx, tier, options, leaseAccessConditions, modifiedAccessConditions)
 }

--- a/sdk/storage/azblob/internal/shared/blob_batch.go
+++ b/sdk/storage/azblob/internal/shared/blob_batch.go
@@ -76,9 +76,8 @@ func UpdateSubRequestHeaders(req *policy.Request) {
 	req.Raw().Header[HeaderXmsDate] = []string{dt}
 
 	// remove x-ms-version header from the request header
-	req.Raw().Header.Del(HeaderXmsVersion)
-	for k, _ := range req.Raw().Header {
-		if strings.ToLower(k) == strings.ToLower(HeaderXmsVersion) {
+	for k := range req.Raw().Header {
+		if strings.EqualFold(k, HeaderXmsVersion) {
 			delete(req.Raw().Header, k)
 		}
 	}
@@ -99,7 +98,7 @@ func BuildSubRequest(req *policy.Request) string {
 	batchSubRequest.WriteString(fmt.Sprintf("%s %s %s%s", req.Raw().Method, blobPath, HttpVersion, HttpNewline))
 
 	for k, v := range req.Raw().Header {
-		if strings.ToLower(k) == HeaderXmsVersion {
+		if strings.EqualFold(k, HeaderXmsVersion) {
 			continue
 		}
 		if len(v) > 0 {

--- a/sdk/storage/azblob/internal/shared/blob_batch.go
+++ b/sdk/storage/azblob/internal/shared/blob_batch.go
@@ -1,0 +1,96 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package shared
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"
+)
+
+const (
+	BatchIdPrefix = "batch_"
+	HttpVersion   = "HTTP/1.1"
+	HttpNewline   = "\r\n"
+)
+
+func CreateBatchID() (string, error) {
+	batchID, err := uuid.New()
+	if err != nil {
+		return "", err
+	}
+
+	return BatchIdPrefix + batchID.String(), nil
+}
+
+func GetBatchRequestDelimiter(batchID string, prefixDash bool, postfixDash bool) string {
+	outString := ""
+
+	if prefixDash {
+		outString = "--"
+	}
+
+	outString += batchID
+
+	if postfixDash {
+		outString += "--"
+	}
+
+	return outString
+}
+
+func CreateSubReqHeader(batchID string, contentID int) string {
+	var subReqHeader strings.Builder
+	subReqHeader.WriteString(GetBatchRequestDelimiter(batchID, true, false) + HttpNewline)
+	subReqHeader.WriteString("Content-Type: application/http" + HttpNewline)
+	subReqHeader.WriteString("Content-Transfer-Encoding: binary" + HttpNewline)
+	subReqHeader.WriteString("Content-ID: " + strconv.Itoa(contentID) + HttpNewline)
+	subReqHeader.WriteString(HttpNewline)
+
+	return subReqHeader.String()
+}
+
+func UpdateSubRequestHeaders(req *policy.Request) {
+	// setting x-ms-date header
+	dt := time.Now().UTC().Format(http.TimeFormat)
+	req.Raw().Header[HeaderXmsDate] = []string{dt}
+
+	// remove x-ms-version header from the request header
+	req.Raw().Header.Del(HeaderXmsVersion)
+	for k, _ := range req.Raw().Header {
+		if strings.ToLower(k) == strings.ToLower(HeaderXmsVersion) {
+			delete(req.Raw().Header, k)
+		}
+	}
+}
+
+func BuildSubRequest(req *policy.Request) string {
+	var batchSubRequest strings.Builder
+	blobPath := req.Raw().URL.Path
+	if len(req.Raw().URL.RawQuery) > 0 {
+		blobPath += "?" + req.Raw().URL.RawQuery
+	}
+
+	batchSubRequest.WriteString(fmt.Sprintf("%s %s %s%s", req.Raw().Method, blobPath, HttpVersion, HttpNewline))
+
+	for k, v := range req.Raw().Header {
+		if strings.ToLower(k) == HeaderXmsVersion {
+			continue
+		}
+		if len(v) > 0 {
+			batchSubRequest.WriteString(fmt.Sprintf("%v: %v%v", k, v[0], HttpNewline))
+		}
+	}
+
+	batchSubRequest.WriteString(HttpNewline)
+	return batchSubRequest.String()
+}

--- a/sdk/storage/azblob/internal/shared/shared.go
+++ b/sdk/storage/azblob/internal/shared/shared.go
@@ -38,6 +38,7 @@ const (
 	HeaderIfNoneMatch       = "If-None-Match"
 	HeaderIfUnmodifiedSince = "If-Unmodified-Since"
 	HeaderRange             = "Range"
+	HeaderXmsVersion        = "x-ms-version"
 )
 
 const crc64Polynomial uint64 = 0x9A6C9329AC4BC9B5


### PR DESCRIPTION
The [Blob Batch](https://learn.microsoft.com/en-us/rest/api/storageservices/blob-batch) operation allows multiple API calls to be embedded into a single HTTP request. This API supports two types of subrequests: Set Blob Tier for block blobs and Delete Blob.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
