### PR TITLE
Added some additional LRO terminal state values

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Added non-conformant LRO terminal states `Cancelled` and `Completed`.
 
 ### Other Changes
 

--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -29,19 +29,26 @@ const (
 	StatusInProgress = "InProgress"
 )
 
+// these are non-conformant states that we've seen in the wild.
+// we support them for back-compat.
+const (
+	StatusCancelled = "Cancelled"
+	StatusCompleted = "Completed"
+)
+
 // IsTerminalState returns true if the LRO's state is terminal.
 func IsTerminalState(s string) bool {
-	return strings.EqualFold(s, StatusSucceeded) || strings.EqualFold(s, StatusFailed) || strings.EqualFold(s, StatusCanceled)
+	return Failed(s) || Succeeded(s)
 }
 
 // Failed returns true if the LRO's state is terminal failure.
 func Failed(s string) bool {
-	return strings.EqualFold(s, StatusFailed) || strings.EqualFold(s, StatusCanceled)
+	return strings.EqualFold(s, StatusFailed) || strings.EqualFold(s, StatusCanceled) || strings.EqualFold(s, StatusCancelled)
 }
 
 // Succeeded returns true if the LRO's state is terminal success.
 func Succeeded(s string) bool {
-	return strings.EqualFold(s, StatusSucceeded)
+	return strings.EqualFold(s, StatusSucceeded) || strings.EqualFold(s, StatusCompleted)
 }
 
 // returns true if the LRO response contains a valid HTTP status code

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -22,8 +22,10 @@ import (
 func TestIsTerminalState(t *testing.T) {
 	require.False(t, IsTerminalState("Updating"), "Updating is not a terminal state")
 	require.True(t, IsTerminalState("Succeeded"), "Succeeded is a terminal state")
+	require.True(t, IsTerminalState("Completed"), "Completed is a terminal state")
 	require.True(t, IsTerminalState("failed"), "failed is a terminal state")
 	require.True(t, IsTerminalState("canceled"), "canceled is a terminal state")
+	require.True(t, IsTerminalState("cancelled"), "cancelled is a terminal state")
 }
 
 func TestStatusCodeValid(t *testing.T) {
@@ -91,6 +93,7 @@ func TestFailed(t *testing.T) {
 	require.False(t, Failed("Succeeded"))
 	require.False(t, Failed("Updating"))
 	require.True(t, Failed("failed"))
+	require.True(t, Failed("Cancelled"))
 }
 
 func TestGetJSON(t *testing.T) {

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 func TestIsTerminalState(t *testing.T) {
-	require.False(t, IsTerminalState("Updating"), "Updating is not a terminal state")
-	require.True(t, IsTerminalState("Succeeded"), "Succeeded is a terminal state")
-	require.True(t, IsTerminalState("Completed"), "Completed is a terminal state")
-	require.True(t, IsTerminalState("failed"), "failed is a terminal state")
-	require.True(t, IsTerminalState("canceled"), "canceled is a terminal state")
-	require.True(t, IsTerminalState("cancelled"), "cancelled is a terminal state")
+	require.False(t, IsTerminalState("upDAting"), "Updating is not a terminal state")
+	require.True(t, IsTerminalState("SuccEEded"), "Succeeded is a terminal state")
+	require.True(t, IsTerminalState("completEd"), "Completed is a terminal state")
+	require.True(t, IsTerminalState("faIled"), "failed is a terminal state")
+	require.True(t, IsTerminalState("canCeled"), "canceled is a terminal state")
+	require.True(t, IsTerminalState("canceLLed"), "cancelled is a terminal state")
 }
 
 func TestStatusCodeValid(t *testing.T) {
@@ -90,10 +90,10 @@ func TestIsValidURL(t *testing.T) {
 }
 
 func TestFailed(t *testing.T) {
-	require.False(t, Failed("Succeeded"))
-	require.False(t, Failed("Updating"))
-	require.True(t, Failed("failed"))
-	require.True(t, Failed("Cancelled"))
+	require.False(t, Failed("sUcceeded"))
+	require.False(t, Failed("ppdATing"))
+	require.True(t, Failed("fAilEd"))
+	require.True(t, Failed("caNcElled"))
 }
 
 func TestGetJSON(t *testing.T) {


### PR DESCRIPTION
While they're non-conformant per the RPC spec, we've seen these in the wild and changing them now would be breaking for REST clients.

Fixes
- https://github.com/Azure/azure-sdk-for-go/issues/19209
- https://github.com/Azure/azure-sdk-for-go/issues/20342