### PR TITLE
Prepare azcore v1.5.0-beta.1 for release

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.5.0-beta.1 (2023-03-02)
+
+### Features Added
+* This release includes the features added in v1.4.0-beta.1
+
 ## 1.4.0 (2023-03-02)
 > This release doesn't include features added in v1.4.0-beta.1. They will return in v1.5.0-beta.1.
 

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -32,5 +32,5 @@ const (
 	Module = "azcore"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.4.0-beta.2"
+	Version = "v1.5.0-beta.1"
 )


### PR DESCRIPTION
The target branch here is `release/azcore-1.4.0-beta` with the latest `main` merged in, so v1.5.0-beta.1 combines v1.4.0-beta.1 and the released v1.4.0.