### PR TITLE
generator release-v2: Automatically write tag into autorest.md and filter function parameters

### DIFF
--- a/eng/tools/generator/autorest/model/changelog.go
+++ b/eng/tools/generator/autorest/model/changelog.go
@@ -156,7 +156,7 @@ func getNewContents(c *delta.Content) []string {
 			for _, cs := range existedTypeAlias[k] {
 				aliasValue = fmt.Sprintf("%s`%s`, ", aliasValue, cs)
 			}
-			line := fmt.Sprintf("New value %s added to type alias `%s`", strings.TrimRight(strings.TrimSpace(aliasValue), ","), k)
+			line := fmt.Sprintf("New value %s added to enum type `%s`", strings.TrimRight(strings.TrimSpace(aliasValue), ","), k)
 			items = append(items, line)
 		}
 
@@ -165,7 +165,7 @@ func getNewContents(c *delta.Content) []string {
 			for _, cs := range newTypeAlias[k] {
 				aliasValue = fmt.Sprintf("%s`%s`, ", aliasValue, cs)
 			}
-			line := fmt.Sprintf("New type alias `%s` with values %s", k, strings.TrimRight(strings.TrimSpace(aliasValue), ","))
+			line := fmt.Sprintf("New enum type `%s` with values %s", k, strings.TrimRight(strings.TrimSpace(aliasValue), ","))
 			items = append(items, line)
 		}
 	}

--- a/eng/tools/generator/cmd/v2/common/changelogProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/changelogProcessor.go
@@ -277,7 +277,7 @@ func FuncFilter(changelog *model.Changelog) {
 	if changelog.Modified.HasBreakingChanges() {
 		funcOperation(changelog.Modified.BreakingChanges.Removed)
 
-		// function operation parameters from interface{} to any is not breaking
+		// function operation parameters from interface{} to any is not a breaking change
 		for f, v := range changelog.Modified.BreakingChanges.Funcs {
 			from := strings.Split(v.Params.From, ",")
 			to := strings.Split(v.Params.To, ",")

--- a/eng/tools/generator/cmd/v2/common/changelogProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/changelogProcessor.go
@@ -276,6 +276,31 @@ func FuncFilter(changelog *model.Changelog) {
 
 	if changelog.Modified.HasBreakingChanges() {
 		funcOperation(changelog.Modified.BreakingChanges.Removed)
+
+		// function operation parameters from interface{} to any is not breaking
+		for f, v := range changelog.Modified.BreakingChanges.Funcs {
+			from := strings.Split(v.Params.From, ",")
+			to := strings.Split(v.Params.To, ",")
+			if len(from) != len(to) {
+				continue
+			}
+
+			flag := false
+			for i := range from {
+				if strings.TrimSpace(from[i]) != strings.TrimSpace(to[i]) {
+					if strings.TrimSpace(from[i]) == "interface{}" && strings.TrimSpace(to[i]) == "any" {
+						flag = true
+					} else {
+						flag = false
+						break
+					}
+				}
+			}
+
+			if flag {
+				delete(changelog.Modified.BreakingChanges.Funcs, f)
+			}
+		}
 	}
 }
 

--- a/eng/tools/generator/cmd/v2/common/changelogProcessor_test.go
+++ b/eng/tools/generator/cmd/v2/common/changelogProcessor_test.go
@@ -31,7 +31,7 @@ func TestEnumFilter(t *testing.T) {
 
 	common.FilterChangelog(changelog, common.EnumFilter)
 
-	excepted := fmt.Sprint("### Breaking Changes\n\n- Type alias `EnumRemove` has been removed\n\n### Features Added\n\n- New value `EnumExistB` added to type alias `EnumExist`\n- New type alias `EnumAdd` with values `EnumAddA`, `EnumAddB`\n")
+	excepted := fmt.Sprint("### Breaking Changes\n\n- Type alias `EnumRemove` has been removed\n\n### Features Added\n\n- New value `EnumExistB` added to enum type `EnumExist`\n- New enum type `EnumAdd` with values `EnumAddA`, `EnumAddB`\n")
 	assert.Equal(t, excepted, changelog.ToCompactMarkdown())
 }
 

--- a/eng/tools/generator/cmd/v2/common/changelogProcessor_test.go
+++ b/eng/tools/generator/cmd/v2/common/changelogProcessor_test.go
@@ -142,3 +142,25 @@ func TestTypeToAny(t *testing.T) {
 	excepted := fmt.Sprint("### Breaking Changes\n\n- Type of `Client.M` has been changed from `map[string]string` to `map[string]any`\n\n### Features Added\n\n- Type of `Client.A` has been changed from `*int` to `any`\n")
 	assert.Equal(t, excepted, changelog.ToCompactMarkdown())
 }
+
+func TestFuncParameterChange(t *testing.T) {
+	oldExport, err := exports.Get("./testdata/old/parameter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newExport, err := exports.Get("./testdata/new/parameter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changelog, err := autorest.GetChangelogForPackage(&oldExport, &newExport)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	common.FilterChangelog(changelog, common.FuncFilter)
+
+	excepted := fmt.Sprint("### Breaking Changes\n\n- Function `*Client.AfterAny` parameter(s) have been changed from `(context.Context, string, string, interface{}, ClientOption)` to `(context.Context, string, string, any, Option)`\n- Function `*Client.BeforeAny` parameter(s) have been changed from `(context.Context, string, string, interface{}, ClientOption)` to `(context.Context, string, any, any, ClientOption)`\n")
+	assert.Equal(t, excepted, changelog.ToCompactMarkdown())
+}

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -417,3 +417,41 @@ func GetAlwaysSetBodyParamRequiredFlag(path string) (string, error) {
 	}
 	return "", nil
 }
+
+// AddPackageConfig add config in file
+func AddPackageConfig(path, config string) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(b), "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "tag:") {
+			lines[i] = config
+			break
+		}
+
+		// end index
+		if i == len(lines)-1 {
+			for j := len(lines) - 1; j > 0; j-- {
+				if strings.Contains(lines[j], "```") {
+					if lines[j-1] == "" {
+						lines[j-1] = config
+						break
+					} else {
+						newLines := make([]string, len(lines))
+						copy(newLines, lines)
+
+						newLines = append(newLines[:j], config)
+						tailLines := lines[j:]
+						lines = append(newLines, tailLines...)
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
+}

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -160,10 +160,19 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 	}
 
 	// remove tag set
-	if generateParam.RemoveTagSet {
+	if generateParam.RemoveTagSet && generateParam.NamespaceConfig == "" {
 		log.Printf("Remove tag set for swagger config in `autorest.md`...")
 		autorestMdPath := filepath.Join(packagePath, "autorest.md")
 		if err := RemoveTagSet(autorestMdPath); err != nil {
+			return nil, err
+		}
+	}
+
+	// add package config
+	if !onBoard && generateParam.NamespaceConfig != "" {
+		log.Printf("Add package config in `autorest.md`...")
+		autorestMdPath := filepath.Join(packagePath, "autorest.md")
+		if err := AddPackageConfig(autorestMdPath, generateParam.NamespaceConfig); err != nil {
 			return nil, err
 		}
 	}

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -160,7 +160,7 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 	}
 
 	// remove tag set
-	if generateParam.RemoveTagSet && generateParam.NamespaceConfig == "" {
+	if generateParam.RemoveTagSet {
 		log.Printf("Remove tag set for swagger config in `autorest.md`...")
 		autorestMdPath := filepath.Join(packagePath, "autorest.md")
 		if err := RemoveTagSet(autorestMdPath); err != nil {
@@ -169,7 +169,7 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 	}
 
 	// add package config
-	if !onBoard && generateParam.NamespaceConfig != "" {
+	if !generateParam.RemoveTagSet && generateParam.NamespaceConfig != "" {
 		log.Printf("Add package config in `autorest.md`...")
 		autorestMdPath := filepath.Join(packagePath, "autorest.md")
 		if err := AddPackageConfig(autorestMdPath, generateParam.NamespaceConfig); err != nil {

--- a/eng/tools/generator/cmd/v2/common/testdata/new/parameter/parameter.go
+++ b/eng/tools/generator/cmd/v2/common/testdata/new/parameter/parameter.go
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package parameter
+
+type Client struct {
+}
+
+func (c *Client) NotChange(ctx context.Context, resourceGroupName string, serviceName string, value string, option ClientOption) {
+
+}
+
+func (c *Client) OnlyToAny(ctx context.Context, resourceGroupName string, serviceName string, value any, option ClientOption) {
+
+}
+
+func (c *Client) BeforeAny(ctx context.Context, resourceGroupName string, serviceName any, value any, option ClientOption) {
+
+}
+
+func (c *Client) AfterAny(ctx context.Context, resourceGroupName string, serviceName string, value any, option Option) {
+
+}

--- a/eng/tools/generator/cmd/v2/common/testdata/old/parameter/parameter.go
+++ b/eng/tools/generator/cmd/v2/common/testdata/old/parameter/parameter.go
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package parameter
+
+type Client struct {
+}
+
+func (c *Client) NotChange(ctx context.Context, resourceGroupName string, serviceName string, value string, option ClientOption) {
+
+}
+
+func (c *Client) OnlyToAny(ctx context.Context, resourceGroupName string, serviceName string, value interface{}, option ClientOption) {
+
+}
+
+func (c *Client) BeforeAny(ctx context.Context, resourceGroupName string, serviceName string, value interface{}, option ClientOption) {
+
+}
+
+func (c *Client) AfterAny(ctx context.Context, resourceGroupName string, serviceName string, value interface{}, option ClientOption) {
+
+}

--- a/eng/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/eng/tools/generator/cmd/v2/release/releaseCmd.go
@@ -205,6 +205,7 @@ func (c *commandContext) generateFromRequest(sdkRepo repo.SDKRepository, specRep
 			c.rpName = arm
 			c.namespaceName = info.Name
 			c.flags.SpecRPName = info.SpecName
+			c.flags.PackageConfig = info.Config
 			if info.ReleaseDate != nil {
 				c.flags.ReleaseDate = info.ReleaseDate.Format("2006-01-02")
 			}

--- a/eng/tools/generator/config/validate/validator.go
+++ b/eng/tools/generator/config/validate/validator.go
@@ -53,6 +53,7 @@ func ParseTrack2(config *config.Config, specRoot string) (armServices map[string
 				for i := range packageInfos {
 					packageInfos[i].RequestLink = request.RequestLink
 					packageInfos[i].ReleaseDate = request.TargetDate
+					packageInfos[i].Config = fmt.Sprintf("tag: %s", request.PackageFlag)
 				}
 			}
 


### PR DESCRIPTION
1. tag comes from `Readme Tag` in [release-request](https://github.com/Azure/sdk-release-request) and release-v2 command `--package-config` flag
2. filter function parameters：from interface{} type to any type is not a breaking change