### PR TITLE
Adding MD5 from UploadFileOptions

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Added TransactionalContentMD5 to UploadOptions and CommitBlockListOptions. Fixes [20092](https://github.com/Azure/azure-sdk-for-go/issues/20092).
 
 ### Other Changes
 

--- a/sdk/storage/azblob/blockblob/models.go
+++ b/sdk/storage/azblob/blockblob/models.go
@@ -228,24 +228,26 @@ func (o *uploadFromReaderOptions) getStageBlockOptions() *StageBlockOptions {
 
 func (o *uploadFromReaderOptions) getUploadBlockBlobOptions() *UploadOptions {
 	return &UploadOptions{
-		Tags:             o.Tags,
-		Metadata:         o.Metadata,
-		Tier:             o.AccessTier,
-		HTTPHeaders:      o.HTTPHeaders,
-		AccessConditions: o.AccessConditions,
-		CPKInfo:          o.CPKInfo,
-		CPKScopeInfo:     o.CPKScopeInfo,
+		Tags:                    o.Tags,
+		Metadata:                o.Metadata,
+		Tier:                    o.AccessTier,
+		TransactionalContentMD5: o.TransactionalContentMD5,
+		HTTPHeaders:             o.HTTPHeaders,
+		AccessConditions:        o.AccessConditions,
+		CPKInfo:                 o.CPKInfo,
+		CPKScopeInfo:            o.CPKScopeInfo,
 	}
 }
 
 func (o *uploadFromReaderOptions) getCommitBlockListOptions() *CommitBlockListOptions {
 	return &CommitBlockListOptions{
-		Tags:         o.Tags,
-		Metadata:     o.Metadata,
-		Tier:         o.AccessTier,
-		HTTPHeaders:  o.HTTPHeaders,
-		CPKInfo:      o.CPKInfo,
-		CPKScopeInfo: o.CPKScopeInfo,
+		Tags:                    o.Tags,
+		Metadata:                o.Metadata,
+		Tier:                    o.AccessTier,
+		TransactionalContentMD5: o.TransactionalContentMD5,
+		HTTPHeaders:             o.HTTPHeaders,
+		CPKInfo:                 o.CPKInfo,
+		CPKScopeInfo:            o.CPKScopeInfo,
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-go/issues/20092

Adds MD5 from UploadFileOptions to UploadOptions and CommitBlockListOptions. 

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
