### PR TITLE
Add DragonflyBSD to supported builds

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+* Add `dragonfly` to the list of build constraints for `blockblob`.
+
 ## 1.1.0-beta.1 (2023-05-09)
 
 ### Features Added

--- a/sdk/storage/azblob/blockblob/mmf_unix.go
+++ b/sdk/storage/azblob/blockblob/mmf_unix.go
@@ -1,6 +1,6 @@
-//go:build go1.18 && (linux || darwin || freebsd || openbsd || netbsd || solaris)
+//go:build go1.18 && (linux || darwin || dragonfly || freebsd || openbsd || netbsd || solaris)
 // +build go1.18
-// +build linux darwin freebsd openbsd netbsd solaris
+// +build linux darwin dragonfly freebsd openbsd netbsd solaris
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.


### PR DESCRIPTION
BSD derivative with the same CRT as other BSDs.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/20885