### PR TITLE
Fix bug in Azure-AsyncOperation polling

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed a bug polling on `Azure-AsyncOperation` LRO endpoints that could cause an inadvertent final GET which fails.
 
 ### Other Changes
 


### PR DESCRIPTION
Prefer the specified final-state-via when specified, falling back to heuristics per spec in its absense.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/19889