### PR TITLE
[azservicebus] Fixing error check in recovery, adding some more tests

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.2.0 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.2.0 (2023-02-07)
 
 ### Bugs Fixed
 
 - Links could hang when closing, preventing recovery from completing and making a link appear stalled. (PR#19886)
-
-### Other Changes
 
 ## 1.1.4 (2023-01-10)
 

--- a/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
@@ -63,6 +63,8 @@ func MustCreateStressContext(testName string) *StressContext {
 		"TestRunId": testRunID,
 	}
 
+	log.Printf("Common properties\n:%#v", telemetryClient.Context().CommonProperties)
+
 	ctx, cancel := NewCtrlCContext()
 
 	azlog.SetEvents(azservicebus.EventSender, azservicebus.EventReceiver, azservicebus.EventConn)

--- a/sdk/messaging/azservicebus/internal/stress/tests/empty_sessions.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/empty_sessions.go
@@ -18,7 +18,13 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/stress/shared"
 )
 
+// EmptySessions attempts to get the next available session from a session-enabled subscription that has no
+// available sessions. This makes sure the server-enforced timeout works properly in our code over a long
+// period of time.
 func EmptySessions(remainingArgs []string) {
+	// Queries:
+	// customMetrics | where customDimensions['TestRunId'] == '17402ab9210e0340' and name == "SessionTimeoutMS" | project timestamp, seconds=valueMax/1000 | render timechart
+
 	params := struct {
 		numAttempts int
 		rounds      int
@@ -46,9 +52,7 @@ func EmptySessions(remainingArgs []string) {
 
 	client, err := azservicebus.NewClientFromConnectionString(sc.ConnectionString, &azservicebus.ClientOptions{
 		RetryOptions: azservicebus.RetryOptions{
-			// barrel through retryable failures - we're specifically trying to see if we ever stop
-			// receiving the standard "no session within time limit" error.
-			MaxRetries: 10,
+			MaxRetries: -1,
 		},
 	})
 	sc.NoError(err)
@@ -60,14 +64,35 @@ func EmptySessions(remainingArgs []string) {
 	for round := 0; round < params.rounds; round++ {
 		for i := 0; i < params.numAttempts; i++ {
 			// the default "wait for next session" timeout is basically a minute. If we exceed that then something is broken.
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-			sessionReceiver, err := client.AcceptNextSessionForSubscription(ctx, topicName, "sub1", nil)
-			cancel()
+			// we give it a little bit of time in case the connection needed to be started/recovered as well.
+			acceptCtx, cancelAccept := context.WithTimeout(context.Background(), 4*time.Minute)
+
+			start := time.Now()
+
+			sessionReceiver, err := client.AcceptNextSessionForSubscription(acceptCtx, topicName, "sub1", nil)
+			cancelAccept()
 			sc.Nil(sessionReceiver)
+
+			endMS := time.Since(start) / time.Millisecond
+
+			sc.TrackMetric(string(MetricNameSessionTimeoutMS), float64(endMS))
 
 			// the error should indicate that we timed out waiting for a new session
 			if sbErr := (*azservicebus.Error)(nil); errors.As(err, &sbErr) {
-				sc.Equal(azservicebus.CodeTimeout, sbErr.Code)
+				switch sbErr.Code {
+				case azservicebus.CodeConnectionLost:
+					// these are okay, we'll just let it recover on the next call.
+					sc.TrackMetric(string(MetricNameConnectionLost), 1)
+				case azservicebus.CodeTimeout:
+					// great! this is what we expect to get - the service-side timeout fires off since there's
+					// no session available.
+				default:
+					sc.Failf("Unexpected service code '%s'", sbErr.Code)
+				}
+			} else if errors.Is(err, context.DeadlineExceeded) {
+				// this means we gave the service a max timeout (passed in via
+				// the link attach request) and there was some issue
+				sc.Failf("Deadline exceeded, session timeout took too long (%dms)", endMS)
 			} else if err != nil {
 				sc.PanicOnError("A non-timeout error occurred", err)
 			}

--- a/sdk/messaging/azservicebus/internal/stress/tests/infinite_send_and_receive.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/infinite_send_and_receive.go
@@ -15,11 +15,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/stress/shared"
 )
 
-// test metrics
-const (
-	MetricMessageSent = "MessageSent"
-)
-
 func InfiniteSendAndReceiveRun(remainingArgs []string) {
 	sc := shared.MustCreateStressContext("InfiniteSendAndReceiveRun")
 	defer sc.End()
@@ -106,7 +101,7 @@ func continuallySend(sc *shared.StressContext, queueName string) {
 		}, nil)
 
 		atomic.AddInt32(&senderStats.Sent, 1)
-		sc.TrackMetric(MetricMessageSent, 1)
+		sc.TrackMetric(string(MetricNameMessageSent), 1)
 
 		if err != nil {
 			if err == context.Canceled || err == context.DeadlineExceeded {

--- a/sdk/messaging/azservicebus/internal/stress/tests/metric_names.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/metric_names.go
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tests
+
+type MetricName string
+
+const (
+	MetricNameSessionTimeoutMS MetricName = "SessionTimeoutMS"
+	MetricNameConnectionLost   MetricName = "ConnectionLost"
+	MetricNameMessageSent      MetricName = "MessageSent"
+)


### PR DESCRIPTION
* On recovery check for the specific errConnResetNeeded error rather than a cancellation error.
  I've merged those code paths into one.
* Update the empty sessions test to be more realistic, handle connection failures, etc..
* Make the rapid open/close test do more rounds and more iterations.
* Add in some logging for the "link error being upgraded to a connection error".