### PR TITLE
Cosmos DB: Fixes value queries

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed unmarshalling error when using projections in value queries
 
 ### Other Changes
 

--- a/sdk/data/azcosmos/cosmos_query_response.go
+++ b/sdk/data/azcosmos/cosmos_query_response.go
@@ -58,7 +58,7 @@ func newQueryResponse(resp *http.Response) (QueryItemsResponse, error) {
 }
 
 type queryServiceResponse struct {
-	Documents []map[string]interface{} `json:"Documents,omitempty"`
+	Documents []any `json:"Documents,omitempty"`
 }
 
 // QueryContainersResponse contains response from the container query operation.

--- a/sdk/data/azcosmos/cosmos_query_response_test.go
+++ b/sdk/data/azcosmos/cosmos_query_response_test.go
@@ -95,6 +95,79 @@ func TestQueryResponseParsing(t *testing.T) {
 	}
 }
 
+func TestQueryResponseValueParsing(t *testing.T) {
+	queryResponseRaw := map[string][]string{
+		"Documents": {"id1", "id2"},
+	}
+
+	jsonString, err := json.Marshal(queryResponseRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithBody(jsonString),
+		mock.WithHeader(cosmosHeaderEtag, "someEtag"),
+		mock.WithHeader(cosmosHeaderQueryMetrics, "someQueryMetrics"),
+		mock.WithHeader(cosmosHeaderIndexUtilization, "indexUtilization"),
+		mock.WithHeader(cosmosHeaderActivityId, "someActivityId"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "13.42"))
+
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	resp, _ := pl.Do(req)
+	parsedResponse, err := newQueryResponse(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsedResponse.RawResponse == nil {
+		t.Fatal("parsedResponse.RawResponse is nil")
+	}
+
+	if parsedResponse.ActivityID != "someActivityId" {
+		t.Errorf("Expected ActivityId to be %s, but got %s", "someActivityId", parsedResponse.ActivityID)
+	}
+
+	if parsedResponse.RequestCharge != 13.42 {
+		t.Errorf("Expected RequestCharge to be %f, but got %f", 13.42, parsedResponse.RequestCharge)
+	}
+
+	if parsedResponse.ETag != "someEtag" {
+		t.Errorf("Expected ETag to be %s, but got %s", "someEtag", parsedResponse.ETag)
+	}
+
+	if *parsedResponse.QueryMetrics != "someQueryMetrics" {
+		t.Errorf("Expected IndexMetrics to be %s, but got %s", "someQueryMetrics", *parsedResponse.IndexMetrics)
+	}
+
+	if *parsedResponse.IndexMetrics != "indexUtilization" {
+		t.Errorf("Expected IndexUtilization to be %s, but got %s", "indexUtilization", *parsedResponse.IndexMetrics)
+	}
+
+	if len(parsedResponse.Items) != 2 {
+		t.Errorf("Expected 2 documents, but got %d", len(parsedResponse.Items))
+	}
+
+	for index, item := range parsedResponse.Items {
+		var itemResponseBody string
+		err = json.Unmarshal(item, &itemResponseBody)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal item response: %v", err)
+		}
+
+		if itemResponseBody != ("id" + strconv.Itoa(index+1)) {
+			t.Errorf("Expected id to be %s, but got %s", "id"+strconv.Itoa(index+1), itemResponseBody)
+		}
+	}
+}
+
 func TestQueryContainersResponseParsing(t *testing.T) {
 	queryResponseRaw := map[string][]map[string]string{
 		"DocumentCollections": {

--- a/sdk/data/azcosmos/emulator_cosmos_query_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_query_test.go
@@ -219,6 +219,92 @@ func TestSinglePartitionQueryWithParameters(t *testing.T) {
 	}
 }
 
+func TestSinglePartitionQueryWithProjection(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t)
+
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	properties := ContainerProperties{
+		ID: "aContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths: []string{"/pk"},
+		},
+	}
+
+	_, err := database.CreateContainer(context.TODO(), properties, nil)
+	if err != nil {
+		t.Fatalf("Failed to create container: %v", err)
+	}
+
+	container, _ := database.NewContainer("aContainer")
+	documentsPerPk := 10
+	createSampleItems(t, container, documentsPerPk)
+
+	numberOfPages := 0
+	receivedIds := []string{}
+	opt := QueryOptions{PageSizeHint: 5}
+	queryPager := container.NewQueryItemsPager("select value c.id from c", NewPartitionKeyString("1"), &opt)
+	for queryPager.More() {
+		queryResponse, err := queryPager.NextPage(context.TODO())
+		if err != nil {
+			t.Fatalf("Failed to query items: %v", err)
+		}
+
+		numberOfPages++
+		for _, item := range queryResponse.Items {
+			var itemResponseBody string
+			err = json.Unmarshal(item, &itemResponseBody)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+			receivedIds = append(receivedIds, itemResponseBody)
+		}
+
+		if queryPager.More() && queryResponse.ContinuationToken == "" {
+			t.Fatal("Query has more pages but no continuation was provided")
+		}
+
+		if queryResponse.QueryMetrics == nil {
+			t.Fatal("Query metrics were not returned")
+		}
+
+		if queryResponse.IndexMetrics != nil {
+			t.Fatal("Index metrics were returned")
+		}
+
+		if queryResponse.ActivityID == "" {
+			t.Fatal("Activity id was not returned")
+		}
+
+		if queryResponse.RequestCharge == 0 {
+			t.Fatal("Request charge was not returned")
+		}
+
+		if len(queryResponse.Items) != 5 && len(queryResponse.Items) != 0 {
+			t.Fatalf("Expected 5 items, got %d", len(queryResponse.Items))
+		}
+
+		if numberOfPages == 2 && opt.ContinuationToken != "" {
+			t.Fatalf("Original options should not be modified, initial continuation was empty, now it has %v", opt.ContinuationToken)
+		}
+	}
+
+	if numberOfPages != 2 {
+		t.Fatalf("Expected 2 pages, got %d", numberOfPages)
+	}
+
+	if len(receivedIds) != documentsPerPk {
+		t.Fatalf("Expected %d documents, got %d", documentsPerPk, len(receivedIds))
+	}
+
+	for i := 0; i < documentsPerPk; i++ {
+		if receivedIds[i] != strconv.Itoa(i) {
+			t.Fatalf("Expected id %d, got %s", i, receivedIds[i])
+		}
+	}
+}
+
 func createSampleItems(t *testing.T, container *ContainerClient, documentsPerPk int) {
 	for i := 0; i < documentsPerPk; i++ {
 		item := map[string]string{


### PR DESCRIPTION
Value queries like `select value c.id from c` fail to be executed with the error:

```
unmarshalling type *azcosmos.queryServiceResponse: json: cannot unmarshal string into Go struct field queryServiceResponse.Documents of type map[string]interface {}
```

- [X] The purpose of this PR is explained in this or a referenced issue.
- [X] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [X] Tests are included and/or updated for code changes.
- [X] Updates to [CHANGELOG.md][] are included.
- [X] MIT license headers are included in each file.



Closes https://github.com/Azure/azure-sdk-for-go/issues/20651