### PR TITLE
Synchronize goroutines within GetToken

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Credentials now synchronize within `GetToken()` so a single instance can be shared among goroutines
+  ([#20044](https://github.com/Azure/azure-sdk-for-go/issues/20044))
 
 ### Other Changes
 

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -94,41 +93,6 @@ var getPublicClient = func(clientID, tenantID string, co *azcore.ClientOptions, 
 		o = append(o, public.WithInstanceDiscovery(false))
 	}
 	return public.New(clientID, o...)
-}
-
-// resolveAdditionallyAllowedTenants returns a copy of tenants, simplified when tenants contains a wildcard
-func resolveAdditionallyAllowedTenants(tenants []string) []string {
-	if len(tenants) == 0 {
-		return nil
-	}
-	for _, t := range tenants {
-		// a wildcard makes all other values redundant
-		if t == "*" {
-			return []string{"*"}
-		}
-	}
-	cp := make([]string, len(tenants))
-	copy(cp, tenants)
-	return cp
-}
-
-// resolveTenant returns the correct tenant for a token request given a credential's configuration
-func resolveTenant(defaultTenant, reqTenant string, allowedTenants []string) (string, error) {
-	if reqTenant == "" || reqTenant == defaultTenant {
-		return defaultTenant, nil
-	}
-	if defaultTenant == "adfs" {
-		return "", errors.New("ADFS doesn't support tenants")
-	}
-	if !validTenantID(reqTenant) {
-		return "", errors.New(tenantIDValidationErr)
-	}
-	for _, tenant := range allowedTenants {
-		if tenant == "*" || tenant == reqTenant {
-			return reqTenant, nil
-		}
-	}
-	return "", fmt.Errorf(`this credential isn't configured to acquire tokens for tenant "%s". To enable acquiring tokens for this tenant add it to the AdditionallyAllowedTenants on the credential options, or add "*" to allow acquiring tokens for any tenant`, reqTenant)
 }
 
 // setAuthorityHost initializes the authority host for credentials. Precedence is:

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -340,7 +340,7 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 						AdditionallyAllowedTenants: test.allowed,
 						tokenProvider: func(ctx context.Context, resource, tenantID string) ([]byte, error) {
 							if tenantID != test.expected {
-								t.Fatalf(`unexpected tenantID "%s"`, tenantID)
+								t.Logf(`unexpected tenantID "%s"`, tenantID)
 							}
 							return mockCLITokenProviderSuccess(ctx, resource, tenantID)
 						},
@@ -652,55 +652,6 @@ func TestClaims(t *testing.T) {
 				}
 			})
 		}
-	}
-}
-
-func TestResolveTenant(t *testing.T) {
-	defaultTenant := "default-tenant"
-	otherTenant := "other-tenant"
-	for _, test := range []struct {
-		allowed          []string
-		expected, tenant string
-		expectError      bool
-	}{
-		// no alternate tenant specified -> should get default
-		{expected: defaultTenant},
-		{allowed: []string{""}, expected: defaultTenant},
-		{allowed: []string{"*"}, expected: defaultTenant},
-		{allowed: []string{otherTenant}, expected: defaultTenant},
-
-		// alternate tenant specified and allowed -> should get that tenant
-		{allowed: []string{"*"}, expected: otherTenant, tenant: otherTenant},
-		{allowed: []string{otherTenant}, expected: otherTenant, tenant: otherTenant},
-		{allowed: []string{"not-" + otherTenant, otherTenant}, expected: otherTenant, tenant: otherTenant},
-		{allowed: []string{"not-" + otherTenant, "*"}, expected: otherTenant, tenant: otherTenant},
-
-		// invalid or not allowed tenant -> should get an error
-		{tenant: otherTenant, expectError: true},
-		{allowed: []string{""}, tenant: otherTenant, expectError: true},
-		{allowed: []string{defaultTenant}, tenant: otherTenant, expectError: true},
-		{tenant: badTenantID, expectError: true},
-		{allowed: []string{""}, tenant: badTenantID, expectError: true},
-		{allowed: []string{"*", badTenantID}, tenant: badTenantID, expectError: true},
-		{tenant: "invalid@tenant", expectError: true},
-		{tenant: "invalid/tenant", expectError: true},
-		{tenant: "invalid(tenant", expectError: true},
-		{tenant: "invalid:tenant", expectError: true},
-	} {
-		t.Run("", func(t *testing.T) {
-			tenant, err := resolveTenant(defaultTenant, test.tenant, test.allowed)
-			if err != nil {
-				if test.expectError {
-					return
-				}
-				t.Fatal(err)
-			} else if test.expectError {
-				t.Fatal("expected an error")
-			}
-			if tenant != test.expected {
-				t.Fatalf(`expected "%s", got "%s"`, test.expected, tenant)
-			}
-		})
 	}
 }
 

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -340,7 +340,7 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 						AdditionallyAllowedTenants: test.allowed,
 						tokenProvider: func(ctx context.Context, resource, tenantID string) ([]byte, error) {
 							if tenantID != test.expected {
-								t.Logf(`unexpected tenantID "%s"`, tenantID)
+								t.Errorf(`unexpected tenantID "%s"`, tenantID)
 							}
 							return mockCLITokenProviderSuccess(ctx, resource, tenantID)
 						},

--- a/sdk/azidentity/client_assertion_credential.go
+++ b/sdk/azidentity/client_assertion_credential.go
@@ -24,11 +24,8 @@ const credNameAssertion = "ClientAssertionCredential"
 //
 // [Azure AD documentation]: https://docs.microsoft.com/azure/active-directory/develop/active-directory-certificate-credentials#assertion-format
 type ClientAssertionCredential struct {
-	additionallyAllowedTenants []string
-	client                     confidentialClient
-	// name enables replacing "ClientAssertionCredential" with "WorkloadIdentityCredential" in log messages
-	name   string
-	tenant string
+	client confidentialClient
+	s      *syncer
 }
 
 // ClientAssertionCredentialOptions contains optional parameters for ClientAssertionCredential.
@@ -60,34 +57,23 @@ func NewClientAssertionCredential(tenantID, clientID string, getAssertion func(c
 	if err != nil {
 		return nil, err
 	}
-	return &ClientAssertionCredential{
-		additionallyAllowedTenants: resolveAdditionallyAllowedTenants(options.AdditionallyAllowedTenants),
-		client:                     c,
-		name:                       credNameAssertion,
-		tenant:                     tenantID,
-	}, nil
+	cac := ClientAssertionCredential{client: c}
+	cac.s = newSyncer(credNameAssertion, tenantID, options.AdditionallyAllowedTenants, cac.requestToken, cac.silentAuth)
+	return &cac, nil
 }
 
 // GetToken requests an access token from Azure Active Directory. This method is called automatically by Azure SDK clients.
 func (c *ClientAssertionCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	if len(opts.Scopes) == 0 {
-		return azcore.AccessToken{}, errors.New(credNameAssertion + ": GetToken() requires at least one scope")
-	}
-	tenant, err := resolveTenant(c.tenant, opts.TenantID, c.additionallyAllowedTenants)
-	if err != nil {
-		return azcore.AccessToken{}, err
-	}
-	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(tenant))
-	if err == nil {
-		logGetTokenSuccessImpl(c.name, opts)
-		return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
-	}
+	return c.s.GetToken(ctx, opts)
+}
 
-	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(tenant))
-	if err != nil {
-		return azcore.AccessToken{}, newAuthenticationFailedErrorFromMSALError(c.name, err)
-	}
-	logGetTokenSuccessImpl(c.name, opts)
+func (c *ClientAssertionCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(opts.TenantID))
+	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
+}
+
+func (c *ClientAssertionCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -39,9 +39,8 @@ type ClientCertificateCredentialOptions struct {
 
 // ClientCertificateCredential authenticates a service principal with a certificate.
 type ClientCertificateCredential struct {
-	additionallyAllowedTenants []string
-	client                     confidentialClient
-	tenant                     string
+	client confidentialClient
+	s      *syncer
 }
 
 // NewClientCertificateCredential constructs a ClientCertificateCredential. Pass nil for options to accept defaults.
@@ -65,33 +64,23 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 	if err != nil {
 		return nil, err
 	}
-	return &ClientCertificateCredential{
-		additionallyAllowedTenants: resolveAdditionallyAllowedTenants(options.AdditionallyAllowedTenants),
-		client:                     c,
-		tenant:                     tenantID,
-	}, nil
+	cc := ClientCertificateCredential{client: c}
+	cc.s = newSyncer(credNameCert, tenantID, options.AdditionallyAllowedTenants, cc.requestToken, cc.silentAuth)
+	return &cc, nil
 }
 
 // GetToken requests an access token from Azure Active Directory. This method is called automatically by Azure SDK clients.
 func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	if len(opts.Scopes) == 0 {
-		return azcore.AccessToken{}, errors.New(credNameCert + ": GetToken() requires at least one scope")
-	}
-	tenant, err := resolveTenant(c.tenant, opts.TenantID, c.additionallyAllowedTenants)
-	if err != nil {
-		return azcore.AccessToken{}, err
-	}
-	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(tenant))
-	if err == nil {
-		logGetTokenSuccess(c, opts)
-		return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
-	}
+	return c.s.GetToken(ctx, opts)
+}
 
-	ar, err = c.client.AcquireTokenByCredential(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(tenant))
-	if err != nil {
-		return azcore.AccessToken{}, newAuthenticationFailedErrorFromMSALError(credNameCert, err)
-	}
-	logGetTokenSuccess(c, opts)
+func (c *ClientCertificateCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(opts.TenantID))
+	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
+}
+
+func (c *ClientCertificateCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -295,7 +295,7 @@ func TestClientCertificateCredential_InvalidCertLive(t *testing.T) {
 		t.Fatalf("expected AuthenticationFailedError, received %T", err)
 	}
 	if !strings.HasPrefix(err.Error(), credNameCert) {
-		t.Fatal("missing credential type prefix")
+		t.Fatalf("error is missing credential type prefix: %q", err.Error())
 	}
 }
 

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -67,7 +67,6 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 			additionalTenants = strings.Split(tenants, ";")
 		}
 	}
-	additionalTenants = resolveAdditionallyAllowedTenants(additionalTenants)
 
 	envCred, err := NewEnvironmentCredential(&EnvironmentCredentialOptions{
 		ClientOptions: options.ClientOptions, DisableInstanceDiscovery: options.DisableInstanceDiscovery, additionallyAllowedTenants: additionalTenants},

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -9,6 +9,7 @@ package azidentity
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -80,7 +81,7 @@ func TestDeviceCodeCredential_UserPromptError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if err.Error() != success {
+	if expected := fmt.Sprintf("%s: %s", credNameDeviceCode, success); err.Error() != expected {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -93,7 +93,6 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 			additionalTenants = strings.Split(tenants, ";")
 		}
 	}
-	additionalTenants = resolveAdditionallyAllowedTenants(additionalTenants)
 	if clientSecret := os.Getenv(azureClientSecret); clientSecret != "" {
 		log.Write(EventAuthentication, "EnvironmentCredential will authenticate with ClientSecretCredential")
 		o := &ClientSecretCredentialOptions{

--- a/sdk/azidentity/errors.go
+++ b/sdk/azidentity/errors.go
@@ -45,11 +45,6 @@ func newAuthenticationFailedError(credType string, message string, resp *http.Re
 	return &AuthenticationFailedError{credType: credType, message: message, RawResponse: resp}
 }
 
-func newAuthenticationFailedErrorFromMSALError(credType string, err error) error {
-	res := getResponseFromError(err)
-	return newAuthenticationFailedError(credType, err.Error(), res)
-}
-
 // Error implements the error interface. Note that the message contents are not contractual and can change over time.
 func (e *AuthenticationFailedError) Error() string {
 	if e.RawResponse == nil {

--- a/sdk/azidentity/logging.go
+++ b/sdk/azidentity/logging.go
@@ -6,28 +6,9 @@
 
 package azidentity
 
-import (
-	"fmt"
-	"strings"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
-)
+import "github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 
 // EventAuthentication entries contain information about authentication.
 // This includes information like the names of environment variables
 // used when obtaining credentials and the type of credential used.
 const EventAuthentication log.Event = "Authentication"
-
-func logGetTokenSuccess(cred azcore.TokenCredential, opts policy.TokenRequestOptions) {
-	logGetTokenSuccessImpl(fmt.Sprintf("%T", cred), opts)
-}
-
-func logGetTokenSuccessImpl(credName string, opts policy.TokenRequestOptions) {
-	if log.Should(EventAuthentication) {
-		scope := strings.Join(opts.Scopes, ", ")
-		msg := fmt.Sprintf(`%s.GetToken() acquired a token for scope "%s"\n`, credName, scope)
-		log.Write(EventAuthentication, msg)
-	}
-}

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -115,12 +115,12 @@ func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.To
 }
 
 func (c *ManagedIdentityCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(opts.TenantID))
+	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes)
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 
 func (c *ManagedIdentityCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(opts.TenantID))
+	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes)
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 

--- a/sdk/azidentity/managed_identity_credential.go
+++ b/sdk/azidentity/managed_identity_credential.go
@@ -73,6 +73,7 @@ type ManagedIdentityCredentialOptions struct {
 type ManagedIdentityCredential struct {
 	client confidentialClient
 	mic    *managedIdentityClient
+	s      *syncer
 }
 
 // NewManagedIdentityCredential creates a ManagedIdentityCredential. Pass nil to accept default options.
@@ -97,7 +98,9 @@ func NewManagedIdentityCredential(options *ManagedIdentityCredentialOptions) (*M
 	if err != nil {
 		return nil, err
 	}
-	return &ManagedIdentityCredential{client: c, mic: mic}, nil
+	m := ManagedIdentityCredential{client: c, mic: mic}
+	m.s = newSyncer(credNameManagedIdentity, "", nil, m.requestToken, m.silentAuth)
+	return &m, nil
 }
 
 // GetToken requests an access token from the hosting environment. This method is called automatically by Azure SDK clients.
@@ -107,17 +110,17 @@ func (c *ManagedIdentityCredential) GetToken(ctx context.Context, opts policy.To
 		return azcore.AccessToken{}, err
 	}
 	// managed identity endpoints require an AADv1 resource (i.e. token audience), not a v2 scope, so we remove "/.default" here
-	scopes := []string{strings.TrimSuffix(opts.Scopes[0], defaultSuffix)}
-	ar, err := c.client.AcquireTokenSilent(ctx, scopes)
-	if err == nil {
-		logGetTokenSuccess(c, opts)
-		return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, nil
-	}
-	ar, err = c.client.AcquireTokenByCredential(ctx, scopes)
-	if err != nil {
-		return azcore.AccessToken{}, err
-	}
-	logGetTokenSuccess(c, opts)
+	opts.Scopes = []string{strings.TrimSuffix(opts.Scopes[0], defaultSuffix)}
+	return c.s.GetToken(ctx, opts)
+}
+
+func (c *ManagedIdentityCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(opts.TenantID))
+	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
+}
+
+func (c *ManagedIdentityCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, confidential.WithClaims(opts.Claims), confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 

--- a/sdk/azidentity/on_behalf_of_credential.go
+++ b/sdk/azidentity/on_behalf_of_credential.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
-	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -26,9 +25,9 @@ const credNameOBO = "OnBehalfOfCredential"
 //
 // [Azure Active Directory documentation]: https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow
 type OnBehalfOfCredential struct {
-	additionallyAllowedTenants []string
-	assertion, tenant          string
-	client                     confidentialClient
+	assertion string
+	client    confidentialClient
+	s         *syncer
 }
 
 // OnBehalfOfCredentialOptions contains optional parameters for OnBehalfOfCredential
@@ -79,30 +78,22 @@ func newOnBehalfOfCredential(tenantID, clientID, userAssertion string, cred conf
 	if err != nil {
 		return nil, err
 	}
-	return &OnBehalfOfCredential{
-		additionallyAllowedTenants: resolveAdditionallyAllowedTenants(options.AdditionallyAllowedTenants),
-		assertion:                  userAssertion,
-		client:                     c,
-		tenant:                     tenantID,
-	}, nil
+	obo := OnBehalfOfCredential{assertion: userAssertion, client: c}
+	obo.s = newSyncer(credNameOBO, tenantID, options.AdditionallyAllowedTenants, obo.requestToken, obo.requestToken)
+	return &obo, nil
 }
 
 // GetToken requests an access token from Azure Active Directory. This method is called automatically by Azure SDK clients.
 func (o *OnBehalfOfCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	if len(opts.Scopes) == 0 {
-		return azcore.AccessToken{}, errors.New(credNameSecret + ": GetToken() requires at least one scope")
-	}
-	tenant, err := resolveTenant(o.tenant, opts.TenantID, o.additionallyAllowedTenants)
-	if err != nil {
-		return azcore.AccessToken{}, err
-	}
+	return o.s.GetToken(ctx, opts)
+}
+
+func (o *OnBehalfOfCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	ar, err := o.client.AcquireTokenOnBehalfOf(ctx, o.assertion, opts.Scopes,
 		confidential.WithClaims(opts.Claims),
-		confidential.WithTenantID(tenant),
+		confidential.WithTenantID(opts.TenantID),
 	)
-	if err != nil {
-		return azcore.AccessToken{}, newAuthenticationFailedErrorFromMSALError(credNameOBO, err)
-	}
-	logGetTokenSuccess(o, opts)
-	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, nil
+	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
+
+var _ azcore.TokenCredential = (*OnBehalfOfCredential)(nil)

--- a/sdk/azidentity/syncer.go
+++ b/sdk/azidentity/syncer.go
@@ -1,0 +1,130 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
+)
+
+type authFn func(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error)
+
+// syncer synchronizes authentication calls so that goroutines can share a credential instance
+type syncer struct {
+	addlTenants      []string
+	authing          bool
+	cond             *sync.Cond
+	reqToken, silent authFn
+	name, tenant     string
+}
+
+func newSyncer(name, tenant string, additionalTenants []string, reqToken, silentAuth authFn) *syncer {
+	return &syncer{
+		addlTenants: resolveAdditionalTenants(additionalTenants),
+		cond:        &sync.Cond{L: &sync.Mutex{}},
+		name:        name,
+		reqToken:    reqToken,
+		silent:      silentAuth,
+		tenant:      tenant,
+	}
+}
+
+// GetToken ensures that only one goroutine authenticates at a time
+func (s *syncer) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	var at azcore.AccessToken
+	var err error
+	if len(opts.Scopes) == 0 {
+		return at, errors.New(s.name + ".GetToken() requires at least one scope")
+	}
+	// we don't resolve the tenant for managed identities because they can acquire tokens only from their home tenants
+	if s.name != credNameManagedIdentity {
+		tenant, err := s.resolveTenant(opts.TenantID)
+		if err != nil {
+			return at, err
+		}
+		opts.TenantID = tenant
+	}
+	auth := false
+	s.cond.L.Lock()
+	defer s.cond.L.Unlock()
+	for {
+		at, err = s.silent(ctx, opts)
+		if err == nil {
+			// got a token
+			break
+		}
+		if !s.authing {
+			// this goroutine will request a token
+			s.authing, auth = true, true
+			break
+		}
+		// another goroutine is acquiring a token; wait for it to finish, then try silent auth again
+		s.cond.Wait()
+	}
+	if auth {
+		s.authing = false
+		at, err = s.reqToken(ctx, opts)
+		s.cond.Broadcast()
+	}
+	if err != nil {
+		// Return credentialUnavailableError directly because that type affects the behavior of credential chains.
+		// Otherwise, return AuthenticationFailedError.
+		var unavailableErr *credentialUnavailableError
+		if !errors.As(err, &unavailableErr) {
+			res := getResponseFromError(err)
+			err = newAuthenticationFailedError(s.name, err.Error(), res)
+		}
+	} else if log.Should(EventAuthentication) {
+		scope := strings.Join(opts.Scopes, ", ")
+		msg := fmt.Sprintf(`%s.GetToken() acquired a token for scope "%s"\n`, s.name, scope)
+		log.Write(EventAuthentication, msg)
+	}
+	return at, err
+}
+
+// resolveTenant returns the correct tenant for a token request given the credential's
+// configuration, or an error when the specified tenant isn't allowed by that configuration
+func (s *syncer) resolveTenant(requested string) (string, error) {
+	if requested == "" || requested == s.tenant {
+		return s.tenant, nil
+	}
+	if s.tenant == "adfs" {
+		return "", errors.New("ADFS doesn't support tenants")
+	}
+	if !validTenantID(requested) {
+		return "", errors.New(tenantIDValidationErr)
+	}
+	for _, t := range s.addlTenants {
+		if t == "*" || t == requested {
+			return requested, nil
+		}
+	}
+	return "", fmt.Errorf(`%s isn't configured to acquire tokens for tenant %q. To enable acquiring tokens for this tenant add it to the AdditionallyAllowedTenants on the credential options, or add "*" to allow acquiring tokens for any tenant`, s.name, requested)
+}
+
+// resolveAdditionalTenants returns a copy of tenants, simplified when tenants contains a wildcard
+func resolveAdditionalTenants(tenants []string) []string {
+	if len(tenants) == 0 {
+		return nil
+	}
+	for _, t := range tenants {
+		// a wildcard makes all other values redundant
+		if t == "*" {
+			return []string{"*"}
+		}
+	}
+	cp := make([]string, len(tenants))
+	copy(cp, tenants)
+	return cp
+}

--- a/sdk/azidentity/syncer_test.go
+++ b/sdk/azidentity/syncer_test.go
@@ -1,0 +1,104 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+func TestResolveTenant(t *testing.T) {
+	defaultTenant := "default-tenant"
+	otherTenant := "other-tenant"
+	for _, test := range []struct {
+		allowed          []string
+		expected, tenant string
+		expectError      bool
+	}{
+		// no alternate tenant specified -> should get default
+		{expected: defaultTenant},
+		{allowed: []string{""}, expected: defaultTenant},
+		{allowed: []string{"*"}, expected: defaultTenant},
+		{allowed: []string{otherTenant}, expected: defaultTenant},
+
+		// alternate tenant specified and allowed -> should get that tenant
+		{allowed: []string{"*"}, expected: otherTenant, tenant: otherTenant},
+		{allowed: []string{otherTenant}, expected: otherTenant, tenant: otherTenant},
+		{allowed: []string{"not-" + otherTenant, otherTenant}, expected: otherTenant, tenant: otherTenant},
+		{allowed: []string{"not-" + otherTenant, "*"}, expected: otherTenant, tenant: otherTenant},
+
+		// invalid or not allowed tenant -> should get an error
+		{tenant: otherTenant, expectError: true},
+		{allowed: []string{""}, tenant: otherTenant, expectError: true},
+		{allowed: []string{defaultTenant}, tenant: otherTenant, expectError: true},
+		{tenant: badTenantID, expectError: true},
+		{allowed: []string{""}, tenant: badTenantID, expectError: true},
+		{allowed: []string{"*", badTenantID}, tenant: badTenantID, expectError: true},
+		{tenant: "invalid@tenant", expectError: true},
+		{tenant: "invalid/tenant", expectError: true},
+		{tenant: "invalid(tenant", expectError: true},
+		{tenant: "invalid:tenant", expectError: true},
+	} {
+		t.Run("", func(t *testing.T) {
+			s := newSyncer("", defaultTenant, test.allowed, nil, nil)
+			tenant, err := s.resolveTenant(test.tenant)
+			if err != nil {
+				if test.expectError {
+					return
+				}
+				t.Fatal(err)
+			} else if test.expectError {
+				t.Fatal("expected an error")
+			}
+			if tenant != test.expected {
+				t.Fatalf(`expected "%s", got "%s"`, test.expected, tenant)
+			}
+		})
+	}
+}
+
+func TestSyncer(t *testing.T) {
+	silentAuths, tokenRequests := 0, 0
+	s := newSyncer("", "tenant", nil,
+		func(ctx context.Context, tro policy.TokenRequestOptions) (azcore.AccessToken, error) {
+			tokenRequests++
+			return azcore.AccessToken{}, nil
+		},
+		func(ctx context.Context, tro policy.TokenRequestOptions) (azcore.AccessToken, error) {
+			var err error
+			if tokenRequests == 0 {
+				err = errors.New("cache miss")
+			}
+			silentAuths++
+			return azcore.AccessToken{}, err
+		},
+	)
+	goroutines := 50
+	wg := sync.WaitGroup{}
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			_, err := s.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if tokenRequests != 1 {
+		t.Errorf("expected 1 token request, got %d", tokenRequests)
+	}
+	if silentAuths != goroutines {
+		t.Errorf("expected %d silent auth attempts, got %d", goroutines, silentAuths)
+	}
+}

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -8,7 +8,6 @@ package azidentity
 
 import (
 	"context"
-	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -34,10 +33,10 @@ type UsernamePasswordCredentialOptions struct {
 // with any form of multi-factor authentication, and the application must already have user or admin consent.
 // This credential can only authenticate work and school accounts; it can't authenticate Microsoft accounts.
 type UsernamePasswordCredential struct {
-	account                    public.Account
-	additionallyAllowedTenants []string
-	client                     publicClient
-	password, tenant, username string
+	account            public.Account
+	client             publicClient
+	password, username string
+	s                  *syncer
 }
 
 // NewUsernamePasswordCredential creates a UsernamePasswordCredential. clientID is the ID of the application the user
@@ -50,39 +49,30 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 	if err != nil {
 		return nil, err
 	}
-	return &UsernamePasswordCredential{
-		additionallyAllowedTenants: resolveAdditionallyAllowedTenants(options.AdditionallyAllowedTenants),
-		client:                     c,
-		password:                   password,
-		tenant:                     tenantID,
-		username:                   username,
-	}, nil
+	upc := UsernamePasswordCredential{client: c, password: password, username: username}
+	upc.s = newSyncer(credNameUserPassword, tenantID, options.AdditionallyAllowedTenants, upc.requestToken, upc.silentAuth)
+	return &upc, nil
 }
 
 // GetToken requests an access token from Azure Active Directory. This method is called automatically by Azure SDK clients.
 func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	if len(opts.Scopes) == 0 {
-		return azcore.AccessToken{}, errors.New(credNameUserPassword + ": GetToken() requires at least one scope")
+	return c.s.GetToken(ctx, opts)
+}
+
+func (c *UsernamePasswordCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	ar, err := c.client.AcquireTokenByUsernamePassword(ctx, opts.Scopes, c.username, c.password, public.WithClaims(opts.Claims), public.WithTenantID(opts.TenantID))
+	if err == nil {
+		c.account = ar.Account
 	}
-	tenant, err := resolveTenant(c.tenant, opts.TenantID, c.additionallyAllowedTenants)
-	if err != nil {
-		return azcore.AccessToken{}, err
-	}
+	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
+}
+
+func (c *UsernamePasswordCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes,
 		public.WithClaims(opts.Claims),
 		public.WithSilentAccount(c.account),
-		public.WithTenantID(tenant),
+		public.WithTenantID(opts.TenantID),
 	)
-	if err == nil {
-		logGetTokenSuccess(c, opts)
-		return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
-	}
-	ar, err = c.client.AcquireTokenByUsernamePassword(ctx, opts.Scopes, c.username, c.password, public.WithClaims(opts.Claims), public.WithTenantID(tenant))
-	if err != nil {
-		return azcore.AccessToken{}, newAuthenticationFailedErrorFromMSALError(credNameUserPassword, err)
-	}
-	c.account = ar.Account
-	logGetTokenSuccess(c, opts)
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 

--- a/sdk/azidentity/workload_identity.go
+++ b/sdk/azidentity/workload_identity.go
@@ -57,7 +57,8 @@ func NewWorkloadIdentityCredential(tenantID, clientID, file string, options *Wor
 	if err != nil {
 		return nil, err
 	}
-	cred.name = credNameWorkloadIdentity
+	// we want "WorkloadIdentityCredential" in log messages, not "ClientAssertionCredential"
+	cred.s.name = credNameWorkloadIdentity
 	w.cred = cred
 	return &w, nil
 }


### PR DESCRIPTION
Sharing a credential instance among goroutines can produce redundant token requests because goroutines may race to populate the credential's cache. This PR refactors `GetToken()` into two callbacks, one for silent auth (checking the cache) and one for requesting a new token, and adds a new `syncer` type to synchronize them. (Credentials that don't distinguish checking the cache from requesting a token use the same method for both callbacks.) Credentials will allow only one goroutine to authenticate at a time, and waiting goroutines will check the cache again when they wake up. Closes #20044