### PR TITLE
Disable CP1 for regional STS test

### DIFF
--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -311,6 +311,12 @@ func TestClientCertificateCredential_Regional(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// regional STS returns an error for CP1
+	before := disableCP1
+	defer func() { disableCP1 = before }()
+	disableCP1 = true
+
 	cred, err := NewClientCertificateCredential(
 		liveSP.tenantID, liveSP.clientID, cert, key, &ClientCertificateCredentialOptions{SendCertificateChain: true, ClientOptions: opts},
 	)


### PR DESCRIPTION
Regional STS (westus2 at least) has begun responding with an error when we claim CP1 in a token request: `AADSTS100034: AAD Regional does not support issuing tokens with CAE claims`. This seems weird to me because the prior behavior, silently ignoring the claim, was a deliberate part of the design and harmless so far as I know, however we can just forego the claim in this test because CAE is irrelevant to it.

If your application is affected by this, set environment variable `AZURE_IDENTITY_DISABLE_CP1` to `true` or switch to a stable azidentity version.