### PR TITLE
Update package regex to detect arbitrary length directory trees

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -37,10 +37,12 @@ function Get-GoModuleVersionInfo($modPath)
 function Get-GoModuleProperties($goModPath)
 {
   $goModPath = $goModPath -replace "\\", "/"
-  if ($goModPath -match "(?<modPath>sdk/(?<serviceDir>(resourcemanager/)?([^/]+/)?(?<modName>[^/]+$)))")
+  # We should keep this regex in sync with what is in the azure-sdk repo at https://github.com/Azure/azure-sdk/blob/main/eng/scripts/Query-Azure-Packages.ps1#L227
+  # The serviceName named capture group is unused but used in azure-sdk, so it's kept here for parity
+  if ($goModPath -match "(?<modPath>sdk/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
   {
     $modPath = $matches["modPath"]
-    $modName = $matches["modName"] # We may need to start readong this from the go.mod file if the path and mod config start to differ
+    $modName = $matches["modName"] # We may need to start reading this from the go.mod file if the path and mod config start to differ
     $serviceDir = $matches["serviceDir"]
     $sdkType = "client"
     if ($modName.StartsWith("arm") -or $modPath.Contains("resourcemanager")) { $sdkType = "mgmt" }


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-sdk-for-go/pull/19879#discussion_r1093893548 to support packages like `security/keyvault/internal` for #19879 

Needs to go in with https://github.com/Azure/azure-sdk/pull/5534