### PR TITLE
Major version upgrade when processing fake

### DIFF
--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -298,7 +298,7 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 			return nil, err
 		}
 
-		if isGenerateFake(packagePath) {
+		if changelog.HasBreakingChanges() && isGenerateFake(packagePath) {
 			log.Printf("Replace fake module v2+...")
 			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, previousVersion, version.String(),
 				"fake", "_server.go"); err != nil {

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -300,7 +300,8 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 
 		if changelog.HasBreakingChanges() && isGenerateFake(packagePath) {
 			log.Printf("Replace fake module v2+...")
-			if err = replaceFakeImport(packagePath, generateParam.RPName, generateParam.NamespaceName, previousVersion, version.String()); err != nil {
+			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, previousVersion, version.String(),
+				"fake", "_server.go"); err != nil {
 				return nil, err
 			}
 		}

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -298,6 +298,13 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 			return nil, err
 		}
 
+		if changelog.HasBreakingChanges() && isGenerateFake(packagePath) {
+			log.Printf("Replace fake module v2+...")
+			if err = replaceFakeImport(packagePath, generateParam.RPName, generateParam.NamespaceName, previousVersion, version.String()); err != nil {
+				return nil, err
+			}
+		}
+
 		// Example generation should be the last step because the package import relay on the new calculated version
 		if !generateParam.SkipGenerateExample {
 			log.Printf("Generate examples...")

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -298,7 +298,7 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 			return nil, err
 		}
 
-		if changelog.HasBreakingChanges() && isGenerateFake(packagePath) {
+		if isGenerateFake(packagePath) {
 			log.Printf("Replace fake module v2+...")
 			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, previousVersion, version.String(),
 				"fake", "_server.go"); err != nil {


### PR DESCRIPTION
The major version was upgraded when the fake was generated, and the module in fake _server.go needs to be replaced.