### PR TITLE
Retry policy will always clone the *http.Request

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Retry policy always clones the underlying `*http.Request` before invoking the next policy.
 
 ### Other Changes
 

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -125,7 +125,8 @@ func (p *retryPolicy) Do(req *policy.Request) (resp *http.Response, err error) {
 		}
 
 		if options.TryTimeout == 0 {
-			resp, err = req.Next()
+			clone := req.Clone(req.Raw().Context())
+			resp, err = clone.Next()
 		} else {
 			// Set the per-try time for this particular retry operation and then Do the operation.
 			tryCtx, tryCancel := context.WithTimeout(req.Raw().Context(), options.TryTimeout)

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -828,11 +828,6 @@ func TestRetryPolicySuccessWithRetryPreserveHeaders(t *testing.T) {
 	require.True(t, body.closed)
 }
 
-type reqBody struct {
-	body        io.ReadSeekCloser
-	contentType string
-}
-
 func challengeLikePolicy(req *policy.Request) (*http.Response, error) {
 	if req.Body() == nil {
 		return nil, errors.New("request body wasn't restored")
@@ -841,12 +836,9 @@ func challengeLikePolicy(req *policy.Request) (*http.Response, error) {
 		return nil, errors.New("content-type header wasn't restored")
 	}
 
-	if body := req.Body(); body != nil {
-		rb := reqBody{body, req.Raw().Header.Get("content-type")}
-		req.SetOperationValue(rb)
-		if err := req.SetBody(nil, ""); err != nil {
-			return nil, err
-		}
+	// remove the body and header. the retry policy should restore them
+	if err := req.SetBody(nil, ""); err != nil {
+		return nil, err
 	}
 	return req.Next()
 }


### PR DESCRIPTION
This ensures that the entirety of the request is restored on retries.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
