### PR TITLE
Some refactoring of the fakes package

### DIFF
--- a/sdk/azcore/fake/example_test.go
+++ b/sdk/azcore/fake/example_test.go
@@ -50,9 +50,9 @@ func ExampleResponder() {
 	resp := fake.Responder[WidgetResponse]{}
 
 	// here we set the instance of Widget the Responder is to return
-	resp.Set(WidgetResponse{
+	resp.SetResponse(WidgetResponse{
 		Widget{ID: 123, Shape: "triangle"},
-	})
+	}, nil)
 
 	// optional HTTP headers can also be included in the raw response
 	resp.SetHeader("custom-header1", "value1")
@@ -128,7 +128,7 @@ func ExamplePollerResponder() {
 			ID:    987,
 			Shape: "dodecahedron",
 		},
-	})
+	}, nil)
 }
 
 func ExamplePollerResponder_SetTerminalError() {

--- a/sdk/azcore/fake/example_test.go
+++ b/sdk/azcore/fake/example_test.go
@@ -119,7 +119,7 @@ func ExamplePollerResponder() {
 
 	// non-terminal errors can also be included in the sequence of responses.
 	// use this to simulate an error during polling.
-	pollerResp.AddNonTerminalError(errors.New("flaky network"))
+	pollerResp.AddPollingError(errors.New("flaky network"))
 
 	// use SetTerminalResponse to successfully terminate the long-running operation.
 	// the provided value will be returned as the terminal response.

--- a/sdk/azcore/fake/fake.go
+++ b/sdk/azcore/fake/fake.go
@@ -63,7 +63,7 @@ type Responder[T any] struct {
 	opts   SetResponseOptions
 }
 
-// Set sets the specified value to be returned.
+// SetResponse sets the specified value to be returned.
 //   - resp is the response to be returned
 //   - o contains optional values, pass nil to accept the defaults
 func (r *Responder[T]) SetResponse(resp T, o *SetResponseOptions) {

--- a/sdk/azcore/fake/fake.go
+++ b/sdk/azcore/fake/fake.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 )
 
@@ -228,9 +229,13 @@ func MarshalResponseAsJSON(content ResponseContent, v any, req *http.Request) (*
 
 // MarshalResponseAsText converts the body into text and returns it in a *http.Response.
 // This function is typically called by the fake server internals.
-func MarshalResponseAsText(content ResponseContent, body string, req *http.Request) (*http.Response, error) {
+func MarshalResponseAsText(content ResponseContent, body *string, req *http.Request) (*http.Response, error) {
 	resp := newResponse(content, req)
-	resp = setResponseBody(resp, []byte(body), shared.ContentTypeTextPlain)
+	// if the fake forgot to set the body, substitute an empty string (better than a panic)
+	if body == nil {
+		body = to.Ptr("")
+	}
+	resp = setResponseBody(resp, []byte(*body), shared.ContentTypeTextPlain)
 	return resp, nil
 }
 

--- a/sdk/azcore/fake/fake.go
+++ b/sdk/azcore/fake/fake.go
@@ -12,14 +12,15 @@
 package fake
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -57,22 +58,39 @@ func (t *TokenCredential) GetToken(ctx context.Context, opts policy.TokenRequest
 
 // Responder represents a scalar response.
 type Responder[T any] struct {
-	h    http.Header
-	resp T
+	resp   T
+	header http.Header
+	opts   SetResponseOptions
 }
 
 // Set sets the specified value to be returned.
-func (r *Responder[T]) Set(b T) {
-	r.resp = b
+//   - resp is the response to be returned
+//   - o contains optional values, pass nil to accept the defaults
+func (r *Responder[T]) SetResponse(resp T, o *SetResponseOptions) {
+	r.resp = resp
+	if o != nil {
+		r.opts = *o
+	}
 }
 
 // SetHeader sets the specified header key/value pairs to be returned.
 // Call multiple times to set multiple headers.
 func (r *Responder[T]) SetHeader(key, value string) {
-	if r.h == nil {
-		r.h = http.Header{}
+	if r.header == nil {
+		r.header = http.Header{}
 	}
-	r.h.Set(key, value)
+	r.header.Set(key, value)
+}
+
+// SetResponseOptions contains the optional values for Responder[T].SetResponse.
+type SetResponseOptions struct {
+	// StatusCode is the HTTP status code to return in the response.
+	// The default value is http.StatusOK (200).
+	StatusCode int
+
+	// Status is the HTTP status message to return in the response.
+	// The default value is "OK".
+	Status string
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -89,6 +107,8 @@ func (e *ErrorResponder) SetError(err error) {
 }
 
 // SetResponseError sets an *azcore.ResponseError with the specified values to be returned.
+//   - errorCode is the value to be used in the ResponseError.Code field
+//   - httpStatus is the HTTP status code
 func (e *ErrorResponder) SetResponseError(errorCode string, httpStatus int) {
 	e.err = &nonRetriableError{err: &azcore.ResponseError{ErrorCode: errorCode, StatusCode: httpStatus}}
 }
@@ -102,6 +122,8 @@ type PagerResponder[T any] struct {
 }
 
 // AddPage adds a page to the sequence of respones.
+//   - page is the response page to be added
+//   - o contains optional values, pass nil to accept the defaults
 func (p *PagerResponder[T]) AddPage(page T, o *AddPageOptions) {
 	p.pages = append(p.pages, page)
 }
@@ -146,7 +168,7 @@ func (p *PollerResponder[T]) AddNonTerminalError(err error) {
 }
 
 // SetTerminalResponse sets the provided value as the successful, terminal response.
-func (p *PollerResponder[T]) SetTerminalResponse(result T) {
+func (p *PollerResponder[T]) SetTerminalResponse(result T, o *SetTerminalResponseOptions) {
 	p.res = &result
 }
 
@@ -160,26 +182,72 @@ type AddNonTerminalResponseOptions struct {
 	// place holder for future optional values
 }
 
+// SetTerminalResponseOptions contains the optional values for PollerResponder[T].SetTerminalResponse.
+type SetTerminalResponseOptions struct {
+	// place holder for future optional values
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // the following APIs are intended for use by fake servers
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// ResponseContent is used when building the *http.Response.
+// This type is typically used by the fake server internals.
+type ResponseContent struct {
+	StatusCode int
+	Status     string
+	Header     http.Header
+}
+
+// NewResponse returns a *http.Response.
+// This function is typically called by the fake server internals.
+func NewResponse(content ResponseContent, req *http.Request) (*http.Response, error) {
+	resp := newResponse(content, req)
+	return resp, nil
+}
+
+// NewBinaryResponse acquires the binary response and returns it in a *http.Response.
+// This function is typically called by the fake server internals.
+func NewBinaryResponse(content ResponseContent, body io.ReadCloser, req *http.Request) (*http.Response, error) {
+	resp := newResponse(content, req)
+	resp.Body = body
+	return resp, nil
+}
+
 // MarshalResponseAsJSON converts the body into JSON and returns it in a *http.Response.
-// This method is typically called by the fake server internals.
-func MarshalResponseAsJSON[T any](r Responder[T], req *http.Request) (*http.Response, error) {
-	body, err := json.Marshal(r.resp)
+// This function is typically called by the fake server internals.
+func MarshalResponseAsJSON(content ResponseContent, v any, req *http.Request) (*http.Response, error) {
+	body, err := json.Marshal(v)
 	if err != nil {
 		return nil, &nonRetriableError{err}
 	}
-	resp := newResponse(http.StatusOK, "OK", req, string(body))
-	for key := range r.h {
-		resp.Header.Set(key, r.h.Get(key))
+	resp := newResponse(content, req)
+	resp = setResponseBody(resp, body, shared.ContentTypeAppJSON)
+	return resp, nil
+}
+
+// MarshalResponseAsText converts the body into text and returns it in a *http.Response.
+// This function is typically called by the fake server internals.
+func MarshalResponseAsText(content ResponseContent, body string, req *http.Request) (*http.Response, error) {
+	resp := newResponse(content, req)
+	resp = setResponseBody(resp, []byte(body), shared.ContentTypeTextPlain)
+	return resp, nil
+}
+
+// MarshalResponseAsXML converts the body into XML and returns it in a *http.Response.
+// This function is typically called by the fake server internals.
+func MarshalResponseAsXML(content ResponseContent, v any, req *http.Request) (*http.Response, error) {
+	body, err := xml.Marshal(v)
+	if err != nil {
+		return nil, &nonRetriableError{err}
 	}
+	resp := newResponse(content, req)
+	resp = setResponseBody(resp, body, shared.ContentTypeAppXML)
 	return resp, nil
 }
 
 // UnmarshalRequestAsJSON unmarshalls the request body into an instance of T.
-// This method is typically called by the fake server internals.
+// This function is typically called by the fake server internals.
 func UnmarshalRequestAsJSON[T any](req *http.Request) (T, error) {
 	tt := *new(T)
 	body, err := io.ReadAll(req.Body)
@@ -193,8 +261,60 @@ func UnmarshalRequestAsJSON[T any](req *http.Request) (T, error) {
 	return tt, err
 }
 
+// UnmarshalRequestAsText unmarshalls the request body into a string.
+// This function is typically called by the fake server internals.
+func UnmarshalRequestAsText(req *http.Request) (string, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return "", &nonRetriableError{err}
+	}
+	req.Body.Close()
+	return string(body), nil
+}
+
+// UnmarshalRequestAsXML unmarshalls the request body into an instance of T.
+// This function is typically called by the fake server internals.
+func UnmarshalRequestAsXML[T any](req *http.Request) (T, error) {
+	tt := *new(T)
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return tt, &nonRetriableError{err}
+	}
+	req.Body.Close()
+	if err = xml.Unmarshal(body, &tt); err != nil {
+		err = &nonRetriableError{err}
+	}
+	return tt, err
+}
+
+// GetResponse returns the response associated with the Responder.
+// This function is typically called by the fake server internals.
+func GetResponse[T any](r Responder[T]) T {
+	return r.resp
+}
+
+// GetResponseContent returns the ResponseContent associated with the Responder.
+// This function is typically called by the fake server internals.
+func GetResponseContent[T any](r Responder[T]) ResponseContent {
+	content := ResponseContent{
+		StatusCode: http.StatusOK,
+		Status:     "OK",
+		Header:     r.header,
+	}
+	if r.opts.StatusCode != 0 {
+		content.StatusCode = r.opts.StatusCode
+	}
+	if r.opts.Status != "" {
+		content.Status = r.opts.Status
+	}
+	if content.Header == nil {
+		content.Header = http.Header{}
+	}
+	return content
+}
+
 // GetError returns the error for this responder.
-// This method is typically called by the fake server internals.
+// This function is typically called by the fake server internals.
 func GetError(e ErrorResponder, req *http.Request) error {
 	if e.err == nil {
 		return nil
@@ -209,7 +329,7 @@ func GetError(e ErrorResponder, req *http.Request) error {
 }
 
 // PagerResponderNext returns the next response in the sequence (a T or an error).
-// This method is typically called by the fake server internals.
+// This function is typically called by the fake server internals.
 func PagerResponderNext[T any](p *PagerResponder[T], req *http.Request) (*http.Response, error) {
 	if len(p.pages) == 0 {
 		return nil, &nonRetriableError{errors.New("paged response has no pages")}
@@ -224,7 +344,13 @@ func PagerResponderNext[T any](p *PagerResponder[T], req *http.Request) (*http.R
 		if err != nil {
 			return nil, &nonRetriableError{err}
 		}
-		return newResponse(http.StatusOK, "OK", req, string(body)), nil
+		content := ResponseContent{
+			StatusCode: http.StatusOK,
+			Status:     "OK",
+			Header:     http.Header{},
+		}
+		resp := newResponse(content, req)
+		return setResponseBody(resp, body, shared.ContentTypeAppJSON), nil
 	}
 
 	err := page.(error)
@@ -237,7 +363,7 @@ func PagerResponderNext[T any](p *PagerResponder[T], req *http.Request) (*http.R
 }
 
 // PagerResponderMore returns true if there are more responses for consumption.
-// This method is typically called by the fake server internals.
+// This function is typically called by the fake server internals.
 func PagerResponderMore[T any](p *PagerResponder[T]) bool {
 	return len(p.pages) > 0
 }
@@ -249,7 +375,7 @@ type pageindex[T any] struct {
 
 // PagerResponderInjectNextLinks is used to populate the nextLink field.
 // The inject callback is executed for every T in the sequence except for the last one.
-// This method is typically called by the fake server internals.
+// This function is typically called by the fake server internals.
 func PagerResponderInjectNextLinks[T any](p *PagerResponder[T], req *http.Request, inject func(page *T, createLink func() string)) {
 	// first find all the actual pages in the list
 	pages := make([]pageindex[T], 0, len(p.pages))
@@ -279,13 +405,13 @@ func PagerResponderInjectNextLinks[T any](p *PagerResponder[T], req *http.Reques
 }
 
 // PollerResponderMore returns true if there are more responses for consumption.
-// This method is typically called by the fake server internals.
+// This function is typically called by the fake server internals.
 func PollerResponderMore[T any](p *PollerResponder[T]) bool {
 	return len(p.nonTermResps) > 0 || p.err != nil || p.res != nil
 }
 
 // PollerResponderNext returns the next response in the sequence (a *http.Response or an error).
-// This method is typically called by the fake server internals.
+// This function is typically called by the fake server internals.
 func PollerResponderNext[T any](p *PollerResponder[T], req *http.Request) (*http.Response, error) {
 	if len(p.nonTermResps) > 0 {
 		resp := p.nonTermResps[0]
@@ -295,7 +421,12 @@ func PollerResponderNext[T any](p *PollerResponder[T], req *http.Request) (*http
 			return nil, &nonRetriableError{resp.err}
 		}
 
-		httpResp := newResponse(http.StatusOK, "OK", req, "")
+		content := ResponseContent{
+			StatusCode: http.StatusOK,
+			Status:     "OK",
+			Header:     http.Header{},
+		}
+		httpResp := newResponse(content, req)
 		httpResp.Header.Set(shared.HeaderFakePollerStatus, resp.status)
 
 		if resp.retryAfter > 0 {
@@ -316,7 +447,12 @@ func PollerResponderNext[T any](p *PollerResponder[T], req *http.Request) (*http
 			return nil, &nonRetriableError{err}
 		}
 		p.res = nil
-		httpResp := newResponse(http.StatusOK, "OK", req, string(body))
+		content := ResponseContent{
+			StatusCode: http.StatusOK,
+			Status:     "OK",
+			Header:     http.Header{},
+		}
+		httpResp := setResponseBody(newResponse(content, req), body, shared.ContentTypeAppJSON)
 		httpResp.Header.Set(shared.HeaderFakePollerStatus, "Succeeded")
 		return httpResp, nil
 	} else {
@@ -330,29 +466,35 @@ type nonTermResp struct {
 	err        error
 }
 
-func newResponse(statusCode int, status string, req *http.Request, body string) *http.Response {
-	resp := &http.Response{
+func setResponseBody(resp *http.Response, body []byte, contentType string) *http.Response {
+	if l := int64(len(body)); l > 0 {
+		resp.Header.Set(shared.HeaderContentType, contentType)
+		resp.ContentLength = l
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	return resp
+}
+
+func newResponse(content ResponseContent, req *http.Request) *http.Response {
+	return &http.Response{
 		Body:       http.NoBody,
-		Header:     http.Header{},
+		Header:     content.Header,
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
 		Request:    req,
-		Status:     status,
-		StatusCode: statusCode,
+		Status:     content.Status,
+		StatusCode: content.StatusCode,
 	}
-
-	if l := int64(len(body)); l > 0 {
-		resp.Header.Set(shared.HeaderContentType, shared.ContentTypeAppJSON)
-		resp.ContentLength = l
-		resp.Body = io.NopCloser(strings.NewReader(body))
-	}
-
-	return resp
 }
 
 func newErrorResponse(errorCode string, statusCode int, req *http.Request) *http.Response {
-	resp := newResponse(statusCode, "Operation Failed", req, "")
+	content := ResponseContent{
+		StatusCode: statusCode,
+		Status:     "Operation Failed",
+		Header:     http.Header{},
+	}
+	resp := newResponse(content, req)
 	resp.Header.Set(shared.HeaderXMSErrorCode, errorCode)
 	return resp
 }

--- a/sdk/azcore/fake/fake.go
+++ b/sdk/azcore/fake/fake.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 )
 
@@ -231,11 +230,11 @@ func MarshalResponseAsJSON(content ResponseContent, v any, req *http.Request) (*
 // This function is typically called by the fake server internals.
 func MarshalResponseAsText(content ResponseContent, body *string, req *http.Request) (*http.Response, error) {
 	resp := newResponse(content, req)
-	// if the fake forgot to set the body, substitute an empty string (better than a panic)
-	if body == nil {
-		body = to.Ptr("")
+	var bodyAsBytes []byte
+	if body != nil {
+		bodyAsBytes = []byte(*body)
 	}
-	resp = setResponseBody(resp, []byte(*body), shared.ContentTypeTextPlain)
+	resp = setResponseBody(resp, bodyAsBytes, shared.ContentTypeTextPlain)
 	return resp, nil
 }
 

--- a/sdk/azcore/fake/fake.go
+++ b/sdk/azcore/fake/fake.go
@@ -189,21 +189,31 @@ type SetTerminalResponseOptions struct {
 // ResponseContent is used when building the *http.Response.
 // This type is typically used by the fake server internals.
 type ResponseContent struct {
+	// Header contains the headers from Responder[T].SetHeader to include in the HTTP response.
 	Header http.Header
+}
+
+// ResponseOptions contains the optional values for NewResponse().
+type ResponseOptions struct {
+	// Body is the HTTP response body.
+	Body io.ReadCloser
+
+	// ContentType is the value for the Content-Type HTTP header.
+	ContentType string
 }
 
 // NewResponse returns a *http.Response.
 // This function is typically called by the fake server internals.
-func NewResponse(content ResponseContent, req *http.Request) (*http.Response, error) {
+func NewResponse(content ResponseContent, req *http.Request, opts *ResponseOptions) (*http.Response, error) {
 	resp := newResponse(content, req)
-	return resp, nil
-}
-
-// NewBinaryResponse acquires the binary response and returns it in a *http.Response.
-// This function is typically called by the fake server internals.
-func NewBinaryResponse(content ResponseContent, body io.ReadCloser, req *http.Request) (*http.Response, error) {
-	resp := newResponse(content, req)
-	resp.Body = body
+	if opts != nil {
+		if opts.Body != nil {
+			resp.Body = opts.Body
+		}
+		if opts.ContentType != "" {
+			resp.Header.Set(shared.HeaderContentType, opts.ContentType)
+		}
+	}
 	return resp, nil
 }
 

--- a/sdk/azcore/fake/fake_test.go
+++ b/sdk/azcore/fake/fake_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
@@ -371,17 +372,21 @@ func TestPollerResponderTerminalFailure(t *testing.T) {
 func TestNewResponse(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPut, "https://foo.bar/baz", nil)
 	require.NoError(t, err)
-	resp, err := NewResponse(ResponseContent{}, req)
+	resp, err := NewResponse(ResponseContent{}, req, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestNewBinaryResponse(t *testing.T) {
+func TestNewResponseWithOptions(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPut, "https://foo.bar/baz", nil)
 	require.NoError(t, err)
-	resp, err := NewBinaryResponse(ResponseContent{}, io.NopCloser(strings.NewReader("the body")), req)
+	resp, err := NewResponse(ResponseContent{}, req, &ResponseOptions{
+		Body:        io.NopCloser(strings.NewReader("the body")),
+		ContentType: shared.ContentTypeTextPlain,
+	})
 	require.NoError(t, err)
 	require.EqualValues(t, http.StatusOK, resp.StatusCode)
+	require.EqualValues(t, shared.ContentTypeTextPlain, resp.Header.Get(shared.HeaderContentType))
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.EqualValues(t, "the body", string(body))

--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -8,6 +8,8 @@ package exported
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -68,4 +70,36 @@ type TokenRequestOptions struct {
 type TokenCredential interface {
 	// GetToken requests an access token for the specified set of scopes.
 	GetToken(ctx context.Context, options TokenRequestOptions) (AccessToken, error)
+}
+
+// DecodeByteArray will base-64 decode the provided string into v.
+// Exported as runtime.DecodeByteArray()
+func DecodeByteArray(s string, v *[]byte, format Base64Encoding) error {
+	if len(s) == 0 {
+		return nil
+	}
+	payload := string(s)
+	if payload[0] == '"' {
+		// remove surrounding quotes
+		payload = payload[1 : len(payload)-1]
+	}
+	switch format {
+	case Base64StdFormat:
+		decoded, err := base64.StdEncoding.DecodeString(payload)
+		if err == nil {
+			*v = decoded
+			return nil
+		}
+		return err
+	case Base64URLFormat:
+		// use raw encoding as URL format should not contain any '=' characters
+		decoded, err := base64.RawURLEncoding.DecodeString(payload)
+		if err == nil {
+			*v = decoded
+			return nil
+		}
+		return err
+	default:
+		return fmt.Errorf("unrecognized byte array format: %d", format)
+	}
 }

--- a/sdk/azcore/internal/exported/request.go
+++ b/sdk/azcore/internal/exported/request.go
@@ -8,6 +8,7 @@ package exported
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +18,28 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 )
+
+// Base64Encoding is usesd to specify which base-64 encoder/decoder to use when
+// encoding/decoding a slice of bytes to/from a string.
+// Exported as runtime.Base64Encoding
+type Base64Encoding int
+
+const (
+	// Base64StdFormat uses base64.StdEncoding for encoding and decoding payloads.
+	Base64StdFormat Base64Encoding = 0
+
+	// Base64URLFormat uses base64.RawURLEncoding for encoding and decoding payloads.
+	Base64URLFormat Base64Encoding = 1
+)
+
+// EncodeByteArray will base-64 encode the byte slice v.
+// Exported as runtime.EncodeByteArray()
+func EncodeByteArray(v []byte, format Base64Encoding) string {
+	if format == Base64URLFormat {
+		return base64.RawURLEncoding.EncodeToString(v)
+	}
+	return base64.StdEncoding.EncodeToString(v)
+}
 
 // Request is an abstraction over the creation of an HTTP request as it passes through the pipeline.
 // Don't use this type directly, use NewRequest() instead.

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -7,8 +7,9 @@
 package shared
 
 const (
-	ContentTypeAppJSON = "application/json"
-	ContentTypeAppXML  = "application/xml"
+	ContentTypeAppJSON   = "application/json"
+	ContentTypeAppXML    = "application/xml"
+	ContentTypeTextPlain = "text/plain"
 )
 
 const (

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -9,7 +9,6 @@ package runtime
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -28,14 +27,14 @@ import (
 
 // Base64Encoding is usesd to specify which base-64 encoder/decoder to use when
 // encoding/decoding a slice of bytes to/from a string.
-type Base64Encoding int
+type Base64Encoding = exported.Base64Encoding
 
 const (
 	// Base64StdFormat uses base64.StdEncoding for encoding and decoding payloads.
-	Base64StdFormat Base64Encoding = 0
+	Base64StdFormat Base64Encoding = exported.Base64StdFormat
 
 	// Base64URLFormat uses base64.RawURLEncoding for encoding and decoding payloads.
-	Base64URLFormat Base64Encoding = 1
+	Base64URLFormat Base64Encoding = exported.Base64URLFormat
 )
 
 // NewRequest creates a new policy.Request with the specified input.
@@ -79,10 +78,7 @@ func JoinPaths(root string, paths ...string) string {
 
 // EncodeByteArray will base-64 encode the byte slice v.
 func EncodeByteArray(v []byte, format Base64Encoding) string {
-	if format == Base64URLFormat {
-		return base64.RawURLEncoding.EncodeToString(v)
-	}
-	return base64.StdEncoding.EncodeToString(v)
+	return exported.EncodeByteArray(v, format)
 }
 
 // MarshalAsByteArray will base-64 encode the byte slice v, then calls SetBody.

--- a/sdk/azcore/runtime/response.go
+++ b/sdk/azcore/runtime/response.go
@@ -8,13 +8,13 @@ package runtime
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
 
+	azexported "github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/exported"
 )
 
@@ -105,31 +105,5 @@ func removeBOM(resp *http.Response) error {
 
 // DecodeByteArray will base-64 decode the provided string into v.
 func DecodeByteArray(s string, v *[]byte, format Base64Encoding) error {
-	if len(s) == 0 {
-		return nil
-	}
-	payload := string(s)
-	if payload[0] == '"' {
-		// remove surrounding quotes
-		payload = payload[1 : len(payload)-1]
-	}
-	switch format {
-	case Base64StdFormat:
-		decoded, err := base64.StdEncoding.DecodeString(payload)
-		if err == nil {
-			*v = decoded
-			return nil
-		}
-		return err
-	case Base64URLFormat:
-		// use raw encoding as URL format should not contain any '=' characters
-		decoded, err := base64.RawURLEncoding.DecodeString(payload)
-		if err == nil {
-			*v = decoded
-			return nil
-		}
-		return err
-	default:
-		return fmt.Errorf("unrecognized byte array format: %d", format)
-	}
+	return azexported.DecodeByteArray(s, v, format)
 }


### PR DESCRIPTION
Deeper testing uncovered some deficiencies as well as general API improvements like slight renaming and adding options types.
Marshalling APIs (used by fake server) now take an any type instead of a Responder[T] in order to handle cases where we marshal from a scalar.
Added support for binary, text, and XML formats (binary was halfway there already, supporting form and multipart but not vanilla).
Added support for specifying an HTTP status code in a fake response.
Added and cleaned up various doc comments.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
