### PR TITLE
Fix azcore changelog entry

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Breaking Changes
 > These changes affect only code written against a beta version such as v1.5.0-beta.1
-* Removed `Claims` and `TenantID` fields from `policy.TokenRequestOptions`
+* Removed `TokenRequestOptions.Claims`
 * Removed CAE support for ARM clients
 
 ### Bugs Fixed


### PR DESCRIPTION
`TokenRequestOptions.TenantID` field remains and shouldn't be removed; it's part of ARM cross-tenant auth, not the CAE support which was removed.