### PR TITLE
Remove trailing slash from directory or subdirectory name

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Fixed the issue where trailing slash is encoded when passed in directory or subdirectory name while creating the directory client.
+
 ### Other Changes
 
 ## 0.1.0 (2023-05-09)

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_8927e5eb65"
+  "Tag": "go/storage/azfile_600a15563c"
 }

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_f1e8c5b99b"
+  "Tag": "go/storage/azfile_8927e5eb65"
 }

--- a/sdk/storage/azfile/directory/client.go
+++ b/sdk/storage/azfile/directory/client.go
@@ -91,7 +91,7 @@ func (d *Client) URL() string {
 // NewSubdirectoryClient creates a new Client object by concatenating subDirectoryName to the end of this Client's URL.
 // The new subdirectory Client uses the same request policy pipeline as the parent directory Client.
 func (d *Client) NewSubdirectoryClient(subDirectoryName string) *Client {
-	subDirectoryName = url.PathEscape(subDirectoryName)
+	subDirectoryName = url.PathEscape(strings.TrimRight(subDirectoryName, "/"))
 	subDirectoryURL := runtime.JoinPaths(d.URL(), subDirectoryName)
 	return (*Client)(base.NewDirectoryClient(subDirectoryURL, d.generated().Pipeline(), d.sharedKey()))
 }

--- a/sdk/storage/azfile/directory/client_test.go
+++ b/sdk/storage/azfile/directory/client_test.go
@@ -73,10 +73,13 @@ func (d *DirectoryRecordedTestsSuite) TestDirNewDirectoryClient() {
 	shareClient := svcClient.NewShareClient(shareName)
 
 	dirName := testcommon.GenerateDirectoryName(testName)
-	dirClient := shareClient.NewDirectoryClient(dirName)
+	dirClient := shareClient.NewDirectoryClient(dirName + "/") // directory name having trailing '/'
+
+	correctDirURL := "https://" + accountName + ".file.core.windows.net/" + shareName + "/" + dirName
+	_require.Equal(dirClient.URL(), correctDirURL)
 
 	subDirName := "inner" + dirName
-	subDirClient := dirClient.NewSubdirectoryClient(subDirName)
+	subDirClient := dirClient.NewSubdirectoryClient(subDirName + "/") // subdirectory name having trailing '/'
 
 	correctURL := "https://" + accountName + ".file.core.windows.net/" + shareName + "/" + dirName + "/" + subDirName
 	_require.Equal(subDirClient.URL(), correctURL)

--- a/sdk/storage/azfile/directory/client_test.go
+++ b/sdk/storage/azfile/directory/client_test.go
@@ -1118,3 +1118,25 @@ func (d *DirectoryRecordedTestsSuite) TestDirectoryCreateNegativeWithoutSAS() {
 	_, err = dirClient.Create(context.Background(), nil)
 	_require.Error(err)
 }
+
+func (d *DirectoryRecordedTestsSuite) TestDirectoryCreateWithTrailingSlash() {
+	_require := require.New(d.T())
+	testName := d.T().Name()
+
+	svcClient, err := testcommon.GetServiceClient(d.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, testcommon.GenerateShareName(testName), svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	dirName := testcommon.GenerateDirectoryName(testName) + "/"
+	dirClient := shareClient.NewDirectoryClient(dirName)
+
+	_, err = dirClient.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	subDirClient := dirClient.NewSubdirectoryClient("subdir/")
+
+	_, err = subDirClient.Create(context.Background(), nil)
+	_require.NoError(err)
+}

--- a/sdk/storage/azfile/share/client.go
+++ b/sdk/storage/azfile/share/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/sas"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -88,7 +89,7 @@ func (s *Client) URL() string {
 // NewDirectoryClient creates a new directory.Client object by concatenating directoryName to the end of this Client's URL.
 // The new directory.Client uses the same request policy pipeline as the Client.
 func (s *Client) NewDirectoryClient(directoryName string) *directory.Client {
-	directoryName = url.PathEscape(directoryName)
+	directoryName = url.PathEscape(strings.TrimRight(directoryName, "/"))
 	directoryURL := runtime.JoinPaths(s.URL(), directoryName)
 	return (*directory.Client)(base.NewDirectoryClient(directoryURL, s.generated().Pipeline(), s.sharedKey()))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
