### PR TITLE
Add `Clone()` method for `arm/policy.ClientOptions`

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## 1.3.2 (Unreleased)
 
 ### Features Added
+* Add `Copy()` method for `arm/policy.ClientOptions`.
 
 ### Breaking Changes
 
 ### Bugs Fixed
 * ARM's RP registration policy will no longer swallow unrecognized errors.
 * Fixed an issue in `runtime.NewPollerFromResumeToken()` when resuming a `Poller` with a custom `PollingHandler`.
+* Fixed wrong policy copy in `arm/runtime.NewPipeline()`.
 
 ### Other Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.3.2 (Unreleased)
 
 ### Features Added
-* Add `Copy()` method for `arm/policy.ClientOptions`.
+* Add `Clone()` method for `arm/policy.ClientOptions`.
 
 ### Breaking Changes
 

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -47,3 +47,40 @@ type ClientOptions struct {
 	// DisableRPRegistration disables the auto-RP registration policy. Defaults to false.
 	DisableRPRegistration bool
 }
+
+// Copy return a deep copy of the current options.
+func (o *ClientOptions) Copy() *ClientOptions {
+	if o == nil {
+		return nil
+	}
+	copiedOptions := *o
+	copiedOptions.Cloud.Services = copyMap(copiedOptions.Cloud.Services)
+	copiedOptions.Logging.AllowedHeaders = copyArray(copiedOptions.Logging.AllowedHeaders)
+	copiedOptions.Logging.AllowedQueryParams = copyArray(copiedOptions.Logging.AllowedQueryParams)
+	copiedOptions.Retry.StatusCodes = copyArray(copiedOptions.Retry.StatusCodes)
+	copiedOptions.PerRetryPolicies = copyArray(copiedOptions.PerRetryPolicies)
+	copiedOptions.PerCallPolicies = copyArray(copiedOptions.PerCallPolicies)
+	return &copiedOptions
+}
+
+// copyMap return a new map with all the key value pair in the src map
+func copyMap[K comparable, V any](src map[K]V) map[K]V {
+	if src == nil {
+		return nil
+	}
+	copiedMap := make(map[K]V)
+	for k, v := range src {
+		copiedMap[k] = v
+	}
+	return copiedMap
+}
+
+// copyMap return a new array with all the elements in the src array
+func copyArray[T any](src []T) []T {
+	if src == nil {
+		return nil
+	}
+	copiedArray := make([]T, len(src))
+	copy(copiedArray, src)
+	return copiedArray
+}

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -48,8 +48,8 @@ type ClientOptions struct {
 	DisableRPRegistration bool
 }
 
-// Copy return a deep copy of the current options.
-func (o *ClientOptions) Copy() *ClientOptions {
+// Clone return a deep copy of the current options.
+func (o *ClientOptions) Clone() *ClientOptions {
 	if o == nil {
 		return nil
 	}

--- a/sdk/azcore/arm/policy/policy_test.go
+++ b/sdk/azcore/arm/policy/policy_test.go
@@ -1,3 +1,9 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package policy
 
 import (
@@ -11,7 +17,7 @@ import (
 
 func TestClientOptions_Copy(t *testing.T) {
 	var option *ClientOptions
-	require.Nil(t, option.Copy())
+	require.Nil(t, option.Clone())
 
 	option = &ClientOptions{ClientOptions: policy.ClientOptions{
 		Cloud: cloud.AzurePublic,
@@ -23,7 +29,7 @@ func TestClientOptions_Copy(t *testing.T) {
 		PerRetryPolicies: []policy.Policy{runtime.NewLogPolicy(nil)},
 		PerCallPolicies:  []policy.Policy{runtime.NewLogPolicy(nil)},
 	}}
-	copiedOption := option.Copy()
+	copiedOption := option.Clone()
 	require.Equal(t, option.APIVersion, copiedOption.APIVersion)
 	require.NotEqual(t, fmt.Sprintf("%p", &option.APIVersion), fmt.Sprintf("%p", &copiedOption.APIVersion))
 	require.Equal(t, option.Cloud.Services, copiedOption.Cloud.Services)

--- a/sdk/azcore/arm/policy/policy_test.go
+++ b/sdk/azcore/arm/policy/policy_test.go
@@ -1,0 +1,41 @@
+package policy
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestClientOptions_Copy(t *testing.T) {
+	var option *ClientOptions
+	require.Nil(t, option.Copy())
+
+	option = &ClientOptions{ClientOptions: policy.ClientOptions{
+		Cloud: cloud.AzurePublic,
+		Logging: policy.LogOptions{
+			AllowedHeaders:     []string{"test1", "test2"},
+			AllowedQueryParams: []string{"test1", "test2"},
+		},
+		Retry:            policy.RetryOptions{StatusCodes: []int{1, 2}},
+		PerRetryPolicies: []policy.Policy{runtime.NewLogPolicy(nil)},
+		PerCallPolicies:  []policy.Policy{runtime.NewLogPolicy(nil)},
+	}}
+	copiedOption := option.Copy()
+	require.Equal(t, option.APIVersion, copiedOption.APIVersion)
+	require.NotEqual(t, fmt.Sprintf("%p", &option.APIVersion), fmt.Sprintf("%p", &copiedOption.APIVersion))
+	require.Equal(t, option.Cloud.Services, copiedOption.Cloud.Services)
+	require.NotEqual(t, fmt.Sprintf("%p", option.Cloud.Services), fmt.Sprintf("%p", copiedOption.Cloud.Services))
+	require.Equal(t, option.Logging.AllowedHeaders, copiedOption.Logging.AllowedHeaders)
+	require.NotEqual(t, fmt.Sprintf("%p", option.Logging.AllowedHeaders), fmt.Sprintf("%p", copiedOption.Logging.AllowedHeaders))
+	require.Equal(t, option.Logging.AllowedQueryParams, copiedOption.Logging.AllowedQueryParams)
+	require.NotEqual(t, fmt.Sprintf("%p", option.Logging.AllowedQueryParams), fmt.Sprintf("%p", copiedOption.Logging.AllowedQueryParams))
+	require.Equal(t, option.Retry.StatusCodes, copiedOption.Retry.StatusCodes)
+	require.NotEqual(t, fmt.Sprintf("%p", option.Retry.StatusCodes), fmt.Sprintf("%p", copiedOption.Retry.StatusCodes))
+	require.Equal(t, option.PerRetryPolicies, copiedOption.PerRetryPolicies)
+	require.NotEqual(t, fmt.Sprintf("%p", option.PerRetryPolicies), fmt.Sprintf("%p", copiedOption.PerRetryPolicies))
+	require.Equal(t, option.PerCallPolicies, copiedOption.PerCallPolicies)
+	require.NotEqual(t, fmt.Sprintf("%p", option.PerCallPolicies), fmt.Sprintf("%p", copiedOption.PerCallPolicies))
+}

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -29,7 +29,7 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 		return azruntime.Pipeline{}, err
 	}
 	authPolicy := NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{Scopes: []string{conf.Audience + "/.default"}})
-	perRetry := make([]azpolicy.Policy, 0, len(plOpts.PerRetry)+1)
+	perRetry := make([]azpolicy.Policy, len(plOpts.PerRetry), len(plOpts.PerRetry)+1)
 	copy(perRetry, plOpts.PerRetry)
 	plOpts.PerRetry = append(perRetry, authPolicy)
 	if !options.DisableRPRegistration {
@@ -38,7 +38,7 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 		if err != nil {
 			return azruntime.Pipeline{}, err
 		}
-		perCall := make([]azpolicy.Policy, 0, len(plOpts.PerCall)+1)
+		perCall := make([]azpolicy.Policy, len(plOpts.PerCall), len(plOpts.PerCall)+1)
 		copy(perCall, plOpts.PerCall)
 		plOpts.PerCall = append(perCall, regPolicy)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md

Also fix a bug for `arm/runtime.NewPipeline`.