### PR TITLE
[azeventhubs] Remove the epoch options for the Processor

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Breaking Changes
 
+- ProcessorOptions.OwnerLevel has been removed. The Processor uses 0 as the owner level.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/messaging/azeventhubs/processor_unit_test.go
+++ b/sdk/messaging/azeventhubs/processor_unit_test.go
@@ -364,6 +364,10 @@ func (cc *fakeConsumerClient) GetEventHubProperties(ctx context.Context, options
 }
 
 func (cc *fakeConsumerClient) NewPartitionClient(partitionID string, options *PartitionClientOptions) (*PartitionClient, error) {
+	if *options.OwnerLevel != 0 {
+		panic(fmt.Sprintf("Invalid owner level passed for the Processor: got %d instead of 0", *options.OwnerLevel))
+	}
+
 	if cc.newPartitionClientFn != nil {
 		return cc.newPartitionClientFn(partitionID, options)
 	}


### PR DESCRIPTION
Remove the epoch options for the Processor. This wasn't intended to be configurable and should always be set and always be zero.

Fixes #19848