### PR TITLE
azfile: Update azcore to 1.7.0

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Other Changes
 
-* Updated version of azcore to 1.6.1 and azidentity to 1.3.0.
+* Updated version of azcore to 1.7.0 and azidentity to 1.3.0.
 
 ## 0.1.1 (Unreleased)
 

--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Updated service version to STG 87(2022-11-02).
 * Added OAuth support.
+* Added [Rename Directory API](https://learn.microsoft.com/rest/api/storageservices/rename-directory).
+* Added [Rename File API](https://learn.microsoft.com/rest/api/storageservices/rename-file).
 
 ### Breaking Changes
 

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_ad7538c783"
+  "Tag": "go/storage/azfile_a4fc259673"
 }

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_b53cd6a3cc"
+  "Tag": "go/storage/azfile_1871113b9d"
 }

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_1871113b9d"
+  "Tag": "go/storage/azfile_ad7538c783"
 }

--- a/sdk/storage/azfile/directory/client.go
+++ b/sdk/storage/azfile/directory/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/base"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/exported"
@@ -144,18 +143,7 @@ func (d *Client) NewSubdirectoryClient(subDirectoryName string) *Client {
 func (d *Client) NewFileClient(fileName string) *file.Client {
 	fileName = url.PathEscape(fileName)
 	fileURL := runtime.JoinPaths(d.URL(), fileName)
-
-	// TODO: remove new azcore.Client creation after the API for shallow copying with new client name is implemented
-	clOpts := d.getClientOptions()
-	azClient, err := azcore.NewClient(shared.FileClient, exported.ModuleVersion, *(base.GetPipelineOptions(clOpts)), &(clOpts.ClientOptions))
-	if err != nil {
-		if log.Should(exported.EventError) {
-			log.Writef(exported.EventError, err.Error())
-		}
-		return nil
-	}
-
-	return (*file.Client)(base.NewFileClient(fileURL, azClient, d.sharedKey(), clOpts))
+	return (*file.Client)(base.NewFileClient(fileURL, d.generated().InternalClient().WithClientName(shared.FileClient), d.sharedKey(), d.getClientOptions()))
 }
 
 // Create operation creates a new directory under the specified share or parent directory.

--- a/sdk/storage/azfile/directory/client.go
+++ b/sdk/storage/azfile/directory/client.go
@@ -160,8 +160,8 @@ func (d *Client) NewFileClient(fileName string) *file.Client {
 // file.ParseNTFSFileAttributes method can be used to convert the file attributes returned in response to NTFSFileAttributes.
 // For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/create-directory.
 func (d *Client) Create(ctx context.Context, options *CreateOptions) (CreateResponse, error) {
-	fileAttributes, opts := options.format()
-	resp, err := d.generated().Create(ctx, fileAttributes, opts)
+	opts := options.format()
+	resp, err := d.generated().Create(ctx, opts)
 	return resp, err
 }
 
@@ -171,6 +171,16 @@ func (d *Client) Create(ctx context.Context, options *CreateOptions) (CreateResp
 func (d *Client) Delete(ctx context.Context, options *DeleteOptions) (DeleteResponse, error) {
 	opts := options.format()
 	resp, err := d.generated().Delete(ctx, opts)
+	return resp, err
+}
+
+// Rename operation renames a directory, and can optionally set system properties for the directory.
+//   - newName: the copy identifier provided in the x-ms-copy-id header of the original Copy File operation.
+//
+// For more information, see https://learn.microsoft.com/rest/api/storageservices/rename-directory.
+func (d *Client) Rename(ctx context.Context, newName string, options *RenameOptions) (RenameResponse, error) {
+	opts, srcLease, destLease, smbInfo := options.format()
+	resp, err := d.generated().Rename(ctx, newName, opts, srcLease, destLease, smbInfo)
 	return resp, err
 }
 
@@ -187,8 +197,8 @@ func (d *Client) GetProperties(ctx context.Context, options *GetPropertiesOption
 // file.ParseNTFSFileAttributes method can be used to convert the file attributes returned in response to NTFSFileAttributes.
 // For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/set-directory-properties.
 func (d *Client) SetProperties(ctx context.Context, options *SetPropertiesOptions) (SetPropertiesResponse, error) {
-	fileAttributes, opts := options.format()
-	resp, err := d.generated().SetProperties(ctx, fileAttributes, opts)
+	opts := options.format()
+	resp, err := d.generated().SetProperties(ctx, opts)
 	return resp, err
 }
 

--- a/sdk/storage/azfile/directory/client_test.go
+++ b/sdk/storage/azfile/directory/client_test.go
@@ -1803,12 +1803,17 @@ func (d *DirectoryRecordedTestsSuite) TestDirectoryRenameDestLease() {
 	_, err = destFileClient.Create(context.Background(), 2048, nil)
 	_require.NoError(err)
 
+	proposedLeaseID := "c820a799-76d7-4ee2-6e15-546f19325c2c"
+
 	// acquire lease on destFile
-	fileLeaseClient, err := lease.NewFileClient(destFileClient, nil)
+	fileLeaseClient, err := lease.NewFileClient(destFileClient, &lease.FileClientOptions{
+		LeaseID: &proposedLeaseID,
+	})
 	_require.NoError(err)
 	acqResp, err := fileLeaseClient.Acquire(context.Background(), nil)
 	_require.NoError(err)
 	_require.NotNil(acqResp.LeaseID)
+	_require.Equal(*acqResp.LeaseID, proposedLeaseID)
 
 	destPath := "dir2/testFile"
 	_, err = srcDirCl.Rename(context.Background(), destPath, &directory.RenameOptions{

--- a/sdk/storage/azfile/directory/client_test.go
+++ b/sdk/storage/azfile/directory/client_test.go
@@ -1805,6 +1805,7 @@ func (d *DirectoryRecordedTestsSuite) TestDirectoryRenameDestLease() {
 
 	// acquire lease on destFile
 	fileLeaseClient, err := lease.NewFileClient(destFileClient, nil)
+	_require.NoError(err)
 	acqResp, err := fileLeaseClient.Acquire(context.Background(), nil)
 	_require.NoError(err)
 	_require.NotNil(acqResp.LeaseID)

--- a/sdk/storage/azfile/directory/models.go
+++ b/sdk/storage/azfile/directory/models.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/generated"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/shared"
 	"reflect"
 )
 
@@ -22,6 +21,12 @@ type SharedKeyCredential = exported.SharedKeyCredential
 func NewSharedKeyCredential(accountName, accountKey string) (*SharedKeyCredential, error) {
 	return exported.NewSharedKeyCredential(accountName, accountKey)
 }
+
+// SourceLeaseAccessConditions contains optional parameters to access the source directory.
+type SourceLeaseAccessConditions = generated.SourceLeaseAccessConditions
+
+// DestinationLeaseAccessConditions contains optional parameters to access the destination directory.
+type DestinationLeaseAccessConditions = generated.DestinationLeaseAccessConditions
 
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -35,16 +40,17 @@ type CreateOptions struct {
 	Metadata map[string]*string
 }
 
-func (o *CreateOptions) format() (string, *generated.DirectoryClientCreateOptions) {
+func (o *CreateOptions) format() *generated.DirectoryClientCreateOptions {
 	if o == nil {
-		return shared.FileAttributesDirectory, nil
+		return nil
 	}
 
-	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.FileSMBProperties.Format(true, shared.FileAttributesDirectory)
+	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.FileSMBProperties.Format(true)
 
 	permission, permissionKey := o.FilePermissions.Format()
 
 	createOptions := &generated.DirectoryClientCreateOptions{
+		FileAttributes:    fileAttributes,
 		FileChangeTime:    fileChangeTime,
 		FileCreationTime:  fileCreationTime,
 		FileLastWriteTime: fileLastWriteTime,
@@ -53,7 +59,7 @@ func (o *CreateOptions) format() (string, *generated.DirectoryClientCreateOption
 		Metadata:          o.Metadata,
 	}
 
-	return fileAttributes, createOptions
+	return createOptions
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -65,6 +71,57 @@ type DeleteOptions struct {
 
 func (o *DeleteOptions) format() *generated.DirectoryClientDeleteOptions {
 	return nil
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+// RenameOptions contains the optional parameters for the Client.Rename method.
+type RenameOptions struct {
+	// FileSMBProperties contains the optional parameters regarding the SMB/NTFS properties for a file.
+	FileSMBProperties *file.SMBProperties
+	// FilePermissions contains the optional parameters for the permissions on the file.
+	FilePermissions *file.Permissions
+	// IgnoreReadOnly specifies whether the ReadOnly attribute on a pre-existing destination file should be respected.
+	// If true, rename will succeed, otherwise, a previous file at the destination with the ReadOnly attribute set will cause rename to fail.
+	IgnoreReadOnly *bool
+	// A name-value pair to associate with a file storage object.
+	Metadata map[string]*string
+	// ReplaceIfExists specifies that if the destination file already exists, whether this request will overwrite the file or not.
+	// If true, rename will succeed and will overwrite the destination file. If not provided or if false and the destination file does exist,
+	// the request will not overwrite the destination file.
+	// If provided and the destination file does not exist, rename will succeed.
+	ReplaceIfExists *bool
+	// SourceLeaseAccessConditions contains optional parameters to access the source directory.
+	SourceLeaseAccessConditions *SourceLeaseAccessConditions
+	// DestinationLeaseAccessConditions contains optional parameters to access the destination directory.
+	DestinationLeaseAccessConditions *DestinationLeaseAccessConditions
+}
+
+func (o *RenameOptions) format() (*generated.DirectoryClientRenameOptions, *generated.SourceLeaseAccessConditions, *generated.DestinationLeaseAccessConditions, *generated.CopyFileSMBInfo) {
+	if o == nil {
+		return nil, nil, nil, nil
+	}
+
+	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.FileSMBProperties.Format(true)
+
+	permission, permissionKey := o.FilePermissions.Format()
+
+	renameOpts := &generated.DirectoryClientRenameOptions{
+		FilePermission:    permission,
+		FilePermissionKey: permissionKey,
+		IgnoreReadOnly:    o.IgnoreReadOnly,
+		Metadata:          o.Metadata,
+		ReplaceIfExists:   o.ReplaceIfExists,
+	}
+
+	smbInfo := &generated.CopyFileSMBInfo{
+		FileAttributes:    fileAttributes,
+		FileChangeTime:    fileChangeTime,
+		FileCreationTime:  fileCreationTime,
+		FileLastWriteTime: fileLastWriteTime,
+	}
+
+	return renameOpts, o.SourceLeaseAccessConditions, o.DestinationLeaseAccessConditions, smbInfo
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -95,23 +152,24 @@ type SetPropertiesOptions struct {
 	FilePermissions *file.Permissions
 }
 
-func (o *SetPropertiesOptions) format() (string, *generated.DirectoryClientSetPropertiesOptions) {
+func (o *SetPropertiesOptions) format() *generated.DirectoryClientSetPropertiesOptions {
 	if o == nil {
-		return shared.DefaultPreserveString, nil
+		return nil
 	}
 
-	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.FileSMBProperties.Format(true, shared.DefaultPreserveString)
+	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.FileSMBProperties.Format(true)
 
 	permission, permissionKey := o.FilePermissions.Format()
 
 	setPropertiesOptions := &generated.DirectoryClientSetPropertiesOptions{
+		FileAttributes:    fileAttributes,
 		FileChangeTime:    fileChangeTime,
 		FileCreationTime:  fileCreationTime,
 		FileLastWriteTime: fileLastWriteTime,
 		FilePermission:    permission,
 		FilePermissionKey: permissionKey,
 	}
-	return fileAttributes, setPropertiesOptions
+	return setPropertiesOptions
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/sdk/storage/azfile/directory/responses.go
+++ b/sdk/storage/azfile/directory/responses.go
@@ -15,7 +15,10 @@ type CreateResponse = generated.DirectoryClientCreateResponse
 type DeleteResponse = generated.DirectoryClientDeleteResponse
 
 // RenameResponse contains the response from method Client.Rename.
-type RenameResponse = generated.DirectoryClientRenameResponse
+type RenameResponse struct {
+	generated.DirectoryClientRenameResponse
+	Client *Client
+}
 
 // GetPropertiesResponse contains the response from method Client.GetProperties.
 type GetPropertiesResponse = generated.DirectoryClientGetPropertiesResponse

--- a/sdk/storage/azfile/directory/responses.go
+++ b/sdk/storage/azfile/directory/responses.go
@@ -14,6 +14,9 @@ type CreateResponse = generated.DirectoryClientCreateResponse
 // DeleteResponse contains the response from method Client.Delete.
 type DeleteResponse = generated.DirectoryClientDeleteResponse
 
+// RenameResponse contains the response from method Client.Rename.
+type RenameResponse = generated.DirectoryClientRenameResponse
+
 // GetPropertiesResponse contains the response from method Client.GetProperties.
 type GetPropertiesResponse = generated.DirectoryClientGetPropertiesResponse
 

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -141,8 +141,8 @@ func (f *Client) URL() string {
 // ParseNTFSFileAttributes method can be used to convert the file attributes returned in response to NTFSFileAttributes.
 // For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/create-file.
 func (f *Client) Create(ctx context.Context, fileContentLength int64, options *CreateOptions) (CreateResponse, error) {
-	fileAttributes, fileCreateOptions, fileHTTPHeaders, leaseAccessConditions := options.format()
-	resp, err := f.generated().Create(ctx, fileContentLength, fileAttributes, fileCreateOptions, fileHTTPHeaders, leaseAccessConditions)
+	fileCreateOptions, fileHTTPHeaders, leaseAccessConditions := options.format()
+	resp, err := f.generated().Create(ctx, fileContentLength, fileCreateOptions, fileHTTPHeaders, leaseAccessConditions)
 	return resp, err
 }
 
@@ -167,8 +167,8 @@ func (f *Client) GetProperties(ctx context.Context, options *GetPropertiesOption
 // ParseNTFSFileAttributes method can be used to convert the file attributes returned in response to NTFSFileAttributes.
 // For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/set-file-properties.
 func (f *Client) SetHTTPHeaders(ctx context.Context, options *SetHTTPHeadersOptions) (SetHTTPHeadersResponse, error) {
-	fileAttributes, opts, fileHTTPHeaders, leaseAccessConditions := options.format()
-	resp, err := f.generated().SetHTTPHeaders(ctx, fileAttributes, opts, fileHTTPHeaders, leaseAccessConditions)
+	opts, fileHTTPHeaders, leaseAccessConditions := options.format()
+	resp, err := f.generated().SetHTTPHeaders(ctx, opts, fileHTTPHeaders, leaseAccessConditions)
 	return resp, err
 }
 
@@ -203,8 +203,8 @@ func (f *Client) AbortCopy(ctx context.Context, copyID string, options *AbortCop
 // Resize operation resizes the file to the specified size.
 // For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/set-file-properties.
 func (f *Client) Resize(ctx context.Context, size int64, options *ResizeOptions) (ResizeResponse, error) {
-	fileAttributes, opts, leaseAccessConditions := options.format(size)
-	resp, err := f.generated().SetHTTPHeaders(ctx, fileAttributes, opts, nil, leaseAccessConditions)
+	opts, leaseAccessConditions := options.format(size)
+	resp, err := f.generated().SetHTTPHeaders(ctx, opts, nil, leaseAccessConditions)
 	return resp, err
 }
 

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -3639,19 +3639,27 @@ func (f *FileRecordedTestsSuite) TestFileRenameSrcDestLease() {
 	srcFileClient := testcommon.CreateNewFileFromShare(context.Background(), _require, "file1", 2048, shareClient)
 	destFileClient := testcommon.CreateNewFileFromShare(context.Background(), _require, "file2", 2048, shareClient)
 
+	var proposedLeaseIDs = []*string{to.Ptr("c820a799-76d7-4ee2-6e15-546f19325c2c"), to.Ptr("326cc5e1-746e-4af8-4811-a50e6629a8ca")}
+
 	// acquire lease on source file
-	srcFileLeaseClient, err := lease.NewFileClient(srcFileClient, nil)
+	srcFileLeaseClient, err := lease.NewFileClient(srcFileClient, &lease.FileClientOptions{
+		LeaseID: proposedLeaseIDs[0],
+	})
 	_require.NoError(err)
 	srcAcqResp, err := srcFileLeaseClient.Acquire(context.Background(), nil)
 	_require.NoError(err)
 	_require.NotNil(srcAcqResp.LeaseID)
+	_require.Equal(*srcAcqResp.LeaseID, *proposedLeaseIDs[0])
 
 	// acquire lease on destination file
-	destFileLeaseClient, err := lease.NewFileClient(destFileClient, nil)
+	destFileLeaseClient, err := lease.NewFileClient(destFileClient, &lease.FileClientOptions{
+		LeaseID: proposedLeaseIDs[1],
+	})
 	_require.NoError(err)
 	destAcqResp, err := destFileLeaseClient.Acquire(context.Background(), nil)
 	_require.NoError(err)
 	_require.NotNil(destAcqResp.LeaseID)
+	_require.Equal(*destAcqResp.LeaseID, *proposedLeaseIDs[1])
 
 	_, err = srcFileClient.Rename(context.Background(), "file2", &file.RenameOptions{
 		ReplaceIfExists: to.Ptr(true),

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -66,6 +66,12 @@ type ClearRange = generated.ClearRange
 // ShareFileRange - An Azure Storage file range.
 type ShareFileRange = generated.FileRange
 
+// SourceLeaseAccessConditions contains optional parameters to access the source directory.
+type SourceLeaseAccessConditions = generated.SourceLeaseAccessConditions
+
+// DestinationLeaseAccessConditions contains optional parameters to access the destination directory.
+type DestinationLeaseAccessConditions = generated.DestinationLeaseAccessConditions
+
 // ---------------------------------------------------------------------------------------------------------------------
 
 // CreateOptions contains the optional parameters for the Client.Create method.
@@ -115,6 +121,63 @@ func (o *DeleteOptions) format() (*generated.FileClientDeleteOptions, *generated
 		return nil, nil
 	}
 	return nil, o.LeaseAccessConditions
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+// RenameOptions contains the optional parameters for the Client.Rename method.
+type RenameOptions struct {
+	// SMBProperties contains the optional parameters regarding the SMB/NTFS properties for a file.
+	SMBProperties *SMBProperties
+	// Permissions contains the optional parameters for the permissions on the file.
+	Permissions *Permissions
+	// ContentType sets the content type of the file.
+	ContentType *string
+	// IgnoreReadOnly specifies whether the ReadOnly attribute on a pre-existing destination file should be respected.
+	// If true, rename will succeed, otherwise, a previous file at the destination with the ReadOnly attribute set will cause rename to fail.
+	IgnoreReadOnly *bool
+	// A name-value pair to associate with a file storage object.
+	Metadata map[string]*string
+	// ReplaceIfExists specifies that if the destination file already exists, whether this request will overwrite the file or not.
+	// If true, rename will succeed and will overwrite the destination file. If not provided or if false and the destination file does exist,
+	// the request will not overwrite the destination file.
+	// If provided and the destination file does not exist, rename will succeed.
+	ReplaceIfExists *bool
+	// SourceLeaseAccessConditions contains optional parameters to access the source directory.
+	SourceLeaseAccessConditions *SourceLeaseAccessConditions
+	// DestinationLeaseAccessConditions contains optional parameters to access the destination directory.
+	DestinationLeaseAccessConditions *DestinationLeaseAccessConditions
+}
+
+func (o *RenameOptions) format() (*generated.FileClientRenameOptions, *generated.SourceLeaseAccessConditions, *generated.DestinationLeaseAccessConditions, *generated.CopyFileSMBInfo, *generated.ShareFileHTTPHeaders) {
+	if o == nil {
+		return nil, nil, nil, nil, nil
+	}
+
+	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.SMBProperties.Format(false)
+
+	permission, permissionKey := o.Permissions.Format()
+
+	renameOpts := &generated.FileClientRenameOptions{
+		FilePermission:    permission,
+		FilePermissionKey: permissionKey,
+		IgnoreReadOnly:    o.IgnoreReadOnly,
+		Metadata:          o.Metadata,
+		ReplaceIfExists:   o.ReplaceIfExists,
+	}
+
+	smbInfo := &generated.CopyFileSMBInfo{
+		FileAttributes:    fileAttributes,
+		FileChangeTime:    fileChangeTime,
+		FileCreationTime:  fileCreationTime,
+		FileLastWriteTime: fileLastWriteTime,
+	}
+
+	fileHTTPHeaders := &generated.ShareFileHTTPHeaders{
+		ContentType: o.ContentType,
+	}
+
+	return renameOpts, o.SourceLeaseAccessConditions, o.DestinationLeaseAccessConditions, smbInfo, fileHTTPHeaders
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -80,16 +80,17 @@ type CreateOptions struct {
 	Metadata map[string]*string
 }
 
-func (o *CreateOptions) format() (string, *generated.FileClientCreateOptions, *generated.ShareFileHTTPHeaders, *LeaseAccessConditions) {
+func (o *CreateOptions) format() (*generated.FileClientCreateOptions, *generated.ShareFileHTTPHeaders, *LeaseAccessConditions) {
 	if o == nil {
-		return shared.FileAttributesNone, nil, nil, nil
+		return nil, nil, nil
 	}
 
-	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.SMBProperties.Format(false, shared.FileAttributesNone)
+	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.SMBProperties.Format(false)
 
 	permission, permissionKey := o.Permissions.Format()
 
 	createOptions := &generated.FileClientCreateOptions{
+		FileAttributes:    fileAttributes,
 		FileChangeTime:    fileChangeTime,
 		FileCreationTime:  fileCreationTime,
 		FileLastWriteTime: fileLastWriteTime,
@@ -98,7 +99,7 @@ func (o *CreateOptions) format() (string, *generated.FileClientCreateOptions, *g
 		Metadata:          o.Metadata,
 	}
 
-	return fileAttributes, createOptions, o.HTTPHeaders, o.LeaseAccessConditions
+	return createOptions, o.HTTPHeaders, o.LeaseAccessConditions
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -152,16 +153,17 @@ type SetHTTPHeadersOptions struct {
 	LeaseAccessConditions *LeaseAccessConditions
 }
 
-func (o *SetHTTPHeadersOptions) format() (string, *generated.FileClientSetHTTPHeadersOptions, *generated.ShareFileHTTPHeaders, *LeaseAccessConditions) {
+func (o *SetHTTPHeadersOptions) format() (*generated.FileClientSetHTTPHeadersOptions, *generated.ShareFileHTTPHeaders, *LeaseAccessConditions) {
 	if o == nil {
-		return shared.DefaultPreserveString, nil, nil, nil
+		return nil, nil, nil
 	}
 
-	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.SMBProperties.Format(false, shared.DefaultPreserveString)
+	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := o.SMBProperties.Format(false)
 
 	permission, permissionKey := o.Permissions.Format()
 
 	opts := &generated.FileClientSetHTTPHeadersOptions{
+		FileAttributes:    fileAttributes,
 		FileChangeTime:    fileChangeTime,
 		FileCreationTime:  fileCreationTime,
 		FileLastWriteTime: fileLastWriteTime,
@@ -170,7 +172,7 @@ func (o *SetHTTPHeadersOptions) format() (string, *generated.FileClientSetHTTPHe
 		FilePermissionKey: permissionKey,
 	}
 
-	return fileAttributes, opts, o.HTTPHeaders, o.LeaseAccessConditions
+	return opts, o.HTTPHeaders, o.LeaseAccessConditions
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -437,9 +439,7 @@ type ResizeOptions struct {
 	LeaseAccessConditions *LeaseAccessConditions
 }
 
-func (o *ResizeOptions) format(contentLength int64) (string, *generated.FileClientSetHTTPHeadersOptions, *LeaseAccessConditions) {
-	fileAttributes := shared.DefaultPreserveString
-
+func (o *ResizeOptions) format(contentLength int64) (*generated.FileClientSetHTTPHeadersOptions, *LeaseAccessConditions) {
 	opts := &generated.FileClientSetHTTPHeadersOptions{
 		FileContentLength: &contentLength,
 	}
@@ -449,7 +449,7 @@ func (o *ResizeOptions) format(contentLength int64) (string, *generated.FileClie
 		leaseAccessConditions = o.LeaseAccessConditions
 	}
 
-	return fileAttributes, opts, leaseAccessConditions
+	return opts, leaseAccessConditions
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/sdk/storage/azfile/file/responses.go
+++ b/sdk/storage/azfile/file/responses.go
@@ -18,6 +18,12 @@ type CreateResponse = generated.FileClientCreateResponse
 // DeleteResponse contains the response from method Client.Delete.
 type DeleteResponse = generated.FileClientDeleteResponse
 
+// RenameResponse contains the response from method Client.Rename.
+type RenameResponse struct {
+	generated.FileClientRenameResponse
+	Client *Client
+}
+
 // GetPropertiesResponse contains the response from method Client.GetProperties.
 type GetPropertiesResponse = generated.FileClientGetPropertiesResponse
 

--- a/sdk/storage/azfile/go.mod
+++ b/sdk/storage/azfile/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-sdk-for-go/sdk/storage/azfile
 go 1.18
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0

--- a/sdk/storage/azfile/go.sum
+++ b/sdk/storage/azfile/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0 h1:8q4SaHjFsClSvuVne0ID/5Ka8u3fcIHyqkLjcFpNRHQ=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0 h1:vcYCAze6p19qBW7MhZybIsqD8sMV8js0NyQM8JDnVtg=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0/go.mod h1:OQeznEEkTZ9OrhHJoDD8ZDq51FHgXjqtP9z6bEwBq9U=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=

--- a/sdk/storage/azfile/internal/exported/log_events.go
+++ b/sdk/storage/azfile/internal/exported/log_events.go
@@ -14,7 +14,4 @@ import (
 const (
 	// EventUpload is used when we compute number of chunks to upload and size of each chunk.
 	EventUpload log.Event = "azfile.Upload"
-
-	// EventError is used for logging errors.
-	EventError log.Event = "azfile.Error"
 )

--- a/sdk/storage/azfile/internal/exported/smb_property.go
+++ b/sdk/storage/azfile/internal/exported/smb_property.go
@@ -28,19 +28,17 @@ type SMBProperties struct {
 }
 
 // Format returns file attributes, creation time and last write time.
-func (sp *SMBProperties) Format(isDir bool, defaultFileAttributes string) (fileAttributes string, creationTime *string, lastWriteTime *string, changeTime *string) {
+func (sp *SMBProperties) Format(isDir bool) (fileAttributes *string, creationTime *string, lastWriteTime *string, changeTime *string) {
 	if sp == nil {
-		return defaultFileAttributes, nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
-	fileAttributes = defaultFileAttributes
+	fileAttributes = nil
 	if sp.Attributes != nil {
-		fileAttributes = sp.Attributes.String()
-		if fileAttributes == "" {
-			fileAttributes = defaultFileAttributes
-		} else if isDir && strings.ToLower(fileAttributes) != "none" {
+		fileAttributes = to.Ptr(sp.Attributes.String())
+		if isDir && fileAttributes != nil && strings.ToLower(*fileAttributes) != "none" {
 			// Directories need to have this attribute included, if setting any attributes.
-			fileAttributes += "|Directory"
+			*fileAttributes += "|Directory"
 		}
 	}
 

--- a/sdk/storage/azfile/internal/generated/autorest.md
+++ b/sdk/storage/azfile/internal/generated/autorest.md
@@ -333,3 +333,13 @@ directive:
   transform: >
     $.Handle["x-ms-go-omit-serde-methods"] = true;
 ```
+
+### Convert FileAttributes to an optional parameter
+
+``` yaml
+directive:
+- from: swagger-document
+  where: $.parameters.FileAttributes
+  transform: >
+    $.required = false;
+```

--- a/sdk/storage/azfile/internal/generated/zz_directory_client.go
+++ b/sdk/storage/azfile/internal/generated/zz_directory_client.go
@@ -36,11 +36,9 @@ type DirectoryClient struct {
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2022-11-02
-//   - fileAttributes - If specified, the provided file attributes shall be set. Default value: ‘Archive’ for file and ‘Directory’
-//     for directory. ‘None’ can also be specified as default.
 //   - options - DirectoryClientCreateOptions contains the optional parameters for the DirectoryClient.Create method.
-func (client *DirectoryClient) Create(ctx context.Context, fileAttributes string, options *DirectoryClientCreateOptions) (DirectoryClientCreateResponse, error) {
-	req, err := client.createCreateRequest(ctx, fileAttributes, options)
+func (client *DirectoryClient) Create(ctx context.Context, options *DirectoryClientCreateOptions) (DirectoryClientCreateResponse, error) {
+	req, err := client.createCreateRequest(ctx, options)
 	if err != nil {
 		return DirectoryClientCreateResponse{}, err
 	}
@@ -55,7 +53,7 @@ func (client *DirectoryClient) Create(ctx context.Context, fileAttributes string
 }
 
 // createCreateRequest creates the Create request.
-func (client *DirectoryClient) createCreateRequest(ctx context.Context, fileAttributes string, options *DirectoryClientCreateOptions) (*policy.Request, error) {
+func (client *DirectoryClient) createCreateRequest(ctx context.Context, options *DirectoryClientCreateOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -83,7 +81,9 @@ func (client *DirectoryClient) createCreateRequest(ctx context.Context, fileAttr
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}
 	}
-	req.Raw().Header["x-ms-file-attributes"] = []string{fileAttributes}
+	if options != nil && options.FileAttributes != nil {
+		req.Raw().Header["x-ms-file-attributes"] = []string{*options.FileAttributes}
+	}
 	if options != nil && options.FileCreationTime != nil {
 		req.Raw().Header["x-ms-file-creation-time"] = []string{*options.FileCreationTime}
 	}
@@ -848,11 +848,9 @@ func (client *DirectoryClient) setMetadataHandleResponse(resp *http.Response) (D
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2022-11-02
-//   - fileAttributes - If specified, the provided file attributes shall be set. Default value: ‘Archive’ for file and ‘Directory’
-//     for directory. ‘None’ can also be specified as default.
 //   - options - DirectoryClientSetPropertiesOptions contains the optional parameters for the DirectoryClient.SetProperties method.
-func (client *DirectoryClient) SetProperties(ctx context.Context, fileAttributes string, options *DirectoryClientSetPropertiesOptions) (DirectoryClientSetPropertiesResponse, error) {
-	req, err := client.setPropertiesCreateRequest(ctx, fileAttributes, options)
+func (client *DirectoryClient) SetProperties(ctx context.Context, options *DirectoryClientSetPropertiesOptions) (DirectoryClientSetPropertiesResponse, error) {
+	req, err := client.setPropertiesCreateRequest(ctx, options)
 	if err != nil {
 		return DirectoryClientSetPropertiesResponse{}, err
 	}
@@ -867,7 +865,7 @@ func (client *DirectoryClient) SetProperties(ctx context.Context, fileAttributes
 }
 
 // setPropertiesCreateRequest creates the SetProperties request.
-func (client *DirectoryClient) setPropertiesCreateRequest(ctx context.Context, fileAttributes string, options *DirectoryClientSetPropertiesOptions) (*policy.Request, error) {
+func (client *DirectoryClient) setPropertiesCreateRequest(ctx context.Context, options *DirectoryClientSetPropertiesOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -886,7 +884,9 @@ func (client *DirectoryClient) setPropertiesCreateRequest(ctx context.Context, f
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}
 	}
-	req.Raw().Header["x-ms-file-attributes"] = []string{fileAttributes}
+	if options != nil && options.FileAttributes != nil {
+		req.Raw().Header["x-ms-file-attributes"] = []string{*options.FileAttributes}
+	}
 	if options != nil && options.FileCreationTime != nil {
 		req.Raw().Header["x-ms-file-creation-time"] = []string{*options.FileCreationTime}
 	}

--- a/sdk/storage/azfile/internal/generated/zz_file_client.go
+++ b/sdk/storage/azfile/internal/generated/zz_file_client.go
@@ -369,13 +369,11 @@ func (client *FileClient) changeLeaseHandleResponse(resp *http.Response) (FileCl
 //
 // Generated from API version 2022-11-02
 //   - fileContentLength - Specifies the maximum size for the file, up to 4 TB.
-//   - fileAttributes - If specified, the provided file attributes shall be set. Default value: ‘Archive’ for file and ‘Directory’
-//     for directory. ‘None’ can also be specified as default.
 //   - options - FileClientCreateOptions contains the optional parameters for the FileClient.Create method.
 //   - ShareFileHTTPHeaders - ShareFileHTTPHeaders contains a group of parameters for the FileClient.Create method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
-func (client *FileClient) Create(ctx context.Context, fileContentLength int64, fileAttributes string, options *FileClientCreateOptions, shareFileHTTPHeaders *ShareFileHTTPHeaders, leaseAccessConditions *LeaseAccessConditions) (FileClientCreateResponse, error) {
-	req, err := client.createCreateRequest(ctx, fileContentLength, fileAttributes, options, shareFileHTTPHeaders, leaseAccessConditions)
+func (client *FileClient) Create(ctx context.Context, fileContentLength int64, options *FileClientCreateOptions, shareFileHTTPHeaders *ShareFileHTTPHeaders, leaseAccessConditions *LeaseAccessConditions) (FileClientCreateResponse, error) {
+	req, err := client.createCreateRequest(ctx, fileContentLength, options, shareFileHTTPHeaders, leaseAccessConditions)
 	if err != nil {
 		return FileClientCreateResponse{}, err
 	}
@@ -390,7 +388,7 @@ func (client *FileClient) Create(ctx context.Context, fileContentLength int64, f
 }
 
 // createCreateRequest creates the Create request.
-func (client *FileClient) createCreateRequest(ctx context.Context, fileContentLength int64, fileAttributes string, options *FileClientCreateOptions, shareFileHTTPHeaders *ShareFileHTTPHeaders, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *FileClient) createCreateRequest(ctx context.Context, fileContentLength int64, options *FileClientCreateOptions, shareFileHTTPHeaders *ShareFileHTTPHeaders, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -437,7 +435,9 @@ func (client *FileClient) createCreateRequest(ctx context.Context, fileContentLe
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}
 	}
-	req.Raw().Header["x-ms-file-attributes"] = []string{fileAttributes}
+	if options != nil && options.FileAttributes != nil {
+		req.Raw().Header["x-ms-file-attributes"] = []string{*options.FileAttributes}
+	}
 	if options != nil && options.FileCreationTime != nil {
 		req.Raw().Header["x-ms-file-creation-time"] = []string{*options.FileCreationTime}
 	}
@@ -1494,13 +1494,11 @@ func (client *FileClient) renameHandleResponse(resp *http.Response) (FileClientR
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2022-11-02
-//   - fileAttributes - If specified, the provided file attributes shall be set. Default value: ‘Archive’ for file and ‘Directory’
-//     for directory. ‘None’ can also be specified as default.
 //   - options - FileClientSetHTTPHeadersOptions contains the optional parameters for the FileClient.SetHTTPHeaders method.
 //   - ShareFileHTTPHeaders - ShareFileHTTPHeaders contains a group of parameters for the FileClient.Create method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
-func (client *FileClient) SetHTTPHeaders(ctx context.Context, fileAttributes string, options *FileClientSetHTTPHeadersOptions, shareFileHTTPHeaders *ShareFileHTTPHeaders, leaseAccessConditions *LeaseAccessConditions) (FileClientSetHTTPHeadersResponse, error) {
-	req, err := client.setHTTPHeadersCreateRequest(ctx, fileAttributes, options, shareFileHTTPHeaders, leaseAccessConditions)
+func (client *FileClient) SetHTTPHeaders(ctx context.Context, options *FileClientSetHTTPHeadersOptions, shareFileHTTPHeaders *ShareFileHTTPHeaders, leaseAccessConditions *LeaseAccessConditions) (FileClientSetHTTPHeadersResponse, error) {
+	req, err := client.setHTTPHeadersCreateRequest(ctx, options, shareFileHTTPHeaders, leaseAccessConditions)
 	if err != nil {
 		return FileClientSetHTTPHeadersResponse{}, err
 	}
@@ -1515,7 +1513,7 @@ func (client *FileClient) SetHTTPHeaders(ctx context.Context, fileAttributes str
 }
 
 // setHTTPHeadersCreateRequest creates the SetHTTPHeaders request.
-func (client *FileClient) setHTTPHeadersCreateRequest(ctx context.Context, fileAttributes string, options *FileClientSetHTTPHeadersOptions, shareFileHTTPHeaders *ShareFileHTTPHeaders, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *FileClient) setHTTPHeadersCreateRequest(ctx context.Context, options *FileClientSetHTTPHeadersOptions, shareFileHTTPHeaders *ShareFileHTTPHeaders, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1554,7 +1552,9 @@ func (client *FileClient) setHTTPHeadersCreateRequest(ctx context.Context, fileA
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}
 	}
-	req.Raw().Header["x-ms-file-attributes"] = []string{fileAttributes}
+	if options != nil && options.FileAttributes != nil {
+		req.Raw().Header["x-ms-file-attributes"] = []string{*options.FileAttributes}
+	}
 	if options != nil && options.FileCreationTime != nil {
 		req.Raw().Header["x-ms-file-creation-time"] = []string{*options.FileCreationTime}
 	}

--- a/sdk/storage/azfile/internal/generated/zz_models.go
+++ b/sdk/storage/azfile/internal/generated/zz_models.go
@@ -107,6 +107,9 @@ type Directory struct {
 
 // DirectoryClientCreateOptions contains the optional parameters for the DirectoryClient.Create method.
 type DirectoryClientCreateOptions struct {
+	// If specified, the provided file attributes shall be set. Default value: ‘Archive’ for file and ‘Directory’ for directory.
+	// ‘None’ can also be specified as default.
+	FileAttributes *string
 	// Change time for the file/directory. Default value: Now.
 	FileChangeTime *string
 	// Creation time for the file/directory. Default value: Now.
@@ -241,6 +244,9 @@ type DirectoryClientSetMetadataOptions struct {
 
 // DirectoryClientSetPropertiesOptions contains the optional parameters for the DirectoryClient.SetProperties method.
 type DirectoryClientSetPropertiesOptions struct {
+	// If specified, the provided file attributes shall be set. Default value: ‘Archive’ for file and ‘Directory’ for directory.
+	// ‘None’ can also be specified as default.
+	FileAttributes *string
 	// Change time for the file/directory. Default value: Now.
 	FileChangeTime *string
 	// Creation time for the file/directory. Default value: Now.
@@ -319,6 +325,9 @@ type FileClientChangeLeaseOptions struct {
 
 // FileClientCreateOptions contains the optional parameters for the FileClient.Create method.
 type FileClientCreateOptions struct {
+	// If specified, the provided file attributes shall be set. Default value: ‘Archive’ for file and ‘Directory’ for directory.
+	// ‘None’ can also be specified as default.
+	FileAttributes *string
 	// Change time for the file/directory. Default value: Now.
 	FileChangeTime *string
 	// Creation time for the file/directory. Default value: Now.
@@ -451,6 +460,9 @@ type FileClientRenameOptions struct {
 
 // FileClientSetHTTPHeadersOptions contains the optional parameters for the FileClient.SetHTTPHeaders method.
 type FileClientSetHTTPHeadersOptions struct {
+	// If specified, the provided file attributes shall be set. Default value: ‘Archive’ for file and ‘Directory’ for directory.
+	// ‘None’ can also be specified as default.
+	FileAttributes *string
 	// Change time for the file/directory. Default value: Now.
 	FileChangeTime *string
 	// Resizes a file to the specified size. If the specified byte value is less than the current size of the file, then all ranges

--- a/sdk/storage/azfile/internal/testcommon/common.go
+++ b/sdk/storage/azfile/internal/testcommon/common.go
@@ -101,6 +101,7 @@ func BeforeTest(t *testing.T, suite string, test string) {
 	require.NoError(t, recording.AddURISanitizer(FakeStorageURL, urlRegex, nil))
 	require.NoError(t, recording.AddHeaderRegexSanitizer("x-ms-copy-source", FakeStorageURL, urlRegex, nil))
 	require.NoError(t, recording.AddHeaderRegexSanitizer("x-ms-copy-source-authorization", FakeToken, tokenRegex, nil))
+	require.NoError(t, recording.AddHeaderRegexSanitizer("x-ms-file-rename-source", FakeStorageURL, urlRegex, nil))
 	// we freeze request IDs and timestamps to avoid creating noisy diffs
 	// NOTE: we can't freeze time stamps as that breaks some tests that use if-modified-since etc (maybe it can be fixed?)
 	//testframework.AddHeaderRegexSanitizer("X-Ms-Date", "Wed, 10 Aug 2022 23:34:14 GMT", "", nil)

--- a/sdk/storage/azfile/log.go
+++ b/sdk/storage/azfile/log.go
@@ -13,7 +13,4 @@ import (
 const (
 	// EventUpload is used for logging events related to upload operation.
 	EventUpload = exported.EventUpload
-
-	// EventError is used for logging errors.
-	EventError = exported.EventError
 )

--- a/sdk/storage/azfile/service/client.go
+++ b/sdk/storage/azfile/service/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/base"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/exported"
@@ -132,18 +131,7 @@ func (s *Client) URL() string {
 // The new share.Client uses the same request policy pipeline as the Client.
 func (s *Client) NewShareClient(shareName string) *share.Client {
 	shareURL := runtime.JoinPaths(s.generated().Endpoint(), shareName)
-
-	// TODO: remove new azcore.Client creation after the API for shallow copying with new client name is implemented
-	clOpts := s.getClientOptions()
-	azClient, err := azcore.NewClient(shared.ShareClient, exported.ModuleVersion, *(base.GetPipelineOptions(clOpts)), &(clOpts.ClientOptions))
-	if err != nil {
-		if log.Should(exported.EventError) {
-			log.Writef(exported.EventError, err.Error())
-		}
-		return nil
-	}
-
-	return (*share.Client)(base.NewShareClient(shareURL, azClient, s.sharedKey(), clOpts))
+	return (*share.Client)(base.NewShareClient(shareURL, s.generated().InternalClient().WithClientName(shared.ShareClient), s.sharedKey(), s.getClientOptions()))
 }
 
 // CreateShare is a lifecycle method to creates a new share under the specified account.


### PR DESCRIPTION
Use `azcore.Client.WithClientName(clientName)` method for shallow copy of the client with new client name.
Please review the PR #21143 before this.
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
