### PR TITLE
[azblob][sas] Fix SignWithSharedKey if stored access policy is used  @stotz89

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Fixed service SAS creation where expiry time or permissions can be omitted when stored access policy is used. Fixes [#21229](https://github.com/Azure/azure-sdk-for-go/issues/21229).
+
 ### Other Changes
 
 ## 1.1.0 (2023-07-13)
@@ -25,7 +27,6 @@
 
 * Fixed time formatting for the conditional request headers. Fixes [#20475](https://github.com/Azure/azure-sdk-for-go/issues/20475).
 * Fixed an issue where passing a blob tags map of length 0 would result in the x-ms-tags header to be sent to the service with an empty string as value.
-
 * Fixed block size and number of blocks calculation in `UploadBuffer` and `UploadFile`. Fixes [#20735](https://github.com/Azure/azure-sdk-for-go/issues/20735).
 
 ### Other Changes

--- a/sdk/storage/azblob/container/client_test.go
+++ b/sdk/storage/azblob/container/client_test.go
@@ -1548,7 +1548,7 @@ func (s *ContainerRecordedTestsSuite) TestContainerGetPermissionsPublicAccessNot
 	_require.Equal(*resp.BlobPublicAccess, container.PublicAccessTypeBlob)
 }
 
-func (s *ContainerRecordedTestsSuite) TestContainerSetPermissionsPublicAccessNone() {
+func (s *ContainerUnrecordedTestsSuite) TestContainerSetPermissionsPublicAccessNone() {
 	// Test the basic one by making an anonymous request to ensure it's actually doing it and also with GetPermissions
 	// For all the others, can just use GetPermissions since we've validated that it at least registers on the server correctly
 	_require := require.New(s.T())

--- a/sdk/storage/azblob/sas/service.go
+++ b/sdk/storage/azblob/sas/service.go
@@ -16,9 +16,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
 )
 
-type SharedKeyCredentials interface {
-}
-
 // BlobSignatureValues is used to generate a Shared Access Signature (SAS) for an Azure Storage container or blob.
 // For more information on creating service sas, see https://docs.microsoft.com/rest/api/storageservices/constructing-a-service-sas
 // For more information on creating user delegation sas, see https://docs.microsoft.com/rest/api/storageservices/create-user-delegation-sas

--- a/sdk/storage/azblob/sas/service.go
+++ b/sdk/storage/azblob/sas/service.go
@@ -16,6 +16,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
 )
 
+type SharedKeyCredentials interface {
+}
+
 // BlobSignatureValues is used to generate a Shared Access Signature (SAS) for an Azure Storage container or blob.
 // For more information on creating service sas, see https://docs.microsoft.com/rest/api/storageservices/constructing-a-service-sas
 // For more information on creating user delegation sas, see https://docs.microsoft.com/rest/api/storageservices/create-user-delegation-sas
@@ -51,7 +54,7 @@ func getDirectoryDepth(path string) string {
 
 // SignWithSharedKey uses an account's SharedKeyCredential to sign this signature values to produce the proper SAS query parameters.
 func (v BlobSignatureValues) SignWithSharedKey(sharedKeyCredential *SharedKeyCredential) (QueryParameters, error) {
-	if v.ExpiryTime.IsZero() || v.Permissions == "" {
+	if v.Identifier == "" && (v.ExpiryTime.IsZero() || v.Permissions == "") {
 		return QueryParameters{}, errors.New("service SAS is missing at least one of these: ExpiryTime or Permissions")
 	}
 

--- a/sdk/storage/azblob/sas/service_test.go
+++ b/sdk/storage/azblob/sas/service_test.go
@@ -262,7 +262,7 @@ func TestGetDirectoryDepth(t *testing.T) {
 }
 
 func TestBlobSignatureValues_SignWithSharedKey(t *testing.T) {
-	validSharedKeyCredential, err := exported.NewSharedKeyCredential("fakeaccountname", "AKIAIOSFODNN7EXAMPLE")
+	cred, err := exported.NewSharedKeyCredential("fakeaccountname", "AKIAIOSFODNN7EXAMPLE")
 	require.Nil(t, err, "error creating valid shared key credentials.")
 
 	expiryDate, err := time.Parse("2006-01-02", "2023-07-20")
@@ -270,37 +270,32 @@ func TestBlobSignatureValues_SignWithSharedKey(t *testing.T) {
 
 	testdata := []struct {
 		object        BlobSignatureValues
-		input         *SharedKeyCredential
 		expected      QueryParameters
 		expectedError error
 	}{
 		{
 			object:        BlobSignatureValues{ContainerName: "fakestoragecontainer", Permissions: "a", ExpiryTime: expiryDate},
-			input:         validSharedKeyCredential,
-			expected:      QueryParameters{version: "2020-02-10", permissions: "a", expiryTime: expiryDate, resource: "c"},
+			expected:      QueryParameters{version: Version, permissions: "a", expiryTime: expiryDate, resource: "c"},
 			expectedError: nil,
 		},
 		{
 			object:        BlobSignatureValues{ContainerName: "fakestoragecontainer", Permissions: "", ExpiryTime: expiryDate},
-			input:         validSharedKeyCredential,
 			expected:      QueryParameters{},
 			expectedError: errors.New("service SAS is missing at least one of these: ExpiryTime or Permissions"),
 		},
 		{
 			object:        BlobSignatureValues{ContainerName: "fakestoragecontainer", Permissions: "a", ExpiryTime: *new(time.Time)},
-			input:         validSharedKeyCredential,
 			expected:      QueryParameters{},
 			expectedError: errors.New("service SAS is missing at least one of these: ExpiryTime or Permissions"),
 		},
 		{
 			object:        BlobSignatureValues{ContainerName: "fakestoragecontainer", Permissions: "", ExpiryTime: *new(time.Time), Identifier: "fakepolicyname"},
-			input:         validSharedKeyCredential,
-			expected:      QueryParameters{version: "2020-02-10", resource: "c", identifier: "fakepolicyname"},
+			expected:      QueryParameters{version: Version, resource: "c", identifier: "fakepolicyname"},
 			expectedError: nil,
 		},
 	}
 	for _, c := range testdata {
-		act, err := c.object.SignWithSharedKey(c.input)
+		act, err := c.object.SignWithSharedKey(cred)
 		// ignore signature value
 		act.signature = ""
 		require.Equal(t, c.expected, act)


### PR DESCRIPTION
This PR will fix https://github.com/Azure/azure-sdk-for-go/issues/21229

In addition it adds non-existing unit tests for the fixed method.
