### PR TITLE
DefaultAzureCredential TenantID applies to workload identity

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+* `DefaultAzureCredentialOptions.TenantID` applies to workload identity authentication
 
 ## 1.4.0-beta.1 (2023-06-06)
 

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -47,7 +47,7 @@ type AzureCLICredentialOptions struct {
 // init returns an instance of AzureCLICredentialOptions initialized with default values.
 func (o *AzureCLICredentialOptions) init() {
 	if o.tokenProvider == nil {
-		o.tokenProvider = defaultTokenProvider()
+		o.tokenProvider = defaultTokenProvider
 	}
 }
 
@@ -92,58 +92,56 @@ func (c *AzureCLICredential) requestToken(ctx context.Context, opts policy.Token
 	return at, nil
 }
 
-func defaultTokenProvider() func(ctx context.Context, resource string, tenantID string) ([]byte, error) {
-	return func(ctx context.Context, resource string, tenantID string) ([]byte, error) {
-		match, err := regexp.MatchString("^[0-9a-zA-Z-.:/]+$", resource)
-		if err != nil {
-			return nil, err
-		}
-		if !match {
-			return nil, fmt.Errorf(`%s: unexpected scope "%s". Only alphanumeric characters and ".", ";", "-", and "/" are allowed`, credNameAzureCLI, resource)
-		}
-
-		// set a default timeout for this authentication iff the application hasn't done so already
-		var cancel context.CancelFunc
-		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-			ctx, cancel = context.WithTimeout(ctx, timeoutCLIRequest)
-			defer cancel()
-		}
-
-		commandLine := "az account get-access-token -o json --resource " + resource
-		if tenantID != "" {
-			commandLine += " --tenant " + tenantID
-		}
-		var cliCmd *exec.Cmd
-		if runtime.GOOS == "windows" {
-			dir := os.Getenv("SYSTEMROOT")
-			if dir == "" {
-				return nil, newCredentialUnavailableError(credNameAzureCLI, "environment variable 'SYSTEMROOT' has no value")
-			}
-			cliCmd = exec.CommandContext(ctx, "cmd.exe", "/c", commandLine)
-			cliCmd.Dir = dir
-		} else {
-			cliCmd = exec.CommandContext(ctx, "/bin/sh", "-c", commandLine)
-			cliCmd.Dir = "/bin"
-		}
-		cliCmd.Env = os.Environ()
-		var stderr bytes.Buffer
-		cliCmd.Stderr = &stderr
-
-		output, err := cliCmd.Output()
-		if err != nil {
-			msg := stderr.String()
-			var exErr *exec.ExitError
-			if errors.As(err, &exErr) && exErr.ExitCode() == 127 || strings.HasPrefix(msg, "'az' is not recognized") {
-				msg = "Azure CLI not found on path"
-			}
-			if msg == "" {
-				msg = err.Error()
-			}
-			return nil, newCredentialUnavailableError(credNameAzureCLI, msg)
-		}
-
-		return output, nil
+var defaultTokenProvider azureCLITokenProvider = func(ctx context.Context, resource string, tenantID string) ([]byte, error) {
+	match, err := regexp.MatchString("^[0-9a-zA-Z-.:/]+$", resource)
+	if err != nil {
+		return nil, err
 	}
+	if !match {
+		return nil, fmt.Errorf(`%s: unexpected scope "%s". Only alphanumeric characters and ".", ";", "-", and "/" are allowed`, credNameAzureCLI, resource)
+	}
+
+	// set a default timeout for this authentication iff the application hasn't done so already
+	var cancel context.CancelFunc
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		ctx, cancel = context.WithTimeout(ctx, timeoutCLIRequest)
+		defer cancel()
+	}
+
+	commandLine := "az account get-access-token -o json --resource " + resource
+	if tenantID != "" {
+		commandLine += " --tenant " + tenantID
+	}
+	var cliCmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		dir := os.Getenv("SYSTEMROOT")
+		if dir == "" {
+			return nil, newCredentialUnavailableError(credNameAzureCLI, "environment variable 'SYSTEMROOT' has no value")
+		}
+		cliCmd = exec.CommandContext(ctx, "cmd.exe", "/c", commandLine)
+		cliCmd.Dir = dir
+	} else {
+		cliCmd = exec.CommandContext(ctx, "/bin/sh", "-c", commandLine)
+		cliCmd.Dir = "/bin"
+	}
+	cliCmd.Env = os.Environ()
+	var stderr bytes.Buffer
+	cliCmd.Stderr = &stderr
+
+	output, err := cliCmd.Output()
+	if err != nil {
+		msg := stderr.String()
+		var exErr *exec.ExitError
+		if errors.As(err, &exErr) && exErr.ExitCode() == 127 || strings.HasPrefix(msg, "'az' is not recognized") {
+			msg = "Azure CLI not found on path"
+		}
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, newCredentialUnavailableError(credNameAzureCLI, msg)
+	}
+
+	return output, nil
 }
 
 func (c *AzureCLICredential) createAccessToken(tk []byte) (azcore.AccessToken, error) {


### PR DESCRIPTION
Closes #21053, though that issue is misleading in that multitenant auth already works for workload identities. This change only makes it easier in the context of DefaultAzureCredential.