### PR TITLE
List System Containers

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features Added
 * Added support for [Cold tier](https://learn.microsoft.com/azure/storage/blobs/access-tiers-overview?tabs=azure-portal).
-* Added CopySourceTag option for UploadBlobFromURLOptions
+* Added `CopySourceTag` option for `UploadBlobFromURLOptions`
+* Added `System` option to `ListContainersInculde` to allow listing of system containers. 
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 * Added support for [Cold tier](https://learn.microsoft.com/azure/storage/blobs/access-tiers-overview?tabs=azure-portal).
 * Added `CopySourceTag` option for `UploadBlobFromURLOptions`
-* Added `System` option to `ListContainersInculde` to allow listing of system containers. 
+* Added `System` option to `ListContainersInclude` to allow listing of system containers. 
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_5f550f0ded"
+  "Tag": "go/storage/azblob_816342f61e"
 }

--- a/sdk/storage/azblob/service/client.go
+++ b/sdk/storage/azblob/service/client.go
@@ -194,6 +194,9 @@ func (s *Client) NewListContainersPager(o *ListContainersOptions) *runtime.Pager
 		if o.Include.Metadata {
 			listOptions.Include = append(listOptions.Include, generated.ListContainersIncludeTypeMetadata)
 		}
+		if o.Include.System {
+			listOptions.Include = append(listOptions.Include, generated.ListContainersIncludeTypeSystem)
+		}
 		listOptions.Marker = o.Marker
 		listOptions.Maxresults = o.MaxResults
 		listOptions.Prefix = o.Prefix

--- a/sdk/storage/azblob/service/client_test.go
+++ b/sdk/storage/azblob/service/client_test.go
@@ -160,6 +160,33 @@ func (s *ServiceUnrecordedTestsSuite) TestListContainersBasic() {
 	_require.GreaterOrEqual(count, 0)
 }
 
+func (s *ServiceUnrecordedTestsSuite) TestListContainersSystem() {
+	_require := require.New(s.T())
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.Nil(err)
+
+	listOptions := service.ListContainersOptions{Include: service.ListContainersInclude{System: true}}
+	pager := svcClient.NewListContainersPager(&listOptions)
+
+	count := 0
+	for pager.More() {
+		resp, err := pager.NextPage(context.Background())
+		_require.Nil(err)
+		for _, c := range resp.ContainerItems {
+			_require.NotNil(c.Name)
+			if strings.Contains(*c.Name, "$") {
+				count += 1
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	_require.Nil(err)
+	_require.GreaterOrEqual(count, 1) // every account will always have one system container, i.e. '$logs'
+}
+
 func (s *ServiceRecordedTestsSuite) TestSetPropertiesLogging() {
 	_require := require.New(s.T())
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)

--- a/sdk/storage/azblob/service/client_test.go
+++ b/sdk/storage/azblob/service/client_test.go
@@ -160,7 +160,7 @@ func (s *ServiceUnrecordedTestsSuite) TestListContainersBasic() {
 	_require.GreaterOrEqual(count, 0)
 }
 
-func (s *ServiceUnrecordedTestsSuite) TestListContainersSystem() {
+func (s *ServiceRecordedTestsSuite) TestListContainersSystem() {
 	_require := require.New(s.T())
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
 	_require.Nil(err)

--- a/sdk/storage/azblob/service/models.go
+++ b/sdk/storage/azblob/service/models.go
@@ -156,6 +156,9 @@ type ListContainersInclude struct {
 
 	// Tells the service whether to return soft-deleted containers.
 	Deleted bool
+
+	// Tells the service whether to return system containers.
+	System bool
 }
 
 // ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Added System to ListContainersInclude to allow listing of system contain (i.e., '$logs').

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
