### PR TITLE
[azservicebus] Add support for `DefaultRule` when creating a Subscription

### DIFF
--- a/sdk/messaging/azservicebus/admin/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_test.go
@@ -558,6 +558,153 @@ func testTopicCreation(t *testing.T, isPremium bool) {
 	}, addSubWithPropsResp.SubscriptionProperties)
 }
 
+func TestAdminClient_TopicAndSubscription_WithFalseFilterDefaultSubscriptionRule(t *testing.T) {
+	adminClient, topicName := createAdminClientWithTestTopic(t)
+
+	subscriptionName := createTestSubscriptionWithDefaultRule(
+		t,
+		adminClient,
+		topicName,
+		&RuleProperties{Filter: &FalseFilter{}},
+	)
+
+	// Even though a default rule is created on the subscription, the response body does not include it.
+	// which is why we can discard this response and need to fetch the rule explicitly.
+	// (It is also not included when fetching the subscription)
+	defaultRule, err := adminClient.GetRule(context.Background(), topicName, subscriptionName, "$Default", nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "$Default", defaultRule.Name)
+	require.IsType(t, &FalseFilter{}, defaultRule.Filter)
+	require.Nil(t, defaultRule.Action)
+
+	defer deleteSubscription(t, adminClient, topicName, subscriptionName)
+}
+
+func TestAdminClient_TopicAndSubscription_WithCustomFilterDefaultSubscriptionRule(t *testing.T) {
+	adminClient, topicName := createAdminClientWithTestTopic(t)
+
+	customSqlFilter := &SQLFilter{
+		Expression: "SomeProperty LIKE 'O%'",
+	}
+
+	subscriptionName := createTestSubscriptionWithDefaultRule(
+		t,
+		adminClient,
+		topicName,
+		&RuleProperties{
+			Name:   "TestRule",
+			Filter: customSqlFilter,
+		},
+	)
+
+	defaultRule, err := adminClient.GetRule(context.Background(), topicName, subscriptionName, "TestRule", nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "TestRule", defaultRule.Name)
+	require.Equal(t, customSqlFilter, defaultRule.Filter)
+	require.Nil(t, defaultRule.Action)
+
+	defer deleteSubscription(t, adminClient, topicName, subscriptionName)
+}
+
+func TestAdminClient_TopicAndSubscription_WithActionDefaultSubscriptionRule(t *testing.T) {
+	adminClient, topicName := createAdminClientWithTestTopic(t)
+
+	ruleAction := &SQLAction{
+		Expression: "SET MessageID=@stringVar",
+		Parameters: map[string]any{
+			"@stringVar": "hello world",
+		},
+	}
+
+	subscriptionName := createTestSubscriptionWithDefaultRule(
+		t,
+		adminClient,
+		topicName,
+		&RuleProperties{
+			Action: ruleAction,
+		},
+	)
+
+	defaultRule, err := adminClient.GetRule(context.Background(), topicName, subscriptionName, "$Default", nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "$Default", defaultRule.Name)
+	require.Equal(t, ruleAction, defaultRule.Action)
+	require.Equal(t, defaultRule.Filter, &TrueFilter{})
+
+	defer deleteSubscription(t, adminClient, topicName, subscriptionName)
+}
+
+func TestAdminClient_TopicAndSubscription_WithActionAndFilterDefaultSubscriptionRule(t *testing.T) {
+	adminClient, topicName := createAdminClientWithTestTopic(t)
+
+	ruleAction := &SQLAction{
+		Expression: "SET MessageID=@stringVar",
+		Parameters: map[string]any{
+			"@stringVar": "hello world",
+		},
+	}
+
+	ruleFilter := &SQLFilter{
+		Expression: "SomeProperty LIKE 'O%'",
+	}
+
+	subscriptionName := createTestSubscriptionWithDefaultRule(
+		t,
+		adminClient,
+		topicName,
+		&RuleProperties{
+			Action: ruleAction,
+			Filter: ruleFilter,
+		},
+	)
+
+	defaultRule, err := adminClient.GetRule(context.Background(), topicName, subscriptionName, "$Default", nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "$Default", defaultRule.Name)
+	require.EqualValues(t, ruleAction, defaultRule.Action)
+	require.EqualValues(t, ruleFilter, defaultRule.Filter)
+
+	defer deleteSubscription(t, adminClient, topicName, subscriptionName)
+}
+
+func createAdminClientWithTestTopic(t *testing.T) (*Client, string) {
+	adminClient, err := NewClientFromConnectionString(test.GetConnectionString(t), nil)
+	require.NoError(t, err)
+
+	topicName := fmt.Sprintf("topic-%X", time.Now().UnixNano())
+	_, err = adminClient.CreateTopic(context.Background(), topicName, nil)
+	require.NoError(t, err)
+
+	return adminClient, topicName
+}
+
+func createTestSubscriptionWithDefaultRule(t *testing.T, adminClient *Client, topicName string, defaultRule *RuleProperties) string {
+	subscriptionName := fmt.Sprintf("subscription-%X", time.Now().UnixNano())
+
+	_, err := adminClient.CreateSubscription(context.Background(), topicName, subscriptionName, &CreateSubscriptionOptions{
+		Properties: &SubscriptionProperties{
+			LockDuration:                                    to.Ptr("PT3M"),
+			RequiresSession:                                 to.Ptr(false),
+			DefaultMessageTimeToLive:                        to.Ptr("PT7M"),
+			DeadLetteringOnMessageExpiration:                to.Ptr(true),
+			EnableDeadLetteringOnFilterEvaluationExceptions: to.Ptr(false),
+			MaxDeliveryCount:                                to.Ptr(int32(11)),
+			Status:                                          to.Ptr(EntityStatusActive),
+			EnableBatchedOperations:                         to.Ptr(false),
+			AutoDeleteOnIdle:                                to.Ptr("PT11M"),
+			UserMetadata:                                    to.Ptr("user metadata"),
+			DefaultRule:                                     defaultRule,
+		},
+	})
+	require.NoError(t, err)
+
+	return subscriptionName
+}
+
 func TestAdminClient_Forwarding(t *testing.T) {
 	adminClient, err := NewClientFromConnectionString(test.GetConnectionString(t), nil)
 	require.NoError(t, err)

--- a/sdk/messaging/azservicebus/internal/atom/models.go
+++ b/sdk/messaging/azservicebus/internal/atom/models.go
@@ -169,9 +169,10 @@ type (
 	}
 	// DefaultRuleDescription is the content type for Subscription Rule management requests
 	DefaultRuleDescription struct {
-		XMLName xml.Name          `xml:"DefaultRuleDescription"`
-		Filter  FilterDescription `xml:"Filter"`
-		Name    *string           `xml:"Name,omitempty"`
+		XMLName xml.Name           `xml:"DefaultRuleDescription"`
+		Filter  *FilterDescription `xml:"Filter"`
+		Action  *ActionDescription `xml:"Action,omitempty"`
+		Name    string             `xml:"Name,omitempty"`
 	}
 
 	// FilterDescription describes a filter which can be applied to a subscription to filter messages from the topic.
@@ -268,7 +269,7 @@ type (
 		DefaultMessageTimeToLive                  *string                 `xml:"DefaultMessageTimeToLive,omitempty"`         // DefaultMessageTimeToLive - ISO 8601 default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
 		DeadLetteringOnMessageExpiration          *bool                   `xml:"DeadLetteringOnMessageExpiration,omitempty"` // DeadLetteringOnMessageExpiration - A value that indicates whether this queue has dead letter support when a message expires.
 		DeadLetteringOnFilterEvaluationExceptions *bool                   `xml:"DeadLetteringOnFilterEvaluationExceptions,omitempty"`
-		DefaultRuleDescription                    *DefaultRuleDescription `xml:"DefaultRuleDescription,omitempty"`
+		DefaultRuleDescription                    *DefaultRuleDescription `xml:"DefaultRuleDescription,omitempty"`  // DefaultRuleDescription - A  default rule that is created right when the new subscription is created.
 		MaxDeliveryCount                          *int32                  `xml:"MaxDeliveryCount,omitempty"`        // MaxDeliveryCount - The maximum delivery count. A message is automatically deadlettered after this number of deliveries. default value is 10.
 		MessageCount                              *int64                  `xml:"MessageCount,omitempty"`            // MessageCount - The number of messages in the queue.
 		EnableBatchedOperations                   *bool                   `xml:"EnableBatchedOperations,omitempty"` // EnableBatchedOperations - Value that indicates whether server-side batched operations are enabled.


### PR DESCRIPTION
Hi there! c:

We've recently migrated from a [tool](https://docs.particular.net/transports/azure-service-bus/operational-scripting) that used the Azure SDK for dotnet to manage Service Bus Topics and Subscriptions to the Azure Resource Manager Terraform Provider. Since then, we're struggling with an issue that newly created subscriptions automatically consume all messages in their topic. It seems like there currently is no way to specify a default rule (filter) when creating a subscription with the go api client, which means this option is also not available in the Terraform Provider using this SDK. The dotnet SDK supports this option which is why we didn't have this issue before.

It looks like this option was considered to also be part of the go SDK, which is which is why the option was initially added, [but was left commented out for some reason at that time](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azservicebus/admin/admin_client_subscription.go#L383).

To me it looks like whatever held back the implementation back then is now no longer an issue, which is why I was able to add the necessary changes to make it work. I've tried to keep my changes in the same style as the existing code as well as adding tests for the new feature. I'd love to get any feedback on the changes and am dediacted to work out any kinks, you might not be happy with! Additionally, I could also imagine not exposing a `RuleProperties` object through `SubscriptionProperties` but instead just offer a flag, `DoNotConsumeMessages`, which sets a `FalseFilter` instead of the `TrueFilter` in the default rule.

Changes:
- Add `DefaultRule` field to `SubscriptionProperties`
- Extract conversion functions from `createOrUpdateRule` to make them available when creating a new subscription
- Create a `DefaultRuleDescription` using `SubscriptionProperties`, when creating a  `SubscriptionEnvelope`
- Extend `DefaultRuleDescription` with `Action` and change `Filter` to be a pointer rather than a value to be consistent with the optional `Action`
- Add tests for `Client.CreateSubscription` with a `DefaultRule` in `SubscriptionProperties`