### PR TITLE
[keyvault] delete extra test

### DIFF
--- a/sdk/security/keyvault/azadmin/settings/client_test.go
+++ b/sdk/security/keyvault/azadmin/settings/client_test.go
@@ -113,17 +113,3 @@ func TestUpdateSetting_InvalidSettingName(t *testing.T) {
 	require.Equal(t, "Nocontentprovided", httpErr.ErrorCode)
 	require.Equal(t, 400, httpErr.StatusCode)
 }
-
-func TestUpdateSetting_InvalidUpdateSettingRequest(t *testing.T) {
-	client := startSettingsTest(t)
-
-	res, err := client.UpdateSetting(context.Background(), "AllowKeyManagementOperationsThroughARM", settings.UpdateSettingRequest{Value: to.Ptr("invalid")}, nil)
-	require.Error(t, err)
-	require.Nil(t, res.Name)
-	require.Nil(t, res.Type)
-	require.Nil(t, res.Value)
-	var httpErr *azcore.ResponseError
-	require.ErrorAs(t, err, &httpErr)
-	require.Equal(t, "Nocontentprovided", httpErr.ErrorCode)
-	require.Equal(t, 400, httpErr.StatusCode)
-}


### PR DESCRIPTION
Deleting extra test from azadmin.
TestUpdateSetting_InvalidUpdateSettingRequest hits the same functionality as TestUpdateSetting_InvalidSettingName, so removing to prevent test conflicts.