### PR TITLE
azfile: SAS creation fix when stored access policy is used

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Bugs Fixed
 
+* Fixed service SAS creation where expiry time or permissions can be omitted when stored access policy is used.
+
 ### Other Changes
 
 * Updated version of azcore to 1.7.0 and azidentity to 1.3.0.

--- a/sdk/storage/azfile/sas/service.go
+++ b/sdk/storage/azfile/sas/service.go
@@ -39,7 +39,7 @@ type SignatureValues struct {
 
 // SignWithSharedKey uses an account's SharedKeyCredential to sign this signature values to produce the proper SAS query parameters.
 func (v SignatureValues) SignWithSharedKey(sharedKeyCredential *SharedKeyCredential) (QueryParameters, error) {
-	if v.ExpiryTime.IsZero() || v.Permissions == "" {
+	if v.Identifier == "" && (v.ExpiryTime.IsZero() || v.Permissions == "") {
 		return QueryParameters{}, errors.New("service SAS is missing at least one of these: ExpiryTime or Permissions")
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
