### PR TITLE
Refactor internal MSAL client constructors

### DIFF
--- a/sdk/azidentity/client_assertion_credential.go
+++ b/sdk/azidentity/client_assertion_credential.go
@@ -56,7 +56,11 @@ func NewClientAssertionCredential(tenantID, clientID string, getAssertion func(c
 			return getAssertion(ctx)
 		},
 	)
-	c, err := getConfidentialClient(clientID, tenantID, cred, &options.ClientOptions, confidential.WithInstanceDiscovery(!options.DisableInstanceDiscovery))
+	msalOpts := msalClientOptions{
+		ClientOptions:            options.ClientOptions,
+		DisableInstanceDiscovery: options.DisableInstanceDiscovery,
+	}
+	c, err := getConfidentialClient(clientID, tenantID, cred, msalOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -58,12 +58,12 @@ func NewClientCertificateCredential(tenantID string, clientID string, certs []*x
 	if err != nil {
 		return nil, err
 	}
-	var o []confidential.Option
-	if options.SendCertificateChain {
-		o = append(o, confidential.WithX5C())
+	msalOpts := msalClientOptions{
+		ClientOptions:            options.ClientOptions,
+		DisableInstanceDiscovery: options.DisableInstanceDiscovery,
+		SendX5C:                  options.SendCertificateChain,
 	}
-	o = append(o, confidential.WithInstanceDiscovery(!options.DisableInstanceDiscovery))
-	c, err := getConfidentialClient(clientID, tenantID, cred, &options.ClientOptions, o...)
+	c, err := getConfidentialClient(clientID, tenantID, cred, msalOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/client_secret_credential.go
+++ b/sdk/azidentity/client_secret_credential.go
@@ -46,9 +46,11 @@ func NewClientSecretCredential(tenantID string, clientID string, clientSecret st
 	if err != nil {
 		return nil, err
 	}
-	c, err := getConfidentialClient(
-		clientID, tenantID, cred, &options.ClientOptions, confidential.WithInstanceDiscovery(!options.DisableInstanceDiscovery),
-	)
+	msalOpts := msalClientOptions{
+		ClientOptions:            options.ClientOptions,
+		DisableInstanceDiscovery: options.DisableInstanceDiscovery,
+	}
+	c, err := getConfidentialClient(clientID, tenantID, cred, msalOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -87,9 +87,11 @@ func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeC
 		cp = *options
 	}
 	cp.init()
-	c, err := getPublicClient(
-		cp.ClientID, cp.TenantID, &cp.ClientOptions, public.WithInstanceDiscovery(!cp.DisableInstanceDiscovery),
-	)
+	msalOpts := msalClientOptions{
+		ClientOptions:            cp.ClientOptions,
+		DisableInstanceDiscovery: cp.DisableInstanceDiscovery,
+	}
+	c, err := getPublicClient(cp.ClientID, cp.TenantID, msalOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -69,7 +69,11 @@ func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOption
 		cp = *options
 	}
 	cp.init()
-	c, err := getPublicClient(cp.ClientID, cp.TenantID, &cp.ClientOptions, public.WithInstanceDiscovery(!cp.DisableInstanceDiscovery))
+	msalOpts := msalClientOptions{
+		ClientOptions:            cp.ClientOptions,
+		DisableInstanceDiscovery: cp.DisableInstanceDiscovery,
+	}
+	c, err := getPublicClient(cp.ClientID, cp.TenantID, msalOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/on_behalf_of_credential.go
+++ b/sdk/azidentity/on_behalf_of_credential.go
@@ -72,12 +72,12 @@ func newOnBehalfOfCredential(tenantID, clientID, userAssertion string, cred conf
 	if options == nil {
 		options = &OnBehalfOfCredentialOptions{}
 	}
-	opts := []confidential.Option{}
-	if options.SendCertificateChain {
-		opts = append(opts, confidential.WithX5C())
+	msalOpts := msalClientOptions{
+		ClientOptions:            options.ClientOptions,
+		DisableInstanceDiscovery: options.DisableInstanceDiscovery,
+		SendX5C:                  options.SendCertificateChain,
 	}
-	opts = append(opts, confidential.WithInstanceDiscovery(!options.DisableInstanceDiscovery))
-	c, err := getConfidentialClient(clientID, tenantID, cred, &options.ClientOptions, opts...)
+	c, err := getConfidentialClient(clientID, tenantID, cred, msalOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/azidentity/on_behalf_of_credential_test.go
+++ b/sdk/azidentity/on_behalf_of_credential_test.go
@@ -20,6 +20,7 @@ func TestOnBehalfOfCredential(t *testing.T) {
 	realGetClient := getConfidentialClient
 	t.Cleanup(func() { getConfidentialClient = realGetClient })
 	expectedAssertion := "user-assertion"
+	certs, key := allCertTests[0].certs, allCertTests[0].key
 	for _, test := range []struct {
 		ctor    func(policy.Transporter) (*OnBehalfOfCredential, error)
 		name    string
@@ -27,7 +28,6 @@ func TestOnBehalfOfCredential(t *testing.T) {
 	}{
 		{
 			ctor: func(tp policy.Transporter) (*OnBehalfOfCredential, error) {
-				certs, key := allCertTests[0].certs, allCertTests[0].key
 				o := OnBehalfOfCredentialOptions{ClientOptions: policy.ClientOptions{Transport: tp}}
 				return NewOnBehalfOfCredentialWithCertificate(fakeTenantID, fakeClientID, expectedAssertion, certs, key, &o)
 			},
@@ -35,7 +35,6 @@ func TestOnBehalfOfCredential(t *testing.T) {
 		},
 		{
 			ctor: func(tp policy.Transporter) (*OnBehalfOfCredential, error) {
-				certs, key := allCertTests[0].certs, allCertTests[0].key
 				o := OnBehalfOfCredentialOptions{ClientOptions: policy.ClientOptions{Transport: tp}, SendCertificateChain: true}
 				return NewOnBehalfOfCredentialWithCertificate(fakeTenantID, fakeClientID, expectedAssertion, certs, key, &o)
 			},
@@ -67,6 +66,9 @@ func TestOnBehalfOfCredential(t *testing.T) {
 				}
 				if assertion := r.FormValue("assertion"); assertion != expectedAssertion {
 					t.Errorf(`unexpected assertion "%s"`, assertion)
+				}
+				if test.sendX5C {
+					validateX5C(t, certs)(r)
 				}
 			}}
 			cred, err := test.ctor(&srv)

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -48,7 +48,11 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 	if options == nil {
 		options = &UsernamePasswordCredentialOptions{}
 	}
-	c, err := getPublicClient(clientID, tenantID, &options.ClientOptions, public.WithInstanceDiscovery(!options.DisableInstanceDiscovery))
+	msalOpts := msalClientOptions{
+		ClientOptions:            options.ClientOptions,
+		DisableInstanceDiscovery: options.DisableInstanceDiscovery,
+	}
+	c, err := getPublicClient(clientID, tenantID, msalOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adding an options bag to increase consolidation and shorten signatures. Also fixing a test which wasn't asserting all its expectations.