### PR TITLE
Fixing documentation for GetSASURL and Creating ErrorType 

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 * Add support to log calculated block size and count during uploads
+* Added MissingSharedKeyCredential error type for cleaner UX. Related to [#19864](https://github.com/Azure/azure-sdk-for-go/issues/19864).
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -268,7 +268,7 @@ func (b *Client) CopyFromURL(ctx context.Context, copySource string, options *Co
 // It can only be used if the credential supplied during creation was a SharedKeyCredential.
 func (b *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o *GetSASURLOptions) (string, error) {
 	if b.sharedKey() == nil {
-		return "", bloberror.NoSharedKeyCredential
+		return "", bloberror.MissingSharedKeyCredential
 	}
 
 	urlParts, err := ParseURL(b.URL())

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -8,7 +8,7 @@ package blob
 
 import (
 	"context"
-	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"io"
 	"os"
 	"sync"
@@ -268,7 +268,7 @@ func (b *Client) CopyFromURL(ctx context.Context, copySource string, options *Co
 // It can only be used if the credential supplied during creation was a SharedKeyCredential.
 func (b *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o *GetSASURLOptions) (string, error) {
 	if b.sharedKey() == nil {
-		return "", errors.New("credential is not a SharedKeyCredential. SAS can only be signed with a SharedKeyCredential")
+		return "", bloberror.NoSharedKeyCredential
 	}
 
 	urlParts, err := ParseURL(b.URL())

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3555,6 +3555,7 @@ func (s *BlobUnrecordedTestsSuite) TestSASURLBlobClient() {
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 	blobClient, err := blob.NewClientWithSharedKeyCredential(bbClient.URL(), cred, nil)
+	_require.NoError(err)
 
 	// Adding SAS and options
 	permissions := sas.BlobPermissions{

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3574,10 +3574,7 @@ func (s *BlobUnrecordedTestsSuite) TestSASURLBlobClient() {
 	_require.Nil(err)
 
 	// Get new blob client with sasUrl and attempt GetProperties
-	client, err := blob.NewClientWithNoCredential(sasUrl, nil)
-	_require.Nil(err)
-
-	_, err = client.GetProperties(context.Background(), nil)
+	_, err = blob.NewClientWithNoCredential(sasUrl, nil)
 	_require.Nil(err)
 }
 

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3609,7 +3609,7 @@ func (s *BlobUnrecordedTestsSuite) TestNoSharedKeyCredError() {
 	expiry := start.Add(time.Hour)
 	opts := blob.GetSASURLOptions{StartTime: &start}
 
-	// GetSASURL fails (with NoSharedKeyCredential) because blob client is created without credentials
+	// GetSASURL fails (with MissingSharedKeyCredential) because blob client is created without credentials
 	_, err = bbClient.BlobClient().GetSASURL(permissions, expiry, &opts)
-	_require.Equal(err, bloberror.NoSharedKeyCredential)
+	_require.Equal(err, bloberror.MissingSharedKeyCredential)
 }

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -11,8 +11,11 @@ import (
 	"context"
 	"crypto/md5"
 	"errors"
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"io"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -3529,4 +3532,84 @@ func (s *BlobRecordedTestsSuite) TestSetLegalHold() {
 	_, err = bbClient.Delete(context.Background(), nil)
 	_require.Nil(err)
 
+}
+
+func (s *BlobUnrecordedTestsSuite) TestSASURLBlobClient() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	accountName := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME")
+	accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
+	cred, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	_require.Nil(err)
+
+	// Creating service client with credentials
+	serviceClient, err := service.NewClientWithSharedKeyCredential(fmt.Sprintf("https://%s.blob.core.windows.net/", accountName), cred, nil)
+	_require.Nil(err)
+
+	// Creating container client
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, serviceClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Creating blob client with credentials
+	blockBlobName := testcommon.GenerateBlobName(testName)
+	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
+	blobClient, err := blob.NewClientWithSharedKeyCredential(bbClient.URL(), cred, nil)
+
+	// Adding SAS and options
+	permissions := sas.BlobPermissions{
+		Read:   true,
+		Add:    true,
+		Write:  true,
+		Create: true,
+		Delete: true,
+	}
+	start := time.Now().Add(-time.Hour)
+	expiry := start.Add(time.Hour)
+	opts := blob.GetSASURLOptions{StartTime: &start}
+
+	// BlobSASURL is created with GetSASURL
+	sasUrl, err := blobClient.GetSASURL(permissions, expiry, &opts)
+	_require.Nil(err)
+
+	// Get new blob client with sasUrl and attempt GetProperties
+	client, err := blob.NewClientWithNoCredential(sasUrl, nil)
+	_require.Nil(err)
+
+	_, err = client.GetProperties(context.Background(), nil)
+	_require.Nil(err)
+}
+
+func (s *BlobUnrecordedTestsSuite) TestNoSharedKeyCredError() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	// Creating service client
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	// Creating container client
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Creating blob client without credentials
+	blockBlobName := testcommon.GenerateBlobName(testName)
+	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
+
+	// Adding SAS and options
+	permissions := sas.BlobPermissions{
+		Read:   true,
+		Add:    true,
+		Write:  true,
+		Create: true,
+		Delete: true,
+	}
+	start := time.Now().Add(-time.Hour)
+	expiry := start.Add(time.Hour)
+	opts := blob.GetSASURLOptions{StartTime: &start}
+
+	// GetSASURL fails (with NoSharedKeyCredential) because blob client is created without credentials
+	_, err = bbClient.BlobClient().GetSASURL(permissions, expiry, &opts)
+	_require.Equal(err, bloberror.NoSharedKeyCredential)
 }

--- a/sdk/storage/azblob/bloberror/error_codes.go
+++ b/sdk/storage/azblob/bloberror/error_codes.go
@@ -150,6 +150,7 @@ const (
 	UnsupportedXMLNode                                Code = "UnsupportedXmlNode"
 )
 
+// MissingSharedKeyCredential - Error is returned when SAS URL is being created without SharedKeyCredential.
 var (
-	NoSharedKeyCredential = errors.New("SAS can only be signed with a SharedKeyCredential")
+	MissingSharedKeyCredential = errors.New("SAS can only be signed with a SharedKeyCredential")
 )

--- a/sdk/storage/azblob/bloberror/error_codes.go
+++ b/sdk/storage/azblob/bloberror/error_codes.go
@@ -150,7 +150,7 @@ const (
 	UnsupportedXMLNode                                Code = "UnsupportedXmlNode"
 )
 
-// MissingSharedKeyCredential - Error is returned when SAS URL is being created without SharedKeyCredential.
 var (
+	// MissingSharedKeyCredential - Error is returned when SAS URL is being created without SharedKeyCredential.
 	MissingSharedKeyCredential = errors.New("SAS can only be signed with a SharedKeyCredential")
 )

--- a/sdk/storage/azblob/bloberror/error_codes.go
+++ b/sdk/storage/azblob/bloberror/error_codes.go
@@ -151,5 +151,5 @@ const (
 )
 
 var (
-	SharedKeyDoesNotExist = errors.New("SAS can only be signed with a SharedKeyCredential")
+	NoSharedKeyCredential = errors.New("SAS can only be signed with a SharedKeyCredential")
 )

--- a/sdk/storage/azblob/bloberror/error_codes.go
+++ b/sdk/storage/azblob/bloberror/error_codes.go
@@ -149,3 +149,7 @@ const (
 	UnsupportedQueryParameter                         Code = "UnsupportedQueryParameter"
 	UnsupportedXMLNode                                Code = "UnsupportedXmlNode"
 )
+
+var (
+	SharedKeyDoesNotExist = errors.New("SAS can only be signed with a SharedKeyCredential")
+)

--- a/sdk/storage/azblob/container/client.go
+++ b/sdk/storage/azblob/container/client.go
@@ -8,7 +8,7 @@ package container
 
 import (
 	"context"
-	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"net/http"
 	"net/url"
 	"time"
@@ -308,7 +308,7 @@ func (c *Client) NewListBlobsHierarchyPager(delimiter string, o *ListBlobsHierar
 // It can only be used if the credential supplied during creation was a SharedKeyCredential.
 func (c *Client) GetSASURL(permissions sas.ContainerPermissions, expiry time.Time, o *GetSASURLOptions) (string, error) {
 	if c.sharedKey() == nil {
-		return "", errors.New("SAS can only be signed with a SharedKeyCredential")
+		return "", bloberror.NoSharedKeyCredential
 	}
 	st := o.format()
 	urlParts, err := blob.ParseURL(c.URL())

--- a/sdk/storage/azblob/container/client.go
+++ b/sdk/storage/azblob/container/client.go
@@ -308,7 +308,7 @@ func (c *Client) NewListBlobsHierarchyPager(delimiter string, o *ListBlobsHierar
 // It can only be used if the credential supplied during creation was a SharedKeyCredential.
 func (c *Client) GetSASURL(permissions sas.ContainerPermissions, expiry time.Time, o *GetSASURLOptions) (string, error) {
 	if c.sharedKey() == nil {
-		return "", bloberror.NoSharedKeyCredential
+		return "", bloberror.MissingSharedKeyCredential
 	}
 	st := o.format()
 	urlParts, err := blob.ParseURL(c.URL())

--- a/sdk/storage/azblob/container/client_test.go
+++ b/sdk/storage/azblob/container/client_test.go
@@ -2221,16 +2221,6 @@ func (s *ContainerUnrecordedTestsSuite) TestSASContainerClient() {
 	_require.Nil(err)
 
 	// Create container client with sasUrl
-	client, err := container.NewClientWithNoCredential(sasUrl, nil)
-	_require.Nil(err)
-
-	// Create and upload block blob
-	bbClient := client.NewBlockBlobClient("testing")
-	_require.NotNil(bbClient)
-
-	uploadBlockBlobOptions := blockblob.UploadOptions{
-		Metadata: testcommon.BasicMetadata,
-	}
-	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(strings.NewReader("Content")), &uploadBlockBlobOptions)
+	_, err = container.NewClientWithNoCredential(sasUrl, nil)
 	_require.Nil(err)
 }

--- a/sdk/storage/azblob/container/client_test.go
+++ b/sdk/storage/azblob/container/client_test.go
@@ -9,6 +9,7 @@ package container_test
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"net/url"
 	"sort"
 	"strconv"
@@ -2190,4 +2191,46 @@ func (s *ContainerUnrecordedTestsSuite) TestBlobNameSpecialCharacters() {
 		bc := client.NewBlobClient(blobName)
 		_require.Equal(expected, bc.URL())
 	}
+}
+
+func (s *ContainerUnrecordedTestsSuite) TestSASContainerClient() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	// Creating container client
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Adding SAS and options
+	permissions := sas.ContainerPermissions{
+		Read:   true,
+		Add:    true,
+		Write:  true,
+		Create: true,
+		Delete: true,
+	}
+	start := time.Now().Add(-time.Hour)
+	expiry := start.Add(time.Hour)
+	opts := container.GetSASURLOptions{StartTime: &start}
+
+	// ContainerSASURL is created with GetSASURL
+	sasUrl, err := containerClient.GetSASURL(permissions, expiry, &opts)
+	_require.Nil(err)
+
+	// Create container client with sasUrl
+	client, err := container.NewClientWithNoCredential(sasUrl, nil)
+	_require.Nil(err)
+
+	// Create and upload block blob
+	bbClient := client.NewBlockBlobClient("testing")
+	_require.NotNil(bbClient)
+
+	uploadBlockBlobOptions := blockblob.UploadOptions{
+		Metadata: testcommon.BasicMetadata,
+	}
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(strings.NewReader("Content")), &uploadBlockBlobOptions)
+	_require.Nil(err)
 }

--- a/sdk/storage/azblob/service/client.go
+++ b/sdk/storage/azblob/service/client.go
@@ -245,7 +245,7 @@ func (s *Client) GetStatistics(ctx context.Context, o *GetStatisticsOptions) (Ge
 // It can only be used if the credential supplied during creation was a SharedKeyCredential.
 func (s *Client) GetSASURL(resources sas.AccountResourceTypes, permissions sas.AccountPermissions, services sas.AccountServices, expiry time.Time, o *GetSASURLOptions) (string, error) {
 	if s.sharedKey() == nil {
-		return "", bloberror.SharedKeyDoesNotExist
+		return "", bloberror.NoSharedKeyCredential
 	}
 	st := o.format()
 	qps, err := sas.AccountSignatureValues{

--- a/sdk/storage/azblob/service/client.go
+++ b/sdk/storage/azblob/service/client.go
@@ -8,7 +8,7 @@ package service
 
 import (
 	"context"
-	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"net/http"
 	"strings"
 	"time"
@@ -243,10 +243,9 @@ func (s *Client) GetStatistics(ctx context.Context, o *GetStatisticsOptions) (Ge
 
 // GetSASURL is a convenience method for generating a SAS token for the currently pointed at account.
 // It can only be used if the credential supplied during creation was a SharedKeyCredential.
-// This validity can be checked with CanGetAccountSASToken().
 func (s *Client) GetSASURL(resources sas.AccountResourceTypes, permissions sas.AccountPermissions, services sas.AccountServices, expiry time.Time, o *GetSASURLOptions) (string, error) {
 	if s.sharedKey() == nil {
-		return "", errors.New("SAS can only be signed with a SharedKeyCredential")
+		return "", bloberror.SharedKeyDoesNotExist
 	}
 	st := o.format()
 	qps, err := sas.AccountSignatureValues{

--- a/sdk/storage/azblob/service/client.go
+++ b/sdk/storage/azblob/service/client.go
@@ -245,7 +245,7 @@ func (s *Client) GetStatistics(ctx context.Context, o *GetStatisticsOptions) (Ge
 // It can only be used if the credential supplied during creation was a SharedKeyCredential.
 func (s *Client) GetSASURL(resources sas.AccountResourceTypes, permissions sas.AccountPermissions, services sas.AccountServices, expiry time.Time, o *GetSASURLOptions) (string, error) {
 	if s.sharedKey() == nil {
-		return "", bloberror.NoSharedKeyCredential
+		return "", bloberror.MissingSharedKeyCredential
 	}
 	st := o.format()
 	qps, err := sas.AccountSignatureValues{

--- a/sdk/storage/azblob/service/client_test.go
+++ b/sdk/storage/azblob/service/client_test.go
@@ -623,9 +623,9 @@ func (s *ServiceUnrecordedTestsSuite) TestNoSharedKeyCredError() {
 	expiry := start.Add(time.Hour)
 	opts := service.GetSASURLOptions{StartTime: &start}
 
-	// GetSASURL fails (with NoSharedKeyCredential) because service client is created without credentials
+	// GetSASURL fails (with MissingSharedKeyCredential) because service client is created without credentials
 	_, err = serviceClient.GetSASURL(resources, permissions, services, expiry, &opts)
-	_require.Equal(err, bloberror.NoSharedKeyCredential)
+	_require.Equal(err, bloberror.MissingSharedKeyCredential)
 
 }
 

--- a/sdk/storage/azblob/service/client_test.go
+++ b/sdk/storage/azblob/service/client_test.go
@@ -594,6 +594,41 @@ func (s *ServiceUnrecordedTestsSuite) TestSASServiceClient() {
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.AuthenticationFailed)
 }
 
+func (s *ServiceUnrecordedTestsSuite) TestNoSharedKeyCredError() {
+	_require := require.New(s.T())
+	accountName := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME")
+
+	// Creating service client without credentials
+	serviceClient, err := service.NewClientWithNoCredential(fmt.Sprintf("https://%s.blob.core.windows.net/", accountName), nil)
+	_require.Nil(err)
+
+	// Adding SAS and options
+	resources := sas.AccountResourceTypes{
+		Object:    true,
+		Service:   true,
+		Container: true,
+	}
+	permissions := sas.AccountPermissions{
+		Read:   true,
+		Add:    true,
+		Write:  true,
+		Create: true,
+		Update: true,
+		Delete: true,
+	}
+	services := sas.AccountServices{
+		Blob: true,
+	}
+	start := time.Now().Add(-time.Hour)
+	expiry := start.Add(time.Hour)
+	opts := service.GetSASURLOptions{StartTime: &start}
+
+	// GetSASURL fails (with NoSharedKeyCredential) because service client is created without credentials
+	_, err = serviceClient.GetSASURL(resources, permissions, services, expiry, &opts)
+	_require.Equal(err, bloberror.NoSharedKeyCredential)
+
+}
+
 func (s *ServiceUnrecordedTestsSuite) TestSASContainerClient() {
 	_require := require.New(s.T())
 	testName := s.T().Name()


### PR DESCRIPTION
Related to:https://github.com/Azure/azure-sdk-for-go/issues/19864

Added MissingSharedKeyCredential errortype and tests for GetSASURL.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
