### PR TITLE
[azservicebus,azeventhubs] Switch to using 'any' instead of 'interface'

### DIFF
--- a/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
+++ b/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
@@ -102,7 +102,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 
 		err = mb.AddEventData(&EventData{
 			Body: []byte("small body"),
-			Properties: map[string]interface{}{
+			Properties: map[string]any{
 				"small": "value",
 			},
 		}, nil)
@@ -123,7 +123,7 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 
 		err = mb.AddEventData(&EventData{
 			Body: []byte("small body"),
-			Properties: map[string]interface{}{
+			Properties: map[string]any{
 				"hello":      "world",
 				"anInt":      100,
 				"aFLoat":     100.1,

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap.go
@@ -24,7 +24,7 @@ type AMQPReceiver interface {
 	ModifyMessage(ctx context.Context, msg *amqp.Message, options *amqp.ModifyMessageOptions) error
 
 	LinkName() string
-	LinkSourceFilterValue(name string) interface{}
+	LinkSourceFilterValue(name string) any
 
 	// wrapper only functions,
 
@@ -193,7 +193,7 @@ func (rw *AMQPReceiverWrapper) LinkName() string {
 	return rw.inner.LinkName()
 }
 
-func (rw *AMQPReceiverWrapper) LinkSourceFilterValue(name string) interface{} {
+func (rw *AMQPReceiverWrapper) LinkSourceFilterValue(name string) any {
 	return rw.inner.LinkSourceFilterValue(name)
 }
 

--- a/sdk/messaging/azeventhubs/internal/cbs.go
+++ b/sdk/messaging/azeventhubs/internal/cbs.go
@@ -74,7 +74,7 @@ func NegotiateClaim(ctx context.Context, audience string, conn amqpwrap.AMQPClie
 
 	msg := &amqp.Message{
 		Value: token.Token,
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			cbsOperationKey:  cbsOperationPutToken,
 			cbsTokenTypeKey:  string(token.TokenType),
 			cbsAudienceKey:   audience,

--- a/sdk/messaging/azeventhubs/internal/cbs_test.go
+++ b/sdk/messaging/azeventhubs/internal/cbs_test.go
@@ -32,7 +32,7 @@ func TestNegotiateClaimWithCloseTimeout(t *testing.T) {
 			tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
 
 			mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
-				response.ApplicationProperties = map[string]interface{}{
+				response.ApplicationProperties = map[string]any{
 					"status-code": int32(200),
 				}
 			})
@@ -85,7 +85,7 @@ func TestNegotiateClaimWithAuthFailure(t *testing.T) {
 	mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
 		// this is the kind of error you get if your connection string is inconsistent
 		// (ie, you tamper with the shared key, etc..)
-		response.ApplicationProperties = map[string]interface{}{
+		response.ApplicationProperties = map[string]any{
 			"status-code":        int32(401),
 			"status-description": "InvalidSignature: The token has an invalid signature.",
 			"error-condition":    "com.microsoft:auth-failed",
@@ -117,7 +117,7 @@ func TestNegotiateClaimSuccess(t *testing.T) {
 	receiver.EXPECT().Close(mock.NotCancelledAndHasTimeout)
 
 	mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
-		response.ApplicationProperties = map[string]interface{}{
+		response.ApplicationProperties = map[string]any{
 			"status-code": int32(200),
 		}
 	})

--- a/sdk/messaging/azeventhubs/internal/errors.go
+++ b/sdk/messaging/azeventhubs/internal/errors.go
@@ -266,7 +266,7 @@ type (
 	ErrIncorrectType struct {
 		Key          string
 		ExpectedType reflect.Type
-		ActualValue  interface{}
+		ActualValue  any
 	}
 
 	// ErrAMQP indicates that the server communicated an AMQP error with a particular
@@ -295,7 +295,7 @@ func (e ErrMalformedMessage) Error() string {
 
 // NewErrIncorrectType lets you skip using the `reflect` package. Just provide a variable of the desired type as
 // 'expected'.
-func NewErrIncorrectType(key string, expected, actual interface{}) ErrIncorrectType {
+func NewErrIncorrectType(key string, expected, actual any) ErrIncorrectType {
 	return ErrIncorrectType{
 		Key:          key,
 		ExpectedType: reflect.TypeOf(expected),

--- a/sdk/messaging/azeventhubs/internal/mock/mock_amqp.go
+++ b/sdk/messaging/azeventhubs/internal/mock/mock_amqp.go
@@ -49,7 +49,7 @@ func (m *MockAMQPReceiver) AcceptMessage(ctx context.Context, msg *amqp.Message)
 }
 
 // AcceptMessage indicates an expected call of AcceptMessage.
-func (mr *MockAMQPReceiverMockRecorder) AcceptMessage(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) AcceptMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).AcceptMessage), ctx, msg)
 }
@@ -77,7 +77,7 @@ func (m *MockAMQPReceiver) IssueCredit(credit uint32) error {
 }
 
 // IssueCredit indicates an expected call of IssueCredit.
-func (mr *MockAMQPReceiverMockRecorder) IssueCredit(credit interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) IssueCredit(credit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueCredit", reflect.TypeOf((*MockAMQPReceiver)(nil).IssueCredit), credit)
 }
@@ -97,15 +97,15 @@ func (mr *MockAMQPReceiverMockRecorder) LinkName() *gomock.Call {
 }
 
 // LinkSourceFilterValue mocks base method.
-func (m *MockAMQPReceiver) LinkSourceFilterValue(name string) interface{} {
+func (m *MockAMQPReceiver) LinkSourceFilterValue(name string) any {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LinkSourceFilterValue", name)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(any)
 	return ret0
 }
 
 // LinkSourceFilterValue indicates an expected call of LinkSourceFilterValue.
-func (mr *MockAMQPReceiverMockRecorder) LinkSourceFilterValue(name interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) LinkSourceFilterValue(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSourceFilterValue", reflect.TypeOf((*MockAMQPReceiver)(nil).LinkSourceFilterValue), name)
 }
@@ -119,7 +119,7 @@ func (m *MockAMQPReceiver) ModifyMessage(ctx context.Context, msg *amqp.Message,
 }
 
 // ModifyMessage indicates an expected call of ModifyMessage.
-func (mr *MockAMQPReceiverMockRecorder) ModifyMessage(ctx, msg, options interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) ModifyMessage(ctx, msg, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).ModifyMessage), ctx, msg, options)
 }
@@ -148,7 +148,7 @@ func (m *MockAMQPReceiver) Receive(ctx context.Context) (*amqp.Message, error) {
 }
 
 // Receive indicates an expected call of Receive.
-func (mr *MockAMQPReceiverMockRecorder) Receive(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) Receive(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receive", reflect.TypeOf((*MockAMQPReceiver)(nil).Receive), ctx)
 }
@@ -162,7 +162,7 @@ func (m *MockAMQPReceiver) RejectMessage(ctx context.Context, msg *amqp.Message,
 }
 
 // RejectMessage indicates an expected call of RejectMessage.
-func (mr *MockAMQPReceiverMockRecorder) RejectMessage(ctx, msg, e interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) RejectMessage(ctx, msg, e any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).RejectMessage), ctx, msg, e)
 }
@@ -176,7 +176,7 @@ func (m *MockAMQPReceiver) ReleaseMessage(ctx context.Context, msg *amqp.Message
 }
 
 // ReleaseMessage indicates an expected call of ReleaseMessage.
-func (mr *MockAMQPReceiverMockRecorder) ReleaseMessage(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) ReleaseMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).ReleaseMessage), ctx, msg)
 }
@@ -213,7 +213,7 @@ func (m *MockAMQPReceiverCloser) AcceptMessage(ctx context.Context, msg *amqp.Me
 }
 
 // AcceptMessage indicates an expected call of AcceptMessage.
-func (mr *MockAMQPReceiverCloserMockRecorder) AcceptMessage(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) AcceptMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptMessage", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).AcceptMessage), ctx, msg)
 }
@@ -227,7 +227,7 @@ func (m *MockAMQPReceiverCloser) Close(ctx context.Context) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockAMQPReceiverCloserMockRecorder) Close(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).Close), ctx)
 }
@@ -255,7 +255,7 @@ func (m *MockAMQPReceiverCloser) IssueCredit(credit uint32) error {
 }
 
 // IssueCredit indicates an expected call of IssueCredit.
-func (mr *MockAMQPReceiverCloserMockRecorder) IssueCredit(credit interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) IssueCredit(credit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueCredit", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).IssueCredit), credit)
 }
@@ -275,15 +275,15 @@ func (mr *MockAMQPReceiverCloserMockRecorder) LinkName() *gomock.Call {
 }
 
 // LinkSourceFilterValue mocks base method.
-func (m *MockAMQPReceiverCloser) LinkSourceFilterValue(name string) interface{} {
+func (m *MockAMQPReceiverCloser) LinkSourceFilterValue(name string) any {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LinkSourceFilterValue", name)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(any)
 	return ret0
 }
 
 // LinkSourceFilterValue indicates an expected call of LinkSourceFilterValue.
-func (mr *MockAMQPReceiverCloserMockRecorder) LinkSourceFilterValue(name interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) LinkSourceFilterValue(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSourceFilterValue", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).LinkSourceFilterValue), name)
 }
@@ -297,7 +297,7 @@ func (m *MockAMQPReceiverCloser) ModifyMessage(ctx context.Context, msg *amqp.Me
 }
 
 // ModifyMessage indicates an expected call of ModifyMessage.
-func (mr *MockAMQPReceiverCloserMockRecorder) ModifyMessage(ctx, msg, options interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) ModifyMessage(ctx, msg, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyMessage", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).ModifyMessage), ctx, msg, options)
 }
@@ -326,7 +326,7 @@ func (m *MockAMQPReceiverCloser) Receive(ctx context.Context) (*amqp.Message, er
 }
 
 // Receive indicates an expected call of Receive.
-func (mr *MockAMQPReceiverCloserMockRecorder) Receive(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) Receive(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receive", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).Receive), ctx)
 }
@@ -340,7 +340,7 @@ func (m *MockAMQPReceiverCloser) RejectMessage(ctx context.Context, msg *amqp.Me
 }
 
 // RejectMessage indicates an expected call of RejectMessage.
-func (mr *MockAMQPReceiverCloserMockRecorder) RejectMessage(ctx, msg, e interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) RejectMessage(ctx, msg, e any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectMessage", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).RejectMessage), ctx, msg, e)
 }
@@ -354,7 +354,7 @@ func (m *MockAMQPReceiverCloser) ReleaseMessage(ctx context.Context, msg *amqp.M
 }
 
 // ReleaseMessage indicates an expected call of ReleaseMessage.
-func (mr *MockAMQPReceiverCloserMockRecorder) ReleaseMessage(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) ReleaseMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseMessage", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).ReleaseMessage), ctx, msg)
 }
@@ -419,7 +419,7 @@ func (m *MockAMQPSender) Send(ctx context.Context, msg *amqp.Message) error {
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockAMQPSenderMockRecorder) Send(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPSenderMockRecorder) Send(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockAMQPSender)(nil).Send), ctx, msg)
 }
@@ -456,7 +456,7 @@ func (m *MockAMQPSenderCloser) Close(ctx context.Context) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockAMQPSenderCloserMockRecorder) Close(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPSenderCloserMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPSenderCloser)(nil).Close), ctx)
 }
@@ -498,7 +498,7 @@ func (m *MockAMQPSenderCloser) Send(ctx context.Context, msg *amqp.Message) erro
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockAMQPSenderCloserMockRecorder) Send(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPSenderCloserMockRecorder) Send(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockAMQPSenderCloser)(nil).Send), ctx, msg)
 }
@@ -535,7 +535,7 @@ func (m *MockAMQPSession) Close(ctx context.Context) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockAMQPSessionMockRecorder) Close(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPSession)(nil).Close), ctx)
 }
@@ -550,7 +550,7 @@ func (m *MockAMQPSession) NewReceiver(ctx context.Context, source string, opts *
 }
 
 // NewReceiver indicates an expected call of NewReceiver.
-func (mr *MockAMQPSessionMockRecorder) NewReceiver(ctx, source, opts interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) NewReceiver(ctx, source, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReceiver", reflect.TypeOf((*MockAMQPSession)(nil).NewReceiver), ctx, source, opts)
 }
@@ -565,7 +565,7 @@ func (m *MockAMQPSession) NewSender(ctx context.Context, target string, opts *am
 }
 
 // NewSender indicates an expected call of NewSender.
-func (mr *MockAMQPSessionMockRecorder) NewSender(ctx, target, opts interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) NewSender(ctx, target, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSender", reflect.TypeOf((*MockAMQPSession)(nil).NewSender), ctx, target, opts)
 }
@@ -617,7 +617,7 @@ func (m *MockAMQPClient) NewSession(ctx context.Context, opts *amqp.SessionOptio
 }
 
 // NewSession indicates an expected call of NewSession.
-func (mr *MockAMQPClientMockRecorder) NewSession(ctx, opts interface{}) *gomock.Call {
+func (mr *MockAMQPClientMockRecorder) NewSession(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockAMQPClient)(nil).NewSession), ctx, opts)
 }
@@ -654,7 +654,7 @@ func (m *MockRPCLink) Close(ctx context.Context) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockRPCLinkMockRecorder) Close(ctx interface{}) *gomock.Call {
+func (mr *MockRPCLinkMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRPCLink)(nil).Close), ctx)
 }
@@ -683,7 +683,7 @@ func (m *MockRPCLink) RPC(ctx context.Context, msg *amqp.Message) (*amqpwrap.RPC
 }
 
 // RPC indicates an expected call of RPC.
-func (mr *MockRPCLinkMockRecorder) RPC(ctx, msg interface{}) *gomock.Call {
+func (mr *MockRPCLinkMockRecorder) RPC(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPC", reflect.TypeOf((*MockRPCLink)(nil).RPC), ctx, msg)
 }

--- a/sdk/messaging/azeventhubs/internal/mock/mock_helpers.go
+++ b/sdk/messaging/azeventhubs/internal/mock/mock_helpers.go
@@ -71,7 +71,7 @@ type ContextCancelledMatcher struct {
 }
 
 // Matches returns whether x is a match.
-func (m ContextCancelledMatcher) Matches(x interface{}) bool {
+func (m ContextCancelledMatcher) Matches(x any) bool {
 	ctx := x.(context.Context)
 
 	if m.WantCancelled {
@@ -88,7 +88,7 @@ func (m ContextCancelledMatcher) String() string {
 
 type ContextHasTestValueMatcher struct{}
 
-func (m ContextHasTestValueMatcher) Matches(x interface{}) bool {
+func (m ContextHasTestValueMatcher) Matches(x any) bool {
 	ctx := x.(context.Context)
 	return ctx.Value(testContextKey(0)) == "correctContextWasUsed"
 }

--- a/sdk/messaging/azeventhubs/internal/mock/mock_namespace.go
+++ b/sdk/messaging/azeventhubs/internal/mock/mock_namespace.go
@@ -85,7 +85,7 @@ func (m *MockNamespaceForAMQPLinks) Close(ctx context.Context, permanently bool)
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) Close(ctx, permanently interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) Close(ctx, permanently any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).Close), ctx, permanently)
 }
@@ -99,7 +99,7 @@ func (m *MockNamespaceForAMQPLinks) GetEntityAudience(entityPath string) string 
 }
 
 // GetEntityAudience indicates an expected call of GetEntityAudience.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) GetEntityAudience(entityPath interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) GetEntityAudience(entityPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityAudience", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).GetEntityAudience), entityPath)
 }
@@ -115,7 +115,7 @@ func (m *MockNamespaceForAMQPLinks) NegotiateClaim(ctx context.Context, entityPa
 }
 
 // NegotiateClaim indicates an expected call of NegotiateClaim.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) NegotiateClaim(ctx, entityPath interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) NegotiateClaim(ctx, entityPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NegotiateClaim", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).NegotiateClaim), ctx, entityPath)
 }
@@ -131,7 +131,7 @@ func (m *MockNamespaceForAMQPLinks) NewAMQPSession(ctx context.Context) (amqpwra
 }
 
 // NewAMQPSession indicates an expected call of NewAMQPSession.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) NewAMQPSession(ctx interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) NewAMQPSession(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAMQPSession", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).NewAMQPSession), ctx)
 }
@@ -147,7 +147,7 @@ func (m *MockNamespaceForAMQPLinks) NewRPCLink(ctx context.Context, managementPa
 }
 
 // NewRPCLink indicates an expected call of NewRPCLink.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) NewRPCLink(ctx, managementPath interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) NewRPCLink(ctx, managementPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRPCLink", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).NewRPCLink), ctx, managementPath)
 }
@@ -161,7 +161,7 @@ func (m *MockNamespaceForAMQPLinks) Recover(ctx context.Context, clientRevision 
 }
 
 // Recover indicates an expected call of Recover.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) Recover(ctx, clientRevision interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) Recover(ctx, clientRevision any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recover", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).Recover), ctx, clientRevision)
 }

--- a/sdk/messaging/azeventhubs/internal/mock/mock_token.go
+++ b/sdk/messaging/azeventhubs/internal/mock/mock_token.go
@@ -46,7 +46,7 @@ func (m *MockTokenProvider) GetToken(uri string) (*auth.Token, error) {
 }
 
 // GetToken indicates an expected call of GetToken.
-func (mr *MockTokenProviderMockRecorder) GetToken(uri interface{}) *gomock.Call {
+func (mr *MockTokenProviderMockRecorder) GetToken(uri any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockTokenProvider)(nil).GetToken), uri)
 }

--- a/sdk/messaging/azeventhubs/internal/mock/mock_token_credential.go
+++ b/sdk/messaging/azeventhubs/internal/mock/mock_token_credential.go
@@ -48,7 +48,7 @@ func (m *MockTokenCredential) GetToken(ctx context.Context, options policy.Token
 }
 
 // GetToken indicates an expected call of GetToken.
-func (mr *MockTokenCredentialMockRecorder) GetToken(ctx, options interface{}) *gomock.Call {
+func (mr *MockTokenCredentialMockRecorder) GetToken(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockTokenCredential)(nil).GetToken), ctx, options)
 }

--- a/sdk/messaging/azeventhubs/internal/namespace.go
+++ b/sdk/messaging/azeventhubs/internal/namespace.go
@@ -157,7 +157,7 @@ func (ns *Namespace) newClientImpl(ctx context.Context) (amqpwrap.AMQPClient, er
 	connOptions := amqp.ConnOptions{
 		SASLType:    amqp.SASLTypeAnonymous(),
 		MaxSessions: 65535,
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"product":    "MSGolangClient",
 			"version":    Version,
 			"platform":   runtime.GOOS,

--- a/sdk/messaging/azeventhubs/internal/rpc.go
+++ b/sdk/messaging/azeventhubs/internal/rpc.go
@@ -228,7 +228,7 @@ func (l *rpcLink) RPC(ctx context.Context, msg *amqp.Message) (*amqpwrap.RPCResp
 	msg.Properties.ReplyTo = &l.clientAddress
 
 	if msg.ApplicationProperties == nil {
-		msg.ApplicationProperties = make(map[string]interface{})
+		msg.ApplicationProperties = make(map[string]any)
 	}
 
 	if _, ok := msg.ApplicationProperties["server-timeout"]; !ok {

--- a/sdk/messaging/azservicebus/admin/admin_client.go
+++ b/sdk/messaging/azservicebus/admin/admin_client.go
@@ -120,14 +120,14 @@ func (ac *Client) GetNamespaceProperties(ctx context.Context, options *GetNamesp
 	return props, nil
 }
 
-type pagerFunc func(ctx context.Context, pv interface{}) (*http.Response, error)
+type pagerFunc func(ctx context.Context, pv any) (*http.Response, error)
 
 // newPagerFunc gets a function that can be used to page sequentially through an ATOM resource
-func (ac *Client) newPagerFunc(baseFragment string, maxPageSize int32, lenV func(pv interface{}) int) pagerFunc {
+func (ac *Client) newPagerFunc(baseFragment string, maxPageSize int32, lenV func(pv any) int) pagerFunc {
 	eof := false
 	skip := int32(0)
 
-	return func(ctx context.Context, pv interface{}) (*http.Response, error) {
+	return func(ctx context.Context, pv any) (*http.Response, error) {
 		if eof {
 			return nil, nil
 		}

--- a/sdk/messaging/azservicebus/admin/admin_client_rules.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_rules.go
@@ -47,7 +47,7 @@ type SQLAction struct {
 	Expression string
 
 	// Parameters is a map of string to values of type string, number, or boolean.
-	Parameters map[string]interface{}
+	Parameters map[string]any
 }
 
 func (a *SQLAction) ruleAction() {}
@@ -72,7 +72,7 @@ type SQLFilter struct {
 	Expression string
 
 	// Parameters is a map of string to values of type string, number, or boolean.
-	Parameters map[string]interface{}
+	Parameters map[string]any
 }
 
 func (f *SQLFilter) ruleFilter() {}
@@ -91,7 +91,7 @@ func (f *FalseFilter) ruleFilter() {}
 // and system properties of messages for a subscription.
 type CorrelationFilter struct {
 	// ApplicationProperties will be matched against the application properties for the message.
-	ApplicationProperties map[string]interface{}
+	ApplicationProperties map[string]any
 
 	// ContentType will be matched against the ContentType property for the message.
 	ContentType *string
@@ -508,7 +508,7 @@ func (ac *Client) newRuleProperties(env *atom.RuleEnvelope) (*RuleProperties, er
 	return &props, nil
 }
 
-func publicSQLParametersToInternal(publicParams map[string]interface{}) (*atom.KeyValueList, error) {
+func publicSQLParametersToInternal(publicParams map[string]any) (*atom.KeyValueList, error) {
 	if len(publicParams) == 0 {
 		return nil, nil
 	}
@@ -571,12 +571,12 @@ func publicSQLParametersToInternal(publicParams map[string]interface{}) (*atom.K
 	return &atom.KeyValueList{KeyValues: params}, nil
 }
 
-func internalSQLParametersToPublic(kvlist *atom.KeyValueList) (map[string]interface{}, error) {
+func internalSQLParametersToPublic(kvlist *atom.KeyValueList) (map[string]any, error) {
 	if kvlist == nil {
 		return nil, nil
 	}
 
-	params := map[string]interface{}{}
+	params := map[string]any{}
 
 	for _, p := range kvlist.KeyValues {
 		// we only care about the actual type here since we can assume the

--- a/sdk/messaging/azservicebus/admin/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_test.go
@@ -1086,7 +1086,7 @@ type fakeEM struct {
 	getResponses []string
 }
 
-func (em *fakeEM) Get(ctx context.Context, entityPath string, respObj interface{}) (*http.Response, error) {
+func (em *fakeEM) Get(ctx context.Context, entityPath string, respObj any) (*http.Response, error) {
 	jsonPath := em.getResponses[0]
 	em.getResponses = em.getResponses[1:]
 
@@ -1245,7 +1245,7 @@ func TestAdminClient_CreateRules(t *testing.T) {
 			Name: "ruleWithSQLFilterWithParams",
 			Filter: &SQLFilter{
 				Expression: "MessageID=@stringVar OR MessageID=@intVar OR MessageID=@floatVar OR MessageID=@dateTimeVar OR MessageID=@boolVar",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"@stringVar":   "hello world",
 					"@intVar":      int64(100),
 					"@floatVar":    float64(100.1),
@@ -1268,7 +1268,7 @@ func TestAdminClient_CreateRules(t *testing.T) {
 				SessionID:        to.Ptr("sessionID"),
 				Subject:          to.Ptr("subject"),
 				To:               to.Ptr("to"),
-				ApplicationProperties: map[string]interface{}{
+				ApplicationProperties: map[string]any{
 					"CustomProp1": "hello",
 				},
 			},
@@ -1283,7 +1283,7 @@ func TestAdminClient_CreateRules(t *testing.T) {
 			Name: "ruleWithAction",
 			Action: &SQLAction{
 				Expression: "SET MessageID=@stringVar SET MessageID=@intVar SET MessageID=@floatVar SET MessageID=@dateTimeVar SET MessageID=@boolVar",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"@stringVar":   "hello world",
 					"@intVar":      int64(100),
 					"@floatVar":    float64(100.1),
@@ -1302,7 +1302,7 @@ func TestAdminClient_CreateRules(t *testing.T) {
 			Name: "ruleWithFilterAndAction",
 			Filter: &SQLFilter{
 				Expression: "MessageID=@stringVar OR MessageID=@intVar OR MessageID=@floatVar OR MessageID=@dateTimeVar OR MessageID=@boolVar",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"@stringVar":   "hello world",
 					"@intVar":      int64(100),
 					"@floatVar":    float64(100.1),
@@ -1312,7 +1312,7 @@ func TestAdminClient_CreateRules(t *testing.T) {
 			},
 			Action: &SQLAction{
 				Expression: "SET MessageID=@stringVar SET MessageID=@intVar SET MessageID=@floatVar SET MessageID=@dateTimeVar SET MessageID=@boolVar",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"@stringVar":   "hello world",
 					"@intVar":      int64(100),
 					"@floatVar":    float64(100.1),
@@ -1465,7 +1465,7 @@ type emwrap struct {
 	inner atom.EntityManager
 }
 
-func (em *emwrap) Put(ctx context.Context, entityPath string, body interface{}, respObj interface{}, options *atom.ExecuteOptions) (*http.Response, error) {
+func (em *emwrap) Put(ctx context.Context, entityPath string, body any, respObj any, options *atom.ExecuteOptions) (*http.Response, error) {
 	resp, err := em.inner.Put(ctx, entityPath, body, respObj, options)
 
 	if err != nil {
@@ -1481,7 +1481,7 @@ func (em *emwrap) Delete(ctx context.Context, entityPath string) (*http.Response
 }
 func (em *emwrap) TokenProvider() auth.TokenProvider { return em.inner.TokenProvider() }
 
-func (em *emwrap) Get(ctx context.Context, entityPath string, respObj interface{}) (*http.Response, error) {
+func (em *emwrap) Get(ctx context.Context, entityPath string, respObj any) (*http.Response, error) {
 	resp, err := em.inner.Get(ctx, entityPath, respObj)
 
 	if err != nil {
@@ -1492,7 +1492,7 @@ func (em *emwrap) Get(ctx context.Context, entityPath string, respObj interface{
 	return resp, err
 }
 
-func (*emwrap) makeFilterAndActionUnknown(respObj interface{}) {
+func (*emwrap) makeFilterAndActionUnknown(respObj any) {
 	switch actual := respObj.(type) {
 	case **atom.RuleEnvelope:
 		f := (*actual).Content.RuleDescription.Filter
@@ -1526,7 +1526,7 @@ func TestAdminClient_UnknownFilterRoundtrippingWorks(t *testing.T) {
 		Name: "ruleWithFilterAndAction",
 		Filter: &SQLFilter{
 			Expression: "MessageID=@stringVar OR MessageID=@intVar OR MessageID=@floatVar OR MessageID=@dateTimeVar OR MessageID=@boolVar",
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"@stringVar":   "hello world",
 				"@intVar":      int64(100),
 				"@floatVar":    float64(100.1),
@@ -1536,7 +1536,7 @@ func TestAdminClient_UnknownFilterRoundtrippingWorks(t *testing.T) {
 		},
 		Action: &SQLAction{
 			Expression: "SET MessageID=@stringVar SET MessageID=@intVar SET MessageID=@floatVar SET MessageID=@dateTimeVar SET MessageID=@boolVar",
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"@stringVar":   "hello world",
 				"@intVar":      int64(100),
 				"@floatVar":    float64(100.1),
@@ -1608,7 +1608,7 @@ type entityManagerForPagerTests struct {
 	getPaths []string
 }
 
-func (em *entityManagerForPagerTests) Get(ctx context.Context, entityPath string, respObj interface{}) (*http.Response, error) {
+func (em *entityManagerForPagerTests) Get(ctx context.Context, entityPath string, respObj any) (*http.Response, error) {
 	em.getPaths = append(em.getPaths, entityPath)
 
 	switch feedPtrPtr := respObj.(type) {
@@ -1634,7 +1634,7 @@ func TestAdminClient_pagerWithLightPage(t *testing.T) {
 	em := &entityManagerForPagerTests{}
 	adminClient.em = em
 
-	pager := adminClient.newPagerFunc("/$Resources/Topics", 10, func(pv interface{}) int {
+	pager := adminClient.newPagerFunc("/$Resources/Topics", 10, func(pv any) int {
 		// note that we're returning fewer results than the max page size
 		// in ATOM < max page size means this is the last page of results.
 		return 3
@@ -1677,7 +1677,7 @@ func TestAdminClient_pagerWithFullPage(t *testing.T) {
 	// first request - got 10 results back, not EOF
 	simulatedPageSize := 10
 
-	pager := adminClient.newPagerFunc("/$Resources/Topics", 10, func(pv interface{}) int {
+	pager := adminClient.newPagerFunc("/$Resources/Topics", 10, func(pv any) int {
 		return simulatedPageSize
 	})
 

--- a/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap.go
+++ b/sdk/messaging/azservicebus/internal/amqpwrap/amqpwrap.go
@@ -25,7 +25,7 @@ type AMQPReceiver interface {
 	ModifyMessage(ctx context.Context, msg *amqp.Message, options *amqp.ModifyMessageOptions) error
 
 	LinkName() string
-	LinkSourceFilterValue(name string) interface{}
+	LinkSourceFilterValue(name string) any
 
 	// wrapper only functions,
 
@@ -184,7 +184,7 @@ func (rw *AMQPReceiverWrapper) LinkName() string {
 	return rw.inner.LinkName()
 }
 
-func (rw *AMQPReceiverWrapper) LinkSourceFilterValue(name string) interface{} {
+func (rw *AMQPReceiverWrapper) LinkSourceFilterValue(name string) any {
 	return rw.inner.LinkSourceFilterValue(name)
 }
 

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -29,8 +29,8 @@ const (
 
 type (
 	EntityManager interface {
-		Get(ctx context.Context, entityPath string, respObj interface{}) (*http.Response, error)
-		Put(ctx context.Context, entityPath string, body interface{}, respObj interface{}, options *ExecuteOptions) (*http.Response, error)
+		Get(ctx context.Context, entityPath string, respObj any) (*http.Response, error)
+		Put(ctx context.Context, entityPath string, body any, respObj any, options *ExecuteOptions) (*http.Response, error)
 		Delete(ctx context.Context, entityPath string) (*http.Response, error)
 		TokenProvider() auth.TokenProvider
 	}
@@ -120,7 +120,7 @@ func NewEntityManager(ns string, tokenCredential azcore.TokenCredential, version
 }
 
 // Get performs an HTTP Get for a given entity path, deserializing the returned XML into `respObj`
-func (em *entityManager) Get(ctx context.Context, entityPath string, respObj interface{}) (*http.Response, error) {
+func (em *entityManager) Get(ctx context.Context, entityPath string, respObj any) (*http.Response, error) {
 	resp, err := em.execute(ctx, http.MethodGet, entityPath, http.NoBody, nil)
 	defer CloseRes(ctx, resp)
 
@@ -132,7 +132,7 @@ func (em *entityManager) Get(ctx context.Context, entityPath string, respObj int
 }
 
 // Put performs an HTTP PUT for a given entity path and body, deserializing the returned XML into `respObj`
-func (em *entityManager) Put(ctx context.Context, entityPath string, body interface{}, respObj interface{}, options *ExecuteOptions) (*http.Response, error) {
+func (em *entityManager) Put(ctx context.Context, entityPath string, body any, respObj any, options *ExecuteOptions) (*http.Response, error) {
 	bodyBytes, err := xml.Marshal(body)
 
 	if err != nil {
@@ -212,7 +212,7 @@ var ErrFeedEmpty = errors.New("entity does not exist")
 // deserializeBody deserializes the body of the response into the type specified by respObj
 // (similar to xml.Unmarshal, which this func is calling).
 // If an empty feed is found, it returns nil.
-func deserializeBody(resp *http.Response, respObj interface{}) (*http.Response, error) {
+func deserializeBody(resp *http.Response, respObj any) (*http.Response, error) {
 	bytes, err := io.ReadAll(resp.Body)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/internal/cbs.go
+++ b/sdk/messaging/azservicebus/internal/cbs.go
@@ -58,7 +58,7 @@ func NegotiateClaim(ctx context.Context, audience string, conn amqpwrap.AMQPClie
 
 	msg := &amqp.Message{
 		Value: token.Token,
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			cbsOperationKey:  cbsOperationPutToken,
 			cbsTokenTypeKey:  string(token.TokenType),
 			cbsAudienceKey:   audience,

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -292,7 +292,7 @@ type (
 	ErrIncorrectType struct {
 		Key          string
 		ExpectedType reflect.Type
-		ActualValue  interface{}
+		ActualValue  any
 	}
 
 	// ErrAMQP indicates that the server communicated an AMQP error with a particular
@@ -321,7 +321,7 @@ func (e ErrMalformedMessage) Error() string {
 
 // NewErrIncorrectType lets you skip using the `reflect` package. Just provide a variable of the desired type as
 // 'expected'.
-func NewErrIncorrectType(key string, expected, actual interface{}) ErrIncorrectType {
+func NewErrIncorrectType(key string, expected, actual any) ErrIncorrectType {
 	return ErrIncorrectType{
 		Key:          key,
 		ExpectedType: reflect.TypeOf(expected),

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -36,10 +36,10 @@ func TestErrMissingField_Error(t *testing.T) {
 
 func TestErrIncorrectType_Error(t *testing.T) {
 	var a int
-	var b map[string]interface{}
+	var b map[string]any
 	var c *float64
 
-	types := map[reflect.Type]interface{}{
+	types := map[reflect.Type]any{
 		reflect.TypeOf(a): 7.0,
 		reflect.TypeOf(b): map[string]string{},
 		reflect.TypeOf(c): int(2),

--- a/sdk/messaging/azservicebus/internal/mgmt.go
+++ b/sdk/messaging/azservicebus/internal/mgmt.go
@@ -39,13 +39,13 @@ func ReceiveDeferred(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName str
 		backwardsMode = 1
 	}
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"sequence-numbers":     sequenceNumbers,
 		"receiver-settle-mode": uint32(backwardsMode), // pick up messages with peek lock
 	}
 
 	msg := &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"operation": "com.microsoft:receive-by-sequence-number",
 		},
 		Value: values,
@@ -67,9 +67,9 @@ func ReceiveDeferred(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName str
 	// 	of arrays
 	// 		of maps (always with one key: "message")
 	// 			of an array with raw encoded Service Bus messages
-	val, ok := rsp.Message.Value.(map[string]interface{})
+	val, ok := rsp.Message.Value.(map[string]any)
 	if !ok {
-		return nil, NewErrIncorrectType(messageField, map[string]interface{}{}, rsp.Message.Value)
+		return nil, NewErrIncorrectType(messageField, map[string]any{}, rsp.Message.Value)
 	}
 
 	rawMessages, ok := val[messagesField]
@@ -77,16 +77,16 @@ func ReceiveDeferred(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName str
 		return nil, ErrMissingField(messagesField)
 	}
 
-	messages, ok := rawMessages.([]interface{})
+	messages, ok := rawMessages.([]any)
 	if !ok {
-		return nil, NewErrIncorrectType(messagesField, []interface{}{}, rawMessages)
+		return nil, NewErrIncorrectType(messagesField, []any{}, rawMessages)
 	}
 
 	transformedMessages := make([]*amqp.Message, len(messages))
 	for i := range messages {
-		rawEntry, ok := messages[i].(map[string]interface{})
+		rawEntry, ok := messages[i].(map[string]any)
 		if !ok {
-			return nil, NewErrIncorrectType(messageField, map[string]interface{}{}, messages[i])
+			return nil, NewErrIncorrectType(messageField, map[string]any{}, messages[i])
 		}
 
 		rawMessage, ok := rawEntry[messageField]
@@ -115,10 +115,10 @@ func PeekMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string
 	const messagesField, messageField = "messages", "message"
 
 	msg := &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"operation": "com.microsoft:peek-message",
 		},
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"from-sequence-number": fromSequenceNumber,
 			"message-count":        messageCount,
 		},
@@ -145,9 +145,9 @@ func PeekMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string
 	// 	of arrays
 	// 		of maps (always with one key: "message")
 	// 			of an array with raw encoded Service Bus messages
-	val, ok := rsp.Message.Value.(map[string]interface{})
+	val, ok := rsp.Message.Value.(map[string]any)
 	if !ok {
-		err = NewErrIncorrectType(messageField, map[string]interface{}{}, rsp.Message.Value)
+		err = NewErrIncorrectType(messageField, map[string]any{}, rsp.Message.Value)
 		return nil, err
 	}
 
@@ -157,17 +157,17 @@ func PeekMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string
 		return nil, err
 	}
 
-	messages, ok := rawMessages.([]interface{})
+	messages, ok := rawMessages.([]any)
 	if !ok {
-		err = NewErrIncorrectType(messagesField, []interface{}{}, rawMessages)
+		err = NewErrIncorrectType(messagesField, []any{}, rawMessages)
 		return nil, err
 	}
 
 	transformedMessages := make([]*amqp.Message, len(messages))
 	for i := range messages {
-		rawEntry, ok := messages[i].(map[string]interface{})
+		rawEntry, ok := messages[i].(map[string]any)
 		if !ok {
-			err = NewErrIncorrectType(messageField, map[string]interface{}{}, messages[i])
+			err = NewErrIncorrectType(messageField, map[string]any{}, messages[i])
 			return nil, err
 		}
 
@@ -215,10 +215,10 @@ func PeekMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string
 // NOTE: this function assumes all the messages received on the same link.
 func RenewLocks(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, lockTokens []amqp.UUID) ([]time.Time, error) {
 	renewRequestMsg := &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"operation": "com.microsoft:renew-lock",
 		},
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"lock-tokens": lockTokens,
 		},
 	}
@@ -239,21 +239,21 @@ func RenewLocks(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, 
 	// extract the new lock renewal times from the response
 	// response.Message.
 
-	val, ok := response.Message.Value.(map[string]interface{})
+	val, ok := response.Message.Value.(map[string]any)
 	if !ok {
-		return nil, NewErrIncorrectType("Message.Value", map[string]interface{}{}, response.Message.Value)
+		return nil, NewErrIncorrectType("Message.Value", map[string]any{}, response.Message.Value)
 	}
 
 	expirations, ok := val["expirations"]
 
 	if !ok {
-		return nil, NewErrIncorrectType("Message.Value[\"expirations\"]", map[string]interface{}{}, response.Message.Value)
+		return nil, NewErrIncorrectType("Message.Value[\"expirations\"]", map[string]any{}, response.Message.Value)
 	}
 
 	asTimes, ok := expirations.([]time.Time)
 
 	if !ok {
-		return nil, NewErrIncorrectType("Message.Value[\"expirations\"] as times", map[string]interface{}{}, response.Message.Value)
+		return nil, NewErrIncorrectType("Message.Value[\"expirations\"] as times", map[string]any{}, response.Message.Value)
 	}
 
 	return asTimes, nil
@@ -261,13 +261,13 @@ func RenewLocks(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, 
 
 // RenewSessionLocks renews a session lock.
 func RenewSessionLock(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, sessionID string) (time.Time, error) {
-	body := map[string]interface{}{
+	body := map[string]any{
 		"session-id": sessionID,
 	}
 
 	msg := &amqp.Message{
 		Value: body,
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"operation": "com.microsoft:renew-session-lock",
 		},
 	}
@@ -280,10 +280,10 @@ func RenewSessionLock(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName st
 		return time.Time{}, err
 	}
 
-	m, ok := resp.Message.Value.(map[string]interface{})
+	m, ok := resp.Message.Value.(map[string]any)
 
 	if !ok {
-		return time.Time{}, NewErrIncorrectType("Message.Value", map[string]interface{}{}, resp.Message.Value)
+		return time.Time{}, NewErrIncorrectType("Message.Value", map[string]any{}, resp.Message.Value)
 	}
 
 	lockedUntil, ok := m["expiration"].(time.Time)
@@ -298,10 +298,10 @@ func RenewSessionLock(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName st
 // GetSessionState retrieves state associated with the session.
 func GetSessionState(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, sessionID string) ([]byte, error) {
 	amqpMsg := &amqp.Message{
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"session-id": sessionID,
 		},
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"operation": "com.microsoft:get-session-state",
 		},
 	}
@@ -318,10 +318,10 @@ func GetSessionState(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName str
 		return nil, ErrAMQP(*resp)
 	}
 
-	asMap, ok := resp.Message.Value.(map[string]interface{})
+	asMap, ok := resp.Message.Value.(map[string]any)
 
 	if !ok {
-		return nil, NewErrIncorrectType("Value", map[string]interface{}{}, resp.Message.Value)
+		return nil, NewErrIncorrectType("Value", map[string]any{}, resp.Message.Value)
 	}
 
 	val := asMap["session-state"]
@@ -349,11 +349,11 @@ func SetSessionState(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName str
 	}
 
 	amqpMsg := &amqp.Message{
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"session-id":    sessionID,
 			"session-state": state,
 		},
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"operation":                 "com.microsoft:set-session-state",
 			"com.microsoft:tracking-id": uuid.String(),
 		},
@@ -377,13 +377,13 @@ func SetSessionState(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName str
 // SendDisposition allows you settle a message using the management link, rather than via your
 // *amqp.Receiver. Use this if the receiver has been closed/lost or if the message isn't associated
 // with a link (ex: deferred messages).
-func SendDisposition(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, lockToken *amqp.UUID, state Disposition, propertiesToModify map[string]interface{}) error {
+func SendDisposition(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, lockToken *amqp.UUID, state Disposition, propertiesToModify map[string]any) error {
 	if lockToken == nil {
 		err := errors.New("lock token on the message is not set, thus cannot send disposition")
 		return err
 	}
 
-	value := map[string]interface{}{
+	value := map[string]any{
 		"disposition-status": string(state.Status),
 		"lock-tokens":        []amqp.UUID{*lockToken},
 	}
@@ -401,7 +401,7 @@ func SendDisposition(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName str
 	}
 
 	msg := &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"operation": "com.microsoft:update-disposition",
 		},
 		Value: value,
@@ -425,7 +425,7 @@ func ScheduleMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName st
 		return nil, errors.New("expected one or more messages")
 	}
 
-	transformed := make([]interface{}, 0, len(messages))
+	transformed := make([]any, 0, len(messages))
 	enqueueTimeAsUTC := enqueueTime.UTC()
 
 	for i := range messages {
@@ -455,7 +455,7 @@ func ScheduleMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName st
 			return nil, err
 		}
 
-		individualMessage := map[string]interface{}{
+		individualMessage := map[string]any{
 			"message-id": messages[i].Properties.MessageID,
 			"message":    encoded,
 		}
@@ -476,10 +476,10 @@ func ScheduleMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName st
 	}
 
 	msg := &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"operation": "com.microsoft:schedule-message",
 		},
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"messages": transformed,
 		},
 	}
@@ -500,7 +500,7 @@ func ScheduleMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName st
 	}
 
 	retval := make([]int64, 0, len(messages))
-	if rawVal, ok := resp.Message.Value.(map[string]interface{}); ok {
+	if rawVal, ok := resp.Message.Value.(map[string]any); ok {
 		const sequenceFieldName = "sequence-numbers"
 		if rawArr, ok := rawVal[sequenceFieldName]; ok {
 			if arr, ok := rawArr.([]int64); ok {
@@ -511,17 +511,17 @@ func ScheduleMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName st
 		}
 		return nil, ErrMissingField(sequenceFieldName)
 	}
-	return nil, NewErrIncorrectType("value", map[string]interface{}{}, resp.Message.Value)
+	return nil, NewErrIncorrectType("value", map[string]any{}, resp.Message.Value)
 }
 
 // CancelScheduledMessages allows for removal of messages that have been handed to the Service Bus broker for later delivery,
 // but have not yet ben enqueued.
 func CancelScheduledMessages(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, seq []int64) error {
 	msg := &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"operation": "com.microsoft:cancel-scheduled-message",
 		},
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"sequence-numbers": seq,
 		},
 	}

--- a/sdk/messaging/azservicebus/internal/mock/mock_amqp.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_amqp.go
@@ -49,7 +49,7 @@ func (m *MockAMQPReceiver) AcceptMessage(ctx context.Context, msg *amqp.Message)
 }
 
 // AcceptMessage indicates an expected call of AcceptMessage.
-func (mr *MockAMQPReceiverMockRecorder) AcceptMessage(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) AcceptMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).AcceptMessage), ctx, msg)
 }
@@ -77,7 +77,7 @@ func (m *MockAMQPReceiver) IssueCredit(credit uint32) error {
 }
 
 // IssueCredit indicates an expected call of IssueCredit.
-func (mr *MockAMQPReceiverMockRecorder) IssueCredit(credit interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) IssueCredit(credit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueCredit", reflect.TypeOf((*MockAMQPReceiver)(nil).IssueCredit), credit)
 }
@@ -97,15 +97,15 @@ func (mr *MockAMQPReceiverMockRecorder) LinkName() *gomock.Call {
 }
 
 // LinkSourceFilterValue mocks base method.
-func (m *MockAMQPReceiver) LinkSourceFilterValue(name string) interface{} {
+func (m *MockAMQPReceiver) LinkSourceFilterValue(name string) any {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LinkSourceFilterValue", name)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(any)
 	return ret0
 }
 
 // LinkSourceFilterValue indicates an expected call of LinkSourceFilterValue.
-func (mr *MockAMQPReceiverMockRecorder) LinkSourceFilterValue(name interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) LinkSourceFilterValue(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSourceFilterValue", reflect.TypeOf((*MockAMQPReceiver)(nil).LinkSourceFilterValue), name)
 }
@@ -119,7 +119,7 @@ func (m *MockAMQPReceiver) ModifyMessage(ctx context.Context, msg *amqp.Message,
 }
 
 // ModifyMessage indicates an expected call of ModifyMessage.
-func (mr *MockAMQPReceiverMockRecorder) ModifyMessage(ctx, msg, options interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) ModifyMessage(ctx, msg, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).ModifyMessage), ctx, msg, options)
 }
@@ -148,7 +148,7 @@ func (m *MockAMQPReceiver) Receive(ctx context.Context) (*amqp.Message, error) {
 }
 
 // Receive indicates an expected call of Receive.
-func (mr *MockAMQPReceiverMockRecorder) Receive(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) Receive(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receive", reflect.TypeOf((*MockAMQPReceiver)(nil).Receive), ctx)
 }
@@ -162,7 +162,7 @@ func (m *MockAMQPReceiver) RejectMessage(ctx context.Context, msg *amqp.Message,
 }
 
 // RejectMessage indicates an expected call of RejectMessage.
-func (mr *MockAMQPReceiverMockRecorder) RejectMessage(ctx, msg, e interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) RejectMessage(ctx, msg, e any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).RejectMessage), ctx, msg, e)
 }
@@ -176,7 +176,7 @@ func (m *MockAMQPReceiver) ReleaseMessage(ctx context.Context, msg *amqp.Message
 }
 
 // ReleaseMessage indicates an expected call of ReleaseMessage.
-func (mr *MockAMQPReceiverMockRecorder) ReleaseMessage(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverMockRecorder) ReleaseMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).ReleaseMessage), ctx, msg)
 }
@@ -213,7 +213,7 @@ func (m *MockAMQPReceiverCloser) AcceptMessage(ctx context.Context, msg *amqp.Me
 }
 
 // AcceptMessage indicates an expected call of AcceptMessage.
-func (mr *MockAMQPReceiverCloserMockRecorder) AcceptMessage(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) AcceptMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptMessage", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).AcceptMessage), ctx, msg)
 }
@@ -227,7 +227,7 @@ func (m *MockAMQPReceiverCloser) Close(ctx context.Context) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockAMQPReceiverCloserMockRecorder) Close(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).Close), ctx)
 }
@@ -255,7 +255,7 @@ func (m *MockAMQPReceiverCloser) IssueCredit(credit uint32) error {
 }
 
 // IssueCredit indicates an expected call of IssueCredit.
-func (mr *MockAMQPReceiverCloserMockRecorder) IssueCredit(credit interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) IssueCredit(credit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueCredit", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).IssueCredit), credit)
 }
@@ -275,15 +275,15 @@ func (mr *MockAMQPReceiverCloserMockRecorder) LinkName() *gomock.Call {
 }
 
 // LinkSourceFilterValue mocks base method.
-func (m *MockAMQPReceiverCloser) LinkSourceFilterValue(name string) interface{} {
+func (m *MockAMQPReceiverCloser) LinkSourceFilterValue(name string) any {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LinkSourceFilterValue", name)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(any)
 	return ret0
 }
 
 // LinkSourceFilterValue indicates an expected call of LinkSourceFilterValue.
-func (mr *MockAMQPReceiverCloserMockRecorder) LinkSourceFilterValue(name interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) LinkSourceFilterValue(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSourceFilterValue", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).LinkSourceFilterValue), name)
 }
@@ -297,7 +297,7 @@ func (m *MockAMQPReceiverCloser) ModifyMessage(ctx context.Context, msg *amqp.Me
 }
 
 // ModifyMessage indicates an expected call of ModifyMessage.
-func (mr *MockAMQPReceiverCloserMockRecorder) ModifyMessage(ctx, msg, options interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) ModifyMessage(ctx, msg, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyMessage", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).ModifyMessage), ctx, msg, options)
 }
@@ -326,7 +326,7 @@ func (m *MockAMQPReceiverCloser) Receive(ctx context.Context) (*amqp.Message, er
 }
 
 // Receive indicates an expected call of Receive.
-func (mr *MockAMQPReceiverCloserMockRecorder) Receive(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) Receive(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receive", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).Receive), ctx)
 }
@@ -340,7 +340,7 @@ func (m *MockAMQPReceiverCloser) RejectMessage(ctx context.Context, msg *amqp.Me
 }
 
 // RejectMessage indicates an expected call of RejectMessage.
-func (mr *MockAMQPReceiverCloserMockRecorder) RejectMessage(ctx, msg, e interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) RejectMessage(ctx, msg, e any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectMessage", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).RejectMessage), ctx, msg, e)
 }
@@ -354,7 +354,7 @@ func (m *MockAMQPReceiverCloser) ReleaseMessage(ctx context.Context, msg *amqp.M
 }
 
 // ReleaseMessage indicates an expected call of ReleaseMessage.
-func (mr *MockAMQPReceiverCloserMockRecorder) ReleaseMessage(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPReceiverCloserMockRecorder) ReleaseMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseMessage", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).ReleaseMessage), ctx, msg)
 }
@@ -419,7 +419,7 @@ func (m *MockAMQPSender) Send(ctx context.Context, msg *amqp.Message) error {
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockAMQPSenderMockRecorder) Send(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPSenderMockRecorder) Send(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockAMQPSender)(nil).Send), ctx, msg)
 }
@@ -456,7 +456,7 @@ func (m *MockAMQPSenderCloser) Close(ctx context.Context) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockAMQPSenderCloserMockRecorder) Close(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPSenderCloserMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPSenderCloser)(nil).Close), ctx)
 }
@@ -498,7 +498,7 @@ func (m *MockAMQPSenderCloser) Send(ctx context.Context, msg *amqp.Message) erro
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockAMQPSenderCloserMockRecorder) Send(ctx, msg interface{}) *gomock.Call {
+func (mr *MockAMQPSenderCloserMockRecorder) Send(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockAMQPSenderCloser)(nil).Send), ctx, msg)
 }
@@ -535,7 +535,7 @@ func (m *MockAMQPSession) Close(ctx context.Context) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockAMQPSessionMockRecorder) Close(ctx interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPSession)(nil).Close), ctx)
 }
@@ -550,7 +550,7 @@ func (m *MockAMQPSession) NewReceiver(ctx context.Context, source string, opts *
 }
 
 // NewReceiver indicates an expected call of NewReceiver.
-func (mr *MockAMQPSessionMockRecorder) NewReceiver(ctx, source, opts interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) NewReceiver(ctx, source, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReceiver", reflect.TypeOf((*MockAMQPSession)(nil).NewReceiver), ctx, source, opts)
 }
@@ -565,7 +565,7 @@ func (m *MockAMQPSession) NewSender(ctx context.Context, target string, opts *am
 }
 
 // NewSender indicates an expected call of NewSender.
-func (mr *MockAMQPSessionMockRecorder) NewSender(ctx, target, opts interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) NewSender(ctx, target, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSender", reflect.TypeOf((*MockAMQPSession)(nil).NewSender), ctx, target, opts)
 }
@@ -631,7 +631,7 @@ func (m *MockAMQPClient) NewSession(ctx context.Context, opts *amqp.SessionOptio
 }
 
 // NewSession indicates an expected call of NewSession.
-func (mr *MockAMQPClientMockRecorder) NewSession(ctx, opts interface{}) *gomock.Call {
+func (mr *MockAMQPClientMockRecorder) NewSession(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockAMQPClient)(nil).NewSession), ctx, opts)
 }

--- a/sdk/messaging/azservicebus/internal/mock/mock_helpers.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_helpers.go
@@ -58,7 +58,7 @@ func NewContextWithValueMatcher[KT comparable, VT comparable](key KT, value VT) 
 	return ContextWithValueMatcher[KT, VT]{key, value}
 }
 
-func (m ContextWithValueMatcher[KT, VT]) Matches(x interface{}) bool {
+func (m ContextWithValueMatcher[KT, VT]) Matches(x any) bool {
 	ctx := x.(context.Context)
 	return ctx.Value(m.Key) == m.Value
 }
@@ -88,7 +88,7 @@ type ContextCancelledMatcher struct {
 }
 
 // Matches returns whether x is a match.
-func (m ContextCancelledMatcher) Matches(x interface{}) bool {
+func (m ContextCancelledMatcher) Matches(x any) bool {
 	ctx := x.(context.Context)
 
 	if m.WantCancelled {
@@ -105,7 +105,7 @@ func (m ContextCancelledMatcher) String() string {
 
 type ContextCreatedForTest struct{}
 
-func (m ContextCreatedForTest) Matches(x interface{}) bool {
+func (m ContextCreatedForTest) Matches(x any) bool {
 	ctx := x.(context.Context)
 	return ctx.Value(testContextKey(0)) != nil
 }

--- a/sdk/messaging/azservicebus/internal/mock/mock_namespace.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_namespace.go
@@ -62,7 +62,7 @@ func (m *MockNamespaceForAMQPLinks) Close(permanently bool) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) Close(permanently interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) Close(permanently any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).Close), permanently)
 }
@@ -76,7 +76,7 @@ func (m *MockNamespaceForAMQPLinks) GetEntityAudience(entityPath string) string 
 }
 
 // GetEntityAudience indicates an expected call of GetEntityAudience.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) GetEntityAudience(entityPath interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) GetEntityAudience(entityPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityAudience", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).GetEntityAudience), entityPath)
 }
@@ -92,7 +92,7 @@ func (m *MockNamespaceForAMQPLinks) NegotiateClaim(ctx context.Context, entityPa
 }
 
 // NegotiateClaim indicates an expected call of NegotiateClaim.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) NegotiateClaim(ctx, entityPath interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) NegotiateClaim(ctx, entityPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NegotiateClaim", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).NegotiateClaim), ctx, entityPath)
 }
@@ -108,7 +108,7 @@ func (m *MockNamespaceForAMQPLinks) NewAMQPSession(ctx context.Context) (amqpwra
 }
 
 // NewAMQPSession indicates an expected call of NewAMQPSession.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) NewAMQPSession(ctx interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) NewAMQPSession(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAMQPSession", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).NewAMQPSession), ctx)
 }
@@ -123,7 +123,7 @@ func (m *MockNamespaceForAMQPLinks) NewRPCLink(ctx context.Context, managementPa
 }
 
 // NewRPCLink indicates an expected call of NewRPCLink.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) NewRPCLink(ctx, managementPath interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) NewRPCLink(ctx, managementPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRPCLink", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).NewRPCLink), ctx, managementPath)
 }
@@ -138,7 +138,7 @@ func (m *MockNamespaceForAMQPLinks) Recover(ctx context.Context, clientRevision 
 }
 
 // Recover indicates an expected call of Recover.
-func (mr *MockNamespaceForAMQPLinksMockRecorder) Recover(ctx, clientRevision interface{}) *gomock.Call {
+func (mr *MockNamespaceForAMQPLinksMockRecorder) Recover(ctx, clientRevision any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recover", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).Recover), ctx, clientRevision)
 }

--- a/sdk/messaging/azservicebus/internal/mock/mock_rpc.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_rpc.go
@@ -49,7 +49,7 @@ func (m *MockRPCLink) Close(ctx context.Context) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockRPCLinkMockRecorder) Close(ctx interface{}) *gomock.Call {
+func (mr *MockRPCLinkMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRPCLink)(nil).Close), ctx)
 }
@@ -64,7 +64,7 @@ func (m *MockRPCLink) RPC(ctx context.Context, msg *amqp.Message) (*amqpwrap.RPC
 }
 
 // RPC indicates an expected call of RPC.
-func (mr *MockRPCLinkMockRecorder) RPC(ctx, msg interface{}) *gomock.Call {
+func (mr *MockRPCLinkMockRecorder) RPC(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPC", reflect.TypeOf((*MockRPCLink)(nil).RPC), ctx, msg)
 }

--- a/sdk/messaging/azservicebus/internal/mock/mock_token.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_token.go
@@ -46,7 +46,7 @@ func (m *MockTokenProvider) GetToken(uri string) (*auth.Token, error) {
 }
 
 // GetToken indicates an expected call of GetToken.
-func (mr *MockTokenProviderMockRecorder) GetToken(uri interface{}) *gomock.Call {
+func (mr *MockTokenProviderMockRecorder) GetToken(uri any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockTokenProvider)(nil).GetToken), uri)
 }

--- a/sdk/messaging/azservicebus/internal/mock/mock_token_credential.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_token_credential.go
@@ -48,7 +48,7 @@ func (m *MockTokenCredential) GetToken(ctx context.Context, options policy.Token
 }
 
 // GetToken indicates an expected call of GetToken.
-func (mr *MockTokenCredentialMockRecorder) GetToken(ctx, options interface{}) *gomock.Call {
+func (mr *MockTokenCredentialMockRecorder) GetToken(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockTokenCredential)(nil).GetToken), ctx, options)
 }

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -164,7 +164,7 @@ func (ns *Namespace) newClientImpl(ctx context.Context) (amqpwrap.AMQPClient, er
 	connOptions := amqp.ConnOptions{
 		SASLType:    amqp.SASLTypeAnonymous(),
 		MaxSessions: 65535,
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"product":    "MSGolangClient",
 			"version":    Version,
 			"platform":   runtime.GOOS,

--- a/sdk/messaging/azservicebus/internal/rpc.go
+++ b/sdk/messaging/azservicebus/internal/rpc.go
@@ -228,7 +228,7 @@ func (l *rpcLink) RPC(ctx context.Context, msg *amqp.Message) (*amqpwrap.RPCResp
 	msg.Properties.ReplyTo = &l.clientAddress
 
 	if msg.ApplicationProperties == nil {
-		msg.ApplicationProperties = make(map[string]interface{})
+		msg.ApplicationProperties = make(map[string]any)
 	}
 
 	if _, ok := msg.ApplicationProperties["server-timeout"]; !ok {

--- a/sdk/messaging/azservicebus/internal/rpc_test.go
+++ b/sdk/messaging/azservicebus/internal/rpc_test.go
@@ -44,7 +44,7 @@ func TestRPCLinkNonErrorRequiresRecovery(t *testing.T) {
 	}
 
 	resp, err := link.RPC(context.Background(), &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			rpcTesterProperty: responses,
 		},
 	})
@@ -99,7 +99,7 @@ func TestRPCLinkNonErrorRequiresNoRecovery(t *testing.T) {
 	}
 
 	resp, err := link.RPC(context.Background(), &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			rpcTesterProperty: responses,
 		},
 		Properties: &amqp.MessageProperties{
@@ -133,7 +133,7 @@ func TestRPCLinkNonErrorLockLostDoesNotBreakAnything(t *testing.T) {
 	require.NotNil(t, link)
 
 	resp, err := link.RPC(context.Background(), &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			rpcTesterProperty: []*rpcTestResp{
 				{M: exampleMessageWithStatusCode(400)},
 			},
@@ -151,7 +151,7 @@ func TestRPCLinkNonErrorLockLostDoesNotBreakAnything(t *testing.T) {
 
 	// validate that a normal error doesn't cause the response router to shut down
 	resp, err = link.RPC(context.Background(), &amqp.Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			rpcTesterProperty: []*rpcTestResp{
 				{M: exampleMessageWithStatusCode(200)},
 			},
@@ -281,7 +281,7 @@ func exampleMessageWithStatusCode(statusCode int32) *amqp.Message {
 			// will get auto-filled in by the test
 			CorrelationID: nil,
 		},
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			statusCodeKey: statusCode,
 		},
 	}

--- a/sdk/messaging/azservicebus/internal/stress/shared/utils.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/utils.go
@@ -38,7 +38,7 @@ func MustGenerateMessages(sc *StressContext, sender *azservicebus.Sender, messag
 	for i := 0; i < messageLimit; i++ {
 		err := streamingBatch.Add(ctx, &azservicebus.Message{
 			Body: extraBytes,
-			ApplicationProperties: map[string]interface{}{
+			ApplicationProperties: map[string]any{
 				"Number": i,
 			},
 		}, nil)

--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -15,7 +15,7 @@ import (
 // ReceivedMessage is a received message from a Client.NewReceiver().
 type ReceivedMessage struct {
 	// ApplicationProperties can be used to store custom metadata for a message.
-	ApplicationProperties map[string]interface{}
+	ApplicationProperties map[string]any
 
 	// Body is the payload for a message.
 	Body []byte
@@ -148,7 +148,7 @@ const (
 // Properties that are pointers are optional.
 type Message struct {
 	// ApplicationProperties can be used to store custom metadata for a message.
-	ApplicationProperties map[string]interface{}
+	ApplicationProperties map[string]any
 
 	// Body corresponds to the first []byte array in the Data section of an AMQP message.
 	Body []byte
@@ -239,7 +239,7 @@ func (m *Message) toAMQPMessage() *amqp.Message {
 		amqpMsg.Header.TTL = *m.TimeToLive
 	}
 
-	var messageID interface{}
+	var messageID any
 
 	if m.MessageID != nil {
 		messageID = *m.MessageID
@@ -268,13 +268,13 @@ func (m *Message) toAMQPMessage() *amqp.Message {
 	amqpMsg.Properties.ReplyToGroupID = m.ReplyToSessionID
 
 	if len(m.ApplicationProperties) > 0 {
-		amqpMsg.ApplicationProperties = make(map[string]interface{})
+		amqpMsg.ApplicationProperties = make(map[string]any)
 		for key, value := range m.ApplicationProperties {
 			amqpMsg.ApplicationProperties[key] = value
 		}
 	}
 
-	amqpMsg.Annotations = map[interface{}]interface{}{}
+	amqpMsg.Annotations = map[any]any{}
 
 	if m.PartitionKey != nil {
 		amqpMsg.Annotations[partitionKeyAnnotation] = *m.PartitionKey
@@ -344,7 +344,7 @@ func newReceivedMessage(amqpMsg *amqp.Message) *ReceivedMessage {
 	}
 
 	if amqpMsg.ApplicationProperties != nil {
-		msg.ApplicationProperties = make(map[string]interface{}, len(amqpMsg.ApplicationProperties))
+		msg.ApplicationProperties = make(map[string]any, len(amqpMsg.ApplicationProperties))
 		for key, value := range amqpMsg.ApplicationProperties {
 			msg.ApplicationProperties[key] = value
 		}
@@ -417,7 +417,7 @@ func newReceivedMessage(amqpMsg *amqp.Message) *ReceivedMessage {
 		// This approach is also consistent with the behavior of .NET:
 		//
 		//	https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.eventdata.systemproperties?view=azure-dotnet#Azure_Messaging_EventHubs_EventData_SystemProperties
-		// msg.SystemProperties.Annotations = make(map[string]interface{})
+		// msg.SystemProperties.Annotations = make(map[string]any)
 		// for key, val := range amqpMsg.Annotations {
 		// 	if s, ok := key.(string); ok {
 		// 		msg.SystemProperties.Annotations[s] = val
@@ -477,7 +477,7 @@ func uuidFromLockTokenBytes(bytes []byte) (*amqp.UUID, error) {
 	return &amqpUUID, nil
 }
 
-func asInt64(v interface{}, defVal int64) int64 {
+func asInt64(v any, defVal int64) int64 {
 	switch v2 := v.(type) {
 	case int32:
 		return int64(v2)

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -75,7 +75,7 @@ func (s *messageSettler) CompleteMessage(ctx context.Context, message *ReceivedM
 // AbandonMessageOptions contains optional parameters for Client.AbandonMessage
 type AbandonMessageOptions struct {
 	// PropertiesToModify specifies properties to modify in the message when it is abandoned.
-	PropertiesToModify map[string]interface{}
+	PropertiesToModify map[string]any
 }
 
 // AbandonMessage will cause a message to be returned to the queue or subscription.
@@ -88,7 +88,7 @@ func (s *messageSettler) AbandonMessage(ctx context.Context, message *ReceivedMe
 				Status: internal.AbandonedDisposition,
 			}
 
-			var propertiesToModify map[string]interface{}
+			var propertiesToModify map[string]any
 
 			if options != nil && options.PropertiesToModify != nil {
 				propertiesToModify = options.PropertiesToModify
@@ -114,7 +114,7 @@ func (s *messageSettler) AbandonMessage(ctx context.Context, message *ReceivedMe
 // DeferMessageOptions contains optional parameters for Client.DeferMessage
 type DeferMessageOptions struct {
 	// PropertiesToModify specifies properties to modify in the message when it is deferred
-	PropertiesToModify map[string]interface{}
+	PropertiesToModify map[string]any
 }
 
 // DeferMessage will cause a message to be deferred. Deferred messages
@@ -126,7 +126,7 @@ func (s *messageSettler) DeferMessage(ctx context.Context, message *ReceivedMess
 				Status: internal.DeferredDisposition,
 			}
 
-			var propertiesToModify map[string]interface{}
+			var propertiesToModify map[string]any
 
 			if options != nil && options.PropertiesToModify != nil {
 				propertiesToModify = options.PropertiesToModify
@@ -160,7 +160,7 @@ type DeadLetterOptions struct {
 	Reason *string
 
 	// PropertiesToModify specifies properties to modify in the message when it is dead lettered.
-	PropertiesToModify map[string]interface{}
+	PropertiesToModify map[string]any
 }
 
 // DeadLetterMessage settles a message by moving it to the dead letter queue for a
@@ -188,7 +188,7 @@ func (s *messageSettler) DeadLetterMessage(ctx context.Context, message *Receive
 				DeadLetterReason:      &reason,
 			}
 
-			var propertiesToModify map[string]interface{}
+			var propertiesToModify map[string]any
 
 			if options != nil && options.PropertiesToModify != nil {
 				propertiesToModify = options.PropertiesToModify
@@ -197,7 +197,7 @@ func (s *messageSettler) DeadLetterMessage(ctx context.Context, message *Receive
 			return internal.SendDisposition(ctx, rpcLink, receiver.LinkName(), bytesToAMQPUUID(message.LockToken), d, propertiesToModify)
 		}
 
-		info := map[string]interface{}{
+		info := map[string]any{
 			"DeadLetterReason":           reason,
 			"DeadLetterErrorDescription": description,
 		}
@@ -222,7 +222,7 @@ func bytesToAMQPUUID(bytes [16]byte) *amqp.UUID {
 	return &uuid
 }
 
-func newAnnotations(propertiesToModify map[string]interface{}) amqp.Annotations {
+func newAnnotations(propertiesToModify map[string]any) amqp.Annotations {
 	var annotations amqp.Annotations
 
 	for k, v := range propertiesToModify {

--- a/sdk/messaging/azservicebus/messageSettler_test.go
+++ b/sdk/messaging/azservicebus/messageSettler_test.go
@@ -30,7 +30,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 
 	// message from queue -> Abandon -> back to the queue
 	err = receiver.AbandonMessage(context.Background(), messages[0], &AbandonMessageOptions{
-		PropertiesToModify: map[string]interface{}{
+		PropertiesToModify: map[string]any{
 			"hello": "world",
 		},
 	})
@@ -67,7 +67,7 @@ func TestMessageSettlementUsingReceiver(t *testing.T) {
 
 	// deferred message from dead letter queue -> Abandon -> dead letter queue
 	err = deadLetterReceiver.AbandonMessage(ctx, messages[0], &AbandonMessageOptions{
-		PropertiesToModify: map[string]interface{}{
+		PropertiesToModify: map[string]any{
 			"hello": "world",
 		},
 	})
@@ -130,7 +130,7 @@ func TestDeferredMessages(t *testing.T) {
 
 		// abandoning the deferred message will increment its delivery count
 		err := receiver.AbandonMessage(ctx, originalDeferredMessage, &AbandonMessageOptions{
-			PropertiesToModify: map[string]interface{}{
+			PropertiesToModify: map[string]any{
 				"hello": "world",
 			},
 		})
@@ -159,7 +159,7 @@ func TestDeferredMessages(t *testing.T) {
 
 		// double defer!
 		err := receiver.DeferMessage(ctx, msg, &DeferMessageOptions{
-			PropertiesToModify: map[string]interface{}{
+			PropertiesToModify: map[string]any{
 				"hello": "world",
 			},
 		})

--- a/sdk/messaging/azservicebus/message_batch_test.go
+++ b/sdk/messaging/azservicebus/message_batch_test.go
@@ -34,7 +34,7 @@ func TestMessageBatchUnitTests(t *testing.T) {
 
 		err := mb.AddMessage(&Message{
 			Body: []byte("small body"),
-			ApplicationProperties: map[string]interface{}{
+			ApplicationProperties: map[string]any{
 				"small": "value",
 			},
 		}, nil)
@@ -54,7 +54,7 @@ func TestMessageBatchUnitTests(t *testing.T) {
 
 		err := mb.AddMessage(&Message{
 			Body: []byte("small body"),
-			ApplicationProperties: map[string]interface{}{
+			ApplicationProperties: map[string]any{
 				"hello":      "world",
 				"anInt":      100,
 				"aFLoat":     100.1,

--- a/sdk/messaging/azservicebus/message_test.go
+++ b/sdk/messaging/azservicebus/message_test.go
@@ -40,7 +40,7 @@ func TestMessageUnitTest(t *testing.T) {
 		require.EqualValues(t, "the body", string(amqpMessage.Data[0]))
 		require.EqualValues(t, 1, len(amqpMessage.Data))
 
-		require.EqualValues(t, map[interface{}]interface{}{
+		require.EqualValues(t, map[any]any{
 			partitionKeyAnnotation:          "partition key",
 			scheduledEnqueuedTimeAnnotation: scheduledEnqueuedTime,
 		}, amqpMessage.Annotations)
@@ -63,7 +63,7 @@ func TestAMQPMessageToReceivedMessage(t *testing.T) {
 			Data: [][]byte{
 				[]byte("hello"),
 			},
-			Annotations: map[interface{}]interface{}{
+			Annotations: map[any]any{
 				"x-opt-locked-until":            lockedUntil,
 				"x-opt-sequence-number":         int64(101),
 				"x-opt-partition-key":           "partitionKey1",
@@ -125,7 +125,7 @@ func TestAMQPMessageToMessage(t *testing.T) {
 			"x-opt-via-partition-key":       "via",
 			"custom-annotation":             "value",
 		},
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"test": "foo",
 		},
 		Header: &amqp.MessageHeader{
@@ -153,14 +153,14 @@ func TestAMQPMessageToMessage(t *testing.T) {
 
 	require.EqualValues(t, msg.LockToken, expectedAMQPEncodedLockTokenGUID, "locktoken")
 
-	require.EqualValues(t, map[string]interface{}{
+	require.EqualValues(t, map[string]any{
 		"test": "foo",
 	}, msg.ApplicationProperties)
 }
 
 func TestMessageState(t *testing.T) {
 	testData := []struct {
-		PropValue interface{}
+		PropValue any
 		Expected  MessageState
 	}{
 		{PropValue: int32(0), Expected: MessageStateActive},

--- a/sdk/messaging/azservicebus/receiver_helpers_test.go
+++ b/sdk/messaging/azservicebus/receiver_helpers_test.go
@@ -31,7 +31,7 @@ type StubAMQPReceiver struct {
 	stubModifyMessageCalled         int
 	stubLinkName                    func(inner amqpwrap.AMQPReceiverCloser) string
 	stubLinkNameCalled              int
-	stubLinkSourceFilterValue       func(inner amqpwrap.AMQPReceiverCloser, name string) interface{}
+	stubLinkSourceFilterValue       func(inner amqpwrap.AMQPReceiverCloser, name string) any
 	stubLinkSourceFilterValueCalled int
 	inner                           amqpwrap.AMQPReceiverCloser
 }
@@ -109,7 +109,7 @@ func (r *StubAMQPReceiver) LinkName() string {
 	return r.inner.LinkName()
 }
 
-func (r *StubAMQPReceiver) LinkSourceFilterValue(name string) interface{} {
+func (r *StubAMQPReceiver) LinkSourceFilterValue(name string) any {
 	r.stubLinkSourceFilterValueCalled++
 	if r.stubLinkSourceFilterValue != nil {
 		return r.stubLinkSourceFilterValue(r.inner, name)

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -601,7 +601,7 @@ func TestReceiverAMQPDataTypes(t *testing.T) {
 
 	require.NoError(t, sender.SendMessage(context.Background(), &Message{
 		Body: []byte("hello, this is the body"),
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			// Some primitive types are missing - it's a bit unclear what the right representation of this would be in Go:
 			// - TypeCodeDecimal32
 			// - TypeCodeDecimal64
@@ -638,7 +638,7 @@ func TestReceiverAMQPDataTypes(t *testing.T) {
 
 	actualProps := messages[0].ApplicationProperties
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"timestamp": expectedTime,
 
 		"byte":   byte(128),

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -192,7 +192,7 @@ func Test_Sender_SendMessages_resend(t *testing.T) {
 	sendAndReceive := func(receiver *Receiver, complete bool) {
 		origSentMsg := &Message{
 			Body: []byte("ResendableMessage"),
-			ApplicationProperties: map[string]interface{}{
+			ApplicationProperties: map[string]any{
 				"Status": "first send",
 			},
 		}
@@ -503,7 +503,7 @@ func TestSender_SendAMQPMessage(t *testing.T) {
 				[]byte("Hello World"),
 			},
 		},
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"hello": "world",
 		},
 	}, nil)
@@ -555,7 +555,7 @@ func TestSender_SendAMQPMessageWithMultipleByteSlicesInData(t *testing.T) {
 				[]byte("Hello World"),
 				[]byte("And another message!"),
 			}},
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"hello": "world",
 		},
 	}, nil)
@@ -634,7 +634,7 @@ func TestSender_SendAMQPMessageWithValue(t *testing.T) {
 	for i, value := range values {
 		err = sender.SendAMQPAnnotatedMessage(context.Background(), &AMQPAnnotatedMessage{
 			Body: AMQPAnnotatedMessageBody{Value: value},
-			ApplicationProperties: map[string]interface{}{
+			ApplicationProperties: map[string]any{
 				"index": i,
 			},
 		}, nil)
@@ -676,7 +676,7 @@ func TestSender_SendAMQPMessageWithSequence(t *testing.T) {
 
 		err = sender.SendAMQPAnnotatedMessage(context.Background(), &AMQPAnnotatedMessage{
 			Body: AMQPAnnotatedMessageBody{Sequence: seq},
-			ApplicationProperties: map[string]interface{}{
+			ApplicationProperties: map[string]any{
 				"index": i,
 			},
 		}, nil)


### PR DESCRIPTION
Tidying: Fixing API surface to use 'any' instead of 'interface{}'

Fixes #18406