### PR TITLE
[Feature STG 85/86] Cold Tier 

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.1.0-beta.2 (Unreleased)
 
 ### Features Added
-* Added `AccessTierCold`.
+* Added support for [Cold tier](https://learn.microsoft.com/azure/storage/blobs/access-tiers-overview?tabs=azure-portal).
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0-beta.2 (Unreleased)
 
 ### Features Added
+* Added `AccessTierCold`.
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_a772b9c866"
+  "Tag": "go/storage/azblob_ec88f3fc4f"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_5cbc6d263b"
+  "Tag": "go/storage/azblob_1a8d8f30f5"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_ec88f3fc4f"
+  "Tag": "go/storage/azblob_5cbc6d263b"
 }

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3274,95 +3274,64 @@ func (s *BlobRecordedTestsSuite) TestPermanentDeleteWithoutPermission() {
 	return nil
 }*/
 
-//
-////func (s *BlobRecordedTestsSuite) TestBlobTierInferred() {
-////	svcClient, err := getPremiumserviceClient()
-////	if err != nil {
-////		c.Skip(err.Error())
-////	}
-////
-////	containerClient, _ := testcommon.CreateNewContainer(c, svcClient)
-////	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
-////	bbClient, _ := createNewPageBlob(c, containerClient)
-////
-////	resp, err := bbClient.GetProperties(context.Background(), nil)
-////	_require.Nil(err)
-////	_assert(resp.AccessTierInferred(), chk.Equals, "true")
-////
-////	resp2, err := containerClient.NewListBlobsFlatPager(ctx, Marker{}, ListBlobsSegmentOptions{})
-////	_require.Nil(err)
-////	_assert(resp2.Segment.BlobItems[0].Properties.AccessTierInferred, chk.NotNil)
-////	_assert(resp2.Segment.BlobItems[0].Properties.AccessTier, chk.Not(chk.Equals), "")
-////
-////	_, err = bbClient.SetTier(ctx, AccessTierP4, LeaseAccessConditions{})
-////	_require.Nil(err)
-////
-////	resp, err = bbClient.GetProperties(context.Background(), nil)
-////	_require.Nil(err)
-////	_assert(resp.AccessTierInferred(), chk.Equals, "")
-////
-////	resp2, err = containerClient.NewListBlobsFlatPager(ctx, Marker{}, ListBlobsSegmentOptions{})
-////	_require.Nil(err)
-////	_assert(resp2.Segment.BlobItems[0].Properties.AccessTierInferred, chk.IsNil) // AccessTierInferred never returned if false
-////}
-////
-////func (s *BlobRecordedTestsSuite) TestBlobArchiveStatus() {
-////	svcClient, err := getBlobStorageserviceClient()
-////	if err != nil {
-////		c.Skip(err.Error())
-////	}
-////
-////	containerClient, _ := testcommon.CreateNewContainer(c, svcClient)
-////	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
-////	bbClient, _ := createNewBlockBlob(c, containerClient)
-////
-////	_, err = bbClient.SetTier(ctx, AccessTierArchive, LeaseAccessConditions{})
-////	_require.Nil(err)
-////	_, err = bbClient.SetTier(ctx, AccessTierCool, LeaseAccessConditions{})
-////	_require.Nil(err)
-////
-////	resp, err := bbClient.GetProperties(context.Background(), nil)
-////	_require.Nil(err)
-////	_assert(resp.ArchiveStatus(), chk.Equals, string(ArchiveStatusRehydratePendingToCool))
-////
-////	resp2, err := containerClient.NewListBlobsFlatPager(ctx, Marker{}, ListBlobsSegmentOptions{})
-////	_require.Nil(err)
-////	_assert(resp2.Segment.BlobItems[0].Properties.ArchiveStatus, chk.Equals, ArchiveStatusRehydratePendingToCool)
-////
-////	// delete first blob
-////	_, err = bbClient.Delete(context.Background(), DeleteSnapshotsOptionNone, nil)
-////	_require.Nil(err)
-////
-////	bbClient, _ = createNewBlockBlob(c, containerClient)
-////
-////	_, err = bbClient.SetTier(ctx, AccessTierArchive, LeaseAccessConditions{})
-////	_require.Nil(err)
-////	_, err = bbClient.SetTier(ctx, AccessTierHot, LeaseAccessConditions{})
-////	_require.Nil(err)
-////
-////	resp, err = bbClient.GetProperties(context.Background(), nil)
-////	_require.Nil(err)
-////	_assert(resp.ArchiveStatus(), chk.Equals, string(ArchiveStatusRehydratePendingToHot))
-////
-////	resp2, err = containerClient.NewListBlobsFlatPager(ctx, Marker{}, ListBlobsSegmentOptions{})
-////	_require.Nil(err)
-////	_assert(resp2.Segment.BlobItems[0].Properties.ArchiveStatus, chk.Equals, ArchiveStatusRehydratePendingToHot)
-////}
-////
-////func (s *BlobRecordedTestsSuite) TestBlobTierInvalidValue() {
-////	svcClient, err := getBlobStorageserviceClient()
-////	if err != nil {
-////		c.Skip(err.Error())
-////	}
-////
-////	containerClient, _ := testcommon.CreateNewContainer(c, svcClient)
-////	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
-////	bbClient, _ := createNewBlockBlob(c, containerClient)
-////
-////	_, err = bbClient.SetTier(ctx, AccessTierType("garbage"), LeaseAccessConditions{})
-////	testcommon.ValidateBlobErrorCode(c, err, bloberror.InvalidHeaderValue)
-////}
-////
+// //func (s *BlobRecordedTestsSuite) TestBlobTierInferred() {
+// //	svcClient, err := getPremiumserviceClient()
+// //	if err != nil {
+// //		c.Skip(err.Error())
+// //	}
+// //
+// //	containerClient, _ := testcommon.CreateNewContainer(c, svcClient)
+// //	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+// //	bbClient, _ := createNewPageBlob(c, containerClient)
+// //
+// //	resp, err := bbClient.GetProperties(context.Background(), nil)
+// //	_require.Nil(err)
+// //	_assert(resp.AccessTierInferred(), chk.Equals, "true")
+// //
+// //	resp2, err := containerClient.NewListBlobsFlatPager(ctx, Marker{}, ListBlobsSegmentOptions{})
+// //	_require.Nil(err)
+// //	_assert(resp2.Segment.BlobItems[0].Properties.AccessTierInferred, chk.NotNil)
+// //	_assert(resp2.Segment.BlobItems[0].Properties.AccessTier, chk.Not(chk.Equals), "")
+// //
+// //	_, err = bbClient.SetTier(ctx, AccessTierP4, LeaseAccessConditions{})
+// //	_require.Nil(err)
+// //
+// //	resp, err = bbClient.GetProperties(context.Background(), nil)
+// //	_require.Nil(err)
+// //	_assert(resp.AccessTierInferred(), chk.Equals, "")
+// //
+// //	resp2, err = containerClient.NewListBlobsFlatPager(ctx, Marker{}, ListBlobsSegmentOptions{})
+// //	_require.Nil(err)
+// //	_assert(resp2.Segment.BlobItems[0].Properties.AccessTierInferred, chk.IsNil) // AccessTierInferred never returned if false
+// //}
+// //
+
+func (s *BlobRecordedTestsSuite) TestBlobSetTierInvalidAndValid() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blockBlobName := testcommon.GenerateBlobName(testName)
+	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
+
+	_, err = bbClient.SetTier(context.Background(), blob.AccessTier("nothing"), nil)
+	_require.Error(err)
+	testcommon.ValidateBlobErrorCode(_require, err, bloberror.InvalidHeaderValue)
+
+	for _, tier := range []blob.AccessTier{blob.AccessTierCool, blob.AccessTierHot, blob.AccessTierCold, blob.AccessTierArchive} {
+		_, err = bbClient.SetTier(context.Background(), tier, nil)
+		_require.NoError(err)
+
+		getResp, err := bbClient.GetProperties(context.Background(), nil)
+		_require.NoError(err)
+		_require.Equal(*getResp.AccessTier, string(tier))
+	}
+}
 
 func (s *BlobRecordedTestsSuite) TestBlobClientPartsSASQueryTimes() {
 	_require := require.New(s.T())

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3274,38 +3274,6 @@ func (s *BlobRecordedTestsSuite) TestPermanentDeleteWithoutPermission() {
 	return nil
 }*/
 
-// //func (s *BlobRecordedTestsSuite) TestBlobTierInferred() {
-// //	svcClient, err := getPremiumserviceClient()
-// //	if err != nil {
-// //		c.Skip(err.Error())
-// //	}
-// //
-// //	containerClient, _ := testcommon.CreateNewContainer(c, svcClient)
-// //	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
-// //	bbClient, _ := createNewPageBlob(c, containerClient)
-// //
-// //	resp, err := bbClient.GetProperties(context.Background(), nil)
-// //	_require.Nil(err)
-// //	_assert(resp.AccessTierInferred(), chk.Equals, "true")
-// //
-// //	resp2, err := containerClient.NewListBlobsFlatPager(ctx, Marker{}, ListBlobsSegmentOptions{})
-// //	_require.Nil(err)
-// //	_assert(resp2.Segment.BlobItems[0].Properties.AccessTierInferred, chk.NotNil)
-// //	_assert(resp2.Segment.BlobItems[0].Properties.AccessTier, chk.Not(chk.Equals), "")
-// //
-// //	_, err = bbClient.SetTier(ctx, AccessTierP4, LeaseAccessConditions{})
-// //	_require.Nil(err)
-// //
-// //	resp, err = bbClient.GetProperties(context.Background(), nil)
-// //	_require.Nil(err)
-// //	_assert(resp.AccessTierInferred(), chk.Equals, "")
-// //
-// //	resp2, err = containerClient.NewListBlobsFlatPager(ctx, Marker{}, ListBlobsSegmentOptions{})
-// //	_require.Nil(err)
-// //	_assert(resp2.Segment.BlobItems[0].Properties.AccessTierInferred, chk.IsNil) // AccessTierInferred never returned if false
-// //}
-// //
-
 func (s *BlobRecordedTestsSuite) TestBlobSetTierInvalidAndValid() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/blob/constants.go
+++ b/sdk/storage/azblob/blob/constants.go
@@ -53,6 +53,7 @@ type AccessTier = generated.AccessTier
 const (
 	AccessTierArchive AccessTier = generated.AccessTierArchive
 	AccessTierCool    AccessTier = generated.AccessTierCool
+	AccessTierCold    AccessTier = generated.AccessTierCold
 	AccessTierHot     AccessTier = generated.AccessTierHot
 	AccessTierP10     AccessTier = generated.AccessTierP10
 	AccessTierP15     AccessTier = generated.AccessTierP15

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -2361,7 +2361,6 @@ func (s *BlockBlobRecordedTestsSuite) TestBlobSetTierAllTiersOnBlockBlob() {
 	blockBlobName := testcommon.GenerateBlobName(testName)
 	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
 
-	setAndCheckBlockBlobTier(_require, bbClient, blob.AccessTierCold)
 	setAndCheckBlockBlobTier(_require, bbClient, blob.AccessTierHot)
 	setAndCheckBlockBlobTier(_require, bbClient, blob.AccessTierCool)
 	setAndCheckBlockBlobTier(_require, bbClient, blob.AccessTierArchive)

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -1986,7 +1986,7 @@ func (s *BlockBlobRecordedTestsSuite) TestBlobSetTierOnCommit() {
 	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
 	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
 
-	for _, tier := range []blob.AccessTier{blob.AccessTierArchive, blob.AccessTierCool, blob.AccessTierHot, blob.AccessTierCold} {
+	for _, tier := range []blob.AccessTier{blob.AccessTierCool, blob.AccessTierHot, blob.AccessTierCold} {
 		blobName := strings.ToLower(string(tier)) + testcommon.GenerateBlobName(testName)
 		bbClient := testcommon.GetBlockBlobClient(blobName, containerClient)
 

--- a/sdk/storage/azblob/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azblob/internal/testcommon/clients_auth.go
@@ -236,6 +236,16 @@ func CreateNewBlobs(ctx context.Context, _require *require.Assertions, blobNames
 	}
 }
 
+func CreateNewBlobsListTier(ctx context.Context, _require *require.Assertions, blobNames []string, containerClient *container.Client, tier *blob.AccessTier) {
+	var bbClientList []*blockblob.Client
+	for _, blobName := range blobNames {
+		bbClient := CreateNewBlockBlob(ctx, _require, blobName, containerClient)
+		_, err := bbClient.SetTier(ctx, *tier, nil)
+		_require.NoError(err)
+		bbClientList = append(bbClientList, bbClient)
+	}
+}
+
 func GetBlockBlobClient(blockBlobName string, containerClient *container.Client) *blockblob.Client {
 	return containerClient.NewBlockBlobClient(blockBlobName)
 }

--- a/sdk/storage/azblob/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azblob/internal/testcommon/clients_auth.go
@@ -237,12 +237,10 @@ func CreateNewBlobs(ctx context.Context, _require *require.Assertions, blobNames
 }
 
 func CreateNewBlobsListTier(ctx context.Context, _require *require.Assertions, blobNames []string, containerClient *container.Client, tier *blob.AccessTier) {
-	var bbClientList []*blockblob.Client
 	for _, blobName := range blobNames {
 		bbClient := CreateNewBlockBlob(ctx, _require, blobName, containerClient)
 		_, err := bbClient.SetTier(ctx, *tier, nil)
 		_require.NoError(err)
-		bbClientList = append(bbClientList, bbClient)
 	}
 }
 

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -154,6 +154,33 @@ func (s *PageBlobRecordedTestsSuite) TestPutGetPages() {
 	}
 }
 
+func (s *PageBlobRecordedTestsSuite) TestBlobTierInferred() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountPremium, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blockBlobName := testcommon.GenerateBlobName(testName)
+	pbClient := createNewPageBlob(context.Background(), _require, blockBlobName, containerClient)
+
+	resp, err := pbClient.GetProperties(context.Background(), nil)
+	_require.Nil(err)
+	_require.Equal(*resp.AccessTierInferred, true)
+	_require.NotEqual(*resp.AccessTier, "")
+
+	_, err = pbClient.SetTier(context.Background(), blob.AccessTierP4, nil)
+	_require.Nil(err)
+
+	resp, err = pbClient.GetProperties(context.Background(), nil)
+	_require.Nil(err)
+	_require.Nil(resp.AccessTierInferred)
+	_require.NotEqual(*resp.AccessTier, "")
+}
+
 // func (s *PageBlobUnrecordedTestsSuite) TestUploadPagesFromURL() {
 //	_require := require.New(s.T())
 //	testName := s.T().Name()


### PR DESCRIPTION
1. Added AccessTierCold to constants.go in blob
2. Added tests or updated tests for the following APIs:
- Container - Flat List Blob, Hierarchy List Blobs
- BlockBlob - Upload(), UploadBlobFromURL/PutBlobFromURL(), CommitBlockList()
- Blob - SetTier(), GetPropertiest(), CopyFromURL(), StartCopyFromURL()
3. Test for Inferred Access Tier in premium account in pageblob/client-test.go
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
