### PR TITLE
azfile: One ClientOptions to be used by all clients

### DIFF
--- a/sdk/storage/azfile/directory/client.go
+++ b/sdk/storage/azfile/directory/client.go
@@ -8,7 +8,6 @@ package directory
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
@@ -22,9 +21,7 @@ import (
 )
 
 // ClientOptions contains the optional parameters when creating a Client.
-type ClientOptions struct {
-	azcore.ClientOptions
-}
+type ClientOptions base.ClientOptions
 
 // Client represents a URL to the Azure Storage directory allowing you to manipulate its directories and files.
 type Client base.Client[generated.DirectoryClient]

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
@@ -27,9 +26,7 @@ import (
 )
 
 // ClientOptions contains the optional parameters when creating a Client.
-type ClientOptions struct {
-	azcore.ClientOptions
-}
+type ClientOptions base.ClientOptions
 
 // Client represents a URL to the Azure Storage file.
 type Client base.Client[generated.FileClient]

--- a/sdk/storage/azfile/internal/base/clients.go
+++ b/sdk/storage/azfile/internal/base/clients.go
@@ -7,10 +7,16 @@
 package base
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/generated"
 )
+
+// ClientOptions contains the optional parameters when creating a Client.
+type ClientOptions struct {
+	azcore.ClientOptions
+}
 
 type Client[T any] struct {
 	inner     *T

--- a/sdk/storage/azfile/lease/client_test.go
+++ b/sdk/storage/azfile/lease/client_test.go
@@ -70,7 +70,7 @@ func (l *LeaseRecordedTestsSuite) TestShareAcquireLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 
@@ -98,11 +98,11 @@ func (l *LeaseRecordedTestsSuite) TestNegativeShareAcquireMultipleLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient0, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient0, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 
-	shareLeaseClient1, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient1, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[1],
 	})
 
@@ -131,7 +131,7 @@ func (l *LeaseRecordedTestsSuite) TestShareDeleteShareWithoutLeaseId() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 
@@ -162,7 +162,7 @@ func (l *LeaseRecordedTestsSuite) TestShareReleaseLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 
@@ -193,7 +193,7 @@ func (l *LeaseRecordedTestsSuite) TestShareRenewLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 
@@ -221,7 +221,7 @@ func (l *LeaseRecordedTestsSuite) TestShareBreakLeaseDefault() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 
@@ -253,7 +253,7 @@ func (l *LeaseRecordedTestsSuite) TestShareBreakLeaseNonDefault() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 
@@ -290,7 +290,7 @@ func (l *LeaseRecordedTestsSuite) TestNegativeShareBreakRenewLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 
@@ -325,7 +325,7 @@ func (l *LeaseRecordedTestsSuite) TestShareChangeLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, _ := lease.ShareLeaseClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 
@@ -373,7 +373,7 @@ func (l *LeaseRecordedTestsSuite) TestFileAcquireLease() {
 	_, err = fileClient.Create(ctx, 0, nil)
 	_require.NoError(err)
 
-	fileLeaseClient, err := lease.NewFileClient(fileClient, &lease.FileClientOptions{
+	fileLeaseClient, err := lease.FileLeaseClient(fileClient, &lease.FileClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 	_require.NoError(err)
@@ -407,12 +407,12 @@ func (l *LeaseRecordedTestsSuite) TestNegativeFileAcquireMultipleLease() {
 	_, err = fileClient.Create(ctx, 0, nil)
 	_require.NoError(err)
 
-	fileLeaseClient0, err := lease.NewFileClient(fileClient, &lease.FileClientOptions{
+	fileLeaseClient0, err := lease.FileLeaseClient(fileClient, &lease.FileClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 	_require.NoError(err)
 
-	fileLeaseClient1, err := lease.NewFileClient(fileClient, &lease.FileClientOptions{
+	fileLeaseClient1, err := lease.FileLeaseClient(fileClient, &lease.FileClientOptions{
 		LeaseID: proposedLeaseIDs[1],
 	})
 	_require.NoError(err)
@@ -450,7 +450,7 @@ func (l *LeaseRecordedTestsSuite) TestDeleteFileWithoutLeaseId() {
 	_, err = fileClient.Create(ctx, 0, nil)
 	_require.NoError(err)
 
-	fileLeaseClient, err := lease.NewFileClient(fileClient, &lease.FileClientOptions{
+	fileLeaseClient, err := lease.FileLeaseClient(fileClient, &lease.FileClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 	_require.NoError(err)
@@ -489,7 +489,7 @@ func (l *LeaseRecordedTestsSuite) TestFileReleaseLease() {
 	_, err = fileClient.Create(ctx, 0, nil)
 	_require.NoError(err)
 
-	fileLeaseClient, err := lease.NewFileClient(fileClient, &lease.FileClientOptions{
+	fileLeaseClient, err := lease.FileLeaseClient(fileClient, &lease.FileClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 	_require.NoError(err)
@@ -526,7 +526,7 @@ func (l *LeaseRecordedTestsSuite) TestFileChangeLease() {
 	_, err = fileClient.Create(ctx, 0, nil)
 	_require.NoError(err)
 
-	fileLeaseClient, err := lease.NewFileClient(fileClient, &lease.FileClientOptions{
+	fileLeaseClient, err := lease.FileLeaseClient(fileClient, &lease.FileClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 	_require.NoError(err)
@@ -570,7 +570,7 @@ func (l *LeaseRecordedTestsSuite) TestNegativeFileDeleteAfterReleaseLease() {
 	_, err = fileClient.Create(ctx, 0, nil)
 	_require.NoError(err)
 
-	fileLeaseClient, err := lease.NewFileClient(fileClient, &lease.FileClientOptions{
+	fileLeaseClient, err := lease.FileLeaseClient(fileClient, &lease.FileClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 	_require.NoError(err)
@@ -612,7 +612,7 @@ func (l *LeaseRecordedTestsSuite) TestFileBreakLease() {
 	_, err = fileClient.Create(ctx, 0, nil)
 	_require.NoError(err)
 
-	fileLeaseClient, err := lease.NewFileClient(fileClient, &lease.FileClientOptions{
+	fileLeaseClient, err := lease.FileLeaseClient(fileClient, &lease.FileClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
 	_require.NoError(err)

--- a/sdk/storage/azfile/lease/file_client.go
+++ b/sdk/storage/azfile/lease/file_client.go
@@ -27,10 +27,10 @@ type FileClientOptions struct {
 	LeaseID *string
 }
 
-// NewFileClient creates a file lease client for the provided file client.
+// FileLeaseClient creates a file lease client for the provided file client.
 //   - client - an instance of a file client
 //   - options - client options; pass nil to accept the default values
-func NewFileClient(client *file.Client, options *FileClientOptions) (*FileClient, error) {
+func FileLeaseClient(client *file.Client, options *FileClientOptions) (*FileClient, error) {
 	var leaseID *string
 	if options != nil {
 		leaseID = options.LeaseID

--- a/sdk/storage/azfile/lease/share_client.go
+++ b/sdk/storage/azfile/lease/share_client.go
@@ -27,10 +27,10 @@ type ShareClientOptions struct {
 	LeaseID *string
 }
 
-// NewShareClient creates a share lease client for the provided share client.
+// ShareLeaseClient creates a share lease client for the provided share client.
 //   - client - an instance of a share client
 //   - options - client options; pass nil to accept the default values
-func NewShareClient(client *share.Client, options *ShareClientOptions) (*ShareClient, error) {
+func ShareLeaseClient(client *share.Client, options *ShareClientOptions) (*ShareClient, error) {
 	var leaseID *string
 	if options != nil {
 		leaseID = options.LeaseID

--- a/sdk/storage/azfile/service/client.go
+++ b/sdk/storage/azfile/service/client.go
@@ -8,7 +8,6 @@ package service
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
@@ -24,9 +23,7 @@ import (
 )
 
 // ClientOptions contains the optional parameters when creating a Client.
-type ClientOptions struct {
-	azcore.ClientOptions
-}
+type ClientOptions base.ClientOptions
 
 // Client represents a URL to the Azure File Storage service allowing you to manipulate file shares.
 type Client base.Client[generated.ServiceClient]

--- a/sdk/storage/azfile/share/client.go
+++ b/sdk/storage/azfile/share/client.go
@@ -8,7 +8,6 @@ package share
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/directory"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
@@ -22,9 +21,7 @@ import (
 )
 
 // ClientOptions contains the optional parameters when creating a Client.
-type ClientOptions struct {
-	azcore.ClientOptions
-}
+type ClientOptions base.ClientOptions
 
 // Client represents a URL to the Azure Storage share allowing you to manipulate its directories and files.
 type Client base.Client[generated.ShareClient]


### PR DESCRIPTION
Also addresses other comments on API View review regarding renaming of lease client methods.
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
