### PR TITLE
Update `CODEOWNERS` paths: fix invalid paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@
 ################
 
 # Git Hub integration and bot rules
-/.github/                    @jsquire @jhendrixMSFT @rickwinter @ronniegeraghty
+/.github/                    @benbp @jsquire @jhendrixMSFT @rickwinter @ronniegeraghty
 
 ###########
 # Eng Sys

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,12 @@
 # Instructions for CODEOWNERS file format and automatic build failure notifications:
 # https://github.com/Azure/azure-sdk/blob/master/docs/policies/opensource.md#codeowners
 
-################
-# Automation
-################
-
-# Git Hub integration and bot rules
-/.github/                    @jsquire @jhendrixMSFT @rickwinter @ronniegeraghty
-
 #############
 # SDK (track2)
 ############# 
 
 # Catch all for non-code project files and unowned files | folders
-*                             @rickwinter @jhendrixMSFT
+/**                           @rickwinter @jhendrixMSFT
 /sdk/                         @rickwinter @chlowell @richardpark-msft
 
 # Samples
@@ -41,13 +34,10 @@
 /sdk/keyvault/                @chlowell @jhendrixMSFT
 
 # PRLabel: %Service Bus
-/sdk/messaging/azservicebus   @richardpark-msft @jhendrixMSFT
+/sdk/messaging/azservicebus/  @richardpark-msft @jhendrixMSFT
 
 # PRLabel: %Event Hubs
-/sdk/messaging/azeventhubs    @richardpark-msft @jhendrixMSFT
-
-# PRLabel: %Service Bus
-/sdk/messaging/internal       @richardpark-msft @jhendrixMSFT
+/sdk/messaging/azeventhubs/   @richardpark-msft @jhendrixMSFT
 
 # PRLabel: %Monitor
 /sdk/monitor/                 @gracewilcox @chlowell @jhendrixMSFT
@@ -58,12 +48,17 @@
 # PRLabel: %Storage
 /sdk/storage/                 @siminsavani-msft @souravgupta-msft @tasherif-msft @jhendrixMSFT @gapra-msft
 
+################
+# Automation
+################
+
+# Git Hub integration and bot rules
+/.github/                    @jsquire @jhendrixMSFT @rickwinter @ronniegeraghty
+
 ###########
 # Eng Sys
 ###########
 /eng/                         @benbp @weshaggard
-/**/ci.yml                    @benbp
-/**/tests.yml                 @benbp
 
 # PRLabel: %EngSys
 /sdk/template/                @benbp @weshaggard


### PR DESCRIPTION
As part of ongoing work of enabling wildcard support for `CODEOWNERS`:
- https://github.com/Azure/azure-sdk-tools/issues/2770
- https://github.com/Azure/azure-sdk-tools/pull/5088

and enabling stricter validation:
- https://github.com/Azure/azure-sdk-tools/issues/4859

this PR:
- fixes invalid paths, to match rules explained [here](https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners);
- removes `/**/tests.yml` and `/**/ci.yml`, to avoid all build failure notifications being routed to it once we enable the new regex-based, wildcard-supporting `CODEOWNERS` matcher, per: https://github.com/Azure/azure-sdk-tools/pull/5088#issuecomment-1397330147

Once this PR is merged, I will enable the new `CODEOWNERS` matcher, similar to how it was done for `net` repo by these two PRs:
- https://github.com/Azure/azure-sdk-tools/pull/5241
- https://github.com/Azure/azure-sdk-tools/pull/5240