### PR TITLE
Cleanup after SetImmutabilityPolicy() and SetLegalHold() tests

### DIFF
--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -2897,7 +2897,11 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendBlobSetBlobTags() {
 	_, err = abClient.AppendBlock(context.Background(), streaming.NopCloser(strings.NewReader("Appending block\n")), nil)
 	_require.Nil(err)
 
-	_, err = abClient.SetTags(context.Background(), testcommon.BasicBlobTagsMap, nil)
+	var tagsMap = map[string]string{
+		"azure": "blob",
+	}
+
+	_, err = abClient.SetTags(context.Background(), tagsMap, nil)
 	_require.Nil(err)
 	time.Sleep(10 * time.Second)
 
@@ -2906,9 +2910,9 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendBlobSetBlobTags() {
 
 	blobTagsSet := blobGetTagsResponse.BlobTagSet
 	_require.NotNil(blobTagsSet)
-	_require.Len(blobTagsSet, 3)
+	_require.Len(blobTagsSet, 1)
 	for _, blobTag := range blobTagsSet {
-		_require.Equal(testcommon.BasicBlobTagsMap[*blobTag.Key], *blobTag.Value)
+		_require.Equal(tagsMap[*blobTag.Key], *blobTag.Value)
 	}
 }
 

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -688,6 +688,8 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendSetImmutabilityPolicy() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
+
 	abName := testcommon.GenerateBlobName(testName)
 	abClient := createNewAppendBlob(context.Background(), _require, abName, containerClient)
 
@@ -724,6 +726,7 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendDeleteImmutabilityPolicy() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
 
 	abName := testcommon.GenerateBlobName(testName)
 	abClient := createNewAppendBlob(context.Background(), _require, abName, containerClient)
@@ -756,6 +759,7 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendSetLegalHold() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
 
 	abName := testcommon.GenerateBlobName(testName)
 	abClient := createNewAppendBlob(context.Background(), _require, abName, containerClient)

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_3eca9f96a5"
+  "Tag": "go/storage/azblob_85d9652918"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_85d9652918"
+  "Tag": "go/storage/azblob_cbcc92f524"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_b92bf5d8e3"
+  "Tag": "go/storage/azblob_3eca9f96a5"
 }

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"io"
 	"net/url"
@@ -3460,12 +3461,65 @@ func (s *BlobRecordedTestsSuite) TestSetImmutabilityPolicy() {
 
 	_, err = bbClient.Delete(context.Background(), nil)
 	_require.NotNil(err)
+	testcommon.ValidateBlobErrorCode(_require, err, bloberror.BlobImmutableDueToPolicy)
 
 	_, err = bbClient.DeleteImmutabilityPolicy(context.Background(), nil)
 	_require.Nil(err)
 
 	_, err = bbClient.Delete(context.Background(), nil)
 	_require.Nil(err)
+
+	//accountName, err := testcommon.GetRequiredEnv(string(testcommon.TestAccountImmutable) + testcommon.AccountNameEnvVar)
+	//_require.NoError(err)
+	//
+	//subscriptionID, err := testcommon.GetRequiredEnv(testcommon.SubscriptionID)
+	//_require.NoError(err)
+	//
+	//resourceGroupName, err := testcommon.GetRequiredEnv(testcommon.SubscriptionID)
+	//_require.NoError(err)
+	//
+	//tenantID, ok := os.LookupEnv("AZURE_STORAGE_TENANT_ID")
+	//if !ok {
+	//	panic("AZURE_STORAGE_TENANT_ID could not be found")
+	//}
+	//clientID, ok := os.LookupEnv("AZURE_STORAGE_CLIENT_ID")
+	//if !ok {
+	//	panic("AZURE_STORAGE_CLIENT_ID could not be found")
+	//}
+	//clientSecret, ok := os.LookupEnv("AZURE_STORAGE_CLIENT_SECRET")
+	//if !ok {
+	//	panic("AZURE_STORAGE_CLIENT_SECRET could not be found")
+	//}
+	//
+	//cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
+	//_require.NoError(err)
+	//
+	//cl, err := armstorage.NewBlobContainersClient(subscriptionID, cred, nil)
+	//_require.NoError(err)
+	//
+	//_, err = cl.Delete(context.Background(), resourceGroupName, accountName, containerName, nil)
+	//_require.NoError(err)
+}
+
+func (s *BlobUnrecordedTestsSuite) TestTokenCredential() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	_require.NoError(err)
+
+	accountName, err := testcommon.GetRequiredEnv(testcommon.AccountNameEnvVar)
+	_require.NoError(err)
+
+	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net/", accountName)
+	svcClient, err := service.NewClient(serviceURL, cred, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	cntClient := svcClient.NewContainerClient(containerName)
+
+	_, err = cntClient.Create(context.Background(), nil)
+	_require.NoError(err)
 }
 
 func (s *BlobRecordedTestsSuite) TestDeleteImmutabilityPolicy() {

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -12,7 +12,6 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"io"
 	"net/url"
@@ -3440,6 +3439,7 @@ func (s *BlobRecordedTestsSuite) TestSetImmutabilityPolicy() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
 
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
@@ -3468,58 +3468,6 @@ func (s *BlobRecordedTestsSuite) TestSetImmutabilityPolicy() {
 
 	_, err = bbClient.Delete(context.Background(), nil)
 	_require.Nil(err)
-
-	//accountName, err := testcommon.GetRequiredEnv(string(testcommon.TestAccountImmutable) + testcommon.AccountNameEnvVar)
-	//_require.NoError(err)
-	//
-	//subscriptionID, err := testcommon.GetRequiredEnv(testcommon.SubscriptionID)
-	//_require.NoError(err)
-	//
-	//resourceGroupName, err := testcommon.GetRequiredEnv(testcommon.ResourceGroupName)
-	//_require.NoError(err)
-	//
-	//tenantID, ok := os.LookupEnv("AZURE_STORAGE_TENANT_ID")
-	//if !ok {
-	//	panic("AZURE_STORAGE_TENANT_ID could not be found")
-	//}
-	//clientID, ok := os.LookupEnv("AZURE_STORAGE_CLIENT_ID")
-	//if !ok {
-	//	panic("AZURE_STORAGE_CLIENT_ID could not be found")
-	//}
-	//clientSecret, ok := os.LookupEnv("AZURE_STORAGE_CLIENT_SECRET")
-	//if !ok {
-	//	panic("AZURE_STORAGE_CLIENT_SECRET could not be found")
-	//}
-	//
-	//cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
-	//_require.NoError(err)
-	//
-	//cl, err := armstorage.NewBlobContainersClient(subscriptionID, cred, nil)
-	//_require.NoError(err)
-	//
-	//_, err = cl.Delete(context.Background(), resourceGroupName, accountName, containerName, nil)
-	//_require.NoError(err)
-}
-
-func (s *BlobUnrecordedTestsSuite) TestTokenCredential() {
-	_require := require.New(s.T())
-	testName := s.T().Name()
-
-	cred, err := azidentity.NewDefaultAzureCredential(nil)
-	_require.NoError(err)
-
-	accountName, err := testcommon.GetRequiredEnv(testcommon.AccountNameEnvVar)
-	_require.NoError(err)
-
-	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net/", accountName)
-	svcClient, err := service.NewClient(serviceURL, cred, nil)
-	_require.NoError(err)
-
-	containerName := testcommon.GenerateContainerName(testName)
-	cntClient := svcClient.NewContainerClient(containerName)
-
-	_, err = cntClient.Create(context.Background(), nil)
-	_require.NoError(err)
 }
 
 func (s *BlobRecordedTestsSuite) TestDeleteImmutabilityPolicy() {
@@ -3530,6 +3478,7 @@ func (s *BlobRecordedTestsSuite) TestDeleteImmutabilityPolicy() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
 
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
@@ -3562,6 +3511,7 @@ func (s *BlobRecordedTestsSuite) TestSetLegalHold() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
 
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3475,7 +3475,7 @@ func (s *BlobRecordedTestsSuite) TestSetImmutabilityPolicy() {
 	//subscriptionID, err := testcommon.GetRequiredEnv(testcommon.SubscriptionID)
 	//_require.NoError(err)
 	//
-	//resourceGroupName, err := testcommon.GetRequiredEnv(testcommon.SubscriptionID)
+	//resourceGroupName, err := testcommon.GetRequiredEnv(testcommon.ResourceGroupName)
 	//_require.NoError(err)
 	//
 	//tenantID, ok := os.LookupEnv("AZURE_STORAGE_TENANT_ID")

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -549,6 +549,7 @@ func (s *BlockBlobRecordedTestsSuite) TestUploadBlockWithImmutabilityPolicy() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
 
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
@@ -594,6 +595,7 @@ func (s *BlockBlobRecordedTestsSuite) TestPutBlockListWithImmutabilityPolicy() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
 
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)

--- a/sdk/storage/azblob/ci.yml
+++ b/sdk/storage/azblob/ci.yml
@@ -26,3 +26,8 @@ stages:
     parameters:
       ServiceDirectory: 'storage/azblob'
       RunLiveTests: true
+      EnvVars:
+        AZURE_CLIENT_ID: $(AZBLOB_CLIENT_ID)
+        AZURE_TENANT_ID: $(AZBLOB_TENANT_ID)
+        AZURE_CLIENT_SECRET: $(AZBLOB_CLIENT_SECRET)
+        AZURE_SUBSCRIPTION_ID: $(AZBLOB_SUBSCRIPTION_ID)

--- a/sdk/storage/azblob/go.mod
+++ b/sdk/storage/azblob/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.2.0
 	github.com/stretchr/testify v1.7.1
 )
 

--- a/sdk/storage/azblob/go.sum
+++ b/sdk/storage/azblob/go.sum
@@ -4,6 +4,10 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0 h1:QkAcEIAKbNL4KoFr4Sath
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0/go.mod h1:bhXu1AjYL+wutSL/kpSq6s7733q2Rb0yuot9Zgfqa/0=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.2.0 h1:leh5DwKv6Ihwi+h60uHtn6UWAxBbZ0q8DwQVMzf61zw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.2.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.0.0 h1:lMW1lD/17LUA5z1XTURo7LcVG2ICBPlyMHjIUrcFZNQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0 h1:ECsQtyERDVz3NP3kvDOTLvbQhqWp/x9EsGKtb4ogUr8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.2.0 h1:Ma67P/GGprNwsslzEH6+Kb8nybI8jpDTm4Wmzu2ReK8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.2.0/go.mod h1:c+Lifp3EDEamAkPVzMooRNOK6CZjNSdEnf1A7jsI9u4=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1 h1:BWe8a+f/t+7KY7zH2mqygeUD0t8hNFXe08p1Pb3/jKE=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/sdk/storage/azblob/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azblob/internal/testcommon/clients_auth.go
@@ -46,6 +46,8 @@ const (
 	AccountNameEnvVar           = "AZURE_STORAGE_ACCOUNT_NAME"
 	AccountKeyEnvVar            = "AZURE_STORAGE_ACCOUNT_KEY"
 	DefaultEndpointSuffixEnvVar = "AZURE_STORAGE_ENDPOINT_SUFFIX"
+	SubscriptionID              = "SUBSCRIPTION_ID"
+	ResourceGroupName           = "RESOURCE_GROUP_NAME"
 )
 
 const (

--- a/sdk/storage/azblob/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azblob/internal/testcommon/clients_auth.go
@@ -370,6 +370,10 @@ func GetAccountSAS(permissions sas.AccountPermissions, resourceTypes sas.Account
 }
 
 func DeleteContainerUsingManagementClient(_require *require.Assertions, accountType TestAccountType, containerName string) {
+	if recording.GetRecordMode() == recording.PlaybackMode {
+		return
+	}
+
 	accountName, err := GetRequiredEnv(string(accountType) + AccountNameEnvVar)
 	_require.NoError(err)
 

--- a/sdk/storage/azblob/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azblob/internal/testcommon/clients_auth.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"strings"
 	"testing"
@@ -365,4 +367,24 @@ func GetAccountSAS(permissions sas.AccountPermissions, resourceTypes sas.Account
 	}
 
 	return sasQueryParams.Encode(), nil
+}
+
+func DeleteContainerUsingManagementClient(_require *require.Assertions, accountType TestAccountType, containerName string) {
+	accountName, err := GetRequiredEnv(string(accountType) + AccountNameEnvVar)
+	_require.NoError(err)
+
+	subscriptionID, err := GetRequiredEnv(SubscriptionID)
+	_require.NoError(err)
+
+	resourceGroupName, err := GetRequiredEnv(ResourceGroupName)
+	_require.NoError(err)
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	_require.NoError(err)
+
+	managementClient, err := armstorage.NewBlobContainersClient(subscriptionID, cred, nil)
+	_require.NoError(err)
+
+	_, err = managementClient.Delete(context.Background(), resourceGroupName, accountName, containerName, nil)
+	_require.NoError(err)
 }

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -3288,6 +3288,8 @@ func (s *PageBlobRecordedTestsSuite) TestPageSetImmutabilityPolicy() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
+
 	blobName := testcommon.GenerateBlobName(testName)
 	pbClient := createNewPageBlob(context.Background(), _require, blobName, containerClient)
 
@@ -3324,6 +3326,7 @@ func (s *PageBlobRecordedTestsSuite) TestPageDeleteImmutabilityPolicy() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
 
 	blobName := testcommon.GenerateBlobName(testName)
 	pbClient := createNewPageBlob(context.Background(), _require, blobName, containerClient)
@@ -3356,6 +3359,7 @@ func (s *PageBlobRecordedTestsSuite) TestPageSetLegalHold() {
 
 	containerName := testcommon.GenerateContainerName(testName)
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainerUsingManagementClient(_require, testcommon.TestAccountImmutable, containerName)
 
 	blobName := testcommon.GenerateBlobName(testName)
 	pbClient := createNewPageBlob(context.Background(), _require, blobName, containerClient)


### PR DESCRIPTION
- Delete containers having immutability policies and legal holds in live test runs
- Add OAuth in azblob pipeline

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
