### PR TITLE
[keyvault] update ID type

### DIFF
--- a/sdk/security/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/security/keyvault/azsecrets/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
+* changed type of `KID` from string to type `ID`
 
 ### Bugs Fixed
 

--- a/sdk/security/keyvault/azsecrets/autorest.md
+++ b/sdk/security/keyvault/azsecrets/autorest.md
@@ -123,6 +123,9 @@ directive:
   - from: models.go
     where: $
     transform: return $.replace(/(\sID \*)string(\s+.*)/g, "$1ID$2")
+  - from: models.go
+    where: $
+    transform: return $.replace(/(\sKID \*)string(\s+.*)/g, "$1ID$2")
 
   # Maxresults -> MaxResults
   - from:

--- a/sdk/security/keyvault/azsecrets/models.go
+++ b/sdk/security/keyvault/azsecrets/models.go
@@ -105,7 +105,7 @@ type DeletedSecret struct {
 
 	// READ-ONLY; If this is a secret backing a KV certificate, then this field specifies the corresponding key backing the KV
 	// certificate.
-	KID *string `json:"kid,omitempty" azure:"ro"`
+	KID *ID `json:"kid,omitempty" azure:"ro"`
 
 	// READ-ONLY; True if the secret's lifetime is managed by key vault. If this is a secret backing a certificate, then managed
 	// will be true.
@@ -178,7 +178,7 @@ type Secret struct {
 
 	// READ-ONLY; If this is a secret backing a KV certificate, then this field specifies the corresponding key backing the KV
 	// certificate.
-	KID *string `json:"kid,omitempty" azure:"ro"`
+	KID *ID `json:"kid,omitempty" azure:"ro"`
 
 	// READ-ONLY; True if the secret's lifetime is managed by key vault. If this is a secret backing a certificate, then managed
 	// will be true.


### PR DESCRIPTION
Updating `azsecrets` so that all [key vault object identifiers](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#object-identifiers) use the module's custom `ID` type.