### PR TITLE
fix wrong order of require.Equal arguments

### DIFF
--- a/sdk/containers/azcontainerregistry/blob_client_test.go
+++ b/sdk/containers/azcontainerregistry/blob_client_test.go
@@ -102,7 +102,7 @@ func TestBlobClient_GetChunk(t *testing.T) {
 	digest := "sha256:042a816809aac8d0f7d7cacac7965782ee2ecac3f21bcf9f24b1de1a7387b769"
 	res, err := client.GetChunk(ctx, "alpine", digest, "bytes=0-999", nil)
 	require.NoError(t, err)
-	require.Equal(t, *res.ContentLength, int64(1000))
+	require.Equal(t, int64(1000), *res.ContentLength)
 }
 
 func TestBlobClient_GetUploadStatus(t *testing.T) {

--- a/sdk/containers/azcontainerregistry/client_test.go
+++ b/sdk/containers/azcontainerregistry/client_test.go
@@ -342,13 +342,13 @@ func TestClient_UpdateManifestProperties(t *testing.T) {
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, false, *res.Manifest.ChangeableAttributes.CanWrite)
+	require.False(t, *res.Manifest.ChangeableAttributes.CanWrite)
 	res, err = client.UpdateManifestProperties(ctx, "alpine", digest, &ClientUpdateManifestPropertiesOptions{Value: &ManifestWriteableProperties{
 		CanWrite: to.Ptr(true),
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, true, *res.Manifest.ChangeableAttributes.CanWrite)
+	require.True(t, *res.Manifest.ChangeableAttributes.CanWrite)
 }
 
 func TestClient_UpdateManifestProperties_wrongDigest(t *testing.T) {
@@ -372,13 +372,13 @@ func TestClient_UpdateRepositoryProperties(t *testing.T) {
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, false, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
+	require.False(t, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
 	res, err = client.UpdateRepositoryProperties(ctx, "ubuntu", &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{
 		CanWrite: to.Ptr(true),
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, true, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
+	require.True(t, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
 }
 
 func TestClient_UpdateRepositoryProperties_wrongRepository(t *testing.T) {
@@ -405,13 +405,13 @@ func TestClient_UpdateTagProperties(t *testing.T) {
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, false, *res.Tag.ChangeableAttributes.CanWrite)
+	require.False(t, *res.Tag.ChangeableAttributes.CanWrite)
 	res, err = client.UpdateTagProperties(ctx, "alpine", "3.17.1", &ClientUpdateTagPropertiesOptions{Value: &TagWriteableProperties{
 		CanWrite: to.Ptr(true),
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, true, *res.Tag.ChangeableAttributes.CanWrite)
+	require.True(t, *res.Tag.ChangeableAttributes.CanWrite)
 }
 
 func TestClient_UpdateTagProperties_wrongTag(t *testing.T) {

--- a/sdk/containers/azcontainerregistry/client_test.go
+++ b/sdk/containers/azcontainerregistry/client_test.go
@@ -100,7 +100,7 @@ func TestClient_GetManifestProperties(t *testing.T) {
 	require.NoError(t, err)
 	tagRes, err := client.GetManifestProperties(ctx, "alpine", *resp.Tag.Digest, nil)
 	require.NoError(t, err)
-	require.Equal(t, *tagRes.Manifest.Digest, digest)
+	require.Equal(t, digest, *tagRes.Manifest.Digest)
 }
 
 func TestClient_GetManifestProperties_wrongDigest(t *testing.T) {
@@ -184,8 +184,8 @@ func TestClient_NewListManifestsPager(t *testing.T) {
 			items++
 		}
 	}
-	require.Equal(t, pages, 32)
-	require.Equal(t, items, 32)
+	require.Equal(t, 32, pages)
+	require.Equal(t, 32, items)
 
 	pager = client.NewListManifestsPager("alpine", &ClientListManifestsOptions{
 		OrderBy: to.Ptr(ArtifactManifestOrderByLastUpdatedOnDescending),
@@ -253,8 +253,8 @@ func TestClient_NewListRepositoriesPager(t *testing.T) {
 			items++
 		}
 	}
-	require.Equal(t, pages, 3)
-	require.Equal(t, items, 3)
+	require.Equal(t, 3, pages)
+	require.Equal(t, 3, items)
 }
 
 func TestClient_NewListTagsPager(t *testing.T) {
@@ -273,14 +273,14 @@ func TestClient_NewListTagsPager(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, page.Tags)
 		pages++
-		require.Equal(t, len(page.Tags), 1)
+		require.Equal(t, 1, len(page.Tags))
 		for i, v := range page.Tags {
 			fmt.Printf("page %d tag %d: %s\n", pages, i+1, *v.Name)
 			items++
 		}
 	}
-	require.Equal(t, pages, 3)
-	require.Equal(t, items, 3)
+	require.Equal(t, 3, pages)
+	require.Equal(t, 3, items)
 
 	pager = client.NewListTagsPager("alpine", &ClientListTagsOptions{
 		OrderBy: to.Ptr(ArtifactTagOrderByLastUpdatedOnDescending),
@@ -342,13 +342,13 @@ func TestClient_UpdateManifestProperties(t *testing.T) {
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, *res.Manifest.ChangeableAttributes.CanWrite, false)
+	require.Equal(t, false, *res.Manifest.ChangeableAttributes.CanWrite)
 	res, err = client.UpdateManifestProperties(ctx, "alpine", digest, &ClientUpdateManifestPropertiesOptions{Value: &ManifestWriteableProperties{
 		CanWrite: to.Ptr(true),
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, *res.Manifest.ChangeableAttributes.CanWrite, true)
+	require.Equal(t, true, *res.Manifest.ChangeableAttributes.CanWrite)
 }
 
 func TestClient_UpdateManifestProperties_wrongDigest(t *testing.T) {
@@ -372,13 +372,13 @@ func TestClient_UpdateRepositoryProperties(t *testing.T) {
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite, false)
+	require.Equal(t, false, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
 	res, err = client.UpdateRepositoryProperties(ctx, "ubuntu", &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{
 		CanWrite: to.Ptr(true),
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite, true)
+	require.Equal(t, true, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
 }
 
 func TestClient_UpdateRepositoryProperties_wrongRepository(t *testing.T) {
@@ -405,13 +405,13 @@ func TestClient_UpdateTagProperties(t *testing.T) {
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, *res.Tag.ChangeableAttributes.CanWrite, false)
+	require.Equal(t, false, *res.Tag.ChangeableAttributes.CanWrite)
 	res, err = client.UpdateTagProperties(ctx, "alpine", "3.17.1", &ClientUpdateTagPropertiesOptions{Value: &TagWriteableProperties{
 		CanWrite: to.Ptr(true),
 	},
 	})
 	require.NoError(t, err)
-	require.Equal(t, *res.Tag.ChangeableAttributes.CanWrite, true)
+	require.Equal(t, true, *res.Tag.ChangeableAttributes.CanWrite)
 }
 
 func TestClient_UpdateTagProperties_wrongTag(t *testing.T) {

--- a/sdk/resourcemanager/internal/testutil/credential_test.go
+++ b/sdk/resourcemanager/internal/testutil/credential_test.go
@@ -45,9 +45,9 @@ func TestGetCredAndClientOptions(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := pl.Do(req)
 	require.NoError(t, err)
-	require.Equal(t, resp.StatusCode, http.StatusBadRequest)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	if recording.GetRecordMode() == recording.PlaybackMode {
-		require.Equal(t, resp.Request.Header.Get("Authorization"), "Bearer FakeToken")
+		require.Equal(t, "Bearer FakeToken", resp.Request.Header.Get("Authorization"))
 	}
-	require.Equal(t, resp.Request.URL.String(), testEndpoint)
+	require.Equal(t, testEndpoint, resp.Request.URL.String())
 }

--- a/sdk/resourcemanager/internal/testutil/helper_test.go
+++ b/sdk/resourcemanager/internal/testutil/helper_test.go
@@ -24,8 +24,8 @@ const (
 func TestGetEnv(t *testing.T) {
 	err := os.Setenv("test", "test")
 	require.NoError(t, err)
-	require.Equal(t, GetEnv("test", ""), "test")
-	require.Equal(t, GetEnv("testfail", "fail"), "fail")
+	require.Equal(t, "test", GetEnv("test", ""))
+	require.Equal(t, "fail", GetEnv("testfail", "fail"))
 }
 
 func TestCreateDeleteResourceGroup(t *testing.T) {
@@ -36,7 +36,7 @@ func TestCreateDeleteResourceGroup(t *testing.T) {
 	defer stop()
 	resourceGroup, _, err := CreateResourceGroup(ctx, subscriptionID, cred, options, "eastus")
 	require.NoError(t, err)
-	require.Equal(t, strings.HasPrefix(*resourceGroup.Name, "go-sdk-test-"), true)
+	require.Equal(t, true, strings.HasPrefix(*resourceGroup.Name, "go-sdk-test-"))
 	_, err = DeleteResourceGroup(ctx, subscriptionID, cred, options, *resourceGroup.Name)
 	require.NoError(t, err)
 }

--- a/sdk/resourcemanager/internal/testutil/helper_test.go
+++ b/sdk/resourcemanager/internal/testutil/helper_test.go
@@ -36,7 +36,7 @@ func TestCreateDeleteResourceGroup(t *testing.T) {
 	defer stop()
 	resourceGroup, _, err := CreateResourceGroup(ctx, subscriptionID, cred, options, "eastus")
 	require.NoError(t, err)
-	require.Equal(t, true, strings.HasPrefix(*resourceGroup.Name, "go-sdk-test-"))
+	require.True(t, strings.HasPrefix(*resourceGroup.Name, "go-sdk-test-"))
 	_, err = DeleteResourceGroup(ctx, subscriptionID, cred, options, *resourceGroup.Name)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
