### PR TITLE
Removed proposedLeaseID from the option bag for ChangeLease method

### DIFF
--- a/sdk/storage/azblob/lease/models.go
+++ b/sdk/storage/azblob/lease/models.go
@@ -60,7 +60,6 @@ func (o *BlobBreakOptions) format() (*generated.BlobClientBreakLeaseOptions, *Mo
 
 // BlobChangeOptions contains the optional parameters for the LeaseClient.ChangeLease method.
 type BlobChangeOptions struct {
-	ProposedLeaseID          *string
 	ModifiedAccessConditions *ModifiedAccessConditions
 }
 
@@ -140,7 +139,6 @@ func (o *ContainerBreakOptions) format() (*generated.ContainerClientBreakLeaseOp
 
 // ContainerChangeOptions contains the optional parameters for the LeaseClient.ChangeLease method.
 type ContainerChangeOptions struct {
-	ProposedLeaseID          *string
 	ModifiedAccessConditions *ModifiedAccessConditions
 }
 


### PR DESCRIPTION
Removed proposedLeaseID from the option bag for ChangeLease(), since it is already part of the method as a required parameter.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
