### PR TITLE
Add RetryOptions.Predicate field

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.1 (Unreleased)
 
 ### Features Added
+* Added `Predicate` to `policy.RetryOptions` for finer-grained control over when to retry.
 
 ### Breaking Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.4.1 (Unreleased)
 
 ### Features Added
-* Added `Predicate` to `policy.RetryOptions` for finer-grained control over when to retry.
+* Added `ShouldRetry` to `policy.RetryOptions` for finer-grained control over when to retry.
 
 ### Breaking Changes
 

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -113,6 +113,14 @@ type RetryOptions struct {
 	// Specifying values will replace the default values.
 	// Specifying an empty slice will disable retries for HTTP status codes.
 	StatusCodes []int
+
+	// Predicate evaluates if the retry policy should retry the request.
+	// When present, the Predicate overrides comparison against the list of
+	// HTTP status codes and error checking within the retry policy. Context
+	// and NonRetriable errors remain evaluated before the Predicate.
+	// The *http.Response and error parameters are mutually exclusive.
+	// A return value of true means the retry policy should retry.
+	Predicate func(*http.Response, error) bool
 }
 
 // TelemetryOptions configures the telemetry policy's behavior.

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -114,13 +114,14 @@ type RetryOptions struct {
 	// Specifying an empty slice will disable retries for HTTP status codes.
 	StatusCodes []int
 
-	// Predicate evaluates if the retry policy should retry the request.
-	// When present, the Predicate overrides comparison against the list of
+	// ShouldRetry evaluates if the retry policy should retry the request.
+	// When specified, the function overrides comparison against the list of
 	// HTTP status codes and error checking within the retry policy. Context
-	// and NonRetriable errors remain evaluated before the Predicate.
-	// The *http.Response and error parameters are mutually exclusive.
+	// and NonRetriable errors remain evaluated before calling ShouldRetry.
+	// The *http.Response and error parameters are mutually exclusive, i.e.
+	// if one is nil, the other is not nil.
 	// A return value of true means the retry policy should retry.
-	Predicate func(*http.Response, error) bool
+	ShouldRetry func(*http.Response, error) bool
 }
 
 // TelemetryOptions configures the telemetry policy's behavior.

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -161,9 +161,9 @@ func (p *retryPolicy) Do(req *policy.Request) (resp *http.Response, err error) {
 			return
 		}
 
-		if options.Predicate != nil {
+		if options.ShouldRetry != nil {
 			// a non-nil Predicate overrides our HTTP status code check
-			if !options.Predicate(resp, err) {
+			if !options.ShouldRetry(resp, err) {
 				// predicate says we shouldn't retry
 				log.Write(log.EventRetryPolicy, "exit due to Predicate")
 				return

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -162,10 +162,10 @@ func (p *retryPolicy) Do(req *policy.Request) (resp *http.Response, err error) {
 		}
 
 		if options.ShouldRetry != nil {
-			// a non-nil Predicate overrides our HTTP status code check
+			// a non-nil ShouldRetry overrides our HTTP status code check
 			if !options.ShouldRetry(resp, err) {
 				// predicate says we shouldn't retry
-				log.Write(log.EventRetryPolicy, "exit due to Predicate")
+				log.Write(log.EventRetryPolicy, "exit due to ShouldRetry")
 				return
 			}
 		} else if err == nil && !HasStatusCode(resp, options.StatusCodes...) {

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -672,14 +672,14 @@ func TestRetryPolicySuccessWithPerTryTimeoutNoRetryWithBodyDownload(t *testing.T
 	require.Equal(t, largeBody, body)
 }
 
-func TestRetryPolicyWithPredicateNoRetry(t *testing.T) {
+func TestRetryPolicyWithShouldRetryNoRetry(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
 
 	pl := exported.NewPipeline(srv, NewRetryPolicy(&policy.RetryOptions{
 		RetryDelay: time.Millisecond,
-		Predicate: func(r *http.Response, err error) bool {
+		ShouldRetry: func(r *http.Response, err error) bool {
 			return r.StatusCode != http.StatusRequestTimeout
 		},
 	}))
@@ -691,7 +691,7 @@ func TestRetryPolicyWithPredicateNoRetry(t *testing.T) {
 	require.EqualValues(t, 1, srv.Requests())
 }
 
-func TestRetryPolicyWithPredicateRetry(t *testing.T) {
+func TestRetryPolicyWithShouldRetryRetry(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
@@ -699,7 +699,7 @@ func TestRetryPolicyWithPredicateRetry(t *testing.T) {
 
 	pl := exported.NewPipeline(srv, NewRetryPolicy(&policy.RetryOptions{
 		RetryDelay: time.Millisecond,
-		Predicate: func(r *http.Response, err error) bool {
+		ShouldRetry: func(r *http.Response, err error) bool {
 			return r.StatusCode == http.StatusRequestTimeout
 		},
 	}))

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -697,9 +697,11 @@ func TestRetryPolicyWithShouldRetryRetry(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
 	srv.AppendResponse()
 
+	shouldRetryCalled := false
 	pl := exported.NewPipeline(srv, NewRetryPolicy(&policy.RetryOptions{
 		RetryDelay: time.Millisecond,
 		ShouldRetry: func(r *http.Response, err error) bool {
+			shouldRetryCalled = true
 			return r.StatusCode == http.StatusRequestTimeout
 		},
 	}))
@@ -707,6 +709,7 @@ func TestRetryPolicyWithShouldRetryRetry(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := pl.Do(req)
 	require.NoError(t, err)
+	require.True(t, shouldRetryCalled)
 	require.EqualValues(t, http.StatusOK, resp.StatusCode)
 	require.EqualValues(t, 2, srv.Requests())
 }


### PR DESCRIPTION
Allows for finer-grained control over when to retry.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
