### PR TITLE
[azservicebus, azeventhubs] Stress test and logging improvement

### DIFF
--- a/sdk/messaging/azeventhubs/internal/eh/stress/deploy.ps1
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/deploy.ps1
@@ -4,7 +4,7 @@ Set-Location $PSScriptRoot
 function deployUsingLocalAddons() {
     $azureSDKToolsRoot="<Git clone of azure-sdk-tools>"
     $stressTestAddonsFolder = "$azureSDKToolsRoot/tools/stress-cluster/cluster/kubernetes/stress-test-addons"
-    $clusterResourceGroup = "<Resource Group for Cluster"
+    $clusterResourceGroup = "<Resource Group for Cluster>"
     $clusterSubscription = "<Azure Subscription>"
     $helmEnv = "pg2"
 

--- a/sdk/messaging/azeventhubs/internal/eh/stress/templates/stress-test-job.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/templates/stress-test-job.yaml
@@ -22,7 +22,7 @@ spec:
         - >
           set -ex;
           mkdir -p "$DEBUG_SHARE";
-          /app/stress "{{.Stress.testTarget}}" "-rounds" "{{.Stress.rounds}}" "-prefetch" "{{.Stress.prefetch}}" "{{.Stress.verbose}}" "-sleepAfter" "{{.Stress.sleepAfter}}" | tee "${DEBUG_SHARE}/{{ .Stress.Scenario }}.log";
+          /app/stress "{{.Stress.testTarget}}" "-rounds" "{{.Stress.rounds}}" "-prefetch" "{{.Stress.prefetch}}" "{{.Stress.verbose}}" "-sleepAfter" "{{.Stress.sleepAfter}}" | tee -a "${DEBUG_SHARE}/{{ .Stress.Scenario }}-`date +%s`.log";
       # Pulls the image on pod start, always. We tend to push to the same image and tag over and over again
       # when iterating, so this is a must.
       imagePullPolicy: Always
@@ -33,8 +33,8 @@ spec:
       # just uses 'limits' for both.
       resources:
         limits:
-          memory: "1.5Gi"
-          cpu: "1"
+          memory: "0.5Gi"
+          cpu: "0.5"
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}
 

--- a/sdk/messaging/azservicebus/client_test.go
+++ b/sdk/messaging/azservicebus/client_test.go
@@ -442,14 +442,16 @@ func TestClientUnauthorizedCreds(t *testing.T) {
 	})
 
 	t.Run("invalid identity creds", func(t *testing.T) {
-		tenantID := os.Getenv("AZURE_TENANT_ID")
-		clientID := os.Getenv("AZURE_CLIENT_ID")
-		endpoint := os.Getenv("SERVICEBUS_ENDPOINT")
+		identityVars := test.GetIdentityVars(t)
 
-		cliCred, err := azidentity.NewClientSecretCredential(tenantID, clientID, "bogus-client-secret", nil)
+		if identityVars == nil {
+			return
+		}
+
+		cliCred, err := azidentity.NewClientSecretCredential(identityVars.TenantID, identityVars.ClientID, "bogus-client-secret", nil)
 		require.NoError(t, err)
 
-		client, err := NewClient(endpoint, cliCred, nil)
+		client, err := NewClient(identityVars.Endpoint, cliCred, nil)
 		require.NoError(t, err)
 
 		defer test.RequireClose(t, client)

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/amqpwrap"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/go-amqp"
@@ -205,6 +206,14 @@ func (l *FakeAMQPLinks) Retry(ctx context.Context, eventName log.Event, operatio
 	}
 
 	return fn(ctx, lwr, &utils.RetryFnArgs{})
+}
+
+func (l *FakeAMQPLinks) Writef(evt azlog.Event, format string, args ...any) {
+	log.Writef(evt, "[prefix] "+format, args...)
+}
+
+func (l *FakeAMQPLinks) Prefix() string {
+	return "prefix"
 }
 
 func (l *FakeAMQPLinks) Close(ctx context.Context, permanently bool) error {

--- a/sdk/messaging/azservicebus/internal/amqplinks_unit_test.go
+++ b/sdk/messaging/azservicebus/internal/amqplinks_unit_test.go
@@ -88,7 +88,7 @@ func TestAMQPLinksRetriesUnit(t *testing.T) {
 			logMessages := endLogging()
 
 			if testData.ExpectReset {
-				require.Contains(t, logMessages, fmt.Sprintf("[azsb.Conn] (OverallOperation) Link was previously detached. Attempting quick reconnect to recover from error: %s", err.Error()))
+				require.Contains(t, logMessages, fmt.Sprintf("[azsb.Conn] [c:100, l:1, s:name:sender] (OverallOperation) Link was previously detached. Attempting quick reconnect to recover from error: %s", err.Error()))
 			} else {
 				for _, msg := range logMessages {
 					require.NotContains(t, msg, "Link was previously detached")
@@ -126,11 +126,11 @@ func TestAMQPLinks_Logging(t *testing.T) {
 		actualLogs := endCapture()
 
 		expectedLogs := []string{
-			"[azsb.Conn] [] Recovering link for error amqp: link closed",
+			"[azsb.Conn] Recovering link for error amqp: link closed",
 			"[azsb.Conn] Recovering link only",
-			"[azsb.Conn] [] Links closing (permanent: false)",
-			"[azsb.Conn] [c:100, l:1, r:name:fakelink] Links created",
-			"[azsb.Conn] [c:100, l:1, r:name:fakelink] Recovered links"}
+			"[azsb.Conn] Links closing (permanent: false)",
+			"[azsb.Conn] [c:100, l:1, r:name:fakeli] Links created",
+			"[azsb.Conn] [c:100, l:1, r:name:fakeli] Recovered links (old: )"}
 
 		require.Equal(t, expectedLogs, actualLogs)
 	})
@@ -161,14 +161,14 @@ func TestAMQPLinks_Logging(t *testing.T) {
 		actualLogs := endCapture()
 
 		expectedLogs := []string{
-			"[azsb.Conn] [] Recovering link for error amqp: connection closed",
+			"[azsb.Conn] Recovering link for error amqp: connection closed",
 			"[azsb.Conn] Recovering connection (and links)",
 			"[azsb.Conn] closing old link: current:{0 0}, old:{0 0}",
-			"[azsb.Conn] [] Links closing (permanent: false)",
+			"[azsb.Conn] Links closing (permanent: false)",
 			"[azsb.Conn] recreating link: c: true, current:{0 0}, old:{0 0}",
-			"[azsb.Conn] [] Links closing (permanent: false)",
-			"[azsb.Conn] [c:101, l:1, r:name:fakelink] Links created",
-			"[azsb.Conn] [c:101, l:1, r:name:fakelink] Recovered connection and links"}
+			"[azsb.Conn] Links closing (permanent: false)",
+			"[azsb.Conn] [c:101, l:1, r:name:fakeli] Links created",
+			"[azsb.Conn] [c:101, l:1, r:name:fakeli] Recovered connection and links (old: )"}
 
 		require.Equal(t, expectedLogs, actualLogs)
 	})

--- a/sdk/messaging/azservicebus/internal/rpc.go
+++ b/sdk/messaging/azservicebus/internal/rpc.go
@@ -148,13 +148,10 @@ func NewRPCLink(ctx context.Context, args RPCLinkArgs) (amqpwrap.RPCLink, error)
 	return link, nil
 }
 
-const responseRouterShutdownMessage = "Response router has shut down"
-
 // responseRouter is responsible for taking any messages received on the 'response'
 // link and forwarding it to the proper channel. The channel is being select'd by the
 // original `RPC` call.
 func (l *rpcLink) responseRouter() {
-	defer azlog.Writef(l.logEvent, responseRouterShutdownMessage)
 	defer close(l.responseRouterClosed)
 
 	for {

--- a/sdk/messaging/azservicebus/internal/stress/.gitignore
+++ b/sdk/messaging/azservicebus/internal/stress/.gitignore
@@ -3,4 +3,4 @@ stress.exe
 logs
 generatedValues.yaml
 deploy-test-*.ps1
-
+*.log

--- a/sdk/messaging/azservicebus/internal/stress/.helmignore
+++ b/sdk/messaging/azservicebus/internal/stress/.helmignore
@@ -3,3 +3,4 @@ stress.exe
 .env
 Dockerfile
 *.go
+*.log

--- a/sdk/messaging/azservicebus/internal/stress/deploy.ps1
+++ b/sdk/messaging/azservicebus/internal/stress/deploy.ps1
@@ -1,2 +1,25 @@
 Set-Location $PSScriptRoot
+
+function deployUsingLocalAddons() {
+    $azureSDKToolsRoot="<Git clone of azure-sdk-tools>"
+    $stressTestAddonsFolder = "$azureSDKToolsRoot/tools/stress-cluster/cluster/kubernetes/stress-test-addons"
+    $clusterResourceGroup = "<Resource Group for Cluster>"
+    $clusterSubscription = "<Azure Subscription>"
+    $helmEnv = "pg2"
+
+    if (-not (Get-ChildItem $stressTestAddonsFolder)) {
+        Write-Host "Can't find the the new stress test adons folder at $stressTestAddonsFolder"
+        return
+    }
+
+    pwsh "$azureSDKToolsRoot/eng/common/scripts/stress-testing/deploy-stress-tests.ps1" `
+        -LocalAddonsPath "$stressTestAddonsFolder"  `
+        -clusterGroup "$clusterResourceGroup" `
+        -subscription "$clusterSubscription" `
+        -Environment $helmEnv `
+        -Login `
+        -PushImages
+}
+
+#deployUsingLocalAddons
 pwsh "../../../../../eng/common/scripts/stress-testing/deploy-stress-tests.ps1" -Login -PushImages @args

--- a/sdk/messaging/azservicebus/internal/stress/scenarios-matrix.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/scenarios-matrix.yaml
@@ -12,46 +12,46 @@ matrix:
   scenarios:
     constantDetach:
       testTarget: constantDetach
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     constantDetachmentSender:
       testTarget: constantDetachmentSender
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     emptySessions:
       testTarget: emptySessions
       memory: "1.0Gi"
     finitePeeks:
       testTarget: finitePeeks
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     finiteSendAndReceive:
       testTarget: finiteSendAndReceive    
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     finiteSessions:
       testTarget: finiteSessions
       memory: "4Gi"
     idleFastReconnect:
       testTarget: idleFastReconnect
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     infiniteSendAndReceive:
       testTarget: infiniteSendAndReceive
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     infiniteSendAndReceiveWithChaos:
       testTarget: infiniteSendAndReceive
       # this value is injected as a label value in templates/deploy-job.yaml
       # this'll activate our standard chaos policy, which is at the bottom of that file.
       chaos: "true"
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     longRunningRenewLock:
       testTarget: longRunningRenewLock
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     mostlyIdleReceiver:
       testTarget: mostlyIdleReceiver
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     rapidOpenClose:
       testTarget: rapidOpenClose
-      memory: "1.5Gi"      
+      memory: "0.5Gi"      
     receiveCancellation:
       testTarget: receiveCancellation
-      memory: "1.5Gi"
+      memory: "0.5Gi"
     sendAndReceiveDrain:
       testTarget: sendAndReceiveDrain
-      memory: "1.5Gi"
+      memory: "0.5Gi"

--- a/sdk/messaging/azservicebus/internal/stress/templates/stress-test-job.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/templates/stress-test-job.yaml
@@ -17,7 +17,7 @@ spec:
         - >
           set -ex;
           mkdir -p "$DEBUG_SHARE";
-          /app/stress tests "{{ .Stress.testTarget }}" | tee "${DEBUG_SHARE}/{{ .Stress.Scenario }}.log";
+          /app/stress tests "{{ .Stress.testTarget }}" | tee -a "${DEBUG_SHARE}/{{ .Stress.Scenario }}-`date +%s`.log";
       # Pulls the image on pod start, always. We tend to push to the same image and tag over and over again
       # when iterating, so this is a must.
       imagePullPolicy: Always
@@ -29,7 +29,7 @@ spec:
       resources:
         limits:
           memory: {{.Stress.memory }}
-          cpu: "1"
+          cpu: "0.5"
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}
 

--- a/sdk/messaging/azservicebus/internal/stress/tests/finite_peeks.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/finite_peeks.go
@@ -28,11 +28,13 @@ func FinitePeeks(remainingArgs []string) {
 	sender, err := client.NewSender(queueName, nil)
 	sc.PanicOnError("failed to create sender", err)
 
+	log.Printf("Sending a single message")
 	err = sender.SendMessage(sc.Context, &azservicebus.Message{
 		Body: []byte("peekable message"),
 	}, nil)
 	sc.PanicOnError("failed to send message", err)
 
+	log.Printf("Closing sender")
 	_ = sender.Close(sc.Context)
 
 	receiver, err := client.NewReceiverForQueue(queueName, nil)
@@ -51,9 +53,13 @@ func FinitePeeks(remainingArgs []string) {
 	sc.PanicOnError("failed to abandon message",
 		receiver.AbandonMessage(sc.Context, tmp[0], nil))
 
-	for i := 0; i < 10000; i++ {
-		log.Printf("Sleeping for 1 second before iteration %d", i)
-		time.Sleep(time.Second)
+	maxPeeks := 10000
+	peekSleep := 500 * time.Millisecond
+
+	log.Printf("Now peeking %d times, every %dms", maxPeeks, peekSleep/time.Millisecond)
+
+	for i := 1; i <= maxPeeks; i++ {
+		time.Sleep(peekSleep)
 
 		seqNum := int64(0)
 
@@ -65,4 +71,6 @@ func FinitePeeks(remainingArgs []string) {
 
 		receiverStats.AddReceived(int32(1))
 	}
+
+	log.Printf("Done, peeked %d times", maxPeeks)
 }

--- a/sdk/messaging/azservicebus/internal/stress/tests/mostly_idle_receiver.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/mostly_idle_receiver.go
@@ -83,7 +83,7 @@ func MostlyIdleReceiver(remainingArgs []string) {
 			messages, err := receiver.ReceiveMessages(sc.Context, 1, nil)
 			sc.PanicOnError(fmt.Sprintf("failed receiving messages for duration %s", duration), err)
 
-			log.Printf("Received messages %#v", messages)
+			log.Printf("Received %d messages", len(messages))
 			stats.AddReceived(int32(len(messages)))
 
 			for _, msg := range messages {

--- a/sdk/messaging/azservicebus/internal/test/test_helpers.go
+++ b/sdk/messaging/azservicebus/internal/test/test_helpers.go
@@ -67,6 +67,31 @@ func GetConnectionStringListenOnly(t *testing.T) string {
 	return getEnvOrSkipTest(t, "SERVICEBUS_CONNECTION_STRING_LISTEN_ONLY")
 }
 
+func GetIdentityVars(t *testing.T) *struct {
+	TenantID string
+	ClientID string
+	Secret   string
+	Endpoint string
+} {
+	runningLiveTest := GetConnectionString(t) != ""
+
+	if !runningLiveTest {
+		return nil
+	}
+
+	return &struct {
+		TenantID string
+		ClientID string
+		Secret   string
+		Endpoint string
+	}{
+		TenantID: getEnvOrSkipTest(t, "AZURE_TENANT_ID"),
+		ClientID: getEnvOrSkipTest(t, "AZURE_CLIENT_ID"),
+		Endpoint: getEnvOrSkipTest(t, "SERVICEBUS_ENDPOINT"),
+		Secret:   getEnvOrSkipTest(t, "AZURE_CLIENT_SECRET"),
+	}
+}
+
 func getEnvOrSkipTest(t *testing.T, name string) string {
 	cs := os.Getenv(name)
 

--- a/sdk/messaging/azservicebus/internal/utils/logger.go
+++ b/sdk/messaging/azservicebus/internal/utils/logger.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package utils
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/internal/log"
+)
+
+type Logger struct {
+	prefix *atomic.Value
+}
+
+func NewLogger() Logger {
+	value := &atomic.Value{}
+	value.Store("")
+
+	return Logger{
+		prefix: value,
+	}
+}
+
+func (l *Logger) SetPrefix(format string, args ...any) {
+	l.prefix.Store(fmt.Sprintf("["+format+"] ", args...))
+}
+
+func (l *Logger) Prefix() string {
+	return l.prefix.Load().(string)
+}
+
+func (l *Logger) Writef(evt azlog.Event, format string, args ...any) {
+	prefix := l.prefix.Load().(string)
+	azlog.Writef(evt, prefix+format, args...)
+}

--- a/sdk/messaging/azservicebus/internal/utils/retrier.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier.go
@@ -50,7 +50,7 @@ func Retry(ctx context.Context, eventName log.Event, operation string, fn func(c
 	for i := int32(0); i <= ro.MaxRetries; i++ {
 		if i > 0 {
 			sleep := calcDelay(ro, i)
-			log.Writef(eventName, "(%s) Retry attempt %d sleeping for %s", operation, i, sleep)
+			log.Writef(eventName, "%s Retry attempt %d sleeping for %s", operation, i, sleep)
 
 			select {
 			case <-ctx.Done():
@@ -66,7 +66,7 @@ func Retry(ctx context.Context, eventName log.Event, operation string, fn func(c
 		err = fn(ctx, &args)
 
 		if args.resetAttempts {
-			log.Writef(eventName, "(%s) Resetting retry attempts", operation)
+			log.Writef(eventName, "%s Resetting retry attempts", operation)
 
 			// it looks weird, but we're doing -1 here because the post-increment
 			// will set it back to 0, which is what we want - go back to the 0th
@@ -79,13 +79,13 @@ func Retry(ctx context.Context, eventName log.Event, operation string, fn func(c
 		if err != nil {
 			if isFatalFn(err) {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					log.Writef(eventName, "(%s) Retry attempt %d was cancelled, stopping: %s", operation, i, err.Error())
+					log.Writef(eventName, "%s Retry attempt %d was cancelled, stopping: %s", operation, i, err.Error())
 				} else {
-					log.Writef(eventName, "(%s) Retry attempt %d returned non-retryable error: %s", operation, i, err.Error())
+					log.Writef(eventName, "%s Retry attempt %d returned non-retryable error: %s", operation, i, err.Error())
 				}
 				return err
 			} else {
-				log.Writef(eventName, "(%s) Retry attempt %d returned retryable error: %s", operation, i, err.Error())
+				log.Writef(eventName, "%s Retry attempt %d returned retryable error: %s", operation, i, err.Error())
 			}
 
 			continue

--- a/sdk/messaging/azservicebus/internal/utils/retrier_test.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier_test.go
@@ -294,7 +294,7 @@ func TestRetryLogging(t *testing.T) {
 	t.Run("normal error", func(t *testing.T) {
 		logsFn := test.CaptureLogsForTest(false)
 
-		err := Retry(context.Background(), testLogEvent, "my_operation", func(ctx context.Context, args *RetryFnArgs) error {
+		err := Retry(context.Background(), testLogEvent, "(my_operation)", func(ctx context.Context, args *RetryFnArgs) error {
 			azlog.Writef("TestFunc", "Attempt %d, within test func, returning error hello", args.I)
 			return errors.New("hello")
 		}, func(err error) bool {
@@ -325,7 +325,7 @@ func TestRetryLogging(t *testing.T) {
 	t.Run("normal error2", func(t *testing.T) {
 		test.EnableStdoutLogging(t)
 
-		err := Retry(context.Background(), testLogEvent, "my_operation", func(ctx context.Context, args *RetryFnArgs) error {
+		err := Retry(context.Background(), testLogEvent, "(my_operation)", func(ctx context.Context, args *RetryFnArgs) error {
 			azlog.Writef("TestFunc", "Attempt %d, within test func, returning error hello", args.I)
 			return errors.New("hello")
 		}, func(err error) bool {
@@ -339,7 +339,7 @@ func TestRetryLogging(t *testing.T) {
 	t.Run("cancellation error", func(t *testing.T) {
 		logsFn := test.CaptureLogsForTest(false)
 
-		err := Retry(context.Background(), testLogEvent, "test_operation", func(ctx context.Context, args *RetryFnArgs) error {
+		err := Retry(context.Background(), testLogEvent, "(test_operation)", func(ctx context.Context, args *RetryFnArgs) error {
 			azlog.Writef("TestFunc",
 				"Attempt %d, within test func", args.I)
 			return context.Canceled
@@ -359,7 +359,7 @@ func TestRetryLogging(t *testing.T) {
 	t.Run("custom fatal error", func(t *testing.T) {
 		logsFn := test.CaptureLogsForTest(false)
 
-		err := Retry(context.Background(), testLogEvent, "test_operation", func(ctx context.Context, args *RetryFnArgs) error {
+		err := Retry(context.Background(), testLogEvent, "(test_operation)", func(ctx context.Context, args *RetryFnArgs) error {
 			azlog.Writef("TestFunc",
 				"Attempt %d, within test func", args.I)
 			return errors.New("custom fatal error")
@@ -380,7 +380,7 @@ func TestRetryLogging(t *testing.T) {
 		logsFn := test.CaptureLogsForTest(false)
 		reset := false
 
-		err := Retry(context.Background(), testLogEvent, "test_operation", func(ctx context.Context, args *RetryFnArgs) error {
+		err := Retry(context.Background(), testLogEvent, "(test_operation)", func(ctx context.Context, args *RetryFnArgs) error {
 			azlog.Writef("TestFunc", "Attempt %d, within test func", args.I)
 
 			if !reset {

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -11,7 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/amqpwrap"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
@@ -321,7 +320,7 @@ func (r *Receiver) RenewMessageLock(ctx context.Context, msg *ReceivedMessage, o
 func (r *Receiver) Close(ctx context.Context) error {
 	cancelReleaser := r.cancelReleaser.Swap(emptyCancelFn).(func() string)
 	releaserID := cancelReleaser()
-	log.Writef(EventReceiver, "Stopped message releaser with ID '%s'", releaserID)
+	r.amqpLinks.Writef(EventReceiver, "Stopped message releaser with ID '%s'", releaserID)
 
 	r.cleanupOnClose()
 	return r.amqpLinks.Close(ctx, true)
@@ -388,21 +387,21 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 	// might have exited before all credits were used up.
 	currentReceiverCredits := int64(linksWithID.Receiver.Credits())
 	creditsToIssue := int64(maxMessages) - currentReceiverCredits
-	log.Writef(EventReceiver, "Asking for %d credits", maxMessages)
+	r.amqpLinks.Writef(EventReceiver, "Asking for %d credits", maxMessages)
 
 	if creditsToIssue > 0 {
-		log.Writef(EventReceiver, "Only need to issue %d additional credits", creditsToIssue)
+		r.amqpLinks.Writef(EventReceiver, "Only need to issue %d additional credits", creditsToIssue)
 
 		if err := linksWithID.Receiver.IssueCredit(uint32(creditsToIssue)); err != nil {
 			return nil, err
 		}
 	} else {
-		log.Writef(EventReceiver, "No additional credits needed, still have %d credits active", currentReceiverCredits)
+		r.amqpLinks.Writef(EventReceiver, "No additional credits needed, still have %d credits active", currentReceiverCredits)
 	}
 
 	result := r.fetchMessages(ctx, linksWithID.Receiver, maxMessages, r.defaultTimeAfterFirstMsg)
 
-	log.Writef(EventReceiver, "Received %d/%d messages", len(result.Messages), maxMessages)
+	r.amqpLinks.Writef(EventReceiver, "Received %d/%d messages", len(result.Messages), maxMessages)
 
 	// this'll only close anything if the error indicates that the link/connection is bad.
 	// it's safe to call with cancellation errors.
@@ -417,7 +416,7 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 		releaserFunc := r.newReleaserFunc(linksWithID.Receiver)
 		go releaserFunc()
 	} else {
-		log.Writef(EventReceiver, "Failure when receiving messages: %s", result.Error)
+		r.amqpLinks.Writef(EventReceiver, "Failure when receiving messages: %s", result.Error)
 	}
 
 	// If the user does get some messages we ignore 'error' and return only the messages.
@@ -616,7 +615,7 @@ func (r *Receiver) newReleaserFunc(receiver amqpwrap.AMQPReceiver) func() {
 	return func() {
 		defer close(done)
 
-		log.Writef(EventReceiver, "[%s] Message releaser starting...", receiver.LinkName())
+		r.amqpLinks.Writef(EventReceiver, "Message releaser starting...")
 
 		for {
 			// we might not have all the messages we need here.
@@ -631,10 +630,10 @@ func (r *Receiver) newReleaserFunc(receiver amqpwrap.AMQPReceiver) func() {
 			}
 
 			if internal.IsCancelError(err) {
-				log.Writef(exported.EventReceiver, "[%s] Message releaser pausing. Released %d messages", receiver.LinkName(), released)
+				r.amqpLinks.Writef(exported.EventReceiver, "Message releaser pausing. Released %d messages", released)
 				break
 			} else if internal.GetRecoveryKind(err) != internal.RecoveryKindNone {
-				log.Writef(exported.EventReceiver, "[%s] Message releaser stopping because of link failure. Released %d messages. Will start again after next receive: %s", receiver.LinkName(), released, err)
+				r.amqpLinks.Writef(exported.EventReceiver, "Message releaser stopping because of link failure. Released %d messages. Will start again after next receive: %s", released, err)
 				break
 			}
 		}

--- a/sdk/messaging/azservicebus/receiver_simulated_test.go
+++ b/sdk/messaging/azservicebus/receiver_simulated_test.go
@@ -632,7 +632,8 @@ func TestReceiver_CreditsDontExceedMax(t *testing.T) {
 	messages, err = receiver.ReceiveMessages(baseReceiveCtx, 5000, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"hello world"}, getSortedBodies(messages))
-	require.Contains(t, logsFn(), "[azsb.Receiver] No additional credits needed, still have 5000 credits active")
+	logs := logsFn()
+	require.Contains(t, logs, "[azsb.Receiver] [c:1, l:1, r:name:c:001|] No additional credits needed, still have 5000 credits active")
 
 	ctx, cancel = context.WithTimeout(baseReceiveCtx, time.Second)
 	defer cancel()
@@ -644,7 +645,7 @@ func TestReceiver_CreditsDontExceedMax(t *testing.T) {
 	messages, err = receiver.ReceiveMessages(ctx, 5000, nil)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Empty(t, messages)
-	require.Contains(t, logsFn(), "[azsb.Receiver] Only need to issue 1 additional credits")
+	require.Contains(t, logsFn(), "[azsb.Receiver] [c:1, l:1, r:name:c:001|] Only need to issue 1 additional credits")
 
 	require.Equal(t, 1, len(md.Events.GetOpenConns()))
 	require.Equal(t, 3+3, len(md.Events.GetOpenLinks()), "Sender and Receiver each own 3 links apiece ($mgmt, actual link)")

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -183,9 +183,11 @@ func TestReceiver_releaserFunc(t *testing.T) {
 	<-receiverClosed
 	t.Logf("Receiver has closed")
 
+	logs := logsFn()
+
 	require.Contains(t,
-		logsFn(),
-		fmt.Sprintf("[azsb.Receiver] [fakelink] Message releaser pausing. Released %d messages", successfulReleases),
+		logs,
+		fmt.Sprintf("[azsb.Receiver] [prefix] Message releaser pausing. Released %d messages", successfulReleases),
 	)
 }
 
@@ -224,7 +226,7 @@ func TestReceiver_releaserFunc_errorOnFirstMessage(t *testing.T) {
 
 	require.Contains(t,
 		logsFn(),
-		fmt.Sprintf("[azsb.Receiver] [fakelink] Message releaser stopping because of link failure. Released 0 messages. Will start again after next receive: %s", &amqp.LinkError{}))
+		fmt.Sprintf("[azsb.Receiver] Message releaser stopping because of link failure. Released 0 messages. Will start again after next receive: %s", &amqp.LinkError{}))
 }
 
 func TestReceiver_releaserFunc_receiveAndDeleteIsNoop(t *testing.T) {


### PR DESCRIPTION
azeventhubs and azservicebus consistently uses very little CPU and memory, so we can reduce the resources for our tests to be a bit more considerate to other users in the stress cluster.

In addition, the azservicebus package internal logging has been improved - mostly just trimming out some of the repetitive logging and making sure that we have a consistent prefix with link IDs.