### PR TITLE
[azopenai] Fixing example's typo, creating a constructor for KeyCredential

### DIFF
--- a/sdk/cognitiveservices/azopenai/README.md
+++ b/sdk/cognitiveservices/azopenai/README.md
@@ -91,11 +91,9 @@ the [Code of Conduct FAQ][coc_faq] or contact [opencode@microsoft.com][coc_conta
 comments.
 
 <!-- LINKS -->
-<!-- https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/cognitiveservices/azopenai ->
-<!-- https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/cognitiveservices/azopenai -->
 [azure_openai_access]: https://learn.microsoft.com/azure/cognitive-services/openai/overview#how-do-i-get-access-to-azure-openai
-[azopenai_repo]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk
-[azopenai_pkg_go]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk
+[azopenai_repo]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/cognitiveservices/azopenai
+[azopenai_pkg_go]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/cognitiveservices/azopenai
 [azure_identity]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
 [azure_sub]: https://azure.microsoft.com/free/
 [openai_docs]: https://learn.microsoft.com/azure/cognitive-services/openai

--- a/sdk/cognitiveservices/azopenai/assets.json
+++ b/sdk/cognitiveservices/azopenai/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/cognitiveservices/azopenai",
-  "Tag": "go/cognitiveservices/azopenai_0bc6dc4171"
+  "Tag": "go/cognitiveservices/azopenai_49bcacb061"
 }

--- a/sdk/cognitiveservices/azopenai/client_test.go
+++ b/sdk/cognitiveservices/azopenai/client_test.go
@@ -26,7 +26,9 @@ import (
 func TestClient_GetChatCompletions(t *testing.T) {
 	deploymentID := "gpt-35-turbo"
 
-	cred := KeyCredential{APIKey: apiKey}
+	cred, err := NewKeyCredential(apiKey, nil)
+	require.NoError(t, err)
+
 	chatClient, err := NewClientWithKeyCredential(endpoint, cred, deploymentID, newClientOptionsForTest(t))
 	require.NoError(t, err)
 
@@ -158,7 +160,9 @@ func testGetChatCompletions(t *testing.T, chatClient *Client, modelOrDeployment 
 }
 
 func TestClient_GetChatCompletions_InvalidModel(t *testing.T) {
-	cred := KeyCredential{APIKey: apiKey}
+	cred, err := NewKeyCredential(apiKey, nil)
+	require.NoError(t, err)
+
 	chatClient, err := NewClientWithKeyCredential(endpoint, cred, "thisdoesntexist", newClientOptionsForTest(t))
 	require.NoError(t, err)
 
@@ -179,7 +183,9 @@ func TestClient_GetChatCompletions_InvalidModel(t *testing.T) {
 }
 
 func TestClient_GetEmbeddings_InvalidModel(t *testing.T) {
-	cred := KeyCredential{APIKey: apiKey}
+	cred, err := NewKeyCredential(apiKey, nil)
+	require.NoError(t, err)
+
 	chatClient, err := NewClientWithKeyCredential(endpoint, cred, "thisdoesntexist", newClientOptionsForTest(t))
 	require.NoError(t, err)
 
@@ -197,7 +203,9 @@ func TestClient_GetCompletions(t *testing.T) {
 		body         CompletionsOptions
 		options      *GetCompletionsOptions
 	}
-	cred := KeyCredential{APIKey: apiKey}
+	cred, err := NewKeyCredential(apiKey, nil)
+	require.NoError(t, err)
+
 	client, err := NewClientWithKeyCredential(endpoint, cred, streamingModelDeployment, newClientOptionsForTest(t))
 	if err != nil {
 		log.Fatalf("%v", err)
@@ -267,7 +275,9 @@ func TestClient_GetEmbeddings(t *testing.T) {
 	// model deployment points to `text-similarity-curie-001`
 	deploymentID := "embedding"
 
-	cred := KeyCredential{APIKey: apiKey}
+	cred, err := NewKeyCredential(apiKey, nil)
+	require.NoError(t, err)
+
 	client, err := NewClientWithKeyCredential(endpoint, cred, deploymentID, newClientOptionsForTest(t))
 	require.NoError(t, err)
 
@@ -330,7 +340,10 @@ func newOpenAIClientForTest(t *testing.T) *Client {
 		t.Skipf("OPENAI_API_KEY not defined, skipping OpenAI public endpoint test")
 	}
 
-	chatClient, err := NewClientForOpenAI(openAIEndpoint, KeyCredential{APIKey: openAIKey}, newClientOptionsForTest(t))
+	cred, err := NewKeyCredential(openAIKey, nil)
+	require.NoError(t, err)
+
+	chatClient, err := NewClientForOpenAI(openAIEndpoint, cred, newClientOptionsForTest(t))
 	require.NoError(t, err)
 
 	return chatClient

--- a/sdk/cognitiveservices/azopenai/client_test.go
+++ b/sdk/cognitiveservices/azopenai/client_test.go
@@ -26,7 +26,7 @@ import (
 func TestClient_GetChatCompletions(t *testing.T) {
 	deploymentID := "gpt-35-turbo"
 
-	cred, err := NewKeyCredential(apiKey, nil)
+	cred, err := NewKeyCredential(apiKey)
 	require.NoError(t, err)
 
 	chatClient, err := NewClientWithKeyCredential(endpoint, cred, deploymentID, newClientOptionsForTest(t))
@@ -160,7 +160,7 @@ func testGetChatCompletions(t *testing.T, chatClient *Client, modelOrDeployment 
 }
 
 func TestClient_GetChatCompletions_InvalidModel(t *testing.T) {
-	cred, err := NewKeyCredential(apiKey, nil)
+	cred, err := NewKeyCredential(apiKey)
 	require.NoError(t, err)
 
 	chatClient, err := NewClientWithKeyCredential(endpoint, cred, "thisdoesntexist", newClientOptionsForTest(t))
@@ -183,7 +183,7 @@ func TestClient_GetChatCompletions_InvalidModel(t *testing.T) {
 }
 
 func TestClient_GetEmbeddings_InvalidModel(t *testing.T) {
-	cred, err := NewKeyCredential(apiKey, nil)
+	cred, err := NewKeyCredential(apiKey)
 	require.NoError(t, err)
 
 	chatClient, err := NewClientWithKeyCredential(endpoint, cred, "thisdoesntexist", newClientOptionsForTest(t))
@@ -203,7 +203,7 @@ func TestClient_GetCompletions(t *testing.T) {
 		body         CompletionsOptions
 		options      *GetCompletionsOptions
 	}
-	cred, err := NewKeyCredential(apiKey, nil)
+	cred, err := NewKeyCredential(apiKey)
 	require.NoError(t, err)
 
 	client, err := NewClientWithKeyCredential(endpoint, cred, streamingModelDeployment, newClientOptionsForTest(t))
@@ -275,7 +275,7 @@ func TestClient_GetEmbeddings(t *testing.T) {
 	// model deployment points to `text-similarity-curie-001`
 	deploymentID := "embedding"
 
-	cred, err := NewKeyCredential(apiKey, nil)
+	cred, err := NewKeyCredential(apiKey)
 	require.NoError(t, err)
 
 	client, err := NewClientWithKeyCredential(endpoint, cred, deploymentID, newClientOptionsForTest(t))
@@ -340,7 +340,7 @@ func newOpenAIClientForTest(t *testing.T) *Client {
 		t.Skipf("OPENAI_API_KEY not defined, skipping OpenAI public endpoint test")
 	}
 
-	cred, err := NewKeyCredential(openAIKey, nil)
+	cred, err := NewKeyCredential(openAIKey)
 	require.NoError(t, err)
 
 	chatClient, err := NewClientForOpenAI(openAIEndpoint, cred, newClientOptionsForTest(t))

--- a/sdk/cognitiveservices/azopenai/custom_client.go
+++ b/sdk/cognitiveservices/azopenai/custom_client.go
@@ -104,7 +104,7 @@ func newOpenAIPolicy(cred KeyCredential) *openAIPolicy {
 func (b *openAIPolicy) Do(req *policy.Request) (*http.Response, error) {
 	q := req.Raw().URL.Query()
 	q.Del("api-version")
-	req.Raw().Header.Set("authorization", "Bearer "+b.cred.APIKey)
+	req.Raw().Header.Set("authorization", "Bearer "+b.cred.apiKey)
 	return req.Next()
 }
 

--- a/sdk/cognitiveservices/azopenai/custom_client_test.go
+++ b/sdk/cognitiveservices/azopenai/custom_client_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewClient(t *testing.T) {
@@ -78,10 +79,12 @@ func TestNewClientWithKeyCredential(t *testing.T) {
 func TestClient_GetCompletionsStream(t *testing.T) {
 	body := CompletionsOptions{
 		Prompt:      []*string{to.Ptr("What is Azure OpenAI?")},
-		MaxTokens:   to.Ptr(int32(2048 - 127)),
+		MaxTokens:   to.Ptr(int32(2048)),
 		Temperature: to.Ptr(float32(0.0)),
 	}
-	cred := KeyCredential{APIKey: apiKey}
+
+	cred, err := NewKeyCredential(apiKey, nil)
+	require.NoError(t, err)
 
 	client, err := NewClientWithKeyCredential(endpoint, cred, streamingModelDeployment, newClientOptionsForTest(t))
 	if err != nil {

--- a/sdk/cognitiveservices/azopenai/custom_client_test.go
+++ b/sdk/cognitiveservices/azopenai/custom_client_test.go
@@ -83,7 +83,7 @@ func TestClient_GetCompletionsStream(t *testing.T) {
 		Temperature: to.Ptr(float32(0.0)),
 	}
 
-	cred, err := NewKeyCredential(apiKey, nil)
+	cred, err := NewKeyCredential(apiKey)
 	require.NoError(t, err)
 
 	client, err := NewClientWithKeyCredential(endpoint, cred, streamingModelDeployment, newClientOptionsForTest(t))

--- a/sdk/cognitiveservices/azopenai/examples_client_test.go
+++ b/sdk/cognitiveservices/azopenai/examples_client_test.go
@@ -18,7 +18,7 @@ import (
 func ExampleNewClientForOpenAI() {
 	// NOTE: this constructor creates a client that connects to the public OpenAI endpoint.
 	// To connect to an Azure OpenAI endpoint, use azopenai.NewClient() or azopenai.NewClientWithyKeyCredential.
-	keyCredential, err := azopenai.NewKeyCredential("open-ai-apikey", nil)
+	keyCredential, err := azopenai.NewKeyCredential("<OpenAI-APIKey>", nil)
 
 	if err != nil {
 		panic(err)
@@ -55,7 +55,7 @@ func ExampleNewClient() {
 func ExampleNewClientWithKeyCredential() {
 	// NOTE: this constructor creates a client that connects to an Azure OpenAI endpoint.
 	// To connect to the public OpenAI endpoint, use azopenai.NewClientForOpenAI
-	keyCredential, err := azopenai.NewKeyCredential("Azure OpenAI apikey", nil)
+	keyCredential, err := azopenai.NewKeyCredential("<Azure-OpenAI-APIKey>", nil)
 
 	if err != nil {
 		panic(err)

--- a/sdk/cognitiveservices/azopenai/examples_client_test.go
+++ b/sdk/cognitiveservices/azopenai/examples_client_test.go
@@ -18,8 +18,10 @@ import (
 func ExampleNewClientForOpenAI() {
 	// NOTE: this constructor creates a client that connects to the public OpenAI endpoint.
 	// To connect to an Azure OpenAI endpoint, use azopenai.NewClient() or azopenai.NewClientWithyKeyCredential.
-	keyCredential := azopenai.KeyCredential{
-		APIKey: "open-ai-apikey",
+	keyCredential, err := azopenai.NewKeyCredential("open-ai-apikey", nil)
+
+	if err != nil {
+		panic(err)
 	}
 
 	client, err := azopenai.NewClientForOpenAI("https://api.openai.com/v1", keyCredential, nil)
@@ -53,8 +55,10 @@ func ExampleNewClient() {
 func ExampleNewClientWithKeyCredential() {
 	// NOTE: this constructor creates a client that connects to an Azure OpenAI endpoint.
 	// To connect to the public OpenAI endpoint, use azopenai.NewClientForOpenAI
-	keyCredential := azopenai.KeyCredential{
-		APIKey: "Azure OpenAI apikey",
+	keyCredential, err := azopenai.NewKeyCredential("Azure OpenAI apikey", nil)
+
+	if err != nil {
+		panic(err)
 	}
 
 	modelDeploymentID := "model deployment ID"
@@ -78,8 +82,10 @@ func ExampleClient_GetCompletionsStream() {
 		return
 	}
 
-	keyCredential := azopenai.KeyCredential{
-		APIKey: azureOpenAIKey,
+	keyCredential, err := azopenai.NewKeyCredential(azureOpenAIKey, nil)
+
+	if err != nil {
+		panic(err)
 	}
 
 	client, err := azopenai.NewClientWithKeyCredential(azureOpenAIEndpoint, keyCredential, modelDeploymentID, nil)
@@ -90,7 +96,7 @@ func ExampleClient_GetCompletionsStream() {
 
 	resp, err := client.GetCompletionsStream(context.TODO(), azopenai.CompletionsOptions{
 		Prompt:      []*string{to.Ptr("What is Azure OpenAI?")},
-		MaxTokens:   to.Ptr(int32(2048 - 127)),
+		MaxTokens:   to.Ptr(int32(2048)),
 		Temperature: to.Ptr(float32(0.0)),
 	}, nil)
 
@@ -102,7 +108,7 @@ func ExampleClient_GetCompletionsStream() {
 		entry, err := resp.CompletionsStream.Read()
 
 		if errors.Is(err, io.EOF) {
-			fmt.Printf("More more completions")
+			fmt.Printf("No more completions")
 			break
 		}
 

--- a/sdk/cognitiveservices/azopenai/examples_client_test.go
+++ b/sdk/cognitiveservices/azopenai/examples_client_test.go
@@ -18,7 +18,7 @@ import (
 func ExampleNewClientForOpenAI() {
 	// NOTE: this constructor creates a client that connects to the public OpenAI endpoint.
 	// To connect to an Azure OpenAI endpoint, use azopenai.NewClient() or azopenai.NewClientWithyKeyCredential.
-	keyCredential, err := azopenai.NewKeyCredential("<OpenAI-APIKey>", nil)
+	keyCredential, err := azopenai.NewKeyCredential("<OpenAI-APIKey>")
 
 	if err != nil {
 		panic(err)
@@ -55,7 +55,7 @@ func ExampleNewClient() {
 func ExampleNewClientWithKeyCredential() {
 	// NOTE: this constructor creates a client that connects to an Azure OpenAI endpoint.
 	// To connect to the public OpenAI endpoint, use azopenai.NewClientForOpenAI
-	keyCredential, err := azopenai.NewKeyCredential("<Azure-OpenAI-APIKey>", nil)
+	keyCredential, err := azopenai.NewKeyCredential("<Azure-OpenAI-APIKey>")
 
 	if err != nil {
 		panic(err)
@@ -82,7 +82,7 @@ func ExampleClient_GetCompletionsStream() {
 		return
 	}
 
-	keyCredential, err := azopenai.NewKeyCredential(azureOpenAIKey, nil)
+	keyCredential, err := azopenai.NewKeyCredential(azureOpenAIKey)
 
 	if err != nil {
 		panic(err)

--- a/sdk/cognitiveservices/azopenai/policy_apikey.go
+++ b/sdk/cognitiveservices/azopenai/policy_apikey.go
@@ -14,8 +14,19 @@ import (
 
 // KeyCredential is used when doing APIKey-based authentication.
 type KeyCredential struct {
-	// APIKey is the api key for the client.
-	APIKey string
+	// apiKey is the api key for the client.
+	apiKey string
+}
+
+// KeyCredentialOptions contains the optional parameters for the [NewKeyCredential] method.
+type KeyCredentialOptions struct {
+	// For future expansion
+}
+
+// NewKeyCredential creates a KeyCredential containing an API key for
+// either Azure OpenAI or OpenAI.
+func NewKeyCredential(apiKey string, options *KeyCredentialOptions) (KeyCredential, error) {
+	return KeyCredential{apiKey: apiKey}, nil
 }
 
 // apiKeyPolicy authorizes requests with an API key acquired from a KeyCredential.
@@ -35,6 +46,6 @@ func newAPIKeyPolicy(cred KeyCredential, header string) *apiKeyPolicy {
 
 // Do returns a function which authorizes req with a token from the policy's credential
 func (b *apiKeyPolicy) Do(req *policy.Request) (*http.Response, error) {
-	req.Raw().Header.Set(b.header, b.cred.APIKey)
+	req.Raw().Header.Set(b.header, b.cred.apiKey)
 	return req.Next()
 }

--- a/sdk/cognitiveservices/azopenai/policy_apikey.go
+++ b/sdk/cognitiveservices/azopenai/policy_apikey.go
@@ -18,11 +18,6 @@ type KeyCredential struct {
 	apiKey string
 }
 
-// KeyCredentialOptions contains the optional parameters for the [NewKeyCredential] method.
-type KeyCredentialOptions struct {
-	// For future expansion
-}
-
 // NewKeyCredential creates a KeyCredential containing an API key for
 // either Azure OpenAI or OpenAI.
 func NewKeyCredential(apiKey string) (KeyCredential, error) {

--- a/sdk/cognitiveservices/azopenai/policy_apikey.go
+++ b/sdk/cognitiveservices/azopenai/policy_apikey.go
@@ -25,7 +25,7 @@ type KeyCredentialOptions struct {
 
 // NewKeyCredential creates a KeyCredential containing an API key for
 // either Azure OpenAI or OpenAI.
-func NewKeyCredential(apiKey string, options *KeyCredentialOptions) (KeyCredential, error) {
+func NewKeyCredential(apiKey string) (KeyCredential, error) {
 	return KeyCredential{apiKey: apiKey}, nil
 }
 

--- a/sdk/cognitiveservices/azopenai/policy_apikey_test.go
+++ b/sdk/cognitiveservices/azopenai/policy_apikey_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/require"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
@@ -23,7 +24,9 @@ func TestNewAPIKeyPolicy(t *testing.T) {
 		header string
 		cred   KeyCredential
 	}
-	simpleCred := KeyCredential{APIKey: "apiKey"}
+	simpleCred, err := NewKeyCredential("apiKey", nil)
+	require.NoError(t, err)
+
 	simpleHeader := "headerName"
 	tests := []struct {
 		name string
@@ -55,9 +58,10 @@ func TestAPIKeyPolicy_Success(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	cred := KeyCredential{
-		APIKey: "secret",
-	}
+
+	cred, err := NewKeyCredential("secret", nil)
+	require.NoError(t, err)
+
 	authPolicy := newAPIKeyPolicy(cred, "api-key")
 	pipeline := runtime.NewPipeline(
 		"testmodule",

--- a/sdk/cognitiveservices/azopenai/policy_apikey_test.go
+++ b/sdk/cognitiveservices/azopenai/policy_apikey_test.go
@@ -24,7 +24,7 @@ func TestNewAPIKeyPolicy(t *testing.T) {
 		header string
 		cred   KeyCredential
 	}
-	simpleCred, err := NewKeyCredential("apiKey", nil)
+	simpleCred, err := NewKeyCredential("apiKey")
 	require.NoError(t, err)
 
 	simpleHeader := "headerName"
@@ -59,7 +59,7 @@ func TestAPIKeyPolicy_Success(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 
-	cred, err := NewKeyCredential("secret", nil)
+	cred, err := NewKeyCredential("secret")
 	require.NoError(t, err)
 
 	authPolicy := newAPIKeyPolicy(cred, "api-key")


### PR DESCRIPTION
Fixing a few things based on feedback from @JeffreyRichter.
- Example had a typo and a hardcoded calculation. 
- Adding a constructor for KeyCredential.