### PR TITLE
Use unique container names for tests TestSetBlobTagsWithLeaseId

### DIFF
--- a/sdk/storage/azblob/appendblob/client.go
+++ b/sdk/storage/azblob/appendblob/client.go
@@ -259,7 +259,7 @@ func (ab *Client) SetLegalHold(ctx context.Context, legalHold bool, options *blo
 // SetTier
 // Deprecated: SetTier only works for page blob in premium storage account and block blob in blob storage account.
 func (ab *Client) SetTier(ctx context.Context, tier blob.AccessTier, o *blob.SetTierOptions) (blob.SetTierResponse, error) {
-	return blob.SetTierResponse{}, errors.New("Operation will not work on this blob type. SetTier only works for page blob in premium storage account and block blob in blob storage account.")
+	return blob.SetTierResponse{}, errors.New("operation will not work on this blob type. SetTier only works for page blob in premium storage account and block blob in blob storage account")
 }
 
 // SetExpiry operation sets an expiry time on an existing blob. This operation is only allowed on Hierarchical Namespace enabled accounts.
@@ -326,7 +326,7 @@ func (ab *Client) GetTags(ctx context.Context, o *blob.GetTagsOptions) (blob.Get
 // CopyFromURL
 // Deprecated: CopyFromURL works only with block blob
 func (ab *Client) CopyFromURL(ctx context.Context, copySource string, o *blob.CopyFromURLOptions) (blob.CopyFromURLResponse, error) {
-	return blob.CopyFromURLResponse{}, errors.New("Operation will not work on this blob type. CopyFromURL works only with block blob.")
+	return blob.CopyFromURLResponse{}, errors.New("operation will not work on this blob type. CopyFromURL works only with block blob")
 }
 
 // Concurrent Download Functions -----------------------------------------------------------------------------------------

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/binary"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/lease"
 	"hash/crc64"
 	"io"
 	"math/rand"
@@ -31,6 +30,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/testcommon"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/lease"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -2918,7 +2918,7 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendBlobSetBlobTags() {
 
 func (s *AppendBlobUnrecordedTestsSuite) TestSetBlobTagsWithLeaseId() {
 	_require := require.New(s.T())
-	testName := s.T().Name()
+	testName := "ab" + s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
 	_require.NoError(err)
 

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -2288,7 +2288,7 @@ func (s *BlockBlobUnrecordedTestsSuite) TestSetBlobTags() {
 
 func (s *BlockBlobUnrecordedTestsSuite) TestSetBlobTagsWithLeaseId() {
 	_require := require.New(s.T())
-	testName := s.T().Name()
+	testName := "bb" + s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
 	_require.NoError(err)
 


### PR DESCRIPTION
There are two tests with the same name and depending on timing, the container might not have finished being deleted.  Use unique names to avoid the race.
Cleaned up linter warnings for error strings.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
