### PR TITLE
Add DragonFlyBSD in azfile

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+* Added `dragonfly` and `aix` to build constraints in `mmf_unix.go`.
+
 ## 1.0.0 (2023-07-12)
 
 ### Features Added
@@ -19,10 +21,6 @@
 ### Bugs Fixed
 
 * Fixed the issue where trailing slash is encoded when passed in directory or subdirectory name while creating the directory client.
-
-### Other Changes
-
-* Added `dragonfly` and `aix` to build constraints in `mmf_unix.go`.
 
 ## 0.1.0 (2023-05-09)
 

--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Other Changes
 
+* Added `dragonfly` and `aix` to build constraints in `mmf_unix.go`.
+
 ## 0.1.0 (2023-05-09)
 
 ### Features Added

--- a/sdk/storage/azfile/file/mmf_unix.go
+++ b/sdk/storage/azfile/file/mmf_unix.go
@@ -1,6 +1,6 @@
-//go:build go1.18 && (linux || darwin || freebsd || openbsd || netbsd || solaris)
+//go:build go1.18 && (linux || darwin || freebsd || openbsd || netbsd || dragonfly || solaris)
 // +build go1.18
-// +build linux darwin freebsd openbsd netbsd solaris
+// +build linux darwin freebsd openbsd netbsd dragonfly solaris
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/storage/azfile/file/mmf_unix.go
+++ b/sdk/storage/azfile/file/mmf_unix.go
@@ -1,6 +1,6 @@
-//go:build go1.18 && (linux || darwin || freebsd || openbsd || netbsd || dragonfly || solaris)
+//go:build go1.18 && (linux || darwin || dragonfly || freebsd || openbsd || netbsd || solaris || aix)
 // +build go1.18
-// +build linux darwin freebsd openbsd netbsd dragonfly solaris
+// +build linux darwin dragonfly freebsd openbsd netbsd solaris aix
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

Since DragonFlyBSD is already listed as supported in ed939da099c54c2ae8708bfa0316021d081f36fe , add it to azfile too.


[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
