### PR TITLE
Show SDK log for CI test

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -66,6 +66,7 @@ steps:
       PROXY_CERT: $(Build.SourcesDirectory)/eng/common/testproxy/dotnet-devcert.crt
       ${{ insert }}: ${{ parameters.EnvVars }}
       GOTRACEBACK: all
+      AZURE_SDK_GO_LOGGING: all
 
   - task: PowerShell@2
     displayName: 'Build Performance Tests'


### PR DESCRIPTION
To make the debug of CI occasionally failure easier.