### PR TITLE
Favor custom PollingHandler when rehydrating a poller

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 * ARM's RP registration policy will no longer swallow unrecognized errors.
+* Fixed an issue in `runtime.NewPollerFromResumeToken()` when resuming a `Poller` with a custom `PollingHandler`.
 
 ### Other Changes
 

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -146,7 +146,9 @@ func NewPollerFromResumeToken[T any](token string, pl exported.Pipeline, options
 
 	opr := options.Handler
 	// now rehydrate the poller based on the encoded poller type
-	if async.CanResume(asJSON) {
+	if opr != nil {
+		log.Writef(log.EventLRO, "Resuming custom poller %T.", opr)
+	} else if async.CanResume(asJSON) {
 		opr, _ = async.New[T](pl, nil, "")
 	} else if body.CanResume(asJSON) {
 		opr, _ = body.New[T](pl, nil)
@@ -154,8 +156,6 @@ func NewPollerFromResumeToken[T any](token string, pl exported.Pipeline, options
 		opr, _ = loc.New[T](pl, nil)
 	} else if op.CanResume(asJSON) {
 		opr, _ = op.New[T](pl, nil, "")
-	} else if opr != nil {
-		log.Writef(log.EventLRO, "Resuming custom poller %T.", opr)
 	} else {
 		return nil, fmt.Errorf("unhandled poller token %s", string(raw))
 	}


### PR DESCRIPTION
This ensures that the custom handler is used in the event that the custom poller has the same shape as an in-box poller.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/20051