### PR TITLE
Remove azcore multitenant auth API

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,8 +7,9 @@
 
 ### Breaking Changes
 > These changes affect only code written against a beta version such as v1.5.0-beta.1
-* Removed `TokenRequestOptions.Claims`
-* Removed CAE support for ARM clients
+> These features will return in v1.6.0-beta.1.
+* Removed `TokenRequestOptions.Claims` and `.TenantID`
+* Removed ARM client support for CAE and cross-tenant auth.
 
 ### Bugs Fixed
 * Added non-conformant LRO terminal states `Cancelled` and `Completed`.

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -14,12 +14,6 @@ import (
 
 // BearerTokenOptions configures the bearer token policy's behavior.
 type BearerTokenOptions struct {
-	// AuxiliaryTenants are additional tenant IDs for authenticating cross-tenant requests.
-	// The policy will add a token from each of these tenants to every request. The
-	// authenticating user or service principal must be a guest in these tenants, and the
-	// policy's credential must support multitenant authentication.
-	AuxiliaryTenants []string
-
 	// Scopes contains the list of permission scopes required for the token.
 	Scopes []string
 }

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -29,8 +29,7 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 		return azruntime.Pipeline{}, err
 	}
 	authPolicy := NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{
-		AuxiliaryTenants: options.AuxiliaryTenants,
-		Scopes:           []string{conf.Audience + "/.default"},
+		Scopes: []string{conf.Audience + "/.default"},
 	})
 	perRetry := make([]azpolicy.Policy, len(plOpts.PerRetry), len(plOpts.PerRetry)+1)
 	copy(perRetry, plOpts.PerRetry)

--- a/sdk/azcore/arm/runtime/policy_bearer_token.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
@@ -27,19 +26,6 @@ type acquiringResourceState struct {
 	tenant string
 }
 
-// acquire acquires or updates the resource; only one
-// thread/goroutine at a time ever calls this function
-func acquire(state acquiringResourceState) (newResource azcore.AccessToken, newExpiration time.Time, err error) {
-	tk, err := state.p.cred.GetToken(state.ctx, azpolicy.TokenRequestOptions{
-		Scopes:   state.p.scopes,
-		TenantID: state.tenant,
-	})
-	if err != nil {
-		return azcore.AccessToken{}, time.Time{}, err
-	}
-	return tk, tk.ExpiresOn, nil
-}
-
 // BearerTokenPolicy authorizes requests with bearer tokens acquired from a TokenCredential.
 type BearerTokenPolicy struct {
 	auxResources map[string]*temporal.Resource[azcore.AccessToken, acquiringResourceState]
@@ -56,10 +42,6 @@ func NewBearerTokenPolicy(cred azcore.TokenCredential, opts *armpolicy.BearerTok
 		opts = &armpolicy.BearerTokenOptions{}
 	}
 	p := &BearerTokenPolicy{cred: cred}
-	p.auxResources = make(map[string]*temporal.Resource[azcore.AccessToken, acquiringResourceState], len(opts.AuxiliaryTenants))
-	for _, t := range opts.AuxiliaryTenants {
-		p.auxResources[t] = temporal.NewResource(acquire)
-	}
 	p.scopes = make([]string, len(opts.Scopes))
 	copy(p.scopes, opts.Scopes)
 	p.btp = azruntime.NewBearerTokenPolicy(cred, opts.Scopes, &azpolicy.BearerTokenOptions{

--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -163,6 +163,7 @@ func TestBearerPolicy_GetTokenFailsNoDeadlock(t *testing.T) {
 }
 
 func TestAuxiliaryTenants(t *testing.T) {
+	t.Skip("unskip this test after restoring cross-tenant auth support")
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
@@ -176,13 +177,13 @@ func TestAuxiliaryTenants(t *testing.T) {
 			getTokenImpl: func(ctx context.Context, options azpolicy.TokenRequestOptions) (azcore.AccessToken, error) {
 				require.False(t, expectCache, "client should have used a cached token instead of requesting another")
 				tenant := primary
-				if options.TenantID != "" {
-					tenant = options.TenantID
-				}
+				// if options.TenantID != "" {
+				// 	tenant = options.TenantID
+				// }
 				return azcore.AccessToken{Token: tenant, ExpiresOn: time.Now().Add(time.Hour).UTC()}, nil
 			},
 		},
-		&armpolicy.BearerTokenOptions{AuxiliaryTenants: auxTenants, Scopes: []string{scope}},
+		&armpolicy.BearerTokenOptions{ /*AuxiliaryTenants: auxTenants,*/ Scopes: []string{scope}},
 	)
 	pipeline := newTestPipeline(&azpolicy.ClientOptions{Transport: srv, PerRetryPolicies: []azpolicy.Policy{b}})
 	expected := strings.Split(shared.BearerTokenPrefix+strings.Join(auxTenants, ","+shared.BearerTokenPrefix), ",")

--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -53,10 +53,6 @@ type AccessToken struct {
 type TokenRequestOptions struct {
 	// Scopes contains the list of permission scopes required for the token.
 	Scopes []string
-
-	// TenantID identifies the tenant from which to request the token. azidentity credentials authenticate in
-	// their configured default tenants when this field isn't set.
-	TenantID string
 }
 
 // TokenCredential represents a credential capable of providing an OAuth token.


### PR DESCRIPTION
...and the related ARM cross-tenant auth feature. Multitenant auth requires support from both azidentity and azcore. I don't expect to change the API or implementation, however azidentity is staying in beta this release cycle. It's could be quite confusing to users if we ship stable azcore API that requires an azidentity beta to function.