### PR TITLE
Cosmos DB: add support for getting partition key ranges for a container

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added support for getting partition key ranges for a container
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -562,6 +562,34 @@ func (c *ContainerClient) ExecuteTransactionalBatch(ctx context.Context, b Trans
 	return newTransactionalBatchResponse(azResponse)
 }
 
+// PartitionKeyRanges obtains the information for the partition key ranges in a Cosmos container
+// ctx - The context for the request.
+func (c *ContainerClient) PartitionKeyRanges(ctx context.Context) (PartitionKeyRangesResponse, error) {
+	operationContext := pipelineRequestOptions{
+		resourceType:    resourceTypePartitionKeyRange,
+		resourceAddress: c.link,
+	}
+
+	path, err := generatePathForNameBased(resourceTypeCollection, c.link, false)
+	if err != nil {
+		return PartitionKeyRangesResponse{}, err
+	}
+
+	path += "/pkranges"
+
+	azResponse, err := c.database.client.sendGetRequest(
+		path,
+		ctx,
+		operationContext,
+		nil,
+		nil)
+	if err != nil {
+		return PartitionKeyRangesResponse{}, err
+	}
+
+	return newPartitionKeyRangeResponse(azResponse)
+}
+
 func (c *ContainerClient) getRID(ctx context.Context) (string, error) {
 	containerResponse, err := c.Read(ctx, nil)
 	if err != nil {

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -575,7 +575,7 @@ func (c *ContainerClient) PartitionKeyRanges(ctx context.Context) (PartitionKeyR
 		return PartitionKeyRangesResponse{}, err
 	}
 
-	path += "/pkranges"
+	path += "/" + pathSegmentPartitionKeyRange
 
 	azResponse, err := c.database.client.sendGetRequest(
 		path,

--- a/sdk/data/azcosmos/cosmos_partition_key_ranges_properties_test.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_ranges_properties_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestPartitionKeyRangesPropertiesSerialization(t *testing.T) {
+	nowAsUnix := time.Unix(time.Now().Unix(), 0)
+
+	etag := azcore.ETag("etag")
+
+	properties := &PartitionKeyRangesProperties{
+		ResourceID: "someResourceId",
+		Count:      1,
+		PartitionKeyRanges: []PartitionKeyRange{
+			{
+				ID:           "someId",
+				ETag:         &etag,
+				SelfLink:     "someSelfLink",
+				LastModified: nowAsUnix,
+				MinInclusive: "someMinInclusive",
+				MaxExclusive: "someMaxExclusive",
+			},
+		},
+	}
+
+	jsonString, err := json.Marshal(properties)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	otherProperties := &PartitionKeyRangesProperties{}
+	err = json.Unmarshal(jsonString, otherProperties)
+	if err != nil {
+		t.Fatal(err, string(jsonString))
+	}
+
+	if properties.ResourceID != otherProperties.ResourceID {
+		t.Errorf("Expected ResourceID to be %s, but got %s", properties.ResourceID, otherProperties.ResourceID)
+	}
+
+	if properties.Count != otherProperties.Count {
+		t.Errorf("Expected Count to be %d, but got %d", properties.Count, otherProperties.Count)
+	}
+
+	if len(properties.PartitionKeyRanges) != len(otherProperties.PartitionKeyRanges) {
+		t.Errorf("Expected PartitionKeyRanges length to be %d, but got %d", len(properties.PartitionKeyRanges), len(otherProperties.PartitionKeyRanges))
+	}
+
+	if properties.PartitionKeyRanges[0].ID != otherProperties.PartitionKeyRanges[0].ID {
+		t.Errorf("Expected ID to be %s, but got %s", properties.PartitionKeyRanges[0].ID, otherProperties.PartitionKeyRanges[0].ID)
+	}
+
+	if *properties.PartitionKeyRanges[0].ETag != *otherProperties.PartitionKeyRanges[0].ETag {
+		t.Errorf("Expected ETag to be %v, but got %v", properties.PartitionKeyRanges[0].ETag, otherProperties.PartitionKeyRanges[0].ETag)
+	}
+
+	if properties.PartitionKeyRanges[0].SelfLink != otherProperties.PartitionKeyRanges[0].SelfLink {
+		t.Errorf("Expected SelfLink to be %s, but got %s", properties.PartitionKeyRanges[0].SelfLink, otherProperties.PartitionKeyRanges[0].SelfLink)
+	}
+
+	if properties.PartitionKeyRanges[0].LastModified != otherProperties.PartitionKeyRanges[0].LastModified {
+		t.Errorf("Expected LastModified to be %s, but got %s", properties.PartitionKeyRanges[0].LastModified, otherProperties.PartitionKeyRanges[0].LastModified)
+	}
+
+	if properties.PartitionKeyRanges[0].MinInclusive != otherProperties.PartitionKeyRanges[0].MinInclusive {
+		t.Errorf("Expected MinInclusive to be %s, but got %s", properties.PartitionKeyRanges[0].MinInclusive, otherProperties.PartitionKeyRanges[0].MinInclusive)
+	}
+
+	if properties.PartitionKeyRanges[0].MaxExclusive != otherProperties.PartitionKeyRanges[0].MaxExclusive {
+		t.Errorf("Expected MaxExclusive to be %s, but got %s", properties.PartitionKeyRanges[0].MaxExclusive, otherProperties.PartitionKeyRanges[0].MaxExclusive)
+	}
+}

--- a/sdk/data/azcosmos/cosmos_partition_key_ranges_response_test.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_ranges_response_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+)
+
+func TestPartitionKeyRangesResponseParsing(t *testing.T) {
+	nowAsUnix := time.Unix(time.Now().Unix(), 0)
+
+	etag := azcore.ETag("etag")
+	properties := &PartitionKeyRangesProperties{
+		ResourceID: "someResourceId",
+		Count:      1,
+		PartitionKeyRanges: []PartitionKeyRange{
+			{
+				ID:           "someId",
+				ETag:         &etag,
+				SelfLink:     "someSelfLink",
+				LastModified: nowAsUnix,
+				MinInclusive: "someMinInclusive",
+				MaxExclusive: "someMaxExclusive",
+			},
+		},
+	}
+
+	jsonString, err := json.Marshal(properties)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithBody(jsonString),
+		mock.WithHeader(cosmosHeaderEtag, "someEtag"),
+		mock.WithHeader(cosmosHeaderActivityId, "someActivityId"))
+
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	resp, _ := pl.Do(req)
+	parsedResponse, err := newPartitionKeyRangeResponse(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsedResponse.RawResponse == nil {
+		t.Fatal("parsedResponse.RawResponse is nil")
+	}
+
+	if parsedResponse.PartitionKeyRangesProperties == nil {
+		t.Fatal("parsedResponse.PartitionKeyRangesProperties is nil")
+	}
+
+	if properties.ResourceID != parsedResponse.PartitionKeyRangesProperties.ResourceID {
+		t.Errorf("Expected ResourceID to be %s, but got %s", properties.ResourceID, parsedResponse.PartitionKeyRangesProperties.ResourceID)
+	}
+
+	if properties.Count != parsedResponse.PartitionKeyRangesProperties.Count {
+		t.Errorf("Expected Count to be %d, but got %d", properties.Count, parsedResponse.PartitionKeyRangesProperties.Count)
+	}
+
+	if len(properties.PartitionKeyRanges) != len(parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges) {
+		t.Errorf("Expected PartitionKeyRanges length to be %d, but got %d", len(properties.PartitionKeyRanges), len(parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges))
+	}
+
+	if properties.PartitionKeyRanges[0].ID != parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].ID {
+		t.Errorf("Expected ID to be %s, but got %s", properties.PartitionKeyRanges[0].ID, parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].ID)
+	}
+
+	if *properties.PartitionKeyRanges[0].ETag != *parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].ETag {
+		t.Errorf("Expected ETag to be %v, but got %v", properties.PartitionKeyRanges[0].ETag, parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].ETag)
+	}
+
+	if properties.PartitionKeyRanges[0].SelfLink != parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].SelfLink {
+		t.Errorf("Expected SelfLink to be %s, but got %s", properties.PartitionKeyRanges[0].SelfLink, parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].SelfLink)
+	}
+
+	if properties.PartitionKeyRanges[0].LastModified != parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].LastModified {
+		t.Errorf("Expected LastModified to be %s, but got %s", properties.PartitionKeyRanges[0].LastModified, parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].LastModified)
+	}
+
+	if properties.PartitionKeyRanges[0].MinInclusive != parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].MinInclusive {
+		t.Errorf("Expected MinInclusive to be %s, but got %s", properties.PartitionKeyRanges[0].MinInclusive, parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].MinInclusive)
+	}
+
+	if properties.PartitionKeyRanges[0].MaxExclusive != parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].MaxExclusive {
+		t.Errorf("Expected MaxExclusive to be %s, but got %s", properties.PartitionKeyRanges[0].MaxExclusive, parsedResponse.PartitionKeyRangesProperties.PartitionKeyRanges[0].MaxExclusive)
+	}
+
+	if parsedResponse.ActivityID != "someActivityId" {
+		t.Errorf("Expected ActivityId to be %s, but got %s", "someActivityId", parsedResponse.ActivityID)
+	}
+
+	if parsedResponse.ETag != "someEtag" {
+		t.Errorf("Expected ETag to be %s, but got %s", "someEtag", parsedResponse.ETag)
+	}
+}

--- a/sdk/data/azcosmos/partition_key_ranges_properties.go
+++ b/sdk/data/azcosmos/partition_key_ranges_properties.go
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+type (
+	// PartitionKeyRangesProperties represents the response from a partition key ranges request.
+	PartitionKeyRangesProperties struct {
+		// ResourceID contains the resource id of the partition key ranges
+		ResourceID string
+		// Count contains the number of partition key ranges
+		Count int
+		// PartitionKeyRanges contains the list of partition key ranges
+		PartitionKeyRanges []PartitionKeyRange
+	}
+
+	// PartitionKeyRange represents a single partition key range.
+	PartitionKeyRange struct {
+		// ETag contains the entity etag of the partition key range.
+		ETag *azcore.ETag
+		// LastModified contains the last modified time of the partition key range information.
+		LastModified time.Time
+		// SelfLink contains the self-link of the partition key range.
+		SelfLink string
+		// ResourceID contains the resource id of the partition key range.
+		ResourceID string
+		// ID contains the partition key range ID.
+		ID string
+		// MinInclusive contains the minimum value of the partition key range.
+		MinInclusive string
+		// MaxExclusive contains the maximum value of the partition key range.
+		MaxExclusive string
+	}
+)
+
+// MarshalJSON implements the json.Marshaler interface
+func (p *PartitionKeyRangesProperties) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString("{")
+
+	if p.ResourceID != "" {
+		buffer.WriteString(fmt.Sprintf("\"_rid\":\"%s\"", p.ResourceID))
+	}
+
+	buffer.WriteString(fmt.Sprintf(",\"_count\":%d", p.Count))
+
+	if p.Count == 0 {
+		buffer.WriteString(",\"PartitionKeyRanges\":[]}")
+		return buffer.Bytes(), nil
+	}
+
+	buffer.WriteString(",\"PartitionKeyRanges\":[")
+	for _, r := range p.PartitionKeyRanges {
+		buffer.WriteString("{")
+
+		if r.ETag != nil {
+			buffer.WriteString("\"_etag\":")
+			etag, err := json.Marshal(r.ETag)
+			if err != nil {
+				return nil, err
+			}
+			buffer.Write(etag)
+		}
+
+		if r.SelfLink != "" {
+			buffer.WriteString(fmt.Sprintf(",\"_self\":\"%s\"", r.SelfLink))
+		}
+
+		if !r.LastModified.IsZero() {
+			buffer.WriteString(fmt.Sprintf(",\"_ts\":%v", strconv.FormatInt(r.LastModified.Unix(), 10)))
+		}
+
+		if r.ID != "" {
+			buffer.WriteString(fmt.Sprintf(",\"id\":\"%s\"", r.ID))
+		}
+
+		buffer.WriteString(fmt.Sprintf(",\"minInclusive\":\"%s\"", r.MinInclusive))
+		buffer.WriteString(fmt.Sprintf(",\"maxExclusive\":\"%s\"", r.MaxExclusive))
+
+		buffer.WriteString("}")
+	}
+	buffer.WriteString("]}")
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (p *PartitionKeyRangesProperties) UnmarshalJSON(b []byte) error {
+	var attributes map[string]json.RawMessage
+	err := json.Unmarshal(b, &attributes)
+	if err != nil {
+		return err
+	}
+
+	if id, ok := attributes["_rid"]; ok {
+		if err := json.Unmarshal(id, &p.ResourceID); err != nil {
+			return err
+		}
+	}
+
+	if count, ok := attributes["_count"]; ok {
+		if err := json.Unmarshal(count, &p.Count); err != nil {
+			return err
+		}
+	}
+
+	if p.Count == 0 {
+		return nil
+	}
+
+	if _, ok := attributes["PartitionKeyRanges"]; !ok {
+		return nil
+	}
+
+	var pkRanges []json.RawMessage
+	if err := json.Unmarshal(attributes["PartitionKeyRanges"], &pkRanges); err != nil {
+		return err
+	}
+
+	for _, r := range pkRanges {
+		var pkAttributes map[string]json.RawMessage
+		if err := json.Unmarshal(r, &pkAttributes); err != nil {
+			return err
+		}
+
+		var pkr PartitionKeyRange
+
+		if etag, ok := pkAttributes["_etag"]; ok {
+			if err := json.Unmarshal(etag, &pkr.ETag); err != nil {
+				return err
+			}
+		}
+
+		if ts, ok := pkAttributes["_ts"]; ok {
+			var timestamp int64
+			if err := json.Unmarshal(ts, &timestamp); err != nil {
+				return err
+			}
+			pkr.LastModified = time.Unix(timestamp, 0)
+		}
+
+		if id, ok := pkAttributes["id"]; ok {
+			if err := json.Unmarshal(id, &pkr.ID); err != nil {
+				return err
+			}
+		}
+
+		if self, ok := pkAttributes["_self"]; ok {
+			if err := json.Unmarshal(self, &pkr.SelfLink); err != nil {
+				return err
+			}
+		}
+
+		if min, ok := pkAttributes["minInclusive"]; ok {
+			if err := json.Unmarshal(min, &pkr.MinInclusive); err != nil {
+				return err
+			}
+		}
+
+		if max, ok := pkAttributes["maxExclusive"]; ok {
+			if err := json.Unmarshal(max, &pkr.MaxExclusive); err != nil {
+				return err
+			}
+		}
+
+		p.PartitionKeyRanges = append(p.PartitionKeyRanges, pkr)
+	}
+
+	return nil
+}

--- a/sdk/data/azcosmos/partition_key_ranges_response.go
+++ b/sdk/data/azcosmos/partition_key_ranges_response.go
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"net/http"
+)
+
+// PartitionKeyRangesResponse represents the response from a partition key ranges request.
+type PartitionKeyRangesResponse struct {
+	//  PartitionKeyRangesProperties contains the unmarshalled response body in PartitionKeyRangesResponse format.
+	PartitionKeyRangesProperties *PartitionKeyRangesProperties
+	Response
+}
+
+func newPartitionKeyRangeResponse(resp *http.Response) (PartitionKeyRangesResponse, error) {
+	response := PartitionKeyRangesResponse{
+		Response: newResponse(resp),
+	}
+	properties := &PartitionKeyRangesProperties{}
+	err := azruntime.UnmarshalAsJSON(resp, properties)
+	if err != nil {
+		return response, err
+	}
+	response.PartitionKeyRangesProperties = properties
+
+	return response, nil
+}


### PR DESCRIPTION
This PR adds support for getting partition key ranges for a container. It's based on the [REST API documentation](https://learn.microsoft.com/en-us/rest/api/cosmos-db/get-partition-key-ranges).

We are planning to use this feature as part of our work to have more insights on the state of the partitions from the client application.

I've tried to follow the the existing style for marshalling and unmarshalling the responses.

Thank you! ❤️ 

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
