### PR TITLE
[azservicebus] Removing code that handled session/link cancellation

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Authentication errors could cause unnecessary retries, making calls taking longer to fail. (PR#20447)
 - Recovery now includes internal timeouts and also handles restarting a connection if AMQP primitives aren't closed cleanly.
+- Potential leaks for $cbs and $management when there was a partial failure. (PR#20564)
 - Latest go-amqp changes have been merged in with fixes for robustness.
 
 ## 1.2.1 (2023-03-07)

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -131,7 +131,7 @@ func TestNewClientWithWebsockets(t *testing.T) {
 }
 
 func TestNewClientUsingSharedAccessSignature(t *testing.T) {
-	getLogsFn := test.CaptureLogsForTest()
+	getLogsFn := test.CaptureLogsForTest(false)
 
 	sasCS, err := sas.CreateConnectionStringWithSASUsingExpiry(test.GetConnectionString(t), time.Now().UTC().Add(time.Hour))
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -541,7 +541,7 @@ func TestAMQPLinksLiveRace(t *testing.T) {
 }
 
 func TestAMQPLinksLiveRaceLink(t *testing.T) {
-	endCapture := test.CaptureLogsForTest()
+	endCapture := test.CaptureLogsForTest(false)
 	defer func() {
 		messages := endCapture()
 		for _, msg := range messages {

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -225,6 +225,10 @@ func (l *FakeAMQPLinks) ClosedPermanently() bool {
 	return l.permanently
 }
 
+func (s *FakeAMQPSender) LinkName() string {
+	return "sender-link-name"
+}
+
 func (s *FakeAMQPSender) Close(ctx context.Context) error {
 	s.Closed++
 	return nil

--- a/sdk/messaging/azservicebus/internal/amqpwrap/mock_amqp_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpwrap/mock_amqp_test.go
@@ -606,6 +606,20 @@ func (mr *MockAMQPClientMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPClient)(nil).Close))
 }
 
+// Name mocks base method.
+func (m *MockAMQPClient) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockAMQPClientMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockAMQPClient)(nil).Name))
+}
+
 // NewSession mocks base method.
 func (m *MockAMQPClient) NewSession(ctx context.Context, opts *go_amqp.SessionOptions) (AMQPSession, error) {
 	m.ctrl.T.Helper()

--- a/sdk/messaging/azservicebus/internal/cbs.go
+++ b/sdk/messaging/azservicebus/internal/cbs.go
@@ -44,9 +44,6 @@ func NegotiateClaim(ctx context.Context, audience string, conn amqpwrap.AMQPClie
 	}
 
 	closeLink := func(ctx context.Context, origErr error) error {
-		ctx, cancel := contextWithTimeoutFn(ctx, defaultCloseTimeout)
-		defer cancel()
-
 		if err := link.Close(ctx); err != nil {
 			azlog.Writef(exported.EventAuth, "Failed closing claim link: %s", err.Error())
 			return err

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -190,6 +190,10 @@ func GetRecoveryKind(err error) RecoveryKind {
 		return RecoveryKindFatal
 	}
 
+	if errors.Is(err, amqpwrap.ErrConnResetNeeded) {
+		return RecoveryKindConn
+	}
+
 	var netErr net.Error
 
 	// these are errors that can flow from the go-amqp connection to

--- a/sdk/messaging/azservicebus/internal/go-amqp/conn.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/conn.go
@@ -28,6 +28,7 @@ const (
 	defaultIdleTimeout  = 1 * time.Minute
 	defaultMaxFrameSize = 65536
 	defaultMaxSessions  = 65536
+	defaultWriteTimeout = 30 * time.Second
 )
 
 // ConnOptions contains the optional settings for configuring an AMQP connection.
@@ -76,6 +77,17 @@ type ConnOptions struct {
 	// providing a URL scheme of "amqps://" is sufficient.
 	TLSConfig *tls.Config
 
+	// WriteTimeout controls the write deadline when writing AMQP frames to the
+	// underlying net.Conn and no caller provided context.Context is available or
+	// the context contains no deadline (e.g. context.Background()).
+	// The timeout is set per write.
+	//
+	// Setting to a value less than zero means no timeout is set, so writes
+	// defer to the underlying behavior of net.Conn with no write deadline.
+	//
+	// Default: 30s
+	WriteTimeout time.Duration
+
 	// test hook
 	dialer dialer
 }
@@ -90,12 +102,11 @@ type ConnOptions struct {
 //
 // opts: pass nil to accept the default values.
 func Dial(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error) {
-	deadline, _ := ctx.Deadline()
-	c, err := dialConn(deadline, addr, opts)
+	c, err := dialConn(ctx, addr, opts)
 	if err != nil {
 		return nil, err
 	}
-	err = c.start(deadline)
+	err = c.start(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +120,7 @@ func NewConn(ctx context.Context, conn net.Conn, opts *ConnOptions) (*Conn, erro
 	if err != nil {
 		return nil, err
 	}
-	deadline, _ := ctx.Deadline()
-	err = c.start(deadline)
+	err = c.start(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +129,9 @@ func NewConn(ctx context.Context, conn net.Conn, opts *ConnOptions) (*Conn, erro
 
 // Conn is an AMQP connection.
 type Conn struct {
-	net    net.Conn // underlying connection
-	dialer dialer   // used for testing purposes, it allows faking dialing TCP/TLS endpoints
+	net          net.Conn      // underlying connection
+	dialer       dialer        // used for testing purposes, it allows faking dialing TCP/TLS endpoints
+	writeTimeout time.Duration // controls write deadline in absense of a context
 
 	// TLS
 	tlsNegotiation bool        // negotiate TLS
@@ -156,40 +167,43 @@ type Conn struct {
 	sessionsByChannel   map[uint16]*Session
 	sessionsByChannelMu sync.RWMutex
 
+	abandonedSessionsMu sync.Mutex
+	abandonedSessions   []*Session
+
 	// connReader
 	rxBuf  buffer.Buffer // incoming bytes buffer
 	rxDone chan struct{} // closed when connReader exits
 	rxErr  error         // contains last error reading from c.net; DO NOT TOUCH outside of connReader until rxDone has been closed!
 
 	// connWriter
-	txFrame chan frames.Frame // AMQP frames to be sent by connWriter
-	txBuf   buffer.Buffer     // buffer for marshaling frames before transmitting
-	txDone  chan struct{}     // closed when connWriter exits
-	txErr   error             // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
+	txFrame chan frameEnvelope // AMQP frames to be sent by connWriter
+	txBuf   buffer.Buffer      // buffer for marshaling frames before transmitting
+	txDone  chan struct{}      // closed when connWriter exits
+	txErr   error              // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
 }
 
 // used to abstract the underlying dialer for testing purposes
 type dialer interface {
-	NetDialerDial(deadline time.Time, c *Conn, host, port string) error
-	TLSDialWithDialer(deadline time.Time, c *Conn, host, port string) error
+	NetDialerDial(ctx context.Context, c *Conn, host, port string) error
+	TLSDialWithDialer(ctx context.Context, c *Conn, host, port string) error
 }
 
 // implements the dialer interface
 type defaultDialer struct{}
 
-func (defaultDialer) NetDialerDial(deadline time.Time, c *Conn, host, port string) (err error) {
-	dialer := &net.Dialer{Deadline: deadline}
-	c.net, err = dialer.Dial("tcp", net.JoinHostPort(host, port))
+func (defaultDialer) NetDialerDial(ctx context.Context, c *Conn, host, port string) (err error) {
+	dialer := &net.Dialer{}
+	c.net, err = dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
 	return
 }
 
-func (defaultDialer) TLSDialWithDialer(deadline time.Time, c *Conn, host, port string) (err error) {
-	dialer := &net.Dialer{Deadline: deadline}
-	c.net, err = tls.DialWithDialer(dialer, "tcp", net.JoinHostPort(host, port), c.tlsConfig)
+func (defaultDialer) TLSDialWithDialer(ctx context.Context, c *Conn, host, port string) (err error) {
+	dialer := &tls.Dialer{Config: c.tlsConfig}
+	c.net, err = dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
 	return
 }
 
-func dialConn(deadline time.Time, addr string, opts *ConnOptions) (*Conn, error) {
+func dialConn(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
 		return nil, err
@@ -224,11 +238,11 @@ func dialConn(deadline time.Time, addr string, opts *ConnOptions) (*Conn, error)
 
 	switch u.Scheme {
 	case "amqp", "":
-		err = c.dialer.NetDialerDial(deadline, c, host, port)
+		err = c.dialer.NetDialerDial(ctx, c, host, port)
 	case "amqps", "amqp+ssl":
 		c.initTLSConfig()
 		c.tlsNegotiation = false
-		err = c.dialer.TLSDialWithDialer(deadline, c, host, port)
+		err = c.dialer.TLSDialWithDialer(ctx, c, host, port)
 	default:
 		err = fmt.Errorf("unsupported scheme %q", u.Scheme)
 	}
@@ -251,9 +265,10 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 		done:              make(chan struct{}),
 		rxtxExit:          make(chan struct{}),
 		rxDone:            make(chan struct{}),
-		txFrame:           make(chan frames.Frame),
+		txFrame:           make(chan frameEnvelope),
 		txDone:            make(chan struct{}),
 		sessionsByChannel: map[uint16]*Session{},
+		writeTimeout:      defaultWriteTimeout,
 	}
 
 	// apply options
@@ -261,6 +276,11 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 		opts = &ConnOptions{}
 	}
 
+	if opts.WriteTimeout > 0 {
+		c.writeTimeout = opts.WriteTimeout
+	} else if opts.WriteTimeout < 0 {
+		c.writeTimeout = 0
+	}
 	if opts.ContainerID != "" {
 		c.containerID = opts.ContainerID
 	}
@@ -314,25 +334,36 @@ func (c *Conn) initTLSConfig() {
 
 // start establishes the connection and begins multiplexing network IO.
 // It is an error to call Start() on a connection that's been closed.
-func (c *Conn) start(deadline time.Time) error {
-	// set connection establishment deadline
-	_ = c.net.SetDeadline(deadline)
+func (c *Conn) start(ctx context.Context) (err error) {
+	// if the context has a deadline or is cancellable, start the interruptor goroutine.
+	// this will close the underlying net.Conn in response to the context.
 
-	// run connection establishment state machine
-	for state := c.negotiateProto; state != nil; {
-		var err error
-		state, err = state()
-		// check if err occurred
-		if err != nil {
-			close(c.txDone) // close here since connWriter hasn't been started yet
-			close(c.rxDone)
-			_ = c.Close()
-			return err
-		}
+	if ctx.Done() != nil {
+		done := make(chan struct{})
+		interruptRes := make(chan error, 1)
+
+		defer func() {
+			close(done)
+			if ctxErr := <-interruptRes; ctxErr != nil {
+				// return context error to caller
+				err = ctxErr
+			}
+		}()
+
+		go func() {
+			select {
+			case <-ctx.Done():
+				c.closeDuringStart()
+				interruptRes <- ctx.Err()
+			case <-done:
+				interruptRes <- nil
+			}
+		}()
 	}
 
-	// remove connection establishment deadline
-	_ = c.net.SetDeadline(time.Time{})
+	if err = c.startImpl(ctx); err != nil {
+		return err
+	}
 
 	// we can't create the channel bitmap until the connection has been established.
 	// this is because our peer can tell us the max channels they support.
@@ -341,12 +372,44 @@ func (c *Conn) start(deadline time.Time) error {
 	go c.connWriter()
 	go c.connReader()
 
+	return
+}
+
+func (c *Conn) startImpl(ctx context.Context) error {
+	// set connection establishment deadline as required
+	if deadline, ok := ctx.Deadline(); ok && !deadline.IsZero() {
+		_ = c.net.SetDeadline(deadline)
+
+		// remove connection establishment deadline
+		defer func() {
+			_ = c.net.SetDeadline(time.Time{})
+		}()
+	}
+
+	// run connection establishment state machine
+	for state := c.negotiateProto; state != nil; {
+		var err error
+		state, err = state(ctx)
+		// check if err occurred
+		if err != nil {
+			c.closeDuringStart()
+			return err
+		}
+	}
+
 	return nil
 }
 
 // Close closes the connection.
 func (c *Conn) Close() error {
 	c.close()
+
+	// wait until the reader/writer goroutines have exited before proceeding.
+	// this is to prevent a race between calling Close() and a reader/writer
+	// goroutine calling close() due to a terminal error.
+	<-c.txDone
+	<-c.rxDone
+
 	var connErr *ConnError
 	if errors.As(c.doneErr, &connErr) && connErr.RemoteErr == nil && connErr.inner == nil {
 		// an empty ConnectionError means the connection was closed by the caller
@@ -386,7 +449,8 @@ func (c *Conn) close() {
 			// we experienced a peer-initiated close that contained an Error.  return it
 			c.doneErr = &ConnError{RemoteErr: amqpErr}
 		} else if c.txErr != nil {
-			c.doneErr = &ConnError{inner: c.txErr}
+			// c.txErr is already wrapped in a ConnError
+			c.doneErr = c.txErr
 		} else if c.rxErr != nil {
 			c.doneErr = &ConnError{inner: c.rxErr}
 		} else {
@@ -395,25 +459,52 @@ func (c *Conn) close() {
 	})
 }
 
+// closeDuringStart is a special close to be used only during startup (i.e. c.start() and any of its children)
+func (c *Conn) closeDuringStart() {
+	c.closeOnce.Do(func() {
+		c.net.Close()
+	})
+}
+
 // NewSession starts a new session on the connection.
 //   - ctx controls waiting for the peer to acknowledge the session
 //   - opts contains optional values, pass nil to accept the defaults
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned. If the Session was successfully
+// created, it will be cleaned up in future calls to NewSession.
 func (c *Conn) NewSession(ctx context.Context, opts *SessionOptions) (*Session, error) {
+	// clean up any abandoned sessions first
+	if err := c.freeAbandonedSessions(ctx); err != nil {
+		return nil, err
+	}
+
 	session, err := c.newSession(opts)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := session.begin(ctx); err != nil {
-		c.deleteSession(session)
+		c.abandonSession(session)
 		return nil, err
 	}
 
 	return session, nil
+}
+
+func (c *Conn) freeAbandonedSessions(ctx context.Context) error {
+	c.abandonedSessionsMu.Lock()
+	defer c.abandonedSessionsMu.Unlock()
+
+	for _, s := range c.abandonedSessions {
+		fr := frames.PerformEnd{}
+		if err := s.txFrameAndWait(ctx, &fr); err != nil {
+			return err
+		}
+	}
+
+	c.abandonedSessions = nil
+	return nil
 }
 
 func (c *Conn) newSession(opts *SessionOptions) (*Session, error) {
@@ -424,7 +515,10 @@ func (c *Conn) newSession(opts *SessionOptions) (*Session, error) {
 	// note that channel always start at 0
 	channel, ok := c.channels.Next()
 	if !ok {
-		return nil, fmt.Errorf("reached connection channel max (%d)", c.channelMax)
+		if err := c.Close(); err != nil {
+			return nil, err
+		}
+		return nil, &ConnError{inner: fmt.Errorf("reached connection channel max (%d)", c.channelMax)}
 	}
 	session := newSession(c, uint16(channel), opts)
 	c.sessionsByChannel[session.channel] = session
@@ -440,6 +534,12 @@ func (c *Conn) deleteSession(s *Session) {
 	c.channels.Remove(uint32(s.channel))
 }
 
+func (c *Conn) abandonSession(s *Session) {
+	c.abandonedSessionsMu.Lock()
+	defer c.abandonedSessionsMu.Unlock()
+	c.abandonedSessions = append(c.abandonedSessions, s)
+}
+
 // connReader reads from the net.Conn, decodes frames, and either handles
 // them here as appropriate or sends them to the session.rx channel.
 func (c *Conn) connReader() {
@@ -452,7 +552,7 @@ func (c *Conn) connReader() {
 	var err error
 	for {
 		if err != nil {
-			debug.Log(1, "RX (connReader): terminal error: %v", err)
+			debug.Log(1, "RX (connReader %p): terminal error: %v", c, err)
 			c.rxErr = err
 			return
 		}
@@ -463,7 +563,7 @@ func (c *Conn) connReader() {
 			continue
 		}
 
-		debug.Log(1, "RX (connReader): %s", fr)
+		debug.Log(1, "RX (connReader %p): %s", c, fr)
 
 		var (
 			session *Session
@@ -512,6 +612,7 @@ func (c *Conn) connReader() {
 			// the ack (i.e. before passing it on to the session mux) on the session
 			// ending since the numbers are recycled.
 			delete(sessionsByRemoteChannel, fr.Channel)
+			c.deleteSession(session)
 
 		default:
 			// pass on performative to the correct session
@@ -525,7 +626,7 @@ func (c *Conn) connReader() {
 		q := session.rxQ.Acquire()
 		q.Enqueue(fr.Body)
 		session.rxQ.Release(q)
-		debug.Log(2, "RX (connReader): mux frame to session: %s", fr)
+		debug.Log(2, "RX (connReader %p): mux frame to Session (%p): %s", c, session, fr)
 	}
 }
 
@@ -592,7 +693,7 @@ func (c *Conn) readFrame() (frames.Frame, error) {
 
 		// check if body is empty (keepalive)
 		if bodySize == 0 {
-			debug.Log(3, "RX (connReader): received keep-alive frame")
+			debug.Log(3, "RX (connReader %p): received keep-alive frame", c)
 			continue
 		}
 
@@ -609,6 +710,16 @@ func (c *Conn) readFrame() (frames.Frame, error) {
 
 		return frames.Frame{Channel: currentHeader.Channel, Body: parsedBody}, nil
 	}
+}
+
+// frameEnvelope is used when sending a frame to connWriter to be written to net.Conn
+type frameEnvelope struct {
+	Ctx   context.Context
+	Frame frames.Frame
+
+	// optional channel that is closed on successful write to net.Conn or contains the write error
+	// NOTE: use a buffered channel of size 1 when populating
+	Sent chan error
 }
 
 func (c *Conn) connWriter() {
@@ -635,24 +746,32 @@ func (c *Conn) connWriter() {
 	var err error
 	for {
 		if err != nil {
-			debug.Log(1, "TX (connWriter): terminal error: %v", err)
+			debug.Log(1, "TX (connWriter %p): terminal error: %v", c, err)
 			c.txErr = err
 			return
 		}
 
 		select {
 		// frame write request
-		case fr := <-c.txFrame:
-			debug.Log(1, "TX (connWriter): %s", fr)
-			err = c.writeFrame(fr)
-			if err == nil && fr.Done != nil {
-				close(fr.Done)
+		case env := <-c.txFrame:
+			timeout := c.getWriteTimeout(env.Ctx)
+			debug.Log(1, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
+			err = c.writeFrame(timeout, env.Frame)
+			if env.Sent != nil {
+				if err == nil {
+					close(env.Sent)
+				} else {
+					env.Sent <- err
+				}
 			}
 
 		// keepalive timer
 		case <-keepalive:
-			debug.Log(3, "TX (connWriter): sending keep-alive frame")
-			_, err = c.net.Write(keepaliveFrame)
+			debug.Log(3, "TX (connWriter %p): sending keep-alive frame", c)
+			_ = c.net.SetWriteDeadline(time.Now().Add(c.writeTimeout))
+			if _, err = c.net.Write(keepaliveFrame); err != nil {
+				err = &ConnError{inner: err}
+			}
 			// It would be slightly more efficient in terms of network
 			// resources to reset the timer each time a frame is sent.
 			// However, keepalives are small (8 bytes) and the interval
@@ -671,8 +790,8 @@ func (c *Conn) connWriter() {
 				Type: frames.TypeAMQP,
 				Body: &frames.PerformClose{},
 			}
-			debug.Log(1, "TX (connWriter): %s", fr)
-			c.txErr = c.writeFrame(fr)
+			debug.Log(1, "TX (connWriter %p): %s", c, fr)
+			c.txErr = c.writeFrame(c.writeTimeout, fr)
 			return
 		}
 	}
@@ -680,24 +799,36 @@ func (c *Conn) connWriter() {
 
 // writeFrame writes a frame to the network.
 // used externally by SASL only.
-func (c *Conn) writeFrame(fr frames.Frame) error {
+//   - timeout - the write deadline to set. zero means no deadline
+//
+// errors are wrapped in a ConnError as they can be returned to outside callers.
+func (c *Conn) writeFrame(timeout time.Duration, fr frames.Frame) error {
 	// writeFrame into txBuf
 	c.txBuf.Reset()
 	err := frames.Write(&c.txBuf, fr)
 	if err != nil {
-		return err
+		return &ConnError{inner: err}
 	}
 
 	// validate the frame isn't exceeding peer's max frame size
 	requiredFrameSize := c.txBuf.Len()
 	if uint64(requiredFrameSize) > uint64(c.peerMaxFrameSize) {
-		return fmt.Errorf("%T frame size %d larger than peer's max frame size %d", fr, requiredFrameSize, c.peerMaxFrameSize)
+		return &ConnError{inner: fmt.Errorf("%T frame size %d larger than peer's max frame size %d", fr, requiredFrameSize, c.peerMaxFrameSize)}
+	}
+
+	if timeout == 0 {
+		_ = c.net.SetWriteDeadline(time.Time{})
+	} else if timeout > 0 {
+		_ = c.net.SetWriteDeadline(time.Now().Add(timeout))
 	}
 
 	// write to network
 	n, err := c.net.Write(c.txBuf.Bytes())
 	if l := c.txBuf.Len(); n > 0 && n < l && err != nil {
-		debug.Log(1, "TX (writeFrame): wrote %d bytes less than len %d: %v", n, l, err)
+		debug.Log(1, "TX (writeFrame %p): wrote %d bytes less than len %d: %v", c, n, l, err)
+	}
+	if err != nil {
+		err = &ConnError{inner: err}
 	}
 	return err
 }
@@ -713,13 +844,17 @@ func (c *Conn) writeProtoHeader(pID protoID) error {
 var keepaliveFrame = []byte{0x00, 0x00, 0x00, 0x08, 0x02, 0x00, 0x00, 0x00}
 
 // SendFrame is used by sessions and links to send frames across the network.
-func (c *Conn) sendFrame(fr frames.Frame) error {
+//   - ctx is used to provide the write deadline
+//   - fr is the frame to write to net.Conn
+//   - sent is the optional channel that will contain the error if the write fails
+func (c *Conn) sendFrame(ctx context.Context, fr frames.Frame, sent chan error) {
 	select {
-	case c.txFrame <- fr:
-		debug.Log(2, "TX (Conn): mux frame to connWriter: %s", fr)
-		return nil
+	case c.txFrame <- frameEnvelope{Ctx: ctx, Frame: fr, Sent: sent}:
+		debug.Log(2, "TX (Conn %p): mux frame to connWriter: %s", c, fr)
 	case <-c.done:
-		return c.doneErr
+		if sent != nil {
+			sent <- c.doneErr
+		}
 	}
 }
 
@@ -727,11 +862,11 @@ func (c *Conn) sendFrame(fr frames.Frame) error {
 //
 // The state is advanced by returning the next state.
 // The state machine concludes when nil is returned.
-type stateFunc func() (stateFunc, error)
+type stateFunc func(context.Context) (stateFunc, error)
 
 // negotiateProto determines which proto to negotiate next.
 // used externally by SASL only.
-func (c *Conn) negotiateProto() (stateFunc, error) {
+func (c *Conn) negotiateProto(ctx context.Context) (stateFunc, error) {
 	// in the order each must be negotiated
 	switch {
 	case c.tlsNegotiation && !c.tlsComplete:
@@ -832,14 +967,14 @@ func (c *Conn) readProtoHeader() (protoHeader, error) {
 }
 
 // startTLS wraps the conn with TLS and returns to Client.negotiateProto
-func (c *Conn) startTLS() (stateFunc, error) {
+func (c *Conn) startTLS(ctx context.Context) (stateFunc, error) {
 	c.initTLSConfig()
 
 	_ = c.net.SetReadDeadline(time.Time{}) // clear timeout
 
 	// wrap existing net.Conn and perform TLS handshake
 	tlsConn := tls.Client(c.net, c.tlsConfig)
-	if err := tlsConn.Handshake(); err != nil {
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		return nil, err
 	}
 
@@ -852,7 +987,7 @@ func (c *Conn) startTLS() (stateFunc, error) {
 }
 
 // openAMQP round trips the AMQP open performative
-func (c *Conn) openAMQP() (stateFunc, error) {
+func (c *Conn) openAMQP(ctx context.Context) (stateFunc, error) {
 	// send open frame
 	open := &frames.PerformOpen{
 		ContainerID:  c.containerID,
@@ -867,8 +1002,8 @@ func (c *Conn) openAMQP() (stateFunc, error) {
 		Body:    open,
 		Channel: 0,
 	}
-	debug.Log(1, "TX (openAMQP): %s", fr)
-	err := c.writeFrame(fr)
+	debug.Log(1, "TX (openAMQP %p): %s", c, fr)
+	err := c.writeFrame(c.getWriteTimeout(ctx), fr)
 	if err != nil {
 		return nil, err
 	}
@@ -878,7 +1013,7 @@ func (c *Conn) openAMQP() (stateFunc, error) {
 	if err != nil {
 		return nil, err
 	}
-	debug.Log(1, "RX (openAMQP): %s", fr)
+	debug.Log(1, "RX (openAMQP %p): %s", c, fr)
 	o, ok := fr.Body.(*frames.PerformOpen)
 	if !ok {
 		return nil, fmt.Errorf("openAMQP: unexpected frame type %T", fr.Body)
@@ -902,13 +1037,13 @@ func (c *Conn) openAMQP() (stateFunc, error) {
 
 // negotiateSASL returns the SASL handler for the first matched
 // mechanism specified by the server
-func (c *Conn) negotiateSASL() (stateFunc, error) {
+func (c *Conn) negotiateSASL(context.Context) (stateFunc, error) {
 	// read mechanisms frame
 	fr, err := c.readSingleFrame()
 	if err != nil {
 		return nil, err
 	}
-	debug.Log(1, "RX (negotiateSASL): %s", fr)
+	debug.Log(1, "RX (negotiateSASL %p): %s", c, fr)
 	sm, ok := fr.Body.(*frames.SASLMechanisms)
 	if !ok {
 		return nil, fmt.Errorf("negotiateSASL: unexpected frame type %T", fr.Body)
@@ -931,13 +1066,13 @@ func (c *Conn) negotiateSASL() (stateFunc, error) {
 // SASL handlers return this stateFunc when the mechanism specific negotiation
 // has completed.
 // used externally by SASL only.
-func (c *Conn) saslOutcome() (stateFunc, error) {
+func (c *Conn) saslOutcome(context.Context) (stateFunc, error) {
 	// read outcome frame
 	fr, err := c.readSingleFrame()
 	if err != nil {
 		return nil, err
 	}
-	debug.Log(1, "RX (saslOutcome): %s", fr)
+	debug.Log(1, "RX (saslOutcome %p): %s", c, fr)
 	so, ok := fr.Body.(*frames.SASLOutcome)
 	if !ok {
 		return nil, fmt.Errorf("saslOutcome: unexpected frame type %T", fr.Body)
@@ -963,6 +1098,15 @@ func (c *Conn) readSingleFrame() (frames.Frame, error) {
 	}
 
 	return fr, nil
+}
+
+// getWriteTimeout returns the timeout as calculated from the context's deadline
+// or the default write timeout if the context has no deadline.
+func (c *Conn) getWriteTimeout(ctx context.Context) time.Duration {
+	if deadline, ok := ctx.Deadline(); ok {
+		return time.Until(deadline)
+	}
+	return c.writeTimeout
 }
 
 type protoHeader struct {

--- a/sdk/messaging/azservicebus/internal/go-amqp/internal/frames/frames.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/internal/frames/frames.go
@@ -356,9 +356,6 @@ type Frame struct {
 	Type    Type      // AMQP/SASL
 	Channel uint16    // channel this frame is for
 	Body    FrameBody // body of the frame
-
-	// optional channel which will be closed after net transmit
-	Done chan encoding.DeliveryState
 }
 
 // String implements the fmt.Stringer interface for type Frame.

--- a/sdk/messaging/azservicebus/internal/go-amqp/link.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/link.go
@@ -40,12 +40,12 @@ type link struct {
 	rxQ *queue.Holder[frames.FrameBody]
 
 	// used for gracefully closing link
-	close      chan struct{} // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
-	forceClose chan struct{} // used for forcibly terminate a link if Close() times out/is cancelled
-	closeOnce  *sync.Once    // closeOnce protects close from being closed multiple times
+	close     chan struct{} // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
+	closeOnce *sync.Once    // closeOnce protects close from being closed multiple times
 
-	done    chan struct{} // closed when the link has terminated (mux exited); DO NOT wait on this from within a link's mux() as it will never trigger!
-	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of link.go until done has been closed!
+	done     chan struct{} // closed when the link has terminated (mux exited); DO NOT wait on this from within a link's mux() as it will never trigger!
+	doneErr  error         // contains the mux error state; ONLY written to by the mux and MUST only be read from after done is closed!
+	closeErr error         // contains the error state returned from closeLink(); ONLY closeLink() reads/writes this!
 
 	session    *Session                // parent session
 	source     *frames.Source          // used for Receiver links
@@ -73,12 +73,11 @@ type link struct {
 
 func newLink(s *Session, r encoding.Role) link {
 	l := link{
-		key:        linkKey{shared.RandString(40), r},
-		session:    s,
-		close:      make(chan struct{}),
-		forceClose: make(chan struct{}),
-		closeOnce:  &sync.Once{},
-		done:       make(chan struct{}),
+		key:       linkKey{shared.RandString(40), r},
+		session:   s,
+		close:     make(chan struct{}),
+		closeOnce: &sync.Once{},
+		done:      make(chan struct{}),
 	}
 
 	// set the segment size relative to respective window
@@ -115,7 +114,9 @@ func (l *link) waitForFrame(ctx context.Context) (frames.FrameBody, error) {
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
 func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
-	if err := l.session.allocateHandle(l); err != nil {
+	if err := l.session.freeAbandonedLinks(ctx); err != nil {
+		return err
+	} else if err := l.session.allocateHandle(ctx, l); err != nil {
 		return err
 	}
 
@@ -133,18 +134,20 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 	// link-specific configuration of the attach frame
 	beforeAttach(attach)
 
-	_ = l.session.txFrame(attach, nil)
+	if err := l.txFrameAndWait(ctx, attach); err != nil {
+		return err
+	}
 
 	// wait for response
 	fr, err := l.waitForFrame(ctx)
 	if err != nil {
-		l.session.deallocateHandle(l)
+		l.session.abandonLink(l)
 		return err
 	}
 
 	resp, ok := fr.(*frames.PerformAttach)
 	if !ok {
-		debug.Log(1, "RX (link): unexpected attach response frame %T", fr)
+		debug.Log(1, "RX (link %p): unexpected attach response frame %T", l, fr)
 		if err := l.session.conn.Close(); err != nil {
 			return err
 		}
@@ -164,7 +167,9 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 		// wait for detach
 		fr, err := l.waitForFrame(ctx)
 		if err != nil {
-			l.session.deallocateHandle(l)
+			// we timed out waiting for the peer to close the link, this really isn't an abandoned link.
+			// however, we still need to send the detach performative to ack the peer.
+			l.session.abandonLink(l)
 			return err
 		}
 
@@ -181,7 +186,9 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 			Handle: l.handle,
 			Closed: true,
 		}
-		_ = l.session.txFrame(fr, nil)
+		if err := l.txFrameAndWait(ctx, fr); err != nil {
+			return err
+		}
 
 		if detach.Error == nil {
 			return fmt.Errorf("received detach with no error specified")
@@ -202,7 +209,9 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 			Handle: l.handle,
 			Closed: true,
 		}
-		_ = l.session.txFrame(dr, nil)
+		if err := l.txFrameAndWait(ctx, dr); err != nil {
+			return err
+		}
 		return err
 	}
 
@@ -262,11 +271,11 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 			Handle: l.handle,
 			Closed: true,
 		}
-		_ = l.session.txFrame(dr, nil)
+		l.txFrame(context.Background(), dr, nil)
 		return &LinkError{RemoteErr: fr.Error}
 
 	default:
-		debug.Log(1, "RX (link): unexpected frame: %s", fr)
+		debug.Log(1, "RX (link %p): unexpected frame: %s", l, fr)
 		l.closeWithError(ErrCondInternalError, fmt.Sprintf("link received unexpected frame %T", fr))
 		return nil
 	}
@@ -277,12 +286,21 @@ func (l *link) closeLink(ctx context.Context) error {
 	var ctxErr error
 	l.closeOnce.Do(func() {
 		close(l.close)
+
+		// once the mux has received the ack'ing detach performative, the mux will
+		// exit which deletes the link and closes l.done.
 		select {
 		case <-l.done:
-			// mux exited
+			l.closeErr = l.doneErr
 		case <-ctx.Done():
-			close(l.forceClose)
+			// notify the caller that the close timed out/was cancelled.
+			// the mux will remain running and once the ack is received it will terminate.
 			ctxErr = ctx.Err()
+
+			// record that the close timed out/was cancelled.
+			// subsequent calls to closeLink() will return this
+			debug.Log(1, "TX (link %p) closing %s: %v", l, l.key.name, ctxErr)
+			l.closeErr = &LinkError{inner: ctxErr}
 		}
 	})
 
@@ -291,11 +309,11 @@ func (l *link) closeLink(ctx context.Context) error {
 	}
 
 	var linkErr *LinkError
-	if errors.As(l.doneErr, &linkErr) && linkErr.inner == nil {
-		// an empty LinkError means the link was closed by the caller
+	if errors.As(l.closeErr, &linkErr) && linkErr.RemoteErr == nil && linkErr.inner == nil {
+		// an empty LinkError means the link was cleanly closed by the caller
 		return nil
 	}
-	return l.doneErr
+	return l.closeErr
 }
 
 // closeWithError initiates closing the link with the specified AMQP error.
@@ -306,7 +324,7 @@ func (l *link) closeLink(ctx context.Context) error {
 func (l *link) closeWithError(cnd ErrCond, desc string) {
 	amqpErr := &Error{Condition: cnd, Description: desc}
 	if l.closeInProgress {
-		debug.Log(3, "TX (link) close error already pending, discarding %v", amqpErr)
+		debug.Log(3, "TX (link %p) close error already pending, discarding %v", l, amqpErr)
 		return
 	}
 
@@ -317,5 +335,45 @@ func (l *link) closeWithError(cnd ErrCond, desc string) {
 	}
 	l.closeInProgress = true
 	l.doneErr = &LinkError{inner: fmt.Errorf("%s: %s", cnd, desc)}
-	_ = l.session.txFrame(dr, nil)
+	l.txFrame(context.Background(), dr, nil)
+}
+
+// txFrame sends the specified frame via the link's session.
+// you MUST call this instead of session.txFrame() to ensure
+// that frames are not sent during session shutdown.
+func (l *link) txFrame(ctx context.Context, fr frames.FrameBody, sent chan error) {
+	// NOTE: there is no need to select on l.done as this is either
+	// called from a link's mux or before the mux has even started.
+	select {
+	case <-l.session.done:
+		if sent != nil {
+			sent <- l.session.doneErr
+		}
+	case <-l.session.endSent:
+		// we swallow this to prevent the link's mux from terminating.
+		// l.session.done will soon close so this is temporary.
+		return
+	case l.session.tx <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
+		debug.Log(2, "TX (link %p): mux frame to Session (%p): %s", l, l.session, fr)
+	}
+}
+
+// txFrame sends the specified frame via the link's session.
+// you MUST call this instead of session.txFrame() to ensure
+// that frames are not sent during session shutdown.
+func (l *link) txFrameAndWait(ctx context.Context, fr frames.FrameBody) error {
+	// NOTE: there is no need to select on l.done as this is either
+	// called from a link's mux or before the mux has even started.
+	sent := make(chan error, 1)
+	select {
+	case <-l.session.done:
+		return l.session.doneErr
+	case <-l.session.endSent:
+		// we swallow this to prevent the link's mux from terminating.
+		// l.session.done will soon close so this is temporary.
+		return nil
+	case l.session.tx <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
+		debug.Log(2, "TX (link %p): mux frame to Session (%p): %s", l, l.session, fr)
+		return <-sent
+	}
 }

--- a/sdk/messaging/azservicebus/internal/go-amqp/link.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/link.go
@@ -116,7 +116,10 @@ func (l *link) waitForFrame(ctx context.Context) (frames.FrameBody, error) {
 func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
 	if err := l.session.freeAbandonedLinks(ctx); err != nil {
 		return err
-	} else if err := l.session.allocateHandle(ctx, l); err != nil {
+	}
+
+	// once the abandoned links have been cleaned up we can create our link
+	if err := l.session.allocateHandle(ctx, l); err != nil {
 		return err
 	}
 

--- a/sdk/messaging/azservicebus/internal/go-amqp/message.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/message.go
@@ -338,35 +338,6 @@ func (h *MessageHeader) Unmarshal(r *buffer.Buffer) error {
 	}...)
 }
 
-// AMQP types
-type (
-	// AMQPAddress corresponds to the 'address' type in the AMQP spec.
-	// <type name="address-string" class="restricted" source="string" provides="address"/>
-	Address = string
-
-	// AMQPMessageID corresponds to the 'message-id' type in the AMQP spec. Internally it can
-	// be one of the following:
-	// - uint64:    <type name="message-id-ulong" class="restricted" source="ulong" provides="message-id"/>
-	// - amqp.UUID: <type name="message-id-uuid" class="restricted" source="uuid" provides="message-id"/>
-	// - []byte:    <type name="message-id-binary" class="restricted" source="binary" provides="message-id"/>
-	// - string:    <type name="message-id-string" class="restricted" source="string" provides="message-id"/>
-	MessageID = any
-
-	// AMQPSymbol corresponds to the 'symbol' type in the AMQP spec.
-	// <type name="symbol" class="primitive"/>
-	// And either:
-	// - variable-width, 1 byte size	up to 2^8 - 1 seven bit ASCII characters representing a symbolic value
-	// - variable-width, 4 byte size	up to 2^32 - 1 seven bit ASCII characters representing a symbolic value
-	Symbol = string
-
-	// AMQPSequenceNumber corresponds to the `sequence-no` type in the AMQP spec.
-	// <type name="sequence-no" class="restricted" source="uint"/>
-	SequenceNumber = uint32
-
-	// AMQPBinary corresponds to the `binary` type in the AMQP spec.
-	Binary = []byte
-)
-
 /*
 <type name="properties" class="composite" source="list" provides="section">
     <descriptor name="amqp:properties:list" code="0x00000000:0x00000073"/>
@@ -393,25 +364,31 @@ type MessageProperties struct {
 	// such a way that it is assured to be globally unique. A broker MAY discard a
 	// message as a duplicate if the value of the message-id matches that of a
 	// previously received message sent to the same node.
-	MessageID MessageID // uint64, UUID, []byte, or string
+	//
+	// The value is restricted to the following types
+	//   - uint64, UUID, []byte, or string
+	MessageID any
 
 	// The identity of the user responsible for producing the message.
 	// The client sets this value, and it MAY be authenticated by intermediaries.
-	UserID Binary
+	UserID []byte
 
 	// The to field identifies the node that is the intended destination of the message.
 	// On any given transfer this might not be the node at the receiving end of the link.
-	To *Address
+	To *string
 
 	// A common field for summary information about the message content and purpose.
 	Subject *string
 
 	// The address of the node to send replies to.
-	ReplyTo *Address
+	ReplyTo *string
 
 	// This is a client-specific id that can be used to mark or identify messages
 	// between clients.
-	CorrelationID MessageID // uint64, UUID, []byte, or string
+	//
+	// The value is restricted to the following types
+	//   - uint64, UUID, []byte, or string
+	CorrelationID any
 
 	// The RFC-2046 [RFC2046] MIME type for the message's application-data section
 	// (body). As per RFC-2046 [RFC2046] this can contain a charset parameter defining
@@ -424,7 +401,7 @@ type MessageProperties struct {
 	//
 	// When using an application-data section with a section code other than data,
 	// content-type SHOULD NOT be set.
-	ContentType *Symbol
+	ContentType *string
 
 	// The content-encoding property is used as a modifier to the content-type.
 	// When present, its value indicates what additional content encodings have been
@@ -449,7 +426,7 @@ type MessageProperties struct {
 	//
 	// Implementations SHOULD NOT specify multiple content-encoding values except as to
 	// be compatible with messages originally sent with other protocols, e.g. HTTP or SMTP.
-	ContentEncoding *Symbol
+	ContentEncoding *string
 
 	// An absolute time when this message is considered to be expired.
 	AbsoluteExpiryTime *time.Time
@@ -461,7 +438,9 @@ type MessageProperties struct {
 	GroupID *string
 
 	// The relative position of this message within its group.
-	GroupSequence *SequenceNumber // RFC-1982 sequence number
+	//
+	// The value is defined as a RFC-1982 sequence number
+	GroupSequence *uint32
 
 	// This is a client-specific id that is used so that client can send replies to this
 	// message to a specific group.

--- a/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
@@ -254,12 +254,10 @@ func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint
 
 	sent := make(chan error, 1)
 	select {
-	case <-r.l.done:
-		return r.l.doneErr
-	case <-ctx.Done():
-		return ctx.Err()
 	case r.txDisposition <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
 		debug.Log(2, "TX (Receiver %p): mux txDisposition %s", r, fr)
+	case <-r.l.done:
+		return r.l.doneErr
 	}
 
 	select {
@@ -318,6 +316,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 
 	case <-ctx.Done():
 		// didn't receive the ack in the time allotted, leave message as unsettled
+		// TODO: if the ack arrives later, we need to remove the message from the unsettled map and reclaim the credit
 		return ctx.Err()
 	}
 }

--- a/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/receiver.go
@@ -29,6 +29,7 @@ type Receiver struct {
 	// message receiving
 	receiverReady chan struct{}          // receiver sends on this when mux is paused to indicate it can handle more messages
 	messagesQ     *queue.Holder[Message] // used to send completed messages to receiver
+	txDisposition chan frameBodyEnvelope // used to funnel disposition frames through the mux
 
 	unsettledMessages     map[string]struct{} // used to keep track of messages being handled downstream
 	unsettledMessagesLock sync.RWMutex        // lock to protect concurrent access to unsettledMessages
@@ -89,7 +90,7 @@ func (r *Receiver) Prefetched() *Message {
 		return nil
 	}
 
-	debug.Log(3, "RX (Receiver): prefetched delivery ID %d", msg.deliveryID)
+	debug.Log(3, "RX (Receiver %p): prefetched delivery ID %d", r, msg.deliveryID)
 
 	if msg.settled {
 		r.onSettlement(1)
@@ -119,7 +120,7 @@ func (r *Receiver) Receive(ctx context.Context, opts *ReceiveOptions) (*Message,
 	case q := <-r.messagesQ.Wait():
 		msg := q.Dequeue()
 		debug.Assert(msg != nil)
-		debug.Log(3, "RX (Receiver): received delivery ID %d", msg.deliveryID)
+		debug.Log(3, "RX (Receiver %p): received delivery ID %d", r, msg.deliveryID)
 		r.messagesQ.Release(q)
 		if msg.settled {
 			r.onSettlement(1)
@@ -234,14 +235,15 @@ func (r *Receiver) LinkSourceFilterValue(name string) any {
 //   - ctx controls waiting for the peer to acknowledge the close
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned.  However, the operation will continue to
+// execute in the background. Subsequent calls will return a *LinkError
+// that contains the context's error message.
 func (r *Receiver) Close(ctx context.Context) error {
 	return r.l.closeLink(ctx)
 }
 
 // sendDisposition sends a disposition frame to the peer
-func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.DeliveryState) error {
+func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint32, state encoding.DeliveryState) error {
 	fr := &frames.PerformDisposition{
 		Role:    encoding.RoleReceiver,
 		First:   first,
@@ -250,12 +252,15 @@ func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.De
 		State:   state,
 	}
 
+	sent := make(chan error, 1)
 	select {
+	case r.txDisposition <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
+		debug.Log(2, "TX (Receiver %p): mux txDisposition %s", r, fr)
+		return <-sent
 	case <-r.l.done:
 		return r.l.doneErr
-	default:
-		// TODO: this is racy
-		return r.l.session.txFrame(fr, nil)
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -264,13 +269,17 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 		return nil
 	}
 
+	// NOTE: we MUST add to the in-flight map before sending the disposition. if not, it's possible
+	// to receive the ack'ing disposition frame *before* the in-flight map has been updated which
+	// will cause the below <-wait to never trigger.
+
 	var wait chan error
 	if r.l.receiverSettleMode != nil && *r.l.receiverSettleMode == ReceiverSettleModeSecond {
-		debug.Log(3, "TX (Receiver): delivery ID %d is in flight", msg.deliveryID)
+		debug.Log(3, "TX (Receiver %p): delivery ID %d is in flight", r, msg.deliveryID)
 		wait = r.inFlight.add(msg.deliveryID)
 	}
 
-	if err := r.sendDisposition(msg.deliveryID, nil, state); err != nil {
+	if err := r.sendDisposition(ctx, msg.deliveryID, nil, state); err != nil {
 		return err
 	}
 
@@ -283,12 +292,24 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 
 	select {
 	case err := <-wait:
-		debug.Log(3, "RX (Receiver): delivery ID %d has been settled", msg.deliveryID)
-		// we've received confirmation of disposition
-		r.deleteUnsettled(msg)
-		r.onSettlement(1)
-		msg.settled = true
+		// err has three possibilities
+		//   - nil, meaning the peer acknowledged the settlement
+		//   - an *Error, meaning the peer rejected the message with a provided error
+		//   - a non-AMQP error. this comes from calls to inFlight.clear() during mux unwind.
+		// only for the first two cases is the message considered settled
+
+		if amqpErr := (&Error{}); err == nil || errors.As(err, &amqpErr) {
+			debug.Log(3, "RX (Receiver %p): delivery ID %d has been settled", r, msg.deliveryID)
+			// we've received confirmation of disposition
+			r.deleteUnsettled(msg)
+			r.onSettlement(1)
+			msg.settled = true
+			return err
+		}
+
+		debug.Log(3, "RX (Receiver %p): error settling delivery ID %d: %v", r, msg.deliveryID, err)
 		return err
+
 	case <-ctx.Done():
 		// didn't receive the ack in the time allotted, leave message as unsettled
 		return ctx.Err()
@@ -342,6 +363,7 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 		l:             l,
 		autoSendFlow:  true,
 		receiverReady: make(chan struct{}, 1),
+		txDisposition: make(chan frameBodyEnvelope),
 	}
 
 	r.messagesQ = queue.NewHolder(queue.New[Message](int(session.incomingWindow)))
@@ -451,12 +473,24 @@ func (r *Receiver) attach(ctx context.Context) error {
 		return err
 	}
 
-	go r.mux()
-
 	return nil
 }
 
-func (r *Receiver) mux() {
+func nop() {}
+
+type receiverTestHooks struct {
+	MuxStart  func()
+	MuxSelect func()
+}
+
+func (r *Receiver) mux(hooks receiverTestHooks) {
+	if hooks.MuxSelect == nil {
+		hooks.MuxSelect = nop
+	}
+	if hooks.MuxStart == nil {
+		hooks.MuxStart = nop
+	}
+
 	defer func() {
 		// unblock any in flight message dispositions
 		r.inFlight.clear(r.l.doneErr)
@@ -466,9 +500,10 @@ func (r *Receiver) mux() {
 			r.creditor.EndDrain()
 		}
 
-		r.l.session.deallocateHandle(&r.l)
 		close(r.l.done)
 	}()
+
+	hooks.MuxStart()
 
 	if r.autoSendFlow {
 		r.l.doneErr = r.muxFlow(r.l.linkCredit, false)
@@ -493,10 +528,12 @@ func (r *Receiver) mux() {
 		// fixed threshold to ensure credit is reclaimed in cases where the number of unsettled
 		// messages remains high for whatever reason.
 		if r.autoSendFlow && previousSettlementCount > 0 && previousSettlementCount >= r.l.linkCredit {
-			debug.Log(1, "RX (Receiver) (auto): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver %p) (auto): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
 			r.l.doneErr = r.creditor.IssueCredit(previousSettlementCount)
 		} else if r.l.linkCredit == 0 {
-			debug.Log(1, "RX (Receiver) (pause): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver %p) (pause): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
 		}
 
 		if r.l.doneErr != nil {
@@ -505,8 +542,8 @@ func (r *Receiver) mux() {
 
 		drain, credits := r.creditor.FlowBits(r.l.linkCredit)
 		if drain || credits > 0 {
-			debug.Log(1, "RX (Receiver) (flow): source: %q, inflight: %d, curLinkCredit: %d, newLinkCredit: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
-				r.l.source.Address, r.inFlight.len(), r.l.linkCredit, credits, drain, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver %p) (flow): source: %q, inflight: %d, curLinkCredit: %d, newLinkCredit: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, credits, drain, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
 
 			// send a flow frame.
 			r.l.doneErr = r.muxFlow(credits, drain)
@@ -516,18 +553,21 @@ func (r *Receiver) mux() {
 			return
 		}
 
+		txDisposition := r.txDisposition
 		closed := r.l.close
 		if r.l.closeInProgress {
 			// swap out channel so it no longer triggers
 			closed = nil
+
+			// disable sending of disposition frames once closing is in progress.
+			// this is to prevent races between mux shutdown and clearing of
+			// any in-flight dispositions.
+			txDisposition = nil
 		}
 
-		select {
-		case <-r.l.forceClose:
-			// the call to r.Close() timed out waiting for the ack
-			r.l.doneErr = &LinkError{inner: errors.New("the receiver was forcibly closed")}
-			return
+		hooks.MuxSelect()
 
+		select {
 		case q := <-r.l.rxQ.Wait():
 			// populated queue
 			fr := *q.Dequeue()
@@ -541,6 +581,9 @@ func (r *Receiver) mux() {
 				return
 			}
 
+		case env := <-txDisposition:
+			r.l.txFrame(env.Ctx, env.FrameBody, env.Sent)
+
 		case <-r.receiverReady:
 			continue
 
@@ -549,13 +592,14 @@ func (r *Receiver) mux() {
 				// a client-side close due to protocol error is in progress
 				continue
 			}
+
 			// receiver is being closed by the client
 			r.l.closeInProgress = true
 			fr := &frames.PerformDetach{
 				Handle: r.l.handle,
 				Closed: true,
 			}
-			_ = r.l.session.txFrame(fr, nil)
+			r.l.txFrame(context.Background(), fr, nil)
 
 		case <-r.l.session.done:
 			r.l.doneErr = r.l.session.doneErr
@@ -590,8 +634,8 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 	}
 
 	select {
-	case r.l.session.tx <- fr:
-		debug.Log(2, "TX (Receiver): %s", fr)
+	case r.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: fr}:
+		debug.Log(2, "TX (Receiver %p): mux frame to Session (%p): %d, %s", r, r.l.session, r.l.session.channel, fr)
 		return nil
 	case <-r.l.close:
 		return nil
@@ -602,7 +646,7 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 
 // muxHandleFrame processes fr based on type.
 func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
-	debug.Log(2, "RX (Receiver): %s", fr)
+	debug.Log(2, "RX (Receiver %p): %s", r, fr)
 	switch fr := fr.(type) {
 	// message frame
 	case *frames.PerformTransfer:
@@ -634,8 +678,8 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 		}
 
 		select {
-		case r.l.session.tx <- resp:
-			debug.Log(2, "TX (Sender): %s", resp)
+		case r.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: resp}:
+			debug.Log(2, "TX (Receiver %p): mux frame to Session (%p): %d, %s", r, r.l.session, r.l.session.channel, resp)
 		case <-r.l.close:
 			return nil
 		case <-r.l.session.done:
@@ -758,7 +802,7 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) {
 	// send to receiver
 	if !r.msg.settled {
 		r.addUnsettled(&r.msg)
-		debug.Log(3, "RX (Receiver): add unsettled delivery ID %d", r.msg.deliveryID)
+		debug.Log(3, "RX (Receiver %p): add unsettled delivery ID %d", r, r.msg.deliveryID)
 	}
 
 	q := r.messagesQ.Acquire()
@@ -773,7 +817,7 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) {
 	// decrement link-credit after entire message received
 	r.l.deliveryCount++
 	r.l.linkCredit--
-	debug.Log(3, "RX (Receiver) link %s - deliveryCount: %d, linkCredit: %d, len(messages): %d", r.l.key.name, r.l.deliveryCount, r.l.linkCredit, msgLen)
+	debug.Log(3, "RX (Receiver %p) link %s - deliveryCount: %d, linkCredit: %d, len(messages): %d", r, r.l.key.name, r.l.deliveryCount, r.l.linkCredit, msgLen)
 }
 
 // inFlight tracks in-flight message dispositions allowing receivers

--- a/sdk/messaging/azservicebus/internal/go-amqp/sasl.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/sasl.go
@@ -48,8 +48,11 @@ func SASLTypePlain(username, password string) SASLType {
 				Body: init,
 			}
 			debug.Log(1, "TX (ConnSASLPlain %p): %s", c, fr)
-			err := c.writeFrame(c.getWriteTimeout(ctx), fr)
+			timeout, err := c.getWriteTimeout(ctx)
 			if err != nil {
+				return nil, err
+			}
+			if err = c.writeFrame(timeout, fr); err != nil {
 				return nil, err
 			}
 
@@ -79,8 +82,11 @@ func SASLTypeAnonymous() SASLType {
 				Body: init,
 			}
 			debug.Log(1, "TX (ConnSASLAnonymous %p): %s", c, fr)
-			err := c.writeFrame(c.getWriteTimeout(ctx), fr)
+			timeout, err := c.getWriteTimeout(ctx)
 			if err != nil {
+				return nil, err
+			}
+			if err = c.writeFrame(timeout, fr); err != nil {
 				return nil, err
 			}
 
@@ -112,8 +118,11 @@ func SASLTypeExternal(resp string) SASLType {
 				Body: init,
 			}
 			debug.Log(1, "TX (ConnSASLExternal %p): %s", c, fr)
-			err := c.writeFrame(c.getWriteTimeout(ctx), fr)
+			timeout, err := c.getWriteTimeout(ctx)
 			if err != nil {
+				return nil, err
+			}
+			if err = c.writeFrame(timeout, fr); err != nil {
 				return nil, err
 			}
 
@@ -169,7 +178,11 @@ func (s saslXOAUTH2Handler) init(ctx context.Context) (stateFunc, error) {
 	if s.maxFrameSizeOverride > s.conn.peerMaxFrameSize {
 		s.conn.peerMaxFrameSize = s.maxFrameSizeOverride
 	}
-	err := s.conn.writeFrame(s.conn.getWriteTimeout(ctx), frames.Frame{
+	timeout, err := s.conn.getWriteTimeout(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = s.conn.writeFrame(timeout, frames.Frame{
 		Type: frames.TypeSASL,
 		Body: &frames.SASLInit{
 			Mechanism:       saslMechanismXOAUTH2,
@@ -206,8 +219,13 @@ func (s saslXOAUTH2Handler) step(ctx context.Context) (stateFunc, error) {
 		if s.errorResponse == nil {
 			s.errorResponse = v.Challenge
 
+			timeout, err := s.conn.getWriteTimeout(ctx)
+			if err != nil {
+				return nil, err
+			}
+
 			// The SASL protocol requires clients to send an empty response to this challenge.
-			err := s.conn.writeFrame(s.conn.getWriteTimeout(ctx), frames.Frame{
+			err = s.conn.writeFrame(timeout, frames.Frame{
 				Type: frames.TypeSASL,
 				Body: &frames.SASLResponse{
 					Response: []byte{},

--- a/sdk/messaging/azservicebus/internal/go-amqp/sender.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/sender.go
@@ -172,7 +172,7 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (cha
 		case <-s.l.done:
 			return nil, s.l.doneErr
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, &Error{Condition: ErrCondTransferLimitExceeded, Description: fmt.Sprintf("credit limit exceeded for sending link %s", s.l.key.name)}
 		}
 
 		select {
@@ -456,8 +456,6 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 			Last:    fr.Last,
 			Settled: true,
 		}
-
-		// TODO: the context used here should be the one associated with the original Send()
 
 		select {
 		case s.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: dr}:

--- a/sdk/messaging/azservicebus/internal/go-amqp/session.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/session.go
@@ -475,7 +475,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 					continue
 				}
 
-				if body.Echo {
+				if body.Echo && !closeInProgress {
 					niID := nextIncomingID
 					resp := &frames.PerformFlow{
 						NextIncomingID: &niID,
@@ -538,7 +538,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}
 
 				// Update peer's outgoing window if half has been consumed.
-				if s.needFlowCount >= s.incomingWindow/2 {
+				if s.needFlowCount >= s.incomingWindow/2 && !closeInProgress {
 					debug.Log(3, "RX (Session %p): channel %d: flow - s.needFlowCount(%d) >= s.incomingWindow(%d)/2\n", s, s.channel, s.needFlowCount, s.incomingWindow)
 					s.needFlowCount = 0
 					nID := nextIncomingID

--- a/sdk/messaging/azservicebus/internal/go-amqp/session.go
+++ b/sdk/messaging/azservicebus/internal/go-amqp/session.go
@@ -36,11 +36,11 @@ type SessionOptions struct {
 //
 // A session multiplexes Receivers.
 type Session struct {
-	channel       uint16                       // session's local channel
-	remoteChannel uint16                       // session's remote channel, owned by conn.connReader
-	conn          *Conn                        // underlying conn
-	tx            chan frames.FrameBody        // non-transfer frames to be sent; session must track disposition
-	txTransfer    chan *frames.PerformTransfer // transfer frames to be sent; session must track disposition
+	channel       uint16                 // session's local channel
+	remoteChannel uint16                 // session's remote channel, owned by conn.connReader
+	conn          *Conn                  // underlying conn
+	tx            chan frameBodyEnvelope // non-transfer frames to be sent; session must track disposition
+	txTransfer    chan transferEnvelope  // transfer frames to be sent; session must track disposition
 
 	// frames destined for this session are added to this queue by conn.connReader
 	rxQ *queue.Holder[frames.FrameBody]
@@ -57,30 +57,34 @@ type Session struct {
 	linksByKey map[linkKey]*link // mapping of name+role link
 	handles    *bitmap.Bitmap    // allocated handles
 
+	abandonedLinksMu sync.Mutex
+	abandonedLinks   []*link
+
 	// used for gracefully closing session
-	close      chan struct{}
-	forceClose chan struct{}
-	closeOnce  sync.Once
+	close     chan struct{} // closed by calling Close(). it signals that the end performative should be sent
+	closeOnce sync.Once
 
 	// part of internal public surface area
-	done    chan struct{} // closed when the session has terminated (mux exited); DO NOT wait on this from within Session.mux() as it will never trigger!
-	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of session.go until done has been closed!
+	done     chan struct{} // closed when the session has terminated (mux exited); DO NOT wait on this from within Session.mux() as it will never trigger!
+	endSent  chan struct{} // closed when the end performative has been sent; once this is closed, links MUST NOT send any frames!
+	doneErr  error         // contains the mux error state; ONLY written to by the mux and MUST only be read from after done is closed!
+	closeErr error         // contains the error state returned from Close(); ONLY Close() reads/writes this!
 }
 
 func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 	s := &Session{
 		conn:           c,
 		channel:        channel,
-		tx:             make(chan frames.FrameBody),
-		txTransfer:     make(chan *frames.PerformTransfer),
+		tx:             make(chan frameBodyEnvelope),
+		txTransfer:     make(chan transferEnvelope),
 		incomingWindow: defaultWindow,
 		outgoingWindow: defaultWindow,
 		handleMax:      math.MaxUint32,
 		linksMu:        sync.RWMutex{},
 		linksByKey:     make(map[linkKey]*link),
 		close:          make(chan struct{}),
-		forceClose:     make(chan struct{}),
 		done:           make(chan struct{}),
+		endSent:        make(chan struct{}),
 	}
 
 	if opts != nil {
@@ -130,7 +134,9 @@ func (s *Session) begin(ctx context.Context) error {
 		HandleMax:      s.handleMax,
 	}
 
-	_ = s.txFrame(begin, nil)
+	if err := s.txFrameAndWait(ctx, begin); err != nil {
+		return err
+	}
 
 	// wait for response
 	fr, err := s.waitForFrame(ctx)
@@ -149,7 +155,7 @@ func (s *Session) begin(ctx context.Context) error {
 		// either swallow the frame or blow up in some other way, both causing this call to hang.
 		// deallocate session on error.  we can't call
 		// s.Close() as the session mux hasn't started yet.
-		debug.Log(1, "RX (Session): unexpected begin response frame %T", fr)
+		debug.Log(1, "RX (Session %p): unexpected begin response frame %T", s, fr)
 		s.conn.deleteSession(s)
 		if err := s.conn.Close(); err != nil {
 			return err
@@ -167,18 +173,29 @@ func (s *Session) begin(ctx context.Context) error {
 //   - ctx controls waiting for the peer to acknowledge the session is closed
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned.  However, the operation will continue to
+// execute in the background. Subsequent calls will return a *SessionError
+// that contains the context's error message.
 func (s *Session) Close(ctx context.Context) error {
 	var ctxErr error
 	s.closeOnce.Do(func() {
 		close(s.close)
+
+		// once the mux has received the ack'ing end performative, the mux will
+		// exit which deletes the session and closes s.done.
 		select {
 		case <-s.done:
-			// mux has exited
+			s.closeErr = s.doneErr
+
 		case <-ctx.Done():
-			close(s.forceClose)
+			// notify the caller that the close timed out/was cancelled.
+			// the mux will remain running and once the ack is received it will terminate.
 			ctxErr = ctx.Err()
+
+			// record that the close timed out/was cancelled.
+			// subsequent calls to Close() will return this
+			debug.Log(1, "TX (Session %p) channel %d: %v", s, s.channel, ctxErr)
+			s.closeErr = &SessionError{inner: ctxErr}
 		}
 	})
 
@@ -187,22 +204,33 @@ func (s *Session) Close(ctx context.Context) error {
 	}
 
 	var sessionErr *SessionError
-	if errors.As(s.doneErr, &sessionErr) && sessionErr.RemoteErr == nil && sessionErr.inner == nil {
-		// an empty SessionError means the session was closed by the caller
+	if errors.As(s.closeErr, &sessionErr) && sessionErr.RemoteErr == nil && sessionErr.inner == nil {
+		// an empty SessionError means the session was cleanly closed by the caller
 		return nil
 	}
-	return s.doneErr
+	return s.closeErr
 }
 
 // txFrame sends a frame to the connWriter.
-// it returns an error if the connection has been closed.
-func (s *Session) txFrame(p frames.FrameBody, done chan encoding.DeliveryState) error {
-	return s.conn.sendFrame(frames.Frame{
+//   - ctx is used to provide the write deadline
+//   - fr is the frame to write to net.Conn
+//   - sent is the optional channel that will contain the error if the write fails
+func (s *Session) txFrame(ctx context.Context, fr frames.FrameBody, sent chan error) {
+	debug.Log(2, "TX (Session %p) mux frame to Conn (%p): %s", s, s.conn, fr)
+	s.conn.sendFrame(ctx, frames.Frame{
 		Type:    frames.TypeAMQP,
 		Channel: s.channel,
-		Body:    p,
-		Done:    done,
-	})
+		Body:    fr,
+	}, sent)
+}
+
+// txFrameAndWait sends a frame to the connWriter and waits for the write to complete
+//   - ctx is used to provide the write deadline
+//   - fr is the frame to write to net.Conn
+func (s *Session) txFrameAndWait(ctx context.Context, fr frames.FrameBody) error {
+	sent := make(chan error, 1)
+	s.txFrame(ctx, fr, sent)
+	return <-sent
 }
 
 // NewReceiver opens a new receiver link on the session.
@@ -211,8 +239,8 @@ func (s *Session) txFrame(p frames.FrameBody, done chan encoding.DeliveryState) 
 //   - opts contains optional values, pass nil to accept the defaults
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned. If the Receiver was successfully
+// created, it will be cleaned up in future calls to NewReceiver.
 func (s *Session) NewReceiver(ctx context.Context, source string, opts *ReceiverOptions) (*Receiver, error) {
 	r, err := newReceiver(source, s, opts)
 	if err != nil {
@@ -221,6 +249,8 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 	if err = r.attach(ctx); err != nil {
 		return nil, err
 	}
+
+	go r.mux(receiverTestHooks{})
 
 	return r, nil
 }
@@ -231,8 +261,8 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 //   - opts contains optional values, pass nil to accept the defaults
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned. If the Sender was successfully
+// created, it will be cleaned up in future calls to NewSender.
 func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOptions) (*Sender, error) {
 	l, err := newSender(target, s, opts)
 	if err != nil {
@@ -247,7 +277,6 @@ func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOpti
 
 func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 	defer func() {
-		s.conn.deleteSession(s)
 		if s.doneErr == nil {
 			s.doneErr = &SessionError{}
 		} else if connErr := (&ConnError{}); !errors.As(s.doneErr, &connErr) {
@@ -284,29 +313,34 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 	closeWithError := func(e1 *Error, e2 error) {
 		if closeInProgress {
-			debug.Log(3, "TX (Session): close already pending, discarding %v", e1)
+			debug.Log(3, "TX (Session %p): close already pending, discarding %v", s, e1)
 			return
 		}
 
 		closeInProgress = true
 		s.doneErr = e2
-		_ = s.txFrame(&frames.PerformEnd{Error: e1}, nil)
+		s.txFrame(context.Background(), &frames.PerformEnd{Error: e1}, nil)
+		close(s.endSent)
 	}
 
 	for {
 		txTransfer := s.txTransfer
 		// disable txTransfer if flow control windows have been exceeded
 		if remoteIncomingWindow == 0 || s.outgoingWindow == 0 {
-			debug.Log(1, "TX (Session): disabling txTransfer - window exceeded. remoteIncomingWindow: %d outgoingWindow: %d",
-				remoteIncomingWindow,
-				s.outgoingWindow)
+			debug.Log(1, "TX (Session %p): disabling txTransfer - window exceeded. remoteIncomingWindow: %d outgoingWindow: %d",
+				s, remoteIncomingWindow, s.outgoingWindow)
 			txTransfer = nil
 		}
 
+		tx := s.tx
 		closed := s.close
 		if closeInProgress {
 			// swap out channel so it no longer triggers
 			closed = nil
+
+			// once the end performative is sent, we're not allowed to send any frames
+			tx = nil
+			txTransfer = nil
 		}
 
 		// notes on client-side closing session
@@ -324,11 +358,6 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			s.doneErr = s.conn.doneErr
 			return
 
-		case <-s.forceClose:
-			// the call to s.Close() timed out waiting for the ack
-			s.doneErr = errors.New("the session was forcibly closed")
-			return
-
 		case <-closed:
 			if closeInProgress {
 				// a client-side close due to protocol error is in progress
@@ -336,14 +365,14 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			}
 			// session is being closed by the client
 			closeInProgress = true
-			fr := frames.PerformEnd{}
-			_ = s.txFrame(&fr, nil)
+			s.txFrame(context.Background(), &frames.PerformEnd{}, nil)
+			close(s.endSent)
 
 		// incoming frame
 		case q := <-s.rxQ.Wait():
 			fr := *q.Dequeue()
 			s.rxQ.Release(q)
-			debug.Log(2, "RX (Session): %s", fr)
+			debug.Log(2, "RX (Session %p): %s", s, fr)
 
 			switch body := fr.(type) {
 			// Disposition frames can reference transfers from more than one
@@ -362,7 +391,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 					handle, ok := handles[deliveryID]
 					if !ok {
-						debug.Log(2, "RX (Session): role %s: didn't find deliveryID %d in handles map", body.Role, deliveryID)
+						debug.Log(2, "RX (Session %p): role %s: didn't find deliveryID %d in handles map", s, body.Role, deliveryID)
 						continue
 					}
 					delete(handles, deliveryID)
@@ -421,7 +450,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				// initial-outgoing-id(endpoint) + incoming-window(flow) - next-outgoing-id(endpoint)"
 				remoteIncomingWindow = body.IncomingWindow - nextOutgoingID
 				remoteIncomingWindow += *body.NextIncomingID
-				debug.Log(3, "RX (Session): flow - remoteOutgoingWindow: %d remoteIncomingWindow: %d nextOutgoingID: %d", remoteOutgoingWindow, remoteIncomingWindow, nextOutgoingID)
+				debug.Log(3, "RX (Session %p): flow - remoteOutgoingWindow: %d remoteIncomingWindow: %d nextOutgoingID: %d", s, remoteOutgoingWindow, remoteIncomingWindow, nextOutgoingID)
 
 				// Send to link if handle is set
 				if body.Handle != nil {
@@ -446,7 +475,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 						NextOutgoingID: nextOutgoingID,
 						OutgoingWindow: s.outgoingWindow,
 					}
-					_ = s.txFrame(resp, nil)
+					s.txFrame(context.Background(), resp, nil)
 				}
 
 			case *frames.PerformAttach:
@@ -493,17 +522,16 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}
 
 				s.muxFrameToLink(link, fr)
-				debug.Log(2, "RX (Session): mux transfer to link: %s", fr)
 
 				// if this message is received unsettled and link rcv-settle-mode == second, add to handlesByRemoteDeliveryID
 				if !body.Settled && body.DeliveryID != nil && link.receiverSettleMode != nil && *link.receiverSettleMode == ReceiverSettleModeSecond {
-					debug.Log(1, "RX (Session): adding handle to handlesByRemoteDeliveryID. delivery ID: %d", *body.DeliveryID)
+					debug.Log(1, "RX (Session %p): adding handle to handlesByRemoteDeliveryID. delivery ID: %d", s, *body.DeliveryID)
 					handlesByRemoteDeliveryID[*body.DeliveryID] = body.Handle
 				}
 
 				// Update peer's outgoing window if half has been consumed.
 				if s.needFlowCount >= s.incomingWindow/2 {
-					debug.Log(3, "RX (Session): channel %d: flow - s.needFlowCount(%d) >= s.incomingWindow(%d)/2\n", s.channel, s.needFlowCount, s.incomingWindow)
+					debug.Log(3, "RX (Session %p): channel %d: flow - s.needFlowCount(%d) >= s.incomingWindow(%d)/2\n", s, s.channel, s.needFlowCount, s.incomingWindow)
 					s.needFlowCount = 0
 					nID := nextIncomingID
 					flow := &frames.PerformFlow{
@@ -512,7 +540,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 						NextOutgoingID: nextOutgoingID,
 						OutgoingWindow: s.outgoingWindow,
 					}
-					_ = s.txFrame(flow, nil)
+					s.txFrame(context.Background(), flow, nil)
 				}
 
 			case *frames.PerformDetach:
@@ -533,6 +561,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				// are safe to clean up its state.
 				delete(links, link.remoteHandle)
 				delete(deliveryIDByHandle, link.handle)
+				s.deallocateHandle(link)
 
 			case *frames.PerformEnd:
 				// there are two possibilities:
@@ -549,28 +578,21 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}
 
 				fr := frames.PerformEnd{}
-				_ = s.txFrame(&fr, nil)
+				s.txFrame(context.Background(), &fr, nil)
 
 				// per spec, when end is received, we're no longer allowed to receive frames
 				return
 
 			default:
-				debug.Log(1, "RX (Session): unexpected frame: %s\n", body)
+				debug.Log(1, "RX (Session %p): unexpected frame: %s\n", s, body)
 				closeWithError(&Error{
 					Condition:   ErrCondInternalError,
 					Description: "session received unexpected frame",
 				}, fmt.Errorf("internal error: unexpected frame %T", body))
 			}
 
-		case fr := <-txTransfer:
-			if closeInProgress {
-				// now that the end performative has been sent we're
-				// not allowed to send any more frames.
-				debug.Log(1, "TX (Session): discarding transfer: %s\n", fr)
-				continue
-			}
-
-			debug.Log(2, "TX (Session): %d, %s", s.channel, fr)
+		case env := <-txTransfer:
+			fr := &env.Frame
 			// record current delivery ID
 			var deliveryID uint32
 			if fr.DeliveryID == &needsDeliveryID {
@@ -589,19 +611,30 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				deliveryID = deliveryIDByHandle[fr.Handle]
 			}
 
+			// log after the delivery ID has been assigned
+			debug.Log(2, "TX (Session %p): %d, %s", s, s.channel, fr)
+
 			// frame has been sender-settled, remove from map
 			if fr.Settled {
 				delete(handlesByDeliveryID, deliveryID)
 			}
 
-			// if not settled, add done chan to map
-			// and clear from frame so conn doesn't close it.
-			if !fr.Settled && fr.Done != nil {
-				settlementByDeliveryID[deliveryID] = fr.Done
-				fr.Done = nil
+			s.txFrame(env.Ctx, fr, env.Sent)
+			if sendErr := <-env.Sent; sendErr != nil {
+				s.doneErr = sendErr
+
+				// put the error back as our sender will read from this channel
+				env.Sent <- sendErr
+				return
 			}
 
-			_ = s.txFrame(fr, fr.Done)
+			// if not settled, add done chan to map
+			if !fr.Settled && fr.Done != nil {
+				settlementByDeliveryID[deliveryID] = fr.Done
+			} else if fr.Done != nil {
+				// sender-settled, close done now that the transfer has been sent
+				close(fr.Done)
+			}
 
 			// "Upon sending a transfer, the sending endpoint will increment
 			// its next-outgoing-id, decrement its remote-incoming-window,
@@ -612,16 +645,10 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				remoteIncomingWindow--
 			}
 
-		case fr := <-s.tx:
-			if closeInProgress {
-				// now that the end performative has been sent we're
-				// not allowed to send any more frames.
-				debug.Log(1, "TX (Session): discarding frame: %s\n", fr)
-				continue
-			}
-
-			debug.Log(2, "TX (Session): %d, %s", s.channel, fr)
-			switch fr := fr.(type) {
+		case env := <-tx:
+			fr := env.FrameBody
+			debug.Log(2, "TX (Session %p): %d, %s", s, s.channel, fr)
+			switch fr := env.FrameBody.(type) {
 			case *frames.PerformDisposition:
 				if fr.Settled && fr.Role == encoding.RoleSender {
 					// sender with a peer that's in mode second; sending confirmation of disposition.
@@ -645,24 +672,24 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 						}
 					}
 				}
-				_ = s.txFrame(fr, nil)
+				s.txFrame(env.Ctx, fr, env.Sent)
 			case *frames.PerformFlow:
 				niID := nextIncomingID
 				fr.NextIncomingID = &niID
 				fr.IncomingWindow = s.incomingWindow
 				fr.NextOutgoingID = nextOutgoingID
 				fr.OutgoingWindow = s.outgoingWindow
-				_ = s.txFrame(fr, nil)
+				s.txFrame(context.Background(), fr, env.Sent)
 			case *frames.PerformTransfer:
 				panic("transfer frames must use txTransfer")
 			default:
-				_ = s.txFrame(fr, nil)
+				s.txFrame(context.Background(), fr, env.Sent)
 			}
 		}
 	}
 }
 
-func (s *Session) allocateHandle(l *link) error {
+func (s *Session) allocateHandle(ctx context.Context, l *link) error {
 	s.linksMu.Lock()
 	defer s.linksMu.Unlock()
 
@@ -674,8 +701,11 @@ func (s *Session) allocateHandle(l *link) error {
 
 	next, ok := s.handles.Next()
 	if !ok {
+		if err := s.Close(ctx); err != nil {
+			return err
+		}
 		// handle numbers are zero-based, report the actual count
-		return fmt.Errorf("reached session handle max (%d)", s.handleMax+1)
+		return &SessionError{inner: fmt.Errorf("reached session handle max (%d)", s.handleMax+1)}
 	}
 
 	l.handle = next         // allocate handle to the link
@@ -692,11 +722,50 @@ func (s *Session) deallocateHandle(l *link) {
 	s.handles.Remove(l.handle)
 }
 
+func (s *Session) abandonLink(l *link) {
+	s.abandonedLinksMu.Lock()
+	defer s.abandonedLinksMu.Unlock()
+	s.abandonedLinks = append(s.abandonedLinks, l)
+}
+
+func (s *Session) freeAbandonedLinks(ctx context.Context) error {
+	s.abandonedLinksMu.Lock()
+	defer s.abandonedLinksMu.Unlock()
+
+	for _, l := range s.abandonedLinks {
+		dr := &frames.PerformDetach{
+			Handle: l.handle,
+			Closed: true,
+		}
+		if err := s.txFrameAndWait(ctx, dr); err != nil {
+			return err
+		}
+	}
+
+	s.abandonedLinks = nil
+	return nil
+}
+
 func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
 	q := l.rxQ.Acquire()
 	q.Enqueue(fr)
 	l.rxQ.Release(q)
-	debug.Log(2, "RX (Session): mux frame to link: %s, %s", l.key.name, fr)
+	debug.Log(2, "RX (Session %p): mux frame to link (%p): %s, %s", s, l, l.key.name, fr)
+}
+
+// transferEnvelope is used by senders to send transfer frames
+type transferEnvelope struct {
+	Ctx   context.Context
+	Frame frames.PerformTransfer
+	Sent  chan error
+}
+
+// frameBodyEnvelope is used by senders and receivers to send frames.
+// these frames come from the mux which is why there's no Sent channel.
+type frameBodyEnvelope struct {
+	Ctx       context.Context
+	FrameBody frames.FrameBody
+	Sent      chan error
 }
 
 // the address of this var is a sentinel value indicating

--- a/sdk/messaging/azservicebus/internal/mock/mock_amqp.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_amqp.go
@@ -635,3 +635,286 @@ func (mr *MockAMQPClientMockRecorder) NewSession(ctx, opts interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockAMQPClient)(nil).NewSession), ctx, opts)
 }
+
+// MockgoamqpConn is a mock of goamqpConn interface.
+type MockgoamqpConn struct {
+	ctrl     *gomock.Controller
+	recorder *MockgoamqpConnMockRecorder
+}
+
+// MockgoamqpConnMockRecorder is the mock recorder for MockgoamqpConn.
+type MockgoamqpConnMockRecorder struct {
+	mock *MockgoamqpConn
+}
+
+// NewMockgoamqpConn creates a new mock instance.
+func NewMockgoamqpConn(ctrl *gomock.Controller) *MockgoamqpConn {
+	mock := &MockgoamqpConn{ctrl: ctrl}
+	mock.recorder = &MockgoamqpConnMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockgoamqpConn) EXPECT() *MockgoamqpConnMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockgoamqpConn) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockgoamqpConnMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockgoamqpConn)(nil).Close))
+}
+
+// NewSession mocks base method.
+func (m *MockgoamqpConn) NewSession(ctx context.Context, opts *amqp.SessionOptions) (*amqp.Session, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewSession", ctx, opts)
+	ret0, _ := ret[0].(*amqp.Session)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewSession indicates an expected call of NewSession.
+func (mr *MockgoamqpConnMockRecorder) NewSession(ctx, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockgoamqpConn)(nil).NewSession), ctx, opts)
+}
+
+// MockgoamqpSession is a mock of goamqpSession interface.
+type MockgoamqpSession struct {
+	ctrl     *gomock.Controller
+	recorder *MockgoamqpSessionMockRecorder
+}
+
+// MockgoamqpSessionMockRecorder is the mock recorder for MockgoamqpSession.
+type MockgoamqpSessionMockRecorder struct {
+	mock *MockgoamqpSession
+}
+
+// NewMockgoamqpSession creates a new mock instance.
+func NewMockgoamqpSession(ctrl *gomock.Controller) *MockgoamqpSession {
+	mock := &MockgoamqpSession{ctrl: ctrl}
+	mock.recorder = &MockgoamqpSessionMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockgoamqpSession) EXPECT() *MockgoamqpSessionMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockgoamqpSession) Close(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockgoamqpSessionMockRecorder) Close(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockgoamqpSession)(nil).Close), ctx)
+}
+
+// NewReceiver mocks base method.
+func (m *MockgoamqpSession) NewReceiver(ctx context.Context, source string, opts *amqp.ReceiverOptions) (*amqp.Receiver, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewReceiver", ctx, source, opts)
+	ret0, _ := ret[0].(*amqp.Receiver)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewReceiver indicates an expected call of NewReceiver.
+func (mr *MockgoamqpSessionMockRecorder) NewReceiver(ctx, source, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReceiver", reflect.TypeOf((*MockgoamqpSession)(nil).NewReceiver), ctx, source, opts)
+}
+
+// NewSender mocks base method.
+func (m *MockgoamqpSession) NewSender(ctx context.Context, target string, opts *amqp.SenderOptions) (*amqp.Sender, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewSender", ctx, target, opts)
+	ret0, _ := ret[0].(*amqp.Sender)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewSender indicates an expected call of NewSender.
+func (mr *MockgoamqpSessionMockRecorder) NewSender(ctx, target, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSender", reflect.TypeOf((*MockgoamqpSession)(nil).NewSender), ctx, target, opts)
+}
+
+// MockgoamqpReceiver is a mock of goamqpReceiver interface.
+type MockgoamqpReceiver struct {
+	ctrl     *gomock.Controller
+	recorder *MockgoamqpReceiverMockRecorder
+}
+
+// MockgoamqpReceiverMockRecorder is the mock recorder for MockgoamqpReceiver.
+type MockgoamqpReceiverMockRecorder struct {
+	mock *MockgoamqpReceiver
+}
+
+// NewMockgoamqpReceiver creates a new mock instance.
+func NewMockgoamqpReceiver(ctrl *gomock.Controller) *MockgoamqpReceiver {
+	mock := &MockgoamqpReceiver{ctrl: ctrl}
+	mock.recorder = &MockgoamqpReceiverMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockgoamqpReceiver) EXPECT() *MockgoamqpReceiverMockRecorder {
+	return m.recorder
+}
+
+// AcceptMessage mocks base method.
+func (m *MockgoamqpReceiver) AcceptMessage(ctx context.Context, msg *amqp.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AcceptMessage", ctx, msg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AcceptMessage indicates an expected call of AcceptMessage.
+func (mr *MockgoamqpReceiverMockRecorder) AcceptMessage(ctx, msg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptMessage", reflect.TypeOf((*MockgoamqpReceiver)(nil).AcceptMessage), ctx, msg)
+}
+
+// Close mocks base method.
+func (m *MockgoamqpReceiver) Close(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockgoamqpReceiverMockRecorder) Close(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockgoamqpReceiver)(nil).Close), ctx)
+}
+
+// IssueCredit mocks base method.
+func (m *MockgoamqpReceiver) IssueCredit(credit uint32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IssueCredit", credit)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IssueCredit indicates an expected call of IssueCredit.
+func (mr *MockgoamqpReceiverMockRecorder) IssueCredit(credit interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueCredit", reflect.TypeOf((*MockgoamqpReceiver)(nil).IssueCredit), credit)
+}
+
+// LinkName mocks base method.
+func (m *MockgoamqpReceiver) LinkName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LinkName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// LinkName indicates an expected call of LinkName.
+func (mr *MockgoamqpReceiverMockRecorder) LinkName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkName", reflect.TypeOf((*MockgoamqpReceiver)(nil).LinkName))
+}
+
+// LinkSourceFilterValue mocks base method.
+func (m *MockgoamqpReceiver) LinkSourceFilterValue(name string) any {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LinkSourceFilterValue", name)
+	ret0, _ := ret[0].(any)
+	return ret0
+}
+
+// LinkSourceFilterValue indicates an expected call of LinkSourceFilterValue.
+func (mr *MockgoamqpReceiverMockRecorder) LinkSourceFilterValue(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSourceFilterValue", reflect.TypeOf((*MockgoamqpReceiver)(nil).LinkSourceFilterValue), name)
+}
+
+// ModifyMessage mocks base method.
+func (m *MockgoamqpReceiver) ModifyMessage(ctx context.Context, msg *amqp.Message, options *amqp.ModifyMessageOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyMessage", ctx, msg, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ModifyMessage indicates an expected call of ModifyMessage.
+func (mr *MockgoamqpReceiverMockRecorder) ModifyMessage(ctx, msg, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyMessage", reflect.TypeOf((*MockgoamqpReceiver)(nil).ModifyMessage), ctx, msg, options)
+}
+
+// Prefetched mocks base method.
+func (m *MockgoamqpReceiver) Prefetched() *amqp.Message {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Prefetched")
+	ret0, _ := ret[0].(*amqp.Message)
+	return ret0
+}
+
+// Prefetched indicates an expected call of Prefetched.
+func (mr *MockgoamqpReceiverMockRecorder) Prefetched() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prefetched", reflect.TypeOf((*MockgoamqpReceiver)(nil).Prefetched))
+}
+
+// Receive mocks base method.
+func (m *MockgoamqpReceiver) Receive(ctx context.Context, o *amqp.ReceiveOptions) (*amqp.Message, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Receive", ctx, o)
+	ret0, _ := ret[0].(*amqp.Message)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Receive indicates an expected call of Receive.
+func (mr *MockgoamqpReceiverMockRecorder) Receive(ctx, o interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receive", reflect.TypeOf((*MockgoamqpReceiver)(nil).Receive), ctx, o)
+}
+
+// RejectMessage mocks base method.
+func (m *MockgoamqpReceiver) RejectMessage(ctx context.Context, msg *amqp.Message, e *amqp.Error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RejectMessage", ctx, msg, e)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RejectMessage indicates an expected call of RejectMessage.
+func (mr *MockgoamqpReceiverMockRecorder) RejectMessage(ctx, msg, e interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectMessage", reflect.TypeOf((*MockgoamqpReceiver)(nil).RejectMessage), ctx, msg, e)
+}
+
+// ReleaseMessage mocks base method.
+func (m *MockgoamqpReceiver) ReleaseMessage(ctx context.Context, msg *amqp.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReleaseMessage", ctx, msg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReleaseMessage indicates an expected call of ReleaseMessage.
+func (mr *MockgoamqpReceiverMockRecorder) ReleaseMessage(ctx, msg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseMessage", reflect.TypeOf((*MockgoamqpReceiver)(nil).ReleaseMessage), ctx, msg)
+}

--- a/sdk/messaging/azservicebus/internal/namespace_test.go
+++ b/sdk/messaging/azservicebus/internal/namespace_test.go
@@ -246,7 +246,7 @@ func TestNamespaceNegotiateClaimFatalErrors(t *testing.T) {
 		return nil
 	}
 
-	endCapture := test.CaptureLogsForTest()
+	endCapture := test.CaptureLogsForTest(false)
 	defer endCapture()
 
 	ns.newClientFn = func(ctx context.Context) (amqpwrap.AMQPClient, error) {

--- a/sdk/messaging/azservicebus/internal/rpc_sb.go
+++ b/sdk/messaging/azservicebus/internal/rpc_sb.go
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package internal
+
+import "net/http"
+
+// Response codes that come back over the "RPC" style links like cbs or management.
+const (
+	// RPCResponseCodeLockLost comes back if you lose a message lock _or_ a session lock.
+	// (NOTE: this is the one HTTP code that doesn't make intuitive sense. For all others I've just
+	// used the HTTP status code instead.
+	RPCResponseCodeLockLost = http.StatusGone
+)

--- a/sdk/messaging/azservicebus/internal/rpc_test.go
+++ b/sdk/messaging/azservicebus/internal/rpc_test.go
@@ -5,13 +5,16 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/amqpwrap"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/go-amqp"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/mock"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/test"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,7 +37,7 @@ func TestRPCLinkNonErrorRequiresRecovery(t *testing.T) {
 	defer func() { require.NoError(t, link.Close(context.Background())) }()
 
 	messagesCh := make(chan string, 10000)
-	endCapture := test.CaptureLogsForTestWithChannel(messagesCh)
+	endCapture := test.CaptureLogsForTestWithChannel(messagesCh, false)
 	defer endCapture()
 
 	responses := []*rpcTestResp{
@@ -84,7 +87,7 @@ func TestRPCLinkNonErrorRequiresNoRecovery(t *testing.T) {
 
 	defer func() { require.NoError(t, link.Close(context.Background())) }()
 
-	cleanupLogs := test.CaptureLogsForTest()
+	cleanupLogs := test.CaptureLogsForTest(false)
 	defer cleanupLogs()
 
 	responses := []*rpcTestResp{
@@ -161,6 +164,86 @@ func TestRPCLinkNonErrorLockLostDoesNotBreakAnything(t *testing.T) {
 	require.Equal(t, "response from service", resp.Message.Value)
 	acceptedMessage = <-tester.Accepted
 	require.Equal(t, "response from service", acceptedMessage.Value, "successfully received message is accepted")
+}
+
+func TestRPCLinkClosingClean_SessionCreationFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	conn := mock.NewMockAMQPClient(ctrl)
+
+	sessionErr := errors.New("failed to create session")
+
+	conn.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(nil, sessionErr)
+
+	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client:   conn,
+		Address:  "rpcAddress",
+		LogEvent: "Testing",
+	})
+	require.EqualError(t, err, sessionErr.Error())
+	require.Nil(t, rpcLink)
+}
+
+func TestRPCLinkClosingClean_SenderCreationFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	conn := mock.NewMockAMQPClient(ctrl)
+	sess := mock.NewMockAMQPSession(ctrl)
+
+	senderErr := errors.New("failed to create sender")
+
+	conn.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(sess, nil)
+	sess.EXPECT().NewSender(mock.NotCancelled, "rpcAddress", gomock.Any()).Return(nil, senderErr)
+	sess.EXPECT().Close(mock.NotCancelled).Return(nil)
+
+	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client:   conn,
+		Address:  "rpcAddress",
+		LogEvent: "Testing",
+	})
+	require.EqualError(t, err, senderErr.Error())
+	require.Nil(t, rpcLink)
+}
+
+func TestRPCLinkClosingClean_ReceiverCreationFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	conn := mock.NewMockAMQPClient(ctrl)
+	sess := mock.NewMockAMQPSession(ctrl)
+	sender := mock.NewMockAMQPSenderCloser(ctrl)
+
+	receiverErr := errors.New("failed to create receiver")
+
+	conn.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(sess, nil)
+	sess.EXPECT().NewSender(mock.NotCancelled, "rpcAddress", gomock.Any()).Return(sender, nil)
+	sess.EXPECT().NewReceiver(mock.NotCancelled, "rpcAddress", gomock.Any()).Return(nil, receiverErr)
+
+	sess.EXPECT().Close(mock.NotCancelled).Return(nil)
+
+	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client:   conn,
+		Address:  "rpcAddress",
+		LogEvent: "Testing",
+	})
+	require.EqualError(t, err, receiverErr.Error())
+	require.Nil(t, rpcLink)
+}
+
+func TestRPCLinkClosingClean_CreationFailsButSessionCloseFailsToo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	conn := mock.NewMockAMQPClient(ctrl)
+	sess := mock.NewMockAMQPSession(ctrl)
+
+	senderErr := errors.New("failed to create receiver")
+
+	conn.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(sess, nil)
+	sess.EXPECT().NewSender(mock.NotCancelled, "rpcAddress", gomock.Any()).Return(nil, senderErr)
+	sess.EXPECT().Close(mock.NotCancelled).Return(errors.New("session closing failed"))
+
+	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client:   conn,
+		Address:  "rpcAddress",
+		LogEvent: "Testing",
+	})
+	require.EqualError(t, err, senderErr.Error(), "original error is more relevant, so we favor it over session.Close()")
+	require.Nil(t, rpcLink)
 }
 
 // rpcTester has all the functions needed (for our RPC tests) to be:

--- a/sdk/messaging/azservicebus/internal/rpc_test.go
+++ b/sdk/messaging/azservicebus/internal/rpc_test.go
@@ -246,6 +246,21 @@ func TestRPCLinkClosingClean_CreationFailsButSessionCloseFailsToo(t *testing.T) 
 	require.Nil(t, rpcLink)
 }
 
+func TestRPCLinkClosingQuickly(t *testing.T) {
+	tester := &rpcTester{t: t, ResponsesCh: make(chan *rpcTestResp, 1000), Accepted: make(chan *amqp.Message, 1)}
+
+	link, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client: &rpcTesterClient{
+			session: tester,
+		},
+		Address:  "some-address",
+		LogEvent: "rpctesting",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, link)
+	require.NoError(t, link.Close(context.Background()))
+}
+
 // rpcTester has all the functions needed (for our RPC tests) to be:
 // - an AMQPSession
 // - an AMQPReceiverCloser
@@ -307,8 +322,12 @@ func (tester *rpcTester) AcceptMessage(ctx context.Context, msg *amqp.Message) e
 }
 
 func (tester *rpcTester) Receive(ctx context.Context, o *amqp.ReceiveOptions) (*amqp.Message, error) {
-	resp := <-tester.ResponsesCh
-	return resp.M, resp.E
+	select {
+	case resp := <-tester.ResponsesCh:
+		return resp.M, resp.E
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // sender functions

--- a/sdk/messaging/azservicebus/internal/stress/.gitignore
+++ b/sdk/messaging/azservicebus/internal/stress/.gitignore
@@ -2,3 +2,5 @@ stress
 stress.exe
 logs
 generatedValues.yaml
+deploy-test-*.ps1
+

--- a/sdk/messaging/azservicebus/internal/stress/Chart.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.yaml
@@ -9,4 +9,4 @@ annotations:
 dependencies:
 - name: stress-test-addons
   version: ~0.2.0
-  repository: https://stresstestcharts.blob.core.windows.net/helm/
+  repository: "@stress-test-charts"

--- a/sdk/messaging/azservicebus/internal/stress/Dockerfile
+++ b/sdk/messaging/azservicebus/internal/stress/Dockerfile
@@ -15,4 +15,4 @@ RUN go build -o stress .
 FROM mcr.microsoft.com/cbl-mariner/base/core:1.0
 WORKDIR /app
 COPY --from=build /src/internal/stress/stress /app/stress
-ENTRYPOINT ["./stress"]
+ENTRYPOINT ["/bin/bash"]

--- a/sdk/messaging/azservicebus/internal/stress/deploy.ps1
+++ b/sdk/messaging/azservicebus/internal/stress/deploy.ps1
@@ -1,2 +1,2 @@
 Set-Location $PSScriptRoot
-pwsh "../../../../../eng/common/scripts/stress-testing/deploy-stress-tests.ps1" -Login -PushImages
+pwsh "../../../../../eng/common/scripts/stress-testing/deploy-stress-tests.ps1" -Login -PushImages @args

--- a/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
@@ -39,7 +39,13 @@ type StressContext struct {
 	cancel context.CancelFunc
 }
 
-func MustCreateStressContext(testName string) *StressContext {
+type StressContextOptions struct {
+	// Duration is the amount of time the stress test should run before
+	// the StressContext.Context expires.
+	Duration time.Duration
+}
+
+func MustCreateStressContext(testName string, options *StressContextOptions) *StressContext {
 	cs := os.Getenv("SERVICEBUS_CONNECTION_STRING")
 
 	if cs == "" {
@@ -66,6 +72,10 @@ func MustCreateStressContext(testName string) *StressContext {
 	log.Printf("Common properties\n:%#v", telemetryClient.Context().CommonProperties)
 
 	ctx, cancel := NewCtrlCContext()
+
+	if options != nil && options.Duration > 0 {
+		ctx, cancel = context.WithTimeout(ctx, options.Duration)
+	}
 
 	azlog.SetEvents(azservicebus.EventSender, azservicebus.EventReceiver, azservicebus.EventConn)
 

--- a/sdk/messaging/azservicebus/internal/stress/templates/stress-test-job.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/templates/stress-test-job.yaml
@@ -12,7 +12,12 @@ spec:
     - name: main
       # az acr list -g rg-stress-cluster-test --subscription "Azure SDK Developer Playground" --query "[0].loginServer"
       image:  {{ .Stress.imageTag }}
-      command: ['/app/stress']
+      command: ['sh', '-c']
+      args: 
+        - >
+          set -ex;
+          mkdir -p "$DEBUG_SHARE";
+          /app/stress tests "{{ .Stress.testTarget }}" | tee "${DEBUG_SHARE}/{{ .Stress.Scenario }}.log";
       # Pulls the image on pod start, always. We tend to push to the same image and tag over and over again
       # when iterating, so this is a must.
       imagePullPolicy: Always
@@ -25,10 +30,6 @@ spec:
         limits:
           memory: {{.Stress.memory }}
           cpu: "1"
-      args: 
-      - "tests"
-      # (this is injected automatically. The full list of scenarios is in `../values.yaml`)
-      - {{ .Stress.testTarget }}
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}
 

--- a/sdk/messaging/azservicebus/internal/stress/tests/constant_detachment.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/constant_detachment.go
@@ -17,7 +17,7 @@ import (
 )
 
 func ConstantDetachment(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("ConstantDetachment")
+	sc := shared.MustCreateStressContext("ConstantDetachment", nil)
 	defer sc.End()
 
 	queueName := fmt.Sprintf("detach-tester-%s", sc.Nano)

--- a/sdk/messaging/azservicebus/internal/stress/tests/constant_detachment_sender.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/constant_detachment_sender.go
@@ -16,7 +16,7 @@ import (
 )
 
 func ConstantDetachmentSender(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("ConstantDetachmentSender")
+	sc := shared.MustCreateStressContext("ConstantDetachmentSender", nil)
 	defer sc.End()
 
 	adminClient, err := admin.NewClientFromConnectionString(sc.ConnectionString, nil)

--- a/sdk/messaging/azservicebus/internal/stress/tests/empty_sessions.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/empty_sessions.go
@@ -38,7 +38,7 @@ func EmptySessions(remainingArgs []string) {
 	topicName := strings.ToLower(fmt.Sprintf("topic-%X", time.Now().UnixNano()))
 	log.Printf("Creating topic %s", topicName)
 
-	sc := shared.MustCreateStressContext("emptysessions")
+	sc := shared.MustCreateStressContext("emptysessions", nil)
 	defer sc.End()
 
 	cleanup := shared.MustCreateSubscriptions(sc, topicName, []string{"sub1"}, &shared.MustCreateSubscriptionsOptions{

--- a/sdk/messaging/azservicebus/internal/stress/tests/finite_peeks.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/finite_peeks.go
@@ -14,7 +14,7 @@ import (
 )
 
 func FinitePeeks(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("FinitePeeks")
+	sc := shared.MustCreateStressContext("FinitePeeks", nil)
 	defer sc.Done()
 
 	queueName := fmt.Sprintf("finite-peeks-%s", sc.Nano)

--- a/sdk/messaging/azservicebus/internal/stress/tests/finite_send_and_receive.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/finite_send_and_receive.go
@@ -18,7 +18,7 @@ import (
 )
 
 func FiniteSendAndReceiveTest(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("FiniteSendAndReceiveTest")
+	sc := shared.MustCreateStressContext("FiniteSendAndReceiveTest", nil)
 
 	sc.TrackEvent("Start")
 	defer sc.End()

--- a/sdk/messaging/azservicebus/internal/stress/tests/finite_sessions.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/finite_sessions.go
@@ -36,7 +36,7 @@ func FiniteSessions(remainingArgs []string) {
 	fs.IntVar(&params.numSessions, "sessions", 2000, "Number of sessions to test")
 	fs.IntVar(&params.rounds, "rounds", 100, "Number of rounds to run with these parameters. -1 means math.MaxInt64")
 
-	sc := shared.MustCreateStressContext("FiniteSessions")
+	sc := shared.MustCreateStressContext("FiniteSessions", nil)
 	defer sc.End()
 
 	topicName := strings.ToLower(fmt.Sprintf("topic-%X", time.Now().UnixNano()))

--- a/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/idle_fast_reconnect.go
@@ -15,7 +15,7 @@ import (
 )
 
 func IdleFastReconnect(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("IdleFastReconnect")
+	sc := shared.MustCreateStressContext("IdleFastReconnect", nil)
 
 	topicName := fmt.Sprintf("topic-%s", sc.Nano)
 

--- a/sdk/messaging/azservicebus/internal/stress/tests/long_running_renew_lock.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/long_running_renew_lock.go
@@ -15,7 +15,7 @@ import (
 )
 
 func LongRunningRenewLockTest(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("LongRunningRenewLockTest")
+	sc := shared.MustCreateStressContext("LongRunningRenewLockTest", nil)
 
 	queueName := fmt.Sprintf("renew-lock-test-%s", sc.Nano)
 	shared.MustCreateAutoDeletingQueue(sc, queueName, nil)

--- a/sdk/messaging/azservicebus/internal/stress/tests/mostly_idle_receiver.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/mostly_idle_receiver.go
@@ -16,7 +16,7 @@ import (
 
 // MostlyIdleReceiver tests that if there are long idle periods that our connection continues to work and receive messages.
 func MostlyIdleReceiver(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("MostlyIdleReceiver")
+	sc := shared.MustCreateStressContext("MostlyIdleReceiver", nil)
 	defer sc.End()
 
 	// we'll try several levels of "idleness", with different connections to make sure they don't

--- a/sdk/messaging/azservicebus/internal/stress/tests/rapid_open_close.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/rapid_open_close.go
@@ -14,7 +14,7 @@ import (
 )
 
 func RapidOpenCloseTest(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("RapidOpenCloseTest")
+	sc := shared.MustCreateStressContext("RapidOpenCloseTest", nil)
 	queueName := fmt.Sprintf("rapid_open_close-%X", time.Now().UnixNano())
 
 	shared.MustCreateAutoDeletingQueue(sc, queueName, nil)

--- a/sdk/messaging/azservicebus/internal/stress/tests/receive_cancellation.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/receive_cancellation.go
@@ -14,7 +14,7 @@ import (
 )
 
 func ReceiveCancellation(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("FinitePeeks")
+	sc := shared.MustCreateStressContext("FinitePeeks", nil)
 	defer sc.Done()
 
 	queueName := fmt.Sprintf("finite-peeks-%s", sc.Nano)

--- a/sdk/messaging/azservicebus/internal/stress/tests/send_and_receive drain.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/send_and_receive drain.go
@@ -19,7 +19,7 @@ import (
 )
 
 func SendAndReceiveDrain(remainingArgs []string) {
-	sc := shared.MustCreateStressContext("SendAndReceiveDrainTest")
+	sc := shared.MustCreateStressContext("SendAndReceiveDrainTest", nil)
 
 	sc.TrackEvent("Start")
 	defer sc.End()

--- a/sdk/messaging/azservicebus/internal/utils/retrier_test.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier_test.go
@@ -292,7 +292,7 @@ func TestCalcDelay(t *testing.T) {
 
 func TestRetryLogging(t *testing.T) {
 	t.Run("normal error", func(t *testing.T) {
-		logsFn := test.CaptureLogsForTest()
+		logsFn := test.CaptureLogsForTest(false)
 
 		err := Retry(context.Background(), testLogEvent, "my_operation", func(ctx context.Context, args *RetryFnArgs) error {
 			azlog.Writef("TestFunc", "Attempt %d, within test func, returning error hello", args.I)
@@ -337,7 +337,7 @@ func TestRetryLogging(t *testing.T) {
 	})
 
 	t.Run("cancellation error", func(t *testing.T) {
-		logsFn := test.CaptureLogsForTest()
+		logsFn := test.CaptureLogsForTest(false)
 
 		err := Retry(context.Background(), testLogEvent, "test_operation", func(ctx context.Context, args *RetryFnArgs) error {
 			azlog.Writef("TestFunc",
@@ -357,7 +357,7 @@ func TestRetryLogging(t *testing.T) {
 	})
 
 	t.Run("custom fatal error", func(t *testing.T) {
-		logsFn := test.CaptureLogsForTest()
+		logsFn := test.CaptureLogsForTest(false)
 
 		err := Retry(context.Background(), testLogEvent, "test_operation", func(ctx context.Context, args *RetryFnArgs) error {
 			azlog.Writef("TestFunc",
@@ -377,7 +377,7 @@ func TestRetryLogging(t *testing.T) {
 	})
 
 	t.Run("with reset attempts", func(t *testing.T) {
-		logsFn := test.CaptureLogsForTest()
+		logsFn := test.CaptureLogsForTest(false)
 		reset := false
 
 		err := Retry(context.Background(), testLogEvent, "test_operation", func(ctx context.Context, args *RetryFnArgs) error {

--- a/sdk/messaging/azservicebus/receiver_simulated_test.go
+++ b/sdk/messaging/azservicebus/receiver_simulated_test.go
@@ -625,7 +625,7 @@ func TestReceiver_CreditsDontExceedMax(t *testing.T) {
 	err = sender.SendMessage(context.Background(), &Message{Body: []byte("hello world")}, nil)
 	require.NoError(t, err)
 
-	logsFn := test.CaptureLogsForTest()
+	logsFn := test.CaptureLogsForTest(false)
 
 	// no issue credit needed - we've still got the 5000 from last time since we didn't
 	// receive any messages.
@@ -637,7 +637,7 @@ func TestReceiver_CreditsDontExceedMax(t *testing.T) {
 	ctx, cancel = context.WithTimeout(baseReceiveCtx, time.Second)
 	defer cancel()
 
-	logsFn = test.CaptureLogsForTest()
+	logsFn = test.CaptureLogsForTest(false)
 
 	// we ate a credit last time since we received a single message, so this time we'll still
 	// need to issue some more to backfill.

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -37,7 +37,7 @@ func TestReceiverCancel(t *testing.T) {
 }
 
 func TestReceiverSendFiveReceiveFive(t *testing.T) {
-	getLogsFn := test.CaptureLogsForTest()
+	getLogsFn := test.CaptureLogsForTest(false)
 
 	serviceBusClient, cleanup, queueName := setupLiveTest(t, nil)
 	defer cleanup()
@@ -555,7 +555,7 @@ func TestReceiver_RenewMessageLock(t *testing.T) {
 		messages[0].LockToken[i] = 0
 	}
 
-	endCaptureFn := test.CaptureLogsForTest()
+	endCaptureFn := test.CaptureLogsForTest(false)
 	defer endCaptureFn()
 	expectedLockBadError := receiver.RenewMessageLock(context.Background(), messages[0], nil)
 

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -169,7 +169,7 @@ func TestReceiver_releaserFunc(t *testing.T) {
 		},
 	}
 
-	logsFn := test.CaptureLogsForTest()
+	logsFn := test.CaptureLogsForTest(false)
 
 	releaserFn := receiver.newReleaserFunc(&amqpReceiver)
 	releaserFn()
@@ -212,7 +212,7 @@ func TestReceiver_releaserFunc_errorOnFirstMessage(t *testing.T) {
 		}
 	}
 
-	logsFn := test.CaptureLogsForTest()
+	logsFn := test.CaptureLogsForTest(false)
 
 	releaserFn := receiver.newReleaserFunc(&amqpReceiver)
 	releaserFn()


### PR DESCRIPTION
This removes the special cancellation handling we added after the latest go-amqp update. 

The problems mostly stem from how many thorny cases pop up when you try to handle this outside of the protocol stack. The first pass at this actually resulted in too many connection resets, which made the common use-case for AcceptNextSession() hazardous as every cancellation there would result in the connection resetting, and all existing sessions losing their link.

Even in non-session cases it could result in unnecessary interrupts for Receivers.

While looking at this I also found some bugs in our cleanup code for RPCLink. I fixed those and optimized it a bit to just close the session, rather than waiting and attempting to close each link individually. 