### PR TITLE
Increase timeout for azkeys live tests

### DIFF
--- a/sdk/keyvault/azkeys/ci.yml
+++ b/sdk/keyvault/azkeys/ci.yml
@@ -24,6 +24,7 @@ pr:
 stages:
 - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
+    TimeoutInMinutes: 120
     ServiceDirectory: 'keyvault/azkeys'
     RunLiveTests: true
     AdditionalMatrixConfigs:


### PR DESCRIPTION
We need to allow more time because de/provisioning resources (MHSM) can be very slow (~50 minutes).