### PR TITLE
[azeventhubs] Client identifier support

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.5.1 (Unreleased)
+## 0.6.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added the `ConsumerClientOptions.Identifier` field. This optional field can enhance error messages from 
+- Added the `ConsumerClientOptions.InstanceID` field. This optional field can enhance error messages from 
   Event Hubs. For example, error messages related to ownership changes for a partition will contain the 
   name of the link that has taken ownership, which can help with traceability.
 

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features Added
 
+- Added the `ConsumerClientOptions.Identifier` field. This optional field can enhance error messages from 
+  Event Hubs. For example, error messages related to ownership changes for a partition will contain the 
+  name of the link that has taken ownership, which can help with traceability.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Breaking Changes
 
+- `ConsumerClient.ID()` renamed to `ConsumerClient.InstanceID()`.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -65,10 +65,10 @@ type ConsumerClient struct {
 	consumerGroup string
 	eventHub      string
 
-	// identifier is a customer supplied identifier that can be passed to Event Hubs.
+	// instanceID is a customer supplied instanceID that can be passed to Event Hubs.
 	// It'll be returned in error messages and can be useful for customers when
 	// troubleshooting.
-	identifier string
+	instanceID string
 
 	links        *internal.Links[amqpwrap.AMQPReceiverCloser]
 	namespace    *internal.Namespace
@@ -150,7 +150,7 @@ func (cc *ConsumerClient) NewPartitionClient(partitionID string, options *Partit
 		namespace:     cc.namespace,
 		eventHub:      cc.eventHub,
 		partitionID:   partitionID,
-		identifier:    cc.identifier,
+		instanceID:    cc.instanceID,
 		consumerGroup: cc.consumerGroup,
 		retryOptions:  cc.retryOptions,
 	}, options)
@@ -182,7 +182,7 @@ func (cc *ConsumerClient) GetPartitionProperties(ctx context.Context, partitionI
 
 // InstanceID is the identifier for this ConsumerClient.
 func (cc *ConsumerClient) InstanceID() string {
-	return cc.identifier
+	return cc.instanceID
 }
 
 type consumerClientDetails struct {
@@ -197,7 +197,7 @@ func (cc *ConsumerClient) getDetails() consumerClientDetails {
 		FullyQualifiedNamespace: cc.namespace.FQDN,
 		ConsumerGroup:           cc.consumerGroup,
 		EventHubName:            cc.eventHub,
-		ClientID:                cc.identifier,
+		ClientID:                cc.InstanceID(),
 	}
 }
 
@@ -231,7 +231,7 @@ func newConsumerClient(args consumerClientArgs, options *ConsumerClientOptions) 
 	client := &ConsumerClient{
 		consumerGroup: args.consumerGroup,
 		eventHub:      args.eventHub,
-		identifier:    identifier,
+		instanceID:    identifier,
 	}
 
 	var nsOptions []internal.NamespaceOption

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -39,11 +39,13 @@ const (
 
 // ConsumerClientOptions configures optional parameters for a ConsumerClient.
 type ConsumerClientOptions struct {
-	// TLSConfig configures a client with a custom *tls.Config.
-	TLSConfig *tls.Config
-
-	// Application ID that will be passed to the namespace.
+	// ApplicationID is used as the identifier when setting the User-Agent property.
 	ApplicationID string
+
+	// Identifier is a unique name used to identify the consumer. This can help with
+	// diagnostics as this name will be returned in error messages. By default,
+	// an identifier will be automatically generated.
+	Identifier string
 
 	// NewWebSocketConn is a function that can create a net.Conn for use with websockets.
 	// For an example, see ExampleNewClient_usingWebsockets() function in example_client_test.go.
@@ -52,6 +54,9 @@ type ConsumerClientOptions struct {
 	// RetryOptions controls how often operations are retried from this client and any
 	// Receivers and Senders created from this client.
 	RetryOptions RetryOptions
+
+	// TLSConfig configures a client with a custom *tls.Config.
+	TLSConfig *tls.Config
 }
 
 // ConsumerClient can create PartitionClient instances, which can read events from
@@ -59,11 +64,15 @@ type ConsumerClientOptions struct {
 type ConsumerClient struct {
 	consumerGroup string
 	eventHub      string
-	retryOptions  RetryOptions
-	namespace     *internal.Namespace
-	links         *internal.Links[amqpwrap.AMQPReceiverCloser]
 
-	clientID string
+	// identifier is a customer supplied identifier that can be passed to Event Hubs.
+	// It'll be returned in error messages and can be useful for customers when
+	// troubleshooting.
+	identifier string
+
+	links        *internal.Links[amqpwrap.AMQPReceiverCloser]
+	namespace    *internal.Namespace
+	retryOptions RetryOptions
 }
 
 // NewConsumerClient creates a ConsumerClient which uses an azcore.TokenCredential for authentication. You
@@ -141,6 +150,7 @@ func (cc *ConsumerClient) NewPartitionClient(partitionID string, options *Partit
 		namespace:     cc.namespace,
 		eventHub:      cc.eventHub,
 		partitionID:   partitionID,
+		identifier:    cc.identifier,
 		consumerGroup: cc.consumerGroup,
 		retryOptions:  cc.retryOptions,
 	}, options)
@@ -172,7 +182,7 @@ func (cc *ConsumerClient) GetPartitionProperties(ctx context.Context, partitionI
 
 // ID is the identifier for this ConsumerClient.
 func (cc *ConsumerClient) ID() string {
-	return cc.clientID
+	return cc.identifier
 }
 
 type consumerClientDetails struct {
@@ -187,7 +197,7 @@ func (cc *ConsumerClient) getDetails() consumerClientDetails {
 		FullyQualifiedNamespace: cc.namespace.FQDN,
 		ConsumerGroup:           cc.consumerGroup,
 		EventHubName:            cc.eventHub,
-		ClientID:                cc.clientID,
+		ClientID:                cc.identifier,
 	}
 }
 
@@ -212,7 +222,7 @@ func newConsumerClient(args consumerClientArgs, options *ConsumerClientOptions) 
 		options = &ConsumerClientOptions{}
 	}
 
-	clientUUID, err := uuid.New()
+	identifier, err := getIdentifier(options.Identifier)
 
 	if err != nil {
 		return nil, err
@@ -221,7 +231,7 @@ func newConsumerClient(args consumerClientArgs, options *ConsumerClientOptions) 
 	client := &ConsumerClient{
 		consumerGroup: args.consumerGroup,
 		eventHub:      args.eventHub,
-		clientID:      clientUUID.String(),
+		identifier:    identifier,
 	}
 
 	var nsOptions []internal.NamespaceOption
@@ -262,4 +272,19 @@ func newConsumerClient(args consumerClientArgs, options *ConsumerClientOptions) 
 	client.links = internal.NewLinks[amqpwrap.AMQPReceiverCloser](tempNS, fmt.Sprintf("%s/$management", client.eventHub), nil, nil)
 
 	return client, nil
+}
+
+func getIdentifier(identifier string) (string, error) {
+	if identifier != "" {
+		return identifier, nil
+	}
+
+	// generate a new one
+	id, err := uuid.New()
+
+	if err != nil {
+		return "", err
+	}
+
+	return id.String(), nil
 }

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -222,7 +222,7 @@ func newConsumerClient(args consumerClientArgs, options *ConsumerClientOptions) 
 		options = &ConsumerClientOptions{}
 	}
 
-	identifier, err := getIdentifier(options.InstanceID)
+	instanceID, err := getInstanceID(options.InstanceID)
 
 	if err != nil {
 		return nil, err
@@ -231,7 +231,7 @@ func newConsumerClient(args consumerClientArgs, options *ConsumerClientOptions) 
 	client := &ConsumerClient{
 		consumerGroup: args.consumerGroup,
 		eventHub:      args.eventHub,
-		instanceID:    identifier,
+		instanceID:    instanceID,
 	}
 
 	var nsOptions []internal.NamespaceOption
@@ -274,9 +274,9 @@ func newConsumerClient(args consumerClientArgs, options *ConsumerClientOptions) 
 	return client, nil
 }
 
-func getIdentifier(identifier string) (string, error) {
-	if identifier != "" {
-		return identifier, nil
+func getInstanceID(optionalID string) (string, error) {
+	if optionalID != "" {
+		return optionalID, nil
 	}
 
 	// generate a new one

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -42,10 +42,10 @@ type ConsumerClientOptions struct {
 	// ApplicationID is used as the identifier when setting the User-Agent property.
 	ApplicationID string
 
-	// Identifier is a unique name used to identify the consumer. This can help with
+	// InstanceID is a unique name used to identify the consumer. This can help with
 	// diagnostics as this name will be returned in error messages. By default,
 	// an identifier will be automatically generated.
-	Identifier string
+	InstanceID string
 
 	// NewWebSocketConn is a function that can create a net.Conn for use with websockets.
 	// For an example, see ExampleNewClient_usingWebsockets() function in example_client_test.go.
@@ -180,8 +180,8 @@ func (cc *ConsumerClient) GetPartitionProperties(ctx context.Context, partitionI
 	return getPartitionProperties(ctx, cc.namespace, rpcLink.Link, cc.eventHub, partitionID, options)
 }
 
-// ID is the identifier for this ConsumerClient.
-func (cc *ConsumerClient) ID() string {
+// InstanceID is the identifier for this ConsumerClient.
+func (cc *ConsumerClient) InstanceID() string {
 	return cc.identifier
 }
 
@@ -222,7 +222,7 @@ func newConsumerClient(args consumerClientArgs, options *ConsumerClientOptions) 
 		options = &ConsumerClientOptions{}
 	}
 
-	identifier, err := getIdentifier(options.Identifier)
+	identifier, err := getIdentifier(options.InstanceID)
 
 	if err != nil {
 		return nil, err

--- a/sdk/messaging/azeventhubs/consumer_client_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_test.go
@@ -712,10 +712,10 @@ func TestConsumerClient_StartPosition_Latest(t *testing.T) {
 	}
 }
 
-func TestConsumerClient_ClientID(t *testing.T) {
+func TestConsumerClient_InstanceID(t *testing.T) {
 	testParams := test.GetConnectionParamsForTest(t)
 
-	var identifier string
+	var instanceID string
 
 	// create a partition client with owner level 1 that's fully initialized.
 	{
@@ -729,7 +729,7 @@ func TestConsumerClient_ClientID(t *testing.T) {
 
 		consumerClient, err := azeventhubs.NewConsumerClientFromConnectionString(testParams.ConnectionString, testParams.EventHubName, azeventhubs.DefaultConsumerGroup, &azeventhubs.ConsumerClientOptions{
 			// We'll just let this one be auto-generated.
-			//Identifier: "",
+			//InstanceID: "",
 		})
 		require.NoError(t, err)
 		defer test.RequireClose(t, consumerClient)
@@ -738,7 +738,7 @@ func TestConsumerClient_ClientID(t *testing.T) {
 		require.NotZero(t, parsedUUID)
 		require.NoError(t, err)
 
-		identifier = consumerClient.InstanceID()
+		instanceID = consumerClient.InstanceID()
 
 		partitionClient, err := consumerClient.NewPartitionClient("0", &azeventhubs.PartitionClientOptions{
 			OwnerLevel:    to.Ptr(int64(1)),
@@ -769,7 +769,7 @@ func TestConsumerClient_ClientID(t *testing.T) {
 
 	_, err = failedPartitionClient.ReceiveEvents(context.Background(), 1, nil)
 
-	require.Contains(t, err.Error(), fmt.Sprintf("Description: Receiver '%s' with a higher epoch '1' already exists. Receiver 'LosesBecauseOfLowOwnerLevel' with epoch 0 cannot be created. Make sure you are creating receiver with increasing epoch value to ensure connectivity, or ensure all old epoch receivers are closed or disconnected", identifier))
+	require.Contains(t, err.Error(), fmt.Sprintf("Description: Receiver '%s' with a higher epoch '1' already exists. Receiver 'LosesBecauseOfLowOwnerLevel' with epoch 0 cannot be created. Make sure you are creating receiver with increasing epoch value to ensure connectivity, or ensure all old epoch receivers are closed or disconnected", instanceID))
 }
 
 // mustSendEventsToAllPartitions sends the event given in evt to each partition in the

--- a/sdk/messaging/azeventhubs/consumer_client_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_test.go
@@ -734,11 +734,11 @@ func TestConsumerClient_ClientID(t *testing.T) {
 		require.NoError(t, err)
 		defer test.RequireClose(t, consumerClient)
 
-		parsedUUID, err := uuid.Parse(consumerClient.ID())
+		parsedUUID, err := uuid.Parse(consumerClient.InstanceID())
 		require.NotZero(t, parsedUUID)
 		require.NoError(t, err)
 
-		identifier = consumerClient.ID()
+		identifier = consumerClient.InstanceID()
 
 		partitionClient, err := consumerClient.NewPartitionClient("0", &azeventhubs.PartitionClientOptions{
 			OwnerLevel:    to.Ptr(int64(1)),
@@ -753,7 +753,7 @@ func TestConsumerClient_ClientID(t *testing.T) {
 	}
 
 	failedConsumerClient, err := azeventhubs.NewConsumerClientFromConnectionString(testParams.ConnectionString, testParams.EventHubName, azeventhubs.DefaultConsumerGroup, &azeventhubs.ConsumerClientOptions{
-		Identifier: "LosesBecauseOfLowOwnerLevel",
+		InstanceID: "LosesBecauseOfLowOwnerLevel",
 		RetryOptions: azeventhubs.RetryOptions{
 			MaxRetries: -1, // just fail immediately, don't retry.
 		},

--- a/sdk/messaging/azeventhubs/consumer_client_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_test.go
@@ -4,6 +4,7 @@ package azeventhubs_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/test"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub"
@@ -710,6 +712,66 @@ func TestConsumerClient_StartPosition_Latest(t *testing.T) {
 	}
 }
 
+func TestConsumerClient_ClientID(t *testing.T) {
+	testParams := test.GetConnectionParamsForTest(t)
+
+	var identifier string
+
+	// create a partition client with owner level 1 that's fully initialized.
+	{
+		producerClient, err := azeventhubs.NewProducerClientFromConnectionString(testParams.ConnectionString, testParams.EventHubName, nil)
+		require.NoError(t, err)
+		defer test.RequireClose(t, producerClient)
+
+		props := sendEventToPartition(t, producerClient, "0", []*azeventhubs.EventData{
+			{Body: []byte("hello")},
+		})
+
+		consumerClient, err := azeventhubs.NewConsumerClientFromConnectionString(testParams.ConnectionString, testParams.EventHubName, azeventhubs.DefaultConsumerGroup, &azeventhubs.ConsumerClientOptions{
+			// We'll just let this one be auto-generated.
+			//Identifier: "",
+		})
+		require.NoError(t, err)
+		defer test.RequireClose(t, consumerClient)
+
+		parsedUUID, err := uuid.Parse(consumerClient.ID())
+		require.NotZero(t, parsedUUID)
+		require.NoError(t, err)
+
+		identifier = consumerClient.ID()
+
+		partitionClient, err := consumerClient.NewPartitionClient("0", &azeventhubs.PartitionClientOptions{
+			OwnerLevel:    to.Ptr(int64(1)),
+			StartPosition: getStartPosition(props),
+		})
+		require.NoError(t, err)
+
+		// receive an event so we know the link is alive.
+		events, err := partitionClient.ReceiveEvents(context.Background(), 1, nil)
+		require.NotEmpty(t, events)
+		require.NoError(t, err)
+	}
+
+	failedConsumerClient, err := azeventhubs.NewConsumerClientFromConnectionString(testParams.ConnectionString, testParams.EventHubName, azeventhubs.DefaultConsumerGroup, &azeventhubs.ConsumerClientOptions{
+		Identifier: "LosesBecauseOfLowOwnerLevel",
+		RetryOptions: azeventhubs.RetryOptions{
+			MaxRetries: -1, // just fail immediately, don't retry.
+		},
+	})
+	require.NoError(t, err)
+	defer test.RequireClose(t, failedConsumerClient)
+
+	failedPartitionClient, err := failedConsumerClient.NewPartitionClient("0", &azeventhubs.PartitionClientOptions{
+		// the other partition client already has the partition open with owner level 1. So our attempt to connect will fail.
+		OwnerLevel: to.Ptr(int64(0)),
+	})
+	require.NoError(t, err)
+
+	_, err = failedPartitionClient.ReceiveEvents(context.Background(), 1, nil)
+
+	require.Contains(t, err.Error(), fmt.Sprintf("Description: Receiver '%s' with a higher epoch '1' already exists. Receiver 'LosesBecauseOfLowOwnerLevel' with epoch 0 cannot be created. Make sure you are creating receiver with increasing epoch value to ensure connectivity, or ensure all old epoch receivers are closed or disconnected", identifier))
+}
+
 // mustSendEventsToAllPartitions sends the event given in evt to each partition in the
 // eventHub, returning the sequence number just before the new message.
 //
@@ -741,29 +803,8 @@ func mustSendEventsToAllPartitions(t *testing.T, events []*azeventhubs.EventData
 		go func(partitionID string) {
 			defer wg.Done()
 
-			partProps, err := producer.GetPartitionProperties(context.Background(), partitionID, nil)
-			require.NoError(t, err)
+			partProps := sendEventToPartition(t, producer, partitionID, events)
 			partitionsCh <- partProps
-
-			// send the message to the partition.
-			batch, err := producer.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
-				PartitionID: &partitionID,
-			})
-			require.NoError(t, err)
-
-			for _, event := range events {
-				if event.Properties == nil {
-					event.Properties = map[string]any{}
-				}
-
-				event.Properties["DestPartitionID"] = partitionID
-
-				err = batch.AddEventData(event, nil)
-				require.NoError(t, err)
-			}
-
-			err = producer.SendEventDataBatch(context.Background(), batch, nil)
-			require.NoError(t, err)
 		}(partitionID)
 	}
 
@@ -801,4 +842,37 @@ func getSortedBodies(events []*azeventhubs.ReceivedEventData) []string {
 	}
 
 	return bodies
+}
+
+func sendEventToPartition(t *testing.T, producer *azeventhubs.ProducerClient, partitionID string, events []*azeventhubs.EventData) azeventhubs.PartitionProperties {
+	partProps, err := producer.GetPartitionProperties(context.Background(), partitionID, nil)
+	require.NoError(t, err)
+
+	// send the message to the partition.
+	batch, err := producer.NewEventDataBatch(context.Background(), &azeventhubs.EventDataBatchOptions{
+		PartitionID: &partitionID,
+	})
+	require.NoError(t, err)
+
+	for _, event := range events {
+		eventToSend := *event
+
+		props := map[string]any{
+			"DestPartitionID": partitionID,
+		}
+
+		for k, v := range event.Properties {
+			props[k] = v
+		}
+
+		eventToSend.Properties = props
+
+		err = batch.AddEventData(event, nil)
+		require.NoError(t, err)
+	}
+
+	err = producer.SendEventDataBatch(context.Background(), batch, nil)
+	require.NoError(t, err)
+
+	return partProps
 }

--- a/sdk/messaging/azeventhubs/internal/constants.go
+++ b/sdk/messaging/azeventhubs/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v0.5.1"
+const Version = "v0.6.0"

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/processor_stress_tester.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/processor_stress_tester.go
@@ -124,7 +124,7 @@ func (inf *processorStressTest) Run(ctx context.Context) error {
 			return err
 		}
 
-		shortConsumerID := string(cc.ID()[0:5])
+		shortConsumerID := string(cc.InstanceID()[0:5])
 
 		go func() {
 			for {

--- a/sdk/messaging/azeventhubs/partition_client.go
+++ b/sdk/messaging/azeventhubs/partition_client.go
@@ -265,7 +265,7 @@ type partitionClientArgs struct {
 
 	consumerGroup string
 	eventHub      string
-	identifier    string
+	instanceID    string
 	partitionID   string
 	retryOptions  RetryOptions
 }
@@ -294,7 +294,7 @@ func newPartitionClient(args partitionClientArgs, options *PartitionClientOption
 		partitionID:      args.partitionID,
 		prefetch:         options.Prefetch,
 		retryOptions:     args.retryOptions,
-		identifier:       args.identifier,
+		identifier:       args.instanceID,
 	}
 
 	client.links = internal.NewLinks(args.namespace, fmt.Sprintf("%s/$management", client.eventHub), client.getEntityPath, client.newEventHubConsumerLink)

--- a/sdk/messaging/azeventhubs/partition_client.go
+++ b/sdk/messaging/azeventhubs/partition_client.go
@@ -63,7 +63,7 @@ type StartPosition struct {
 type PartitionClient struct {
 	consumerGroup    string
 	eventHub         string
-	identifier       string
+	instanceID       string
 	links            internal.LinksForPartitionClient[amqpwrap.AMQPReceiverCloser]
 	offsetExpression string
 	ownerLevel       *int64
@@ -207,7 +207,7 @@ func (pc *PartitionClient) newEventHubConsumerLink(ctx context.Context, session 
 		// this lets Event Hubs return error messages that identify which Receiver stole ownership (and other things) within
 		// error messages.
 		// Ex: (ownershiplost): link detached, reason: *Error{Condition: amqp:link:stolen, Description: New receiver 'EventHubConsumerClientTestID-Interloper' with higher epoch of '1' is created hence current receiver 'EventHubConsumerClientTestID' with epoch '0' is getting disconnected. If you are recreating the receiver, make sure a higher epoch is used. TrackingId:8031553f0000a5060009a59b63f517a0_G4_B22, SystemTracker:riparkdev:eventhub:tests~10922|$default, Timestamp:2023-02-21T19:12:41, Info: map[]}
-		"com.microsoft:receiver-name": pc.identifier,
+		"com.microsoft:receiver-name": pc.instanceID,
 	}
 
 	if pc.ownerLevel != nil {
@@ -220,7 +220,7 @@ func (pc *PartitionClient) newEventHubConsumerLink(ctx context.Context, session 
 			amqp.LinkFilterSelector(pc.offsetExpression),
 		},
 		Properties:    props,
-		TargetAddress: pc.identifier,
+		TargetAddress: pc.instanceID,
 	}
 
 	if pc.prefetch > 0 {
@@ -237,9 +237,9 @@ func (pc *PartitionClient) newEventHubConsumerLink(ctx context.Context, session 
 		receiverOptions.Credit = defaultMaxCreditSize
 	}
 
-	log.Writef(EventConsumer, "Creating receiver:\n  source:%s\n  identifier: %s\n  owner level: %d\n  offset: %s\n  manual: %v\n  prefetch: %d",
+	log.Writef(EventConsumer, "Creating receiver:\n  source:%s\n  instanceID: %s\n  owner level: %d\n  offset: %s\n  manual: %v\n  prefetch: %d",
 		entityPath,
-		pc.identifier,
+		pc.instanceID,
 		pc.ownerLevel,
 		pc.offsetExpression,
 		receiverOptions.ManualCredits,
@@ -294,7 +294,7 @@ func newPartitionClient(args partitionClientArgs, options *PartitionClientOption
 		partitionID:      args.partitionID,
 		prefetch:         options.Prefetch,
 		retryOptions:     args.retryOptions,
-		identifier:       args.instanceID,
+		instanceID:       args.instanceID,
 	}
 
 	client.links = internal.NewLinks(args.namespace, fmt.Sprintf("%s/$management", client.eventHub), client.getEntityPath, client.newEventHubConsumerLink)

--- a/sdk/messaging/azeventhubs/producer_client.go
+++ b/sdk/messaging/azeventhubs/producer_client.go
@@ -28,9 +28,6 @@ type RetryOptions = exported.RetryOptions
 // ProducerClientOptions contains options for the `NewProducerClient` and `NewProducerClientFromConnectionString`
 // functions.
 type ProducerClientOptions struct {
-	// TLSConfig configures a client with a custom *tls.Config.
-	TLSConfig *tls.Config
-
 	// Application ID that will be passed to the namespace.
 	ApplicationID string
 
@@ -41,15 +38,17 @@ type ProducerClientOptions struct {
 	// RetryOptions controls how often operations are retried from this client and any
 	// Receivers and Senders created from this client.
 	RetryOptions RetryOptions
+
+	// TLSConfig configures a client with a custom *tls.Config.
+	TLSConfig *tls.Config
 }
 
 // ProducerClient can be used to send events to an Event Hub.
 type ProducerClient struct {
-	retryOptions RetryOptions
-	namespace    internal.NamespaceForProducerOrConsumer
 	eventHub     string
-
-	links *internal.Links[amqpwrap.AMQPSenderCloser]
+	links        *internal.Links[amqpwrap.AMQPSenderCloser]
+	namespace    internal.NamespaceForProducerOrConsumer
+	retryOptions RetryOptions
 }
 
 // anyPartitionID is what we target if we want to send a message and let Event Hubs pick a partition
@@ -262,6 +261,10 @@ func newProducerClientImpl(creds producerClientCreds, options *ProducerClientOpt
 		}
 
 		nsOptions = append(nsOptions, internal.NamespaceWithRetryOptions(options.RetryOptions))
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	tmpNS, err := internal.NewNamespace(nsOptions...)

--- a/sdk/messaging/azeventhubs/producer_client_test.go
+++ b/sdk/messaging/azeventhubs/producer_client_test.go
@@ -530,6 +530,9 @@ func receiveEventFromAnyPartition(ctx context.Context, t *testing.T, consumer *a
 				eventCh <- events[0]
 				cancelPartitionReceiving()
 			}
+
+			t.Logf("No error returned and no events received")
+			eventCh <- nil
 		}(partitionClientContext, partProps)
 	}
 

--- a/sdk/messaging/azeventhubs/producer_client_test.go
+++ b/sdk/messaging/azeventhubs/producer_client_test.go
@@ -199,7 +199,7 @@ func testSendAny(t *testing.T, args struct {
 	require.NoError(t, err)
 
 	consumer, err := azeventhubs.NewConsumerClientFromConnectionString(testParams.ConnectionString, testParams.EventHubName, azeventhubs.DefaultConsumerGroup, &azeventhubs.ConsumerClientOptions{
-		Identifier: args.identifier,
+		InstanceID: args.identifier,
 	})
 	require.NoError(t, err)
 

--- a/sdk/messaging/azeventhubs/producer_client_test.go
+++ b/sdk/messaging/azeventhubs/producer_client_test.go
@@ -130,44 +130,44 @@ func TestProducerClient_SendToAny(t *testing.T) {
 	//    be placed into the same partition but let the overall distribution of the partition keys
 	//    happen through Event Hubs.
 
-	t.Run("no partition key, no client identifier", func(t *testing.T) {
+	t.Run("no partition key, no client instanceID", func(t *testing.T) {
 		testSendAny(t, struct {
-			identifier   string
+			instanceID   string
 			partitionKey *string
 		}{})
 	})
 
-	t.Run("no partition key, with client identifier", func(t *testing.T) {
+	t.Run("no partition key, with client instanceID", func(t *testing.T) {
 		testSendAny(t, struct {
-			identifier   string
+			instanceID   string
 			partitionKey *string
 		}{
-			identifier: "client ID",
+			instanceID: "client ID",
 		})
 	})
 
-	t.Run("actual partition key, no client identifier", func(t *testing.T) {
+	t.Run("actual partition key, no client instanceID", func(t *testing.T) {
 		testSendAny(t, struct {
-			identifier   string
+			instanceID   string
 			partitionKey *string
 		}{
 			partitionKey: to.Ptr("my special partition key"),
 		})
 	})
 
-	t.Run("actual partition key, with client identifier", func(t *testing.T) {
+	t.Run("actual partition key, with client instanceID", func(t *testing.T) {
 		testSendAny(t, struct {
-			identifier   string
+			instanceID   string
 			partitionKey *string
 		}{
-			identifier:   "client ID",
+			instanceID:   "client ID",
 			partitionKey: to.Ptr("my special partition key"),
 		})
 	})
 }
 
 func testSendAny(t *testing.T, args struct {
-	identifier   string
+	instanceID   string
 	partitionKey *string
 }) {
 	testParams := test.GetConnectionParamsForTest(t)
@@ -199,7 +199,7 @@ func testSendAny(t *testing.T, args struct {
 	require.NoError(t, err)
 
 	consumer, err := azeventhubs.NewConsumerClientFromConnectionString(testParams.ConnectionString, testParams.EventHubName, azeventhubs.DefaultConsumerGroup, &azeventhubs.ConsumerClientOptions{
-		InstanceID: args.identifier,
+		InstanceID: args.instanceID,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Event Hubs has an optional parameter you can pass that lets you identify a consumer link. This name will come back in error messages like when link ownership is contested. Given the distributed nature of consumers this identifier can help diagnose issues where consumers are battling over links.

Fixes #15074