### PR TITLE
[azservicebus,azeventhubs] Updating code coverage numbers to reflect what they are today

### DIFF
--- a/eng/config.json
+++ b/eng/config.json
@@ -70,8 +70,12 @@
             "CoverageGoal": 0.10
         },
         {
+            "Name": "messaging/azservicebus",
+            "CoverageGoal": 0.50
+        },
+        {
             "Name": "messaging/azeventhubs",
-            "CoverageGoal": 0.0
+            "CoverageGoal": 0.60
         },
         {
             "Name": "messaging/internal",


### PR DESCRIPTION
We're not at the target of 90% set in #15756 but we can document where we're at currently.