### PR TITLE
Added support for get account info in blob and container clients

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Added [Blob Batch API](https://learn.microsoft.com/rest/api/storageservices/blob-batch).
 * Added support for bearer challenge for identity based managed disks.
+* Added support for GetAccountInfo to container and blob level clients. 
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/appendblob/client.go
+++ b/sdk/storage/azblob/appendblob/client.go
@@ -279,6 +279,12 @@ func (ab *Client) GetProperties(ctx context.Context, o *blob.GetPropertiesOption
 	return ab.BlobClient().GetProperties(ctx, o)
 }
 
+// GetAccountInfo provides account level information
+// For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures.
+func (ab *Client) GetAccountInfo(ctx context.Context, o *blob.GetAccountInfoOptions) (blob.GetAccountInfoResponse, error) {
+	return ab.BlobClient().GetAccountInfo(ctx, o)
+}
+
 // SetHTTPHeaders changes a blob's HTTP headers.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/set-blob-properties.
 func (ab *Client) SetHTTPHeaders(ctx context.Context, HTTPHeaders blob.HTTPHeaders, o *blob.SetHTTPHeadersOptions) (blob.SetHTTPHeadersResponse, error) {

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -2963,7 +2963,7 @@ func (s *AppendBlobUnrecordedTestsSuite) TestSetBlobTagsWithLeaseId() {
 	}
 }
 
-func (s *AppendBlobRecordedTestsSuite) TestGetAccountInfo() {
+func (s *AppendBlobRecordedTestsSuite) TestAppendGetAccountInfo() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -2962,3 +2962,23 @@ func (s *AppendBlobUnrecordedTestsSuite) TestSetBlobTagsWithLeaseId() {
 		_require.Equal(testcommon.BasicBlobTagsMap[*blobTag.Key], *blobTag.Value)
 	}
 }
+
+func (s *AppendBlobRecordedTestsSuite) TestGetAccountInfo() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	abClient := getAppendBlobClient(testcommon.GenerateBlobName(testName), containerClient)
+	_, err = abClient.Create(context.Background(), nil)
+	_require.Nil(err)
+
+	// Ensure the call succeeded. Don't test for specific account properties because we can't/don't want to set account properties.
+	bAccInfo, err := abClient.GetAccountInfo(context.Background(), nil)
+	_require.Nil(err)
+	_require.NotZero(bAccInfo)
+}

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_cbcc92f524"
+  "Tag": "go/storage/azblob_095ab85d07"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_095ab85d07"
+  "Tag": "go/storage/azblob_5d20008f59"
 }

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -268,6 +268,14 @@ func (b *Client) CopyFromURL(ctx context.Context, copySource string, options *Co
 	return resp, err
 }
 
+// GetAccountInfo provides account level information
+// For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures.
+func (b *Client) GetAccountInfo(ctx context.Context, o *GetAccountInfoOptions) (GetAccountInfoResponse, error) {
+	getAccountInfoOptions := o.format()
+	resp, err := b.generated().GetAccountInfo(ctx, getAccountInfoOptions)
+	return resp, err
+}
+
 // GetSASURL is a convenience method for generating a SAS token for the currently pointed at blob.
 // It can only be used if the credential supplied during creation was a SharedKeyCredential.
 func (b *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o *GetSASURLOptions) (string, error) {

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3610,7 +3610,7 @@ func (s *BlobUnrecordedTestsSuite) TestNoSharedKeyCredError() {
 	_require.Equal(err, bloberror.MissingSharedKeyCredential)
 }
 
-func (s *BlobRecordedTestsSuite) TestGetAccountInfo() {
+func (s *BlobRecordedTestsSuite) TestBlobGetAccountInfo() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3609,3 +3609,22 @@ func (s *BlobUnrecordedTestsSuite) TestNoSharedKeyCredError() {
 	_, err = bbClient.BlobClient().GetSASURL(permissions, expiry, &opts)
 	_require.Equal(err, bloberror.MissingSharedKeyCredential)
 }
+
+func (s *BlobRecordedTestsSuite) TestGetAccountInfo() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blockBlobName := testcommon.GenerateBlobName(testName)
+	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
+
+	// Ensure the call succeeded. Don't test for specific account properties because we can't/don't want to set account properties.
+	bAccInfo, err := bbClient.GetAccountInfo(context.Background(), nil)
+	_require.Nil(err)
+	_require.NotZero(bAccInfo)
+}

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -565,3 +565,14 @@ func (o *CopyFromURLOptions) format() (*generated.BlobClientCopyFromURLOptions, 
 	leaseAccessConditions, modifiedAccessConditions := exported.FormatBlobAccessConditions(o.BlobAccessConditions)
 	return options, o.SourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions
 }
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+// GetAccountInfoOptions provides set of options for Client.GetAccountInfo
+type GetAccountInfoOptions struct {
+	// placeholder for future options
+}
+
+func (o *GetAccountInfoOptions) format() *generated.BlobClientGetAccountInfoOptions {
+	return nil
+}

--- a/sdk/storage/azblob/blob/responses.go
+++ b/sdk/storage/azblob/blob/responses.go
@@ -100,6 +100,9 @@ type SetLegalHoldResponse = generated.BlobClientSetLegalHoldResponse
 // CopyFromURLResponse contains the response from method BlobClient.CopyFromURL.
 type CopyFromURLResponse = generated.BlobClientCopyFromURLResponse
 
+// GetAccountInfoResponse contains the response from method BlobClient.GetAccountInfo.
+type GetAccountInfoResponse = generated.BlobClientGetAccountInfoResponse
+
 // AcquireLeaseResponse contains the response from method BlobClient.AcquireLease.
 type AcquireLeaseResponse = generated.BlobClientAcquireLeaseResponse
 

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -316,6 +316,12 @@ func (bb *Client) GetProperties(ctx context.Context, o *blob.GetPropertiesOption
 	return bb.BlobClient().GetProperties(ctx, o)
 }
 
+// GetAccountInfo provides account level information
+// For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures.
+func (bb *Client) GetAccountInfo(ctx context.Context, o *blob.GetAccountInfoOptions) (blob.GetAccountInfoResponse, error) {
+	return bb.BlobClient().GetAccountInfo(ctx, o)
+}
+
 // SetHTTPHeaders changes a blob's HTTP headers.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/set-blob-properties.
 func (bb *Client) SetHTTPHeaders(ctx context.Context, HTTPHeaders blob.HTTPHeaders, o *blob.SetHTTPHeadersOptions) (blob.SetHTTPHeadersResponse, error) {

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -3900,7 +3900,7 @@ func (s *BlockBlobUnrecordedTestsSuite) TestLargeBlockBufferedUploadInParallel()
 	_require.Equal(*(committed[1].Size), largeBlockSize)
 }
 
-func (s *BlockBlobRecordedTestsSuite) TestGetAccountInfo() {
+func (s *BlockBlobRecordedTestsSuite) TestBlockGetAccountInfo() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -3900,6 +3900,25 @@ func (s *BlockBlobUnrecordedTestsSuite) TestLargeBlockBufferedUploadInParallel()
 	_require.Equal(*(committed[1].Size), largeBlockSize)
 }
 
+func (s *BlockBlobRecordedTestsSuite) TestGetAccountInfo() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blockBlobName := testcommon.GenerateBlobName(testName)
+	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
+
+	// Ensure the call succeeded. Don't test for specific account properties because we can't/don't want to set account properties.
+	bAccInfo, err := bbClient.GetAccountInfo(context.Background(), nil)
+	_require.Nil(err)
+	_require.NotZero(bAccInfo)
+}
+
 type fakeBlockBlob struct {
 	totalStaged int64
 }

--- a/sdk/storage/azblob/container/client.go
+++ b/sdk/storage/azblob/container/client.go
@@ -239,6 +239,14 @@ func (c *Client) SetAccessPolicy(ctx context.Context, o *SetAccessPolicyOptions)
 	return resp, err
 }
 
+// GetAccountInfo provides account level information
+// For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures.
+func (c *Client) GetAccountInfo(ctx context.Context, o *GetAccountInfoOptions) (GetAccountInfoResponse, error) {
+	getAccountInfoOptions := o.format()
+	resp, err := c.generated().GetAccountInfo(ctx, getAccountInfoOptions)
+	return resp, err
+}
+
 // NewListBlobsFlatPager returns a pager for blobs starting from the specified Marker. Use an empty
 // Marker to start enumeration from the beginning. Blob names are returned in lexicographic order.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/list-blobs.

--- a/sdk/storage/azblob/container/client_test.go
+++ b/sdk/storage/azblob/container/client_test.go
@@ -97,6 +97,22 @@ type ContainerUnrecordedTestsSuite struct {
 //	_require.Equal(testURL.URL(), correctURL)
 //}
 
+func (s *ContainerRecordedTestsSuite) TestGetAccountInfo() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Ensure the call succeeded. Don't test for specific account properties because we can't/don't want to set account properties.
+	cAccInfo, err := containerClient.GetAccountInfo(context.Background(), nil)
+	_require.Nil(err)
+	_require.NotZero(cAccInfo)
+}
+
 func (s *ContainerRecordedTestsSuite) TestContainerCreateInvalidName() {
 	_require := require.New(s.T())
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)

--- a/sdk/storage/azblob/container/client_test.go
+++ b/sdk/storage/azblob/container/client_test.go
@@ -97,7 +97,7 @@ type ContainerUnrecordedTestsSuite struct {
 //	_require.Equal(testURL.URL(), correctURL)
 //}
 
-func (s *ContainerRecordedTestsSuite) TestGetAccountInfo() {
+func (s *ContainerRecordedTestsSuite) TestContainerGetAccountInfo() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)

--- a/sdk/storage/azblob/container/models.go
+++ b/sdk/storage/azblob/container/models.go
@@ -333,6 +333,17 @@ func formatTime(c *SignedIdentifier) error {
 
 // ---------------------------------------------------------------------------------------------------------------------
 
+// GetAccountInfoOptions provides set of options for Client.GetAccountInfo
+type GetAccountInfoOptions struct {
+	// placeholder for future options
+}
+
+func (o *GetAccountInfoOptions) format() *generated.ContainerClientGetAccountInfoOptions {
+	return nil
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
 // BatchDeleteOptions contains the optional parameters for the BatchBuilder.Delete method.
 type BatchDeleteOptions struct {
 	blob.DeleteOptions

--- a/sdk/storage/azblob/container/responses.go
+++ b/sdk/storage/azblob/container/responses.go
@@ -44,6 +44,9 @@ type GetAccessPolicyResponse = generated.ContainerClientGetAccessPolicyResponse
 // SetAccessPolicyResponse contains the response from method Client.SetAccessPolicy.
 type SetAccessPolicyResponse = generated.ContainerClientSetAccessPolicyResponse
 
+// GetAccountInfoResponse contains the response from method Client.GetAccountInfo.
+type GetAccountInfoResponse = generated.ContainerClientGetAccountInfoResponse
+
 // SubmitBatchResponse contains the response from method Client.SubmitBatch.
 type SubmitBatchResponse struct {
 	// Responses contains the responses of the sub-requests in the batch

--- a/sdk/storage/azblob/pageblob/client.go
+++ b/sdk/storage/azblob/pageblob/client.go
@@ -363,6 +363,12 @@ func (pb *Client) GetProperties(ctx context.Context, o *blob.GetPropertiesOption
 	return pb.BlobClient().GetProperties(ctx, o)
 }
 
+// GetAccountInfo provides account level information
+// For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures.
+func (pb *Client) GetAccountInfo(ctx context.Context, o *blob.GetAccountInfoOptions) (blob.GetAccountInfoResponse, error) {
+	return pb.BlobClient().GetAccountInfo(ctx, o)
+}
+
 // SetHTTPHeaders changes a blob's HTTP headers.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/set-blob-properties.
 func (pb *Client) SetHTTPHeaders(ctx context.Context, HTTPHeaders blob.HTTPHeaders, o *blob.SetHTTPHeadersOptions) (blob.SetHTTPHeadersResponse, error) {

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -4634,3 +4634,23 @@ func (s *PageBlobRecordedTestsSuite) TestUndeletePageBlobSnapshot() {
 	})
 	testcommon.ListBlobsCount(context.Background(), _require, listPager, 6) // 5 snapshots and 1 current version
 }
+
+func (s *PageBlobRecordedTestsSuite) TestGetAccountInfo() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	pbClient := getPageBlobClient(testcommon.GenerateBlobName(testName), containerClient)
+	_, err = pbClient.Create(context.Background(), pageblob.PageBytes*10, nil)
+	_require.Nil(err)
+
+	// Ensure the call succeeded. Don't test for specific account properties because we can't/don't want to set account properties.
+	bAccInfo, err := pbClient.GetAccountInfo(context.Background(), nil)
+	_require.Nil(err)
+	_require.NotZero(bAccInfo)
+}

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -4635,7 +4635,7 @@ func (s *PageBlobRecordedTestsSuite) TestUndeletePageBlobSnapshot() {
 	testcommon.ListBlobsCount(context.Background(), _require, listPager, 6) // 5 snapshots and 1 current version
 }
 
-func (s *PageBlobRecordedTestsSuite) TestGetAccountInfo() {
+func (s *PageBlobRecordedTestsSuite) TestPageGetAccountInfo() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)

--- a/sdk/storage/azblob/service/client.go
+++ b/sdk/storage/azblob/service/client.go
@@ -167,6 +167,7 @@ func (s *Client) RestoreContainer(ctx context.Context, deletedContainerName stri
 }
 
 // GetAccountInfo provides account level information
+// For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures.
 func (s *Client) GetAccountInfo(ctx context.Context, o *GetAccountInfoOptions) (GetAccountInfoResponse, error) {
 	getAccountInfoOptions := o.format()
 	resp, err := s.generated().GetAccountInfo(ctx, getAccountInfoOptions)

--- a/sdk/storage/azblob/service/client_test.go
+++ b/sdk/storage/azblob/service/client_test.go
@@ -69,7 +69,7 @@ type ServiceUnrecordedTestsSuite struct {
 	suite.Suite
 }
 
-func (s *ServiceRecordedTestsSuite) TestGetAccountInfo() {
+func (s *ServiceRecordedTestsSuite) TestServiceGetAccountInfo() {
 	_require := require.New(s.T())
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
 	_require.NoError(err)


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-go/issues/20537
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
