### PR TITLE
[azeventhubs] Improperly resetting etag in the checkpoint store

### DIFF
--- a/sdk/messaging/azeventhubs/inmemory_checkpoint_store_test.go
+++ b/sdk/messaging/azeventhubs/inmemory_checkpoint_store_test.go
@@ -206,13 +206,18 @@ func (cps *testCheckpointStore) ClaimOwnership(ctx context.Context, partitionOwn
 
 			current, exists := cps.ownerships[key]
 
-			if exists && po.ETag != nil && *current.ETag != *po.ETag {
-				// can't own it, didn't have the expected etag
-				return nil, nil
+			if exists {
+				if po.ETag == nil {
+					panic("Ownership blob exists, we should have claimed it using an etag")
+				}
+
+				if *po.ETag != *current.ETag {
+					// can't own it, didn't have the expected etag
+					return nil, nil
+				}
 			}
 
 			newOwnership := po
-
 			uuid, err := uuid.New()
 
 			if err != nil {

--- a/sdk/messaging/azeventhubs/internal/errors.go
+++ b/sdk/messaging/azeventhubs/internal/errors.go
@@ -148,6 +148,7 @@ var amqpConditionsToRecoveryKind = map[amqp.ErrCond]RecoveryKind{
 	amqp.ErrCondNotAllowed:                                 RecoveryKindFatal, // "amqp:not-allowed"
 	amqp.ErrCond("com.microsoft:entity-disabled"):          RecoveryKindFatal, // entity is disabled in the portal
 	amqp.ErrCond("com.microsoft:session-cannot-be-locked"): RecoveryKindFatal,
+	amqp.ErrCond("com.microsoft:argument-out-of-range"):    RecoveryKindFatal, // asked for a partition ID that doesn't exist
 	errorConditionLockLost:                                 RecoveryKindFatal,
 }
 


### PR DESCRIPTION
We shouldn't be resetting the etag to nil - it's what we use to enforce a "single winner" when doing ownership claims.
    
The bug here was two-fold: I had bad logic in my previous claim ownership, which I fixed in a previous PR, but we need to reflect that same constraint properly in our in-memory checkpoint store for these tests.
