### PR TITLE
Use underlying error when checking for context errors

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed an issue in `DefaultAzureCredential` that could cause the managed identity endpoint check to fail in rare circumstances.
 
 ### Other Changes
 

--- a/sdk/azidentity/chained_token_credential.go
+++ b/sdk/azidentity/chained_token_credential.go
@@ -117,7 +117,7 @@ func (c *ChainedTokenCredential) GetToken(ctx context.Context, opts policy.Token
 			err = newCredentialUnavailableError(c.name, msg)
 		} else {
 			res := getResponseFromError(err)
-			err = newAuthenticationFailedError(c.name, msg, res)
+			err = newAuthenticationFailedError(c.name, msg, res, err)
 		}
 	}
 	return token, err

--- a/sdk/azidentity/chained_token_credential_test.go
+++ b/sdk/azidentity/chained_token_credential_test.go
@@ -113,7 +113,7 @@ func TestChainedTokenCredential_GetTokenSuccess(t *testing.T) {
 
 func TestChainedTokenCredential_GetTokenFail(t *testing.T) {
 	c := NewFakeCredential()
-	c.SetResponse(azcore.AccessToken{}, newAuthenticationFailedError("test", "something went wrong", nil))
+	c.SetResponse(azcore.AccessToken{}, newAuthenticationFailedError("test", "something went wrong", nil, nil))
 	cred, err := NewChainedTokenCredential([]azcore.TokenCredential{c}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -158,7 +158,7 @@ func TestChainedTokenCredential_MultipleCredentialsGetTokenAuthenticationFailed(
 	c2 := NewFakeCredential()
 	c2.SetResponse(azcore.AccessToken{}, newCredentialUnavailableError("unavailableCredential2", "Unavailable expected error"))
 	c3 := NewFakeCredential()
-	c3.SetResponse(azcore.AccessToken{}, newAuthenticationFailedError("authenticationFailedCredential3", "Authentication failed expected error", nil))
+	c3.SetResponse(azcore.AccessToken{}, newAuthenticationFailedError("authenticationFailedCredential3", "Authentication failed expected error", nil, nil))
 	cred, err := NewChainedTokenCredential([]azcore.TokenCredential{c1, c2, c3}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -263,7 +263,7 @@ func TestChainedTokenCredential_Race(t *testing.T) {
 	successFake := NewFakeCredential()
 	successFake.SetResponse(azcore.AccessToken{Token: "*", ExpiresOn: time.Now().Add(time.Hour)}, nil)
 	authFailFake := NewFakeCredential()
-	authFailFake.SetResponse(azcore.AccessToken{}, newAuthenticationFailedError("", "", nil))
+	authFailFake.SetResponse(azcore.AccessToken{}, newAuthenticationFailedError("", "", nil, nil))
 	unavailableFake := NewFakeCredential()
 	unavailableFake.SetResponse(azcore.AccessToken{}, newCredentialUnavailableError("", ""))
 	tro := policy.TokenRequestOptions{Scopes: []string{liveTestScope}}

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -182,11 +182,11 @@ func (w *timeoutWrapper) GetToken(ctx context.Context, opts policy.TokenRequestO
 		c, cancel := context.WithTimeout(ctx, w.timeout)
 		defer cancel()
 		tk, err = w.mic.GetToken(c, opts)
-		if err == nil {
+		if isAuthFailedDueToContext(err) {
+			err = newCredentialUnavailableError(credNameManagedIdentity, "managed identity timed out")
+		} else {
 			// some managed identity implementation is available, so don't apply the timeout to future calls
 			w.timeout = 0
-		} else if isAuthFailedDueToContext(err) {
-			err = newCredentialUnavailableError(credNameManagedIdentity, "managed identity timed out")
 		}
 	} else {
 		tk, err = w.mic.GetToken(ctx, opts)

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -182,7 +182,8 @@ func (w *timeoutWrapper) GetToken(ctx context.Context, opts policy.TokenRequestO
 		c, cancel := context.WithTimeout(ctx, w.timeout)
 		defer cancel()
 		tk, err = w.mic.GetToken(c, opts)
-		if ce := c.Err(); errors.Is(ce, context.DeadlineExceeded) {
+		var authFailedErr *AuthenticationFailedError
+		if errors.As(err, &authFailedErr) && (errors.Is(authFailedErr.err, context.Canceled) || errors.Is(authFailedErr.err, context.DeadlineExceeded)) {
 			err = newCredentialUnavailableError(credNameManagedIdentity, "managed identity timed out")
 		} else {
 			// some managed identity implementation is available, so don't apply the timeout to future calls

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -182,15 +182,26 @@ func (w *timeoutWrapper) GetToken(ctx context.Context, opts policy.TokenRequestO
 		c, cancel := context.WithTimeout(ctx, w.timeout)
 		defer cancel()
 		tk, err = w.mic.GetToken(c, opts)
-		var authFailedErr *AuthenticationFailedError
-		if errors.As(err, &authFailedErr) && (errors.Is(authFailedErr.err, context.Canceled) || errors.Is(authFailedErr.err, context.DeadlineExceeded)) {
-			err = newCredentialUnavailableError(credNameManagedIdentity, "managed identity timed out")
-		} else {
+		if err == nil {
 			// some managed identity implementation is available, so don't apply the timeout to future calls
 			w.timeout = 0
+		} else if isAuthFailedDueToContext(err) {
+			err = newCredentialUnavailableError(credNameManagedIdentity, "managed identity timed out")
 		}
 	} else {
 		tk, err = w.mic.GetToken(ctx, opts)
 	}
 	return tk, err
+}
+
+// unwraps nested AuthenticationFailedErrors to get the root error
+func isAuthFailedDueToContext(err error) bool {
+	for {
+		var authFailedErr *AuthenticationFailedError
+		if !errors.As(err, &authFailedErr) {
+			break
+		}
+		err = authFailedErr.err
+	}
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -201,7 +201,7 @@ func TestDefaultAzureCredential_timeoutWrapper(t *testing.T) {
 		// expecting credentialUnavailableError because delay exceeds the wrapper's timeout
 		_, err = chain.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{liveTestScope}})
 		if _, ok := err.(*credentialUnavailableError); !ok {
-			t.Fatalf("expected credentialUnavailableError, got %v", err)
+			t.Fatalf("expected credentialUnavailableError, got %T: %v", err, err)
 		}
 	}
 

--- a/sdk/azidentity/errors.go
+++ b/sdk/azidentity/errors.go
@@ -39,15 +39,16 @@ type AuthenticationFailedError struct {
 
 	credType string
 	message  string
+	err      error
 }
 
-func newAuthenticationFailedError(credType string, message string, resp *http.Response) error {
-	return &AuthenticationFailedError{credType: credType, message: message, RawResponse: resp}
+func newAuthenticationFailedError(credType string, message string, resp *http.Response, err error) error {
+	return &AuthenticationFailedError{credType: credType, message: message, RawResponse: resp, err: err}
 }
 
 func newAuthenticationFailedErrorFromMSALError(credType string, err error) error {
 	res := getResponseFromError(err)
-	return newAuthenticationFailedError(credType, err.Error(), res)
+	return newAuthenticationFailedError(credType, err.Error(), res, err)
 }
 
 // Error implements the error interface. Note that the message contents are not contractual and can change over time.

--- a/sdk/azidentity/errors_test.go
+++ b/sdk/azidentity/errors_test.go
@@ -31,7 +31,7 @@ func TestAuthenticationFailedErrorInterface(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewBufferString(resBodyString)),
 		Request:    req,
 	}
-	err = newAuthenticationFailedError(credNameAzureCLI, "error message", res)
+	err = newAuthenticationFailedError(credNameAzureCLI, "error message", res, nil)
 	if e, ok := err.(*AuthenticationFailedError); ok {
 		if e.RawResponse == nil {
 			t.Fatal("expected a non-nil RawResponse")


### PR DESCRIPTION
There is a race between error propagation and closing a context's
deadline channel.  The result is that while the API that takes a context
returns the correct error, context.Err() might return nil.
    
See https://github.com/golang/go/issues/31863 for more info.