### PR TITLE
Handle more error codes when an RP isn't registered

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bugs Fixed
 * Retry policy always clones the underlying `*http.Request` before invoking the next policy.
+* Added `MissingRegistrationForResourceProvider` to the list of error codes for unregistered resource providers.
 
 ### Other Changes
 

--- a/sdk/azcore/arm/runtime/pipeline_test.go
+++ b/sdk/azcore/arm/runtime/pipeline_test.go
@@ -104,7 +104,7 @@ func TestDisableAutoRPRegistration(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	// initial response that RP is unregistered
-	srv.SetResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
+	srv.SetResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp1)))
 	opts := &armpolicy.ClientOptions{DisableRPRegistration: true, ClientOptions: policy.ClientOptions{Transport: srv}}
 	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {

--- a/sdk/azcore/arm/runtime/policy_register_rp.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp.go
@@ -80,7 +80,6 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 		// policy is disabled
 		return req.Next()
 	}
-	const unregisteredRPCode = "MissingSubscriptionRegistration"
 	const registeredState = "Registered"
 	var rp string
 	var resp *http.Response
@@ -101,7 +100,7 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 			// to the caller so its error unmarshalling will kick in
 			return resp, err
 		}
-		if !strings.EqualFold(reqErr.ServiceError.Code, unregisteredRPCode) {
+		if !isUnregisteredRPCode(reqErr.ServiceError.Code) {
 			// not a 409 due to unregistered RP. just return the response
 			// to the caller so its error unmarshalling will kick in
 			return resp, err
@@ -171,6 +170,20 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 	}
 	// if we get here it means we exceeded the number of attempts
 	return resp, fmt.Errorf("exceeded attempts to register %s", rp)
+}
+
+var unregisteredRPCodes = []string{
+	"MissingSubscriptionRegistration",
+	"MissingRegistrationForResourceProvider",
+}
+
+func isUnregisteredRPCode(errorCode string) bool {
+	for _, code := range unregisteredRPCodes {
+		if strings.EqualFold(errorCode, code) {
+			return true
+		}
+	}
+	return false
 }
 
 func getSubscription(path string) (string, error) {

--- a/sdk/azcore/arm/runtime/policy_register_rp_test.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp_test.go
@@ -24,12 +24,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const rpUnregisteredResp = `{
+const rpUnregisteredResp1 = `{
 	"error":{
 		"code":"MissingSubscriptionRegistration",
 		"message":"The subscription registration is in 'Unregistered' state. The subscription must be registered to use namespace 'Microsoft.Storage'. See https://aka.ms/rps-not-found for how to register subscriptions.",
 		"details":[{
 				"code":"MissingSubscriptionRegistration",
+				"target":"Microsoft.Storage",
+				"message":"The subscription registration is in 'Unregistered' state. The subscription must be registered to use namespace 'Microsoft.Storage'. See https://aka.ms/rps-not-found for how to register subscriptions."
+			}
+		]
+	}
+}`
+
+const rpUnregisteredResp2 = `{
+	"error":{
+		"code":"MissingRegistrationForResourceProvider",
+		"message":"The subscription registration is in 'Unregistered' state. The subscription must be registered to use namespace 'Microsoft.Storage'. See https://aka.ms/rps-not-found for how to register subscriptions.",
+		"details":[{
+				"code":"MissingRegistrationForResourceProvider",
 				"target":"Microsoft.Storage",
 				"message":"The subscription registration is in 'Unregistered' state. The subscription must be registered to use namespace 'Microsoft.Storage'. See https://aka.ms/rps-not-found for how to register subscriptions."
 			}
@@ -89,7 +102,7 @@ func TestRPRegistrationPolicySuccess(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	// initial response that RP is unregistered
-	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp1)))
 	// polling responses to Register() and Get(), in progress
 	srv.RepeatResponse(5, mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(rpRegisteringResp)))
 	// polling response, successful registration
@@ -180,7 +193,7 @@ func TestRPRegistrationPolicyTimesOut(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	// initial response that RP is unregistered
-	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp1)))
 	// polling responses to Register() and Get(), in progress but slow
 	// tests registration takes too long, times out
 	srv.RepeatResponse(10, mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(rpRegisteringResp)), mock.WithSlowResponse(400*time.Millisecond))
@@ -212,7 +225,7 @@ func TestRPRegistrationPolicyExceedsAttempts(t *testing.T) {
 	// add a cycle of unregistered->registered so that we keep retrying and hit the cap
 	for i := 0; i < 4; i++ {
 		// initial response that RP is unregistered
-		srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
+		srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp1)))
 		// polling responses to Register() and Get(), in progress
 		srv.RepeatResponse(2, mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(rpRegisteringResp)))
 		// polling response, successful registration
@@ -246,7 +259,7 @@ func TestRPRegistrationPolicyCanCancel(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	// initial response that RP is unregistered
-	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp2)))
 	// polling responses to Register() and Get(), in progress but slow so we have time to cancel
 	srv.RepeatResponse(10, mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(rpRegisteringResp)), mock.WithSlowResponse(300*time.Millisecond))
 	// log only RP registration
@@ -287,7 +300,7 @@ func TestRPRegistrationPolicyDisabled(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	// initial response that RP is unregistered
-	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp2)))
 	ops := testRPRegistrationOptions(srv)
 	ops.MaxAttempts = -1
 	client := newFakeClient(t, srv, ops)
@@ -305,7 +318,7 @@ func TestRPRegistrationPolicyDisabled(t *testing.T) {
 	require.Error(t, err)
 	var respErr *exported.ResponseError
 	require.ErrorAs(t, err, &respErr)
-	require.EqualValues(t, "MissingSubscriptionRegistration", respErr.ErrorCode)
+	require.EqualValues(t, "MissingRegistrationForResourceProvider", respErr.ErrorCode)
 	require.Zero(t, resp)
 	// shouldn't be any log entries
 	require.Zero(t, logEntries)
@@ -315,7 +328,7 @@ func TestRPRegistrationPolicyAudience(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	// initial response that RP is unregistered
-	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusConflict), mock.WithBody([]byte(rpUnregisteredResp2)))
 	// polling responses to Register() and Get(), in progress
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(rpRegisteringResp)))
 	// polling response, successful registration


### PR DESCRIPTION
There's more than one error code returned from unregistered RPs.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/20823