### PR TITLE
[azservicebus] Validate that credits are within limits (not over or under)

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - Fixing issues where we could over-request credit (#19965) or allow for negative/zero credits (#19743), both of
-  which could cause issues with go-amqp. (PR#TBD)
+  which could cause issues with go-amqp. (PR#19992)
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fixing issues where we could over-request credit (#19965) or allow for negative/zero credits (#19743), both of
+  which could cause issues with go-amqp. (PR#TBD)
+
 ### Other Changes
 
 ## 1.2.0 (2023-02-07)

--- a/sdk/messaging/azservicebus/internal/mgmt.go
+++ b/sdk/messaging/azservicebus/internal/mgmt.go
@@ -504,9 +504,7 @@ func ScheduleMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName st
 		const sequenceFieldName = "sequence-numbers"
 		if rawArr, ok := rawVal[sequenceFieldName]; ok {
 			if arr, ok := rawArr.([]int64); ok {
-				for i := range arr {
-					retval = append(retval, arr[i])
-				}
+				retval = append(retval, arr...)
 				return retval, nil
 			}
 			return nil, NewErrIncorrectType(sequenceFieldName, []int64{}, rawArr)

--- a/sdk/messaging/azservicebus/internal/mock/emulation/mock_data_receiver.go
+++ b/sdk/messaging/azservicebus/internal/mock/emulation/mock_data_receiver.go
@@ -76,6 +76,7 @@ func (md *MockData) NewReceiver(ctx context.Context, source string, opts *amqp.R
 		Source:                 source,
 		Status:                 NewStatus(sess.Status),
 		TargetAddress:          opts.TargetAddress,
+		Opts:                   opts,
 	}
 
 	id := fmt.Sprintf("%s|%s|%s|e:%s", sess.Conn.Name(), sess.ID, md.nextUniqueName("r"), source)

--- a/sdk/messaging/azservicebus/internal/mock/mock_helpers.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_helpers.go
@@ -49,6 +49,23 @@ func SetupRPC(sender *MockAMQPSenderCloser, receiver *MockAMQPReceiverCloser, ex
 	}
 }
 
+type ContextWithValueMatcher[KT comparable, VT comparable] struct {
+	Key   KT
+	Value VT
+}
+
+func NewContextWithValueMatcher[KT comparable, VT comparable](key KT, value VT) ContextWithValueMatcher[KT, VT] {
+	return ContextWithValueMatcher[KT, VT]{key, value}
+}
+
+func (m ContextWithValueMatcher[KT, VT]) Matches(x interface{}) bool {
+	ctx := x.(context.Context)
+	return ctx.Value(m.Key) == m.Value
+}
+func (m ContextWithValueMatcher[KT, VT]) String() string {
+	return fmt.Sprintf("Context has key %v and value %v", m.Key, m.Value)
+}
+
 // Cancelled matches context.Context instances that are cancelled.
 var Cancelled gomock.Matcher = ContextCancelledMatcher{true}
 

--- a/sdk/messaging/azservicebus/internal/test/test_helpers.go
+++ b/sdk/messaging/azservicebus/internal/test/test_helpers.go
@@ -28,11 +28,12 @@ var (
 
 func init() {
 	addSwappableLogger()
-	rand.Seed(time.Now().Unix())
 }
 
 // RandomString generates a random string with prefix
 func RandomString(prefix string, length int) string {
+	rand := rand.New(rand.NewSource(time.Now().Unix()))
+
 	b := make([]rune, length)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]

--- a/sdk/messaging/azservicebus/internal/test/test_helpers.go
+++ b/sdk/messaging/azservicebus/internal/test/test_helpers.go
@@ -143,15 +143,18 @@ func CaptureLogsForTestWithChannel(messagesCh chan string) func() []string {
 			return nil
 		}
 
-		close(messagesCh)
-
 		var messages []string
 
-		for msg := range messagesCh {
-			messages = append(messages, msg)
+	Loop:
+		for {
+			select {
+			case msg := <-messagesCh:
+				messages = append(messages, msg)
+			default:
+				break Loop
+			}
 		}
 
-		messagesCh = nil
 		return messages
 	}
 }

--- a/sdk/messaging/azservicebus/internal/utils/retrier_test.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier_test.go
@@ -323,8 +323,7 @@ func TestRetryLogging(t *testing.T) {
 	})
 
 	t.Run("normal error2", func(t *testing.T) {
-		cleanup := test.EnableStdoutLogging()
-		defer cleanup()
+		test.EnableStdoutLogging(t)
 
 		err := Retry(context.Background(), testLogEvent, "my_operation", func(ctx context.Context, args *RetryFnArgs) error {
 			azlog.Writef("TestFunc", "Attempt %d, within test func, returning error hello", args.I)

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -81,7 +81,7 @@ type ReceiverOptions struct {
 	SubQueue SubQueue
 }
 
-const defaultLinkRxBuffer = 10000
+const defaultLinkRxBuffer uint32 = 10000
 
 func applyReceiverOptions(receiver *Receiver, entity *entity, options *ReceiverOptions) error {
 	if options == nil {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -81,7 +81,10 @@ type ReceiverOptions struct {
 	SubQueue SubQueue
 }
 
-const defaultLinkRxBuffer uint32 = 10000
+// defaultLinkRxBuffer is the maximum number of transfer frames we can handle
+// on the Receiver. This matches the current default window size that go-amqp
+// uses for sessions.
+const defaultLinkRxBuffer uint32 = 5000
 
 func applyReceiverOptions(receiver *Receiver, entity *entity, options *ReceiverOptions) error {
 	if options == nil {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -45,22 +45,18 @@ const (
 
 // Receiver receives messages using pull based functions (ReceiveMessages).
 type Receiver struct {
-	receiveMode ReceiveMode
-	entityPath  string
-
-	settler        settler
-	retryOptions   RetryOptions
-	cleanupOnClose func()
-
-	lastPeekedSequenceNumber int64
 	amqpLinks                internal.AMQPLinks
-
-	mu        sync.Mutex
-	receiving bool
-
+	cancelReleaser           *atomic.Value
+	cleanupOnClose           func()
 	defaultTimeAfterFirstMsg time.Duration
-
-	cancelReleaser *atomic.Value
+	entityPath               string
+	lastPeekedSequenceNumber int64
+	maxAllowedCredits        uint32
+	mu                       sync.Mutex
+	receiveMode              ReceiveMode
+	receiving                bool
+	retryOptions             RetryOptions
+	settler                  settler
 }
 
 // ReceiverOptions contains options for the `Client.NewReceiverForQueue` or `Client.NewReceiverForSubscription`
@@ -85,7 +81,7 @@ type ReceiverOptions struct {
 	SubQueue SubQueue
 }
 
-const defaultLinkRxBuffer = 2048
+const defaultLinkRxBuffer = 10000
 
 func applyReceiverOptions(receiver *Receiver, entity *entity, options *ReceiverOptions) error {
 	if options == nil {
@@ -131,11 +127,12 @@ func newReceiver(args newReceiverArgs, options *ReceiverOptions) (*Receiver, err
 	}
 
 	receiver := &Receiver{
-		lastPeekedSequenceNumber: 0,
+		cancelReleaser:           &atomic.Value{},
 		cleanupOnClose:           args.cleanupOnClose,
 		defaultTimeAfterFirstMsg: 20 * time.Millisecond,
+		lastPeekedSequenceNumber: 0,
+		maxAllowedCredits:        defaultLinkRxBuffer,
 		retryOptions:             args.retryOptions,
-		cancelReleaser:           &atomic.Value{},
 	}
 
 	receiver.cancelReleaser.Store(emptyCancelFn)
@@ -363,6 +360,14 @@ func (r *Receiver) DeadLetterMessage(ctx context.Context, message *ReceivedMessa
 func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, options *ReceiveMessagesOptions) ([]*ReceivedMessage, error) {
 	cancelReleaser := r.cancelReleaser.Swap(emptyCancelFn).(func() string)
 	_ = cancelReleaser()
+
+	if maxMessages <= 0 {
+		return nil, internal.NewErrNonRetriable("maxMessages should be greater than 0")
+	}
+
+	if maxMessages > int(r.maxAllowedCredits) {
+		return nil, internal.NewErrNonRetriable(fmt.Sprintf("maxMessages cannot exceed %d", r.maxAllowedCredits))
+	}
 
 	var linksWithID *internal.LinksWithID
 

--- a/sdk/messaging/azservicebus/receiver_simulated_test.go
+++ b/sdk/messaging/azservicebus/receiver_simulated_test.go
@@ -597,6 +597,8 @@ func TestReceiver_CreditsDontExceedMax(t *testing.T) {
 					<-ctx.Done()
 					return nil, ctx.Err()
 				}).AnyTimes()
+
+				require.Equal(t, defaultLinkRxBuffer, mr.Opts.Credit)
 			}
 
 			return nil

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -27,7 +27,8 @@ func TestReceiver_ReceiveMessages_AMQPLinksFailure(t *testing.T) {
 		amqpLinks:   fakeAMQPLinks,
 		receiveMode: ReceiveModePeekLock,
 		// TODO: need to make this test rely less on stubbing.
-		cancelReleaser: &atomic.Value{},
+		cancelReleaser:    &atomic.Value{},
+		maxAllowedCredits: defaultLinkRxBuffer,
 	}
 
 	receiver.cancelReleaser.Store(emptyCancelFn)
@@ -63,7 +64,8 @@ func TestReceiverCancellationUnitTests(t *testing.T) {
 			amqpLinks: &internal.FakeAMQPLinks{
 				Receiver: &internal.FakeAMQPReceiver{},
 			},
-			cancelReleaser: &atomic.Value{},
+			cancelReleaser:    &atomic.Value{},
+			maxAllowedCredits: defaultLinkRxBuffer,
 		}
 
 		r.cancelReleaser.Store(emptyCancelFn)
@@ -89,7 +91,8 @@ func TestReceiverCancellationUnitTests(t *testing.T) {
 					},
 				},
 			},
-			cancelReleaser: &atomic.Value{},
+			cancelReleaser:    &atomic.Value{},
+			maxAllowedCredits: defaultLinkRxBuffer,
 		}
 
 		r.cancelReleaser.Store(emptyCancelFn)

--- a/sdk/messaging/azservicebus/session_receiver_test.go
+++ b/sdk/messaging/azservicebus/session_receiver_test.go
@@ -327,8 +327,7 @@ func TestSessionReceiver_Detach(t *testing.T) {
 		}})
 	defer cleanup()
 
-	stopFn := test.EnableStdoutLogging()
-	defer stopFn()
+	test.EnableStdoutLogging(t)
 
 	adminClient, err := admin.NewClientFromConnectionString(test.GetConnectionString(t), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixing issues where we could over-request credit (#19965) or allow for negative/zero credits (#19743), both of which could cause issues with go-amqp..

Fixes #19965
Fixes #19743 