### PR TITLE
Suppress nested SDK method spans

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Suppress creating spans for nested SDK API calls. The HTTP span will be a child of the outer API span.
+
 ### Other Changes
 
 ## 1.8.0-beta.2 (2023-08-14)


### PR DESCRIPTION
The inner SDK span must be omitted.  However, any REST span it creates must be a child of the outer SDK method span.

https://azure.github.io/azure-sdk/general_implementation.html#distributed-tracing