### PR TITLE
Added support for copy source authorization to append block from url

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added [Blob Batch API](https://learn.microsoft.com/rest/api/storageservices/blob-batch).
 * Added support for bearer challenge for identity based managed disks.
 * Added support for GetAccountInfo to container and blob level clients. 
+* Added support for CopySourceAuthorization to appendblob.AppendBlockFromURL
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -488,7 +488,7 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendBlockFromURLCopySourceAuthNegat
 	_require.Nil(err)
 
 	options := appendblob.AppendBlockFromURLOptions{
-		CopySourceAuthorization: to.Ptr("Bearer XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"),
+		CopySourceAuthorization: to.Ptr("Bearer faketoken"),
 	}
 
 	_, err = destABClient.AppendBlockFromURL(context.Background(), srcABClient.URL(), &options)

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/binary"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"hash/crc64"
 	"io"
 	"math/rand"
@@ -405,6 +407,78 @@ func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlockFromURLWithMD5() {
 	_, err = destBlob.AppendBlockFromURL(context.Background(), srcBlobURLWithSAS, &appendBlockURLOptions)
 	_require.NotNil(err)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.MD5Mismatch)
+}
+
+func (s *AppendBlobRecordedTestsSuite) TestAppendBlockFromURLCopySourceAuth() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	// Getting AAD Authentication
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Create source and destination blobs
+	srcABClient := testcommon.CreateNewAppendBlob(context.Background(), _require, "src "+testName, containerClient)
+	destABClient := testcommon.CreateNewAppendBlob(context.Background(), _require, "dest"+testName, containerClient)
+
+	// Upload some data to source
+	contentSize := 4 * 1024 // 4KB
+	r, sourceData := testcommon.GetRandomDataAndReader(contentSize)
+	_, err = srcABClient.AppendBlock(context.Background(), streaming.NopCloser(r), nil)
+	_require.Nil(err)
+
+	// Getting token
+	token, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{"https://storage.azure.com/.default"}})
+	_require.NoError(err)
+
+	options := appendblob.AppendBlockFromURLOptions{
+		CopySourceAuthorization: to.Ptr("Bearer " + token.Token),
+	}
+
+	pbResp, err := destABClient.AppendBlockFromURL(context.Background(), srcABClient.URL(), &options)
+	_require.NoError(err)
+	_require.NotNil(pbResp)
+
+	// Download data from destination
+	destBuffer := make([]byte, 4*1024)
+	_, err = destABClient.DownloadBuffer(context.Background(), destBuffer, nil)
+	_require.Nil(err)
+	_require.Equal(destBuffer, sourceData)
+}
+
+func (s *AppendBlobRecordedTestsSuite) TestAppendBlockFromURLCopySourceAuthNegative() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Create source and destination blobs
+	srcABClient := testcommon.CreateNewAppendBlob(context.Background(), _require, "src "+testName, containerClient)
+	destABClient := testcommon.CreateNewAppendBlob(context.Background(), _require, "dest"+testName, containerClient)
+
+	// Upload some data to source
+	contentSize := 4 * 1024 // 4KB
+	r, _ := testcommon.GetRandomDataAndReader(contentSize)
+	_, err = srcABClient.AppendBlock(context.Background(), streaming.NopCloser(r), nil)
+	_require.Nil(err)
+
+	options := appendblob.AppendBlockFromURLOptions{
+		CopySourceAuthorization: to.Ptr("Bearer XXXXXXXXXXXXXXXXXXXXX"),
+	}
+
+	_, err = destABClient.AppendBlockFromURL(context.Background(), srcABClient.URL(), &options)
+	_require.Error(err)
+	_require.True(bloberror.HasCode(err, bloberror.CannotVerifyCopySource))
 }
 
 func (s *AppendBlobRecordedTestsSuite) TestBlobCreateAppendMetadataNonEmpty() {

--- a/sdk/storage/azblob/appendblob/models.go
+++ b/sdk/storage/azblob/appendblob/models.go
@@ -100,6 +100,9 @@ func (o *AppendBlockOptions) format() (*generated.AppendBlobClientAppendBlockOpt
 
 // AppendBlockFromURLOptions contains the optional parameters for the Client.AppendBlockFromURL method.
 type AppendBlockFromURLOptions struct {
+	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
+	CopySourceAuthorization *string
+
 	// SourceContentValidation contains the validation mechanism used on the range of bytes read from the source.
 	SourceContentValidation blob.SourceContentValidationType
 
@@ -125,7 +128,8 @@ func (o *AppendBlockFromURLOptions) format() (*generated.AppendBlobClientAppendB
 	}
 
 	options := &generated.AppendBlobClientAppendBlockFromURLOptions{
-		SourceRange: exported.FormatHTTPRange(o.Range),
+		SourceRange:             exported.FormatHTTPRange(o.Range),
+		CopySourceAuthorization: o.CopySourceAuthorization,
 	}
 
 	if o.SourceContentValidation != nil {

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_884047202b"
+  "Tag": "go/storage/azblob_fad5549316"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_37f4885d38"
+  "Tag": "go/storage/azblob_884047202b"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_5d20008f59"
+  "Tag": "go/storage/azblob_37f4885d38"
 }

--- a/sdk/storage/azblob/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azblob/internal/testcommon/clients_auth.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"strings"
 	"testing"
@@ -220,8 +221,20 @@ func CreateNewBlobs(ctx context.Context, _require *require.Assertions, blobNames
 	}
 }
 
+func GetAppendBlobClient(blockBlobName string, containerClient *container.Client) *appendblob.Client {
+	return containerClient.NewAppendBlobClient(blockBlobName)
+}
+
 func GetBlockBlobClient(blockBlobName string, containerClient *container.Client) *blockblob.Client {
 	return containerClient.NewBlockBlobClient(blockBlobName)
+}
+
+func CreateNewAppendBlob(ctx context.Context, _require *require.Assertions, blockBlobName string, containerClient *container.Client) *appendblob.Client {
+	abClient := GetAppendBlobClient(blockBlobName, containerClient)
+
+	_, err := abClient.Create(ctx, nil)
+	_require.Nil(err)
+	return abClient
 }
 
 func CreateNewBlockBlob(ctx context.Context, _require *require.Assertions, blockBlobName string, containerClient *container.Client) *blockblob.Client {

--- a/sdk/storage/azblob/internal/testcommon/common.go
+++ b/sdk/storage/azblob/internal/testcommon/common.go
@@ -10,6 +10,7 @@ package testcommon
 import (
 	"bytes"
 	"context"
+	crypto_rand "crypto/rand"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
@@ -83,7 +84,7 @@ func GetReaderToGeneratedBytes(n int) io.ReadSeekCloser {
 
 func GetRandomDataAndReader(n int) (*bytes.Reader, []byte) {
 	data := make([]byte, n)
-	_, _ = rand.Read(data)
+	_, _ = crypto_rand.Read(data)
 	return bytes.NewReader(data), data
 }
 

--- a/sdk/storage/azblob/internal/testcommon/common.go
+++ b/sdk/storage/azblob/internal/testcommon/common.go
@@ -10,12 +10,12 @@ package testcommon
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"runtime"
 	"strconv"
@@ -84,6 +84,12 @@ func GetReaderToGeneratedBytes(n int) io.ReadSeekCloser {
 func GetRandomDataAndReader(n int) (*bytes.Reader, []byte) {
 	data := make([]byte, n)
 	_, _ = rand.Read(data)
+	return bytes.NewReader(data), data
+}
+
+func GetDataAndReader(r *rand.Rand, n int) (*bytes.Reader, []byte) {
+	data := make([]byte, n)
+	_, _ = r.Read(data)
 	return bytes.NewReader(data), data
 }
 
@@ -181,8 +187,10 @@ func GetRequiredEnv(name string) (string, error) {
 
 func BeforeTest(t *testing.T, suite string, test string) {
 	const urlRegex = `https://\S+\.blob\.core\.windows\.net`
+	const tokenRegex = `(?:Bearer\s).*`
 	require.NoError(t, recording.AddURISanitizer(FakeStorageURL, urlRegex, nil))
 	require.NoError(t, recording.AddHeaderRegexSanitizer("x-ms-copy-source", FakeStorageURL, urlRegex, nil))
+	require.NoError(t, recording.AddHeaderRegexSanitizer("x-ms-copy-source-authorization", FakeToken, tokenRegex, nil))
 	// we freeze request IDs and timestamps to avoid creating noisy diffs
 	// NOTE: we can't freeze time stamps as that breaks some tests that use if-modified-since etc (maybe it can be fixed?)
 	//testframework.AddHeaderRegexSanitizer("X-Ms-Date", "Wed, 10 Aug 2022 23:34:14 GMT", "", nil)


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
