### PR TITLE
Restore multitenant and ARM cross-tenant authentication API

### DIFF
--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -14,6 +14,12 @@ import (
 
 // BearerTokenOptions configures the bearer token policy's behavior.
 type BearerTokenOptions struct {
+	// AuxiliaryTenants are additional tenant IDs for authenticating cross-tenant requests.
+	// The policy will add a token from each of these tenants to every request. The
+	// authenticating user or service principal must be a guest in these tenants, and the
+	// policy's credential must support multitenant authentication.
+	AuxiliaryTenants []string
+
 	// Scopes contains the list of permission scopes required for the token.
 	Scopes []string
 }

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -50,6 +50,12 @@ type RegistrationOptions struct {
 type ClientOptions struct {
 	policy.ClientOptions
 
+	// AuxiliaryTenants are additional tenant IDs for authenticating cross-tenant requests.
+	// The client will add a token from each of these tenants to every request. The
+	// authenticating user or service principal must be a guest in these tenants, and the
+	// client's credential must support multitenant authentication.
+	AuxiliaryTenants []string
+
 	// DisableRPRegistration disables the auto-RP registration policy. Defaults to false.
 	DisableRPRegistration bool
 }

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -29,7 +29,8 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 		return azruntime.Pipeline{}, err
 	}
 	authPolicy := NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{
-		Scopes: []string{conf.Audience + "/.default"},
+		AuxiliaryTenants: options.AuxiliaryTenants,
+		Scopes:           []string{conf.Audience + "/.default"},
 	})
 	perRetry := make([]azpolicy.Policy, len(plOpts.PerRetry), len(plOpts.PerRetry)+1)
 	copy(perRetry, plOpts.PerRetry)

--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -163,7 +163,6 @@ func TestBearerPolicy_GetTokenFailsNoDeadlock(t *testing.T) {
 }
 
 func TestAuxiliaryTenants(t *testing.T) {
-	t.Skip("unskip this test after restoring cross-tenant auth support")
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
@@ -177,13 +176,13 @@ func TestAuxiliaryTenants(t *testing.T) {
 			getTokenImpl: func(ctx context.Context, options azpolicy.TokenRequestOptions) (azcore.AccessToken, error) {
 				require.False(t, expectCache, "client should have used a cached token instead of requesting another")
 				tenant := primary
-				// if options.TenantID != "" {
-				// 	tenant = options.TenantID
-				// }
+				if options.TenantID != "" {
+					tenant = options.TenantID
+				}
 				return azcore.AccessToken{Token: tenant, ExpiresOn: time.Now().Add(time.Hour).UTC()}, nil
 			},
 		},
-		&armpolicy.BearerTokenOptions{ /*AuxiliaryTenants: auxTenants,*/ Scopes: []string{scope}},
+		&armpolicy.BearerTokenOptions{AuxiliaryTenants: auxTenants, Scopes: []string{scope}},
 	)
 	pipeline := newTestPipeline(&azpolicy.ClientOptions{Transport: srv, PerRetryPolicies: []azpolicy.Policy{b}})
 	expected := strings.Split(shared.BearerTokenPrefix+strings.Join(auxTenants, ","+shared.BearerTokenPrefix), ",")

--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -53,6 +53,10 @@ type AccessToken struct {
 type TokenRequestOptions struct {
 	// Scopes contains the list of permission scopes required for the token.
 	Scopes []string
+
+	// TenantID identifies the tenant from which to request the token. azidentity credentials authenticate in
+	// their configured default tenants when this field isn't set.
+	TenantID string
 }
 
 // TokenCredential represents a credential capable of providing an OAuth token.

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -279,7 +279,6 @@ func Test_NonHTTPSAuthorityHost(t *testing.T) {
 }
 
 func TestAdditionallyAllowedTenants(t *testing.T) {
-	t.Skip("unskip this test after restoring TokenRequestOptions.TenantID")
 	af := filepath.Join(t.TempDir(), t.Name()+credNameWorkloadIdentity)
 	if err := os.WriteFile(af, []byte("assertion"), os.ModePerm); err != nil {
 		t.Fatal(err)
@@ -321,7 +320,7 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 			err:    true,
 		},
 	} {
-		tro := policy.TokenRequestOptions{Scopes: []string{liveTestScope}}
+		tro := policy.TokenRequestOptions{Scopes: []string{liveTestScope}, TenantID: test.tenant}
 		for _, subtest := range []struct {
 			ctor func(azcore.ClientOptions) (azcore.TokenCredential, error)
 			env  map[string]string

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -81,7 +81,7 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequ
 }
 
 func (c *AzureCLICredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	b, err := c.tokenProvider(ctx, opts.Scopes[0], "")
+	b, err := c.tokenProvider(ctx, opts.Scopes[0], opts.TenantID)
 	if err != nil {
 		return azcore.AccessToken{}, err
 	}

--- a/sdk/azidentity/azure_cli_credential_test.go
+++ b/sdk/azidentity/azure_cli_credential_test.go
@@ -65,7 +65,6 @@ func TestAzureCLICredential_GetTokenInvalidToken(t *testing.T) {
 }
 
 func TestAzureCLICredential_TenantID(t *testing.T) {
-	t.Skip("unskip this test after restoring TokenRequestOptions.TenantID")
 	expected := "expected-tenant-id"
 	called := false
 	options := AzureCLICredentialOptions{

--- a/sdk/azidentity/client_assertion_credential.go
+++ b/sdk/azidentity/client_assertion_credential.go
@@ -69,12 +69,12 @@ func (c *ClientAssertionCredential) GetToken(ctx context.Context, opts policy.To
 }
 
 func (c *ClientAssertionCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes)
+	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 
 func (c *ClientAssertionCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes)
+	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes, confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -76,12 +76,12 @@ func (c *ClientCertificateCredential) GetToken(ctx context.Context, opts policy.
 }
 
 func (c *ClientCertificateCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes)
+	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 
 func (c *ClientCertificateCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes)
+	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes, confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -59,12 +59,12 @@ func (c *ClientSecretCredential) GetToken(ctx context.Context, opts policy.Token
 }
 
 func (c *ClientSecretCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes)
+	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes, confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 
 func (c *ClientSecretCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes)
+	ar, err := c.client.AcquireTokenByCredential(ctx, opts.Scopes, confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -101,7 +101,7 @@ func (c *DeviceCodeCredential) GetToken(ctx context.Context, opts policy.TokenRe
 }
 
 func (c *DeviceCodeCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	dc, err := c.client.AcquireTokenByDeviceCode(ctx, opts.Scopes)
+	dc, err := c.client.AcquireTokenByDeviceCode(ctx, opts.Scopes, public.WithTenantID(opts.TenantID))
 	if err != nil {
 		return azcore.AccessToken{}, err
 	}
@@ -124,6 +124,7 @@ func (c *DeviceCodeCredential) requestToken(ctx context.Context, opts policy.Tok
 func (c *DeviceCodeCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes,
 		public.WithSilentAccount(c.account),
+		public.WithTenantID(opts.TenantID),
 	)
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -85,6 +85,7 @@ func (c *InteractiveBrowserCredential) requestToken(ctx context.Context, opts po
 	ar, err := c.client.AcquireTokenInteractive(ctx, opts.Scopes,
 		public.WithLoginHint(c.options.LoginHint),
 		public.WithRedirectURI(c.options.RedirectURL),
+		public.WithTenantID(opts.TenantID),
 	)
 	if err == nil {
 		c.account = ar.Account
@@ -95,6 +96,7 @@ func (c *InteractiveBrowserCredential) requestToken(ctx context.Context, opts po
 func (c *InteractiveBrowserCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes,
 		public.WithSilentAccount(c.account),
+		public.WithTenantID(opts.TenantID),
 	)
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }

--- a/sdk/azidentity/on_behalf_of_credential.go
+++ b/sdk/azidentity/on_behalf_of_credential.go
@@ -90,7 +90,7 @@ func (o *OnBehalfOfCredential) GetToken(ctx context.Context, opts policy.TokenRe
 }
 
 func (o *OnBehalfOfCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := o.client.AcquireTokenOnBehalfOf(ctx, o.assertion, opts.Scopes)
+	ar, err := o.client.AcquireTokenOnBehalfOf(ctx, o.assertion, opts.Scopes, confidential.WithTenantID(opts.TenantID))
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 

--- a/sdk/azidentity/syncer.go
+++ b/sdk/azidentity/syncer.go
@@ -48,6 +48,13 @@ func (s *syncer) GetToken(ctx context.Context, opts policy.TokenRequestOptions) 
 		return at, errors.New(s.name + ".GetToken() requires at least one scope")
 	}
 	// we don't resolve the tenant for managed identities because they can acquire tokens only from their home tenants
+	if s.name != credNameManagedIdentity {
+		tenant, err := s.resolveTenant(opts.TenantID)
+		if err != nil {
+			return at, err
+		}
+		opts.TenantID = tenant
+	}
 	auth := false
 	s.cond.L.Lock()
 	defer s.cond.L.Unlock()

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -61,7 +61,7 @@ func (c *UsernamePasswordCredential) GetToken(ctx context.Context, opts policy.T
 }
 
 func (c *UsernamePasswordCredential) requestToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	ar, err := c.client.AcquireTokenByUsernamePassword(ctx, opts.Scopes, c.username, c.password)
+	ar, err := c.client.AcquireTokenByUsernamePassword(ctx, opts.Scopes, c.username, c.password, public.WithTenantID(opts.TenantID))
 	if err == nil {
 		c.account = ar.Account
 	}
@@ -71,6 +71,7 @@ func (c *UsernamePasswordCredential) requestToken(ctx context.Context, opts poli
 func (c *UsernamePasswordCredential) silentAuth(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	ar, err := c.client.AcquireTokenSilent(ctx, opts.Scopes,
 		public.WithSilentAccount(c.account),
+		public.WithTenantID(opts.TenantID),
 	)
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }


### PR DESCRIPTION
Previously removed these to enable releasing a stable azcore from main without them because end-to-end scenarios require azidentity, which was staying in beta. I plan to ship stable versions of both features next month.