### PR TITLE
[azeventhubs] example file was referring to an internal constant

### DIFF
--- a/sdk/messaging/azeventhubs/example_consuming_with_checkpoints_test.go
+++ b/sdk/messaging/azeventhubs/example_consuming_with_checkpoints_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/checkpoints"
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 )
 
@@ -118,7 +117,7 @@ func processEventsForPartition(partitionClient *azeventhubs.ProcessorPartitionCl
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 			var eventHubError *azeventhubs.Error
 
-			if errors.As(err, &eventHubError) && eventHubError.Code == exported.ErrorCodeOwnershipLost {
+			if errors.As(err, &eventHubError) && eventHubError.Code == azeventhubs.ErrorCodeOwnershipLost {
 				return nil
 			}
 


### PR DESCRIPTION
A customer noticed our example file refers to an constant `ErrorCodeOwnershipLost` by it's `internal/exported` name. This is some fallout from the way that we expose the constants using aliases, and autocomplete.

