### PR TITLE
[azeventhubs] Fix credit requesting errors

### DIFF
--- a/sdk/messaging/azeventhubs/internal/eh/stress/Dockerfile
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.18 as build
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.20 as build
 # you'll need to run this build from the root of the azeventhubs module
 ENV GOOS=linux 
 ENV GOARCH=amd64 

--- a/sdk/messaging/azeventhubs/internal/eh/stress/stress.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/stress.go
@@ -5,10 +5,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"sort"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/eh/stress/tests"
 )
@@ -42,8 +40,6 @@ func main() {
 
 	for _, test := range tests {
 		if test.name == testName {
-			rand.Seed(time.Now().UnixNano())
-
 			if err := test.fn(context.Background()); err != nil {
 				fmt.Printf("ERROR: %s\n", err)
 				os.Exit(1)

--- a/sdk/messaging/azeventhubs/partition_client_unit_test.go
+++ b/sdk/messaging/azeventhubs/partition_client_unit_test.go
@@ -5,11 +5,13 @@ package azeventhubs
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +41,43 @@ func TestUnit_PartitionClient_PrefetchOff(t *testing.T) {
 	require.Equal(t, []uint32{uint32(3)}, ns.Receiver.IssuedCredit, "Non-prefetch scenarios will issue credit at the time of request")
 	require.Equal(t, uint32(0), ns.Receiver.ActiveCredits, "All messages should have been received")
 	require.True(t, ns.Receiver.ManualCreditsSetFromOptions)
+}
+
+func TestUnit_PartitionClient_PrefetchOff_CreditLimits(t *testing.T) {
+	ns := &internal.FakeNSForPartClient{
+		Receiver: &internal.FakeAMQPReceiver{
+			Messages: fakeMessages(int(defaultMaxCreditSize)),
+		},
+	}
+
+	client, err := newPartitionClient(partitionClientArgs{
+		namespace: ns,
+	}, &PartitionClientOptions{
+		Prefetch: -1,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// can't request over the max
+	events, err := client.ReceiveEvents(ctx, int(defaultMaxCreditSize+1), nil)
+	require.EqualError(t, err, "count cannot exceed 5000")
+	require.Empty(t, events)
+
+	// can't request negative/0 credits
+	events, err = client.ReceiveEvents(ctx, 0, nil)
+	require.EqualError(t, err, "count should be greater than 0")
+	require.Empty(t, events)
+
+	events, err = client.ReceiveEvents(ctx, -1, nil)
+	require.EqualError(t, err, "count should be greater than 0")
+	require.Empty(t, events)
+
+	// can request the max
+	events, err = client.ReceiveEvents(ctx, int(defaultMaxCreditSize), nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, events)
 }
 
 func TestUnit_PartitionClient_PrefetchOffOnlyBackfillsCredits(t *testing.T) {
@@ -115,4 +154,78 @@ func TestUnit_PartitionClient_PrefetchOn(t *testing.T) {
 
 		require.Equal(t, uint32(td.initialCredits-3), ns.Receiver.ActiveCredits, "All messages should have been received")
 	}
+}
+
+func TestUnit_PartitionClient_PrefetchLimit(t *testing.T) {
+	newPartitionClient := func(prefetch int32) (*PartitionClient, error) {
+		ns := &internal.FakeNSForPartClient{
+			Receiver: &internal.FakeAMQPReceiver{
+				Messages: fakeMessages(int(defaultMaxCreditSize) + 1),
+			},
+		}
+
+		client, err := newPartitionClient(partitionClientArgs{namespace: ns}, &PartitionClientOptions{
+			Prefetch: prefetch,
+		})
+
+		return client, err
+	}
+
+	t.Run("max allowed credits is defaultMaxCreditSize", func(t *testing.T) {
+		client, err := newPartitionClient(int32(defaultMaxCreditSize))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		test.RequireClose(t, client)
+	})
+
+	t.Run("can't request zero or negative credits", func(t *testing.T) {
+		client, err := newPartitionClient(int32(defaultMaxCreditSize))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		events, err := client.ReceiveEvents(context.Background(), 0, nil)
+		require.EqualError(t, err, "count should be greater than 0")
+		require.Empty(t, events)
+
+		events, err = client.ReceiveEvents(context.Background(), -1, nil)
+		require.EqualError(t, err, "count should be greater than 0")
+		require.Empty(t, events)
+
+		test.RequireClose(t, client)
+	})
+
+	t.Run("can receive more than defaultMaxCreditSize in prefetch mode", func(t *testing.T) {
+		client, err := newPartitionClient(0)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// if you're using prefetch it's fine to ask for more than the `defaultMaxCreditSize`
+		// since it doesn't actually cause to request more credits than is allowed.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		events, err := client.ReceiveEvents(ctx, int(defaultMaxCreditSize+1), nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, events)
+
+		test.RequireClose(t, client)
+	})
+
+	t.Run("can't set a option.Prefetch > defaultMaxCreditSize", func(t *testing.T) {
+		// and you can't create a PartitionClient that uses more credits than allowed.
+		client, err := newPartitionClient(int32(defaultMaxCreditSize) + 1)
+		require.EqualError(t, err, fmt.Sprintf("options.Prefetch cannot exceed %d", defaultMaxCreditSize))
+		require.Nil(t, client)
+	})
+}
+
+func fakeMessages(count int) []*amqp.Message {
+	var messages []*amqp.Message
+
+	for i := 0; i < count; i++ {
+		messages = append(messages, &amqp.Message{})
+	}
+
+	return messages
 }


### PR DESCRIPTION
The current go-amqp can have issues if your active credits are greater than the session window size. We have a blocking-release bug here: https://github.com/Azure/go-amqp/issues/240.

I've also added validation to prevent asking for <= 0 credits as well, which isn't supported.