### PR TITLE
Update to latest internal module

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added non-conformant LRO terminal states `Cancelled` and `Completed`.
 
 ### Other Changes
+* Updated to latest `internal` module.
 
 ## 1.5.0-beta.1 (2023-03-02)
 

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-sdk-for-go/sdk/azcore
 go 1.18
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.8.0
 )

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.2.0 h1:leh5DwKv6Ihwi+h60uHtn6UWAxBbZ0q8DwQVMzf61zw=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.2.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -11,8 +11,6 @@ import (
 	"io"
 	"net/http"
 	"time"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 )
 
 type nopCloser struct {
@@ -41,24 +39,6 @@ func HasStatusCode(resp *http.Response, statusCodes ...int) bool {
 		}
 	}
 	return false
-}
-
-// Payload reads and returns the response body or an error.
-// On a successful read, the response body is cached.
-// Subsequent reads will access the cached value.
-// Exported as runtime.Payload().
-func Payload(resp *http.Response) ([]byte, error) {
-	// r.Body won't be a nopClosingBytesReader if downloading was skipped
-	if buf, ok := resp.Body.(*shared.NopClosingBytesReader); ok {
-		return buf.Bytes(), nil
-	}
-	bytesBody, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-	resp.Body = shared.NewNopClosingBytesReader(bytesBody)
-	return bytesBody, nil
 }
 
 // AccessToken represents an Azure service bearer access token with expiry information.

--- a/sdk/azcore/internal/exported/exported_test.go
+++ b/sdk/azcore/internal/exported/exported_test.go
@@ -7,7 +7,6 @@
 package exported
 
 import (
-	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -32,26 +31,5 @@ func TestHasStatusCode(t *testing.T) {
 	}
 	if !HasStatusCode(&http.Response{StatusCode: http.StatusOK}, http.StatusAccepted, http.StatusOK, http.StatusNoContent) {
 		t.Fatal("unexpected failure")
-	}
-}
-
-func TestPayload(t *testing.T) {
-	const val = "payload"
-	resp := &http.Response{
-		Body: io.NopCloser(strings.NewReader(val)),
-	}
-	b, err := Payload(resp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(b) != val {
-		t.Fatalf("got %s, want %s", string(b), val)
-	}
-	b, err = Payload(resp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(b) != val {
-		t.Fatalf("got %s, want %s", string(b), val)
 	}
 }

--- a/sdk/azcore/internal/exported/response_error.go
+++ b/sdk/azcore/internal/exported/response_error.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/exported"
 )
 
 // NewResponseError creates a new *ResponseError from the provided HTTP response.
@@ -29,7 +31,7 @@ func NewResponseError(resp *http.Response) error {
 	}
 
 	// if we didn't get x-ms-error-code, check in the response body
-	body, err := Payload(resp)
+	body, err := exported.Payload(resp, nil)
 	if err != nil {
 		return err
 	}
@@ -121,7 +123,7 @@ func (e *ResponseError) Error() string {
 		fmt.Fprintln(msg, "ERROR CODE UNAVAILABLE")
 	}
 	fmt.Fprintln(msg, "--------------------------------------------------------------------------------")
-	body, err := Payload(e.RawResponse)
+	body, err := exported.Payload(e.RawResponse, nil)
 	if err != nil {
 		// this really shouldn't fail at this point as the response
 		// body is already cached (it was read in NewResponseError)

--- a/sdk/azcore/internal/pollers/async/async.go
+++ b/sdk/azcore/internal/pollers/async/async.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/poller"
 )
 
 // see https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/async-api-reference.md
@@ -68,15 +69,15 @@ func New[T any](pl exported.Pipeline, resp *http.Response, finalState pollers.Fi
 	if asyncURL == "" {
 		return nil, errors.New("response is missing Azure-AsyncOperation header")
 	}
-	if !pollers.IsValidURL(asyncURL) {
+	if !poller.IsValidURL(asyncURL) {
 		return nil, fmt.Errorf("invalid polling URL %s", asyncURL)
 	}
 	// check for provisioning state.  if the operation is a RELO
 	// and terminates synchronously this will prevent extra polling.
 	// it's ok if there's no provisioning state.
-	state, _ := pollers.GetProvisioningState(resp)
+	state, _ := poller.GetProvisioningState(resp)
 	if state == "" {
-		state = pollers.StatusInProgress
+		state = poller.StatusInProgress
 	}
 	p := &Poller[T]{
 		pl:         pl,
@@ -93,17 +94,17 @@ func New[T any](pl exported.Pipeline, resp *http.Response, finalState pollers.Fi
 
 // Done returns true if the LRO is in a terminal state.
 func (p *Poller[T]) Done() bool {
-	return pollers.IsTerminalState(p.CurState)
+	return poller.IsTerminalState(p.CurState)
 }
 
 // Poll retrieves the current state of the LRO.
 func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 	err := pollers.PollHelper(ctx, p.AsyncURL, p.pl, func(resp *http.Response) (string, error) {
-		if !pollers.StatusCodeValid(resp) {
+		if !poller.StatusCodeValid(resp) {
 			p.resp = resp
 			return "", exported.NewResponseError(resp)
 		}
-		state, err := pollers.GetStatus(resp)
+		state, err := poller.GetStatus(resp)
 		if err != nil {
 			return "", err
 		} else if state == "" {
@@ -122,7 +123,7 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 	if p.resp.StatusCode == http.StatusNoContent {
 		return nil
-	} else if pollers.Failed(p.CurState) {
+	} else if poller.Failed(p.CurState) {
 		return exported.NewResponseError(p.resp)
 	}
 	var req *exported.Request
@@ -154,5 +155,5 @@ func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 		p.resp = resp
 	}
 
-	return pollers.ResultHelper(p.resp, pollers.Failed(p.CurState), out)
+	return pollers.ResultHelper(p.resp, poller.Failed(p.CurState), out)
 }

--- a/sdk/azcore/internal/pollers/loc/loc_test.go
+++ b/sdk/azcore/internal/pollers/loc/loc_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/poller"
 	"github.com/stretchr/testify/require"
 )
 
@@ -167,9 +167,9 @@ func TestSynchronousCompletion(t *testing.T) {
 	resp := initialResponse()
 	resp.Body = io.NopCloser(strings.NewReader(`{ "properties": { "provisioningState": "Succeeded" } }`))
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New[struct{}](exported.Pipeline{}, resp)
+	lp, err := New[struct{}](exported.Pipeline{}, resp)
 	require.NoError(t, err)
-	require.Equal(t, fakeLocationURL, poller.PollURL)
-	require.Equal(t, pollers.StatusSucceeded, poller.CurState)
-	require.True(t, poller.Done())
+	require.Equal(t, fakeLocationURL, lp.PollURL)
+	require.Equal(t, poller.StatusSucceeded, lp.CurState)
+	require.True(t, lp.Done())
 }

--- a/sdk/azcore/internal/pollers/op/op.go
+++ b/sdk/azcore/internal/pollers/op/op.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/poller"
 )
 
 // Applicable returns true if the LRO is using Operation-Location.
@@ -54,19 +55,19 @@ func New[T any](pl exported.Pipeline, resp *http.Response, finalState pollers.Fi
 	if opURL == "" {
 		return nil, errors.New("response is missing Operation-Location header")
 	}
-	if !pollers.IsValidURL(opURL) {
+	if !poller.IsValidURL(opURL) {
 		return nil, fmt.Errorf("invalid Operation-Location URL %s", opURL)
 	}
 	locURL := resp.Header.Get(shared.HeaderLocation)
 	// Location header is optional
-	if locURL != "" && !pollers.IsValidURL(locURL) {
+	if locURL != "" && !poller.IsValidURL(locURL) {
 		return nil, fmt.Errorf("invalid Location URL %s", locURL)
 	}
 	// default initial state to InProgress.  if the
 	// service sent us a status then use that instead.
-	curState := pollers.StatusInProgress
-	status, err := pollers.GetStatus(resp)
-	if err != nil && !errors.Is(err, pollers.ErrNoBody) {
+	curState := poller.StatusInProgress
+	status, err := poller.GetStatus(resp)
+	if err != nil && !errors.Is(err, poller.ErrNoBody) {
 		return nil, err
 	}
 	if status != "" {
@@ -86,16 +87,16 @@ func New[T any](pl exported.Pipeline, resp *http.Response, finalState pollers.Fi
 }
 
 func (p *Poller[T]) Done() bool {
-	return pollers.IsTerminalState(p.CurState)
+	return poller.IsTerminalState(p.CurState)
 }
 
 func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 	err := pollers.PollHelper(ctx, p.OpLocURL, p.pl, func(resp *http.Response) (string, error) {
-		if !pollers.StatusCodeValid(resp) {
+		if !poller.StatusCodeValid(resp) {
 			p.resp = resp
 			return "", exported.NewResponseError(resp)
 		}
-		state, err := pollers.GetStatus(resp)
+		state, err := poller.GetStatus(resp)
 		if err != nil {
 			return "", err
 		} else if state == "" {
@@ -118,7 +119,7 @@ func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 		req, err = exported.NewRequest(ctx, http.MethodGet, p.LocURL)
 	} else if p.FinalState == pollers.FinalStateViaOpLocation && p.Method == http.MethodPost {
 		// no final GET required, terminal response should have it
-	} else if rl, rlErr := pollers.GetResourceLocation(p.resp); rlErr != nil && !errors.Is(rlErr, pollers.ErrNoBody) {
+	} else if rl, rlErr := poller.GetResourceLocation(p.resp); rlErr != nil && !errors.Is(rlErr, poller.ErrNoBody) {
 		return rlErr
 	} else if rl != "" {
 		req, err = exported.NewRequest(ctx, http.MethodGet, rl)
@@ -140,5 +141,5 @@ func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 		p.resp = resp
 	}
 
-	return pollers.ResultHelper(p.resp, pollers.Failed(p.CurState), out)
+	return pollers.ResultHelper(p.resp, poller.Failed(p.CurState), out)
 }

--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -12,55 +12,14 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"reflect"
-	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
+	azexported "github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/poller"
 )
-
-// the well-known set of LRO status/provisioning state values.
-const (
-	StatusSucceeded  = "Succeeded"
-	StatusCanceled   = "Canceled"
-	StatusFailed     = "Failed"
-	StatusInProgress = "InProgress"
-)
-
-// these are non-conformant states that we've seen in the wild.
-// we support them for back-compat.
-const (
-	StatusCancelled = "Cancelled"
-	StatusCompleted = "Completed"
-)
-
-// IsTerminalState returns true if the LRO's state is terminal.
-func IsTerminalState(s string) bool {
-	return Failed(s) || Succeeded(s)
-}
-
-// Failed returns true if the LRO's state is terminal failure.
-func Failed(s string) bool {
-	return strings.EqualFold(s, StatusFailed) || strings.EqualFold(s, StatusCanceled) || strings.EqualFold(s, StatusCancelled)
-}
-
-// Succeeded returns true if the LRO's state is terminal success.
-func Succeeded(s string) bool {
-	return strings.EqualFold(s, StatusSucceeded) || strings.EqualFold(s, StatusCompleted)
-}
-
-// returns true if the LRO response contains a valid HTTP status code
-func StatusCodeValid(resp *http.Response) bool {
-	return exported.HasStatusCode(resp, http.StatusOK, http.StatusAccepted, http.StatusCreated, http.StatusNoContent)
-}
-
-// IsValidURL verifies that the URL is valid and absolute.
-func IsValidURL(s string) bool {
-	u, err := url.Parse(s)
-	return err == nil && u.IsAbs()
-}
 
 // getTokenTypeName creates a type name from the type parameter T.
 func getTokenTypeName[T any]() (string, error) {
@@ -137,102 +96,6 @@ func IsTokenValid[T any](token string) error {
 	return nil
 }
 
-// ErrNoBody is returned if the response didn't contain a body.
-var ErrNoBody = errors.New("the response did not contain a body")
-
-// GetJSON reads the response body into a raw JSON object.
-// It returns ErrNoBody if there was no content.
-func GetJSON(resp *http.Response) (map[string]interface{}, error) {
-	body, err := exported.Payload(resp)
-	if err != nil {
-		return nil, err
-	}
-	if len(body) == 0 {
-		return nil, ErrNoBody
-	}
-	// unmarshall the body to get the value
-	var jsonBody map[string]interface{}
-	if err = json.Unmarshal(body, &jsonBody); err != nil {
-		return nil, err
-	}
-	return jsonBody, nil
-}
-
-// provisioningState returns the provisioning state from the response or the empty string.
-func provisioningState(jsonBody map[string]interface{}) string {
-	jsonProps, ok := jsonBody["properties"]
-	if !ok {
-		return ""
-	}
-	props, ok := jsonProps.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-	rawPs, ok := props["provisioningState"]
-	if !ok {
-		return ""
-	}
-	ps, ok := rawPs.(string)
-	if !ok {
-		return ""
-	}
-	return ps
-}
-
-// status returns the status from the response or the empty string.
-func status(jsonBody map[string]interface{}) string {
-	rawStatus, ok := jsonBody["status"]
-	if !ok {
-		return ""
-	}
-	status, ok := rawStatus.(string)
-	if !ok {
-		return ""
-	}
-	return status
-}
-
-// GetStatus returns the LRO's status from the response body.
-// Typically used for Azure-AsyncOperation flows.
-// If there is no status in the response body the empty string is returned.
-func GetStatus(resp *http.Response) (string, error) {
-	jsonBody, err := GetJSON(resp)
-	if err != nil {
-		return "", err
-	}
-	return status(jsonBody), nil
-}
-
-// GetProvisioningState returns the LRO's state from the response body.
-// If there is no state in the response body the empty string is returned.
-func GetProvisioningState(resp *http.Response) (string, error) {
-	jsonBody, err := GetJSON(resp)
-	if err != nil {
-		return "", err
-	}
-	return provisioningState(jsonBody), nil
-}
-
-// GetResourceLocation returns the LRO's resourceLocation value from the response body.
-// Typically used for Operation-Location flows.
-// If there is no resourceLocation in the response body the empty string is returned.
-func GetResourceLocation(resp *http.Response) (string, error) {
-	jsonBody, err := GetJSON(resp)
-	if err != nil {
-		return "", err
-	}
-	v, ok := jsonBody["resourceLocation"]
-	if !ok {
-		// it might be ok if the field doesn't exist, the caller must make that determination
-		return "", nil
-	}
-	vv, ok := v.(string)
-	if !ok {
-		return "", fmt.Errorf("the resourceLocation value %v was not in string format", v)
-	}
-	return vv, nil
-}
-
 // used if the operation synchronously completed
 type NopPoller[T any] struct {
 	resp   *http.Response
@@ -246,7 +109,7 @@ func NewNopPoller[T any](resp *http.Response) (*NopPoller[T], error) {
 	if resp.StatusCode == http.StatusNoContent {
 		return np, nil
 	}
-	payload, err := exported.Payload(resp)
+	payload, err := exported.Payload(resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -276,8 +139,8 @@ func (p *NopPoller[T]) Result(ctx context.Context, out *T) error {
 // If the request fails, the update func is not called.
 // The update func returns the state of the operation for logging purposes or an error
 // if it fails to extract the required state from the response.
-func PollHelper(ctx context.Context, endpoint string, pl exported.Pipeline, update func(resp *http.Response) (string, error)) error {
-	req, err := exported.NewRequest(ctx, http.MethodGet, endpoint)
+func PollHelper(ctx context.Context, endpoint string, pl azexported.Pipeline, update func(resp *http.Response) (string, error)) error {
+	req, err := azexported.NewRequest(ctx, http.MethodGet, endpoint)
 	if err != nil {
 		return err
 	}
@@ -303,13 +166,13 @@ func ResultHelper[T any](resp *http.Response, failed bool, out *T) error {
 	}
 
 	defer resp.Body.Close()
-	if !StatusCodeValid(resp) || failed {
+	if !poller.StatusCodeValid(resp) || failed {
 		// the LRO failed.  unmarshall the error and update state
-		return exported.NewResponseError(resp)
+		return azexported.NewResponseError(resp)
 	}
 
 	// success case
-	payload, err := exported.Payload(resp)
+	payload, err := exported.Payload(resp, nil)
 	if err != nil {
 		return err
 	}

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -19,25 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsTerminalState(t *testing.T) {
-	require.False(t, IsTerminalState("upDAting"), "Updating is not a terminal state")
-	require.True(t, IsTerminalState("SuccEEded"), "Succeeded is a terminal state")
-	require.True(t, IsTerminalState("completEd"), "Completed is a terminal state")
-	require.True(t, IsTerminalState("faIled"), "failed is a terminal state")
-	require.True(t, IsTerminalState("canCeled"), "canceled is a terminal state")
-	require.True(t, IsTerminalState("canceLLed"), "cancelled is a terminal state")
-}
-
-func TestStatusCodeValid(t *testing.T) {
-	require.True(t, StatusCodeValid(&http.Response{StatusCode: http.StatusOK}))
-	require.True(t, StatusCodeValid(&http.Response{StatusCode: http.StatusAccepted}))
-	require.True(t, StatusCodeValid(&http.Response{StatusCode: http.StatusCreated}))
-	require.True(t, StatusCodeValid(&http.Response{StatusCode: http.StatusNoContent}))
-	require.False(t, StatusCodeValid(&http.Response{StatusCode: http.StatusPartialContent}))
-	require.False(t, StatusCodeValid(&http.Response{StatusCode: http.StatusBadRequest}))
-	require.False(t, StatusCodeValid(&http.Response{StatusCode: http.StatusInternalServerError}))
-}
-
 type fakeResult[T any] struct {
 	Result T
 }
@@ -82,98 +63,6 @@ func TestIsTokenValid(t *testing.T) {
 	require.Error(t, err)
 	err = IsTokenValid[int](`{"type":"int","token":{"Result":0}}`)
 	require.NoError(t, err)
-}
-
-func TestIsValidURL(t *testing.T) {
-	require.False(t, IsValidURL("/foo"))
-	require.True(t, IsValidURL("https://foo.bar/baz"))
-}
-
-func TestFailed(t *testing.T) {
-	require.False(t, Failed("sUcceeded"))
-	require.False(t, Failed("ppdATing"))
-	require.True(t, Failed("fAilEd"))
-	require.True(t, Failed("caNcElled"))
-}
-
-func TestGetJSON(t *testing.T) {
-	j, err := GetJSON(&http.Response{Body: http.NoBody})
-	require.ErrorIs(t, err, ErrNoBody)
-	require.Nil(t, j)
-	j, err = GetJSON(&http.Response{Body: io.NopCloser(strings.NewReader(`{ "foo": "bar" }`))})
-	require.NoError(t, err)
-	require.Equal(t, "bar", j["foo"])
-}
-
-func TestGetStatusSuccess(t *testing.T) {
-	const jsonBody = `{ "status": "InProgress" }`
-	resp := &http.Response{
-		Body: io.NopCloser(strings.NewReader(jsonBody)),
-	}
-	status, err := GetStatus(resp)
-	require.NoError(t, err)
-	require.Equal(t, "InProgress", status)
-}
-
-func TestGetNoBody(t *testing.T) {
-	resp := &http.Response{
-		Body: http.NoBody,
-	}
-	status, err := GetStatus(resp)
-	require.ErrorIs(t, err, ErrNoBody)
-	require.Empty(t, status)
-	status, err = GetProvisioningState(resp)
-	require.ErrorIs(t, err, ErrNoBody)
-	require.Empty(t, status)
-}
-
-func TestGetStatusError(t *testing.T) {
-	resp := &http.Response{
-		Body: io.NopCloser(strings.NewReader("{}")),
-	}
-	status, err := GetStatus(resp)
-	require.NoError(t, err)
-	require.Empty(t, status)
-}
-
-func TestGetProvisioningState(t *testing.T) {
-	const jsonBody = `{ "properties": { "provisioningState": "Canceled" } }`
-	resp := &http.Response{
-		Body: io.NopCloser(strings.NewReader(jsonBody)),
-	}
-	state, err := GetProvisioningState(resp)
-	require.NoError(t, err)
-	require.Equal(t, "Canceled", state)
-}
-
-func TestGetResourceLocation(t *testing.T) {
-	resp := &http.Response{
-		Body: http.NoBody,
-	}
-	resLoc, err := GetResourceLocation(resp)
-	require.Error(t, err)
-	require.Empty(t, resLoc)
-	resp.Body = io.NopCloser(strings.NewReader(`{"status": "succeeded"}`))
-	resLoc, err = GetResourceLocation(resp)
-	require.NoError(t, err)
-	require.Empty(t, resLoc)
-	resp.Body = io.NopCloser(strings.NewReader(`{"resourceLocation": 123}`))
-	resLoc, err = GetResourceLocation(resp)
-	require.Error(t, err)
-	require.Empty(t, resLoc)
-	resp.Body = io.NopCloser(strings.NewReader(`{"resourceLocation": "here"}`))
-	resLoc, err = GetResourceLocation(resp)
-	require.NoError(t, err)
-	require.Equal(t, "here", resLoc)
-}
-
-func TestGetProvisioningStateError(t *testing.T) {
-	resp := &http.Response{
-		Body: io.NopCloser(strings.NewReader("{}")),
-	}
-	state, err := GetProvisioningState(resp)
-	require.NoError(t, err)
-	require.Empty(t, state)
 }
 
 func TestNopPoller(t *testing.T) {

--- a/sdk/azcore/internal/shared/shared.go
+++ b/sdk/azcore/internal/shared/shared.go
@@ -8,9 +8,7 @@ package shared
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -63,71 +61,6 @@ func TypeOfT[T any]() reflect.Type {
 	// a type parameter, so this is the trick
 	return reflect.TypeOf((*T)(nil)).Elem()
 }
-
-// BytesSetter abstracts replacing a byte slice on some type.
-type BytesSetter interface {
-	Set(b []byte)
-}
-
-// NewNopClosingBytesReader creates a new *NopClosingBytesReader for the specified slice.
-func NewNopClosingBytesReader(data []byte) *NopClosingBytesReader {
-	return &NopClosingBytesReader{s: data}
-}
-
-// NopClosingBytesReader is an io.ReadSeekCloser around a byte slice.
-// It also provides direct access to the byte slice to avoid rereading.
-type NopClosingBytesReader struct {
-	s []byte
-	i int64
-}
-
-// Bytes returns the underlying byte slice.
-func (r *NopClosingBytesReader) Bytes() []byte {
-	return r.s
-}
-
-// Close implements the io.Closer interface.
-func (*NopClosingBytesReader) Close() error {
-	return nil
-}
-
-// Read implements the io.Reader interface.
-func (r *NopClosingBytesReader) Read(b []byte) (n int, err error) {
-	if r.i >= int64(len(r.s)) {
-		return 0, io.EOF
-	}
-	n = copy(b, r.s[r.i:])
-	r.i += int64(n)
-	return
-}
-
-// Set replaces the existing byte slice with the specified byte slice and resets the reader.
-func (r *NopClosingBytesReader) Set(b []byte) {
-	r.s = b
-	r.i = 0
-}
-
-// Seek implements the io.Seeker interface.
-func (r *NopClosingBytesReader) Seek(offset int64, whence int) (int64, error) {
-	var i int64
-	switch whence {
-	case io.SeekStart:
-		i = offset
-	case io.SeekCurrent:
-		i = r.i + offset
-	case io.SeekEnd:
-		i = int64(len(r.s)) + offset
-	default:
-		return 0, errors.New("nopClosingBytesReader: invalid whence")
-	}
-	if i < 0 {
-		return 0, errors.New("nopClosingBytesReader: negative position")
-	}
-	r.i = i
-	return i, nil
-}
-
-var _ BytesSetter = (*NopClosingBytesReader)(nil)
 
 // TransportFunc is a helper to use a first-class func to satisfy the Transporter interface.
 type TransportFunc func(*http.Request) (*http.Response, error)

--- a/sdk/azcore/internal/shared/shared_test.go
+++ b/sdk/azcore/internal/shared/shared_test.go
@@ -8,7 +8,6 @@ package shared
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -68,68 +67,6 @@ func TestTypeOfT(t *testing.T) {
 	}
 	if tt := TypeOfT[int32](); tt == reflect.TypeOf(3.14) {
 		t.Fatal("didn't expect types to match")
-	}
-}
-
-func TestNopClosingBytesReader(t *testing.T) {
-	const val1 = "the data"
-	ncbr := NewNopClosingBytesReader([]byte(val1))
-	if ncbr.Bytes() == nil {
-		t.Fatal("unexpected nil value")
-	}
-	b, err := io.ReadAll(ncbr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(b) != val1 {
-		t.Fatalf("got %s, want %s", string(b), val1)
-	}
-	const val2 = "something else"
-	ncbr.Set([]byte(val2))
-	b, err = io.ReadAll(ncbr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(b) != val2 {
-		t.Fatalf("got %s, want %s", string(b), val2)
-	}
-	if err = ncbr.Close(); err != nil {
-		t.Fatal(err)
-	}
-	// seek to beginning and read again
-	i, err := ncbr.Seek(0, io.SeekStart)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if i != 0 {
-		t.Fatalf("got %d, want %d", i, 0)
-	}
-	b, err = io.ReadAll(ncbr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(b) != val2 {
-		t.Fatalf("got %s, want %s", string(b), val2)
-	}
-	// seek to middle from the end
-	i, err = ncbr.Seek(-4, io.SeekEnd)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if l := int64(len(val2)) - 4; i != l {
-		t.Fatalf("got %d, want %d", l, i)
-	}
-	b, err = io.ReadAll(ncbr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(b) != "else" {
-		t.Fatalf("got %s, want %s", string(b), "else")
-	}
-	// underflow
-	_, err = ncbr.Seek(-int64(len(val2)+1), io.SeekCurrent)
-	if err == nil {
-		t.Fatal("unexpected nil error")
 	}
 }
 

--- a/sdk/azcore/runtime/policy_body_download.go
+++ b/sdk/azcore/runtime/policy_body_download.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 )
@@ -29,7 +28,7 @@ func bodyDownloadPolicy(req *policy.Request) (*http.Response, error) {
 	}
 	// Either bodyDownloadPolicyOpValues was not specified (so skip is false)
 	// or it was specified and skip is false: don't skip downloading the body
-	_, err = exported.Payload(resp)
+	_, err = Payload(resp)
 	if err != nil {
 		return resp, newBodyDownloadError(err, req)
 	}

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/exported"
 )
 
 const (
@@ -133,7 +134,7 @@ func (p *retryPolicy) Do(req *policy.Request) (resp *http.Response, err error) {
 			// if the body was already downloaded or there was an error it's safe to cancel the context now
 			if err != nil {
 				tryCancel()
-			} else if _, ok := resp.Body.(*shared.NopClosingBytesReader); ok {
+			} else if exported.PayloadDownloaded(resp) {
 				tryCancel()
 			} else {
 				// must cancel the context after the body has been read and closed

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers/loc"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers/op"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/poller"
 )
 
 // FinalStateVia is the enumerated type for the possible final-state-via values.
@@ -75,7 +76,7 @@ func NewPoller[T any](resp *http.Response, pl exported.Pipeline, options *NewPol
 	defer resp.Body.Close()
 	// this is a back-stop in case the swagger is incorrect (i.e. missing one or more status codes for success).
 	// ideally the codegen should return an error if the initial response failed and not even create a poller.
-	if !pollers.StatusCodeValid(resp) {
+	if !poller.StatusCodeValid(resp) {
 		return nil, errors.New("the operation failed or was cancelled")
 	}
 


### PR DESCRIPTION
Removed LRO and payload helpers that are now in the internal module.
Complimentary to https://github.com/Azure/azure-sdk-for-go/pull/20539

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
