### PR TITLE
[azeventhubs] Removing code that handled session/link cancellation

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Release History
 
-## 1.0.0 (Unreleased)
+## 1.0.0 (2023-04-11)
 
 ### Features Added
 
 - First stable release of the azeventhubs package.
 - Authentication errors are indicated with an `azeventhubs.Error`, with a `Code` of `azeventhubs.ErrorCodeUnauthorizedAccess`. (PR#20450)
-
-### Breaking Changes
 
 ### Bugs Fixed
 
@@ -15,8 +13,6 @@
 - Recovery now includes internal timeouts and also handles restarting a connection if AMQP primitives aren't closed cleanly.
 - Potential leaks for $cbs and $management when there was a partial failure. (PR#20564)
 - Latest go-amqp changes have been merged in with fixes for robustness.
-
-### Other Changes
 
 ## 0.6.0 (2023-03-07)
 

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Authentication errors could cause unnecessary retries, making calls taking longer to fail. (PR#20450)
 - Recovery now includes internal timeouts and also handles restarting a connection if AMQP primitives aren't closed cleanly.
+- Potential leaks for $cbs and $management when there was a partial failure. (PR#20564)
 - Latest go-amqp changes have been merged in with fixes for robustness.
 
 ### Other Changes

--- a/sdk/messaging/azeventhubs/consumer_client_internal_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_internal_test.go
@@ -20,14 +20,6 @@ import (
 )
 
 func TestConsumerClient_Recovery(t *testing.T) {
-	for i := 0; i < 30; i++ {
-		t.Run(fmt.Sprintf("testConsumerClient_Recovery(%d)", i), func(t *testing.T) {
-			testConsumerClient_Recovery(t)
-		})
-	}
-}
-
-func testConsumerClient_Recovery(t *testing.T) {
 	testParams := test.GetConnectionParamsForTest(t)
 
 	// Uncomment to see the entire recovery playbook run.

--- a/sdk/messaging/azeventhubs/consumer_client_internal_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_internal_test.go
@@ -94,7 +94,7 @@ func testConsumerClient_Recovery(t *testing.T) {
 
 			t.Logf("[%s] After props %#v", pid, afterPartProps)
 
-			require.Equal(t, int64(2), afterPartProps.LastEnqueuedSequenceNumber-partProps.LastEnqueuedSequenceNumber)
+			require.Equalf(t, int64(2), afterPartProps.LastEnqueuedSequenceNumber-partProps.LastEnqueuedSequenceNumber, "Expected only 2 messages in partition %s", pid)
 
 			sendResults[i] = sendResult{PartitionID: pid, OffsetBefore: partProps.LastEnqueuedOffset}
 		}(i, pid)

--- a/sdk/messaging/azeventhubs/event_data_batch.go
+++ b/sdk/messaging/azeventhubs/event_data_batch.go
@@ -211,9 +211,11 @@ func newEventDataBatch(sender amqpwrap.AMQPSenderCloser, options *EventDataBatch
 	if options.PartitionID != nil {
 		// they want to send to a particular partition. The batch size should be the same for any
 		// link but we might as well use the one they're going to send to.
-		batch.partitionID = options.PartitionID
+		pid := *options.PartitionID
+		batch.partitionID = &pid
 	} else if options.PartitionKey != nil {
-		batch.partitionKey = options.PartitionKey
+		partKey := *options.PartitionKey
+		batch.partitionKey = &partKey
 	}
 
 	if options.MaxBytes == 0 {

--- a/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
+++ b/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/amqpwrap"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/mock"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -201,6 +203,37 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 
 		wg.Wait()
 		require.EqualValues(t, 100, mb.NumEvents())
+	})
+}
+
+func TestUnitEventDataBatchDontReuseOptions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	sender := mock.NewMockAMQPSenderCloser(ctrl)
+	sender.EXPECT().MaxMessageSize().Return(uint64(200)).AnyTimes()
+
+	t.Run("partitionID", func(t *testing.T) {
+		pid := "6"
+		batchForPartition, err := newEventDataBatch(sender, &EventDataBatchOptions{
+			PartitionID: &pid,
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, "6", *batchForPartition.partitionID)
+		pid = "7"
+		require.Equal(t, "6", *batchForPartition.partitionID)
+	})
+
+	t.Run("partitionKey", func(t *testing.T) {
+		pkey := "hello"
+
+		batchForPartitionKey, err := newEventDataBatch(sender, &EventDataBatchOptions{
+			PartitionKey: &pkey,
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, "hello", *batchForPartitionKey.partitionKey)
+		pkey = "world"
+		require.Equal(t, "hello", *batchForPartitionKey.partitionKey)
 	})
 }
 

--- a/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
+++ b/sdk/messaging/azeventhubs/event_data_batch_unit_test.go
@@ -113,7 +113,9 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 		require.EqualValues(t, 1, mb.NumEvents())
 		require.EqualValues(t, 172, mb.NumBytes())
 
-		actualBytes, err := mb.toAMQPMessage().MarshalBinary()
+		msg, err := mb.toAMQPMessage()
+		require.NoError(t, err)
+		actualBytes, err := msg.MarshalBinary()
 		require.NoError(t, err)
 
 		require.Equal(t, 172, len(actualBytes))
@@ -137,7 +139,10 @@ func TestUnitEventDataBatchUnitTests(t *testing.T) {
 		require.EqualValues(t, 1, mb.NumEvents())
 		require.EqualValues(t, 4357, mb.NumBytes())
 
-		actualBytes, err := mb.toAMQPMessage().MarshalBinary()
+		msg, err := mb.toAMQPMessage()
+		require.NoError(t, err)
+
+		actualBytes, err := msg.MarshalBinary()
 		require.NoError(t, err)
 
 		require.Equal(t, 4357, len(actualBytes))
@@ -234,6 +239,39 @@ func TestUnitEventDataBatchDontReuseOptions(t *testing.T) {
 		require.Equal(t, "hello", *batchForPartitionKey.partitionKey)
 		pkey = "world"
 		require.Equal(t, "hello", *batchForPartitionKey.partitionKey)
+	})
+}
+
+func TestUnitEventDataBatchAlwaysHasProperties(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	sender := mock.NewMockAMQPSenderCloser(ctrl)
+	sender.EXPECT().MaxMessageSize().Return(uint64(200)).AnyTimes()
+
+	batch, err := newEventDataBatch(sender, nil)
+	require.NoError(t, err)
+
+	t.Run("empty", func(t *testing.T) {
+		amqpMsg, err := batch.toAMQPMessage()
+		require.Nil(t, amqpMsg)
+		require.EqualError(t, err, "batch is nil or empty")
+	})
+
+	t.Run("annotated message, empty", func(t *testing.T) {
+		err = batch.AddAMQPAnnotatedMessage(&AMQPAnnotatedMessage{}, nil)
+		require.NoError(t, err)
+
+		msg, err := batch.toAMQPMessage()
+		require.NoError(t, err)
+		require.NotEmpty(t, msg, msg.Properties.MessageID)
+	})
+
+	t.Run("regular event, empty", func(t *testing.T) {
+		err = batch.AddEventData(&EventData{}, nil)
+		require.NoError(t, err)
+
+		msg, err := batch.toAMQPMessage()
+		require.NoError(t, err)
+		require.NotEmpty(t, msg, msg.Properties.MessageID)
 	})
 }
 

--- a/sdk/messaging/azeventhubs/internal/amqp_fakes.go
+++ b/sdk/messaging/azeventhubs/internal/amqp_fakes.go
@@ -111,9 +111,10 @@ func (r *FakeAMQPReceiver) Receive(ctx context.Context, o *amqp.ReceiveOptions) 
 		m := r.Messages[0]
 		r.Messages = r.Messages[1:]
 		return m, nil
+	} else {
+		<-ctx.Done()
+		return nil, ctx.Err()
 	}
-
-	return nil, nil
 }
 
 func (r *FakeAMQPReceiver) Close(ctx context.Context) error {

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap.go
@@ -66,22 +66,6 @@ type AMQPClient interface {
 	NewSession(ctx context.Context, opts *amqp.SessionOptions) (AMQPSession, error)
 }
 
-// RPCLink is implemented by *rpc.Link
-type RPCLink interface {
-	Close(ctx context.Context) error
-	RPC(ctx context.Context, msg *amqp.Message) (*RPCResponse, error)
-	LinkName() string
-}
-
-// RPCResponse is the simplified response structure from an RPC like call
-type RPCResponse struct {
-	// Code is the response code - these originate from Service Bus. Some
-	// common values are called out below, with the RPCResponseCode* constants.
-	Code        int
-	Description string
-	Message     *amqp.Message
-}
-
 type goamqpConn interface {
 	NewSession(ctx context.Context, opts *amqp.SessionOptions) (*amqp.Session, error)
 	Close() error

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap.go
@@ -8,6 +8,7 @@ package amqpwrap
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
 )
@@ -123,49 +124,50 @@ func (w *AMQPClientWrapper) NewSession(ctx context.Context, opts *amqp.SessionOp
 	sess, err := w.Inner.NewSession(ctx, opts)
 
 	if err != nil {
-		return nil, HandleNewOrCloseError(err)
+		return nil, err
 	}
 
 	return &AMQPSessionWrapper{
-		Inner: sess,
+		Inner:                sess,
+		ContextWithTimeoutFn: context.WithTimeout,
 	}, nil
 }
 
 type AMQPSessionWrapper struct {
-	Inner goamqpSession
+	Inner                goamqpSession
+	ContextWithTimeoutFn ContextWithTimeoutFn
 }
 
 func (w *AMQPSessionWrapper) Close(ctx context.Context) error {
-	if err := w.Inner.Close(ctx); err != nil {
-		return HandleNewOrCloseError(err)
-	}
-
-	return nil
+	ctx, cancel := w.ContextWithTimeoutFn(ctx, defaultCloseTimeout)
+	defer cancel()
+	return w.Inner.Close(ctx)
 }
 
 func (w *AMQPSessionWrapper) NewReceiver(ctx context.Context, source string, opts *amqp.ReceiverOptions) (AMQPReceiverCloser, error) {
 	receiver, err := w.Inner.NewReceiver(ctx, source, opts)
 
 	if err != nil {
-		return nil, HandleNewOrCloseError(err)
+		return nil, err
 	}
 
-	return &AMQPReceiverWrapper{inner: receiver}, nil
+	return &AMQPReceiverWrapper{Inner: receiver, ContextWithTimeoutFn: context.WithTimeout}, nil
 }
 
 func (w *AMQPSessionWrapper) NewSender(ctx context.Context, target string, opts *amqp.SenderOptions) (AMQPSenderCloser, error) {
 	sender, err := w.Inner.NewSender(ctx, target, opts)
 
 	if err != nil {
-		return nil, HandleNewOrCloseError(err)
+		return nil, err
 	}
 
-	return sender, nil
+	return &AMQPSenderWrapper{Inner: sender, ContextWithTimeoutFn: context.WithTimeout}, nil
 }
 
 type AMQPReceiverWrapper struct {
-	inner   goamqpReceiver
-	credits uint32
+	Inner                goamqpReceiver
+	credits              uint32
+	ContextWithTimeoutFn ContextWithTimeoutFn
 }
 
 func (rw *AMQPReceiverWrapper) Credits() uint32 {
@@ -173,7 +175,7 @@ func (rw *AMQPReceiverWrapper) Credits() uint32 {
 }
 
 func (rw *AMQPReceiverWrapper) IssueCredit(credit uint32) error {
-	err := rw.inner.IssueCredit(credit)
+	err := rw.Inner.IssueCredit(credit)
 
 	if err == nil {
 		rw.credits += credit
@@ -183,7 +185,7 @@ func (rw *AMQPReceiverWrapper) IssueCredit(credit uint32) error {
 }
 
 func (rw *AMQPReceiverWrapper) Receive(ctx context.Context, o *amqp.ReceiveOptions) (*amqp.Message, error) {
-	message, err := rw.inner.Receive(ctx, o)
+	message, err := rw.Inner.Receive(ctx, o)
 
 	if err != nil {
 		return nil, err
@@ -194,7 +196,7 @@ func (rw *AMQPReceiverWrapper) Receive(ctx context.Context, o *amqp.ReceiveOptio
 }
 
 func (rw *AMQPReceiverWrapper) Prefetched() *amqp.Message {
-	msg := rw.inner.Prefetched()
+	msg := rw.Inner.Prefetched()
 
 	if msg == nil {
 		return nil
@@ -206,69 +208,62 @@ func (rw *AMQPReceiverWrapper) Prefetched() *amqp.Message {
 
 // settlement functions
 func (rw *AMQPReceiverWrapper) AcceptMessage(ctx context.Context, msg *amqp.Message) error {
-	return rw.inner.AcceptMessage(ctx, msg)
+	return rw.Inner.AcceptMessage(ctx, msg)
 }
 
 func (rw *AMQPReceiverWrapper) RejectMessage(ctx context.Context, msg *amqp.Message, e *amqp.Error) error {
-	return rw.inner.RejectMessage(ctx, msg, e)
+	return rw.Inner.RejectMessage(ctx, msg, e)
 }
 
 func (rw *AMQPReceiverWrapper) ReleaseMessage(ctx context.Context, msg *amqp.Message) error {
-	return rw.inner.ReleaseMessage(ctx, msg)
+	return rw.Inner.ReleaseMessage(ctx, msg)
 }
 
 func (rw *AMQPReceiverWrapper) ModifyMessage(ctx context.Context, msg *amqp.Message, options *amqp.ModifyMessageOptions) error {
-	return rw.inner.ModifyMessage(ctx, msg, options)
+	return rw.Inner.ModifyMessage(ctx, msg, options)
 }
 
 func (rw *AMQPReceiverWrapper) LinkName() string {
-	return rw.inner.LinkName()
+	return rw.Inner.LinkName()
 }
 
 func (rw *AMQPReceiverWrapper) LinkSourceFilterValue(name string) any {
-	return rw.inner.LinkSourceFilterValue(name)
+	return rw.Inner.LinkSourceFilterValue(name)
 }
 
 func (rw *AMQPReceiverWrapper) Close(ctx context.Context) error {
-	if err := rw.inner.Close(ctx); err != nil {
-		return HandleNewOrCloseError(err)
-	}
-
-	return nil
+	ctx, cancel := rw.ContextWithTimeoutFn(ctx, defaultCloseTimeout)
+	defer cancel()
+	return rw.Inner.Close(ctx)
 }
 
 type AMQPSenderWrapper struct {
-	inner AMQPSenderCloser
+	Inner                AMQPSenderCloser
+	ContextWithTimeoutFn ContextWithTimeoutFn
 }
 
 func (sw *AMQPSenderWrapper) Send(ctx context.Context, msg *amqp.Message, o *amqp.SendOptions) error {
-	return sw.inner.Send(ctx, msg, o)
+	return sw.Inner.Send(ctx, msg, o)
 }
 
 func (sw *AMQPSenderWrapper) MaxMessageSize() uint64 {
-	return sw.inner.MaxMessageSize()
+	return sw.Inner.MaxMessageSize()
 }
 
 func (sw *AMQPSenderWrapper) LinkName() string {
-	return sw.inner.LinkName()
+	return sw.Inner.LinkName()
 }
 
 func (sw *AMQPSenderWrapper) Close(ctx context.Context) error {
-	if err := sw.inner.Close(ctx); err != nil {
-		return HandleNewOrCloseError(err)
-	}
-
-	return nil
-}
-
-func HandleNewOrCloseError(err error) error {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		// we treat this a bit differently when creating or closing entities. The big concern here is
-		// that failing to cleanup stray
-		return ErrConnResetNeeded
-	}
-
-	return err
+	ctx, cancel := sw.ContextWithTimeoutFn(ctx, defaultCloseTimeout)
+	defer cancel()
+	return sw.Inner.Close(ctx)
 }
 
 var ErrConnResetNeeded = errors.New("connection must be reset, link/connection state may be inconsistent")
+
+const defaultCloseTimeout = time.Minute
+
+// ContextWithTimeoutFn matches the signature for `context.WithTimeout` and is used when we want to
+// stub things out for tests.
+type ContextWithTimeoutFn func(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc)

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/rpc.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/rpc.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package amqpwrap
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
+)
+
+// RPCResponse is the simplified response structure from an RPC like call
+type RPCResponse struct {
+	// Code is the response code - these originate from Service Bus. Some
+	// common values are called out below, with the RPCResponseCode* constants.
+	Code        int
+	Description string
+	Message     *amqp.Message
+}
+
+// RPCLink is implemented by *rpc.Link
+type RPCLink interface {
+	Close(ctx context.Context) error
+	RPC(ctx context.Context, msg *amqp.Message) (*RPCResponse, error)
+	LinkName() string
+}

--- a/sdk/messaging/azeventhubs/internal/cbs.go
+++ b/sdk/messaging/azeventhubs/internal/cbs.go
@@ -24,10 +24,7 @@ const (
 )
 
 // NegotiateClaim attempts to put a token to the $cbs management endpoint to negotiate auth for the given audience
-//
-// contextWithTimeoutFn is intended to be context.WithTimeout in production code, but can be stubbed out when writing
-// unit tests to keep timeouts reasonable.
-func NegotiateClaim(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider, contextWithTimeoutFn contextWithTimeoutFn) error {
+func NegotiateClaim(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider) error {
 	link, err := NewRPCLink(ctx, RPCLinkArgs{
 		Client:   conn,
 		Address:  cbsAddress,
@@ -47,9 +44,6 @@ func NegotiateClaim(ctx context.Context, audience string, conn amqpwrap.AMQPClie
 	}
 
 	closeLink := func(ctx context.Context, origErr error) error {
-		ctx, cancel := contextWithTimeoutFn(ctx, defaultCloseTimeout)
-		defer cancel()
-
 		if err := link.Close(ctx); err != nil {
 			azlog.Writef(exported.EventAuth, "Failed closing claim link: %s", err.Error())
 			return err

--- a/sdk/messaging/azeventhubs/internal/cbs_test.go
+++ b/sdk/messaging/azeventhubs/internal/cbs_test.go
@@ -37,29 +37,21 @@ func TestNegotiateClaimWithCloseTimeout(t *testing.T) {
 				}
 			})
 
+			callerCtx, cancelCallerCtx := context.WithCancel(context.Background())
+			defer cancelCallerCtx()
+
 			// the context passed to these calls are already cancelled since the parent
 			// context was cancelled. This basically just falls through the error handling
 			// but it's okay - each resource should close any local state they can before
 			// returning and we're going to end up abandoning ship on the connection.
-			session.EXPECT().Close(mock.CancelledAndHasTimeout)
-			sender.EXPECT().Close(mock.CancelledAndHasTimeout)
-
-			// When links fail to close in a timely manner it's either because the connection is (somehow)
-			// no longer valid _or_ conditions are preventing us from closing the link. In either case we
-			// have to be careful since it means that some resources (for instance, singleton links like $cbs)
-			// might "leak" since they can't be closed.
-			//
-			// Rather than attempt to do some complicated piecemeal recovery, we instead invalidate the entire
-			// connection, which is the only safe way to ensure the client and service agree on what is open and
-			// active.
-			receiver.EXPECT().Close(mock.NotCancelledAndHasTimeout).DoAndReturn(func(ctx context.Context) error {
+			session.EXPECT().Close(mock.NotCancelled).DoAndReturn(func(ctx context.Context) error {
+				cancelCallerCtx()
 				<-ctx.Done()
-				return ctx.Err()
+				return errToReturn
 			})
 
-			err := NegotiateClaim(context.Background(), "audience", client, tp, mock.NewContextWithTimeoutForTests)
-			require.EqualError(t, err, "connection must be reset, link/connection state may be inconsistent")
-			require.Equal(t, GetRecoveryKind(err), RecoveryKindConn)
+			err := NegotiateClaim(callerCtx, "audience", client, tp)
+			require.ErrorIs(t, err, errToReturn)
 		})
 	}
 }
@@ -78,9 +70,7 @@ func TestNegotiateClaimWithAuthFailure(t *testing.T) {
 	session.EXPECT().NewSender(mock.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
 	tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
 
-	session.EXPECT().Close(mock.NotCancelledAndHasTimeout)
-	sender.EXPECT().Close(mock.NotCancelledAndHasTimeout)
-	receiver.EXPECT().Close(mock.NotCancelledAndHasTimeout)
+	session.EXPECT().Close(mock.NotCancelled)
 
 	mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
 		// this is the kind of error you get if your connection string is inconsistent
@@ -92,7 +82,7 @@ func TestNegotiateClaimWithAuthFailure(t *testing.T) {
 		}
 	})
 
-	err := NegotiateClaim(context.Background(), "audience", client, tp, mock.NewContextWithTimeoutForTests)
+	err := NegotiateClaim(context.Background(), "audience", client, tp)
 
 	require.EqualError(t, err, "rpc: failed, status code 401 and description: InvalidSignature: The token has an invalid signature.")
 	require.Equal(t, GetRecoveryKind(err), RecoveryKindFatal)
@@ -112,9 +102,7 @@ func TestNegotiateClaimSuccess(t *testing.T) {
 	session.EXPECT().NewSender(mock.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
 	tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
 
-	session.EXPECT().Close(mock.NotCancelledAndHasTimeout)
-	sender.EXPECT().Close(mock.NotCancelledAndHasTimeout)
-	receiver.EXPECT().Close(mock.NotCancelledAndHasTimeout)
+	session.EXPECT().Close(mock.NotCancelled)
 
 	mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
 		response.ApplicationProperties = map[string]any{
@@ -122,6 +110,6 @@ func TestNegotiateClaimSuccess(t *testing.T) {
 		}
 	})
 
-	err := NegotiateClaim(context.Background(), "audience", client, tp, mock.NewContextWithTimeoutForTests)
+	err := NegotiateClaim(context.Background(), "audience", client, tp)
 	require.NoError(t, err)
 }

--- a/sdk/messaging/azeventhubs/internal/cbs_test.go
+++ b/sdk/messaging/azeventhubs/internal/cbs_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/amqpwrap"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/auth"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/mock"
@@ -55,7 +54,7 @@ func TestNegotiateClaimWithCloseTimeout(t *testing.T) {
 			// active.
 			receiver.EXPECT().Close(mock.NotCancelledAndHasTimeout).DoAndReturn(func(ctx context.Context) error {
 				<-ctx.Done()
-				return amqpwrap.HandleNewOrCloseError(ctx.Err())
+				return ctx.Err()
 			})
 
 			err := NegotiateClaim(context.Background(), "audience", client, tp, mock.NewContextWithTimeoutForTests)

--- a/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
-  repository: https://stresstestcharts.blob.core.windows.net/helm/
+  repository: file:///home/me/src/_/azsdktools-stress-pg2/tools/stress-cluster/cluster/kubernetes/stress-test-addons
   version: 0.2.0
-digest: sha256:59fff3930e78c4ca9f9c0120433c7695d31db63f36ac61d50abcc91b1f1835a0
-generated: "2023-01-06T23:57:35.96426915Z"
+digest: sha256:cdbff4339a3380a641472a5ed66ed3e85e49144907b509c9bc441137abbc3f4a
+generated: "2023-04-21T11:52:07.415961962-07:00"

--- a/sdk/messaging/azeventhubs/internal/eh/stress/Chart.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Chart.yaml
@@ -9,4 +9,4 @@ annotations:
 dependencies:
 - name: stress-test-addons
   version: ~0.2.0
-  repository: https://stresstestcharts.blob.core.windows.net/helm/
+  repository: "@stress-test-charts"

--- a/sdk/messaging/azeventhubs/internal/eh/stress/Dockerfile
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Dockerfile
@@ -15,4 +15,4 @@ RUN go build -o stress .
 FROM mcr.microsoft.com/cbl-mariner/base/core:1.0
 WORKDIR /app
 COPY --from=build /src/internal/eh/stress/stress /app/stress
-ENTRYPOINT ["./stress"]
+ENTRYPOINT ["/bin/bash"]

--- a/sdk/messaging/azeventhubs/internal/eh/stress/deploy.ps1
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/deploy.ps1
@@ -1,2 +1,26 @@
 Set-Location $PSScriptRoot
-pwsh "../../../../../../eng/common/scripts/stress-testing/deploy-stress-tests.ps1" -Login -PushImages
+
+# If you want to run against a local clone of the stress helm chart:
+function deployUsingLocalAddons() {
+    $azureSDKToolsRoot="<Git clone of azure-sdk-tools>"
+    $stressTestAddonsFolder = "$azureSDKToolsRoot/tools/stress-cluster/cluster/kubernetes/stress-test-addons"
+    $clusterResourceGroup = "<Resource Group for Cluster"
+    $clusterSubscription = "<Azure Subscription>"
+    $helmEnv = "pg2"
+
+    if (-not (Get-ChildItem $stressTestAddonsFolder)) {
+        Write-Host "Can't find the the new stress test adons folder at $stressTestAddonsFolder"
+        return
+    }
+
+    pwsh "$azureSDKToolsRoot/eng/common/scripts/stress-testing/deploy-stress-tests.ps1" `
+        -LocalAddonsPath "$stressTestAddonsFolder"  `
+        -clusterGroup "$clusterResourceGroup" `
+        -subscription "$clusterSubscription" `
+        -Environment $helmEnv `
+        -Login `
+        -PushImages
+}
+
+# deployUsingLocalAddons
+pwsh "../../../../../../eng/common/scripts/stress-testing/deploy-stress-tests.ps1" -Login -PushImages @args

--- a/sdk/messaging/azeventhubs/internal/eh/stress/templates/stress-test-job.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/templates/stress-test-job.yaml
@@ -12,7 +12,17 @@ spec:
     - name: main
       # az acr list -g rg-stress-cluster-pg --subscription "Azure SDK Developer Playground" --query "[0].loginServer"
       image:  {{ .Stress.imageTag }}
-      command: ['/app/stress']
+      command: ['sh', '-c']
+      # these 'testTarget' names come from the scenarios-matrix.yaml.
+      #
+      # NOTE: -verbose activates _all_ the Azure internal logging, which can get quite large.
+      # so it's not enabled for every target in here. We also have an issue filed to whittle it
+      # down (https://github.com/Azure/azure-sdk-for-go/issues/19459)
+      args: 
+        - >
+          set -ex;
+          mkdir -p "$DEBUG_SHARE";
+          /app/stress "{{.Stress.testTarget}}" "-rounds" "{{.Stress.rounds}}" "-prefetch" "{{.Stress.prefetch}}" "{{.Stress.verbose}}" "-sleepAfter" "{{.Stress.sleepAfter}}" | tee "${DEBUG_SHARE}/{{ .Stress.Scenario }}.log";
       # Pulls the image on pod start, always. We tend to push to the same image and tag over and over again
       # when iterating, so this is a must.
       imagePullPolicy: Always
@@ -25,20 +35,6 @@ spec:
         limits:
           memory: "1.5Gi"
           cpu: "1"
-      args: 
-      # these 'testTarget' names come from the scenarios-matrix.yaml.
-      #
-      # NOTE: -verbose activates _all_ the Azure internal logging, which can get quite large.
-      # so it's not enabled for every target in here. We also have an issue filed to whittle it
-      # down (https://github.com/Azure/azure-sdk-for-go/issues/19459)
-      - "{{.Stress.testTarget}}"
-      - "-rounds"
-      - "{{.Stress.rounds}}"
-      - "-prefetch"
-      - "{{.Stress.prefetch}}"
-      - "{{.Stress.verbose}}"
-      - "-sleepAfter"
-      - "{{.Stress.sleepAfter}}"
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}
 

--- a/sdk/messaging/azeventhubs/internal/go-amqp/conn.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/conn.go
@@ -28,6 +28,7 @@ const (
 	defaultIdleTimeout  = 1 * time.Minute
 	defaultMaxFrameSize = 65536
 	defaultMaxSessions  = 65536
+	defaultWriteTimeout = 30 * time.Second
 )
 
 // ConnOptions contains the optional settings for configuring an AMQP connection.
@@ -76,6 +77,17 @@ type ConnOptions struct {
 	// providing a URL scheme of "amqps://" is sufficient.
 	TLSConfig *tls.Config
 
+	// WriteTimeout controls the write deadline when writing AMQP frames to the
+	// underlying net.Conn and no caller provided context.Context is available or
+	// the context contains no deadline (e.g. context.Background()).
+	// The timeout is set per write.
+	//
+	// Setting to a value less than zero means no timeout is set, so writes
+	// defer to the underlying behavior of net.Conn with no write deadline.
+	//
+	// Default: 30s
+	WriteTimeout time.Duration
+
 	// test hook
 	dialer dialer
 }
@@ -90,12 +102,11 @@ type ConnOptions struct {
 //
 // opts: pass nil to accept the default values.
 func Dial(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error) {
-	deadline, _ := ctx.Deadline()
-	c, err := dialConn(deadline, addr, opts)
+	c, err := dialConn(ctx, addr, opts)
 	if err != nil {
 		return nil, err
 	}
-	err = c.start(deadline)
+	err = c.start(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +120,7 @@ func NewConn(ctx context.Context, conn net.Conn, opts *ConnOptions) (*Conn, erro
 	if err != nil {
 		return nil, err
 	}
-	deadline, _ := ctx.Deadline()
-	err = c.start(deadline)
+	err = c.start(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +129,9 @@ func NewConn(ctx context.Context, conn net.Conn, opts *ConnOptions) (*Conn, erro
 
 // Conn is an AMQP connection.
 type Conn struct {
-	net    net.Conn // underlying connection
-	dialer dialer   // used for testing purposes, it allows faking dialing TCP/TLS endpoints
+	net          net.Conn      // underlying connection
+	dialer       dialer        // used for testing purposes, it allows faking dialing TCP/TLS endpoints
+	writeTimeout time.Duration // controls write deadline in absense of a context
 
 	// TLS
 	tlsNegotiation bool        // negotiate TLS
@@ -156,40 +167,43 @@ type Conn struct {
 	sessionsByChannel   map[uint16]*Session
 	sessionsByChannelMu sync.RWMutex
 
+	abandonedSessionsMu sync.Mutex
+	abandonedSessions   []*Session
+
 	// connReader
 	rxBuf  buffer.Buffer // incoming bytes buffer
 	rxDone chan struct{} // closed when connReader exits
 	rxErr  error         // contains last error reading from c.net; DO NOT TOUCH outside of connReader until rxDone has been closed!
 
 	// connWriter
-	txFrame chan frames.Frame // AMQP frames to be sent by connWriter
-	txBuf   buffer.Buffer     // buffer for marshaling frames before transmitting
-	txDone  chan struct{}     // closed when connWriter exits
-	txErr   error             // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
+	txFrame chan frameEnvelope // AMQP frames to be sent by connWriter
+	txBuf   buffer.Buffer      // buffer for marshaling frames before transmitting
+	txDone  chan struct{}      // closed when connWriter exits
+	txErr   error              // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
 }
 
 // used to abstract the underlying dialer for testing purposes
 type dialer interface {
-	NetDialerDial(deadline time.Time, c *Conn, host, port string) error
-	TLSDialWithDialer(deadline time.Time, c *Conn, host, port string) error
+	NetDialerDial(ctx context.Context, c *Conn, host, port string) error
+	TLSDialWithDialer(ctx context.Context, c *Conn, host, port string) error
 }
 
 // implements the dialer interface
 type defaultDialer struct{}
 
-func (defaultDialer) NetDialerDial(deadline time.Time, c *Conn, host, port string) (err error) {
-	dialer := &net.Dialer{Deadline: deadline}
-	c.net, err = dialer.Dial("tcp", net.JoinHostPort(host, port))
+func (defaultDialer) NetDialerDial(ctx context.Context, c *Conn, host, port string) (err error) {
+	dialer := &net.Dialer{}
+	c.net, err = dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
 	return
 }
 
-func (defaultDialer) TLSDialWithDialer(deadline time.Time, c *Conn, host, port string) (err error) {
-	dialer := &net.Dialer{Deadline: deadline}
-	c.net, err = tls.DialWithDialer(dialer, "tcp", net.JoinHostPort(host, port), c.tlsConfig)
+func (defaultDialer) TLSDialWithDialer(ctx context.Context, c *Conn, host, port string) (err error) {
+	dialer := &tls.Dialer{Config: c.tlsConfig}
+	c.net, err = dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
 	return
 }
 
-func dialConn(deadline time.Time, addr string, opts *ConnOptions) (*Conn, error) {
+func dialConn(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
 		return nil, err
@@ -224,11 +238,11 @@ func dialConn(deadline time.Time, addr string, opts *ConnOptions) (*Conn, error)
 
 	switch u.Scheme {
 	case "amqp", "":
-		err = c.dialer.NetDialerDial(deadline, c, host, port)
+		err = c.dialer.NetDialerDial(ctx, c, host, port)
 	case "amqps", "amqp+ssl":
 		c.initTLSConfig()
 		c.tlsNegotiation = false
-		err = c.dialer.TLSDialWithDialer(deadline, c, host, port)
+		err = c.dialer.TLSDialWithDialer(ctx, c, host, port)
 	default:
 		err = fmt.Errorf("unsupported scheme %q", u.Scheme)
 	}
@@ -251,9 +265,10 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 		done:              make(chan struct{}),
 		rxtxExit:          make(chan struct{}),
 		rxDone:            make(chan struct{}),
-		txFrame:           make(chan frames.Frame),
+		txFrame:           make(chan frameEnvelope),
 		txDone:            make(chan struct{}),
 		sessionsByChannel: map[uint16]*Session{},
+		writeTimeout:      defaultWriteTimeout,
 	}
 
 	// apply options
@@ -261,6 +276,11 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 		opts = &ConnOptions{}
 	}
 
+	if opts.WriteTimeout > 0 {
+		c.writeTimeout = opts.WriteTimeout
+	} else if opts.WriteTimeout < 0 {
+		c.writeTimeout = 0
+	}
 	if opts.ContainerID != "" {
 		c.containerID = opts.ContainerID
 	}
@@ -314,25 +334,36 @@ func (c *Conn) initTLSConfig() {
 
 // start establishes the connection and begins multiplexing network IO.
 // It is an error to call Start() on a connection that's been closed.
-func (c *Conn) start(deadline time.Time) error {
-	// set connection establishment deadline
-	_ = c.net.SetDeadline(deadline)
+func (c *Conn) start(ctx context.Context) (err error) {
+	// if the context has a deadline or is cancellable, start the interruptor goroutine.
+	// this will close the underlying net.Conn in response to the context.
 
-	// run connection establishment state machine
-	for state := c.negotiateProto; state != nil; {
-		var err error
-		state, err = state()
-		// check if err occurred
-		if err != nil {
-			close(c.txDone) // close here since connWriter hasn't been started yet
-			close(c.rxDone)
-			_ = c.Close()
-			return err
-		}
+	if ctx.Done() != nil {
+		done := make(chan struct{})
+		interruptRes := make(chan error, 1)
+
+		defer func() {
+			close(done)
+			if ctxErr := <-interruptRes; ctxErr != nil {
+				// return context error to caller
+				err = ctxErr
+			}
+		}()
+
+		go func() {
+			select {
+			case <-ctx.Done():
+				c.closeDuringStart()
+				interruptRes <- ctx.Err()
+			case <-done:
+				interruptRes <- nil
+			}
+		}()
 	}
 
-	// remove connection establishment deadline
-	_ = c.net.SetDeadline(time.Time{})
+	if err = c.startImpl(ctx); err != nil {
+		return err
+	}
 
 	// we can't create the channel bitmap until the connection has been established.
 	// this is because our peer can tell us the max channels they support.
@@ -341,12 +372,44 @@ func (c *Conn) start(deadline time.Time) error {
 	go c.connWriter()
 	go c.connReader()
 
+	return
+}
+
+func (c *Conn) startImpl(ctx context.Context) error {
+	// set connection establishment deadline as required
+	if deadline, ok := ctx.Deadline(); ok && !deadline.IsZero() {
+		_ = c.net.SetDeadline(deadline)
+
+		// remove connection establishment deadline
+		defer func() {
+			_ = c.net.SetDeadline(time.Time{})
+		}()
+	}
+
+	// run connection establishment state machine
+	for state := c.negotiateProto; state != nil; {
+		var err error
+		state, err = state(ctx)
+		// check if err occurred
+		if err != nil {
+			c.closeDuringStart()
+			return err
+		}
+	}
+
 	return nil
 }
 
 // Close closes the connection.
 func (c *Conn) Close() error {
 	c.close()
+
+	// wait until the reader/writer goroutines have exited before proceeding.
+	// this is to prevent a race between calling Close() and a reader/writer
+	// goroutine calling close() due to a terminal error.
+	<-c.txDone
+	<-c.rxDone
+
 	var connErr *ConnError
 	if errors.As(c.doneErr, &connErr) && connErr.RemoteErr == nil && connErr.inner == nil {
 		// an empty ConnectionError means the connection was closed by the caller
@@ -386,7 +449,8 @@ func (c *Conn) close() {
 			// we experienced a peer-initiated close that contained an Error.  return it
 			c.doneErr = &ConnError{RemoteErr: amqpErr}
 		} else if c.txErr != nil {
-			c.doneErr = &ConnError{inner: c.txErr}
+			// c.txErr is already wrapped in a ConnError
+			c.doneErr = c.txErr
 		} else if c.rxErr != nil {
 			c.doneErr = &ConnError{inner: c.rxErr}
 		} else {
@@ -395,25 +459,52 @@ func (c *Conn) close() {
 	})
 }
 
+// closeDuringStart is a special close to be used only during startup (i.e. c.start() and any of its children)
+func (c *Conn) closeDuringStart() {
+	c.closeOnce.Do(func() {
+		c.net.Close()
+	})
+}
+
 // NewSession starts a new session on the connection.
 //   - ctx controls waiting for the peer to acknowledge the session
 //   - opts contains optional values, pass nil to accept the defaults
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned. If the Session was successfully
+// created, it will be cleaned up in future calls to NewSession.
 func (c *Conn) NewSession(ctx context.Context, opts *SessionOptions) (*Session, error) {
+	// clean up any abandoned sessions first
+	if err := c.freeAbandonedSessions(ctx); err != nil {
+		return nil, err
+	}
+
 	session, err := c.newSession(opts)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := session.begin(ctx); err != nil {
-		c.deleteSession(session)
+		c.abandonSession(session)
 		return nil, err
 	}
 
 	return session, nil
+}
+
+func (c *Conn) freeAbandonedSessions(ctx context.Context) error {
+	c.abandonedSessionsMu.Lock()
+	defer c.abandonedSessionsMu.Unlock()
+
+	for _, s := range c.abandonedSessions {
+		fr := frames.PerformEnd{}
+		if err := s.txFrameAndWait(ctx, &fr); err != nil {
+			return err
+		}
+	}
+
+	c.abandonedSessions = nil
+	return nil
 }
 
 func (c *Conn) newSession(opts *SessionOptions) (*Session, error) {
@@ -424,7 +515,10 @@ func (c *Conn) newSession(opts *SessionOptions) (*Session, error) {
 	// note that channel always start at 0
 	channel, ok := c.channels.Next()
 	if !ok {
-		return nil, fmt.Errorf("reached connection channel max (%d)", c.channelMax)
+		if err := c.Close(); err != nil {
+			return nil, err
+		}
+		return nil, &ConnError{inner: fmt.Errorf("reached connection channel max (%d)", c.channelMax)}
 	}
 	session := newSession(c, uint16(channel), opts)
 	c.sessionsByChannel[session.channel] = session
@@ -440,6 +534,12 @@ func (c *Conn) deleteSession(s *Session) {
 	c.channels.Remove(uint32(s.channel))
 }
 
+func (c *Conn) abandonSession(s *Session) {
+	c.abandonedSessionsMu.Lock()
+	defer c.abandonedSessionsMu.Unlock()
+	c.abandonedSessions = append(c.abandonedSessions, s)
+}
+
 // connReader reads from the net.Conn, decodes frames, and either handles
 // them here as appropriate or sends them to the session.rx channel.
 func (c *Conn) connReader() {
@@ -452,7 +552,7 @@ func (c *Conn) connReader() {
 	var err error
 	for {
 		if err != nil {
-			debug.Log(1, "RX (connReader): terminal error: %v", err)
+			debug.Log(1, "RX (connReader %p): terminal error: %v", c, err)
 			c.rxErr = err
 			return
 		}
@@ -463,7 +563,7 @@ func (c *Conn) connReader() {
 			continue
 		}
 
-		debug.Log(1, "RX (connReader): %s", fr)
+		debug.Log(1, "RX (connReader %p): %s", c, fr)
 
 		var (
 			session *Session
@@ -512,6 +612,7 @@ func (c *Conn) connReader() {
 			// the ack (i.e. before passing it on to the session mux) on the session
 			// ending since the numbers are recycled.
 			delete(sessionsByRemoteChannel, fr.Channel)
+			c.deleteSession(session)
 
 		default:
 			// pass on performative to the correct session
@@ -525,7 +626,7 @@ func (c *Conn) connReader() {
 		q := session.rxQ.Acquire()
 		q.Enqueue(fr.Body)
 		session.rxQ.Release(q)
-		debug.Log(2, "RX (connReader): mux frame to session: %s", fr)
+		debug.Log(2, "RX (connReader %p): mux frame to Session (%p): %s", c, session, fr)
 	}
 }
 
@@ -592,7 +693,7 @@ func (c *Conn) readFrame() (frames.Frame, error) {
 
 		// check if body is empty (keepalive)
 		if bodySize == 0 {
-			debug.Log(3, "RX (connReader): received keep-alive frame")
+			debug.Log(3, "RX (connReader %p): received keep-alive frame", c)
 			continue
 		}
 
@@ -609,6 +710,16 @@ func (c *Conn) readFrame() (frames.Frame, error) {
 
 		return frames.Frame{Channel: currentHeader.Channel, Body: parsedBody}, nil
 	}
+}
+
+// frameEnvelope is used when sending a frame to connWriter to be written to net.Conn
+type frameEnvelope struct {
+	Ctx   context.Context
+	Frame frames.Frame
+
+	// optional channel that is closed on successful write to net.Conn or contains the write error
+	// NOTE: use a buffered channel of size 1 when populating
+	Sent chan error
 }
 
 func (c *Conn) connWriter() {
@@ -635,24 +746,32 @@ func (c *Conn) connWriter() {
 	var err error
 	for {
 		if err != nil {
-			debug.Log(1, "TX (connWriter): terminal error: %v", err)
+			debug.Log(1, "TX (connWriter %p): terminal error: %v", c, err)
 			c.txErr = err
 			return
 		}
 
 		select {
 		// frame write request
-		case fr := <-c.txFrame:
-			debug.Log(1, "TX (connWriter): %s", fr)
-			err = c.writeFrame(fr)
-			if err == nil && fr.Done != nil {
-				close(fr.Done)
+		case env := <-c.txFrame:
+			timeout := c.getWriteTimeout(env.Ctx)
+			debug.Log(1, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
+			err = c.writeFrame(timeout, env.Frame)
+			if env.Sent != nil {
+				if err == nil {
+					close(env.Sent)
+				} else {
+					env.Sent <- err
+				}
 			}
 
 		// keepalive timer
 		case <-keepalive:
-			debug.Log(3, "TX (connWriter): sending keep-alive frame")
-			_, err = c.net.Write(keepaliveFrame)
+			debug.Log(3, "TX (connWriter %p): sending keep-alive frame", c)
+			_ = c.net.SetWriteDeadline(time.Now().Add(c.writeTimeout))
+			if _, err = c.net.Write(keepaliveFrame); err != nil {
+				err = &ConnError{inner: err}
+			}
 			// It would be slightly more efficient in terms of network
 			// resources to reset the timer each time a frame is sent.
 			// However, keepalives are small (8 bytes) and the interval
@@ -671,8 +790,8 @@ func (c *Conn) connWriter() {
 				Type: frames.TypeAMQP,
 				Body: &frames.PerformClose{},
 			}
-			debug.Log(1, "TX (connWriter): %s", fr)
-			c.txErr = c.writeFrame(fr)
+			debug.Log(1, "TX (connWriter %p): %s", c, fr)
+			c.txErr = c.writeFrame(c.writeTimeout, fr)
 			return
 		}
 	}
@@ -680,24 +799,36 @@ func (c *Conn) connWriter() {
 
 // writeFrame writes a frame to the network.
 // used externally by SASL only.
-func (c *Conn) writeFrame(fr frames.Frame) error {
+//   - timeout - the write deadline to set. zero means no deadline
+//
+// errors are wrapped in a ConnError as they can be returned to outside callers.
+func (c *Conn) writeFrame(timeout time.Duration, fr frames.Frame) error {
 	// writeFrame into txBuf
 	c.txBuf.Reset()
 	err := frames.Write(&c.txBuf, fr)
 	if err != nil {
-		return err
+		return &ConnError{inner: err}
 	}
 
 	// validate the frame isn't exceeding peer's max frame size
 	requiredFrameSize := c.txBuf.Len()
 	if uint64(requiredFrameSize) > uint64(c.peerMaxFrameSize) {
-		return fmt.Errorf("%T frame size %d larger than peer's max frame size %d", fr, requiredFrameSize, c.peerMaxFrameSize)
+		return &ConnError{inner: fmt.Errorf("%T frame size %d larger than peer's max frame size %d", fr, requiredFrameSize, c.peerMaxFrameSize)}
+	}
+
+	if timeout == 0 {
+		_ = c.net.SetWriteDeadline(time.Time{})
+	} else if timeout > 0 {
+		_ = c.net.SetWriteDeadline(time.Now().Add(timeout))
 	}
 
 	// write to network
 	n, err := c.net.Write(c.txBuf.Bytes())
 	if l := c.txBuf.Len(); n > 0 && n < l && err != nil {
-		debug.Log(1, "TX (writeFrame): wrote %d bytes less than len %d: %v", n, l, err)
+		debug.Log(1, "TX (writeFrame %p): wrote %d bytes less than len %d: %v", c, n, l, err)
+	}
+	if err != nil {
+		err = &ConnError{inner: err}
 	}
 	return err
 }
@@ -713,13 +844,17 @@ func (c *Conn) writeProtoHeader(pID protoID) error {
 var keepaliveFrame = []byte{0x00, 0x00, 0x00, 0x08, 0x02, 0x00, 0x00, 0x00}
 
 // SendFrame is used by sessions and links to send frames across the network.
-func (c *Conn) sendFrame(fr frames.Frame) error {
+//   - ctx is used to provide the write deadline
+//   - fr is the frame to write to net.Conn
+//   - sent is the optional channel that will contain the error if the write fails
+func (c *Conn) sendFrame(ctx context.Context, fr frames.Frame, sent chan error) {
 	select {
-	case c.txFrame <- fr:
-		debug.Log(2, "TX (Conn): mux frame to connWriter: %s", fr)
-		return nil
+	case c.txFrame <- frameEnvelope{Ctx: ctx, Frame: fr, Sent: sent}:
+		debug.Log(2, "TX (Conn %p): mux frame to connWriter: %s", c, fr)
 	case <-c.done:
-		return c.doneErr
+		if sent != nil {
+			sent <- c.doneErr
+		}
 	}
 }
 
@@ -727,11 +862,11 @@ func (c *Conn) sendFrame(fr frames.Frame) error {
 //
 // The state is advanced by returning the next state.
 // The state machine concludes when nil is returned.
-type stateFunc func() (stateFunc, error)
+type stateFunc func(context.Context) (stateFunc, error)
 
 // negotiateProto determines which proto to negotiate next.
 // used externally by SASL only.
-func (c *Conn) negotiateProto() (stateFunc, error) {
+func (c *Conn) negotiateProto(ctx context.Context) (stateFunc, error) {
 	// in the order each must be negotiated
 	switch {
 	case c.tlsNegotiation && !c.tlsComplete:
@@ -832,14 +967,14 @@ func (c *Conn) readProtoHeader() (protoHeader, error) {
 }
 
 // startTLS wraps the conn with TLS and returns to Client.negotiateProto
-func (c *Conn) startTLS() (stateFunc, error) {
+func (c *Conn) startTLS(ctx context.Context) (stateFunc, error) {
 	c.initTLSConfig()
 
 	_ = c.net.SetReadDeadline(time.Time{}) // clear timeout
 
 	// wrap existing net.Conn and perform TLS handshake
 	tlsConn := tls.Client(c.net, c.tlsConfig)
-	if err := tlsConn.Handshake(); err != nil {
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		return nil, err
 	}
 
@@ -852,7 +987,7 @@ func (c *Conn) startTLS() (stateFunc, error) {
 }
 
 // openAMQP round trips the AMQP open performative
-func (c *Conn) openAMQP() (stateFunc, error) {
+func (c *Conn) openAMQP(ctx context.Context) (stateFunc, error) {
 	// send open frame
 	open := &frames.PerformOpen{
 		ContainerID:  c.containerID,
@@ -867,8 +1002,8 @@ func (c *Conn) openAMQP() (stateFunc, error) {
 		Body:    open,
 		Channel: 0,
 	}
-	debug.Log(1, "TX (openAMQP): %s", fr)
-	err := c.writeFrame(fr)
+	debug.Log(1, "TX (openAMQP %p): %s", c, fr)
+	err := c.writeFrame(c.getWriteTimeout(ctx), fr)
 	if err != nil {
 		return nil, err
 	}
@@ -878,7 +1013,7 @@ func (c *Conn) openAMQP() (stateFunc, error) {
 	if err != nil {
 		return nil, err
 	}
-	debug.Log(1, "RX (openAMQP): %s", fr)
+	debug.Log(1, "RX (openAMQP %p): %s", c, fr)
 	o, ok := fr.Body.(*frames.PerformOpen)
 	if !ok {
 		return nil, fmt.Errorf("openAMQP: unexpected frame type %T", fr.Body)
@@ -902,13 +1037,13 @@ func (c *Conn) openAMQP() (stateFunc, error) {
 
 // negotiateSASL returns the SASL handler for the first matched
 // mechanism specified by the server
-func (c *Conn) negotiateSASL() (stateFunc, error) {
+func (c *Conn) negotiateSASL(context.Context) (stateFunc, error) {
 	// read mechanisms frame
 	fr, err := c.readSingleFrame()
 	if err != nil {
 		return nil, err
 	}
-	debug.Log(1, "RX (negotiateSASL): %s", fr)
+	debug.Log(1, "RX (negotiateSASL %p): %s", c, fr)
 	sm, ok := fr.Body.(*frames.SASLMechanisms)
 	if !ok {
 		return nil, fmt.Errorf("negotiateSASL: unexpected frame type %T", fr.Body)
@@ -931,13 +1066,13 @@ func (c *Conn) negotiateSASL() (stateFunc, error) {
 // SASL handlers return this stateFunc when the mechanism specific negotiation
 // has completed.
 // used externally by SASL only.
-func (c *Conn) saslOutcome() (stateFunc, error) {
+func (c *Conn) saslOutcome(context.Context) (stateFunc, error) {
 	// read outcome frame
 	fr, err := c.readSingleFrame()
 	if err != nil {
 		return nil, err
 	}
-	debug.Log(1, "RX (saslOutcome): %s", fr)
+	debug.Log(1, "RX (saslOutcome %p): %s", c, fr)
 	so, ok := fr.Body.(*frames.SASLOutcome)
 	if !ok {
 		return nil, fmt.Errorf("saslOutcome: unexpected frame type %T", fr.Body)
@@ -963,6 +1098,15 @@ func (c *Conn) readSingleFrame() (frames.Frame, error) {
 	}
 
 	return fr, nil
+}
+
+// getWriteTimeout returns the timeout as calculated from the context's deadline
+// or the default write timeout if the context has no deadline.
+func (c *Conn) getWriteTimeout(ctx context.Context) time.Duration {
+	if deadline, ok := ctx.Deadline(); ok {
+		return time.Until(deadline)
+	}
+	return c.writeTimeout
 }
 
 type protoHeader struct {

--- a/sdk/messaging/azeventhubs/internal/go-amqp/internal/frames/frames.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/internal/frames/frames.go
@@ -356,9 +356,6 @@ type Frame struct {
 	Type    Type      // AMQP/SASL
 	Channel uint16    // channel this frame is for
 	Body    FrameBody // body of the frame
-
-	// optional channel which will be closed after net transmit
-	Done chan encoding.DeliveryState
 }
 
 // String implements the fmt.Stringer interface for type Frame.

--- a/sdk/messaging/azeventhubs/internal/go-amqp/link.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/link.go
@@ -40,12 +40,12 @@ type link struct {
 	rxQ *queue.Holder[frames.FrameBody]
 
 	// used for gracefully closing link
-	close      chan struct{} // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
-	forceClose chan struct{} // used for forcibly terminate a link if Close() times out/is cancelled
-	closeOnce  *sync.Once    // closeOnce protects close from being closed multiple times
+	close     chan struct{} // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
+	closeOnce *sync.Once    // closeOnce protects close from being closed multiple times
 
-	done    chan struct{} // closed when the link has terminated (mux exited); DO NOT wait on this from within a link's mux() as it will never trigger!
-	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of link.go until done has been closed!
+	done     chan struct{} // closed when the link has terminated (mux exited); DO NOT wait on this from within a link's mux() as it will never trigger!
+	doneErr  error         // contains the mux error state; ONLY written to by the mux and MUST only be read from after done is closed!
+	closeErr error         // contains the error state returned from closeLink(); ONLY closeLink() reads/writes this!
 
 	session    *Session                // parent session
 	source     *frames.Source          // used for Receiver links
@@ -73,12 +73,11 @@ type link struct {
 
 func newLink(s *Session, r encoding.Role) link {
 	l := link{
-		key:        linkKey{shared.RandString(40), r},
-		session:    s,
-		close:      make(chan struct{}),
-		forceClose: make(chan struct{}),
-		closeOnce:  &sync.Once{},
-		done:       make(chan struct{}),
+		key:       linkKey{shared.RandString(40), r},
+		session:   s,
+		close:     make(chan struct{}),
+		closeOnce: &sync.Once{},
+		done:      make(chan struct{}),
 	}
 
 	// set the segment size relative to respective window
@@ -115,7 +114,9 @@ func (l *link) waitForFrame(ctx context.Context) (frames.FrameBody, error) {
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
 func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
-	if err := l.session.allocateHandle(l); err != nil {
+	if err := l.session.freeAbandonedLinks(ctx); err != nil {
+		return err
+	} else if err := l.session.allocateHandle(ctx, l); err != nil {
 		return err
 	}
 
@@ -133,18 +134,20 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 	// link-specific configuration of the attach frame
 	beforeAttach(attach)
 
-	_ = l.session.txFrame(attach, nil)
+	if err := l.txFrameAndWait(ctx, attach); err != nil {
+		return err
+	}
 
 	// wait for response
 	fr, err := l.waitForFrame(ctx)
 	if err != nil {
-		l.session.deallocateHandle(l)
+		l.session.abandonLink(l)
 		return err
 	}
 
 	resp, ok := fr.(*frames.PerformAttach)
 	if !ok {
-		debug.Log(1, "RX (link): unexpected attach response frame %T", fr)
+		debug.Log(1, "RX (link %p): unexpected attach response frame %T", l, fr)
 		if err := l.session.conn.Close(); err != nil {
 			return err
 		}
@@ -164,7 +167,9 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 		// wait for detach
 		fr, err := l.waitForFrame(ctx)
 		if err != nil {
-			l.session.deallocateHandle(l)
+			// we timed out waiting for the peer to close the link, this really isn't an abandoned link.
+			// however, we still need to send the detach performative to ack the peer.
+			l.session.abandonLink(l)
 			return err
 		}
 
@@ -181,7 +186,9 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 			Handle: l.handle,
 			Closed: true,
 		}
-		_ = l.session.txFrame(fr, nil)
+		if err := l.txFrameAndWait(ctx, fr); err != nil {
+			return err
+		}
 
 		if detach.Error == nil {
 			return fmt.Errorf("received detach with no error specified")
@@ -202,7 +209,9 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 			Handle: l.handle,
 			Closed: true,
 		}
-		_ = l.session.txFrame(dr, nil)
+		if err := l.txFrameAndWait(ctx, dr); err != nil {
+			return err
+		}
 		return err
 	}
 
@@ -262,11 +271,11 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 			Handle: l.handle,
 			Closed: true,
 		}
-		_ = l.session.txFrame(dr, nil)
+		l.txFrame(context.Background(), dr, nil)
 		return &LinkError{RemoteErr: fr.Error}
 
 	default:
-		debug.Log(1, "RX (link): unexpected frame: %s", fr)
+		debug.Log(1, "RX (link %p): unexpected frame: %s", l, fr)
 		l.closeWithError(ErrCondInternalError, fmt.Sprintf("link received unexpected frame %T", fr))
 		return nil
 	}
@@ -277,12 +286,21 @@ func (l *link) closeLink(ctx context.Context) error {
 	var ctxErr error
 	l.closeOnce.Do(func() {
 		close(l.close)
+
+		// once the mux has received the ack'ing detach performative, the mux will
+		// exit which deletes the link and closes l.done.
 		select {
 		case <-l.done:
-			// mux exited
+			l.closeErr = l.doneErr
 		case <-ctx.Done():
-			close(l.forceClose)
+			// notify the caller that the close timed out/was cancelled.
+			// the mux will remain running and once the ack is received it will terminate.
 			ctxErr = ctx.Err()
+
+			// record that the close timed out/was cancelled.
+			// subsequent calls to closeLink() will return this
+			debug.Log(1, "TX (link %p) closing %s: %v", l, l.key.name, ctxErr)
+			l.closeErr = &LinkError{inner: ctxErr}
 		}
 	})
 
@@ -291,11 +309,11 @@ func (l *link) closeLink(ctx context.Context) error {
 	}
 
 	var linkErr *LinkError
-	if errors.As(l.doneErr, &linkErr) && linkErr.inner == nil {
-		// an empty LinkError means the link was closed by the caller
+	if errors.As(l.closeErr, &linkErr) && linkErr.RemoteErr == nil && linkErr.inner == nil {
+		// an empty LinkError means the link was cleanly closed by the caller
 		return nil
 	}
-	return l.doneErr
+	return l.closeErr
 }
 
 // closeWithError initiates closing the link with the specified AMQP error.
@@ -306,7 +324,7 @@ func (l *link) closeLink(ctx context.Context) error {
 func (l *link) closeWithError(cnd ErrCond, desc string) {
 	amqpErr := &Error{Condition: cnd, Description: desc}
 	if l.closeInProgress {
-		debug.Log(3, "TX (link) close error already pending, discarding %v", amqpErr)
+		debug.Log(3, "TX (link %p) close error already pending, discarding %v", l, amqpErr)
 		return
 	}
 
@@ -317,5 +335,45 @@ func (l *link) closeWithError(cnd ErrCond, desc string) {
 	}
 	l.closeInProgress = true
 	l.doneErr = &LinkError{inner: fmt.Errorf("%s: %s", cnd, desc)}
-	_ = l.session.txFrame(dr, nil)
+	l.txFrame(context.Background(), dr, nil)
+}
+
+// txFrame sends the specified frame via the link's session.
+// you MUST call this instead of session.txFrame() to ensure
+// that frames are not sent during session shutdown.
+func (l *link) txFrame(ctx context.Context, fr frames.FrameBody, sent chan error) {
+	// NOTE: there is no need to select on l.done as this is either
+	// called from a link's mux or before the mux has even started.
+	select {
+	case <-l.session.done:
+		if sent != nil {
+			sent <- l.session.doneErr
+		}
+	case <-l.session.endSent:
+		// we swallow this to prevent the link's mux from terminating.
+		// l.session.done will soon close so this is temporary.
+		return
+	case l.session.tx <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
+		debug.Log(2, "TX (link %p): mux frame to Session (%p): %s", l, l.session, fr)
+	}
+}
+
+// txFrame sends the specified frame via the link's session.
+// you MUST call this instead of session.txFrame() to ensure
+// that frames are not sent during session shutdown.
+func (l *link) txFrameAndWait(ctx context.Context, fr frames.FrameBody) error {
+	// NOTE: there is no need to select on l.done as this is either
+	// called from a link's mux or before the mux has even started.
+	sent := make(chan error, 1)
+	select {
+	case <-l.session.done:
+		return l.session.doneErr
+	case <-l.session.endSent:
+		// we swallow this to prevent the link's mux from terminating.
+		// l.session.done will soon close so this is temporary.
+		return nil
+	case l.session.tx <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
+		debug.Log(2, "TX (link %p): mux frame to Session (%p): %s", l, l.session, fr)
+		return <-sent
+	}
 }

--- a/sdk/messaging/azeventhubs/internal/go-amqp/link.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/link.go
@@ -116,7 +116,10 @@ func (l *link) waitForFrame(ctx context.Context) (frames.FrameBody, error) {
 func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
 	if err := l.session.freeAbandonedLinks(ctx); err != nil {
 		return err
-	} else if err := l.session.allocateHandle(ctx, l); err != nil {
+	}
+
+	// once the abandoned links have been cleaned up we can create our link
+	if err := l.session.allocateHandle(ctx, l); err != nil {
 		return err
 	}
 

--- a/sdk/messaging/azeventhubs/internal/go-amqp/message.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/message.go
@@ -338,35 +338,6 @@ func (h *MessageHeader) Unmarshal(r *buffer.Buffer) error {
 	}...)
 }
 
-// AMQP types
-type (
-	// AMQPAddress corresponds to the 'address' type in the AMQP spec.
-	// <type name="address-string" class="restricted" source="string" provides="address"/>
-	Address = string
-
-	// AMQPMessageID corresponds to the 'message-id' type in the AMQP spec. Internally it can
-	// be one of the following:
-	// - uint64:    <type name="message-id-ulong" class="restricted" source="ulong" provides="message-id"/>
-	// - amqp.UUID: <type name="message-id-uuid" class="restricted" source="uuid" provides="message-id"/>
-	// - []byte:    <type name="message-id-binary" class="restricted" source="binary" provides="message-id"/>
-	// - string:    <type name="message-id-string" class="restricted" source="string" provides="message-id"/>
-	MessageID = any
-
-	// AMQPSymbol corresponds to the 'symbol' type in the AMQP spec.
-	// <type name="symbol" class="primitive"/>
-	// And either:
-	// - variable-width, 1 byte size	up to 2^8 - 1 seven bit ASCII characters representing a symbolic value
-	// - variable-width, 4 byte size	up to 2^32 - 1 seven bit ASCII characters representing a symbolic value
-	Symbol = string
-
-	// AMQPSequenceNumber corresponds to the `sequence-no` type in the AMQP spec.
-	// <type name="sequence-no" class="restricted" source="uint"/>
-	SequenceNumber = uint32
-
-	// AMQPBinary corresponds to the `binary` type in the AMQP spec.
-	Binary = []byte
-)
-
 /*
 <type name="properties" class="composite" source="list" provides="section">
     <descriptor name="amqp:properties:list" code="0x00000000:0x00000073"/>
@@ -393,25 +364,31 @@ type MessageProperties struct {
 	// such a way that it is assured to be globally unique. A broker MAY discard a
 	// message as a duplicate if the value of the message-id matches that of a
 	// previously received message sent to the same node.
-	MessageID MessageID // uint64, UUID, []byte, or string
+	//
+	// The value is restricted to the following types
+	//   - uint64, UUID, []byte, or string
+	MessageID any
 
 	// The identity of the user responsible for producing the message.
 	// The client sets this value, and it MAY be authenticated by intermediaries.
-	UserID Binary
+	UserID []byte
 
 	// The to field identifies the node that is the intended destination of the message.
 	// On any given transfer this might not be the node at the receiving end of the link.
-	To *Address
+	To *string
 
 	// A common field for summary information about the message content and purpose.
 	Subject *string
 
 	// The address of the node to send replies to.
-	ReplyTo *Address
+	ReplyTo *string
 
 	// This is a client-specific id that can be used to mark or identify messages
 	// between clients.
-	CorrelationID MessageID // uint64, UUID, []byte, or string
+	//
+	// The value is restricted to the following types
+	//   - uint64, UUID, []byte, or string
+	CorrelationID any
 
 	// The RFC-2046 [RFC2046] MIME type for the message's application-data section
 	// (body). As per RFC-2046 [RFC2046] this can contain a charset parameter defining
@@ -424,7 +401,7 @@ type MessageProperties struct {
 	//
 	// When using an application-data section with a section code other than data,
 	// content-type SHOULD NOT be set.
-	ContentType *Symbol
+	ContentType *string
 
 	// The content-encoding property is used as a modifier to the content-type.
 	// When present, its value indicates what additional content encodings have been
@@ -449,7 +426,7 @@ type MessageProperties struct {
 	//
 	// Implementations SHOULD NOT specify multiple content-encoding values except as to
 	// be compatible with messages originally sent with other protocols, e.g. HTTP or SMTP.
-	ContentEncoding *Symbol
+	ContentEncoding *string
 
 	// An absolute time when this message is considered to be expired.
 	AbsoluteExpiryTime *time.Time
@@ -461,7 +438,9 @@ type MessageProperties struct {
 	GroupID *string
 
 	// The relative position of this message within its group.
-	GroupSequence *SequenceNumber // RFC-1982 sequence number
+	//
+	// The value is defined as a RFC-1982 sequence number
+	GroupSequence *uint32
 
 	// This is a client-specific id that is used so that client can send replies to this
 	// message to a specific group.

--- a/sdk/messaging/azeventhubs/internal/go-amqp/receiver.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/receiver.go
@@ -254,12 +254,10 @@ func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint
 
 	sent := make(chan error, 1)
 	select {
-	case <-r.l.done:
-		return r.l.doneErr
-	case <-ctx.Done():
-		return ctx.Err()
 	case r.txDisposition <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
 		debug.Log(2, "TX (Receiver %p): mux txDisposition %s", r, fr)
+	case <-r.l.done:
+		return r.l.doneErr
 	}
 
 	select {
@@ -318,6 +316,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 
 	case <-ctx.Done():
 		// didn't receive the ack in the time allotted, leave message as unsettled
+		// TODO: if the ack arrives later, we need to remove the message from the unsettled map and reclaim the credit
 		return ctx.Err()
 	}
 }

--- a/sdk/messaging/azeventhubs/internal/go-amqp/receiver.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/receiver.go
@@ -29,6 +29,7 @@ type Receiver struct {
 	// message receiving
 	receiverReady chan struct{}          // receiver sends on this when mux is paused to indicate it can handle more messages
 	messagesQ     *queue.Holder[Message] // used to send completed messages to receiver
+	txDisposition chan frameBodyEnvelope // used to funnel disposition frames through the mux
 
 	unsettledMessages     map[string]struct{} // used to keep track of messages being handled downstream
 	unsettledMessagesLock sync.RWMutex        // lock to protect concurrent access to unsettledMessages
@@ -89,7 +90,7 @@ func (r *Receiver) Prefetched() *Message {
 		return nil
 	}
 
-	debug.Log(3, "RX (Receiver): prefetched delivery ID %d", msg.deliveryID)
+	debug.Log(3, "RX (Receiver %p): prefetched delivery ID %d", r, msg.deliveryID)
 
 	if msg.settled {
 		r.onSettlement(1)
@@ -119,7 +120,7 @@ func (r *Receiver) Receive(ctx context.Context, opts *ReceiveOptions) (*Message,
 	case q := <-r.messagesQ.Wait():
 		msg := q.Dequeue()
 		debug.Assert(msg != nil)
-		debug.Log(3, "RX (Receiver): received delivery ID %d", msg.deliveryID)
+		debug.Log(3, "RX (Receiver %p): received delivery ID %d", r, msg.deliveryID)
 		r.messagesQ.Release(q)
 		if msg.settled {
 			r.onSettlement(1)
@@ -234,14 +235,15 @@ func (r *Receiver) LinkSourceFilterValue(name string) any {
 //   - ctx controls waiting for the peer to acknowledge the close
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned.  However, the operation will continue to
+// execute in the background. Subsequent calls will return a *LinkError
+// that contains the context's error message.
 func (r *Receiver) Close(ctx context.Context) error {
 	return r.l.closeLink(ctx)
 }
 
 // sendDisposition sends a disposition frame to the peer
-func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.DeliveryState) error {
+func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint32, state encoding.DeliveryState) error {
 	fr := &frames.PerformDisposition{
 		Role:    encoding.RoleReceiver,
 		First:   first,
@@ -250,12 +252,15 @@ func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.De
 		State:   state,
 	}
 
+	sent := make(chan error, 1)
 	select {
+	case r.txDisposition <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
+		debug.Log(2, "TX (Receiver %p): mux txDisposition %s", r, fr)
+		return <-sent
 	case <-r.l.done:
 		return r.l.doneErr
-	default:
-		// TODO: this is racy
-		return r.l.session.txFrame(fr, nil)
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -264,13 +269,17 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 		return nil
 	}
 
+	// NOTE: we MUST add to the in-flight map before sending the disposition. if not, it's possible
+	// to receive the ack'ing disposition frame *before* the in-flight map has been updated which
+	// will cause the below <-wait to never trigger.
+
 	var wait chan error
 	if r.l.receiverSettleMode != nil && *r.l.receiverSettleMode == ReceiverSettleModeSecond {
-		debug.Log(3, "TX (Receiver): delivery ID %d is in flight", msg.deliveryID)
+		debug.Log(3, "TX (Receiver %p): delivery ID %d is in flight", r, msg.deliveryID)
 		wait = r.inFlight.add(msg.deliveryID)
 	}
 
-	if err := r.sendDisposition(msg.deliveryID, nil, state); err != nil {
+	if err := r.sendDisposition(ctx, msg.deliveryID, nil, state); err != nil {
 		return err
 	}
 
@@ -283,12 +292,24 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 
 	select {
 	case err := <-wait:
-		debug.Log(3, "RX (Receiver): delivery ID %d has been settled", msg.deliveryID)
-		// we've received confirmation of disposition
-		r.deleteUnsettled(msg)
-		r.onSettlement(1)
-		msg.settled = true
+		// err has three possibilities
+		//   - nil, meaning the peer acknowledged the settlement
+		//   - an *Error, meaning the peer rejected the message with a provided error
+		//   - a non-AMQP error. this comes from calls to inFlight.clear() during mux unwind.
+		// only for the first two cases is the message considered settled
+
+		if amqpErr := (&Error{}); err == nil || errors.As(err, &amqpErr) {
+			debug.Log(3, "RX (Receiver %p): delivery ID %d has been settled", r, msg.deliveryID)
+			// we've received confirmation of disposition
+			r.deleteUnsettled(msg)
+			r.onSettlement(1)
+			msg.settled = true
+			return err
+		}
+
+		debug.Log(3, "RX (Receiver %p): error settling delivery ID %d: %v", r, msg.deliveryID, err)
 		return err
+
 	case <-ctx.Done():
 		// didn't receive the ack in the time allotted, leave message as unsettled
 		return ctx.Err()
@@ -342,6 +363,7 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 		l:             l,
 		autoSendFlow:  true,
 		receiverReady: make(chan struct{}, 1),
+		txDisposition: make(chan frameBodyEnvelope),
 	}
 
 	r.messagesQ = queue.NewHolder(queue.New[Message](int(session.incomingWindow)))
@@ -451,12 +473,24 @@ func (r *Receiver) attach(ctx context.Context) error {
 		return err
 	}
 
-	go r.mux()
-
 	return nil
 }
 
-func (r *Receiver) mux() {
+func nop() {}
+
+type receiverTestHooks struct {
+	MuxStart  func()
+	MuxSelect func()
+}
+
+func (r *Receiver) mux(hooks receiverTestHooks) {
+	if hooks.MuxSelect == nil {
+		hooks.MuxSelect = nop
+	}
+	if hooks.MuxStart == nil {
+		hooks.MuxStart = nop
+	}
+
 	defer func() {
 		// unblock any in flight message dispositions
 		r.inFlight.clear(r.l.doneErr)
@@ -466,9 +500,10 @@ func (r *Receiver) mux() {
 			r.creditor.EndDrain()
 		}
 
-		r.l.session.deallocateHandle(&r.l)
 		close(r.l.done)
 	}()
+
+	hooks.MuxStart()
 
 	if r.autoSendFlow {
 		r.l.doneErr = r.muxFlow(r.l.linkCredit, false)
@@ -493,10 +528,12 @@ func (r *Receiver) mux() {
 		// fixed threshold to ensure credit is reclaimed in cases where the number of unsettled
 		// messages remains high for whatever reason.
 		if r.autoSendFlow && previousSettlementCount > 0 && previousSettlementCount >= r.l.linkCredit {
-			debug.Log(1, "RX (Receiver) (auto): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver %p) (auto): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
 			r.l.doneErr = r.creditor.IssueCredit(previousSettlementCount)
 		} else if r.l.linkCredit == 0 {
-			debug.Log(1, "RX (Receiver) (pause): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver %p) (pause): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
 		}
 
 		if r.l.doneErr != nil {
@@ -505,8 +542,8 @@ func (r *Receiver) mux() {
 
 		drain, credits := r.creditor.FlowBits(r.l.linkCredit)
 		if drain || credits > 0 {
-			debug.Log(1, "RX (Receiver) (flow): source: %q, inflight: %d, curLinkCredit: %d, newLinkCredit: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
-				r.l.source.Address, r.inFlight.len(), r.l.linkCredit, credits, drain, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver %p) (flow): source: %q, inflight: %d, curLinkCredit: %d, newLinkCredit: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, credits, drain, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
 
 			// send a flow frame.
 			r.l.doneErr = r.muxFlow(credits, drain)
@@ -516,18 +553,21 @@ func (r *Receiver) mux() {
 			return
 		}
 
+		txDisposition := r.txDisposition
 		closed := r.l.close
 		if r.l.closeInProgress {
 			// swap out channel so it no longer triggers
 			closed = nil
+
+			// disable sending of disposition frames once closing is in progress.
+			// this is to prevent races between mux shutdown and clearing of
+			// any in-flight dispositions.
+			txDisposition = nil
 		}
 
-		select {
-		case <-r.l.forceClose:
-			// the call to r.Close() timed out waiting for the ack
-			r.l.doneErr = &LinkError{inner: errors.New("the receiver was forcibly closed")}
-			return
+		hooks.MuxSelect()
 
+		select {
 		case q := <-r.l.rxQ.Wait():
 			// populated queue
 			fr := *q.Dequeue()
@@ -541,6 +581,9 @@ func (r *Receiver) mux() {
 				return
 			}
 
+		case env := <-txDisposition:
+			r.l.txFrame(env.Ctx, env.FrameBody, env.Sent)
+
 		case <-r.receiverReady:
 			continue
 
@@ -549,13 +592,14 @@ func (r *Receiver) mux() {
 				// a client-side close due to protocol error is in progress
 				continue
 			}
+
 			// receiver is being closed by the client
 			r.l.closeInProgress = true
 			fr := &frames.PerformDetach{
 				Handle: r.l.handle,
 				Closed: true,
 			}
-			_ = r.l.session.txFrame(fr, nil)
+			r.l.txFrame(context.Background(), fr, nil)
 
 		case <-r.l.session.done:
 			r.l.doneErr = r.l.session.doneErr
@@ -590,8 +634,8 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 	}
 
 	select {
-	case r.l.session.tx <- fr:
-		debug.Log(2, "TX (Receiver): %s", fr)
+	case r.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: fr}:
+		debug.Log(2, "TX (Receiver %p): mux frame to Session (%p): %d, %s", r, r.l.session, r.l.session.channel, fr)
 		return nil
 	case <-r.l.close:
 		return nil
@@ -602,7 +646,7 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 
 // muxHandleFrame processes fr based on type.
 func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
-	debug.Log(2, "RX (Receiver): %s", fr)
+	debug.Log(2, "RX (Receiver %p): %s", r, fr)
 	switch fr := fr.(type) {
 	// message frame
 	case *frames.PerformTransfer:
@@ -634,8 +678,8 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 		}
 
 		select {
-		case r.l.session.tx <- resp:
-			debug.Log(2, "TX (Sender): %s", resp)
+		case r.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: resp}:
+			debug.Log(2, "TX (Receiver %p): mux frame to Session (%p): %d, %s", r, r.l.session, r.l.session.channel, resp)
 		case <-r.l.close:
 			return nil
 		case <-r.l.session.done:
@@ -758,7 +802,7 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) {
 	// send to receiver
 	if !r.msg.settled {
 		r.addUnsettled(&r.msg)
-		debug.Log(3, "RX (Receiver): add unsettled delivery ID %d", r.msg.deliveryID)
+		debug.Log(3, "RX (Receiver %p): add unsettled delivery ID %d", r, r.msg.deliveryID)
 	}
 
 	q := r.messagesQ.Acquire()
@@ -773,7 +817,7 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) {
 	// decrement link-credit after entire message received
 	r.l.deliveryCount++
 	r.l.linkCredit--
-	debug.Log(3, "RX (Receiver) link %s - deliveryCount: %d, linkCredit: %d, len(messages): %d", r.l.key.name, r.l.deliveryCount, r.l.linkCredit, msgLen)
+	debug.Log(3, "RX (Receiver %p) link %s - deliveryCount: %d, linkCredit: %d, len(messages): %d", r, r.l.key.name, r.l.deliveryCount, r.l.linkCredit, msgLen)
 }
 
 // inFlight tracks in-flight message dispositions allowing receivers

--- a/sdk/messaging/azeventhubs/internal/go-amqp/sasl.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/sasl.go
@@ -48,8 +48,11 @@ func SASLTypePlain(username, password string) SASLType {
 				Body: init,
 			}
 			debug.Log(1, "TX (ConnSASLPlain %p): %s", c, fr)
-			err := c.writeFrame(c.getWriteTimeout(ctx), fr)
+			timeout, err := c.getWriteTimeout(ctx)
 			if err != nil {
+				return nil, err
+			}
+			if err = c.writeFrame(timeout, fr); err != nil {
 				return nil, err
 			}
 
@@ -79,8 +82,11 @@ func SASLTypeAnonymous() SASLType {
 				Body: init,
 			}
 			debug.Log(1, "TX (ConnSASLAnonymous %p): %s", c, fr)
-			err := c.writeFrame(c.getWriteTimeout(ctx), fr)
+			timeout, err := c.getWriteTimeout(ctx)
 			if err != nil {
+				return nil, err
+			}
+			if err = c.writeFrame(timeout, fr); err != nil {
 				return nil, err
 			}
 
@@ -112,8 +118,11 @@ func SASLTypeExternal(resp string) SASLType {
 				Body: init,
 			}
 			debug.Log(1, "TX (ConnSASLExternal %p): %s", c, fr)
-			err := c.writeFrame(c.getWriteTimeout(ctx), fr)
+			timeout, err := c.getWriteTimeout(ctx)
 			if err != nil {
+				return nil, err
+			}
+			if err = c.writeFrame(timeout, fr); err != nil {
 				return nil, err
 			}
 
@@ -169,7 +178,11 @@ func (s saslXOAUTH2Handler) init(ctx context.Context) (stateFunc, error) {
 	if s.maxFrameSizeOverride > s.conn.peerMaxFrameSize {
 		s.conn.peerMaxFrameSize = s.maxFrameSizeOverride
 	}
-	err := s.conn.writeFrame(s.conn.getWriteTimeout(ctx), frames.Frame{
+	timeout, err := s.conn.getWriteTimeout(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = s.conn.writeFrame(timeout, frames.Frame{
 		Type: frames.TypeSASL,
 		Body: &frames.SASLInit{
 			Mechanism:       saslMechanismXOAUTH2,
@@ -206,8 +219,13 @@ func (s saslXOAUTH2Handler) step(ctx context.Context) (stateFunc, error) {
 		if s.errorResponse == nil {
 			s.errorResponse = v.Challenge
 
+			timeout, err := s.conn.getWriteTimeout(ctx)
+			if err != nil {
+				return nil, err
+			}
+
 			// The SASL protocol requires clients to send an empty response to this challenge.
-			err := s.conn.writeFrame(s.conn.getWriteTimeout(ctx), frames.Frame{
+			err = s.conn.writeFrame(timeout, frames.Frame{
 				Type: frames.TypeSASL,
 				Body: &frames.SASLResponse{
 					Response: []byte{},

--- a/sdk/messaging/azeventhubs/internal/go-amqp/sasl.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/sasl.go
@@ -4,6 +4,7 @@
 package amqp
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp/internal/debug"
@@ -35,7 +36,7 @@ func SASLTypePlain(username, password string) SASLType {
 		}
 
 		// add the handler the the map
-		c.saslHandlers[saslMechanismPLAIN] = func() (stateFunc, error) {
+		c.saslHandlers[saslMechanismPLAIN] = func(ctx context.Context) (stateFunc, error) {
 			// send saslInit with PLAIN payload
 			init := &frames.SASLInit{
 				Mechanism:       "PLAIN",
@@ -46,8 +47,8 @@ func SASLTypePlain(username, password string) SASLType {
 				Type: frames.TypeSASL,
 				Body: init,
 			}
-			debug.Log(1, "TX (ConnSASLPlain): %s", fr)
-			err := c.writeFrame(fr)
+			debug.Log(1, "TX (ConnSASLPlain %p): %s", c, fr)
+			err := c.writeFrame(c.getWriteTimeout(ctx), fr)
 			if err != nil {
 				return nil, err
 			}
@@ -68,7 +69,7 @@ func SASLTypeAnonymous() SASLType {
 		}
 
 		// add the handler the the map
-		c.saslHandlers[saslMechanismANONYMOUS] = func() (stateFunc, error) {
+		c.saslHandlers[saslMechanismANONYMOUS] = func(ctx context.Context) (stateFunc, error) {
 			init := &frames.SASLInit{
 				Mechanism:       saslMechanismANONYMOUS,
 				InitialResponse: []byte("anonymous"),
@@ -77,8 +78,8 @@ func SASLTypeAnonymous() SASLType {
 				Type: frames.TypeSASL,
 				Body: init,
 			}
-			debug.Log(1, "TX (ConnSASLAnonymous): %s", fr)
-			err := c.writeFrame(fr)
+			debug.Log(1, "TX (ConnSASLAnonymous %p): %s", c, fr)
+			err := c.writeFrame(c.getWriteTimeout(ctx), fr)
 			if err != nil {
 				return nil, err
 			}
@@ -101,7 +102,7 @@ func SASLTypeExternal(resp string) SASLType {
 		}
 
 		// add the handler the the map
-		c.saslHandlers[saslMechanismEXTERNAL] = func() (stateFunc, error) {
+		c.saslHandlers[saslMechanismEXTERNAL] = func(ctx context.Context) (stateFunc, error) {
 			init := &frames.SASLInit{
 				Mechanism:       saslMechanismEXTERNAL,
 				InitialResponse: []byte(resp),
@@ -110,8 +111,8 @@ func SASLTypeExternal(resp string) SASLType {
 				Type: frames.TypeSASL,
 				Body: init,
 			}
-			debug.Log(1, "TX (ConnSASLExternal): %s", fr)
-			err := c.writeFrame(fr)
+			debug.Log(1, "TX (ConnSASLExternal %p): %s", c, fr)
+			err := c.writeFrame(c.getWriteTimeout(ctx), fr)
 			if err != nil {
 				return nil, err
 			}
@@ -163,12 +164,12 @@ type saslXOAUTH2Handler struct {
 	errorResponse        []byte // https://developers.google.com/gmail/imap/xoauth2-protocol#error_response
 }
 
-func (s saslXOAUTH2Handler) init() (stateFunc, error) {
+func (s saslXOAUTH2Handler) init(ctx context.Context) (stateFunc, error) {
 	originalPeerMaxFrameSize := s.conn.peerMaxFrameSize
 	if s.maxFrameSizeOverride > s.conn.peerMaxFrameSize {
 		s.conn.peerMaxFrameSize = s.maxFrameSizeOverride
 	}
-	err := s.conn.writeFrame(frames.Frame{
+	err := s.conn.writeFrame(s.conn.getWriteTimeout(ctx), frames.Frame{
 		Type: frames.TypeSASL,
 		Body: &frames.SASLInit{
 			Mechanism:       saslMechanismXOAUTH2,
@@ -183,7 +184,7 @@ func (s saslXOAUTH2Handler) init() (stateFunc, error) {
 	return s.step, nil
 }
 
-func (s saslXOAUTH2Handler) step() (stateFunc, error) {
+func (s saslXOAUTH2Handler) step(ctx context.Context) (stateFunc, error) {
 	// read challenge or outcome frame
 	fr, err := s.conn.readFrame()
 	if err != nil {
@@ -206,7 +207,7 @@ func (s saslXOAUTH2Handler) step() (stateFunc, error) {
 			s.errorResponse = v.Challenge
 
 			// The SASL protocol requires clients to send an empty response to this challenge.
-			err := s.conn.writeFrame(frames.Frame{
+			err := s.conn.writeFrame(s.conn.getWriteTimeout(ctx), frames.Frame{
 				Type: frames.TypeSASL,
 				Body: &frames.SASLResponse{
 					Response: []byte{},

--- a/sdk/messaging/azeventhubs/internal/go-amqp/sender.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/sender.go
@@ -341,8 +341,9 @@ Loop:
 
 		// send data
 		case tr := <-outgoingTransfers:
+			tmpTR := tr
 			select {
-			case s.l.session.txTransfer <- &tr:
+			case s.l.session.txTransfer <- &tmpTR:
 				debug.Log(2, "TX (Sender): mux transfer to Session: %d, %s", s.l.session.channel, tr)
 				// decrement link-credit after entire message transferred
 				if !tr.More {

--- a/sdk/messaging/azeventhubs/internal/go-amqp/sender.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/sender.go
@@ -19,7 +19,7 @@ import (
 // Sender sends messages on a single AMQP link.
 type Sender struct {
 	l         link
-	transfers chan frames.PerformTransfer // sender uses to send transfer frames
+	transfers chan transferEnvelope // sender uses to send transfer frames
 
 	mu              sync.Mutex // protects buf and nextDeliveryTag
 	buf             buffer.Buffer
@@ -163,13 +163,20 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (cha
 			fr.Done = make(chan encoding.DeliveryState, 1)
 		}
 
+		// NOTE: we MUST send a copy of fr here since we modify it post send
+
+		sent := make(chan error, 1)
 		select {
-		case s.transfers <- fr:
+		case s.transfers <- transferEnvelope{Ctx: ctx, Frame: fr, Sent: sent}:
 			// frame was sent to our mux
 		case <-s.l.done:
 			return nil, s.l.doneErr
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+
+		if err := <-sent; err != nil {
+			return nil, err
 		}
 
 		// clear values that are only required on first message
@@ -193,8 +200,9 @@ func (s *Sender) Address() string {
 //   - ctx controls waiting for the peer to acknowledge the close
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned.  However, the operation will continue to
+// execute in the background. Subsequent calls will return a *LinkError
+// that contains the context's error message.
 func (s *Sender) Close(ctx context.Context) error {
 	return s.l.closeLink(ctx)
 }
@@ -290,7 +298,7 @@ func (s *Sender) attach(ctx context.Context) error {
 		return err
 	}
 
-	s.transfers = make(chan frames.PerformTransfer)
+	s.transfers = make(chan transferEnvelope)
 
 	go s.mux()
 
@@ -299,32 +307,31 @@ func (s *Sender) attach(ctx context.Context) error {
 
 func (s *Sender) mux() {
 	defer func() {
-		s.l.session.deallocateHandle(&s.l)
 		close(s.l.done)
 	}()
 
 Loop:
 	for {
-		var outgoingTransfers chan frames.PerformTransfer
+		var outgoingTransfers chan transferEnvelope
 		if s.l.linkCredit > 0 {
-			debug.Log(1, "TX (Sender) (enable): target: %q, link credit: %d, deliveryCount: %d", s.l.target.Address, s.l.linkCredit, s.l.deliveryCount)
+			debug.Log(1, "TX (Sender %p) (enable): target: %q, link credit: %d, deliveryCount: %d", s, s.l.target.Address, s.l.linkCredit, s.l.deliveryCount)
 			outgoingTransfers = s.transfers
 		} else {
-			debug.Log(1, "TX (Sender) (pause): target: %q, link credit: %d, deliveryCount: %d", s.l.target.Address, s.l.linkCredit, s.l.deliveryCount)
+			debug.Log(1, "TX (Sender %p) (pause): target: %q, link credit: %d, deliveryCount: %d", s, s.l.target.Address, s.l.linkCredit, s.l.deliveryCount)
 		}
 
 		closed := s.l.close
 		if s.l.closeInProgress {
 			// swap out channel so it no longer triggers
 			closed = nil
+
+			// disable sending once closing is in progress.
+			// this prevents races with mux shutdown and
+			// the peer sending disposition frames.
+			outgoingTransfers = nil
 		}
 
 		select {
-		case <-s.l.forceClose:
-			// the call to s.Close() timed out waiting for the ack
-			s.l.doneErr = &LinkError{inner: errors.New("the sender was forcibly closed")}
-			return
-
 		// received frame
 		case q := <-s.l.rxQ.Wait():
 			// populated queue
@@ -340,17 +347,16 @@ Loop:
 			}
 
 		// send data
-		case tr := <-outgoingTransfers:
-			tmpTR := tr
+		case env := <-outgoingTransfers:
 			select {
-			case s.l.session.txTransfer <- &tmpTR:
-				debug.Log(2, "TX (Sender): mux transfer to Session: %d, %s", s.l.session.channel, tr)
+			case s.l.session.txTransfer <- env:
+				debug.Log(2, "TX (Sender %p): mux transfer to Session: %d, %s", s, s.l.session.channel, env.Frame)
 				// decrement link-credit after entire message transferred
-				if !tr.More {
+				if !env.Frame.More {
 					s.l.deliveryCount++
 					s.l.linkCredit--
 					// we are the sender and we keep track of the peer's link credit
-					debug.Log(3, "TX (Sender): link: %s, link credit: %d", s.l.key.name, s.l.linkCredit)
+					debug.Log(3, "TX (Sender %p): link: %s, link credit: %d", s, s.l.key.name, s.l.linkCredit)
 				}
 				continue Loop
 			case <-s.l.close:
@@ -364,16 +370,16 @@ Loop:
 				// a client-side close due to protocol error is in progress
 				continue
 			}
+
 			// sender is being closed by the client
 			s.l.closeInProgress = true
 			fr := &frames.PerformDetach{
 				Handle: s.l.handle,
 				Closed: true,
 			}
-			_ = s.l.session.txFrame(fr, nil)
+			s.l.txFrame(context.Background(), fr, nil)
 
 		case <-s.l.session.done:
-			// TODO: per spec, if the session has terminated, we're not allowed to send frames
 			s.l.doneErr = s.l.session.doneErr
 			return
 		}
@@ -383,7 +389,7 @@ Loop:
 // muxHandleFrame processes fr based on type.
 // depending on the peer's RSM, it might return a disposition frame for sending
 func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
-	debug.Log(2, "RX (Sender): %s", fr)
+	debug.Log(2, "RX (Sender %p): %s", s, fr)
 	switch fr := fr.(type) {
 	// flow control frame
 	case *frames.PerformFlow:
@@ -416,8 +422,8 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 		}
 
 		select {
-		case s.l.session.tx <- resp:
-			debug.Log(2, "TX (Sender): %s", resp)
+		case s.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: resp}:
+			debug.Log(2, "TX (Sender %p): mux frame to Session (%p): %d, %s", s, s.l.session, s.l.session.channel, resp)
 		case <-s.l.close:
 			return nil
 		case <-s.l.session.done:
@@ -439,9 +445,11 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 			Settled: true,
 		}
 
+		// TODO: the context used here should be the one associated with the original Send()
+
 		select {
-		case s.l.session.tx <- dr:
-			debug.Log(2, "TX (Sender): mux frame to Session: %d, %s", s.l.session.channel, dr)
+		case s.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: dr}:
+			debug.Log(2, "TX (Sender %p): mux frame to Session (%p): %d, %s", s, s.l.session, s.l.session.channel, dr)
 		case <-s.l.close:
 			return nil
 		case <-s.l.session.done:

--- a/sdk/messaging/azeventhubs/internal/go-amqp/sender.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/sender.go
@@ -172,7 +172,7 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (cha
 		case <-s.l.done:
 			return nil, s.l.doneErr
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, &Error{Condition: ErrCondTransferLimitExceeded, Description: fmt.Sprintf("credit limit exceeded for sending link %s", s.l.key.name)}
 		}
 
 		select {
@@ -456,8 +456,6 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 			Last:    fr.Last,
 			Settled: true,
 		}
-
-		// TODO: the context used here should be the one associated with the original Send()
 
 		select {
 		case s.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: dr}:

--- a/sdk/messaging/azeventhubs/internal/go-amqp/session.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/session.go
@@ -475,7 +475,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 					continue
 				}
 
-				if body.Echo {
+				if body.Echo && !closeInProgress {
 					niID := nextIncomingID
 					resp := &frames.PerformFlow{
 						NextIncomingID: &niID,
@@ -538,7 +538,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}
 
 				// Update peer's outgoing window if half has been consumed.
-				if s.needFlowCount >= s.incomingWindow/2 {
+				if s.needFlowCount >= s.incomingWindow/2 && !closeInProgress {
 					debug.Log(3, "RX (Session %p): channel %d: flow - s.needFlowCount(%d) >= s.incomingWindow(%d)/2\n", s, s.channel, s.needFlowCount, s.incomingWindow)
 					s.needFlowCount = 0
 					nID := nextIncomingID

--- a/sdk/messaging/azeventhubs/internal/go-amqp/session.go
+++ b/sdk/messaging/azeventhubs/internal/go-amqp/session.go
@@ -36,11 +36,11 @@ type SessionOptions struct {
 //
 // A session multiplexes Receivers.
 type Session struct {
-	channel       uint16                       // session's local channel
-	remoteChannel uint16                       // session's remote channel, owned by conn.connReader
-	conn          *Conn                        // underlying conn
-	tx            chan frames.FrameBody        // non-transfer frames to be sent; session must track disposition
-	txTransfer    chan *frames.PerformTransfer // transfer frames to be sent; session must track disposition
+	channel       uint16                 // session's local channel
+	remoteChannel uint16                 // session's remote channel, owned by conn.connReader
+	conn          *Conn                  // underlying conn
+	tx            chan frameBodyEnvelope // non-transfer frames to be sent; session must track disposition
+	txTransfer    chan transferEnvelope  // transfer frames to be sent; session must track disposition
 
 	// frames destined for this session are added to this queue by conn.connReader
 	rxQ *queue.Holder[frames.FrameBody]
@@ -57,30 +57,34 @@ type Session struct {
 	linksByKey map[linkKey]*link // mapping of name+role link
 	handles    *bitmap.Bitmap    // allocated handles
 
+	abandonedLinksMu sync.Mutex
+	abandonedLinks   []*link
+
 	// used for gracefully closing session
-	close      chan struct{}
-	forceClose chan struct{}
-	closeOnce  sync.Once
+	close     chan struct{} // closed by calling Close(). it signals that the end performative should be sent
+	closeOnce sync.Once
 
 	// part of internal public surface area
-	done    chan struct{} // closed when the session has terminated (mux exited); DO NOT wait on this from within Session.mux() as it will never trigger!
-	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of session.go until done has been closed!
+	done     chan struct{} // closed when the session has terminated (mux exited); DO NOT wait on this from within Session.mux() as it will never trigger!
+	endSent  chan struct{} // closed when the end performative has been sent; once this is closed, links MUST NOT send any frames!
+	doneErr  error         // contains the mux error state; ONLY written to by the mux and MUST only be read from after done is closed!
+	closeErr error         // contains the error state returned from Close(); ONLY Close() reads/writes this!
 }
 
 func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 	s := &Session{
 		conn:           c,
 		channel:        channel,
-		tx:             make(chan frames.FrameBody),
-		txTransfer:     make(chan *frames.PerformTransfer),
+		tx:             make(chan frameBodyEnvelope),
+		txTransfer:     make(chan transferEnvelope),
 		incomingWindow: defaultWindow,
 		outgoingWindow: defaultWindow,
 		handleMax:      math.MaxUint32,
 		linksMu:        sync.RWMutex{},
 		linksByKey:     make(map[linkKey]*link),
 		close:          make(chan struct{}),
-		forceClose:     make(chan struct{}),
 		done:           make(chan struct{}),
+		endSent:        make(chan struct{}),
 	}
 
 	if opts != nil {
@@ -130,7 +134,9 @@ func (s *Session) begin(ctx context.Context) error {
 		HandleMax:      s.handleMax,
 	}
 
-	_ = s.txFrame(begin, nil)
+	if err := s.txFrameAndWait(ctx, begin); err != nil {
+		return err
+	}
 
 	// wait for response
 	fr, err := s.waitForFrame(ctx)
@@ -149,7 +155,7 @@ func (s *Session) begin(ctx context.Context) error {
 		// either swallow the frame or blow up in some other way, both causing this call to hang.
 		// deallocate session on error.  we can't call
 		// s.Close() as the session mux hasn't started yet.
-		debug.Log(1, "RX (Session): unexpected begin response frame %T", fr)
+		debug.Log(1, "RX (Session %p): unexpected begin response frame %T", s, fr)
 		s.conn.deleteSession(s)
 		if err := s.conn.Close(); err != nil {
 			return err
@@ -167,18 +173,29 @@ func (s *Session) begin(ctx context.Context) error {
 //   - ctx controls waiting for the peer to acknowledge the session is closed
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned.  However, the operation will continue to
+// execute in the background. Subsequent calls will return a *SessionError
+// that contains the context's error message.
 func (s *Session) Close(ctx context.Context) error {
 	var ctxErr error
 	s.closeOnce.Do(func() {
 		close(s.close)
+
+		// once the mux has received the ack'ing end performative, the mux will
+		// exit which deletes the session and closes s.done.
 		select {
 		case <-s.done:
-			// mux has exited
+			s.closeErr = s.doneErr
+
 		case <-ctx.Done():
-			close(s.forceClose)
+			// notify the caller that the close timed out/was cancelled.
+			// the mux will remain running and once the ack is received it will terminate.
 			ctxErr = ctx.Err()
+
+			// record that the close timed out/was cancelled.
+			// subsequent calls to Close() will return this
+			debug.Log(1, "TX (Session %p) channel %d: %v", s, s.channel, ctxErr)
+			s.closeErr = &SessionError{inner: ctxErr}
 		}
 	})
 
@@ -187,22 +204,33 @@ func (s *Session) Close(ctx context.Context) error {
 	}
 
 	var sessionErr *SessionError
-	if errors.As(s.doneErr, &sessionErr) && sessionErr.RemoteErr == nil && sessionErr.inner == nil {
-		// an empty SessionError means the session was closed by the caller
+	if errors.As(s.closeErr, &sessionErr) && sessionErr.RemoteErr == nil && sessionErr.inner == nil {
+		// an empty SessionError means the session was cleanly closed by the caller
 		return nil
 	}
-	return s.doneErr
+	return s.closeErr
 }
 
 // txFrame sends a frame to the connWriter.
-// it returns an error if the connection has been closed.
-func (s *Session) txFrame(p frames.FrameBody, done chan encoding.DeliveryState) error {
-	return s.conn.sendFrame(frames.Frame{
+//   - ctx is used to provide the write deadline
+//   - fr is the frame to write to net.Conn
+//   - sent is the optional channel that will contain the error if the write fails
+func (s *Session) txFrame(ctx context.Context, fr frames.FrameBody, sent chan error) {
+	debug.Log(2, "TX (Session %p) mux frame to Conn (%p): %s", s, s.conn, fr)
+	s.conn.sendFrame(ctx, frames.Frame{
 		Type:    frames.TypeAMQP,
 		Channel: s.channel,
-		Body:    p,
-		Done:    done,
-	})
+		Body:    fr,
+	}, sent)
+}
+
+// txFrameAndWait sends a frame to the connWriter and waits for the write to complete
+//   - ctx is used to provide the write deadline
+//   - fr is the frame to write to net.Conn
+func (s *Session) txFrameAndWait(ctx context.Context, fr frames.FrameBody) error {
+	sent := make(chan error, 1)
+	s.txFrame(ctx, fr, sent)
+	return <-sent
 }
 
 // NewReceiver opens a new receiver link on the session.
@@ -211,8 +239,8 @@ func (s *Session) txFrame(p frames.FrameBody, done chan encoding.DeliveryState) 
 //   - opts contains optional values, pass nil to accept the defaults
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned. If the Receiver was successfully
+// created, it will be cleaned up in future calls to NewReceiver.
 func (s *Session) NewReceiver(ctx context.Context, source string, opts *ReceiverOptions) (*Receiver, error) {
 	r, err := newReceiver(source, s, opts)
 	if err != nil {
@@ -221,6 +249,8 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 	if err = r.attach(ctx); err != nil {
 		return nil, err
 	}
+
+	go r.mux(receiverTestHooks{})
 
 	return r, nil
 }
@@ -231,8 +261,8 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 //   - opts contains optional values, pass nil to accept the defaults
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned. If the Sender was successfully
+// created, it will be cleaned up in future calls to NewSender.
 func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOptions) (*Sender, error) {
 	l, err := newSender(target, s, opts)
 	if err != nil {
@@ -247,7 +277,6 @@ func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOpti
 
 func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 	defer func() {
-		s.conn.deleteSession(s)
 		if s.doneErr == nil {
 			s.doneErr = &SessionError{}
 		} else if connErr := (&ConnError{}); !errors.As(s.doneErr, &connErr) {
@@ -284,29 +313,34 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 	closeWithError := func(e1 *Error, e2 error) {
 		if closeInProgress {
-			debug.Log(3, "TX (Session): close already pending, discarding %v", e1)
+			debug.Log(3, "TX (Session %p): close already pending, discarding %v", s, e1)
 			return
 		}
 
 		closeInProgress = true
 		s.doneErr = e2
-		_ = s.txFrame(&frames.PerformEnd{Error: e1}, nil)
+		s.txFrame(context.Background(), &frames.PerformEnd{Error: e1}, nil)
+		close(s.endSent)
 	}
 
 	for {
 		txTransfer := s.txTransfer
 		// disable txTransfer if flow control windows have been exceeded
 		if remoteIncomingWindow == 0 || s.outgoingWindow == 0 {
-			debug.Log(1, "TX (Session): disabling txTransfer - window exceeded. remoteIncomingWindow: %d outgoingWindow: %d",
-				remoteIncomingWindow,
-				s.outgoingWindow)
+			debug.Log(1, "TX (Session %p): disabling txTransfer - window exceeded. remoteIncomingWindow: %d outgoingWindow: %d",
+				s, remoteIncomingWindow, s.outgoingWindow)
 			txTransfer = nil
 		}
 
+		tx := s.tx
 		closed := s.close
 		if closeInProgress {
 			// swap out channel so it no longer triggers
 			closed = nil
+
+			// once the end performative is sent, we're not allowed to send any frames
+			tx = nil
+			txTransfer = nil
 		}
 
 		// notes on client-side closing session
@@ -324,11 +358,6 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			s.doneErr = s.conn.doneErr
 			return
 
-		case <-s.forceClose:
-			// the call to s.Close() timed out waiting for the ack
-			s.doneErr = errors.New("the session was forcibly closed")
-			return
-
 		case <-closed:
 			if closeInProgress {
 				// a client-side close due to protocol error is in progress
@@ -336,14 +365,14 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			}
 			// session is being closed by the client
 			closeInProgress = true
-			fr := frames.PerformEnd{}
-			_ = s.txFrame(&fr, nil)
+			s.txFrame(context.Background(), &frames.PerformEnd{}, nil)
+			close(s.endSent)
 
 		// incoming frame
 		case q := <-s.rxQ.Wait():
 			fr := *q.Dequeue()
 			s.rxQ.Release(q)
-			debug.Log(2, "RX (Session): %s", fr)
+			debug.Log(2, "RX (Session %p): %s", s, fr)
 
 			switch body := fr.(type) {
 			// Disposition frames can reference transfers from more than one
@@ -362,7 +391,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 					handle, ok := handles[deliveryID]
 					if !ok {
-						debug.Log(2, "RX (Session): role %s: didn't find deliveryID %d in handles map", body.Role, deliveryID)
+						debug.Log(2, "RX (Session %p): role %s: didn't find deliveryID %d in handles map", s, body.Role, deliveryID)
 						continue
 					}
 					delete(handles, deliveryID)
@@ -421,7 +450,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				// initial-outgoing-id(endpoint) + incoming-window(flow) - next-outgoing-id(endpoint)"
 				remoteIncomingWindow = body.IncomingWindow - nextOutgoingID
 				remoteIncomingWindow += *body.NextIncomingID
-				debug.Log(3, "RX (Session): flow - remoteOutgoingWindow: %d remoteIncomingWindow: %d nextOutgoingID: %d", remoteOutgoingWindow, remoteIncomingWindow, nextOutgoingID)
+				debug.Log(3, "RX (Session %p): flow - remoteOutgoingWindow: %d remoteIncomingWindow: %d nextOutgoingID: %d", s, remoteOutgoingWindow, remoteIncomingWindow, nextOutgoingID)
 
 				// Send to link if handle is set
 				if body.Handle != nil {
@@ -446,7 +475,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 						NextOutgoingID: nextOutgoingID,
 						OutgoingWindow: s.outgoingWindow,
 					}
-					_ = s.txFrame(resp, nil)
+					s.txFrame(context.Background(), resp, nil)
 				}
 
 			case *frames.PerformAttach:
@@ -493,17 +522,16 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}
 
 				s.muxFrameToLink(link, fr)
-				debug.Log(2, "RX (Session): mux transfer to link: %s", fr)
 
 				// if this message is received unsettled and link rcv-settle-mode == second, add to handlesByRemoteDeliveryID
 				if !body.Settled && body.DeliveryID != nil && link.receiverSettleMode != nil && *link.receiverSettleMode == ReceiverSettleModeSecond {
-					debug.Log(1, "RX (Session): adding handle to handlesByRemoteDeliveryID. delivery ID: %d", *body.DeliveryID)
+					debug.Log(1, "RX (Session %p): adding handle to handlesByRemoteDeliveryID. delivery ID: %d", s, *body.DeliveryID)
 					handlesByRemoteDeliveryID[*body.DeliveryID] = body.Handle
 				}
 
 				// Update peer's outgoing window if half has been consumed.
 				if s.needFlowCount >= s.incomingWindow/2 {
-					debug.Log(3, "RX (Session): channel %d: flow - s.needFlowCount(%d) >= s.incomingWindow(%d)/2\n", s.channel, s.needFlowCount, s.incomingWindow)
+					debug.Log(3, "RX (Session %p): channel %d: flow - s.needFlowCount(%d) >= s.incomingWindow(%d)/2\n", s, s.channel, s.needFlowCount, s.incomingWindow)
 					s.needFlowCount = 0
 					nID := nextIncomingID
 					flow := &frames.PerformFlow{
@@ -512,7 +540,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 						NextOutgoingID: nextOutgoingID,
 						OutgoingWindow: s.outgoingWindow,
 					}
-					_ = s.txFrame(flow, nil)
+					s.txFrame(context.Background(), flow, nil)
 				}
 
 			case *frames.PerformDetach:
@@ -533,6 +561,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				// are safe to clean up its state.
 				delete(links, link.remoteHandle)
 				delete(deliveryIDByHandle, link.handle)
+				s.deallocateHandle(link)
 
 			case *frames.PerformEnd:
 				// there are two possibilities:
@@ -549,28 +578,21 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}
 
 				fr := frames.PerformEnd{}
-				_ = s.txFrame(&fr, nil)
+				s.txFrame(context.Background(), &fr, nil)
 
 				// per spec, when end is received, we're no longer allowed to receive frames
 				return
 
 			default:
-				debug.Log(1, "RX (Session): unexpected frame: %s\n", body)
+				debug.Log(1, "RX (Session %p): unexpected frame: %s\n", s, body)
 				closeWithError(&Error{
 					Condition:   ErrCondInternalError,
 					Description: "session received unexpected frame",
 				}, fmt.Errorf("internal error: unexpected frame %T", body))
 			}
 
-		case fr := <-txTransfer:
-			if closeInProgress {
-				// now that the end performative has been sent we're
-				// not allowed to send any more frames.
-				debug.Log(1, "TX (Session): discarding transfer: %s\n", fr)
-				continue
-			}
-
-			debug.Log(2, "TX (Session): %d, %s", s.channel, fr)
+		case env := <-txTransfer:
+			fr := &env.Frame
 			// record current delivery ID
 			var deliveryID uint32
 			if fr.DeliveryID == &needsDeliveryID {
@@ -589,19 +611,30 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				deliveryID = deliveryIDByHandle[fr.Handle]
 			}
 
+			// log after the delivery ID has been assigned
+			debug.Log(2, "TX (Session %p): %d, %s", s, s.channel, fr)
+
 			// frame has been sender-settled, remove from map
 			if fr.Settled {
 				delete(handlesByDeliveryID, deliveryID)
 			}
 
-			// if not settled, add done chan to map
-			// and clear from frame so conn doesn't close it.
-			if !fr.Settled && fr.Done != nil {
-				settlementByDeliveryID[deliveryID] = fr.Done
-				fr.Done = nil
+			s.txFrame(env.Ctx, fr, env.Sent)
+			if sendErr := <-env.Sent; sendErr != nil {
+				s.doneErr = sendErr
+
+				// put the error back as our sender will read from this channel
+				env.Sent <- sendErr
+				return
 			}
 
-			_ = s.txFrame(fr, fr.Done)
+			// if not settled, add done chan to map
+			if !fr.Settled && fr.Done != nil {
+				settlementByDeliveryID[deliveryID] = fr.Done
+			} else if fr.Done != nil {
+				// sender-settled, close done now that the transfer has been sent
+				close(fr.Done)
+			}
 
 			// "Upon sending a transfer, the sending endpoint will increment
 			// its next-outgoing-id, decrement its remote-incoming-window,
@@ -612,16 +645,10 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				remoteIncomingWindow--
 			}
 
-		case fr := <-s.tx:
-			if closeInProgress {
-				// now that the end performative has been sent we're
-				// not allowed to send any more frames.
-				debug.Log(1, "TX (Session): discarding frame: %s\n", fr)
-				continue
-			}
-
-			debug.Log(2, "TX (Session): %d, %s", s.channel, fr)
-			switch fr := fr.(type) {
+		case env := <-tx:
+			fr := env.FrameBody
+			debug.Log(2, "TX (Session %p): %d, %s", s, s.channel, fr)
+			switch fr := env.FrameBody.(type) {
 			case *frames.PerformDisposition:
 				if fr.Settled && fr.Role == encoding.RoleSender {
 					// sender with a peer that's in mode second; sending confirmation of disposition.
@@ -645,24 +672,24 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 						}
 					}
 				}
-				_ = s.txFrame(fr, nil)
+				s.txFrame(env.Ctx, fr, env.Sent)
 			case *frames.PerformFlow:
 				niID := nextIncomingID
 				fr.NextIncomingID = &niID
 				fr.IncomingWindow = s.incomingWindow
 				fr.NextOutgoingID = nextOutgoingID
 				fr.OutgoingWindow = s.outgoingWindow
-				_ = s.txFrame(fr, nil)
+				s.txFrame(context.Background(), fr, env.Sent)
 			case *frames.PerformTransfer:
 				panic("transfer frames must use txTransfer")
 			default:
-				_ = s.txFrame(fr, nil)
+				s.txFrame(context.Background(), fr, env.Sent)
 			}
 		}
 	}
 }
 
-func (s *Session) allocateHandle(l *link) error {
+func (s *Session) allocateHandle(ctx context.Context, l *link) error {
 	s.linksMu.Lock()
 	defer s.linksMu.Unlock()
 
@@ -674,8 +701,11 @@ func (s *Session) allocateHandle(l *link) error {
 
 	next, ok := s.handles.Next()
 	if !ok {
+		if err := s.Close(ctx); err != nil {
+			return err
+		}
 		// handle numbers are zero-based, report the actual count
-		return fmt.Errorf("reached session handle max (%d)", s.handleMax+1)
+		return &SessionError{inner: fmt.Errorf("reached session handle max (%d)", s.handleMax+1)}
 	}
 
 	l.handle = next         // allocate handle to the link
@@ -692,11 +722,50 @@ func (s *Session) deallocateHandle(l *link) {
 	s.handles.Remove(l.handle)
 }
 
+func (s *Session) abandonLink(l *link) {
+	s.abandonedLinksMu.Lock()
+	defer s.abandonedLinksMu.Unlock()
+	s.abandonedLinks = append(s.abandonedLinks, l)
+}
+
+func (s *Session) freeAbandonedLinks(ctx context.Context) error {
+	s.abandonedLinksMu.Lock()
+	defer s.abandonedLinksMu.Unlock()
+
+	for _, l := range s.abandonedLinks {
+		dr := &frames.PerformDetach{
+			Handle: l.handle,
+			Closed: true,
+		}
+		if err := s.txFrameAndWait(ctx, dr); err != nil {
+			return err
+		}
+	}
+
+	s.abandonedLinks = nil
+	return nil
+}
+
 func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
 	q := l.rxQ.Acquire()
 	q.Enqueue(fr)
 	l.rxQ.Release(q)
-	debug.Log(2, "RX (Session): mux frame to link: %s, %s", l.key.name, fr)
+	debug.Log(2, "RX (Session %p): mux frame to link (%p): %s, %s", s, l, l.key.name, fr)
+}
+
+// transferEnvelope is used by senders to send transfer frames
+type transferEnvelope struct {
+	Ctx   context.Context
+	Frame frames.PerformTransfer
+	Sent  chan error
+}
+
+// frameBodyEnvelope is used by senders and receivers to send frames.
+// these frames come from the mux which is why there's no Sent channel.
+type frameBodyEnvelope struct {
+	Ctx       context.Context
+	FrameBody frames.FrameBody
+	Sent      chan error
 }
 
 // the address of this var is a sentinel value indicating

--- a/sdk/messaging/azeventhubs/internal/links.go
+++ b/sdk/messaging/azeventhubs/internal/links.go
@@ -98,20 +98,7 @@ func (l *Links[LinkT]) RecoverIfNeeded(ctx context.Context, partitionID string, 
 
 		if err := l.closePartitionLinkIfMatch(ctx, partitionID, lwid.Link.LinkName()); err != nil {
 			azlog.Writef(exported.EventConn, "(%s) Error when cleaning up old link for link recovery: %s", lwid.String(), err)
-
-			if GetRecoveryKind(err) == RecoveryKindConn {
-				log.Writef(exported.EventConn, "Upgrading to connection reset for recovery instead of link")
-
-				if err := l.ns.Recover(ctx, lwid.ConnID); err != nil {
-					log.Writef(exported.EventConn, "failed to recover connection: %s", err.Error())
-
-					// we still need the next recovery to attempt a connection level recovery
-					return amqpwrap.ErrConnResetNeeded
-				}
-			} else {
-				log.Writef(exported.EventConn, "failed to recreate link: %s", err.Error())
-				return err
-			}
+			return err
 		}
 
 		return nil

--- a/sdk/messaging/azeventhubs/internal/links.go
+++ b/sdk/messaging/azeventhubs/internal/links.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	azlog "github.com/Azure/azure-sdk-for-go/sdk/internal/log"
@@ -62,8 +61,6 @@ type Links[LinkT AMQPLink] struct {
 	managementPath string
 	newLinkFn      func(ctx context.Context, session amqpwrap.AMQPSession, partitionID string) (LinkT, error)
 	entityPathFn   func(partitionID string) string
-
-	contextWithTimeoutFn contextWithTimeoutFn // stubbable version of context.WithTimeout
 }
 
 type NewLinksFn[LinkT AMQPLink] func(ctx context.Context, session amqpwrap.AMQPSession, entityPath string) (LinkT, error)
@@ -76,9 +73,8 @@ func NewLinks[LinkT AMQPLink](ns NamespaceForAMQPLinks, managementPath string, e
 		managementLinkMu: &sync.RWMutex{},
 		managementPath:   managementPath,
 
-		newLinkFn:            newLinkFn,
-		entityPathFn:         entityPathFn,
-		contextWithTimeoutFn: context.WithTimeout,
+		newLinkFn:    newLinkFn,
+		entityPathFn: entityPathFn,
 	}
 }
 
@@ -93,9 +89,6 @@ func (l *Links[LinkT]) RecoverIfNeeded(ctx context.Context, partitionID string, 
 	case RecoveryKindNone:
 		return nil
 	case RecoveryKindLink:
-		ctx, cancel := l.contextWithTimeoutFn(ctx, defaultCloseTimeout)
-		defer cancel()
-
 		if err := l.closePartitionLinkIfMatch(ctx, partitionID, lwid.Link.LinkName()); err != nil {
 			azlog.Writef(exported.EventConn, "(%s) Error when cleaning up old link for link recovery: %s", lwid.String(), err)
 			return err
@@ -107,9 +100,6 @@ func (l *Links[LinkT]) RecoverIfNeeded(ctx context.Context, partitionID string, 
 		// We used to close _all_ the links, but no longer do that since it's possible (when we do receiver
 		// redirect) to have more than one active connection at a time which means not all links would be
 		// affected when a single connection goes down.
-		ctx, cancel := l.contextWithTimeoutFn(ctx, defaultCloseTimeout)
-		defer cancel()
-
 		if err := l.closePartitionLinkIfMatch(ctx, partitionID, lwid.Link.LinkName()); err != nil {
 			azlog.Writef(exported.EventConn, "(%s) Error when cleaning up old link: %s", lwid.String(), err)
 
@@ -132,9 +122,6 @@ func (l *Links[LinkT]) RecoverIfNeeded(ctx context.Context, partitionID string, 
 		//
 		// For #2, we may recreate the connection. It's possible we won't if the connection itself
 		// has already been recovered by another goroutine.
-		ctx, cancel = l.contextWithTimeoutFn(ctx, defaultCloseTimeout)
-		defer cancel()
-
 		err := l.ns.Recover(ctx, lwid.ConnID)
 
 		if err != nil {
@@ -511,9 +498,3 @@ func (ls *linkState[LinkT]) Close(ctx context.Context) error {
 
 	return nil
 }
-
-const defaultCloseTimeout = time.Minute
-
-// contextWithTimeoutFn matches the signature for `context.WithTimeout` and is used when we want to
-// stub things out for tests.
-type contextWithTimeoutFn func(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc)

--- a/sdk/messaging/azeventhubs/internal/links_test.go
+++ b/sdk/messaging/azeventhubs/internal/links_test.go
@@ -233,8 +233,8 @@ func newLinksForTest(t *testing.T) (*Namespace, *Links[amqpwrap.AMQPSenderCloser
 	ns, err := NewNamespace(NamespaceWithConnectionString(testParams.ConnectionString))
 	require.NoError(t, err)
 
-	links := NewLinks(ns, fmt.Sprintf("%s/$management", testParams.EventHubName), func(partitionID string) string {
-		return fmt.Sprintf("%s/Partitions/%s", testParams.EventHubName, partitionID)
+	links := NewLinks(ns, fmt.Sprintf("%s/$management", testParams.EventHubLinksOnlyName), func(partitionID string) string {
+		return fmt.Sprintf("%s/Partitions/%s", testParams.EventHubLinksOnlyName, partitionID)
 	}, func(ctx context.Context, session amqpwrap.AMQPSession, entityPath string) (AMQPSenderCloser, error) {
 		select {
 		case <-ctx.Done():

--- a/sdk/messaging/azeventhubs/internal/links_test.go
+++ b/sdk/messaging/azeventhubs/internal/links_test.go
@@ -96,7 +96,7 @@ func TestLinksRecoverLinkWithConnectionFailure(t *testing.T) {
 	requireNewLinkNewConn(t, oldLWID, newLWID)
 
 	err = newLWID.Link.Send(context.Background(), &amqp.Message{
-		Data: [][]byte{[]byte("hello world")},
+		Data: [][]byte{[]byte("TestLinksRecoverLinkWithConnectionFailure")},
 	}, nil)
 	require.NoError(t, err)
 }
@@ -182,7 +182,7 @@ func TestLinkFailureWhenConnectionIsDead(t *testing.T) {
 	requireNewLinkNewConn(t, oldLWID, newLWID)
 
 	err = newLWID.Link.Send(context.Background(), &amqp.Message{
-		Data: [][]byte{[]byte("hello world")},
+		Data: [][]byte{[]byte("TestLinkFailureWhenConnectionIsDead")},
 	}, nil)
 	require.NoError(t, err)
 }

--- a/sdk/messaging/azeventhubs/internal/namespace.go
+++ b/sdk/messaging/azeventhubs/internal/namespace.go
@@ -290,8 +290,7 @@ func (ns *Namespace) Recover(ctx context.Context, theirConnID uint64) error {
 
 // negotiateClaimFn matches the signature for NegotiateClaim, and is used when we want to stub things out for tests.
 type negotiateClaimFn func(
-	ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider,
-	contextWithTimeoutFn contextWithTimeoutFn) error
+	ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider) error
 
 // negotiateClaim performs initial authentication and starts periodic refresh of credentials.
 // the returned func is to cancel() the refresh goroutine.
@@ -334,7 +333,7 @@ func (ns *Namespace) startNegotiateClaimRenewer(ctx context.Context,
 		// The current cbs.NegotiateClaim implementation automatically creates and shuts
 		// down it's own link so we have to guard against that here.
 		ns.negotiateClaimMu.Lock()
-		err = cbsNegotiateClaim(ctx, audience, amqpClient, token, context.WithTimeout)
+		err = cbsNegotiateClaim(ctx, audience, amqpClient, token)
 		ns.negotiateClaimMu.Unlock()
 
 		if err != nil {

--- a/sdk/messaging/azeventhubs/internal/namespace_test.go
+++ b/sdk/messaging/azeventhubs/internal/namespace_test.go
@@ -67,7 +67,7 @@ func TestNamespaceNegotiateClaim(t *testing.T) {
 
 	cbsNegotiateClaimCalled := 0
 
-	cbsNegotiateClaim := func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider, contextWithTimeoutFn contextWithTimeoutFn) error {
+	cbsNegotiateClaim := func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider) error {
 		cbsNegotiateClaimCalled++
 		return nil
 	}
@@ -111,7 +111,7 @@ func TestNamespaceNegotiateClaimRenewal(t *testing.T) {
 
 	cbsNegotiateClaimCalled := 0
 
-	cbsNegotiateClaim := func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider, contextWithTimeoutFn contextWithTimeoutFn) error {
+	cbsNegotiateClaim := func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider) error {
 		cbsNegotiateClaimCalled++
 		return nil
 	}
@@ -160,7 +160,7 @@ func TestNamespaceNegotiateClaimFailsToGetClient(t *testing.T) {
 	cancel, _, err := ns.startNegotiateClaimRenewer(
 		context.Background(),
 		"entity path",
-		func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider, contextWithTimeoutFn contextWithTimeoutFn) error {
+		func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider) error {
 			return errors.New("NegotiateClaim amqp.Client failed")
 		}, func(expirationTime, currentTime time.Time) time.Duration {
 			// refresh immediately since we're in a unit test.
@@ -182,7 +182,7 @@ func TestNamespaceNegotiateClaimNonRenewableToken(t *testing.T) {
 
 	cbsNegotiateClaimCalled := 0
 
-	cbsNegotiateClaim := func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider, contextWithTimeoutFn contextWithTimeoutFn) error {
+	cbsNegotiateClaim := func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider) error {
 		cbsNegotiateClaimCalled++
 		return nil
 	}
@@ -222,7 +222,7 @@ func TestNamespaceNegotiateClaimFails(t *testing.T) {
 	cancel, _, err := ns.startNegotiateClaimRenewer(
 		context.Background(),
 		"entity path",
-		func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider, contextWithTimeoutFn contextWithTimeoutFn) error {
+		func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider) error {
 			return errors.New("NegotiateClaim amqp.Client failed")
 		}, func(expirationTime, currentTime time.Time) time.Duration {
 			// not even used.
@@ -240,7 +240,7 @@ func TestNamespaceNegotiateClaimFatalErrors(t *testing.T) {
 
 	cbsNegotiateClaimCalled := 0
 
-	cbsNegotiateClaim := func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider, contextWithTimeoutFn contextWithTimeoutFn) error {
+	cbsNegotiateClaim := func(ctx context.Context, audience string, conn amqpwrap.AMQPClient, provider auth.TokenProvider) error {
 		cbsNegotiateClaimCalled++
 
 		// work the first time, fail on renewals.

--- a/sdk/messaging/azeventhubs/internal/rpc.go
+++ b/sdk/messaging/azeventhubs/internal/rpc.go
@@ -309,7 +309,11 @@ func (l *rpcLink) RPC(ctx context.Context, msg *amqp.Message) (*amqpwrap.RPCResp
 // Close the link receiver, sender and session
 func (l *rpcLink) Close(ctx context.Context) error {
 	l.rpcLinkCtxCancel()
-	<-l.responseRouterClosed
+
+	// select {
+	// case <-l.responseRouterClosed:
+	// case <-ctx.Done():
+	// }
 
 	if l.session != nil {
 		return l.session.Close(ctx)

--- a/sdk/messaging/azeventhubs/internal/rpc.go
+++ b/sdk/messaging/azeventhubs/internal/rpc.go
@@ -82,7 +82,7 @@ type RPCLinkArgs struct {
 }
 
 // NewRPCLink will build a new request response link
-func NewRPCLink(ctx context.Context, args RPCLinkArgs) (*rpcLink, error) {
+func NewRPCLink(ctx context.Context, args RPCLinkArgs) (amqpwrap.RPCLink, error) {
 	session, err := args.Client.NewSession(ctx, nil)
 
 	if err != nil {

--- a/sdk/messaging/azeventhubs/internal/rpc_test.go
+++ b/sdk/messaging/azeventhubs/internal/rpc_test.go
@@ -39,8 +39,11 @@ func TestRPCLink(t *testing.T) {
 			Address:  "fake-address",
 			LogEvent: log.Event("testing"),
 		})
+
 		require.NoError(t, err)
 		require.NotNil(t, rpcLink)
+
+		defer test.RequireClose(t, rpcLink)
 
 		require.Zero(t, fakeClient.session.CloseCalled)
 		require.Zero(t, fakeClient.session.NS.Receiver.CloseCalled)

--- a/sdk/messaging/azeventhubs/internal/rpc_test.go
+++ b/sdk/messaging/azeventhubs/internal/rpc_test.go
@@ -6,9 +6,16 @@ package internal
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/amqpwrap"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/go-amqp"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/mock"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/test"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,4 +82,356 @@ func TestRPCLink(t *testing.T) {
 		require.Equal(t, 1, fakeClient.session.NS.NewSenderCalled, "sender creation failed, but was called")
 		require.Equal(t, 1, fakeClient.session.CloseCalled, "session closed as part of cleanup")
 	})
+}
+
+// TestRPCLinkNonErrorRequiresRecovery shows that an error, if it requires recovery,
+// will cause the RPCLink to properly broadcast the failure so the caller can initiate
+// a link recreation/connection recovery (or potentially just fail out)
+func TestRPCLinkNonErrorRequiresRecovery(t *testing.T) {
+	tester := &rpcTester{t: t, ResponsesCh: make(chan *rpcTestResp, 1000)}
+
+	link, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client: &rpcTesterClient{
+			session: tester,
+		},
+		Address:  "some-address",
+		LogEvent: "rpctesting",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, link)
+
+	defer func() { require.NoError(t, link.Close(context.Background())) }()
+
+	messagesCh := make(chan string, 10000)
+	endCapture := test.CaptureLogsForTestWithChannel(messagesCh)
+	defer endCapture()
+
+	responses := []*rpcTestResp{
+		// this error requires recovery (in this case, connection but there's no
+		// distinction between types in RPCLink)
+		{E: &net.DNSError{}},
+	}
+
+	resp, err := link.RPC(context.Background(), &amqp.Message{
+		ApplicationProperties: map[string]any{
+			rpcTesterProperty: responses,
+		},
+	})
+	require.Nil(t, resp)
+
+	// (give the response router a teeny bit to shut down)
+	time.Sleep(500 * time.Millisecond)
+
+	var netOpError net.Error
+	require.ErrorAs(t, err, &netOpError)
+
+LogLoop:
+	for {
+		select {
+		case msg := <-messagesCh:
+			if msg == "[rpctesting] "+responseRouterShutdownMessage {
+				break LogLoop
+			}
+		default:
+			require.Fail(t, "RPC router never shut down")
+		}
+	}
+}
+
+func TestRPCLinkNonErrorRequiresNoRecovery(t *testing.T) {
+	tester := &rpcTester{t: t, ResponsesCh: make(chan *rpcTestResp, 1000), Accepted: make(chan *amqp.Message, 1)}
+
+	link, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client: &rpcTesterClient{
+			session: tester,
+		},
+		Address:  "some-address",
+		LogEvent: "rpctesting",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, link)
+
+	defer func() { require.NoError(t, link.Close(context.Background())) }()
+
+	cleanupLogs := test.CaptureLogsForTest()
+	defer cleanupLogs()
+
+	responses := []*rpcTestResp{
+		// server busy is a "retry, no reconnect needed" type of error. The response router
+		// will just immediately go back to receiving.
+		{E: exampleServerBusyError},
+		// uncorrelated message, will generate a warning but we'll continue on
+		{M: exampleUncorrelatedMessage},
+		// this is an actual response and it correlates to the message we sent. We'll get this
+		// response back.
+		{M: exampleMessageWithStatusCode(200)},
+	}
+
+	resp, err := link.RPC(context.Background(), &amqp.Message{
+		ApplicationProperties: map[string]any{
+			rpcTesterProperty: responses,
+		},
+		Properties: &amqp.MessageProperties{
+			MessageID: "hello",
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Code)
+	require.Equal(t, "response from service", resp.Message.Value)
+
+	acceptedMessage := <-tester.Accepted
+	require.Equal(t, "response from service", acceptedMessage.Value, "successfully received message is accepted")
+
+	logMessages := cleanupLogs()
+	require.Contains(t, logMessages, "[rpctesting] RPCLink had no response channel for correlation ID you've-never-seen-this", "exampleUncorrelatedMessage causes warning for uncorrelated message")
+	require.Contains(t, logMessages, "[rpctesting] Non-fatal error in RPCLink, starting to receive again: *Error{Condition: com.microsoft:server-busy, Description: , Info: map[]}")
+}
+
+func TestRPCLinkNonErrorLockLostDoesNotBreakAnything(t *testing.T) {
+	tester := &rpcTester{t: t, ResponsesCh: make(chan *rpcTestResp, 1000), Accepted: make(chan *amqp.Message, 1)}
+
+	link, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client: &rpcTesterClient{
+			session: tester,
+		},
+		Address:  "some-address",
+		LogEvent: "rpctesting",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, link)
+
+	resp, err := link.RPC(context.Background(), &amqp.Message{
+		ApplicationProperties: map[string]any{
+			rpcTesterProperty: []*rpcTestResp{
+				{M: exampleMessageWithStatusCode(400)},
+			},
+		},
+	})
+
+	// the 400 automatically gets translated into an RPC error. The response router should still be running.
+	require.Nil(t, resp)
+	var rpcErr RPCError
+	require.ErrorAs(t, err, &rpcErr)
+	require.Equal(t, 400, rpcErr.RPCCode())
+
+	acceptedMessage := <-tester.Accepted
+	require.Equal(t, "response from service", acceptedMessage.Value, "successfully received message is accepted")
+
+	// validate that a normal error doesn't cause the response router to shut down
+	resp, err = link.RPC(context.Background(), &amqp.Message{
+		ApplicationProperties: map[string]any{
+			rpcTesterProperty: []*rpcTestResp{
+				{M: exampleMessageWithStatusCode(200)},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "response from service", resp.Message.Value)
+	acceptedMessage = <-tester.Accepted
+	require.Equal(t, "response from service", acceptedMessage.Value, "successfully received message is accepted")
+}
+
+func TestRPCLinkClosingClean_SessionCreationFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	conn := mock.NewMockAMQPClient(ctrl)
+
+	sessionErr := errors.New("failed to create session")
+
+	conn.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(nil, sessionErr)
+
+	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client:   conn,
+		Address:  "rpcAddress",
+		LogEvent: "Testing",
+	})
+	require.EqualError(t, err, sessionErr.Error())
+	require.Nil(t, rpcLink)
+}
+
+func TestRPCLinkClosingClean_SenderCreationFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	conn := mock.NewMockAMQPClient(ctrl)
+	sess := mock.NewMockAMQPSession(ctrl)
+
+	senderErr := errors.New("failed to create sender")
+
+	conn.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(sess, nil)
+	sess.EXPECT().NewSender(mock.NotCancelled, "rpcAddress", gomock.Any()).Return(nil, senderErr)
+	sess.EXPECT().Close(mock.NotCancelled).Return(nil)
+
+	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client:   conn,
+		Address:  "rpcAddress",
+		LogEvent: "Testing",
+	})
+	require.EqualError(t, err, senderErr.Error())
+	require.Nil(t, rpcLink)
+}
+
+func TestRPCLinkClosingClean_ReceiverCreationFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	conn := mock.NewMockAMQPClient(ctrl)
+	sess := mock.NewMockAMQPSession(ctrl)
+	sender := mock.NewMockAMQPSenderCloser(ctrl)
+
+	receiverErr := errors.New("failed to create receiver")
+
+	conn.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(sess, nil)
+	sess.EXPECT().NewSender(mock.NotCancelled, "rpcAddress", gomock.Any()).Return(sender, nil)
+	sess.EXPECT().NewReceiver(mock.NotCancelled, "rpcAddress", gomock.Any()).Return(nil, receiverErr)
+
+	sess.EXPECT().Close(mock.NotCancelled).Return(nil)
+
+	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client:   conn,
+		Address:  "rpcAddress",
+		LogEvent: "Testing",
+	})
+	require.EqualError(t, err, receiverErr.Error())
+	require.Nil(t, rpcLink)
+}
+
+func TestRPCLinkClosingClean_CreationFailsButSessionCloseFailsToo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	conn := mock.NewMockAMQPClient(ctrl)
+	sess := mock.NewMockAMQPSession(ctrl)
+
+	senderErr := errors.New("failed to create receiver")
+
+	conn.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(sess, nil)
+	sess.EXPECT().NewSender(mock.NotCancelled, "rpcAddress", gomock.Any()).Return(nil, senderErr)
+	sess.EXPECT().Close(mock.NotCancelled).Return(errors.New("session closing failed"))
+
+	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
+		Client:   conn,
+		Address:  "rpcAddress",
+		LogEvent: "Testing",
+	})
+	require.EqualError(t, err, senderErr.Error(), "original error is more relevant, so we favor it over session.Close()")
+	require.Nil(t, rpcLink)
+}
+
+// rpcTester has all the functions needed (for our RPC tests) to be:
+// - an AMQPSession
+// - an AMQPReceiverCloser
+// - an AMQPSenderCloser
+// This just makes it simpler since there's this request/response pattern that the tests need. Rather than
+// spread it out we can do all the communicating here.
+type rpcTester struct {
+	amqpwrap.AMQPSenderCloser
+	amqpwrap.AMQPReceiverCloser
+
+	// Accepted contains all the messages where we called AcceptMessage(msg)
+	// We only call this when we
+	Accepted    chan *amqp.Message
+	ResponsesCh chan *rpcTestResp
+	t           *testing.T
+}
+
+type rpcTestResp struct {
+	M *amqp.Message
+	E error
+}
+
+type rpcTesterClient struct {
+	session amqpwrap.AMQPSession
+}
+
+func (c *rpcTesterClient) Name() string {
+	return "rpcClientName"
+}
+
+func (c *rpcTesterClient) NewSession(ctx context.Context, opts *amqp.SessionOptions) (amqpwrap.AMQPSession, error) {
+	return c.session, nil
+}
+
+func (c *rpcTesterClient) Close() error { return nil }
+
+func (tester *rpcTester) NewReceiver(ctx context.Context, source string, opts *amqp.ReceiverOptions) (amqpwrap.AMQPReceiverCloser, error) {
+	return tester, nil
+}
+
+func (tester *rpcTester) NewSender(ctx context.Context, target string, opts *amqp.SenderOptions) (amqpwrap.AMQPSenderCloser, error) {
+	return tester, nil
+}
+
+func (tester *rpcTester) Close(ctx context.Context) error {
+	return nil
+}
+
+func (tester *rpcTester) LinkName() string {
+	return "hello"
+}
+
+// receiver functions
+
+func (tester *rpcTester) AcceptMessage(ctx context.Context, msg *amqp.Message) error {
+	require.NotNil(tester.t, tester.Accepted, "No messages should be AcceptMessage()'d since the tester.Accepted channel was nil")
+	tester.Accepted <- msg
+	return nil
+}
+
+func (tester *rpcTester) Receive(ctx context.Context, o *amqp.ReceiveOptions) (*amqp.Message, error) {
+	resp := <-tester.ResponsesCh
+	return resp.M, resp.E
+}
+
+// sender functions
+
+func (tester *rpcTester) Send(ctx context.Context, msg *amqp.Message, o *amqp.SendOptions) error {
+	require.NotEmpty(tester.t, msg.Properties.MessageID)
+
+	// we'll let the payload dictate the response
+	if msg.ApplicationProperties["test-send-error"] != nil {
+		sendErr := msg.ApplicationProperties["test-send-error"].(error)
+		delete(msg.ApplicationProperties, "test-send-error")
+
+		if sendErr != nil {
+			return sendErr
+		}
+	}
+
+	// okay, we're simulating a Send() that works. Let's enqueue the appropriate
+	// test response.
+	resps := msg.ApplicationProperties[rpcTesterProperty].([]*rpcTestResp)
+
+	for _, resp := range resps {
+		if resp.M != nil && resp.M.Properties.CorrelationID == nil {
+			// auto-associate it since it's intended to be the response for this message
+			resp.M.Properties.CorrelationID = msg.Properties.MessageID
+		}
+
+		tester.ResponsesCh <- resp
+	}
+
+	return nil
+}
+
+// rpcTesterProperty is the property we can shove some messages under that will get
+// routed through our rpcTester. It's 100% a test only thing.
+const rpcTesterProperty = "test-resps"
+
+var exampleServerBusyError error = &amqp.Error{Condition: amqp.ErrCond("com.microsoft:server-busy")}
+
+var exampleUncorrelatedMessage = &amqp.Message{
+	Value: "response from service",
+	Properties: &amqp.MessageProperties{
+		// this message doesn't actually correlate to a message that was sent
+		// it just gets logged and ignored
+		CorrelationID: "you've-never-seen-this",
+	},
+}
+
+func exampleMessageWithStatusCode(statusCode int32) *amqp.Message {
+	return &amqp.Message{
+		Value: "response from service",
+		Properties: &amqp.MessageProperties{
+			// will get auto-filled in by the test
+			CorrelationID: nil,
+		},
+		ApplicationProperties: map[string]any{
+			statusCodeKey: statusCode,
+		},
+	}
 }

--- a/sdk/messaging/azeventhubs/internal/rpc_test.go
+++ b/sdk/messaging/azeventhubs/internal/rpc_test.go
@@ -183,6 +183,7 @@ func TestRPCLinkNonErrorRequiresNoRecovery(t *testing.T) {
 	acceptedMessage := <-tester.Accepted
 	require.Equal(t, "response from service", acceptedMessage.Value, "successfully received message is accepted")
 
+	require.NoError(t, link.Close(context.Background()))
 	logMessages := cleanupLogs()
 	require.Contains(t, logMessages, "[rpctesting] RPCLink had no response channel for correlation ID you've-never-seen-this", "exampleUncorrelatedMessage causes warning for uncorrelated message")
 	require.Contains(t, logMessages, "[rpctesting] Non-fatal error in RPCLink, starting to receive again: *Error{Condition: com.microsoft:server-busy, Description: , Info: map[]}")

--- a/sdk/messaging/azeventhubs/internal/test/test_helpers.go
+++ b/sdk/messaging/azeventhubs/internal/test/test_helpers.go
@@ -92,6 +92,7 @@ func RandomString(prefix string, length int) string {
 }
 
 type ConnectionParamsForTest struct {
+	ClientID                   string
 	ConnectionString           string
 	ConnectionStringListenOnly string
 	ConnectionStringSendOnly   string
@@ -100,6 +101,7 @@ type ConnectionParamsForTest struct {
 	ResourceGroup              string
 	StorageConnectionString    string
 	SubscriptionID             string
+	TenantID                   string
 }
 
 func GetConnectionParamsForTest(t *testing.T) ConnectionParamsForTest {
@@ -110,6 +112,8 @@ func GetConnectionParamsForTest(t *testing.T) ConnectionParamsForTest {
 	}
 
 	envVars := mustGetEnvironmentVars(t, []string{
+		"AZURE_TENANT_ID",
+		"AZURE_CLIENT_ID",
 		"AZURE_SUBSCRIPTION_ID",
 		"CHECKPOINTSTORE_STORAGE_CONNECTION_STRING",
 		"EVENTHUB_CONNECTION_STRING_LISTEN_ONLY",
@@ -131,6 +135,8 @@ func GetConnectionParamsForTest(t *testing.T) ConnectionParamsForTest {
 		ResourceGroup:              envVars["RESOURCE_GROUP"],
 		StorageConnectionString:    envVars["CHECKPOINTSTORE_STORAGE_CONNECTION_STRING"],
 		SubscriptionID:             envVars["AZURE_SUBSCRIPTION_ID"],
+		TenantID:                   envVars["AZURE_TENANT_ID"],
+		ClientID:                   envVars["AZURE_CLIENT_ID"],
 	}
 }
 

--- a/sdk/messaging/azeventhubs/internal/test/test_helpers.go
+++ b/sdk/messaging/azeventhubs/internal/test/test_helpers.go
@@ -97,6 +97,7 @@ type ConnectionParamsForTest struct {
 	ConnectionStringListenOnly string
 	ConnectionStringSendOnly   string
 	EventHubName               string
+	EventHubLinksOnlyName      string
 	EventHubNamespace          string
 	ResourceGroup              string
 	StorageConnectionString    string
@@ -120,6 +121,7 @@ func GetConnectionParamsForTest(t *testing.T) ConnectionParamsForTest {
 		"EVENTHUB_CONNECTION_STRING_SEND_ONLY",
 		"EVENTHUB_CONNECTION_STRING",
 		"EVENTHUB_NAME",
+		"EVENTHUB_LINKSONLY_NAME",
 		"RESOURCE_GROUP",
 	})
 
@@ -131,6 +133,7 @@ func GetConnectionParamsForTest(t *testing.T) ConnectionParamsForTest {
 		ConnectionStringListenOnly: envVars["EVENTHUB_CONNECTION_STRING_LISTEN_ONLY"],
 		ConnectionStringSendOnly:   envVars["EVENTHUB_CONNECTION_STRING_SEND_ONLY"],
 		EventHubName:               envVars["EVENTHUB_NAME"],
+		EventHubLinksOnlyName:      envVars["EVENTHUB_LINKSONLY_NAME"],
 		EventHubNamespace:          connProps.FullyQualifiedNamespace,
 		ResourceGroup:              envVars["RESOURCE_GROUP"],
 		StorageConnectionString:    envVars["CHECKPOINTSTORE_STORAGE_CONNECTION_STRING"],

--- a/sdk/messaging/azeventhubs/producer_client_test.go
+++ b/sdk/messaging/azeventhubs/producer_client_test.go
@@ -49,7 +49,7 @@ func TestProducerClient_SAS(t *testing.T) {
 	require.NoError(t, err)
 
 	err = batch.AddEventData(&azeventhubs.EventData{
-		Body: []byte("hello world"),
+		Body: []byte("TestProducerClient_SAS"),
 	}, nil)
 	require.NoError(t, err)
 
@@ -251,34 +251,41 @@ func TestProducerClient_SendToAny(t *testing.T) {
 
 	t.Run("no partition key, no client instanceID", func(t *testing.T) {
 		testSendAny(t, struct {
+			testName     string
 			instanceID   string
 			partitionKey *string
-		}{})
+		}{testName: "no partition key, no client instanceID"})
 	})
 
 	t.Run("no partition key, with client instanceID", func(t *testing.T) {
 		testSendAny(t, struct {
+			testName     string
 			instanceID   string
 			partitionKey *string
 		}{
+			testName:   "no partition key, with client instanceID",
 			instanceID: "client ID",
 		})
 	})
 
 	t.Run("actual partition key, no client instanceID", func(t *testing.T) {
 		testSendAny(t, struct {
+			testName     string
 			instanceID   string
 			partitionKey *string
 		}{
+			testName:     "actual partition key, no client instanceID",
 			partitionKey: to.Ptr("my special partition key"),
 		})
 	})
 
 	t.Run("actual partition key, with client instanceID", func(t *testing.T) {
 		testSendAny(t, struct {
+			testName     string
 			instanceID   string
 			partitionKey *string
 		}{
+			testName:     "actual partition key, with client instanceID",
 			instanceID:   "client ID",
 			partitionKey: to.Ptr("my special partition key"),
 		})
@@ -286,6 +293,7 @@ func TestProducerClient_SendToAny(t *testing.T) {
 }
 
 func testSendAny(t *testing.T, args struct {
+	testName     string
 	instanceID   string
 	partitionKey *string
 }) {
@@ -302,7 +310,7 @@ func testSendAny(t *testing.T, args struct {
 	require.NoError(t, err)
 
 	err = batch.AddEventData(&azeventhubs.EventData{
-		Body:          []byte("hello world"),
+		Body:          []byte(args.testName),
 		ContentType:   to.Ptr("content type"),
 		CorrelationID: "correlation id",
 		MessageID:     to.Ptr("message id"),
@@ -330,7 +338,7 @@ func testSendAny(t *testing.T, args struct {
 	receivedEvent := receiveEventFromAnyPartition(ctx, t, consumer, partitionsBeforeSend)
 
 	require.Equal(t, azeventhubs.EventData{
-		Body:          []byte("hello world"),
+		Body:          []byte(args.testName),
 		ContentType:   to.Ptr("content type"),
 		CorrelationID: "correlation id",
 		MessageID:     to.Ptr("message id"),

--- a/sdk/messaging/azeventhubs/producer_client_test.go
+++ b/sdk/messaging/azeventhubs/producer_client_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -141,10 +140,9 @@ func TestClientsUnauthorizedCreds(t *testing.T) {
 	})
 
 	t.Run("invalid identity creds", func(t *testing.T) {
-		tenantID := os.Getenv("AZEVENTHUBS_TENANT_ID")
-		clientID := os.Getenv("AZEVENTHUBS_CLIENT_ID")
+		testData := test.GetConnectionParamsForTest(t)
 
-		cliCred, err := azidentity.NewClientSecretCredential(tenantID, clientID, "bogus-client-secret", nil)
+		cliCred, err := azidentity.NewClientSecretCredential(testData.TenantID, testData.ClientID, "bogus-client-secret", nil)
 		require.NoError(t, err)
 
 		prodClient, err := azeventhubs.NewProducerClient(testParams.EventHubNamespace, testParams.EventHubName, cliCred, nil)

--- a/sdk/messaging/azeventhubs/test-resources.bicep
+++ b/sdk/messaging/azeventhubs/test-resources.bicep
@@ -199,7 +199,7 @@ resource iot 'Microsoft.Devices/IotHubs@2018-04-01' = {
 }
 
 output EVENTHUB_NAME string = eventHub.name
-output EVENTHUB_LINKSONLY_NAME=linksonly.name
+output EVENTHUB_LINKSONLY_NAME string = linksonly.name
 output EVENTHUB_CONNECTION_STRING string = listKeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', namespaceName, 'RootManageSharedAccessKey'), apiVersion).primaryConnectionString
 output EVENTHUB_CONNECTION_STRING_LISTEN_ONLY string = listKeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', namespaceName, authorizedListenOnly.name), apiVersion).primaryConnectionString
 output EVENTHUB_CONNECTION_STRING_SEND_ONLY string = listKeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', namespaceName, authorizedSendOnly.name), apiVersion).primaryConnectionString

--- a/sdk/messaging/azeventhubs/test-resources.bicep
+++ b/sdk/messaging/azeventhubs/test-resources.bicep
@@ -73,6 +73,16 @@ resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2017-04-01' = {
   parent: namespace
 }
 
+resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2017-04-01' = {
+  name: 'linksonly'
+  properties: {
+    messageRetentionInDays: 1
+    partitionCount: 1
+  }
+  parent: namespace
+}
+
+
 resource namespaceName_default 'Microsoft.EventHub/namespaces/networkRuleSets@2017-04-01' = {
   name: 'default'
   parent: namespace
@@ -189,6 +199,7 @@ resource iot 'Microsoft.Devices/IotHubs@2018-04-01' = {
 }
 
 output EVENTHUB_NAME string = eventHub.name
+output EVENTHUB_LINKSONLY_NAME=linksonly.name
 output EVENTHUB_CONNECTION_STRING string = listKeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', namespaceName, 'RootManageSharedAccessKey'), apiVersion).primaryConnectionString
 output EVENTHUB_CONNECTION_STRING_LISTEN_ONLY string = listKeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', namespaceName, authorizedListenOnly.name), apiVersion).primaryConnectionString
 output EVENTHUB_CONNECTION_STRING_SEND_ONLY string = listKeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', namespaceName, authorizedSendOnly.name), apiVersion).primaryConnectionString

--- a/sdk/messaging/azeventhubs/test-resources.bicep
+++ b/sdk/messaging/azeventhubs/test-resources.bicep
@@ -73,7 +73,7 @@ resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2017-04-01' = {
   parent: namespace
 }
 
-resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2017-04-01' = {
+resource linksonly 'Microsoft.EventHub/namespaces/eventhubs@2017-04-01' = {
   name: 'linksonly'
   properties: {
     messageRetentionInDays: 1


### PR DESCRIPTION
This removes the special cancellation handling we added after the latest go-amqp update.

The problems mostly stem from how many thorny cases pop up when you try to handle this outside of the protocol stack. go-amqp is going to be changed to handle most of these cases internally, by making sure we don't re-use handles when we're in ambiguous states and waiting eventual DETACH/END calls.

Companion to #20564