### PR TITLE
Replace internal IMDS timeout with public API workaround

### DIFF
--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
@@ -97,7 +96,7 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 	}
 	miCred, err := NewManagedIdentityCredential(o)
 	if err == nil {
-		creds = append(creds, timeoutWrapper{mic: miCred, timeout: to.Ptr(time.Second)})
+		creds = append(creds, &timeoutWrapper{mic: miCred, timeout: time.Second})
 	} else {
 		errorMessages = append(errorMessages, credNameManagedIdentity+": "+err.Error())
 		creds = append(creds, &defaultCredentialErrorReporter{credType: credNameManagedIdentity, err: err})
@@ -166,25 +165,25 @@ var _ azcore.TokenCredential = (*defaultCredentialErrorReporter)(nil)
 // timeoutWrapper prevents a potentially very long timeout when managed identity isn't available
 type timeoutWrapper struct {
 	mic *ManagedIdentityCredential
-	// timeout applies to all auth attempts until one doesn't time out. It's a pointer because GetToken() has a value receiver.
-	timeout *time.Duration
+	// timeout applies to all auth attempts until one doesn't time out
+	timeout time.Duration
 }
 
 // GetToken wraps DefaultAzureCredential's initial managed identity auth attempt with a short timeout
 // because managed identity may not be available and connecting to IMDS can take several minutes to time out.
-func (w timeoutWrapper) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+func (w *timeoutWrapper) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	var tk azcore.AccessToken
 	var err error
 	// no need to synchronize around this value because it's written only within ChainedTokenCredential's critical section
-	if *w.timeout > 0 {
-		c, cancel := context.WithTimeout(ctx, *w.timeout)
+	if w.timeout > 0 {
+		c, cancel := context.WithTimeout(ctx, w.timeout)
 		defer cancel()
 		tk, err = w.mic.GetToken(c, opts)
 		if ce := c.Err(); errors.Is(ce, context.DeadlineExceeded) {
 			err = newCredentialUnavailableError(credNameManagedIdentity, "managed identity timed out")
 		} else {
 			// some managed identity implementation is available, so don't apply the timeout to future calls
-			*w.timeout = 0
+			w.timeout = 0
 		}
 	} else {
 		tk, err = w.mic.GetToken(ctx, opts)

--- a/sdk/azidentity/example_credential_unavailable_test.go
+++ b/sdk/azidentity/example_credential_unavailable_test.go
@@ -1,0 +1,58 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+)
+
+// timeoutWrapper signals ChainedTokenCredential to try another credential when managed identity times out
+type timeoutWrapper struct {
+	cred *azidentity.ManagedIdentityCredential
+}
+
+// GetToken implements the azcore.TokenCredential interface
+func (w timeoutWrapper) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	c, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	tk, err := w.cred.GetToken(c, opts)
+	if ce := c.Err(); errors.Is(ce, context.DeadlineExceeded) {
+		// The Context reached its deadline, probably because no managed identity is available.
+		// A credential unavailable error signals the chain to try its next credential, if any.
+		err = azidentity.NewCredentialUnavailableError("managed identity timed out")
+	}
+	return tk, err
+}
+
+// This example demonstrates a small wrapper that sets a deadline for authentication and signals
+// [ChainedTokenCredential] to try another credential when managed identity authentication times out.
+func ExampleNewChainedTokenCredential_managedIdentityTimeout() {
+	mic, err := azidentity.NewManagedIdentityCredential(nil)
+	if err != nil {
+		// TODO: handle error
+	}
+	azCLI, err := azidentity.NewAzureCLICredential(nil)
+	if err != nil {
+		// TODO: handle error
+	}
+	creds := []azcore.TokenCredential{
+		timeoutWrapper{mic},
+		azCLI,
+	}
+	chain, err := azidentity.NewChainedTokenCredential(creds, nil)
+	if err != nil {
+		// TODO: handle error
+	}
+	// TODO: construct a client with the credential chain
+	_ = chain
+}


### PR DESCRIPTION
A couple of users have asked us to export the internal API DefaultAzureCredential uses to impose a timeout on managed identity authentication, to avoid a long timeout when IMDS is unavailable (#19699, #19721). We don't want to do that because it means adding a redundant, esoteric cancellation mechanism that conflicts with cancellation via `context.Context`. This example shows how to reimplement this DefaultAzureCredential behavior with Context and a small wrapper.

I'm also tempted to replace the internal API with this wrapper. That would steer future readers of the source in the right direction, and I believe it would simplify some of the implementation as well. Thoughts?