### PR TITLE
Revert breaking change to Span.End()

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Added function `SanitizePagerPollerPath` to the `server` package to centralize sanitization and formalize the contract.
 
 ### Breaking Changes
+> These changes affect only code written against beta versions `v1.7.0-beta.2` and `v1.8.0-beta.1`.
+* Removed parameter from method `Span.End()` and its type `tracing.SpanEndOptions`. This API GA'ed in `v1.2.0` so we cannot change it.
 
 ### Bugs Fixed
 

--- a/sdk/azcore/runtime/policy_http_trace.go
+++ b/sdk/azcore/runtime/policy_http_trace.go
@@ -78,7 +78,7 @@ func (h *httpTracePolicy) Do(req *policy.Request) (resp *http.Response, err erro
 				// so instead of attempting to sanitize the output, we simply output the error type.
 				span.SetStatus(tracing.SpanStatusError, fmt.Sprintf("%T", err))
 			}
-			span.End(nil)
+			span.End()
 		}()
 
 		req = req.WithContext(ctx)
@@ -112,6 +112,6 @@ func StartSpan(ctx context.Context, name string, tracer tracing.Tracer, options 
 			errType := strings.Replace(fmt.Sprintf("%T", err), "*exported.", "*azcore.", 1)
 			span.SetStatus(tracing.SpanStatusError, fmt.Sprintf("%s:\n%s", errType, err.Error()))
 		}
-		span.End(nil)
+		span.End()
 	}
 }

--- a/sdk/azcore/tracing/tracing.go
+++ b/sdk/azcore/tracing/tracing.go
@@ -149,7 +149,7 @@ type Span struct {
 
 // End terminates the span and MUST be called before the span leaves scope.
 // Any further updates to the span will be ignored after End is called.
-func (s Span) End(opts *SpanEndOptions) {
+func (s Span) End() {
 	if s.impl.End != nil {
 		s.impl.End()
 	}
@@ -175,11 +175,6 @@ func (s Span) SetStatus(code SpanStatus, desc string) {
 	if s.impl.SetStatus != nil {
 		s.impl.SetStatus(code, desc)
 	}
-}
-
-// SpanEndOptions contains the optional values for the Span.End() method.
-type SpanEndOptions struct {
-	// for future expansion
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/sdk/azcore/tracing/tracing_test.go
+++ b/sdk/azcore/tracing/tracing_test.go
@@ -23,7 +23,7 @@ func TestProviderZeroValues(t *testing.T) {
 	require.Equal(t, context.Background(), ctx)
 	require.Zero(t, sp)
 	sp.AddEvent("event")
-	sp.End(nil)
+	sp.End()
 	sp.SetAttributes(Attribute{})
 	sp.SetStatus(SpanStatusError, "boom")
 	spCtx := tr.SpanFromContext(ctx)
@@ -67,7 +67,7 @@ func TestProvider(t *testing.T) {
 	require.NotZero(t, sp)
 
 	sp.AddEvent("event")
-	sp.End(nil)
+	sp.End()
 	sp.SetAttributes()
 	sp.SetStatus(SpanStatusError, "desc")
 	require.True(t, addEventCalled)


### PR DESCRIPTION
The method has been in GA since v1.2.0 so we can't change it.

Thanks to @heaths for pointing this out.