### PR TITLE
Revert instance discovery option name change

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### Breaking Changes
 > These changes affect only code written against a beta version such as v1.3.0-beta.5
-* Renamed `DisableInstanceDiscovery` to `DisableAuthorityValidationAndInstanceDiscovery`
 * Renamed `NewOnBehalfOfCredentialFromCertificate` to `NewOnBehalfOfCredentialWithCertificate`
 * Renamed `NewOnBehalfOfCredentialFromSecret` to `NewOnBehalfOfCredentialWithSecret`
 

--- a/sdk/azidentity/client_assertion_credential.go
+++ b/sdk/azidentity/client_assertion_credential.go
@@ -36,12 +36,11 @@ type ClientAssertionCredentialOptions struct {
 	// Add the wildcard value "*" to allow the credential to acquire tokens for any tenant in which the
 	// application is registered.
 	AdditionallyAllowedTenants []string
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 }
 
 // NewClientAssertionCredential constructs a ClientAssertionCredential. The getAssertion function must be thread safe. Pass nil for options to accept defaults.
@@ -57,7 +56,7 @@ func NewClientAssertionCredential(tenantID, clientID string, getAssertion func(c
 			return getAssertion(ctx)
 		},
 	)
-	c, err := getConfidentialClient(clientID, tenantID, cred, &options.ClientOptions, confidential.WithInstanceDiscovery(!options.DisableAuthorityValidationAndInstanceDiscovery))
+	c, err := getConfidentialClient(clientID, tenantID, cred, &options.ClientOptions, confidential.WithInstanceDiscovery(!options.DisableInstanceDiscovery))
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/client_assertion_credential_test.go
+++ b/sdk/azidentity/client_assertion_credential_test.go
@@ -100,10 +100,7 @@ func TestClientAssertionCredential_Live(t *testing.T) {
 				func(context.Context) (string, error) {
 					return getAssertion(certs[0], key)
 				},
-				&ClientAssertionCredentialOptions{
-					ClientOptions: o,
-					DisableAuthorityValidationAndInstanceDiscovery: d,
-				},
+				&ClientAssertionCredentialOptions{ClientOptions: o, DisableInstanceDiscovery: d},
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -29,12 +29,11 @@ type ClientCertificateCredentialOptions struct {
 	// Add the wildcard value "*" to allow the credential to acquire tokens for any tenant in which the
 	// application is registered.
 	AdditionallyAllowedTenants []string
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 	// SendCertificateChain controls whether the credential sends the public certificate chain in the x5c
 	// header of each token request's JWT. This is required for Subject Name/Issuer (SNI) authentication.
 	// Defaults to False.
@@ -63,7 +62,7 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 	if options.SendCertificateChain {
 		o = append(o, confidential.WithX5C())
 	}
-	o = append(o, confidential.WithInstanceDiscovery(!options.DisableAuthorityValidationAndInstanceDiscovery))
+	o = append(o, confidential.WithInstanceDiscovery(!options.DisableInstanceDiscovery))
 	c, err := getConfidentialClient(clientID, tenantID, cred, &options.ClientOptions, o...)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -239,7 +239,7 @@ func TestClientCertificateCredential_Live(t *testing.T) {
 		}
 		o, stop := initRecording(t)
 		defer stop()
-		opts := &ClientCertificateCredentialOptions{ClientOptions: o, DisableAuthorityValidationAndInstanceDiscovery: true}
+		opts := &ClientCertificateCredentialOptions{ClientOptions: o, DisableInstanceDiscovery: true}
 		cred, err := NewClientCertificateCredential(liveSP.tenantID, liveSP.clientID, certs, key, opts)
 		if err != nil {
 			t.Fatalf("failed to construct credential: %v", err)
@@ -265,7 +265,7 @@ func TestClientCertificateCredentialADFS_Live(t *testing.T) {
 	o, stop := initRecording(t)
 	defer stop()
 	o.Cloud.ActiveDirectoryAuthorityHost = adfsAuthority
-	opts := &ClientCertificateCredentialOptions{ClientOptions: o, DisableAuthorityValidationAndInstanceDiscovery: true}
+	opts := &ClientCertificateCredentialOptions{ClientOptions: o, DisableInstanceDiscovery: true}
 	cred, err := NewClientCertificateCredential("adfs", adfsLiveSP.clientID, certs, key, opts)
 	if err != nil {
 		t.Fatalf("failed to construct credential: %v", err)

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -24,12 +24,11 @@ type ClientSecretCredentialOptions struct {
 	// Add the wildcard value "*" to allow the credential to acquire tokens for any tenant in which the
 	// application is registered.
 	AdditionallyAllowedTenants []string
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 }
 
 // ClientSecretCredential authenticates an application with a client secret.
@@ -48,7 +47,7 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 		return nil, err
 	}
 	c, err := getConfidentialClient(
-		clientID, tenantID, cred, &options.ClientOptions, confidential.WithInstanceDiscovery(!options.DisableAuthorityValidationAndInstanceDiscovery),
+		clientID, tenantID, cred, &options.ClientOptions, confidential.WithInstanceDiscovery(!options.DisableInstanceDiscovery),
 	)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -49,7 +49,7 @@ func TestClientSecretCredential_Live(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			opts, stop := initRecording(t)
 			defer stop()
-			o := ClientSecretCredentialOptions{ClientOptions: opts, DisableAuthorityValidationAndInstanceDiscovery: disabledID}
+			o := ClientSecretCredentialOptions{ClientOptions: opts, DisableInstanceDiscovery: disabledID}
 			cred, err := NewClientSecretCredential(liveSP.tenantID, liveSP.clientID, liveSP.secret, &o)
 			if err != nil {
 				t.Fatalf("failed to construct credential: %v", err)
@@ -68,7 +68,7 @@ func TestClientSecretCredentialADFS_Live(t *testing.T) {
 	opts, stop := initRecording(t)
 	defer stop()
 	opts.Cloud.ActiveDirectoryAuthorityHost = adfsAuthority
-	o := ClientSecretCredentialOptions{ClientOptions: opts, DisableAuthorityValidationAndInstanceDiscovery: true}
+	o := ClientSecretCredentialOptions{ClientOptions: opts, DisableInstanceDiscovery: true}
 	cred, err := NewClientSecretCredential("adfs", adfsLiveSP.clientID, adfsLiveSP.secret, &o)
 	if err != nil {
 		t.Fatalf("failed to construct credential: %v", err)

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -27,12 +27,11 @@ type DefaultAzureCredentialOptions struct {
 	// the wildcard value "*" to allow the credential to acquire tokens for any tenant. This value can also be
 	// set as a semicolon delimited list of tenants in the environment variable AZURE_ADDITIONALLY_ALLOWED_TENANTS.
 	AdditionallyAllowedTenants []string
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 	// TenantID identifies the tenant the Azure CLI should authenticate in.
 	// Defaults to the CLI's default tenant, which is typically the home tenant of the user logged in to the CLI.
 	TenantID string
@@ -73,9 +72,9 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 	}
 
 	envCred, err := NewEnvironmentCredential(&EnvironmentCredentialOptions{
-		ClientOptions: options.ClientOptions,
-		DisableAuthorityValidationAndInstanceDiscovery: options.DisableAuthorityValidationAndInstanceDiscovery,
-		additionallyAllowedTenants:                     additionalTenants,
+		ClientOptions:              options.ClientOptions,
+		DisableInstanceDiscovery:   options.DisableInstanceDiscovery,
+		additionallyAllowedTenants: additionalTenants,
 	})
 	if err == nil {
 		creds = append(creds, envCred)
@@ -88,7 +87,7 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 	wic, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
 		AdditionallyAllowedTenants: additionalTenants,
 		ClientOptions:              options.ClientOptions,
-		DisableAuthorityValidationAndInstanceDiscovery: options.DisableAuthorityValidationAndInstanceDiscovery,
+		DisableInstanceDiscovery:   options.DisableInstanceDiscovery,
 	})
 	if err == nil {
 		creds = append(creds, wic)

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -27,12 +27,11 @@ type DeviceCodeCredentialOptions struct {
 	// ClientID is the ID of the application users will authenticate to.
 	// Defaults to the ID of an Azure development application.
 	ClientID string
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 	// TenantID is the Azure Active Directory tenant the credential authenticates in. Defaults to the
 	// "organizations" tenant, which can authenticate work and school accounts. Required for single-tenant
 	// applications.
@@ -89,7 +88,7 @@ func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeC
 	}
 	cp.init()
 	c, err := getPublicClient(
-		cp.ClientID, cp.TenantID, &cp.ClientOptions, public.WithInstanceDiscovery(!cp.DisableAuthorityValidationAndInstanceDiscovery),
+		cp.ClientID, cp.TenantID, &cp.ClientOptions, public.WithInstanceDiscovery(!cp.DisableInstanceDiscovery),
 	)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -99,7 +99,7 @@ func TestDeviceCodeCredential_Live(t *testing.T) {
 		},
 		{
 			desc: "instance discovery disabled",
-			opts: DeviceCodeCredentialOptions{DisableAuthorityValidationAndInstanceDiscovery: true, TenantID: liveSP.tenantID},
+			opts: DeviceCodeCredentialOptions{DisableInstanceDiscovery: true, TenantID: liveSP.tenantID},
 		},
 		{
 			desc: "optional tenant",
@@ -133,9 +133,10 @@ func TestDeviceCodeCredentialADFS_Live(t *testing.T) {
 	defer stop()
 	o.Cloud.ActiveDirectoryAuthorityHost = adfsAuthority
 	opts := DeviceCodeCredentialOptions{
-		ClientID:      adfsLiveUser.clientID,
-		ClientOptions: o, DisableAuthorityValidationAndInstanceDiscovery: true,
-		TenantID: "adfs",
+		ClientID:                 adfsLiveUser.clientID,
+		ClientOptions:            o,
+		DisableInstanceDiscovery: true,
+		TenantID:                 "adfs",
 	}
 	if recording.GetRecordMode() == recording.PlaybackMode {
 		opts.UserPrompt = func(ctx context.Context, m DeviceCodeMessage) error { return nil }

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -24,12 +24,11 @@ const envVarSendCertChain = "AZURE_CLIENT_SEND_CERTIFICATE_CHAIN"
 type EnvironmentCredentialOptions struct {
 	azcore.ClientOptions
 
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 	// additionallyAllowedTenants is used only by NewDefaultAzureCredential() to enable that constructor's explicit
 	// option to override the value of AZURE_ADDITIONALLY_ALLOWED_TENANTS. Applications using EnvironmentCredential
 	// directly should set that variable instead. This field should remain unexported to preserve this credential's
@@ -102,7 +101,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 		o := &ClientSecretCredentialOptions{
 			AdditionallyAllowedTenants: additionalTenants,
 			ClientOptions:              options.ClientOptions,
-			DisableAuthorityValidationAndInstanceDiscovery: options.DisableAuthorityValidationAndInstanceDiscovery,
+			DisableInstanceDiscovery:   options.DisableInstanceDiscovery,
 		}
 		cred, err := NewClientSecretCredential(tenantID, clientID, clientSecret, o)
 		if err != nil {
@@ -127,7 +126,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 		o := &ClientCertificateCredentialOptions{
 			AdditionallyAllowedTenants: additionalTenants,
 			ClientOptions:              options.ClientOptions,
-			DisableAuthorityValidationAndInstanceDiscovery: options.DisableAuthorityValidationAndInstanceDiscovery,
+			DisableInstanceDiscovery:   options.DisableInstanceDiscovery,
 		}
 		if v, ok := os.LookupEnv(envVarSendCertChain); ok {
 			o.SendCertificateChain = v == "1" || strings.ToLower(v) == "true"
@@ -144,7 +143,7 @@ func NewEnvironmentCredential(options *EnvironmentCredentialOptions) (*Environme
 			o := &UsernamePasswordCredentialOptions{
 				AdditionallyAllowedTenants: additionalTenants,
 				ClientOptions:              options.ClientOptions,
-				DisableAuthorityValidationAndInstanceDiscovery: options.DisableAuthorityValidationAndInstanceDiscovery,
+				DisableInstanceDiscovery:   options.DisableInstanceDiscovery,
 			}
 			cred, err := NewUsernamePasswordCredential(tenantID, clientID, username, password, o)
 			if err != nil {

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -248,8 +248,8 @@ func TestEnvironmentCredential_ClientSecretLive(t *testing.T) {
 			opts, stop := initRecording(t)
 			defer stop()
 			cred, err := NewEnvironmentCredential(&EnvironmentCredentialOptions{
-				ClientOptions: opts,
-				DisableAuthorityValidationAndInstanceDiscovery: disabledID,
+				ClientOptions:            opts,
+				DisableInstanceDiscovery: disabledID,
 			})
 			if err != nil {
 				t.Fatalf("failed to construct credential: %v", err)
@@ -275,8 +275,8 @@ func TestEnvironmentCredentialADFS_ClientSecretLive(t *testing.T) {
 	opts, stop := initRecording(t)
 	defer stop()
 	cred, err := NewEnvironmentCredential(&EnvironmentCredentialOptions{
-		ClientOptions: opts,
-		DisableAuthorityValidationAndInstanceDiscovery: true,
+		ClientOptions:            opts,
+		DisableInstanceDiscovery: true,
 	})
 	if err != nil {
 		t.Fatalf("failed to construct credential: %v", err)
@@ -330,8 +330,8 @@ func TestEnvironmentCredential_UserPasswordLive(t *testing.T) {
 			opts, stop := initRecording(t)
 			defer stop()
 			cred, err := NewEnvironmentCredential(&EnvironmentCredentialOptions{
-				ClientOptions: opts,
-				DisableAuthorityValidationAndInstanceDiscovery: disabledID,
+				ClientOptions:            opts,
+				DisableInstanceDiscovery: disabledID,
 			})
 			if err != nil {
 				t.Fatalf("failed to construct credential: %v", err)
@@ -358,8 +358,8 @@ func TestEnvironmentCredentialADFS_UserPasswordLive(t *testing.T) {
 	opts, stop := initRecording(t)
 	defer stop()
 	cred, err := NewEnvironmentCredential(&EnvironmentCredentialOptions{
-		ClientOptions: opts,
-		DisableAuthorityValidationAndInstanceDiscovery: true,
+		ClientOptions:            opts,
+		DisableInstanceDiscovery: true,
 	})
 	if err != nil {
 		t.Fatalf("failed to construct credential: %v", err)

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -27,12 +27,11 @@ type InteractiveBrowserCredentialOptions struct {
 	// Defaults to the ID of an Azure development application.
 	ClientID string
 
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 
 	// LoginHint pre-populates the account prompt with a username. Users may choose to authenticate a different account.
 	LoginHint string
@@ -70,7 +69,7 @@ func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOption
 		cp = *options
 	}
 	cp.init()
-	c, err := getPublicClient(cp.ClientID, cp.TenantID, &cp.ClientOptions, public.WithInstanceDiscovery(!cp.DisableAuthorityValidationAndInstanceDiscovery))
+	c, err := getPublicClient(cp.ClientID, cp.TenantID, &cp.ClientOptions, public.WithInstanceDiscovery(!cp.DisableInstanceDiscovery))
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -111,7 +111,7 @@ func TestInteractiveBrowserCredential_Live(t *testing.T) {
 				PerCallPolicies: []policy.Policy{
 					&instanceDiscoveryPolicy{t},
 				}},
-			DisableAuthorityValidationAndInstanceDiscovery: true,
+			DisableInstanceDiscovery: true,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -135,11 +135,11 @@ func TestInteractiveBrowserCredentialADFS_Live(t *testing.T) {
 	clientOptions := policy.ClientOptions{Cloud: cloudConfig}
 
 	cred, err := NewInteractiveBrowserCredential(&InteractiveBrowserCredentialOptions{
-		ClientOptions: clientOptions,
-		ClientID:      adfsLiveUser.clientID,
-		DisableAuthorityValidationAndInstanceDiscovery: true,
-		RedirectURL: url,
-		TenantID:    "adfs",
+		ClientOptions:            clientOptions,
+		ClientID:                 adfsLiveUser.clientID,
+		DisableInstanceDiscovery: true,
+		RedirectURL:              url,
+		TenantID:                 "adfs",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/on_behalf_of_credential.go
+++ b/sdk/azidentity/on_behalf_of_credential.go
@@ -38,12 +38,11 @@ type OnBehalfOfCredentialOptions struct {
 	// Add the wildcard value "*" to allow the credential to acquire tokens for any tenant in which the
 	// application is registered.
 	AdditionallyAllowedTenants []string
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 	// SendCertificateChain applies only when the credential is configured to authenticate with a certificate.
 	// This setting controls whether the credential sends the public certificate chain in the x5c header of each
 	// token request's JWT. This is required for, and only used in, Subject Name/Issuer (SNI) authentication.
@@ -77,7 +76,7 @@ func newOnBehalfOfCredential(tenantID, clientID, userAssertion string, cred conf
 	if options.SendCertificateChain {
 		opts = append(opts, confidential.WithX5C())
 	}
-	opts = append(opts, confidential.WithInstanceDiscovery(!options.DisableAuthorityValidationAndInstanceDiscovery))
+	opts = append(opts, confidential.WithInstanceDiscovery(!options.DisableInstanceDiscovery))
 	c, err := getConfidentialClient(clientID, tenantID, cred, &options.ClientOptions, opts...)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -24,12 +24,11 @@ type UsernamePasswordCredentialOptions struct {
 	// Add the wildcard value "*" to allow the credential to acquire tokens for any tenant in which the
 	// application is registered.
 	AdditionallyAllowedTenants []string
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 }
 
 // UsernamePasswordCredential authenticates a user with a password. Microsoft doesn't recommend this kind of authentication,
@@ -49,7 +48,7 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 	if options == nil {
 		options = &UsernamePasswordCredentialOptions{}
 	}
-	c, err := getPublicClient(clientID, tenantID, &options.ClientOptions, public.WithInstanceDiscovery(!options.DisableAuthorityValidationAndInstanceDiscovery))
+	c, err := getPublicClient(clientID, tenantID, &options.ClientOptions, public.WithInstanceDiscovery(!options.DisableInstanceDiscovery))
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/username_password_credential_test.go
+++ b/sdk/azidentity/username_password_credential_test.go
@@ -47,7 +47,7 @@ func TestUsernamePasswordCredential_Live(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			o, stop := initRecording(t)
 			defer stop()
-			opts := UsernamePasswordCredentialOptions{ClientOptions: o, DisableAuthorityValidationAndInstanceDiscovery: disabledID}
+			opts := UsernamePasswordCredentialOptions{ClientOptions: o, DisableInstanceDiscovery: disabledID}
 			cred, err := NewUsernamePasswordCredential(liveUser.tenantID, developerSignOnClientID, liveUser.username, liveUser.password, &opts)
 			if err != nil {
 				t.Fatalf("Unable to create credential. Received: %v", err)
@@ -66,7 +66,7 @@ func TestUsernamePasswordCredentialADFS_Live(t *testing.T) {
 	o, stop := initRecording(t)
 	o.Cloud.ActiveDirectoryAuthorityHost = adfsAuthority
 	defer stop()
-	opts := UsernamePasswordCredentialOptions{ClientOptions: o, DisableAuthorityValidationAndInstanceDiscovery: true}
+	opts := UsernamePasswordCredentialOptions{ClientOptions: o, DisableInstanceDiscovery: true}
 	cred, err := NewUsernamePasswordCredential("adfs", adfsLiveUser.clientID, adfsLiveUser.username, adfsLiveUser.password, &opts)
 	if err != nil {
 		t.Fatalf("Unable to create credential. Received: %v", err)

--- a/sdk/azidentity/workload_identity.go
+++ b/sdk/azidentity/workload_identity.go
@@ -40,12 +40,11 @@ type WorkloadIdentityCredentialOptions struct {
 	AdditionallyAllowedTenants []string
 	// ClientID of the service principal. Defaults to the value of the environment variable AZURE_CLIENT_ID.
 	ClientID string
-	// DisableAuthorityValidationAndInstanceDiscovery should be set true only by applications authenticating
-	// in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential
-	// requests Azure AD instance metadata from https://login.microsoft.com before authenticating. Setting
-	// this to true will skip this request, making the application responsible for ensuring the configured
-	// authority is valid and trustworthy.
-	DisableAuthorityValidationAndInstanceDiscovery bool
+	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
+	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
+	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
+	// the application responsible for ensuring the configured authority is valid and trustworthy.
+	DisableInstanceDiscovery bool
 	// TenantID of the service principal. Defaults to the value of the environment variable AZURE_TENANT_ID.
 	TenantID string
 	// TokenFilePath is the path a file containing the workload identity token. Defaults to the value of the
@@ -82,7 +81,7 @@ func NewWorkloadIdentityCredential(options *WorkloadIdentityCredentialOptions) (
 	caco := ClientAssertionCredentialOptions{
 		AdditionallyAllowedTenants: options.AdditionallyAllowedTenants,
 		ClientOptions:              options.ClientOptions,
-		DisableAuthorityValidationAndInstanceDiscovery: options.DisableAuthorityValidationAndInstanceDiscovery,
+		DisableInstanceDiscovery:   options.DisableInstanceDiscovery,
 	}
 	cred, err := NewClientAssertionCredential(tenantID, clientID, w.getAssertion, &caco)
 	if err != nil {

--- a/sdk/azidentity/workload_identity_test.go
+++ b/sdk/azidentity/workload_identity_test.go
@@ -71,11 +71,11 @@ func TestWorkloadIdentityCredential_Live(t *testing.T) {
 			co, stop := initRecording(t)
 			defer stop()
 			cred, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
-				ClientID:      liveSP.clientID,
-				ClientOptions: co,
-				DisableAuthorityValidationAndInstanceDiscovery: b,
-				TenantID:      liveSP.tenantID,
-				TokenFilePath: f,
+				ClientID:                 liveSP.clientID,
+				ClientOptions:            co,
+				DisableInstanceDiscovery: b,
+				TenantID:                 liveSP.tenantID,
+				TokenFilePath:            f,
 			})
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Reverting #20674, going back to `DisableInstanceDiscovery` per architect discussions