### PR TITLE
[azservicebus/azeventhubs] Redirect stderr and stdout to tee

### DIFF
--- a/sdk/messaging/azeventhubs/internal/eh/stress/deploy.ps1
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/deploy.ps1
@@ -9,7 +9,7 @@ function deployUsingLocalAddons() {
     $helmEnv = "pg2"
 
     if (-not (Get-ChildItem $stressTestAddonsFolder)) {
-        Write-Host "Can't find the the new stress test adons folder at $stressTestAddonsFolder"
+        Write-Host "Can't find the the new stress test addons folder at $stressTestAddonsFolder"
         return
     }
 

--- a/sdk/messaging/azeventhubs/internal/eh/stress/templates/stress-test-job.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/templates/stress-test-job.yaml
@@ -22,7 +22,7 @@ spec:
         - >
           set -ex;
           mkdir -p "$DEBUG_SHARE";
-          /app/stress "{{.Stress.testTarget}}" "-rounds" "{{.Stress.rounds}}" "-prefetch" "{{.Stress.prefetch}}" "{{.Stress.verbose}}" "-sleepAfter" "{{.Stress.sleepAfter}}" | tee -a "${DEBUG_SHARE}/{{ .Stress.Scenario }}-`date +%s`.log";
+          /app/stress "{{.Stress.testTarget}}" "-rounds" "{{.Stress.rounds}}" "-prefetch" "{{.Stress.prefetch}}" "{{.Stress.verbose}}" "-sleepAfter" "{{.Stress.sleepAfter}}" 2>&1 | tee -a "${DEBUG_SHARE}/{{ .Stress.Scenario }}-`date +%s`.log";
       # Pulls the image on pod start, always. We tend to push to the same image and tag over and over again
       # when iterating, so this is a must.
       imagePullPolicy: Always

--- a/sdk/messaging/azservicebus/internal/stress/deploy.ps1
+++ b/sdk/messaging/azservicebus/internal/stress/deploy.ps1
@@ -8,7 +8,7 @@ function deployUsingLocalAddons() {
     $helmEnv = "pg2"
 
     if (-not (Get-ChildItem $stressTestAddonsFolder)) {
-        Write-Host "Can't find the the new stress test adons folder at $stressTestAddonsFolder"
+        Write-Host "Can't find the the new stress test addons folder at $stressTestAddonsFolder"
         return
     }
 

--- a/sdk/messaging/azservicebus/internal/stress/templates/stress-test-job.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/templates/stress-test-job.yaml
@@ -17,7 +17,7 @@ spec:
         - >
           set -ex;
           mkdir -p "$DEBUG_SHARE";
-          /app/stress tests "{{ .Stress.testTarget }}" | tee -a "${DEBUG_SHARE}/{{ .Stress.Scenario }}-`date +%s`.log";
+          /app/stress tests "{{ .Stress.testTarget }}" 2>&1 | tee -a "${DEBUG_SHARE}/{{ .Stress.Scenario }}-`date +%s`.log";
       # Pulls the image on pod start, always. We tend to push to the same image and tag over and over again
       # when iterating, so this is a must.
       imagePullPolicy: Always


### PR DESCRIPTION
Had a bug in the kubernetes job yaml where I wasn't redirecting stderr which is probably why I sometimes see empty log files for tests that have disappeared.
