### PR TITLE
Use otel tracerProvider interface instead of specific type

### DIFF
--- a/sdk/tracing/azotel/CHANGELOG.md
+++ b/sdk/tracing/azotel/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+* The type for parameter `tracerProvider` in function `NewTracingProvider()` has changed to `trace.TracerProvider`.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/tracing/azotel/otel.go
+++ b/sdk/tracing/azotel/otel.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	otelsdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -26,7 +25,7 @@ type TracingProviderOptions struct {
 // NewTracingProvider creates a new tracing.Provider that wraps the specified OpenTelemetry TracerProvider.
 //   - tracerProvider - the TracerProvider to wrap
 //   - opts - optional configuration. pass nil to accept the default values
-func NewTracingProvider(tracerProvider *otelsdk.TracerProvider, opts *TracingProviderOptions) tracing.Provider {
+func NewTracingProvider(tracerProvider trace.TracerProvider, opts *TracingProviderOptions) tracing.Provider {
 	return tracing.NewProvider(func(namespace, version string) tracing.Tracer {
 		tracer := tracerProvider.Tracer(namespace, trace.WithInstrumentationVersion(version), trace.WithSchemaURL("https://opentelemetry.io/schemas/1.17.0"))
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md

This PR allows custom tracer providers to be used by accepting a tracer provider interface, instead of relying on the specific struct used in otelsdk.

For an example scenario, one might want to get the globally configured tracer provider, instead of defining a new one.
```go
sc, err := aztables.NewServiceClientFromConnectionString("...", &aztables.ClientOptions{
	ClientOptions: azcore.ClientOptions{
		TracingProvider: azotel.NewTracingProvider(otel.GetTracerProvider(), nil),
	},
})
```

`otel.GetTracerProvider()` returns the registered global trace provider. If none is registered then an instance of `NoopTracerProvider` is returned.