### PR TITLE
Support profile directory as top level directory for package properties

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -39,7 +39,7 @@ function Get-GoModuleProperties($goModPath)
   $goModPath = $goModPath -replace "\\", "/"
   # We should keep this regex in sync with what is in the azure-sdk repo at https://github.com/Azure/azure-sdk/blob/main/eng/scripts/Query-Azure-Packages.ps1#L227
   # The serviceName named capture group is unused but used in azure-sdk, so it's kept here for parity
-  if ($goModPath -match "(?<modPath>sdk/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
+  if ($goModPath -match "(?<modPath>(sdk|profile)/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
   {
     $modPath = $matches["modPath"]
     $modName = $matches["modName"] # We may need to start reading this from the go.mod file if the path and mod config start to differ


### PR DESCRIPTION
Change to support https://github.com/Azure/azure-sdk-for-go/pull/18841, see [discussion](https://github.com/Azure/azure-sdk-for-go/pull/18841#issuecomment-1451179175).

Paired with https://github.com/Azure/azure-sdk/pull/5748