### PR TITLE
Fixed issue in challenge policy to prevent multiple requests from being sent in the happy case.

### DIFF
--- a/sdk/storage/azblob/internal/shared/challenge_policy.go
+++ b/sdk/storage/azblob/internal/shared/challenge_policy.go
@@ -31,10 +31,6 @@ func NewStorageChallengePolicy(cred azcore.TokenCredential) policy.Policy {
 }
 
 func (s *storageAuthorizer) onRequest(req *policy.Request, authNZ func(policy.TokenRequestOptions) error) error {
-	if len(s.scopes) == 0 || s.tenantID == "" {
-		// returning nil indicates the bearer token policy should send the request
-		return nil
-	}
 	return authNZ(policy.TokenRequestOptions{Scopes: s.scopes})
 }
 

--- a/sdk/storage/azblob/internal/shared/challenge_policy_test.go
+++ b/sdk/storage/azblob/internal/shared/challenge_policy_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/stretchr/testify/require"
-	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -25,52 +24,69 @@ func (cf credentialFunc) GetToken(ctx context.Context, options policy.TokenReque
 	return cf(ctx, options)
 }
 
-func TestChallengePolicy(t *testing.T) {
+func TestChallengePolicyStorage(t *testing.T) {
 	accessToken := "***"
-	storageResource := "https://storage.azure.com"
 	storageScope := "https://storage.azure.com/.default"
-	challenge := `Bearer authorization_uri="https://login.microsoftonline.com/{tenant}", resource_id="{storageResource}"`
+
+	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer close()
+	srv.AppendResponse(
+		mock.WithStatusCode(200),
+	)
+	authenticated := false
+	cred := credentialFunc(func(ctx context.Context, tro policy.TokenRequestOptions) (azcore.AccessToken, error) {
+		authenticated = true
+		require.Equal(t, []string{storageScope}, tro.Scopes)
+		return azcore.AccessToken{Token: accessToken, ExpiresOn: time.Now().Add(time.Hour)}, nil
+	})
+	p := NewStorageChallengePolicy(cred)
+	pl := runtime.NewPipeline("", "",
+		runtime.PipelineOptions{PerRetry: []policy.Policy{p}},
+		&policy.ClientOptions{Transport: srv},
+	)
+	req, err := runtime.NewRequest(context.Background(), "GET", "https://localhost")
+	require.NoError(t, err)
+	_, err = pl.Do(req)
+	require.NoError(t, err)
+	require.True(t, authenticated, "policy should have authenticated")
+}
+
+func TestChallengePolicyDisk(t *testing.T) {
+	accessToken := "***"
 	diskResource := "https://disk.azure.com/"
 	diskScope := "https://disk.azure.com//.default"
+	challenge := `Bearer authorization_uri="https://login.microsoftonline.com/{tenant}", resource_id="{storageResource}"`
 
-	for _, test := range []struct {
-		expectedScope, format, resource string
-	}{
-		{format: challenge, resource: storageResource, expectedScope: storageScope},
-		{format: challenge, resource: diskResource, expectedScope: diskScope},
-	} {
-		t.Run("", func(t *testing.T) {
-			srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
-			defer close()
-			srv.AppendResponse(
-				mock.WithHeader("WWW-Authenticate", strings.ReplaceAll(test.format, "{storageResource}", test.resource)),
-				mock.WithStatusCode(401),
-			)
-			srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
-				if authz := r.Header.Values("Authorization"); len(authz) != 1 || authz[0] != "Bearer "+accessToken {
-					t.Errorf(`unexpected Authorization "%s"`, authz)
-				}
-				return true
-			}))
-			srv.AppendResponse()
-			authenticated := false
-			cred := credentialFunc(func(ctx context.Context, tro policy.TokenRequestOptions) (azcore.AccessToken, error) {
-				authenticated = true
-				require.Equal(t, []string{test.expectedScope}, tro.Scopes)
-				return azcore.AccessToken{Token: accessToken, ExpiresOn: time.Now().Add(time.Hour)}, nil
-			})
-			p := NewStorageChallengePolicy(cred)
-			pl := runtime.NewPipeline("", "",
-				runtime.PipelineOptions{PerRetry: []policy.Policy{p}},
-				&policy.ClientOptions{Transport: srv},
-			)
-			req, err := runtime.NewRequest(context.Background(), "GET", "https://localhost")
-			require.NoError(t, err)
-			_, err = pl.Do(req)
-			require.NoError(t, err)
-			require.True(t, authenticated, "policy should have authenticated")
-		})
-	}
+	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer close()
+	srv.AppendResponse(
+		mock.WithHeader("WWW-Authenticate", strings.ReplaceAll(challenge, "{storageResource}", diskResource)),
+		mock.WithStatusCode(401),
+	)
+	srv.AppendResponse(
+		mock.WithStatusCode(200),
+	)
+	attemptedAuthentication := false
+	authenticated := false
+	cred := credentialFunc(func(ctx context.Context, tro policy.TokenRequestOptions) (azcore.AccessToken, error) {
+		if attemptedAuthentication {
+			authenticated = true
+			require.Equal(t, []string{diskScope}, tro.Scopes)
+			return azcore.AccessToken{Token: accessToken, ExpiresOn: time.Now().Add(time.Hour)}, nil
+		}
+		attemptedAuthentication = true
+		return azcore.AccessToken{}, nil
+	})
+	p := NewStorageChallengePolicy(cred)
+	pl := runtime.NewPipeline("", "",
+		runtime.PipelineOptions{PerRetry: []policy.Policy{p}},
+		&policy.ClientOptions{Transport: srv},
+	)
+	req, err := runtime.NewRequest(context.Background(), "GET", "https://localhost")
+	require.NoError(t, err)
+	_, err = pl.Do(req)
+	require.NoError(t, err)
+	require.True(t, authenticated, "policy should have authenticated")
 }
 
 func TestParseTenant(t *testing.T) {


### PR DESCRIPTION
Note: Changelog entry is not necessary since this hasn't been released yet

I re-ran the test in pageblob/managed_disk_test.go manually and it passed. 

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
