### PR TITLE
Enable TLS renegotiation

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Enable TLS renegotiation in the default transport policy.
+
 ### Other Changes
 
 ## 1.8.0-beta.1 (2023-07-12)

--- a/sdk/azcore/runtime/transport_default_http_client.go
+++ b/sdk/azcore/runtime/transport_default_http_client.go
@@ -28,7 +28,8 @@ func init() {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
+			MinVersion:    tls.VersionTLS12,
+			Renegotiation: tls.RenegotiateFreelyAsClient,
 		},
 	}
 	defaultHTTPClient = &http.Client{


### PR DESCRIPTION
Some endpoints require TLS renegotiation.  There is no change in behavior for endpoints that don't.

Partial fix for https://github.com/Azure/azure-sdk-for-go/issues/19469