### PR TITLE
Enable gocritic during linting

### DIFF
--- a/eng/.golangci.yml
+++ b/eng/.golangci.yml
@@ -3,3 +3,13 @@ run:
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true
+  timeout: 10m
+
+linters:
+  enable:
+    - gocritic
+
+linters-settings:
+  gocritic:
+    enabled-checks:
+      - evalOrder

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
-  GoLintCLIVersion: 'v1.51.1'
+  GoLintCLIVersion: 'v1.52.2'
   Package.EnableSBOMSigning: true
   # Enable go native component governance detection
   # https://docs.opensource.microsoft.com/tools/cg/index.html

--- a/sdk/storage/azblob/blockblob/mmf_windows.go
+++ b/sdk/storage/azblob/blockblob/mmf_windows.go
@@ -26,7 +26,9 @@ func newMMB(size int64) (mmb, error) {
 	if err != nil {
 		return nil, os.NewSyscallError("CreateFileMapping", err)
 	}
-	defer syscall.CloseHandle(hMMF)
+	defer func() {
+		_ = syscall.CloseHandle(hMMF)
+	}()
 
 	addr, err := syscall.MapViewOfFile(hMMF, access, 0, 0, uintptr(size))
 	if err != nil {


### PR DESCRIPTION
Enabled gocritic's evalOrder to catch dependencies on undefined behavior on return statements.
Updated to latest version of golangci-lint.
Fixed issue in azblob flagged by latest linter.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
