### PR TITLE
[azeventhubs] Changes to make errors and low level types carry connectionID and linkID

### DIFF
--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqp_error.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqp_error.go
@@ -27,7 +27,7 @@ func (e Error) Is(target error) bool {
 	return errors.Is(e.Err, target)
 }
 
-func NewError(err error, connID uint64, linkName string) error {
+func WrapError(err error, connID uint64, linkName string) error {
 	if err == nil {
 		return nil
 	}

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqp_error.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqp_error.go
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package amqpwrap
+
+import (
+	"errors"
+)
+
+// Error is a wrapper that has the context of which connection and
+// link the error happened with.
+type Error struct {
+	ConnID   uint64
+	LinkName string
+	Err      error
+}
+
+func (e Error) Error() string {
+	return e.Err.Error()
+}
+
+func (e Error) As(target any) bool {
+	return errors.As(e.Err, target)
+}
+
+func (e Error) Is(target error) bool {
+	return errors.Is(e.Err, target)
+}
+
+func NewError(err error, connID uint64, linkName string) error {
+	if err == nil {
+		return nil
+	}
+
+	if _, ok := err.(Error); ok {
+		return err
+	}
+
+	return Error{
+		ConnID:   connID,
+		LinkName: linkName,
+		Err:      err,
+	}
+}

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap.go
@@ -3,7 +3,6 @@
 
 // Package amqpwrap has some simple wrappers to make it easier to
 // abstract the go-amqp types.
-
 package amqpwrap
 
 import (

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap_test.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap_test.go
@@ -128,7 +128,7 @@ func TestAMQPSenderWrapper(t *testing.T) {
 
 		assertErr := func(err error, msg string) {
 			t.Helper()
-			var wrapErr *Error
+			var wrapErr Error
 
 			require.ErrorAs(t, err, &wrapErr)
 			require.EqualError(t, wrapErr, msg)
@@ -202,7 +202,7 @@ func TestAMQPSessionWrapper(t *testing.T) {
 
 		assertErr := func(err error, msg string) {
 			t.Helper()
-			var wrapErr *Error
+			var wrapErr Error
 
 			require.ErrorAs(t, err, &wrapErr)
 			require.EqualError(t, wrapErr, msg)
@@ -248,7 +248,7 @@ func TestAMQPConnWrapper(t *testing.T) {
 
 		assertErr := func(err error, msg string) {
 			t.Helper()
-			var wrapErr *Error
+			var wrapErr Error
 			require.ErrorAs(t, err, &wrapErr)
 			require.EqualError(t, wrapErr, msg)
 			require.Equal(t, uint64(101), wrapErr.ConnID)

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap_test.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap_test.go
@@ -7,115 +7,268 @@ package amqpwrap
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/test"
+	"github.com/Azure/go-amqp"
 	gomock "github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAMQPReceiverWrapper(t *testing.T) {
-	for _, expectedErr := range []error{context.Canceled, context.DeadlineExceeded} {
-		t.Run(expectedErr.Error(), func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			r := NewMockgoamqpReceiver(ctrl)
+	t.Run("errors are wrapped", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		inner := NewMockgoamqpReceiver(ctrl)
 
-			r.EXPECT().Close(gomock.Any()).Return(expectedErr)
+		inner.EXPECT().LinkName().Return("receiver").AnyTimes()
 
-			rw := &AMQPReceiverWrapper{Inner: r, ContextWithTimeoutFn: context.WithTimeout}
+		inner.EXPECT().Receive(gomock.Any(), gomock.Any()).Return(nil, errors.New("receive failed"))
+		inner.EXPECT().AcceptMessage(gomock.Any(), gomock.Any()).Return(errors.New("accept failed"))
+		inner.EXPECT().ModifyMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("modify failed"))
+		inner.EXPECT().RejectMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("reject failed"))
+		inner.EXPECT().ReleaseMessage(gomock.Any(), gomock.Any()).Return(errors.New("release failed"))
+		inner.EXPECT().IssueCredit(gomock.Any()).Return(errors.New("issue credit failed"))
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-			err := rw.Close(ctx)
-			require.ErrorIs(t, err, expectedErr)
-		})
-	}
+		inner.EXPECT().Close(test.NotCancelledAndHasTimeout).Return(errors.New("close failed"))
+		inner.EXPECT().Close(test.CancelledAndHasTimeout).Return(context.Canceled)
+
+		rw := &AMQPReceiverWrapper{Inner: inner, ContextWithTimeoutFn: test.NewContextWithTimeoutForTests, connID: uint64(101)}
+
+		assertErr := func(err error, msg string) {
+			t.Helper()
+			var wrapErr Error
+			require.ErrorAs(t, err, &wrapErr)
+			require.EqualError(t, wrapErr, msg)
+			require.Equal(t, uint64(101), wrapErr.ConnID)
+			require.Equal(t, "receiver", wrapErr.LinkName)
+		}
+
+		_, err := rw.Receive(context.Background(), nil)
+		assertErr(err, "receive failed")
+
+		err = rw.AcceptMessage(context.Background(), nil)
+		assertErr(err, "accept failed")
+
+		err = rw.ModifyMessage(context.Background(), nil, nil)
+		assertErr(err, "modify failed")
+
+		err = rw.ReleaseMessage(context.Background(), nil)
+		assertErr(err, "release failed")
+
+		err = rw.RejectMessage(context.Background(), nil, nil)
+		assertErr(err, "reject failed")
+
+		err = rw.IssueCredit(uint32(100))
+		assertErr(err, "issue credit failed")
+
+		err = rw.Close(context.Background())
+		assertErr(err, "close failed")
+
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err = rw.Close(cancelledCtx)
+		require.ErrorIs(t, err, context.Canceled)
+		assertErr(err, "context canceled")
+	})
+
+	t.Run("normal usage", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		inner := NewMockgoamqpReceiver(ctrl)
+
+		inner.EXPECT().LinkName().Return("receiver").AnyTimes()
+		inner.EXPECT().IssueCredit(gomock.Any()).Return(nil)
+		inner.EXPECT().Receive(test.NotCancelled, gomock.Any()).Return(&amqp.Message{}, nil)
+		inner.EXPECT().Receive(test.Cancelled, gomock.Any()).Return(nil, context.Canceled)
+		inner.EXPECT().Prefetched().Return(&amqp.Message{})
+		inner.EXPECT().Prefetched().Return(nil)
+		inner.EXPECT().LinkSourceFilterValue("hello").Return("world")
+
+		rw := &AMQPReceiverWrapper{Inner: inner, ContextWithTimeoutFn: test.NewContextWithTimeoutForTests, connID: uint64(101)}
+
+		require.Equal(t, uint64(101), rw.ConnID())
+		require.Equal(t, "world", rw.LinkSourceFilterValue("hello"))
+
+		require.Equal(t, uint32(0), rw.Credits())
+
+		err := rw.IssueCredit(10)
+		require.NoError(t, err)
+
+		require.Equal(t, uint32(10), rw.Credits())
+
+		msg, err := rw.Receive(context.Background(), nil)
+		require.NotNil(t, msg)
+		require.NoError(t, err)
+
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		msg, err = rw.Receive(cancelledCtx, nil)
+		require.Nil(t, msg)
+		require.ErrorIs(t, err, context.Canceled)
+
+		require.Equal(t, uint32(9), rw.Credits())
+
+		msg = rw.Prefetched()
+		require.NotNil(t, msg)
+
+		require.Equal(t, uint32(8), rw.Credits())
+
+		msg = rw.Prefetched()
+		require.Nil(t, msg)
+
+		require.Equal(t, uint32(8), rw.Credits(), "no message returned, no credits used")
+	})
 }
 
 func TestAMQPSenderWrapper(t *testing.T) {
-	for _, expectedErr := range []error{context.Canceled, context.DeadlineExceeded} {
-		t.Run(expectedErr.Error(), func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			s := NewMockAMQPSenderCloser(ctrl)
+	t.Run("errors are wrapped", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s := NewMockAMQPSenderCloser(ctrl)
 
-			s.EXPECT().Close(gomock.Any()).Return(expectedErr)
+		assertErr := func(err error, msg string) {
+			t.Helper()
+			var wrapErr *Error
 
-			rw := &AMQPSenderWrapper{Inner: s, ContextWithTimeoutFn: context.WithTimeout}
+			require.ErrorAs(t, err, &wrapErr)
+			require.EqualError(t, wrapErr, msg)
+			require.Equal(t, uint64(101), wrapErr.ConnID)
+			require.Equal(t, "sender", wrapErr.LinkName)
+		}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-			require.ErrorIs(t, rw.Close(ctx), expectedErr)
-		})
-	}
+		s.EXPECT().LinkName().Return("sender").AnyTimes()
+		s.EXPECT().Send(test.NotCancelled, gomock.Any(), gomock.Any()).Return(errors.New("send failed"))
+
+		s.EXPECT().Close(test.CancelledAndHasTimeout).Return(context.Canceled)
+		s.EXPECT().Close(test.NotCancelledAndHasTimeout).Return(errors.New("close failed"))
+
+		sw := &AMQPSenderWrapper{Inner: s, ContextWithTimeoutFn: test.NewContextWithTimeoutForTests, connID: 101}
+
+		err := sw.Send(context.Background(), nil, nil)
+		assertErr(err, "send failed")
+
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err = sw.Close(cancelledCtx)
+		require.ErrorIs(t, err, context.Canceled)
+		assertErr(err, "context canceled")
+
+		err = sw.Close(context.Background())
+		assertErr(err, "close failed")
+	})
+
+	t.Run("", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s := NewMockAMQPSenderCloser(ctrl)
+
+		s.EXPECT().MaxMessageSize().Return(uint64(99))
+
+		sw := &AMQPSenderWrapper{Inner: s, ContextWithTimeoutFn: test.NewContextWithTimeoutForTests, connID: 101}
+		require.Equal(t, uint64(99), sw.MaxMessageSize())
+		require.Equal(t, uint64(101), sw.ConnID())
+	})
 }
 
 func TestAMQPSessionWrapper(t *testing.T) {
-	for _, expectedErr := range []error{context.Canceled, context.DeadlineExceeded} {
-		t.Run(fmt.Sprintf("Close() == %s", expectedErr.Error()), func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			s := NewMockgoamqpSession(ctrl)
+	t.Run("ConnID is propagated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		sess := NewMockgoamqpSession(ctrl)
 
-			s.EXPECT().Close(gomock.Any()).Return(expectedErr)
+		sess.EXPECT().NewReceiver(gomock.Any(), gomock.Any(), gomock.Any()).Return(&amqp.Receiver{}, nil)
+		sess.EXPECT().NewSender(gomock.Any(), gomock.Any(), gomock.Any()).Return(&amqp.Sender{}, nil)
 
-			rw := &AMQPSessionWrapper{Inner: s, ContextWithTimeoutFn: context.WithTimeout}
+		sessWrapper := &AMQPSessionWrapper{connID: uint64(101), Inner: sess, ContextWithTimeoutFn: context.WithTimeout}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-			require.ErrorIs(t, rw.Close(ctx), expectedErr)
-		})
-	}
+		require.Equal(t, uint64(101), sessWrapper.ConnID())
 
-	for _, expectedErr := range []error{context.Canceled, context.DeadlineExceeded} {
-		t.Run(fmt.Sprintf("NewReceiver() == %s", expectedErr.Error()), func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			inner := NewMockgoamqpSession(ctrl)
+		rc, err := sessWrapper.NewReceiver(context.Background(), "source", nil)
+		require.NoError(t, err)
+		require.Equal(t, sessWrapper.ConnID(), rc.ConnID())
 
-			inner.EXPECT().NewReceiver(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, expectedErr)
+		sc, err := sessWrapper.NewSender(context.Background(), "target", nil)
+		require.NoError(t, err)
+		require.Equal(t, sessWrapper.ConnID(), sc.ConnID())
+	})
 
-			rw := &AMQPSessionWrapper{Inner: inner, ContextWithTimeoutFn: context.WithTimeout}
+	t.Run("errors are wrapped", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		sess := NewMockgoamqpSession(ctrl)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-			receiver, err := rw.NewReceiver(ctx, "source", nil)
-			require.ErrorIs(t, err, expectedErr)
-			require.Nil(t, receiver)
-		})
-	}
+		sess.EXPECT().NewReceiver(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("new receiver failed"))
+		sess.EXPECT().NewSender(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("new sender failed"))
+		sess.EXPECT().Close(test.CancelledAndHasTimeout).Return(context.Canceled)
 
-	for _, expectedErr := range []error{context.Canceled, context.DeadlineExceeded} {
-		t.Run(fmt.Sprintf("NewSender() == %s", expectedErr.Error()), func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			inner := NewMockgoamqpSession(ctrl)
+		sw := &AMQPSessionWrapper{connID: uint64(101), Inner: sess, ContextWithTimeoutFn: test.NewContextWithTimeoutForTests}
 
-			inner.EXPECT().NewSender(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, expectedErr)
+		assertErr := func(err error, msg string) {
+			t.Helper()
+			var wrapErr *Error
 
-			rw := &AMQPSessionWrapper{Inner: inner}
+			require.ErrorAs(t, err, &wrapErr)
+			require.EqualError(t, wrapErr, msg)
+			require.Equal(t, uint64(101), wrapErr.ConnID)
+			require.Empty(t, wrapErr.LinkName)
+		}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-			sender, err := rw.NewSender(ctx, "target", nil)
-			require.ErrorIs(t, err, expectedErr)
-			require.Nil(t, sender)
-		})
-	}
+		_, err := sw.NewReceiver(context.Background(), "source", nil)
+		assertErr(err, "new receiver failed")
+
+		_, err = sw.NewSender(context.Background(), "target", nil)
+		assertErr(err, "new sender failed")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err = sw.Close(ctx)
+		assertErr(err, "context canceled")
+		require.ErrorIs(t, err, context.Canceled)
+	})
 }
 
 func TestAMQPConnWrapper(t *testing.T) {
-	for _, expectedErr := range []error{context.Canceled, context.DeadlineExceeded} {
-		t.Run(expectedErr.Error(), func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			inner := NewMockgoamqpConn(ctrl)
+	t.Run("ConnID is propagated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		innerConn := NewMockgoamqpConn(ctrl)
 
-			inner.EXPECT().NewSession(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
+		innerConn.EXPECT().NewSession(gomock.Any(), gomock.Any()).Return(&amqp.Session{}, nil)
 
-			conn := &AMQPClientWrapper{Inner: inner}
+		cw := AMQPClientWrapper{
+			ConnID: uint64(101),
+			Inner:  innerConn,
+		}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
+		sess, err := cw.NewSession(context.Background(), nil)
+		require.NoError(t, err)
 
-			sess, err := conn.NewSession(ctx, nil)
-			require.ErrorIs(t, err, expectedErr)
-			require.Nil(t, sess)
-		})
-	}
+		require.Equal(t, uint64(101), sess.ConnID())
+	})
+
+	t.Run("errors are wrapped", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		innerConn := NewMockgoamqpConn(ctrl)
+
+		assertErr := func(err error, msg string) {
+			t.Helper()
+			var wrapErr *Error
+			require.ErrorAs(t, err, &wrapErr)
+			require.EqualError(t, wrapErr, msg)
+			require.Equal(t, uint64(101), wrapErr.ConnID)
+			require.Empty(t, wrapErr.LinkName)
+		}
+
+		innerConn.EXPECT().NewSession(gomock.Any(), gomock.Any()).Return(nil, errors.New("new session failed"))
+		innerConn.EXPECT().Close().Return(errors.New("close failed"))
+
+		cw := AMQPClientWrapper{
+			ConnID: uint64(101),
+			Inner:  innerConn,
+		}
+
+		require.Equal(t, uint64(101), cw.ID())
+
+		_, err := cw.NewSession(context.Background(), nil)
+		assertErr(err, "new session failed")
+
+		err = cw.Close()
+		assertErr(err, "close failed")
+	})
 }

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/mock_amqp_test.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/mock_amqp_test.go
@@ -53,6 +53,20 @@ func (mr *MockAMQPReceiverMockRecorder) AcceptMessage(ctx, msg interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).AcceptMessage), ctx, msg)
 }
 
+// ConnID mocks base method.
+func (m *MockAMQPReceiver) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPReceiverMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPReceiver)(nil).ConnID))
+}
+
 // Credits mocks base method.
 func (m *MockAMQPReceiver) Credits() uint32 {
 	m.ctrl.T.Helper()
@@ -231,6 +245,20 @@ func (mr *MockAMQPReceiverCloserMockRecorder) Close(ctx interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).Close), ctx)
 }
 
+// ConnID mocks base method.
+func (m *MockAMQPReceiverCloser) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPReceiverCloserMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).ConnID))
+}
+
 // Credits mocks base method.
 func (m *MockAMQPReceiverCloser) Credits() uint32 {
 	m.ctrl.T.Helper()
@@ -381,6 +409,20 @@ func (m *MockAMQPSender) EXPECT() *MockAMQPSenderMockRecorder {
 	return m.recorder
 }
 
+// ConnID mocks base method.
+func (m *MockAMQPSender) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPSenderMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPSender)(nil).ConnID))
+}
+
 // LinkName mocks base method.
 func (m *MockAMQPSender) LinkName() string {
 	m.ctrl.T.Helper()
@@ -458,6 +500,20 @@ func (m *MockAMQPSenderCloser) Close(ctx context.Context) error {
 func (mr *MockAMQPSenderCloserMockRecorder) Close(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPSenderCloser)(nil).Close), ctx)
+}
+
+// ConnID mocks base method.
+func (m *MockAMQPSenderCloser) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPSenderCloserMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPSenderCloser)(nil).ConnID))
 }
 
 // LinkName mocks base method.
@@ -539,6 +595,20 @@ func (mr *MockAMQPSessionMockRecorder) Close(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPSession)(nil).Close), ctx)
 }
 
+// ConnID mocks base method.
+func (m *MockAMQPSession) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPSessionMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPSession)(nil).ConnID))
+}
+
 // NewReceiver mocks base method.
 func (m *MockAMQPSession) NewReceiver(ctx context.Context, source string, opts *go_amqp.ReceiverOptions) (AMQPReceiverCloser, error) {
 	m.ctrl.T.Helper()
@@ -606,6 +676,20 @@ func (mr *MockAMQPClientMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPClient)(nil).Close))
 }
 
+// ID mocks base method.
+func (m *MockAMQPClient) ID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ID indicates an expected call of ID.
+func (mr *MockAMQPClientMockRecorder) ID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockAMQPClient)(nil).ID))
+}
+
 // NewSession mocks base method.
 func (m *MockAMQPClient) NewSession(ctx context.Context, opts *go_amqp.SessionOptions) (AMQPSession, error) {
 	m.ctrl.T.Helper()
@@ -619,72 +703,6 @@ func (m *MockAMQPClient) NewSession(ctx context.Context, opts *go_amqp.SessionOp
 func (mr *MockAMQPClientMockRecorder) NewSession(ctx, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockAMQPClient)(nil).NewSession), ctx, opts)
-}
-
-// MockRPCLink is a mock of RPCLink interface.
-type MockRPCLink struct {
-	ctrl     *gomock.Controller
-	recorder *MockRPCLinkMockRecorder
-}
-
-// MockRPCLinkMockRecorder is the mock recorder for MockRPCLink.
-type MockRPCLinkMockRecorder struct {
-	mock *MockRPCLink
-}
-
-// NewMockRPCLink creates a new mock instance.
-func NewMockRPCLink(ctrl *gomock.Controller) *MockRPCLink {
-	mock := &MockRPCLink{ctrl: ctrl}
-	mock.recorder = &MockRPCLinkMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRPCLink) EXPECT() *MockRPCLinkMockRecorder {
-	return m.recorder
-}
-
-// Close mocks base method.
-func (m *MockRPCLink) Close(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockRPCLinkMockRecorder) Close(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRPCLink)(nil).Close), ctx)
-}
-
-// LinkName mocks base method.
-func (m *MockRPCLink) LinkName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LinkName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// LinkName indicates an expected call of LinkName.
-func (mr *MockRPCLinkMockRecorder) LinkName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkName", reflect.TypeOf((*MockRPCLink)(nil).LinkName))
-}
-
-// RPC mocks base method.
-func (m *MockRPCLink) RPC(ctx context.Context, msg *go_amqp.Message) (*RPCResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RPC", ctx, msg)
-	ret0, _ := ret[0].(*RPCResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RPC indicates an expected call of RPC.
-func (mr *MockRPCLinkMockRecorder) RPC(ctx, msg interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPC", reflect.TypeOf((*MockRPCLink)(nil).RPC), ctx, msg)
 }
 
 // MockgoamqpConn is a mock of goamqpConn interface.
@@ -968,4 +986,83 @@ func (m *MockgoamqpReceiver) ReleaseMessage(ctx context.Context, msg *go_amqp.Me
 func (mr *MockgoamqpReceiverMockRecorder) ReleaseMessage(ctx, msg interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseMessage", reflect.TypeOf((*MockgoamqpReceiver)(nil).ReleaseMessage), ctx, msg)
+}
+
+// MockgoamqpSender is a mock of goamqpSender interface.
+type MockgoamqpSender struct {
+	ctrl     *gomock.Controller
+	recorder *MockgoamqpSenderMockRecorder
+}
+
+// MockgoamqpSenderMockRecorder is the mock recorder for MockgoamqpSender.
+type MockgoamqpSenderMockRecorder struct {
+	mock *MockgoamqpSender
+}
+
+// NewMockgoamqpSender creates a new mock instance.
+func NewMockgoamqpSender(ctrl *gomock.Controller) *MockgoamqpSender {
+	mock := &MockgoamqpSender{ctrl: ctrl}
+	mock.recorder = &MockgoamqpSenderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockgoamqpSender) EXPECT() *MockgoamqpSenderMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockgoamqpSender) Close(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockgoamqpSenderMockRecorder) Close(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockgoamqpSender)(nil).Close), ctx)
+}
+
+// LinkName mocks base method.
+func (m *MockgoamqpSender) LinkName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LinkName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// LinkName indicates an expected call of LinkName.
+func (mr *MockgoamqpSenderMockRecorder) LinkName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkName", reflect.TypeOf((*MockgoamqpSender)(nil).LinkName))
+}
+
+// MaxMessageSize mocks base method.
+func (m *MockgoamqpSender) MaxMessageSize() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MaxMessageSize")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// MaxMessageSize indicates an expected call of MaxMessageSize.
+func (mr *MockgoamqpSenderMockRecorder) MaxMessageSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxMessageSize", reflect.TypeOf((*MockgoamqpSender)(nil).MaxMessageSize))
+}
+
+// Send mocks base method.
+func (m *MockgoamqpSender) Send(ctx context.Context, msg *go_amqp.Message, o *go_amqp.SendOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Send", ctx, msg, o)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Send indicates an expected call of Send.
+func (mr *MockgoamqpSenderMockRecorder) Send(ctx, msg, o interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockgoamqpSender)(nil).Send), ctx, msg, o)
 }

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/rpc.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/rpc.go
@@ -21,6 +21,7 @@ type RPCResponse struct {
 // RPCLink is implemented by *rpc.Link
 type RPCLink interface {
 	Close(ctx context.Context) error
+	ConnID() uint64
 	RPC(ctx context.Context, msg *amqp.Message) (*RPCResponse, error)
 	LinkName() string
 }

--- a/sdk/messaging/azeventhubs/internal/cbs_test.go
+++ b/sdk/messaging/azeventhubs/internal/cbs_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/auth"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/mock"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/test"
 	"github.com/Azure/go-amqp"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -26,9 +27,9 @@ func TestNegotiateClaimWithCloseTimeout(t *testing.T) {
 			session := mock.NewMockAMQPSession(ctrl)
 			client := mock.NewMockAMQPClient(ctrl)
 
-			client.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(session, nil)
-			session.EXPECT().NewReceiver(mock.NotCancelled, gomock.Any(), gomock.Any()).Return(receiver, nil)
-			session.EXPECT().NewSender(mock.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
+			client.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(session, nil)
+			session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any()).Return(receiver, nil)
+			session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
 			tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
 
 			mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
@@ -44,7 +45,7 @@ func TestNegotiateClaimWithCloseTimeout(t *testing.T) {
 			// context was cancelled. This basically just falls through the error handling
 			// but it's okay - each resource should close any local state they can before
 			// returning and we're going to end up abandoning ship on the connection.
-			session.EXPECT().Close(mock.NotCancelled).DoAndReturn(func(ctx context.Context) error {
+			session.EXPECT().Close(test.NotCancelled).DoAndReturn(func(ctx context.Context) error {
 				cancelCallerCtx()
 				<-ctx.Done()
 				return errToReturn
@@ -65,12 +66,12 @@ func TestNegotiateClaimWithAuthFailure(t *testing.T) {
 	session := mock.NewMockAMQPSession(ctrl)
 	client := mock.NewMockAMQPClient(ctrl)
 
-	client.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(session, nil)
-	session.EXPECT().NewReceiver(mock.NotCancelled, gomock.Any(), gomock.Any()).Return(receiver, nil)
-	session.EXPECT().NewSender(mock.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
+	client.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(session, nil)
+	session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any()).Return(receiver, nil)
+	session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
 	tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
 
-	session.EXPECT().Close(mock.NotCancelled)
+	session.EXPECT().Close(test.NotCancelled)
 
 	mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
 		// this is the kind of error you get if your connection string is inconsistent
@@ -97,12 +98,12 @@ func TestNegotiateClaimSuccess(t *testing.T) {
 	session := mock.NewMockAMQPSession(ctrl)
 	client := mock.NewMockAMQPClient(ctrl)
 
-	client.EXPECT().NewSession(mock.NotCancelled, gomock.Any()).Return(session, nil)
-	session.EXPECT().NewReceiver(mock.NotCancelled, gomock.Any(), gomock.Any()).Return(receiver, nil)
-	session.EXPECT().NewSender(mock.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
+	client.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(session, nil)
+	session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any()).Return(receiver, nil)
+	session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
 	tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
 
-	session.EXPECT().Close(mock.NotCancelled)
+	session.EXPECT().Close(test.NotCancelled)
 
 	mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
 		response.ApplicationProperties = map[string]any{

--- a/sdk/messaging/azeventhubs/internal/errors.go
+++ b/sdk/messaging/azeventhubs/internal/errors.go
@@ -6,11 +6,9 @@ package internal
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"reflect"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/amqpwrap"
@@ -209,12 +207,6 @@ func GetRecoveryKind(err error) RecoveryKind {
 		return RecoveryKindConn
 	}
 
-	if IsDrainingError(err) {
-		// temporary, operation should just be retryable since drain will
-		// eventually complete.
-		return RecoveryKindNone
-	}
-
 	// then it's _probably_ an actual *amqp.Error, in which case we bucket it by
 	// the 'condition'.
 	var amqpError *amqp.Error
@@ -257,92 +249,11 @@ func GetRecoveryKind(err error) RecoveryKind {
 	return RecoveryKindConn
 }
 
-type (
-	// ErrMissingField indicates that an expected property was missing from an AMQP message. This should only be
-	// encountered when there is an error with this library, or the server has altered its behavior unexpectedly.
-	ErrMissingField string
-
-	// ErrMalformedMessage indicates that a message was expected in the form of []byte was not a []byte. This is likely
-	// a bug and should be reported.
-	ErrMalformedMessage string
-
-	// ErrIncorrectType indicates that type assertion failed. This should only be encountered when there is an error
-	// with this library, or the server has altered its behavior unexpectedly.
-	ErrIncorrectType struct {
-		Key          string
-		ExpectedType reflect.Type
-		ActualValue  any
-	}
-
-	// ErrAMQP indicates that the server communicated an AMQP error with a particular
-	ErrAMQP amqpwrap.RPCResponse
-
-	// ErrNoMessages is returned when an operation returned no messages. It is not indicative that there will not be
-	// more messages in the future.
-	ErrNoMessages struct{}
-
-	// ErrNotFound is returned when an entity is not found (404)
-	ErrNotFound struct {
-		EntityPath string
-	}
-
-	// ErrConnectionClosed indicates that the connection has been closed.
-	ErrConnectionClosed string
-)
-
-func (e ErrMissingField) Error() string {
-	return fmt.Sprintf("missing value %q", string(e))
-}
-
-func (e ErrMalformedMessage) Error() string {
-	return "message was expected in the form of []byte was not a []byte"
-}
-
-// NewErrIncorrectType lets you skip using the `reflect` package. Just provide a variable of the desired type as
-// 'expected'.
-func NewErrIncorrectType(key string, expected, actual any) ErrIncorrectType {
-	return ErrIncorrectType{
-		Key:          key,
-		ExpectedType: reflect.TypeOf(expected),
-		ActualValue:  actual,
-	}
-}
-
-func (e ErrIncorrectType) Error() string {
-	return fmt.Sprintf(
-		"value at %q was expected to be of type %q but was actually of type %q",
-		e.Key,
-		e.ExpectedType,
-		reflect.TypeOf(e.ActualValue))
-}
-
-func (e ErrAMQP) Error() string {
-	return fmt.Sprintf("server says (%d) %s", e.Code, e.Description)
-}
-
-func (e ErrNoMessages) Error() string {
-	return "no messages available"
-}
-
-func (e ErrNotFound) Error() string {
-	return fmt.Sprintf("entity at %s not found", e.EntityPath)
-}
-
-// IsErrNotFound returns true if the error argument is an ErrNotFound type
-func IsErrNotFound(err error) bool {
-	_, ok := err.(ErrNotFound)
-	return ok
-}
-
 func IsNotAllowedError(err error) bool {
 	var e *amqp.Error
 
 	return errors.As(err, &e) &&
 		e.Condition == amqp.ErrCondNotAllowed
-}
-
-func (e ErrConnectionClosed) Error() string {
-	return fmt.Sprintf("the connection has been closed: %s", string(e))
 }
 
 func IsOwnershipLostError(err error) bool {

--- a/sdk/messaging/azeventhubs/internal/errors_test.go
+++ b/sdk/messaging/azeventhubs/internal/errors_test.go
@@ -6,6 +6,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -42,9 +43,35 @@ func TestGetRecoveryKind(t *testing.T) {
 	require.Equal(t, GetRecoveryKind(amqpwrap.ErrConnResetNeeded), RecoveryKindConn)
 	require.Equal(t, GetRecoveryKind(&amqp.LinkError{}), RecoveryKindLink)
 	require.Equal(t, GetRecoveryKind(context.Canceled), RecoveryKindFatal)
-	require.Equal(t, GetRecoveryKind(RPCError{Resp: &amqpwrap.RPCResponse{Code: http.StatusUnauthorized}}), RecoveryKindFatal)
-	require.Equal(t, GetRecoveryKind(RPCError{Resp: &amqpwrap.RPCResponse{Code: http.StatusNotFound}}), RecoveryKindFatal)
 	require.Equal(t, GetRecoveryKind(&amqp.Error{Condition: amqp.ErrCondResourceLimitExceeded}), RecoveryKindFatal)
+
+	// fatal RPC errors
+	for _, code := range []int{http.StatusUnauthorized, http.StatusNotFound} {
+		t.Run(fmt.Sprintf("RPCError.Code==%d is fatal", code), func(t *testing.T) {
+			actual := GetRecoveryKind(RPCError{Resp: &amqpwrap.RPCResponse{Code: code}})
+			require.Equal(t, RecoveryKindFatal, actual)
+		})
+	}
+
+	// recoverable RPC errors
+	for _, code := range []int{http.StatusRequestTimeout, http.StatusServiceUnavailable, http.StatusInternalServerError} {
+		t.Run(fmt.Sprintf("RPCError.Code==%d is retriable", code), func(t *testing.T) {
+			actual := GetRecoveryKind(RPCError{Resp: &amqpwrap.RPCResponse{Code: code}})
+			require.Equal(t, RecoveryKindNone, actual)
+		})
+	}
+}
+
+func TestIsNotAllowedError(t *testing.T) {
+	require.True(t, IsNotAllowedError(&amqp.Error{
+		Condition: amqp.ErrCondNotAllowed,
+	}))
+
+	require.False(t, IsNotAllowedError(&amqp.Error{
+		Condition: amqp.ErrCondConnectionForced,
+	}))
+
+	require.False(t, IsNotAllowedError(errors.New("hello")))
 }
 
 func Test_TransformError(t *testing.T) {

--- a/sdk/messaging/azeventhubs/internal/links_unit_test.go
+++ b/sdk/messaging/azeventhubs/internal/links_unit_test.go
@@ -130,8 +130,8 @@ func TestLinks_ConnectionRecovery(t *testing.T) {
 
 	negotiateClaimCtx, cancelNegotiateClaim := context.WithCancel(context.Background())
 
-	ns.EXPECT().NegotiateClaim(mock.NotCancelled, gomock.Any()).Return(cancelNegotiateClaim, negotiateClaimCtx.Done(), nil)
-	ns.EXPECT().NewAMQPSession(mock.NotCancelled).Return(session, uint64(1), nil)
+	ns.EXPECT().NegotiateClaim(test.NotCancelled, gomock.Any()).Return(cancelNegotiateClaim, negotiateClaimCtx.Done(), nil)
+	ns.EXPECT().NewAMQPSession(test.NotCancelled).Return(session, uint64(1), nil)
 
 	receiver.EXPECT().LinkName().Return("link1").AnyTimes()
 
@@ -149,9 +149,9 @@ func TestLinks_ConnectionRecovery(t *testing.T) {
 	// if the connection has closed in response to an error then it'll propagate it's error to
 	// the children, including receivers. Which means closing the receiver here will _also_ return
 	// a connection error.
-	receiver.EXPECT().Close(mock.NotCancelled).Return(&amqp.ConnError{})
+	receiver.EXPECT().Close(test.NotCancelled).Return(&amqp.ConnError{})
 
-	ns.EXPECT().Recover(mock.NotCancelled, gomock.Any()).Return(nil)
+	ns.EXPECT().Recover(test.NotCancelled, gomock.Any()).Return(nil)
 
 	// initiate a connection level recovery
 	err = links.RecoverIfNeeded(context.Background(), "0", lwid, &amqp.ConnError{})
@@ -222,8 +222,8 @@ func TestLinks_closeWithTimeout(t *testing.T) {
 
 			negotiateClaimCtx, cancelNegotiateClaim := context.WithCancel(context.Background())
 
-			ns.EXPECT().NegotiateClaim(mock.NotCancelled, gomock.Any()).Return(cancelNegotiateClaim, negotiateClaimCtx.Done(), nil)
-			ns.EXPECT().NewAMQPSession(mock.NotCancelled).Return(session, uint64(1), nil)
+			ns.EXPECT().NegotiateClaim(test.NotCancelled, gomock.Any()).Return(cancelNegotiateClaim, negotiateClaimCtx.Done(), nil)
+			ns.EXPECT().NewAMQPSession(test.NotCancelled).Return(session, uint64(1), nil)
 
 			receiver.EXPECT().LinkName().Return("link1").AnyTimes()
 
@@ -241,7 +241,7 @@ func TestLinks_closeWithTimeout(t *testing.T) {
 
 			// now set ourselves up so Close() is "slow" and we end up timing out, or
 			// the user "cancels"
-			receiver.EXPECT().Close(mock.NotCancelled).DoAndReturn(func(ctx context.Context) error {
+			receiver.EXPECT().Close(test.NotCancelled).DoAndReturn(func(ctx context.Context) error {
 				cancelUserCtx()
 				<-ctx.Done()
 				return errToReturn
@@ -266,16 +266,16 @@ func TestLinks_linkRecoveryOnly(t *testing.T) {
 
 	negotiateClaimCtx, cancelNegotiateClaim := context.WithCancel(context.Background())
 
-	fakeNS.EXPECT().NegotiateClaim(mock.NotCancelled, gomock.Any()).Return(
+	fakeNS.EXPECT().NegotiateClaim(test.NotCancelled, gomock.Any()).Return(
 		cancelNegotiateClaim, negotiateClaimCtx.Done(), nil,
 	)
-	fakeNS.EXPECT().NewAMQPSession(mock.NotCancelled).Return(session, uint64(1), nil)
+	fakeNS.EXPECT().NewAMQPSession(test.NotCancelled).Return(session, uint64(1), nil)
 
 	fakeReceiver.EXPECT().LinkName().Return("link1").AnyTimes()
 
 	// super important that when we close we're given a context that properly times out.
 	// (in this test the Close(ctx) call doesn't time out)
-	fakeReceiver.EXPECT().Close(mock.NotCancelled).Return(nil)
+	fakeReceiver.EXPECT().Close(test.NotCancelled).Return(nil)
 
 	links := NewLinks(fakeNS, "managementPath", func(partitionID string) string {
 		return fmt.Sprintf("part:%s", partitionID)
@@ -301,17 +301,17 @@ func TestLinks_linkRecoveryFailsWithLinkFailure(t *testing.T) {
 
 	negotiateClaimCtx, cancelNegotiateClaim := context.WithCancel(context.Background())
 
-	fakeNS.EXPECT().NegotiateClaim(mock.NotCancelled, gomock.Any()).Return(
+	fakeNS.EXPECT().NegotiateClaim(test.NotCancelled, gomock.Any()).Return(
 		cancelNegotiateClaim, negotiateClaimCtx.Done(), nil,
 	)
-	fakeNS.EXPECT().NewAMQPSession(mock.NotCancelled).Return(session, uint64(1), nil)
+	fakeNS.EXPECT().NewAMQPSession(test.NotCancelled).Return(session, uint64(1), nil)
 
 	fakeReceiver.EXPECT().LinkName().Return("link1").AnyTimes()
 
 	// super important that when we close we're given a context that properly times out.
 	// (in this test the Close(ctx) call doesn't time out)
 	detachErr := &amqp.LinkError{RemoteErr: &amqp.Error{Condition: amqp.ErrCondDetachForced}}
-	fakeReceiver.EXPECT().Close(mock.NotCancelled).Return(detachErr)
+	fakeReceiver.EXPECT().Close(test.NotCancelled).Return(detachErr)
 
 	links := NewLinks(fakeNS, "managementPath", func(partitionID string) string {
 		return fmt.Sprintf("part:%s", partitionID)

--- a/sdk/messaging/azeventhubs/internal/mock/mock_amqp.go
+++ b/sdk/messaging/azeventhubs/internal/mock/mock_amqp.go
@@ -54,6 +54,20 @@ func (mr *MockAMQPReceiverMockRecorder) AcceptMessage(ctx, msg interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptMessage", reflect.TypeOf((*MockAMQPReceiver)(nil).AcceptMessage), ctx, msg)
 }
 
+// ConnID mocks base method.
+func (m *MockAMQPReceiver) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPReceiverMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPReceiver)(nil).ConnID))
+}
+
 // Credits mocks base method.
 func (m *MockAMQPReceiver) Credits() uint32 {
 	m.ctrl.T.Helper()
@@ -232,6 +246,20 @@ func (mr *MockAMQPReceiverCloserMockRecorder) Close(ctx interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).Close), ctx)
 }
 
+// ConnID mocks base method.
+func (m *MockAMQPReceiverCloser) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPReceiverCloserMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPReceiverCloser)(nil).ConnID))
+}
+
 // Credits mocks base method.
 func (m *MockAMQPReceiverCloser) Credits() uint32 {
 	m.ctrl.T.Helper()
@@ -382,6 +410,20 @@ func (m *MockAMQPSender) EXPECT() *MockAMQPSenderMockRecorder {
 	return m.recorder
 }
 
+// ConnID mocks base method.
+func (m *MockAMQPSender) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPSenderMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPSender)(nil).ConnID))
+}
+
 // LinkName mocks base method.
 func (m *MockAMQPSender) LinkName() string {
 	m.ctrl.T.Helper()
@@ -459,6 +501,20 @@ func (m *MockAMQPSenderCloser) Close(ctx context.Context) error {
 func (mr *MockAMQPSenderCloserMockRecorder) Close(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPSenderCloser)(nil).Close), ctx)
+}
+
+// ConnID mocks base method.
+func (m *MockAMQPSenderCloser) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPSenderCloserMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPSenderCloser)(nil).ConnID))
 }
 
 // LinkName mocks base method.
@@ -540,6 +596,20 @@ func (mr *MockAMQPSessionMockRecorder) Close(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPSession)(nil).Close), ctx)
 }
 
+// ConnID mocks base method.
+func (m *MockAMQPSession) ConnID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ConnID indicates an expected call of ConnID.
+func (mr *MockAMQPSessionMockRecorder) ConnID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnID", reflect.TypeOf((*MockAMQPSession)(nil).ConnID))
+}
+
 // NewReceiver mocks base method.
 func (m *MockAMQPSession) NewReceiver(ctx context.Context, source string, opts *amqp.ReceiverOptions) (amqpwrap.AMQPReceiverCloser, error) {
 	m.ctrl.T.Helper()
@@ -607,6 +677,20 @@ func (mr *MockAMQPClientMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPClient)(nil).Close))
 }
 
+// ID mocks base method.
+func (m *MockAMQPClient) ID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ID indicates an expected call of ID.
+func (mr *MockAMQPClientMockRecorder) ID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockAMQPClient)(nil).ID))
+}
+
 // NewSession mocks base method.
 func (m *MockAMQPClient) NewSession(ctx context.Context, opts *amqp.SessionOptions) (amqpwrap.AMQPSession, error) {
 	m.ctrl.T.Helper()
@@ -622,31 +706,83 @@ func (mr *MockAMQPClientMockRecorder) NewSession(ctx, opts interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockAMQPClient)(nil).NewSession), ctx, opts)
 }
 
-// MockRPCLink is a mock of RPCLink interface.
-type MockRPCLink struct {
+// MockgoamqpConn is a mock of goamqpConn interface.
+type MockgoamqpConn struct {
 	ctrl     *gomock.Controller
-	recorder *MockRPCLinkMockRecorder
+	recorder *MockgoamqpConnMockRecorder
 }
 
-// MockRPCLinkMockRecorder is the mock recorder for MockRPCLink.
-type MockRPCLinkMockRecorder struct {
-	mock *MockRPCLink
+// MockgoamqpConnMockRecorder is the mock recorder for MockgoamqpConn.
+type MockgoamqpConnMockRecorder struct {
+	mock *MockgoamqpConn
 }
 
-// NewMockRPCLink creates a new mock instance.
-func NewMockRPCLink(ctrl *gomock.Controller) *MockRPCLink {
-	mock := &MockRPCLink{ctrl: ctrl}
-	mock.recorder = &MockRPCLinkMockRecorder{mock}
+// NewMockgoamqpConn creates a new mock instance.
+func NewMockgoamqpConn(ctrl *gomock.Controller) *MockgoamqpConn {
+	mock := &MockgoamqpConn{ctrl: ctrl}
+	mock.recorder = &MockgoamqpConnMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRPCLink) EXPECT() *MockRPCLinkMockRecorder {
+func (m *MockgoamqpConn) EXPECT() *MockgoamqpConnMockRecorder {
 	return m.recorder
 }
 
 // Close mocks base method.
-func (m *MockRPCLink) Close(ctx context.Context) error {
+func (m *MockgoamqpConn) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockgoamqpConnMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockgoamqpConn)(nil).Close))
+}
+
+// NewSession mocks base method.
+func (m *MockgoamqpConn) NewSession(ctx context.Context, opts *amqp.SessionOptions) (*amqp.Session, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewSession", ctx, opts)
+	ret0, _ := ret[0].(*amqp.Session)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewSession indicates an expected call of NewSession.
+func (mr *MockgoamqpConnMockRecorder) NewSession(ctx, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockgoamqpConn)(nil).NewSession), ctx, opts)
+}
+
+// MockgoamqpSession is a mock of goamqpSession interface.
+type MockgoamqpSession struct {
+	ctrl     *gomock.Controller
+	recorder *MockgoamqpSessionMockRecorder
+}
+
+// MockgoamqpSessionMockRecorder is the mock recorder for MockgoamqpSession.
+type MockgoamqpSessionMockRecorder struct {
+	mock *MockgoamqpSession
+}
+
+// NewMockgoamqpSession creates a new mock instance.
+func NewMockgoamqpSession(ctrl *gomock.Controller) *MockgoamqpSession {
+	mock := &MockgoamqpSession{ctrl: ctrl}
+	mock.recorder = &MockgoamqpSessionMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockgoamqpSession) EXPECT() *MockgoamqpSessionMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockgoamqpSession) Close(ctx context.Context) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close", ctx)
 	ret0, _ := ret[0].(error)
@@ -654,13 +790,108 @@ func (m *MockRPCLink) Close(ctx context.Context) error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockRPCLinkMockRecorder) Close(ctx interface{}) *gomock.Call {
+func (mr *MockgoamqpSessionMockRecorder) Close(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRPCLink)(nil).Close), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockgoamqpSession)(nil).Close), ctx)
+}
+
+// NewReceiver mocks base method.
+func (m *MockgoamqpSession) NewReceiver(ctx context.Context, source string, opts *amqp.ReceiverOptions) (*amqp.Receiver, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewReceiver", ctx, source, opts)
+	ret0, _ := ret[0].(*amqp.Receiver)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewReceiver indicates an expected call of NewReceiver.
+func (mr *MockgoamqpSessionMockRecorder) NewReceiver(ctx, source, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReceiver", reflect.TypeOf((*MockgoamqpSession)(nil).NewReceiver), ctx, source, opts)
+}
+
+// NewSender mocks base method.
+func (m *MockgoamqpSession) NewSender(ctx context.Context, target string, opts *amqp.SenderOptions) (*amqp.Sender, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewSender", ctx, target, opts)
+	ret0, _ := ret[0].(*amqp.Sender)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewSender indicates an expected call of NewSender.
+func (mr *MockgoamqpSessionMockRecorder) NewSender(ctx, target, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSender", reflect.TypeOf((*MockgoamqpSession)(nil).NewSender), ctx, target, opts)
+}
+
+// MockgoamqpReceiver is a mock of goamqpReceiver interface.
+type MockgoamqpReceiver struct {
+	ctrl     *gomock.Controller
+	recorder *MockgoamqpReceiverMockRecorder
+}
+
+// MockgoamqpReceiverMockRecorder is the mock recorder for MockgoamqpReceiver.
+type MockgoamqpReceiverMockRecorder struct {
+	mock *MockgoamqpReceiver
+}
+
+// NewMockgoamqpReceiver creates a new mock instance.
+func NewMockgoamqpReceiver(ctrl *gomock.Controller) *MockgoamqpReceiver {
+	mock := &MockgoamqpReceiver{ctrl: ctrl}
+	mock.recorder = &MockgoamqpReceiverMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockgoamqpReceiver) EXPECT() *MockgoamqpReceiverMockRecorder {
+	return m.recorder
+}
+
+// AcceptMessage mocks base method.
+func (m *MockgoamqpReceiver) AcceptMessage(ctx context.Context, msg *amqp.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AcceptMessage", ctx, msg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AcceptMessage indicates an expected call of AcceptMessage.
+func (mr *MockgoamqpReceiverMockRecorder) AcceptMessage(ctx, msg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptMessage", reflect.TypeOf((*MockgoamqpReceiver)(nil).AcceptMessage), ctx, msg)
+}
+
+// Close mocks base method.
+func (m *MockgoamqpReceiver) Close(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockgoamqpReceiverMockRecorder) Close(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockgoamqpReceiver)(nil).Close), ctx)
+}
+
+// IssueCredit mocks base method.
+func (m *MockgoamqpReceiver) IssueCredit(credit uint32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IssueCredit", credit)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IssueCredit indicates an expected call of IssueCredit.
+func (mr *MockgoamqpReceiverMockRecorder) IssueCredit(credit interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueCredit", reflect.TypeOf((*MockgoamqpReceiver)(nil).IssueCredit), credit)
 }
 
 // LinkName mocks base method.
-func (m *MockRPCLink) LinkName() string {
+func (m *MockgoamqpReceiver) LinkName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LinkName")
 	ret0, _ := ret[0].(string)
@@ -668,22 +899,171 @@ func (m *MockRPCLink) LinkName() string {
 }
 
 // LinkName indicates an expected call of LinkName.
-func (mr *MockRPCLinkMockRecorder) LinkName() *gomock.Call {
+func (mr *MockgoamqpReceiverMockRecorder) LinkName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkName", reflect.TypeOf((*MockRPCLink)(nil).LinkName))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkName", reflect.TypeOf((*MockgoamqpReceiver)(nil).LinkName))
 }
 
-// RPC mocks base method.
-func (m *MockRPCLink) RPC(ctx context.Context, msg *amqp.Message) (*amqpwrap.RPCResponse, error) {
+// LinkSourceFilterValue mocks base method.
+func (m *MockgoamqpReceiver) LinkSourceFilterValue(name string) any {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RPC", ctx, msg)
-	ret0, _ := ret[0].(*amqpwrap.RPCResponse)
+	ret := m.ctrl.Call(m, "LinkSourceFilterValue", name)
+	ret0, _ := ret[0].(any)
+	return ret0
+}
+
+// LinkSourceFilterValue indicates an expected call of LinkSourceFilterValue.
+func (mr *MockgoamqpReceiverMockRecorder) LinkSourceFilterValue(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSourceFilterValue", reflect.TypeOf((*MockgoamqpReceiver)(nil).LinkSourceFilterValue), name)
+}
+
+// ModifyMessage mocks base method.
+func (m *MockgoamqpReceiver) ModifyMessage(ctx context.Context, msg *amqp.Message, options *amqp.ModifyMessageOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyMessage", ctx, msg, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ModifyMessage indicates an expected call of ModifyMessage.
+func (mr *MockgoamqpReceiverMockRecorder) ModifyMessage(ctx, msg, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyMessage", reflect.TypeOf((*MockgoamqpReceiver)(nil).ModifyMessage), ctx, msg, options)
+}
+
+// Prefetched mocks base method.
+func (m *MockgoamqpReceiver) Prefetched() *amqp.Message {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Prefetched")
+	ret0, _ := ret[0].(*amqp.Message)
+	return ret0
+}
+
+// Prefetched indicates an expected call of Prefetched.
+func (mr *MockgoamqpReceiverMockRecorder) Prefetched() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prefetched", reflect.TypeOf((*MockgoamqpReceiver)(nil).Prefetched))
+}
+
+// Receive mocks base method.
+func (m *MockgoamqpReceiver) Receive(ctx context.Context, o *amqp.ReceiveOptions) (*amqp.Message, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Receive", ctx, o)
+	ret0, _ := ret[0].(*amqp.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RPC indicates an expected call of RPC.
-func (mr *MockRPCLinkMockRecorder) RPC(ctx, msg interface{}) *gomock.Call {
+// Receive indicates an expected call of Receive.
+func (mr *MockgoamqpReceiverMockRecorder) Receive(ctx, o interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPC", reflect.TypeOf((*MockRPCLink)(nil).RPC), ctx, msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receive", reflect.TypeOf((*MockgoamqpReceiver)(nil).Receive), ctx, o)
+}
+
+// RejectMessage mocks base method.
+func (m *MockgoamqpReceiver) RejectMessage(ctx context.Context, msg *amqp.Message, e *amqp.Error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RejectMessage", ctx, msg, e)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RejectMessage indicates an expected call of RejectMessage.
+func (mr *MockgoamqpReceiverMockRecorder) RejectMessage(ctx, msg, e interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectMessage", reflect.TypeOf((*MockgoamqpReceiver)(nil).RejectMessage), ctx, msg, e)
+}
+
+// ReleaseMessage mocks base method.
+func (m *MockgoamqpReceiver) ReleaseMessage(ctx context.Context, msg *amqp.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReleaseMessage", ctx, msg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReleaseMessage indicates an expected call of ReleaseMessage.
+func (mr *MockgoamqpReceiverMockRecorder) ReleaseMessage(ctx, msg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseMessage", reflect.TypeOf((*MockgoamqpReceiver)(nil).ReleaseMessage), ctx, msg)
+}
+
+// MockgoamqpSender is a mock of goamqpSender interface.
+type MockgoamqpSender struct {
+	ctrl     *gomock.Controller
+	recorder *MockgoamqpSenderMockRecorder
+}
+
+// MockgoamqpSenderMockRecorder is the mock recorder for MockgoamqpSender.
+type MockgoamqpSenderMockRecorder struct {
+	mock *MockgoamqpSender
+}
+
+// NewMockgoamqpSender creates a new mock instance.
+func NewMockgoamqpSender(ctrl *gomock.Controller) *MockgoamqpSender {
+	mock := &MockgoamqpSender{ctrl: ctrl}
+	mock.recorder = &MockgoamqpSenderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockgoamqpSender) EXPECT() *MockgoamqpSenderMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockgoamqpSender) Close(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockgoamqpSenderMockRecorder) Close(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockgoamqpSender)(nil).Close), ctx)
+}
+
+// LinkName mocks base method.
+func (m *MockgoamqpSender) LinkName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LinkName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// LinkName indicates an expected call of LinkName.
+func (mr *MockgoamqpSenderMockRecorder) LinkName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkName", reflect.TypeOf((*MockgoamqpSender)(nil).LinkName))
+}
+
+// MaxMessageSize mocks base method.
+func (m *MockgoamqpSender) MaxMessageSize() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MaxMessageSize")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// MaxMessageSize indicates an expected call of MaxMessageSize.
+func (mr *MockgoamqpSenderMockRecorder) MaxMessageSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxMessageSize", reflect.TypeOf((*MockgoamqpSender)(nil).MaxMessageSize))
+}
+
+// Send mocks base method.
+func (m *MockgoamqpSender) Send(ctx context.Context, msg *amqp.Message, o *amqp.SendOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Send", ctx, msg, o)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Send indicates an expected call of Send.
+func (mr *MockgoamqpSenderMockRecorder) Send(ctx, msg, o interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockgoamqpSender)(nil).Send), ctx, msg, o)
 }

--- a/sdk/messaging/azeventhubs/internal/mock/mock_helpers.go
+++ b/sdk/messaging/azeventhubs/internal/mock/mock_helpers.go
@@ -5,8 +5,6 @@ package mock
 
 import (
 	context "context"
-	"fmt"
-	"time"
 
 	"github.com/Azure/go-amqp"
 	gomock "github.com/golang/mock/gomock"
@@ -47,75 +45,4 @@ func SetupRPC(sender *MockAMQPSenderCloser, receiver *MockAMQPReceiverCloser, ex
 			}
 		})
 	}
-}
-
-// Cancelled matches context.Context instances that are cancelled.
-var Cancelled gomock.Matcher = ContextCancelledMatcher{true}
-
-// NotCancelled matches context.Context instances that are not cancelled.
-var NotCancelled gomock.Matcher = ContextCancelledMatcher{false}
-
-// NotCancelledAndHasTimeout matches context.Context instances that are not cancelled
-// AND were also created from NewContextForTest.
-var NotCancelledAndHasTimeout gomock.Matcher = gomock.All(ContextCancelledMatcher{false}, ContextHasTestValueMatcher{})
-
-// CancelledAndHasTimeout matches context.Context instances that are cancelled
-// AND were also created from NewContextForTest.
-var CancelledAndHasTimeout gomock.Matcher = gomock.All(ContextCancelledMatcher{true}, ContextHasTestValueMatcher{})
-
-type ContextCancelledMatcher struct {
-	// WantCancelled should be set if we expect the context should
-	// be cancelled. If true, we check if Err() != nil, if false we check
-	// that it's nil.
-	WantCancelled bool
-}
-
-// Matches returns whether x is a match.
-func (m ContextCancelledMatcher) Matches(x any) bool {
-	ctx := x.(context.Context)
-
-	if m.WantCancelled {
-		return ctx.Err() != nil
-	} else {
-		return ctx.Err() == nil
-	}
-}
-
-// String describes what the matcher matches.
-func (m ContextCancelledMatcher) String() string {
-	return fmt.Sprintf("want cancelled:%v", m.WantCancelled)
-}
-
-type ContextHasTestValueMatcher struct{}
-
-func (m ContextHasTestValueMatcher) Matches(x any) bool {
-	ctx := x.(context.Context)
-	return ctx.Value(testContextKey(0)) == "correctContextWasUsed"
-}
-
-func (m ContextHasTestValueMatcher) String() string {
-	return "has test context value"
-}
-
-type testContextKey int
-
-// NewContextWithTimeoutForTests creates a context with a lower timeout than requested just to keep
-// unit test times reasonable.
-//
-// It validates that the passed in timeout is the actual defaultCloseTimeout and also
-// adds in a testContextKey(0) as a value, which can be used to verify that the context
-// has been properly propagated.
-func NewContextWithTimeoutForTests(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	// (we're in the wrong package to share the value, but this is meant to match defaultCloseTimeout)
-	if timeout != time.Minute {
-		// panic'ing instead of require.Equal() otherwise I would need to take a 't' and not be signature
-		// compatible with context.WithTimeout.
-		panic(fmt.Sprintf("Incorrect close timeout: expected %s, actual %s", time.Minute, timeout))
-	}
-
-	parentWithValue := context.WithValue(parent, testContextKey(0), "correctContextWasUsed")
-
-	// NOTE: if you're debugging then you might need to bump up this
-	// value so you can single step.
-	return context.WithTimeout(parentWithValue, time.Second)
 }

--- a/sdk/messaging/azeventhubs/internal/namespace.go
+++ b/sdk/messaging/azeventhubs/internal/namespace.go
@@ -54,7 +54,7 @@ type (
 		closedPermanently bool
 
 		// newClientFn exists so we can stub out newClient for unit tests.
-		newClientFn func(ctx context.Context) (amqpwrap.AMQPClient, error)
+		newClientFn func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error)
 	}
 
 	// NamespaceOption provides structure for configuring a new Event Hub namespace
@@ -159,7 +159,7 @@ func NewNamespace(opts ...NamespaceOption) (*Namespace, error) {
 	return ns, nil
 }
 
-func (ns *Namespace) newClientImpl(ctx context.Context) (amqpwrap.AMQPClient, error) {
+func (ns *Namespace) newClientImpl(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 	connOptions := amqp.ConnOptions{
 		SASLType:    amqp.SASLTypeAnonymous(),
 		MaxSessions: 65535,
@@ -187,11 +187,11 @@ func (ns *Namespace) newClientImpl(ctx context.Context) (amqpwrap.AMQPClient, er
 
 		connOptions.HostName = ns.FQDN
 		client, err := amqp.NewConn(ctx, nConn, &connOptions)
-		return &amqpwrap.AMQPClientWrapper{Inner: client}, err
+		return &amqpwrap.AMQPClientWrapper{Inner: client, ConnID: connID}, err
 	}
 
 	client, err := amqp.Dial(ctx, ns.getAMQPHostURI(), &connOptions)
-	return &amqpwrap.AMQPClientWrapper{Inner: client}, err
+	return &amqpwrap.AMQPClientWrapper{Inner: client, ConnID: connID}, err
 }
 
 // NewAMQPSession creates a new AMQP session with the internally cached *amqp.Client.
@@ -442,13 +442,15 @@ func (ns *Namespace) updateClientWithoutLock(ctx context.Context) (amqpwrap.AMQP
 
 	connStart := time.Now()
 	log.Writef(exported.EventConn, "Creating new client, current rev: %d", ns.connID)
-	tempClient, err := ns.newClientFn(ctx)
+
+	newConnID := ns.connID + 1
+	tempClient, err := ns.newClientFn(ctx, newConnID)
 
 	if err != nil {
 		return nil, 0, err
 	}
 
-	ns.connID++
+	ns.connID = newConnID
 	ns.client = tempClient
 	log.Writef(exported.EventConn, "Client created, new rev: %d, took %dms", ns.connID, time.Since(connStart)/time.Millisecond)
 

--- a/sdk/messaging/azeventhubs/internal/namespace_test.go
+++ b/sdk/messaging/azeventhubs/internal/namespace_test.go
@@ -74,7 +74,7 @@ func TestNamespaceNegotiateClaim(t *testing.T) {
 
 	newAMQPClientCalled := 0
 
-	ns.newClientFn = func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+	ns.newClientFn = func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 		newAMQPClientCalled++
 		return &amqpwrap.AMQPClientWrapper{}, nil
 	}
@@ -119,7 +119,7 @@ func TestNamespaceNegotiateClaimRenewal(t *testing.T) {
 	var errorsLogged []error
 	nextRefreshDurationChecks := 0
 
-	ns.newClientFn = func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+	ns.newClientFn = func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 		return &amqpwrap.AMQPClientWrapper{Inner: &amqp.Conn{}}, nil
 	}
 
@@ -153,7 +153,7 @@ func TestNamespaceNegotiateClaimFailsToGetClient(t *testing.T) {
 		TokenProvider: sbauth.NewTokenProvider(&fakeTokenCredential{expires: time.Now()}),
 	}
 
-	ns.newClientFn = func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+	ns.newClientFn = func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 		return nil, errors.New("Getting *amqp.Client failed")
 	}
 
@@ -187,7 +187,7 @@ func TestNamespaceNegotiateClaimNonRenewableToken(t *testing.T) {
 		return nil
 	}
 
-	ns.newClientFn = func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+	ns.newClientFn = func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 		return &amqpwrap.AMQPClientWrapper{Inner: &amqp.Conn{}}, nil
 	}
 
@@ -215,7 +215,7 @@ func TestNamespaceNegotiateClaimFails(t *testing.T) {
 		TokenProvider: sbauth.NewTokenProvider(&fakeTokenCredential{expires: time.Now()}),
 	}
 
-	ns.newClientFn = func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+	ns.newClientFn = func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 		return &fakeAMQPClient{}, nil
 	}
 
@@ -254,7 +254,7 @@ func TestNamespaceNegotiateClaimFatalErrors(t *testing.T) {
 	endCapture := test.CaptureLogsForTest()
 	defer endCapture()
 
-	ns.newClientFn = func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+	ns.newClientFn = func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 		return &amqpwrap.AMQPClientWrapper{Inner: &amqp.Conn{}}, nil
 	}
 
@@ -313,7 +313,7 @@ func TestNamespaceStaleConnection(t *testing.T) {
 	require.Equal(t, 1, fakeClient.closeCalled)
 	require.Nil(t, ns.client)
 
-	ns.newClientFn = func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+	ns.newClientFn = func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 		return &fakeAMQPClient{}, nil
 	}
 
@@ -330,7 +330,7 @@ func TestNamespaceUpdateClientWithoutLock(t *testing.T) {
 	var err error
 
 	ns := &Namespace{
-		newClientFn: func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+		newClientFn: func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 			newClient++
 			return clientToReturn, err
 		},
@@ -374,7 +374,7 @@ func TestNamespaceConnectionRecovery(t *testing.T) {
 		td := &testData{}
 		td.NS = &Namespace{
 			connID: 2,
-			newClientFn: func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+			newClientFn: func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 				td.NewClientCount++
 				return nil, td.FakeClientError
 			},
@@ -437,7 +437,7 @@ func TestNamespaceCantStopRecoverFromClosingConn(t *testing.T) {
 	numClients := 0
 
 	ns := &Namespace{
-		newClientFn: func(ctx context.Context) (amqpwrap.AMQPClient, error) {
+		newClientFn: func(ctx context.Context, connID uint64) (amqpwrap.AMQPClient, error) {
 			select {
 			case <-ctx.Done():
 				numCancels++

--- a/sdk/messaging/azeventhubs/internal/rpc.go
+++ b/sdk/messaging/azeventhubs/internal/rpc.go
@@ -97,6 +97,7 @@ func NewRPCLink(ctx context.Context, args RPCLinkArgs) (amqpwrap.RPCLink, error)
 	}
 
 	id := linkID.String()
+
 	link := &rpcLink{
 		session:       session,
 		clientAddress: strings.Replace("$", "", args.Address, -1) + replyPostfix + id,
@@ -300,6 +301,10 @@ func (l *rpcLink) RPC(ctx context.Context, msg *amqp.Message) (*amqpwrap.RPCResp
 	}
 
 	return response, err
+}
+
+func (l *rpcLink) ConnID() uint64 {
+	return l.session.ConnID()
 }
 
 // Close the link receiver, sender and session

--- a/sdk/messaging/azeventhubs/internal/test/mock_helpers.go
+++ b/sdk/messaging/azeventhubs/internal/test/mock_helpers.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package test
+
+import (
+	context "context"
+	"fmt"
+	"time"
+
+	gomock "github.com/golang/mock/gomock"
+)
+
+// Cancelled matches context.Context instances that are cancelled.
+var Cancelled gomock.Matcher = ContextCancelledMatcher{true}
+
+// NotCancelled matches context.Context instances that are not cancelled.
+var NotCancelled gomock.Matcher = ContextCancelledMatcher{false}
+
+// NotCancelledAndHasTimeout matches context.Context instances that are not cancelled
+// AND were also created from NewContextForTest.
+var NotCancelledAndHasTimeout gomock.Matcher = gomock.All(ContextCancelledMatcher{false}, ContextHasTestValueMatcher{})
+
+// CancelledAndHasTimeout matches context.Context instances that are cancelled
+// AND were also created from NewContextForTest.
+var CancelledAndHasTimeout gomock.Matcher = gomock.All(ContextCancelledMatcher{true}, ContextHasTestValueMatcher{})
+
+type ContextCancelledMatcher struct {
+	// WantCancelled should be set if we expect the context should
+	// be cancelled. If true, we check if Err() != nil, if false we check
+	// that it's nil.
+	WantCancelled bool
+}
+
+// Matches returns whether x is a match.
+func (m ContextCancelledMatcher) Matches(x any) bool {
+	ctx := x.(context.Context)
+
+	if m.WantCancelled {
+		return ctx.Err() != nil
+	} else {
+		return ctx.Err() == nil
+	}
+}
+
+// String describes what the matcher matches.
+func (m ContextCancelledMatcher) String() string {
+	return fmt.Sprintf("want cancelled:%v", m.WantCancelled)
+}
+
+type ContextHasTestValueMatcher struct{}
+
+func (m ContextHasTestValueMatcher) Matches(x any) bool {
+	ctx := x.(context.Context)
+	return ctx.Value(testContextKey(0)) == "correctContextWasUsed"
+}
+
+func (m ContextHasTestValueMatcher) String() string {
+	return "has test context value"
+}
+
+type testContextKey int
+
+// NewContextWithTimeoutForTests creates a context with a lower timeout than requested just to keep
+// unit test times reasonable.
+//
+// It validates that the passed in timeout is the actual defaultCloseTimeout and also
+// adds in a testContextKey(0) as a value, which can be used to verify that the context
+// has been properly propagated.
+func NewContextWithTimeoutForTests(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	// (we're in the wrong package to share the value, but this is meant to match defaultCloseTimeout)
+	if timeout != time.Minute {
+		// panic'ing instead of require.Equal() otherwise I would need to take a 't' and not be signature
+		// compatible with context.WithTimeout.
+		panic(fmt.Sprintf("Incorrect close timeout: expected %s, actual %s", time.Minute, timeout))
+	}
+
+	parentWithValue := context.WithValue(parent, testContextKey(0), "correctContextWasUsed")
+
+	// NOTE: if you're debugging then you might need to bump up this
+	// value so you can single step.
+	return context.WithTimeout(parentWithValue, time.Second)
+}


### PR DESCRIPTION
Make it so the lower level primitives and errors carry more information about the connection ID, rather than requiring us to shuttle it around externally.

- Adding (AMQPReceiver|AMQPSender|AMQPSession).ConnID() fields (and AMQPClient.ID()) fields.
- Errors are now wrapped immediately when returned from the underlying `amqpwrap` types. This is prep for another issue I found where we'd fail to recover a connection in some cases because we didn't have enough context to do it.
- Moved out some universally useful helpers for gomock into the `test` package (basically, splitting up mock_helpers.go into two files).
- Regenerating mocks