### PR TITLE
Propagate unknown errors from RP registration policy

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* ARM's RP registration policy will no longer swallow unrecognized errors.
 
 ### Other Changes
 

--- a/sdk/azcore/arm/runtime/policy_register_rp.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp.go
@@ -97,10 +97,13 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 			return resp, err
 		}
 		if reqErr.ServiceError == nil {
-			return resp, errors.New("missing error information")
+			// missing service error info. just return the response
+			// to the caller so its error unmarshalling will kick in
+			return resp, err
 		}
 		if !strings.EqualFold(reqErr.ServiceError.Code, unregisteredRPCode) {
-			// not a 409 due to unregistered RP
+			// not a 409 due to unregistered RP. just return the response
+			// to the caller so its error unmarshalling will kick in
 			return resp, err
 		}
 		// RP needs to be registered.  start by getting the subscription ID from the original request


### PR DESCRIPTION
If the error response is unrecognized, return the response to the calling API so its error unmarshalling will handle it.  Added a test to cover this case.
Converted RP registration tests to use a fake client which is more of a real-world scenario.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/19956