### PR TITLE
Add GenerateAlphaNumericID for test-proxy to recording package

### DIFF
--- a/sdk/internal/recording/recording.go
+++ b/sdk/internal/recording/recording.go
@@ -237,38 +237,8 @@ func (r *Recording) UUID() uuid.UUID {
 // GenerateAlphaNumericID will generate a recorded random alpha numeric id
 // if the recording has a randomSeed already set, the value will be generated from that seed, else a new random seed will be used
 func (r *Recording) GenerateAlphaNumericID(prefix string, length int, lowercaseOnly bool) (string, error) {
-
-	if length <= len(prefix) {
-		return "", errors.New("length must be greater than prefix")
-	}
-
 	r.initRandomSource()
-
-	sb := strings.Builder{}
-	sb.Grow(length)
-	sb.WriteString(prefix)
-	i := length - len(prefix) - 1
-	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
-	for cache, remain := r.src.Int63(), letterIdxMax; i >= 0; {
-		if remain == 0 {
-			cache, remain = r.src.Int63(), letterIdxMax
-		}
-		if lowercaseOnly {
-			if idx := int(cache & letterIdxMask); idx < len(alphanumericLowercaseBytes) {
-				sb.WriteByte(alphanumericLowercaseBytes[idx])
-				i--
-			}
-		} else {
-			if idx := int(cache & letterIdxMask); idx < len(alphanumericBytes) {
-				sb.WriteByte(alphanumericBytes[idx])
-				i--
-			}
-		}
-		cache >>= letterIdxBits
-		remain--
-	}
-	str := sb.String()
-	return str, nil
+	return generateAlphaNumericID(prefix, length, lowercaseOnly, r.src)
 }
 
 // getRequiredEnv gets an environment variable by name and returns an error if it is not found
@@ -496,22 +466,27 @@ func init() {
 	}
 }
 
-var recordMode string
-var rootCAs *x509.CertPool
+var (
+	recordMode string
+	rootCAs    *x509.CertPool
+)
 
 const (
-	RecordingMode     = "record"
-	PlaybackMode      = "playback"
-	LiveMode          = "live"
-	IDHeader          = "x-recording-id"
-	ModeHeader        = "x-recording-mode"
-	UpstreamURIHeader = "x-recording-upstream-base-uri"
+	RecordingMode                   = "record"
+	PlaybackMode                    = "playback"
+	LiveMode                        = "live"
+	IDHeader                        = "x-recording-id"
+	ModeHeader                      = "x-recording-mode"
+	UpstreamURIHeader               = "x-recording-upstream-base-uri"
+	recordingRandomSeedVariableName = "recordingRandomSeed"
 )
 
 type recordedTest struct {
-	recordingId string
-	liveOnly    bool
-	variables   map[string]interface{}
+	recordingId           string
+	liveOnly              bool
+	variables             map[string]interface{}
+	recordingSeed         int64
+	recordingRandomSource rand.Source
 }
 
 // testMap maps test names to metadata
@@ -532,6 +507,11 @@ func (t *testMap) Load(name string) (recordedTest, bool) {
 // Store sets metadata for the named test
 func (t *testMap) Store(name string, data recordedTest) {
 	t.m.Store(name, data)
+}
+
+// Remove delete metadata for the named test
+func (t *testMap) Remove(name string) {
+	t.m.Delete(name)
 }
 
 var testSuite = testMap{&sync.Map{}}
@@ -778,6 +758,12 @@ func Stop(t *testing.T, options *RecordingOptions) error {
 			// test should only be run live, don't want to generate recording
 			return nil
 		}
+		if testStruct.recordingSeed != 0 {
+			if options.Variables == nil {
+				options.Variables = map[string]interface{}{}
+			}
+			options.Variables[recordingRandomSeedVariableName] = strconv.FormatInt(testStruct.recordingSeed, 10)
+		}
 	}
 
 	url := fmt.Sprintf("%v/%v/stop", options.baseURL(), recordMode)
@@ -801,6 +787,7 @@ func Stop(t *testing.T, options *RecordingOptions) error {
 		return errors.New("Recording ID was never set. Did you call StartRecording?")
 	}
 	req.Header.Set(IDHeader, recTest.recordingId)
+	testSuite.Remove(t.Name())
 	resp, err := client.Do(req)
 	if resp.StatusCode != 200 {
 		b, err := io.ReadAll(resp.Body)
@@ -814,7 +801,76 @@ func Stop(t *testing.T, options *RecordingOptions) error {
 	return err
 }
 
-// This looks up an environment variable and if it is not found, returns the recordedValue
+func getRandomSource(t *testing.T) rand.Source {
+	if testStruct, ok := testSuite.Load(t.Name()); ok {
+		if testStruct.recordingRandomSource != nil {
+			return testStruct.recordingRandomSource
+		}
+	}
+
+	var seed int64
+	var err error
+
+	variables := GetVariables(t)
+	seedString, ok := variables[recordingRandomSeedVariableName]
+	if ok {
+		seed, err = strconv.ParseInt(seedString.(string), 10, 64)
+	}
+
+	// We did not have a random seed already stored; create a new one
+	if !ok || err != nil || GetRecordMode() == "live" {
+		seed = time.Now().Unix()
+	}
+
+	source := rand.NewSource(seed)
+	if testStruct, ok := testSuite.Load(t.Name()); ok {
+		testStruct.recordingSeed = seed
+		testStruct.recordingRandomSource = source
+		testSuite.Store(t.Name(), testStruct)
+	}
+
+	return source
+}
+
+// GenerateAlphaNumericID will generate a recorded random alpha numeric id.
+// When playback mode, a new random seed will be used, otherwise, the random seed is stable and will be stored in recording file.
+func GenerateAlphaNumericID(t *testing.T, prefix string, length int, lowercaseOnly bool) (string, error) {
+	return generateAlphaNumericID(prefix, length, lowercaseOnly, getRandomSource(t))
+}
+
+func generateAlphaNumericID(prefix string, length int, lowercaseOnly bool, randomSource rand.Source) (string, error) {
+	if length <= len(prefix) {
+		return "", errors.New("length must be greater than prefix")
+	}
+
+	sb := strings.Builder{}
+	sb.Grow(length)
+	sb.WriteString(prefix)
+	i := length - len(prefix) - 1
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for cache, remain := randomSource.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = randomSource.Int63(), letterIdxMax
+		}
+		if lowercaseOnly {
+			if idx := int(cache & letterIdxMask); idx < len(alphanumericLowercaseBytes) {
+				sb.WriteByte(alphanumericLowercaseBytes[idx])
+				i--
+			}
+		} else {
+			if idx := int(cache & letterIdxMask); idx < len(alphanumericBytes) {
+				sb.WriteByte(alphanumericBytes[idx])
+				i--
+			}
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+	str := sb.String()
+	return str, nil
+}
+
+// GetEnvVariable looks up an environment variable and if it is not found, returns the recordedValue
 func GetEnvVariable(varName string, recordedValue string) string {
 	val, ok := os.LookupEnv(varName)
 	if !ok || GetRecordMode() == PlaybackMode {
@@ -835,7 +891,7 @@ func LiveOnly(t *testing.T) {
 	}
 }
 
-// Function for sleeping during a test for `duration` seconds. This method will only execute when
+// Sleep during a test for `duration` seconds. This method will only execute when
 // AZURE_RECORD_MODE = "record", if a test is running in playback this will be a noop.
 func Sleep(duration time.Duration) {
 	if GetRecordMode() != PlaybackMode {

--- a/sdk/internal/recording/testdata/recordings/TestGenerateAlphaNumericID.json
+++ b/sdk/internal/recording/testdata/recordings/TestGenerateAlphaNumericID.json
@@ -1,6 +1,6 @@
 {
   "Entries": [],
   "Variables": {
-    "recordingRandomSeed": "1676365801"
+    "randSeed": "1676365801"
   }
 }

--- a/sdk/internal/recording/testdata/recordings/TestGenerateAlphaNumericID.json
+++ b/sdk/internal/recording/testdata/recordings/TestGenerateAlphaNumericID.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "recordingRandomSeed": "1676365801"
+  }
+}


### PR DESCRIPTION
1. Add GenerateAlphaNumericID function.
2. Store random seed in each recording file.
3. This change is to move the similar function under `sdk/resourcemanger/internal` as it should be part of our recording system. 

Part of #19984 