### PR TITLE
Trigger `aztables` when proxy files are updated

### DIFF
--- a/sdk/data/aztables/ci.yml
+++ b/sdk/data/aztables/ci.yml
@@ -21,6 +21,7 @@ pr:
     include:
     - sdk/data/aztables
     - eng/common/testproxy
+    # adding eng/common/testproxy as aztables is a good exercise of the test-proxy features. if a new proxy version works on this build, we can be confident updating to it
 
 stages:
 - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/data/aztables/ci.yml
+++ b/sdk/data/aztables/ci.yml
@@ -20,6 +20,7 @@ pr:
   paths:
     include:
     - sdk/data/aztables
+    - eng/common/testproxy
 
 stages:
 - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml


### PR DESCRIPTION
So that I can avoid manually triggering this pipeline before merging an update to `eng/common/testproxy/target_version.txt`.

