### PR TITLE
[azcore/azeventgrid] Remove json.RawMessage usage in the public API

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Added function `SanitizePagerPollerPath` to the `server` package to centralize sanitization and formalize the contract.
 
 ### Breaking Changes
+
+* `messaging.CloudEvent` deserializes JSON objects as `[]byte`, instead of `json.RawMessage`. See the documentation for CloudEvent.Data for more information.
+
 > These changes affect only code written against beta versions `v1.7.0-beta.2` and `v1.8.0-beta.1`.
 * Removed parameter from method `Span.End()` and its type `tracing.SpanEndOptions`. This API GA'ed in `v1.2.0` so we cannot change it.
 

--- a/sdk/azcore/messaging/cloud_event.go
+++ b/sdk/azcore/messaging/cloud_event.go
@@ -44,12 +44,12 @@ type CloudEvent struct {
 	// Data is the payload for the event.
 	// * []byte will be serialized and deserialized as []byte.
 	// * Any other type will be serialized to a JSON object and deserialized into
-	//   a [json.RawMessage].
+	//   a []byte, containing the JSON text.
 	//
-	// To deserialize a [json.RawMessage] into your chosen type:
+	// To deserialize into your chosen type:
 	//
 	//   var yourData *YourType
-	//   json.Unmarshal(cloudEvent.Data.(json.RawMessage), &yourData)
+	//   json.Unmarshal(cloudEvent.Data.([]byte), &yourData)
 	//
 	Data any
 
@@ -240,7 +240,7 @@ func updateFieldFromValue(ce *CloudEvent, k string, raw json.RawMessage) error {
 	//
 	case "data":
 		// let the user deserialize so they can put it into their own native type.
-		ce.Data = raw
+		ce.Data = []byte(raw)
 	case "datacontenttype":
 		return json.Unmarshal(raw, &ce.DataContentType)
 	case "dataschema":

--- a/sdk/azcore/messaging/cloud_event_test.go
+++ b/sdk/azcore/messaging/cloud_event_test.go
@@ -62,7 +62,7 @@ func TestCloudEventJSONData(t *testing.T) {
 	actualCE := roundTrip(t, ce)
 
 	var dest *map[string]string
-	require.NoError(t, json.Unmarshal(actualCE.Data.(json.RawMessage), &dest))
+	require.NoError(t, json.Unmarshal(actualCE.Data.([]byte), &dest))
 
 	require.Equal(t, data, *dest)
 }

--- a/sdk/azcore/messaging/example_usingcloudevent_test.go
+++ b/sdk/azcore/messaging/example_usingcloudevent_test.go
@@ -32,7 +32,7 @@ func Example_usingCloudEvent() {
 
 	var receivedData *sampleType
 
-	if err := json.Unmarshal(receivedEvent.Data.(json.RawMessage), &receivedData); err != nil {
+	if err := json.Unmarshal(receivedEvent.Data.([]byte), &receivedData); err != nil {
 		panic(err)
 	}
 

--- a/sdk/messaging/azeventgrid/client_test.go
+++ b/sdk/messaging/azeventgrid/client_test.go
@@ -237,7 +237,7 @@ func TestPublishingAndReceivingCloudEvents(t *testing.T) {
 		SpecVersion: "1.0",
 		Source:      "hello-source",
 		Type:        "eventType",
-		Data:        json.RawMessage("\"hello world 1\""),
+		Data:        []byte("\"hello world 1\""),
 	}, resp.Value[0].Event)
 
 	requireEqualCloudEvent(t, messaging.CloudEvent{
@@ -245,7 +245,7 @@ func TestPublishingAndReceivingCloudEvents(t *testing.T) {
 		Source:          "hello-source",
 		Type:            "eventType",
 		DataSchema:      to.Ptr("https://dataschema"),
-		Data:            json.RawMessage("\"hello world 2\""),
+		Data:            []byte("\"hello world 2\""),
 		DataContentType: to.Ptr("data content type"),
 		Subject:         to.Ptr("subject"),
 		Extensions: map[string]any{
@@ -260,7 +260,7 @@ func TestPublishingAndReceivingCloudEvents(t *testing.T) {
 		SpecVersion: "1.0",
 		Source:      "hello-source",
 		Type:        "eventType",
-		Data:        json.RawMessage(bytes),
+		Data:        []byte(bytes),
 	}, resp.Value[2].Event)
 
 	ackArgs := azeventgrid.AcknowledgeOptions{}

--- a/sdk/messaging/azeventgrid/go.mod
+++ b/sdk/messaging/azeventgrid/go.mod
@@ -3,10 +3,15 @@ module github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventgrid
 go 1.18
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.8.0-beta.1
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.8.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.7.0
+)
+
+replace (
+	// temporary until we officially release the next beta.
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.8.0-beta.2 => ../../azcore
 )
 
 require (


### PR DESCRIPTION
This avoids any future customer pain if the `json` types or API were to change.