### PR TITLE
Fix populating module name in telemetry policy (#20967)

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 * Retry policy always clones the underlying `*http.Request` before invoking the next policy.
 * Added some non-standard error codes to the list of error codes for unregistered resource providers.
+* Fixed an issue in `azcore.NewClient()` and `arm.NewClient()` that could cause an incorrect module name to be used in telemetry.
 
 ## 1.6.0 (2023-05-04)
 

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -76,12 +76,13 @@ type Client struct {
 }
 
 // NewClient creates a new Client instance with the provided values.
-//   - clientName - the fully qualified name of the client ("package.Client"); this is used by the tracing provider when creating spans
+//   - clientName - the fully qualified name of the client ("module/package.Client"); this is used by the telemetry policy and tracing provider.
+//     if module and package are the same value, the "module/" prefix can be omitted.
 //   - moduleVersion - the semantic version of the containing module; used by the telemetry policy
 //   - plOpts - pipeline configuration options; can be the zero-value
 //   - options - optional client configurations; pass nil to accept the default values
 func NewClient(clientName, moduleVersion string, plOpts runtime.PipelineOptions, options *ClientOptions) (*Client, error) {
-	pkg, err := shared.ExtractPackageName(clientName)
+	mod, client, err := shared.ExtractModuleName(clientName)
 	if err != nil {
 		return nil, err
 	}
@@ -96,9 +97,9 @@ func NewClient(clientName, moduleVersion string, plOpts runtime.PipelineOptions,
 		}
 	}
 
-	pl := runtime.NewPipeline(pkg, moduleVersion, plOpts, options)
+	pl := runtime.NewPipeline(mod, moduleVersion, plOpts, options)
 
-	tr := options.TracingProvider.NewTracer(clientName, moduleVersion)
+	tr := options.TracingProvider.NewTracer(client, moduleVersion)
 	return &Client{pl: pl, tr: tr}, nil
 }
 

--- a/sdk/azcore/internal/shared/shared_test.go
+++ b/sdk/azcore/internal/shared/shared_test.go
@@ -85,24 +85,54 @@ func TestValidateModVer(t *testing.T) {
 	require.Error(t, ValidateModVer("v1.2"))
 }
 
-func TestExtractPackageName(t *testing.T) {
-	pkg, err := ExtractPackageName("package.Client")
+func TestExtractModuleName(t *testing.T) {
+	mod, client, err := ExtractModuleName("module/package.Client")
 	require.NoError(t, err)
-	require.Equal(t, "package", pkg)
+	require.Equal(t, "module", mod)
+	require.Equal(t, "package.Client", client)
 
-	pkg, err = ExtractPackageName("malformed")
+	mod, client, err = ExtractModuleName("malformed/")
 	require.Error(t, err)
-	require.Empty(t, pkg)
+	require.Empty(t, mod)
+	require.Empty(t, client)
 
-	pkg, err = ExtractPackageName(".malformed")
+	mod, client, err = ExtractModuleName("malformed/malformed")
 	require.Error(t, err)
-	require.Empty(t, pkg)
+	require.Empty(t, mod)
+	require.Empty(t, client)
 
-	pkg, err = ExtractPackageName("malformed.")
+	mod, client, err = ExtractModuleName("malformed/malformed.")
 	require.Error(t, err)
-	require.Empty(t, pkg)
+	require.Empty(t, mod)
+	require.Empty(t, client)
 
-	pkg, err = ExtractPackageName("")
+	mod, client, err = ExtractModuleName("malformed/.malformed")
 	require.Error(t, err)
-	require.Empty(t, pkg)
+	require.Empty(t, mod)
+	require.Empty(t, client)
+
+	mod, client, err = ExtractModuleName("package.Client")
+	require.NoError(t, err)
+	require.Equal(t, "package", mod)
+	require.Equal(t, "package.Client", client)
+
+	mod, client, err = ExtractModuleName("malformed")
+	require.Error(t, err)
+	require.Empty(t, mod)
+	require.Empty(t, client)
+
+	mod, client, err = ExtractModuleName(".malformed")
+	require.Error(t, err)
+	require.Empty(t, mod)
+	require.Empty(t, client)
+
+	mod, client, err = ExtractModuleName("malformed.")
+	require.Error(t, err)
+	require.Empty(t, mod)
+	require.Empty(t, client)
+
+	mod, client, err = ExtractModuleName("")
+	require.Error(t, err)
+	require.Empty(t, mod)
+	require.Empty(t, client)
 }


### PR DESCRIPTION
Cherry-picked ff8cc21d9da4611312f03232985c7ea1a016b31b