### PR TITLE
Fix issue where tags header is passed if map is empty

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bugs Fixed
 
 * Fixed time formatting for the conditional request headers. Fixes [#20475](https://github.com/Azure/azure-sdk-for-go/issues/20475).
+* Fixed an issue where passing a blob tags map of length 0 would result in the x-ms-tags header to be sent to the service with an empty string as value.
 
 ### Other Changes
 

--- a/sdk/storage/azblob/internal/shared/shared.go
+++ b/sdk/storage/azblob/internal/shared/shared.go
@@ -130,9 +130,6 @@ func ParseConnectionString(connectionString string) (ParsedConnectionString, err
 
 // SerializeBlobTags converts tags to generated.BlobTags
 func SerializeBlobTags(tagsMap map[string]string) *generated.BlobTags {
-	if tagsMap == nil {
-		return nil
-	}
 	if len(tagsMap) == 0 {
 		return nil
 	}
@@ -145,9 +142,6 @@ func SerializeBlobTags(tagsMap map[string]string) *generated.BlobTags {
 }
 
 func SerializeBlobTagsToStrPtr(tagsMap map[string]string) *string {
-	if tagsMap == nil {
-		return nil
-	}
 	if len(tagsMap) == 0 {
 		return nil
 	}

--- a/sdk/storage/azblob/internal/shared/shared.go
+++ b/sdk/storage/azblob/internal/shared/shared.go
@@ -133,6 +133,9 @@ func SerializeBlobTags(tagsMap map[string]string) *generated.BlobTags {
 	if tagsMap == nil {
 		return nil
 	}
+	if len(tagsMap) == 0 {
+		return nil
+	}
 	blobTagSet := make([]*generated.BlobTag, 0)
 	for key, val := range tagsMap {
 		newKey, newVal := key, val
@@ -143,6 +146,9 @@ func SerializeBlobTags(tagsMap map[string]string) *generated.BlobTags {
 
 func SerializeBlobTagsToStrPtr(tagsMap map[string]string) *string {
 	if tagsMap == nil {
+		return nil
+	}
+	if len(tagsMap) == 0 {
 		return nil
 	}
 	tags := make([]string, 0)

--- a/sdk/storage/azblob/internal/shared/shared_test.go
+++ b/sdk/storage/azblob/internal/shared/shared_test.go
@@ -7,6 +7,7 @@
 package shared
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -116,12 +117,12 @@ func TestSerializeBlobTags(t *testing.T) {
 	}
 	blobTags = SerializeBlobTags(tags)
 	require.NotNil(t, blobTags)
-	require.Equal(t, "foo", *(*(*blobTags).BlobTagSet[0]).Key)
-	require.Equal(t, "bar", *(*(*blobTags).BlobTagSet[0]).Value)
-	require.Equal(t, "az", *(*(*blobTags).BlobTagSet[1]).Key)
-	require.Equal(t, "sdk", *(*(*blobTags).BlobTagSet[1]).Value)
-	require.Equal(t, "sdk", *(*(*blobTags).BlobTagSet[2]).Key)
-	require.Equal(t, "storage", *(*(*blobTags).BlobTagSet[2]).Value)
+	for _, tagPtr := range (*blobTags).BlobTagSet {
+		require.Contains(t, tags, *tagPtr.Key)
+		require.Equal(t, tags[*tagPtr.Key], *tagPtr.Value)
+		delete(tags, *tagPtr.Key)
+	}
+	require.Len(t, tags, 0)
 }
 
 func TestSerializeBlobTagsToStrPtr(t *testing.T) {
@@ -145,6 +146,13 @@ func TestSerializeBlobTagsToStrPtr(t *testing.T) {
 	}
 	tagsStr = SerializeBlobTagsToStrPtr(tags)
 	require.NotNil(t, tagsStr)
-	require.Equal(t, "foo=bar&az=sdk&sdk=storage", *tagsStr)
-
+	// split string on &
+	kvPairs := strings.Split(*tagsStr, "&")
+	for _, kv := range kvPairs {
+		pair := strings.Split(kv, "=")
+		require.Contains(t, tags, pair[0])
+		require.Equal(t, tags[pair[0]], pair[1])
+		delete(tags, pair[0])
+	}
+	require.Len(t, tags, 0)
 }

--- a/sdk/storage/azblob/internal/shared/shared_test.go
+++ b/sdk/storage/azblob/internal/shared/shared_test.go
@@ -94,3 +94,57 @@ func TestCParseConnectionStringAzurite(t *testing.T) {
 	require.Equal(t, "dummyaccountname", parsed.AccountName)
 	require.Equal(t, "secretkeykey", parsed.AccountKey)
 }
+
+func TestSerializeBlobTags(t *testing.T) {
+	var tags map[string]string
+
+	// Case 1
+	tags = nil
+	blobTags := SerializeBlobTags(tags)
+	require.Nil(t, blobTags)
+
+	// Case 2
+	tags = map[string]string{}
+	blobTags = SerializeBlobTags(tags)
+	require.Nil(t, blobTags)
+
+	// Case 3
+	tags = map[string]string{
+		"foo": "bar",
+		"az":  "sdk",
+		"sdk": "storage",
+	}
+	blobTags = SerializeBlobTags(tags)
+	require.NotNil(t, blobTags)
+	require.Equal(t, "foo", *(*(*blobTags).BlobTagSet[0]).Key)
+	require.Equal(t, "bar", *(*(*blobTags).BlobTagSet[0]).Value)
+	require.Equal(t, "az", *(*(*blobTags).BlobTagSet[1]).Key)
+	require.Equal(t, "sdk", *(*(*blobTags).BlobTagSet[1]).Value)
+	require.Equal(t, "sdk", *(*(*blobTags).BlobTagSet[2]).Key)
+	require.Equal(t, "storage", *(*(*blobTags).BlobTagSet[2]).Value)
+}
+
+func TestSerializeBlobTagsToStrPtr(t *testing.T) {
+	var tags map[string]string
+
+	// Case 1
+	tags = nil
+	tagsStr := SerializeBlobTagsToStrPtr(tags)
+	require.Nil(t, tagsStr)
+
+	// Case 2
+	tags = map[string]string{}
+	tagsStr = SerializeBlobTagsToStrPtr(tags)
+	require.Nil(t, tagsStr)
+
+	// Case 3
+	tags = map[string]string{
+		"foo": "bar",
+		"az":  "sdk",
+		"sdk": "storage",
+	}
+	tagsStr = SerializeBlobTagsToStrPtr(tags)
+	require.NotNil(t, tagsStr)
+	require.Equal(t, "foo=bar&az=sdk&sdk=storage", *tagsStr)
+
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

HNS accounts do not currently support tags. If a customer passes nil OR and empty map, we should not set the x-ms-tags header.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
