### PR TITLE
Update readme to remove all track1 info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Azure SDK for Go
 
 [![godoc](https://godoc.org/github.com/Azure/azure-sdk-for-go?status.svg)](https://godoc.org/github.com/Azure/azure-sdk-for-go)
-[![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/go/Azure.azure-sdk-for-go?branchName=main)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=640&branchName=main)
 
 This repository is for active development of the Azure SDK for Go. For consumers of the SDK you can follow the links below to visit the documentation you are interested in
 * [Overview of Azure SDK for Go](https://docs.microsoft.com/azure/developer/go/)
@@ -19,28 +18,18 @@ To get started with a module, see the README.md file located in the module's pro
 
 ## Packages available
 
-Each service might have a number of modules available from each of the following categories:
-* [Client - New Releases](#client-new-releases)
-* [Client - Previous Versions](#client-previous-versions)
-* [Management - New Releases](#management-new-releases)
-* [Management - Previous Versions](#management-previous-versions)
+Each service can have both 'client' and 'management' modules. 'Client' modules are used to consume the service, whereas 'management' modules are used to configure and manage the service.
 
-### Client: New Releases
+### Client modules
 
-We have a new wave of packages that are being announced as **stable** and several that are currently released in **beta**. These modules allow you to use, consume, and interact with existing resources, for example, uploading a blob. They also share a number of core functionalities including retries, logging, transport protocols, authentication protocols, etc. that can be found in the [azcore](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azcore) module. You can learn more about these modules by reading the [Azure SDK Go guidelines](https://azure.github.io/azure-sdk/golang_introduction.html).
+Our client modules follow the [Azure Go SDK guidelines](https://azure.github.io/azure-sdk/golang_introduction.html). These modules allow you to use, consume, and interact with existing resources, for example, uploading a blob. They also share a number of core functionalities including retries, logging, transport protocols, authentication protocols, etc. that can be found in the [azcore](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azcore) module.
 
 You can find the most up-to-date list of new modules on our [latest page](https://azure.github.io/azure-sdk/releases/latest/index.html#go).
 
 > NOTE: If you need to ensure your code is ready for production use one of the stable, non-beta modules.
 
-### Client: Previous Versions
-
-The last stable versions of packages that have been provided for usage with Azure are production-ready. These packages might not implement the [Azure Go SDK guidelines](https://azure.github.io/azure-sdk/golang_introduction.html) or have the same feature set as the New releases, however they do offer a wider coverage of services.
-
-Previous Go SDK packages are located under [/services folder](https://github.com/Azure/azure-sdk-for-go/tree/legacy/services), and you can see the full list [on this page](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services). 
-
-### Management: New Releases
-A new set of management modules that follow the [Azure SDK Design Guidelines for Go](https://azure.github.io/azure-sdk/golang_introduction.html) are available at `sdk/resourcemanagement`. These new modules provide a number of core capabilities that are shared amongst all Azure SDKs, including the intuitive Azure Identity module, an HTTP Pipeline with custom policies, error-handling, distributed tracing, and much more.
+### Management modules
+Similar to our client modules, the management modules follow the [Azure Go SDK guidelines](https://azure.github.io/azure-sdk/golang_introduction.html). All management modules are available at `sdk/resourcemanagement`. These modules provide a number of core capabilities that are shared amongst all Azure SDKs, including the intuitive Azure Identity module, an HTTP Pipeline with custom policies, error-handling, distributed tracing, and much more.
 
 To get started, please follow the [quickstart guide here](https://aka.ms/azsdk/go/mgmt). To see the benefits of migrating and how to migrate to the new modules, please visit the [migration guide](https://aka.ms/azsdk/go/mgmt/migration).
 
@@ -50,29 +39,15 @@ You can find the [most up to date list of all of the new packages on our page](h
 
 * [Quickstart tutorial for new releases](https://aka.ms/azsdk/go/mgmt). Documentation is also available at each readme file of the individual module (Example: [Readme for Compute Module](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/compute/armcompute))
 
-### Management: Previous Versions
-For a complete list of management modules which enable you to provision and manage Azure resources, please [check here](https://azure.github.io/azure-sdk/releases/latest/all/go.html). They might not have the same feature set as the new releases but they do offer wider coverage of services.
-
-Previous packages are located under [/services folder](https://github.com/Azure/azure-sdk-for-go/tree/legacy/services), and you can see the full list [on this page](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services).
-
-* [Quickstart tutorial for previous versions](https://aka.ms/azsdk/go/mgmt/previous)
-
-## Other Azure Go Packages
-
-Azure provides several other packages for using services from Go, listed below.  These packages do NOT follow the New Release guidelines.
-
-| Service              | Import Path/Repo                                                                                   |
-| -------------------- | -------------------------------------------------------------------------------------------------- |
-| Storage - Files      | [github.com/Azure/azure-storage-file-go](https://github.com/Azure/azure-storage-file-go)           |
-| Storage - Queues     | [github.com/Azure/azure-storage-queue-go](https://github.com/Azure/azure-storage-queue-go)         |
-| Event Hubs           | [github.com/Azure/azure-event-hubs-go](https://github.com/Azure/azure-event-hubs-go)               |
-| Application Insights | [github.com/Microsoft/ApplicationInsights-go](https://github.com/Microsoft/ApplicationInsights-go) |
-
 ## Samples
 
 More code samples for using the management modules for Go SDK can be found in the following locations
 - [Go SDK Code Samples Repo](https://aka.ms/azsdk/go/mgmt/samples)
 - Example files under each package. For example, examples for Network packages can be [found here](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/resourcemanager/network/armnetwork/loadbalancernetworkinterfaces_client_example_test.go)
+
+## Historical releases
+
+Note that the latest modules from Microsoft are grouped by service in the `/sdk` directory. If you're using packages with prefix `github.com/Azure/azure-sdk-for-go/services`/`github.com/Azure/azure-sdk-for-go/storage`/`github.com/Azure/azure-sdk-for-go/profiles`, please consider migrating to the latest libraries. You can find a mapping table from these historical releases to their equivalent [here](https://azure.github.io/azure-sdk/releases/deprecated/index.html#go). 
 
 ## Reporting security issues and security bugs
 


### PR DESCRIPTION
Since we don't want customer to use track1 anymore, I removed related info from readme file. When it is merged, I will also do another update for the readme file under `legacy` branch. Then release a track1 version to refresh the doc for legacy `azure-sdk-for-go` module in [pkg.go.dev](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go).

Resolve: #20010 