### PR TITLE
User authentication API

### DIFF
--- a/sdk/azidentity/assets.json
+++ b/sdk/azidentity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/azidentity",
-  "Tag": "go/azidentity_6225ab0470"
+  "Tag": "go/azidentity_625e4cf3e9"
 }

--- a/sdk/azidentity/authentication_record.go
+++ b/sdk/azidentity/authentication_record.go
@@ -1,0 +1,95 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
+)
+
+var supportedAuthRecordVersions = []string{"1.0"}
+
+// AuthenticationRecord is non-secret account information about an authenticated user that user credentials such as
+// [DeviceCodeCredential] and [InteractiveBrowserCredential] can use to access previously cached authentication
+// data. Call these credentials' Authenticate method to get an AuthenticationRecord for a user.
+type AuthenticationRecord struct {
+	// Authority is the URL of the authority that issued the token.
+	Authority string `json:"authority"`
+
+	// ClientID is the ID of the application that authenticated the user.
+	ClientID string `json:"clientId"`
+
+	// HomeAccountID uniquely identifies the account.
+	HomeAccountID string `json:"homeAccountId"`
+
+	// TenantID identifies the tenant in which the user authenticated.
+	TenantID string `json:"tenantId"`
+
+	// Username is the user's preferred username.
+	Username string `json:"username"`
+
+	// Version of the AuthenticationRecord.
+	Version string `json:"version"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler for AuthenticationRecord
+func (a *AuthenticationRecord) UnmarshalJSON(b []byte) error {
+	// Default unmarshaling is fine but we want to return an error if the record's version isn't supported i.e., we
+	// want to inspect the unmarshalled values before deciding whether to return an error. Unmarshaling a formally
+	// different type enables this by assigning all the fields without recursing into this method.
+	type r AuthenticationRecord
+	err := json.Unmarshal(b, (*r)(a))
+	if err != nil {
+		return err
+	}
+	if a.Version == "" {
+		return errors.New("AuthenticationRecord must have a version")
+	}
+	for _, v := range supportedAuthRecordVersions {
+		if a.Version == v {
+			return nil
+		}
+	}
+	return fmt.Errorf("unsupported AuthenticationRecord version %q. This module supports %v", a.Version, supportedAuthRecordVersions)
+}
+
+// account returns the AuthenticationRecord as an MSAL Account. The account is zero-valued when the AuthenticationRecord is zero-valued.
+func (a *AuthenticationRecord) account() public.Account {
+	return public.Account{
+		Environment:       a.Authority,
+		HomeAccountID:     a.HomeAccountID,
+		PreferredUsername: a.Username,
+	}
+}
+
+func newAuthenticationRecord(ar public.AuthResult) (AuthenticationRecord, error) {
+	u, err := url.Parse(ar.IDToken.Issuer)
+	if err != nil {
+		return AuthenticationRecord{}, fmt.Errorf("Authenticate expected a URL issuer but got %q", ar.IDToken.Issuer)
+	}
+	tenant := ar.IDToken.TenantID
+	if tenant == "" {
+		tenant = strings.Trim(u.Path, "/")
+	}
+	username := ar.IDToken.PreferredUsername
+	if username == "" {
+		username = ar.IDToken.UPN
+	}
+	return AuthenticationRecord{
+		Authority:     fmt.Sprintf("%s://%s", u.Scheme, u.Host),
+		ClientID:      ar.IDToken.Audience,
+		HomeAccountID: ar.Account.HomeAccountID,
+		TenantID:      tenant,
+		Username:      username,
+		Version:       "1.0",
+	}, nil
+}

--- a/sdk/azidentity/authentication_record_test.go
+++ b/sdk/azidentity/authentication_record_test.go
@@ -1,0 +1,56 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAuthenticationRecord_MarshalUnmarshal(t *testing.T) {
+	for _, test := range []struct {
+		desc, version string
+		err           bool
+	}{
+		{desc: "no version", err: true},
+		{desc: "supported version", version: supportedAuthRecordVersions[0]},
+		{desc: "unsupported version", err: true, version: "42"},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			record := AuthenticationRecord{
+				Authority:     "authority",
+				ClientID:      "client",
+				HomeAccountID: "oid.tid",
+				TenantID:      "tenant",
+				Username:      "user",
+				Version:       test.version,
+			}
+			marshaled, err := json.Marshal(record)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var unmarshaled AuthenticationRecord
+			err = json.Unmarshal(marshaled, &unmarshaled)
+			if err != nil {
+				if !test.err {
+					t.Fatal(err)
+				}
+				if actual := err.Error(); !strings.Contains(actual, "version") {
+					t.Fatalf("unexpected error %q", actual)
+				}
+				return
+			} else if test.err {
+				t.Fatal("expected an error")
+			}
+			if !reflect.DeepEqual(unmarshaled, record) {
+				t.Fatal("records should be equal")
+			}
+		})
+	}
+}

--- a/sdk/azidentity/confidential_client.go
+++ b/sdk/azidentity/confidential_client.go
@@ -147,7 +147,7 @@ func (c *confidentialClient) newMSALClient(enableCAE bool) (msalConfidentialClie
 	return confidential.New(authority, c.clientID, c.cred, o...)
 }
 
-// resolveTenant returns the correct tenant for a token request given the client's
+// resolveTenant returns the correct WithTenantID() argument for a token request given the client's
 // configuration, or an error when that configuration doesn't allow the specified tenant
 func (c *confidentialClient) resolveTenant(specified string) (string, error) {
 	return resolveTenant(c.tenantID, specified, c.name, c.opts.AdditionallyAllowedTenants)

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -23,14 +23,26 @@ type DeviceCodeCredentialOptions struct {
 	// AdditionallyAllowedTenants specifies additional tenants for which the credential may acquire
 	// tokens. Add the wildcard value "*" to allow the credential to acquire tokens for any tenant.
 	AdditionallyAllowedTenants []string
+
+	// AuthenticationRecord returned by a call to a credential's Authenticate method. Set this option
+	// to enable the credential to use data from a previous authentication.
+	AuthenticationRecord AuthenticationRecord
+
 	// ClientID is the ID of the application users will authenticate to.
 	// Defaults to the ID of an Azure development application.
 	ClientID string
+
+	// DisableAutomaticAuthentication prevents the credential from automatically prompting the user to authenticate.
+	// When this option is true, [DeviceCodeCredential.GetToken] will return [ErrAuthenticationRequired] when user
+	// interaction is necessary to acquire a token.
+	DisableAutomaticAuthentication bool
+
 	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
 	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
 	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
 	// the application responsible for ensuring the configured authority is valid and trustworthy.
 	DisableInstanceDiscovery bool
+
 	// TenantID is the Azure Active Directory tenant the credential authenticates in. Defaults to the
 	// "organizations" tenant, which can authenticate work and school accounts. Required for single-tenant
 	// applications.
@@ -70,7 +82,7 @@ type DeviceCodeMessage struct {
 // DeviceCodeCredential acquires tokens for a user via the device code flow, which has the
 // user browse to an Azure Active Directory URL, enter a code, and authenticate. It's useful
 // for authenticating a user in an environment without a web browser, such as an SSH session.
-// If a web browser is available, InteractiveBrowserCredential is more convenient because it
+// If a web browser is available, [InteractiveBrowserCredential] is more convenient because it
 // automatically opens a browser to the login page.
 type DeviceCodeCredential struct {
 	client *publicClient
@@ -84,10 +96,11 @@ func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeC
 	}
 	cp.init()
 	msalOpts := publicClientOptions{
-		AdditionallyAllowedTenants: cp.AdditionallyAllowedTenants,
-		ClientOptions:              cp.ClientOptions,
-		DeviceCodePrompt:           cp.UserPrompt,
-		DisableInstanceDiscovery:   cp.DisableInstanceDiscovery,
+		AdditionallyAllowedTenants:     cp.AdditionallyAllowedTenants,
+		ClientOptions:                  cp.ClientOptions,
+		DeviceCodePrompt:               cp.UserPrompt,
+		DisableAutomaticAuthentication: cp.DisableAutomaticAuthentication,
+		DisableInstanceDiscovery:       cp.DisableInstanceDiscovery,
 	}
 	c, err := newPublicClient(cp.TenantID, cp.ClientID, credNameDeviceCode, msalOpts)
 	if err != nil {
@@ -95,6 +108,11 @@ func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeC
 	}
 	c.name = credNameDeviceCode
 	return &DeviceCodeCredential{client: c}, nil
+}
+
+// Authenticate a user via the device code flow. Subsequent calls to GetToken will automatically use the returned AuthenticationRecord.
+func (c *DeviceCodeCredential) Authenticate(ctx context.Context, opts *policy.TokenRequestOptions) (AuthenticationRecord, error) {
+	return c.client.Authenticate(ctx, opts)
 }
 
 // GetToken requests an access token from Azure Active Directory. It will begin the device code flow and poll until the user completes authentication.

--- a/sdk/azidentity/errors.go
+++ b/sdk/azidentity/errors.go
@@ -18,6 +18,10 @@ import (
 	msal "github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors"
 )
 
+// ErrAuthenticationRequired indicates a credential's Authenticate method must be called to acquire a token
+// because user interaction is required and the credential is configured not to automatically prompt the user.
+var ErrAuthenticationRequired error = &credentialUnavailableError{"can't acquire a token without user interaction. Call Authenticate to interactively authenticate a user"}
+
 // getResponseFromError retrieves the response carried by
 // an AuthenticationFailedError or MSAL CallErr, if any
 func getResponseFromError(err error) *http.Response {

--- a/sdk/azidentity/go.mod
+++ b/sdk/azidentity/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/uuid v1.3.0
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.12.0
 )
 
@@ -16,6 +17,7 @@ require (
 	github.com/dnaeon/go-vcr v1.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -18,7 +18,9 @@ github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3P
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
 golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=

--- a/sdk/azidentity/public_client.go
+++ b/sdk/azidentity/public_client.go
@@ -8,37 +8,46 @@ package azidentity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
+
+	// this import ensures well-known configurations in azcore/cloud have ARM audiences for Authenticate()
+	_ "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 )
 
 type publicClientOptions struct {
 	azcore.ClientOptions
 
-	AdditionallyAllowedTenants []string
-	DeviceCodePrompt           func(context.Context, DeviceCodeMessage) error
-	DisableInstanceDiscovery   bool
-	LoginHint, RedirectURL     string
-	Username, Password         string
+	AdditionallyAllowedTenants     []string
+	DeviceCodePrompt               func(context.Context, DeviceCodeMessage) error
+	DisableAutomaticAuthentication bool
+	DisableInstanceDiscovery       bool
+	LoginHint, RedirectURL         string
+	Username, Password             string
 }
 
 // publicClient wraps the MSAL public client
 type publicClient struct {
-	account                  public.Account
 	cae, noCAE               msalPublicClient
 	caeMu, noCAEMu, clientMu *sync.Mutex
 	clientID, tenantID       string
+	defaultScope             []string
 	host                     string
 	name                     string
 	opts                     publicClientOptions
+	record                   AuthenticationRecord
 }
+
+var errScopeRequired = errors.New("authenticating in this environment requires specifying a scope in TokenRequestOptions")
 
 func newPublicClient(tenantID, clientID, name string, o publicClientOptions) (*publicClient, error) {
 	if !validTenantID(tenantID) {
@@ -48,17 +57,64 @@ func newPublicClient(tenantID, clientID, name string, o publicClientOptions) (*p
 	if err != nil {
 		return nil, err
 	}
+	// if the application specified a cloud configuration, use its ARM audience as the default scope for Authenticate()
+	audience := o.Cloud.Services[cloud.ResourceManager].Audience
+	if audience == "" {
+		// no cloud configuration, or no ARM audience, specified; try to map the host to a well-known one (all of which have a trailing slash)
+		if !strings.HasSuffix(host, "/") {
+			host += "/"
+		}
+		switch host {
+		case cloud.AzureChina.ActiveDirectoryAuthorityHost:
+			audience = cloud.AzureChina.Services[cloud.ResourceManager].Audience
+		case cloud.AzureGovernment.ActiveDirectoryAuthorityHost:
+			audience = cloud.AzureGovernment.Services[cloud.ResourceManager].Audience
+		case cloud.AzurePublic.ActiveDirectoryAuthorityHost:
+			audience = cloud.AzurePublic.Services[cloud.ResourceManager].Audience
+		}
+	}
+	// if we didn't come up with an audience, the application will have to specify a scope for Authenticate()
+	var defaultScope []string
+	if audience != "" {
+		defaultScope = []string{audience + defaultSuffix}
+	}
 	o.AdditionallyAllowedTenants = resolveAdditionalTenants(o.AdditionallyAllowedTenants)
 	return &publicClient{
-		caeMu:    &sync.Mutex{},
-		clientID: clientID,
-		clientMu: &sync.Mutex{},
-		host:     host,
-		name:     name,
-		noCAEMu:  &sync.Mutex{},
-		opts:     o,
-		tenantID: tenantID,
+		caeMu:        &sync.Mutex{},
+		clientID:     clientID,
+		clientMu:     &sync.Mutex{},
+		defaultScope: defaultScope,
+		host:         host,
+		name:         name,
+		noCAEMu:      &sync.Mutex{},
+		opts:         o,
+		tenantID:     tenantID,
 	}, nil
+}
+
+func (p *publicClient) Authenticate(ctx context.Context, tro *policy.TokenRequestOptions) (AuthenticationRecord, error) {
+	if tro == nil {
+		tro = &policy.TokenRequestOptions{}
+	}
+	if len(tro.Scopes) == 0 {
+		if p.defaultScope == nil {
+			return AuthenticationRecord{}, errScopeRequired
+		}
+		tro.Scopes = p.defaultScope
+	}
+	client, mu, err := p.client(*tro)
+	if err != nil {
+		return AuthenticationRecord{}, err
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	_, err = p.reqToken(ctx, client, *tro)
+	if err == nil {
+		scope := strings.Join(tro.Scopes, ", ")
+		msg := fmt.Sprintf("%s.Authenticate() acquired a token for scope %q", p.name, scope)
+		log.Write(EventAuthentication, msg)
+	}
+	return p.record, err
 }
 
 // GetToken requests an access token from MSAL, checking the cache first.
@@ -76,9 +132,12 @@ func (p *publicClient) GetToken(ctx context.Context, tro policy.TokenRequestOpti
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	ar, err := client.AcquireTokenSilent(ctx, tro.Scopes, public.WithSilentAccount(p.account), public.WithClaims(tro.Claims), public.WithTenantID(tenant))
+	ar, err := client.AcquireTokenSilent(ctx, tro.Scopes, public.WithSilentAccount(p.record.account()), public.WithClaims(tro.Claims), public.WithTenantID(tenant))
 	if err == nil {
 		return p.token(ar, err)
+	}
+	if p.opts.DisableAutomaticAuthentication {
+		return azcore.AccessToken{}, ErrAuthenticationRequired
 	}
 	at, err := p.reqToken(ctx, client, tro)
 	if err == nil {
@@ -163,7 +222,7 @@ func (p *publicClient) newMSALClient(enableCAE bool) (msalPublicClient, error) {
 
 func (p *publicClient) token(ar public.AuthResult, err error) (azcore.AccessToken, error) {
 	if err == nil {
-		p.account = ar.Account
+		p.record, err = newAuthenticationRecord(ar)
 	} else {
 		res := getResponseFromError(err)
 		err = newAuthenticationFailedError(p.name, err.Error(), res, err)
@@ -171,8 +230,14 @@ func (p *publicClient) token(ar public.AuthResult, err error) (azcore.AccessToke
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 
-// resolveTenant returns the correct tenant for a token request given the client's
+// resolveTenant returns the correct WithTenantID() argument for a token request given the client's
 // configuration, or an error when that configuration doesn't allow the specified tenant
 func (p *publicClient) resolveTenant(specified string) (string, error) {
-	return resolveTenant(p.tenantID, specified, p.name, p.opts.AdditionallyAllowedTenants)
+	t, err := resolveTenant(p.tenantID, specified, p.name, p.opts.AdditionallyAllowedTenants)
+	if t == p.tenantID {
+		// callers pass this value to MSAL's WithTenantID(). There's no need to redundantly specify
+		// the client's default tenant and doing so is an error when that tenant is "organizations"
+		t = ""
+	}
+	return t, err
 }

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -23,6 +23,11 @@ type UsernamePasswordCredentialOptions struct {
 	// Add the wildcard value "*" to allow the credential to acquire tokens for any tenant in which the
 	// application is registered.
 	AdditionallyAllowedTenants []string
+
+	// AuthenticationRecord returned by a call to a credential's Authenticate method. Set this option
+	// to enable the credential to use data from a previous authentication.
+	AuthenticationRecord AuthenticationRecord
+
 	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
 	// private clouds such as Azure Stack. It determines whether the credential requests Azure AD instance metadata
 	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
@@ -56,6 +61,11 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 		return nil, err
 	}
 	return &UsernamePasswordCredential{client: c}, err
+}
+
+// Authenticate the user. Subsequent calls to GetToken will automatically use the returned AuthenticationRecord.
+func (c *UsernamePasswordCredential) Authenticate(ctx context.Context, opts *policy.TokenRequestOptions) (AuthenticationRecord, error) {
+	return c.client.Authenticate(ctx, opts)
 }
 
 // GetToken requests an access token from Azure Active Directory. This method is called automatically by Azure SDK clients.


### PR DESCRIPTION
This API lets applications access data cached during previous executions and control when interactive authentication happens. Usage looks like this in application code (with `TokenCachePersistenceOptions` from #21244):
```go
cred, err := azidentity.NewInteractiveBrowserCredential(&azidentity.InteractiveBrowserCredentialOptions{
	// By default, credentials begin interactive authentication whenever necessary. Set this option to
	// have the credential's GetToken method instead return an error when user interaction is necessary.
	DisableAutomaticAuthentication: true,
	
	// By default, credentials cache in memory. Set TokenCachePersistenceOptions to enable persistent caching.
	TokenCachePersistenceOptions: &azidentity.TokenCachePersistenceOptions{
		// optionally, set Name to isolate this credential's cache from other applications
		Name: "myapp",
	},
})
if err != nil {
	// TODO: handle error
}

// The Authenticate method begins interactive authentication. Call it whenever it's convenient for
// your application to authenticate a user. If Authenticate succeeds, the credential is ready for
// use with a client.
record, err := cred.Authenticate(context.TODO(), nil)
if err != nil {
	// TODO: handle error
}

// The record contains no authentication secrets. You can marshal it for storage.
b, err := json.Marshal(record)
if err != nil {
	// TODO: handle error
}
// TODO: store bytes
_ = b

// An authentication record stored by your application enables other credentials to access data from
// past authentications. If the cache contains sufficient data, your application  won't need to prompt
// for authentication.
var unmarshaled azidentity.AuthenticationRecord
err = json.Unmarshal(b, &unmarshaled)
if err != nil {
	// TODO: handle error
}

// This credential will be able to access authentication data cached by cred above.
newCred, err := azidentity.NewInteractiveBrowserCredential(&azidentity.InteractiveBrowserCredentialOptions{
	AuthenticationRecord:           unmarshaled,
	DisableAutomaticAuthentication: true,
	TokenCachePersistenceOptions:   &azidentity.TokenCachePersistenceOptions{
		Name: "myapp",
	},
})
```
(I'll add an example like this once the whole API is in place)

Part of #16643