### PR TITLE
[azeventhubs] Fixing issue where we'd waste a recovery cycle in some cases

### DIFF
--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -148,7 +148,7 @@ func (cc *ConsumerClient) GetEventHubProperties(ctx context.Context, options *Ge
 		return EventHubProperties{}, err
 	}
 
-	return getEventHubProperties(ctx, cc.namespace, rpcLink.Link, cc.eventHub, options)
+	return getEventHubProperties(ctx, cc.namespace, rpcLink.Link(), cc.eventHub, options)
 }
 
 // GetPartitionProperties gets properties for a specific partition. This includes data like the
@@ -161,7 +161,7 @@ func (cc *ConsumerClient) GetPartitionProperties(ctx context.Context, partitionI
 		return PartitionProperties{}, err
 	}
 
-	return getPartitionProperties(ctx, cc.namespace, rpcLink.Link, cc.eventHub, partitionID, options)
+	return getPartitionProperties(ctx, cc.namespace, rpcLink.Link(), cc.eventHub, partitionID, options)
 }
 
 // InstanceID is the identifier for this ConsumerClient.

--- a/sdk/messaging/azeventhubs/consumer_client_internal_test.go
+++ b/sdk/messaging/azeventhubs/consumer_client_internal_test.go
@@ -279,7 +279,7 @@ func TestConsumerClient_RecoveryLink(t *testing.T) {
 		links := pc.links.(*internal.Links[amqpwrap.AMQPReceiverCloser])
 		lwid, err := links.GetLink(context.Background(), sendResults[i].PartitionID)
 		require.NoError(t, err)
-		require.NoError(t, lwid.Link.Close(context.Background()))
+		require.NoError(t, lwid.Link().Close(context.Background()))
 	}
 
 	log.Printf("== 4. try to read the second event, which force clients to recover ==")

--- a/sdk/messaging/azeventhubs/internal/amqp_fakes.go
+++ b/sdk/messaging/azeventhubs/internal/amqp_fakes.go
@@ -69,7 +69,7 @@ func (ns *FakeNSForPartClient) NewAMQPSession(ctx context.Context) (amqpwrap.AMQ
 	}, 1, nil
 }
 
-func (sess *FakeAMQPSession) NewReceiver(ctx context.Context, source string, opts *amqp.ReceiverOptions) (amqpwrap.AMQPReceiverCloser, error) {
+func (sess *FakeAMQPSession) NewReceiver(ctx context.Context, source string, partitionID string, opts *amqp.ReceiverOptions) (amqpwrap.AMQPReceiverCloser, error) {
 	sess.NS.NewReceiverCalled++
 	sess.NS.Receiver.ManualCreditsSetFromOptions = opts.Credit == -1
 	sess.NS.Receiver.CreditsSetFromOptions = opts.Credit
@@ -81,7 +81,7 @@ func (sess *FakeAMQPSession) NewReceiver(ctx context.Context, source string, opt
 	return sess.NS.Receiver, sess.NS.NewReceiverErr
 }
 
-func (sess *FakeAMQPSession) NewSender(ctx context.Context, target string, opts *amqp.SenderOptions) (AMQPSenderCloser, error) {
+func (sess *FakeAMQPSession) NewSender(ctx context.Context, target string, partitionID string, opts *amqp.SenderOptions) (AMQPSenderCloser, error) {
 	sess.NS.NewSenderCalled++
 	return sess.NS.Sender, sess.NS.NewSenderErr
 }

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqp_error.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqp_error.go
@@ -10,9 +10,10 @@ import (
 // Error is a wrapper that has the context of which connection and
 // link the error happened with.
 type Error struct {
-	ConnID   uint64
-	LinkName string
-	Err      error
+	ConnID      uint64
+	LinkName    string
+	PartitionID string
+	Err         error
 }
 
 func (e Error) Error() string {
@@ -27,7 +28,7 @@ func (e Error) Is(target error) bool {
 	return errors.Is(e.Err, target)
 }
 
-func WrapError(err error, connID uint64, linkName string) error {
+func WrapError(err error, connID uint64, linkName string, partitionID string) error {
 	if err == nil {
 		return nil
 	}
@@ -37,8 +38,9 @@ func WrapError(err error, connID uint64, linkName string) error {
 	}
 
 	return Error{
-		ConnID:   connID,
-		LinkName: linkName,
-		Err:      err,
+		ConnID:      connID,
+		LinkName:    linkName,
+		PartitionID: partitionID,
+		Err:         err,
 	}
 }

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap_test.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap_test.go
@@ -128,7 +128,7 @@ func TestAMQPSenderWrapper(t *testing.T) {
 
 		assertErr := func(err error, msg string) {
 			t.Helper()
-			var wrapErr Error
+			var wrapErr *Error
 
 			require.ErrorAs(t, err, &wrapErr)
 			require.EqualError(t, wrapErr, msg)
@@ -202,7 +202,7 @@ func TestAMQPSessionWrapper(t *testing.T) {
 
 		assertErr := func(err error, msg string) {
 			t.Helper()
-			var wrapErr Error
+			var wrapErr *Error
 
 			require.ErrorAs(t, err, &wrapErr)
 			require.EqualError(t, wrapErr, msg)
@@ -248,7 +248,7 @@ func TestAMQPConnWrapper(t *testing.T) {
 
 		assertErr := func(err error, msg string) {
 			t.Helper()
-			var wrapErr Error
+			var wrapErr *Error
 			require.ErrorAs(t, err, &wrapErr)
 			require.EqualError(t, wrapErr, msg)
 			require.Equal(t, uint64(101), wrapErr.ConnID)

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap_test.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/amqpwrap_test.go
@@ -128,7 +128,7 @@ func TestAMQPSenderWrapper(t *testing.T) {
 
 		assertErr := func(err error, msg string) {
 			t.Helper()
-			var wrapErr *Error
+			var wrapErr Error
 
 			require.ErrorAs(t, err, &wrapErr)
 			require.EqualError(t, wrapErr, msg)
@@ -181,11 +181,11 @@ func TestAMQPSessionWrapper(t *testing.T) {
 
 		require.Equal(t, uint64(101), sessWrapper.ConnID())
 
-		rc, err := sessWrapper.NewReceiver(context.Background(), "source", nil)
+		rc, err := sessWrapper.NewReceiver(context.Background(), "source", "1", nil)
 		require.NoError(t, err)
 		require.Equal(t, sessWrapper.ConnID(), rc.ConnID())
 
-		sc, err := sessWrapper.NewSender(context.Background(), "target", nil)
+		sc, err := sessWrapper.NewSender(context.Background(), "target", "1", nil)
 		require.NoError(t, err)
 		require.Equal(t, sessWrapper.ConnID(), sc.ConnID())
 	})
@@ -202,18 +202,20 @@ func TestAMQPSessionWrapper(t *testing.T) {
 
 		assertErr := func(err error, msg string) {
 			t.Helper()
-			var wrapErr *Error
+			var wrapErr Error
 
 			require.ErrorAs(t, err, &wrapErr)
+
 			require.EqualError(t, wrapErr, msg)
 			require.Equal(t, uint64(101), wrapErr.ConnID)
 			require.Empty(t, wrapErr.LinkName)
+			require.Equal(t, "1", wrapErr.PartitionID)
 		}
 
-		_, err := sw.NewReceiver(context.Background(), "source", nil)
+		_, err := sw.NewReceiver(context.Background(), "source", "1", nil)
 		assertErr(err, "new receiver failed")
 
-		_, err = sw.NewSender(context.Background(), "target", nil)
+		_, err = sw.NewSender(context.Background(), "target", "1", nil)
 		assertErr(err, "new sender failed")
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -248,7 +250,7 @@ func TestAMQPConnWrapper(t *testing.T) {
 
 		assertErr := func(err error, msg string) {
 			t.Helper()
-			var wrapErr *Error
+			var wrapErr Error
 			require.ErrorAs(t, err, &wrapErr)
 			require.EqualError(t, wrapErr, msg)
 			require.Equal(t, uint64(101), wrapErr.ConnID)

--- a/sdk/messaging/azeventhubs/internal/amqpwrap/mock_amqp_test.go
+++ b/sdk/messaging/azeventhubs/internal/amqpwrap/mock_amqp_test.go
@@ -610,33 +610,33 @@ func (mr *MockAMQPSessionMockRecorder) ConnID() *gomock.Call {
 }
 
 // NewReceiver mocks base method.
-func (m *MockAMQPSession) NewReceiver(ctx context.Context, source string, opts *go_amqp.ReceiverOptions) (AMQPReceiverCloser, error) {
+func (m *MockAMQPSession) NewReceiver(ctx context.Context, source, partitionID string, opts *go_amqp.ReceiverOptions) (AMQPReceiverCloser, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewReceiver", ctx, source, opts)
+	ret := m.ctrl.Call(m, "NewReceiver", ctx, source, partitionID, opts)
 	ret0, _ := ret[0].(AMQPReceiverCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewReceiver indicates an expected call of NewReceiver.
-func (mr *MockAMQPSessionMockRecorder) NewReceiver(ctx, source, opts interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) NewReceiver(ctx, source, partitionID, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReceiver", reflect.TypeOf((*MockAMQPSession)(nil).NewReceiver), ctx, source, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReceiver", reflect.TypeOf((*MockAMQPSession)(nil).NewReceiver), ctx, source, partitionID, opts)
 }
 
 // NewSender mocks base method.
-func (m *MockAMQPSession) NewSender(ctx context.Context, target string, opts *go_amqp.SenderOptions) (AMQPSenderCloser, error) {
+func (m *MockAMQPSession) NewSender(ctx context.Context, target, partitionID string, opts *go_amqp.SenderOptions) (AMQPSenderCloser, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewSender", ctx, target, opts)
+	ret := m.ctrl.Call(m, "NewSender", ctx, target, partitionID, opts)
 	ret0, _ := ret[0].(AMQPSenderCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewSender indicates an expected call of NewSender.
-func (mr *MockAMQPSessionMockRecorder) NewSender(ctx, target, opts interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) NewSender(ctx, target, partitionID, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSender", reflect.TypeOf((*MockAMQPSession)(nil).NewSender), ctx, target, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSender", reflect.TypeOf((*MockAMQPSession)(nil).NewSender), ctx, target, partitionID, opts)
 }
 
 // MockAMQPClient is a mock of AMQPClient interface.

--- a/sdk/messaging/azeventhubs/internal/cbs_test.go
+++ b/sdk/messaging/azeventhubs/internal/cbs_test.go
@@ -28,8 +28,8 @@ func TestNegotiateClaimWithCloseTimeout(t *testing.T) {
 			client := mock.NewMockAMQPClient(ctrl)
 
 			client.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(session, nil)
-			session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any()).Return(receiver, nil)
-			session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
+			session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(receiver, nil)
+			session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(sender, nil)
 			tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
 
 			mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
@@ -67,8 +67,8 @@ func TestNegotiateClaimWithAuthFailure(t *testing.T) {
 	client := mock.NewMockAMQPClient(ctrl)
 
 	client.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(session, nil)
-	session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any()).Return(receiver, nil)
-	session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
+	session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(receiver, nil)
+	session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(sender, nil)
 	tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
 
 	session.EXPECT().Close(test.NotCancelled)
@@ -99,8 +99,8 @@ func TestNegotiateClaimSuccess(t *testing.T) {
 	client := mock.NewMockAMQPClient(ctrl)
 
 	client.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(session, nil)
-	session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any()).Return(receiver, nil)
-	session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any()).Return(sender, nil)
+	session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(receiver, nil)
+	session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(sender, nil)
 	tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
 
 	session.EXPECT().Close(test.NotCancelled)

--- a/sdk/messaging/azeventhubs/internal/errors.go
+++ b/sdk/messaging/azeventhubs/internal/errors.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/amqpwrap"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/exported"
@@ -113,11 +112,6 @@ func IsCancelError(err error) bool {
 	}
 
 	return false
-}
-
-func IsDrainingError(err error) bool {
-	// TODO: we should be able to identify these errors programatically
-	return strings.Contains(err.Error(), "link is currently draining")
 }
 
 const errorConditionLockLost = amqp.ErrCond("com.microsoft:message-lock-lost")

--- a/sdk/messaging/azeventhubs/internal/mock/mock_amqp.go
+++ b/sdk/messaging/azeventhubs/internal/mock/mock_amqp.go
@@ -611,33 +611,33 @@ func (mr *MockAMQPSessionMockRecorder) ConnID() *gomock.Call {
 }
 
 // NewReceiver mocks base method.
-func (m *MockAMQPSession) NewReceiver(ctx context.Context, source string, opts *amqp.ReceiverOptions) (amqpwrap.AMQPReceiverCloser, error) {
+func (m *MockAMQPSession) NewReceiver(ctx context.Context, source, partitionID string, opts *amqp.ReceiverOptions) (amqpwrap.AMQPReceiverCloser, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewReceiver", ctx, source, opts)
+	ret := m.ctrl.Call(m, "NewReceiver", ctx, source, partitionID, opts)
 	ret0, _ := ret[0].(amqpwrap.AMQPReceiverCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewReceiver indicates an expected call of NewReceiver.
-func (mr *MockAMQPSessionMockRecorder) NewReceiver(ctx, source, opts interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) NewReceiver(ctx, source, partitionID, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReceiver", reflect.TypeOf((*MockAMQPSession)(nil).NewReceiver), ctx, source, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReceiver", reflect.TypeOf((*MockAMQPSession)(nil).NewReceiver), ctx, source, partitionID, opts)
 }
 
 // NewSender mocks base method.
-func (m *MockAMQPSession) NewSender(ctx context.Context, target string, opts *amqp.SenderOptions) (amqpwrap.AMQPSenderCloser, error) {
+func (m *MockAMQPSession) NewSender(ctx context.Context, target, partitionID string, opts *amqp.SenderOptions) (amqpwrap.AMQPSenderCloser, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewSender", ctx, target, opts)
+	ret := m.ctrl.Call(m, "NewSender", ctx, target, partitionID, opts)
 	ret0, _ := ret[0].(amqpwrap.AMQPSenderCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewSender indicates an expected call of NewSender.
-func (mr *MockAMQPSessionMockRecorder) NewSender(ctx, target, opts interface{}) *gomock.Call {
+func (mr *MockAMQPSessionMockRecorder) NewSender(ctx, target, partitionID, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSender", reflect.TypeOf((*MockAMQPSession)(nil).NewSender), ctx, target, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSender", reflect.TypeOf((*MockAMQPSession)(nil).NewSender), ctx, target, partitionID, opts)
 }
 
 // MockAMQPClient is a mock of AMQPClient interface.

--- a/sdk/messaging/azeventhubs/internal/rpc.go
+++ b/sdk/messaging/azeventhubs/internal/rpc.go
@@ -112,6 +112,7 @@ func NewRPCLink(ctx context.Context, args RPCLinkArgs) (amqpwrap.RPCLink, error)
 	sender, err := session.NewSender(
 		ctx,
 		args.Address,
+		"",
 		nil,
 	)
 	if err != nil {
@@ -134,7 +135,7 @@ func NewRPCLink(ctx context.Context, args RPCLinkArgs) (amqpwrap.RPCLink, error)
 		}
 	}
 
-	receiver, err := session.NewReceiver(ctx, args.Address, receiverOpts)
+	receiver, err := session.NewReceiver(ctx, args.Address, "", receiverOpts)
 	if err != nil {
 		_ = session.Close(ctx)
 		return nil, err

--- a/sdk/messaging/azeventhubs/internal/rpc_test.go
+++ b/sdk/messaging/azeventhubs/internal/rpc_test.go
@@ -260,7 +260,7 @@ func TestRPCLinkClosingClean_SenderCreationFailed(t *testing.T) {
 	senderErr := errors.New("failed to create sender")
 
 	conn.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(sess, nil)
-	sess.EXPECT().NewSender(test.NotCancelled, "rpcAddress", gomock.Any()).Return(nil, senderErr)
+	sess.EXPECT().NewSender(test.NotCancelled, "rpcAddress", gomock.Any(), gomock.Any()).Return(nil, senderErr)
 	sess.EXPECT().Close(test.NotCancelled).Return(nil)
 
 	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
@@ -281,8 +281,8 @@ func TestRPCLinkClosingClean_ReceiverCreationFailed(t *testing.T) {
 	receiverErr := errors.New("failed to create receiver")
 
 	conn.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(sess, nil)
-	sess.EXPECT().NewSender(test.NotCancelled, "rpcAddress", gomock.Any()).Return(sender, nil)
-	sess.EXPECT().NewReceiver(test.NotCancelled, "rpcAddress", gomock.Any()).Return(nil, receiverErr)
+	sess.EXPECT().NewSender(test.NotCancelled, "rpcAddress", gomock.Any(), gomock.Any()).Return(sender, nil)
+	sess.EXPECT().NewReceiver(test.NotCancelled, "rpcAddress", gomock.Any(), gomock.Any()).Return(nil, receiverErr)
 
 	sess.EXPECT().Close(test.NotCancelled).Return(nil)
 
@@ -303,7 +303,7 @@ func TestRPCLinkClosingClean_CreationFailsButSessionCloseFailsToo(t *testing.T) 
 	senderErr := errors.New("failed to create receiver")
 
 	conn.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(sess, nil)
-	sess.EXPECT().NewSender(test.NotCancelled, "rpcAddress", gomock.Any()).Return(nil, senderErr)
+	sess.EXPECT().NewSender(test.NotCancelled, "rpcAddress", gomock.Any(), gomock.Any()).Return(nil, senderErr)
 	sess.EXPECT().Close(test.NotCancelled).Return(errors.New("session closing failed"))
 
 	rpcLink, err := NewRPCLink(context.Background(), RPCLinkArgs{
@@ -377,11 +377,11 @@ func (c *rpcTesterClient) NewSession(ctx context.Context, opts *amqp.SessionOpti
 
 func (c *rpcTesterClient) Close() error { return nil }
 
-func (tester *rpcTester) NewReceiver(ctx context.Context, source string, opts *amqp.ReceiverOptions) (amqpwrap.AMQPReceiverCloser, error) {
+func (tester *rpcTester) NewReceiver(ctx context.Context, source string, partitionID string, opts *amqp.ReceiverOptions) (amqpwrap.AMQPReceiverCloser, error) {
 	return tester, nil
 }
 
-func (tester *rpcTester) NewSender(ctx context.Context, target string, opts *amqp.SenderOptions) (amqpwrap.AMQPSenderCloser, error) {
+func (tester *rpcTester) NewSender(ctx context.Context, target string, partitionID string, opts *amqp.SenderOptions) (amqpwrap.AMQPSenderCloser, error) {
 	return tester, nil
 }
 


### PR DESCRIPTION
In Event Hubs, Links runs AMQP operations inside of a retry loop - a failure in the loop will be picked up and checked in the next iteration. One quirk that I introduced here (and not in SB) is that we no-op if you ask to recover and there's no link information. This could cause to waste a retry loop iteration, resulting in unnecessary delays.

The simplest fix here was just to make sure that all errors carry enough information along to allow for recovery in contexts where we didn't get a link, which is what I plumbed in in #20867. I've extended it to also carry PartitionID, which makes full recovery possible.