### PR TITLE
[azeventhubs] Adding in network chaos to a few tests

### DIFF
--- a/sdk/messaging/azeventhubs/internal/eh/stress/scenarios-matrix.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/scenarios-matrix.yaml
@@ -7,38 +7,57 @@ matrix:
     batch:
       testTarget: batch
       type: "batch"
-      rounds: 100
+      rounds: 1000
       prefetch: 0
       verbose: ""
       sleepAfter: "5m"
     batchprefetchoff:
       testTarget: batch
-      rounds: 100
+      rounds: 1000
       prefetch: -1
       verbose: ""
       sleepAfter: "5m"
     batchinfinite:
       testTarget: batch
       type: "batch"
-      rounds: 100
+      rounds: 1000
       prefetch: 0
       verbose: ""
       sleepAfter: "5m"
+    batchinfinitechaos:
+      testTarget: batch
+      type: "batch"
+      rounds: 1000
+      prefetch: 0
+      verbose: ""
+      sleepAfter: "5m"
+      # this value is injected as a label value in templates/deploy-job.yaml
+      # this'll activate our standard chaos policy, which is at the bottom of that file.
+      chaos: "true"
     processor:
       testTarget: processor
-      rounds: 100
+      rounds: 1000
       prefetch: 0
       verbose: ""
       sleepAfter: "5m"
+    processorchaos:
+      testTarget: processor
+      rounds: 1000
+      prefetch: 0
+      verbose: ""
+      sleepAfter: "5m"
+      # this value is injected as a label value in templates/deploy-job.yaml
+      # this'll activate our standard chaos policy, which is at the bottom of that file.
+      chaos: "true"
     processorprefetchoff:
       testTarget: processor
-      rounds: 100
+      rounds: 1000
       prefetch: -1
       verbose: ""
       sleepAfter: "5m"
     processorinfinite:
       testTarget: processor
-      rounds: 100
+      rounds: 1000
       prefetch: 0
       verbose: ""
       sleepAfter: "5m"

--- a/sdk/messaging/azeventhubs/internal/eh/stress/templates/deploy-job.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/templates/deploy-job.yaml
@@ -5,6 +5,7 @@ metadata:
     testName: "goeh"
     # This'll make it so the resources aren't deleted on test exit.
     # Skip.RemoveTestResources: "true"
+    chaos: "{{ default false .Stress.chaos }}"
 spec:
   containers:
     - name: main
@@ -40,3 +41,37 @@ spec:
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}
 
+{{- include "stress-test-addons.chaos-wrapper.tpl" (list . "stress.network-chaos") -}}
+{{- define "stress.network-chaos" -}}
+# basically: every 5 minutes do 10s of network loss
+kind: Schedule
+apiVersion: chaos-mesh.org/v1alpha1
+spec:
+  schedule: "*/5 * * * *"
+  startingDeadlineSeconds: null
+  concurrencyPolicy: Forbid
+  historyLimit: 1
+  type: NetworkChaos
+  networkChaos:
+    selector:
+      namespaces:
+        - "{{ .Release.Namespace }}"
+      labelSelectors:
+        scenario: {{ .Stress.Scenario }}
+    mode: all
+    action: loss
+    duration: 10s
+    loss:
+      loss: '100'
+      correlation: '100'
+    direction: to
+    target:
+      selector:
+        namespaces:
+          - {{ .Release.Namespace }}
+        labelSelectors:
+          scenario: {{ .Stress.Scenario }}
+      mode: all
+    externalTargets:
+      - {{ .Stress.BaseName }}.servicebus.windows.net
+{{- end -}}


### PR DESCRIPTION
Adding in a chaos policy deployment for the Event Hubs stress tests. Also, bumped up the tests to use larger limits.

Fixes #15371