### PR TITLE
BearerTokenPolicy uses shared.NonRetriableError()

### DIFF
--- a/sdk/azcore/runtime/policy_bearer_token.go
+++ b/sdk/azcore/runtime/policy_bearer_token.go
@@ -4,14 +4,12 @@
 package runtime
 
 import (
-	"errors"
 	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/temporal"
 )
 
@@ -79,7 +77,7 @@ func (b *BearerTokenPolicy) Do(req *policy.Request) (*http.Response, error) {
 		err = b.authenticateAndAuthorize(req)(policy.TokenRequestOptions{Scopes: b.scopes})
 	}
 	if err != nil {
-		return nil, ensureNonRetriable(err)
+		return nil, shared.NonRetriableError(err)
 	}
 
 	res, err := req.Next()
@@ -95,22 +93,8 @@ func (b *BearerTokenPolicy) Do(req *policy.Request) (*http.Response, error) {
 			}
 		}
 	}
-	return res, ensureNonRetriable(err)
-}
-
-func ensureNonRetriable(err error) error {
-	var nre errorinfo.NonRetriable
-	if err != nil && !errors.As(err, &nre) {
-		err = btpError{err}
+	if err != nil {
+		err = shared.NonRetriableError(err)
 	}
-	return err
+	return res, err
 }
-
-// btpError is a wrapper that ensures RetryPolicy doesn't retry requests BearerTokenPolicy couldn't authorize
-type btpError struct {
-	error
-}
-
-func (btpError) NonRetriable() {}
-
-var _ errorinfo.NonRetriable = (*btpError)(nil)


### PR DESCRIPTION
Deleting a one-off error made redundant by #20866