### PR TITLE
Added tags permission for container SAS

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added support for GetAccountInfo to container and blob level clients. 
 * Added [UploadBlobFromURL API](https://learn.microsoft.com/rest/api/storageservices/put-blob-from-url).
 * Added support for CopySourceAuthorization to appendblob.AppendBlockFromURL
+* Added support for tags permission in Container SAS. 
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/container/client_test.go
+++ b/sdk/storage/azblob/container/client_test.go
@@ -2240,6 +2240,46 @@ func (s *ContainerUnrecordedTestsSuite) TestSASContainerClient() {
 	_require.Nil(err)
 }
 
+func (s *ContainerUnrecordedTestsSuite) TestSASContainerClientTags() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	// Creating container client
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Adding SAS and options
+	permissions := sas.ContainerPermissions{
+		Read:   true,
+		Add:    true,
+		Write:  true,
+		Create: true,
+		Delete: true,
+		Tags:   true,
+	}
+	expiry := time.Now().Add(time.Hour)
+
+	// ContainerSASURL is created with GetSASURL
+	sasUrl, err := containerClient.GetSASURL(permissions, expiry, nil)
+	_require.Nil(err)
+
+	// Create container client with sasUrl
+	containerSasClient, err := container.NewClientWithNoCredential(sasUrl, nil)
+	_require.Nil(err)
+
+	// Get Blob Client
+	blobSasClient := containerSasClient.NewAppendBlobClient(testName)
+	_, err = blobSasClient.Create(context.Background(), nil)
+	_require.Nil(err)
+
+	// Try getting tags with container SAS
+	_, err = blobSasClient.GetTags(context.Background(), nil)
+	_require.Nil(err)
+}
+
 func (s *ContainerUnrecordedTestsSuite) TestContainerBlobBatchDeleteSuccessUsingSharedKey() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/sas/service.go
+++ b/sdk/storage/azblob/sas/service.go
@@ -269,8 +269,8 @@ func getCanonicalName(account string, containerName string, blobName string, dir
 // Initialize an instance of this type and then call its String method to set BlobSignatureValues' Permissions field.
 // All permissions descriptions can be found here: https://docs.microsoft.com/en-us/rest/api/storageservices/create-service-sas#permissions-for-a-directory-container-or-blob
 type ContainerPermissions struct {
-	Read, Add, Create, Write, Delete, DeletePreviousVersion, List, FilterByTags, Move, SetImmutabilityPolicy bool
-	Execute, ModifyOwnership, ModifyPermissions                                                              bool // Meant for hierarchical namespace accounts
+	Read, Add, Create, Write, Delete, DeletePreviousVersion, List, Tags, FilterByTags, Move, SetImmutabilityPolicy bool
+	Execute, ModifyOwnership, ModifyPermissions                                                                    bool // Meant for hierarchical namespace accounts
 }
 
 // String produces the SAS permissions string for an Azure Storage container.
@@ -297,6 +297,9 @@ func (p *ContainerPermissions) String() string {
 	}
 	if p.List {
 		b.WriteRune('l')
+	}
+	if p.Tags {
+		b.WriteRune('t')
 	}
 	if p.FilterByTags {
 		b.WriteRune('f')
@@ -338,6 +341,8 @@ func parseContainerPermissions(s string) (ContainerPermissions, error) {
 			p.DeletePreviousVersion = true
 		case 'l':
 			p.List = true
+		case 't':
+			p.Tags = true
 		case 'f':
 			p.FilterByTags = true
 		case 'm':

--- a/sdk/storage/azblob/sas/service_test.go
+++ b/sdk/storage/azblob/sas/service_test.go
@@ -23,6 +23,7 @@ func TestContainerPermissions_String(t *testing.T) {
 		{input: ContainerPermissions{Delete: true}, expected: "d"},
 		{input: ContainerPermissions{DeletePreviousVersion: true}, expected: "x"},
 		{input: ContainerPermissions{List: true}, expected: "l"},
+		{input: ContainerPermissions{Tags: true}, expected: "t"},
 		{input: ContainerPermissions{FilterByTags: true}, expected: "f"},
 		{input: ContainerPermissions{Move: true}, expected: "m"},
 		{input: ContainerPermissions{Execute: true}, expected: "e"},
@@ -37,13 +38,14 @@ func TestContainerPermissions_String(t *testing.T) {
 			Delete:                true,
 			DeletePreviousVersion: true,
 			List:                  true,
+			Tags:                  true,
 			FilterByTags:          true,
 			Move:                  true,
 			Execute:               true,
 			ModifyOwnership:       true,
 			ModifyPermissions:     true,
 			SetImmutabilityPolicy: true,
-		}, expected: "racwdxlfmeopi"},
+		}, expected: "racwdxltfmeopi"},
 	}
 	for _, c := range testdata {
 		require.Equal(t, c.expected, c.input.String())
@@ -62,6 +64,7 @@ func TestContainerPermissions_Parse(t *testing.T) {
 		{expected: ContainerPermissions{Delete: true}, input: "d"},
 		{expected: ContainerPermissions{DeletePreviousVersion: true}, input: "x"},
 		{expected: ContainerPermissions{List: true}, input: "l"},
+		{expected: ContainerPermissions{Tags: true}, input: "t"},
 		{expected: ContainerPermissions{FilterByTags: true}, input: "f"},
 		{expected: ContainerPermissions{Move: true}, input: "m"},
 		{expected: ContainerPermissions{Execute: true}, input: "e"},
@@ -76,13 +79,14 @@ func TestContainerPermissions_Parse(t *testing.T) {
 			Delete:                true,
 			DeletePreviousVersion: true,
 			List:                  true,
+			Tags:                  true,
 			FilterByTags:          true,
 			Move:                  true,
 			Execute:               true,
 			ModifyOwnership:       true,
 			ModifyPermissions:     true,
 			SetImmutabilityPolicy: true,
-		}, input: "racwdxlfmeopi"},
+		}, input: "racwdxltfmeopi"},
 		{expected: ContainerPermissions{
 			Read:                  true,
 			Add:                   true,
@@ -91,13 +95,14 @@ func TestContainerPermissions_Parse(t *testing.T) {
 			Delete:                true,
 			DeletePreviousVersion: true,
 			List:                  true,
+			Tags:                  true,
 			FilterByTags:          true,
 			Move:                  true,
 			Execute:               true,
 			ModifyOwnership:       true,
 			ModifyPermissions:     true,
 			SetImmutabilityPolicy: true,
-		}, input: "cpwxfmreodail"}, // Wrong order parses correctly
+		}, input: "ctpwxfmreodail"}, // Wrong order parses correctly
 	}
 	for _, c := range testdata {
 		permissions, err := parseContainerPermissions(c.input)
@@ -107,9 +112,9 @@ func TestContainerPermissions_Parse(t *testing.T) {
 }
 
 func TestContainerPermissions_ParseNegative(t *testing.T) {
-	_, err := parseContainerPermissions("cpwxtfmreodail") // Here 't' is invalid
+	_, err := parseContainerPermissions("cpwxtfmreodailz") // Here 'z' is invalid
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "116")
+	require.Contains(t, err.Error(), "122")
 }
 
 func TestBlobPermissions_String(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

This is necessary for AzCopy tests to support setting tags. 

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
