### PR TITLE
azqueue: SAS creation fix when stored access policy is used

### DIFF
--- a/sdk/storage/azqueue/CHANGELOG.md
+++ b/sdk/storage/azqueue/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Bugs Fixed
 
+* Fixed service SAS creation where expiry time or permissions can be omitted when stored access policy is used.
+
 #### Other Changes
 
 ### 1.0.0 (2023-05-09)

--- a/sdk/storage/azqueue/sas/service.go
+++ b/sdk/storage/azqueue/sas/service.go
@@ -32,7 +32,7 @@ type QueueSignatureValues struct {
 
 // SignWithSharedKey uses an account's SharedKeyCredential to sign this signature values to produce the proper SAS query parameters.
 func (v QueueSignatureValues) SignWithSharedKey(sharedKeyCredential *SharedKeyCredential) (QueryParameters, error) {
-	if v.ExpiryTime.IsZero() || v.Permissions == "" {
+	if v.Identifier == "" && (v.ExpiryTime.IsZero() || v.Permissions == "") {
 		return QueryParameters{}, errors.New("service SAS is missing at least one of these: ExpiryTime or Permissions")
 	}
 
@@ -75,7 +75,8 @@ func (v QueueSignatureValues) SignWithSharedKey(sharedKeyCredential *SharedKeyCr
 		permissions: v.Permissions,
 		ipRange:     v.IPRange,
 		// Calculated SAS signature
-		signature: signature,
+		signature:  signature,
+		identifier: signedIdentifier,
 	}
 
 	return p, nil


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
