### PR TITLE
Fix live tests for aztables

### DIFF
--- a/sdk/data/aztables/shared_access_signature_test.go
+++ b/sdk/data/aztables/shared_access_signature_test.go
@@ -50,8 +50,9 @@ func TestSASServiceClient(t *testing.T) {
 		Update: true,
 		Delete: true,
 	}
-	start := time.Date(2021, time.August, 4, 1, 1, 0, 0, time.UTC)
-	expiry := time.Date(2022, time.August, 4, 1, 1, 0, 0, time.UTC)
+
+	start := time.Now().Add(-1 * time.Hour).UTC()
+	expiry := time.Now().Add(24 * time.Hour).UTC()
 
 	sasUrl, err := serviceClient.GetAccountSASURL(resources, permissions, start, expiry)
 	require.NoError(t, err)
@@ -95,8 +96,9 @@ func TestSASClient(t *testing.T) {
 		Read: true,
 		Add:  true,
 	}
-	start := time.Date(2021, time.August, 4, 1, 1, 0, 0, time.UTC)
-	expiry := time.Date(2022, time.August, 4, 1, 1, 0, 0, time.UTC)
+
+	start := time.Now().Add(-1 * time.Hour).UTC()
+	expiry := time.Now().Add(24 * time.Hour).UTC()
 
 	c := serviceClient.NewClient(tableName)
 	sasUrl, err := c.GetTableSASURL(permissions, start, expiry)
@@ -149,8 +151,9 @@ func TestSASClientReadOnly(t *testing.T) {
 	permissions := SASPermissions{
 		Read: true,
 	}
-	start := time.Date(2021, time.August, 4, 1, 1, 0, 0, time.UTC)
-	expiry := time.Date(2022, time.August, 4, 1, 1, 0, 0, time.UTC)
+
+	start := time.Now().Add(-1 * time.Hour).UTC()
+	expiry := time.Now().Add(24 * time.Hour).UTC()
 
 	c := serviceClient.NewClient(tableName)
 	sasUrl, err := c.GetTableSASURL(permissions, start, expiry)
@@ -218,8 +221,9 @@ func TestSASCosmosClientReadOnly(t *testing.T) {
 	permissions := SASPermissions{
 		Read: true,
 	}
-	start := time.Date(2021, time.August, 4, 1, 1, 0, 0, time.UTC)
-	expiry := time.Date(2022, time.August, 4, 1, 1, 0, 0, time.UTC)
+
+	start := time.Now().Add(-1 * time.Hour).UTC()
+	expiry := time.Now().Add(24 * time.Hour).UTC()
 
 	c := serviceClient.NewClient(tableName)
 	sasUrl, err := c.GetTableSASURL(permissions, start, expiry)


### PR DESCRIPTION
The SAS tests used hard-coded start and expiry times which are no longer valid and cause false failures.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
