### PR TITLE
[internal] Extend telemetry test regexp

### DIFF
--- a/sdk/internal/telemetry/telemetry_test.go
+++ b/sdk/internal/telemetry/telemetry_test.go
@@ -15,12 +15,13 @@ func TestFormat(t *testing.T) {
 	// Examples:
 	// * azsdk-go-azservicebus/v1.0.0 (go1.19.3; linux)
 	// * azsdk-go-azservicebus/v1.0.0 (go1.19; Windows_NT)
+	// * azsdk-go-azservicebus/v1.0.0 (go1.21rc3; linux)
 	//
 	// The OS varies based on the actual platform but it's a small set.
 	re := `^azsdk-go-azservicebus/v1.0.0` +
 		` ` +
 		`\(` +
-		`go\d+\.\d+(|\.\d+); (Windows_NT|linux|freebsd)` +
+		`go\d+\.\d+(|\.\d+|rc\d+); (Windows_NT|linux|freebsd)` +
 		`\)$`
 
 	require.Regexp(t, re, userAgent)


### PR DESCRIPTION
Regexp checks for major, minor and patch level, but fails with golang release candidate versions, as doesn't match regexp.

Example:

azsdk-go-azservicebus/v1.0.0 (go1.21rc3; linux)

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
