### PR TITLE
Make recording.proxyManualStartEnv private

### DIFF
--- a/sdk/internal/perf/recording_test.go
+++ b/sdk/internal/perf/recording_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 )
 
+const proxyManualStartEnv = "PROXY_MANUAL_START"
+
 func TestRecordingHTTPClient_Do(t *testing.T) {
 	// Ignore manual start in pipeline tests, we always want to exercise install
-	os.Setenv(recording.ProxyManualStartEnv, "false")
+	os.Setenv(proxyManualStartEnv, "false")
 
 	proxy, err := recording.StartTestProxy("", nil)
 	require.NoError(t, err)

--- a/sdk/internal/recording/matchers_test.go
+++ b/sdk/internal/recording/matchers_test.go
@@ -27,7 +27,7 @@ func TestMatchers(t *testing.T) {
 
 func (s *matchersTests) SetupSuite() {
 	// Ignore manual start in pipeline tests, we always want to exercise install
-	os.Setenv(ProxyManualStartEnv, "false")
+	os.Setenv(proxyManualStartEnv, "false")
 	proxy, err := StartTestProxy("", nil)
 	s.proxy = proxy
 	require.NoError(s.T(), err)

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -37,7 +37,7 @@ func TestRecording(t *testing.T) {
 
 func (s *recordingTests) SetupSuite() {
 	// Ignore manual start in pipeline tests, we always want to exercise install
-	os.Setenv(ProxyManualStartEnv, "false")
+	os.Setenv(proxyManualStartEnv, "false")
 	proxy, err := StartTestProxy("", nil)
 	s.proxy = proxy
 	require.NoError(s.T(), err)

--- a/sdk/internal/recording/server.go
+++ b/sdk/internal/recording/server.go
@@ -24,7 +24,7 @@ import (
 	"time"
 )
 
-const ProxyManualStartEnv = "PROXY_MANUAL_START"
+const proxyManualStartEnv = "PROXY_MANUAL_START"
 
 type TestProxyInstance struct {
 	Cmd     *exec.Cmd
@@ -366,9 +366,9 @@ func waitForProxyStart(cmd *exec.Cmd, options *RecordingOptions) (*TestProxyInst
 }
 
 func StartTestProxy(pathToRecordings string, options *RecordingOptions) (*TestProxyInstance, error) {
-	manualStart := strings.ToLower(os.Getenv(ProxyManualStartEnv))
+	manualStart := strings.ToLower(os.Getenv(proxyManualStartEnv))
 	if manualStart == "true" {
-		log.Printf("%s env variable is set to true, not starting test proxy...\n", ProxyManualStartEnv)
+		log.Printf("%s env variable is set to true, not starting test proxy...\n", proxyManualStartEnv)
 		return nil, nil
 	}
 

--- a/sdk/internal/recording/server_test.go
+++ b/sdk/internal/recording/server_test.go
@@ -27,7 +27,7 @@ func TestServer(t *testing.T) {
 
 func (s *serverTests) SetupSuite() {
 	// Ignore manual start in pipeline tests, we always want to exercise install
-	os.Setenv(ProxyManualStartEnv, "false")
+	os.Setenv(proxyManualStartEnv, "false")
 }
 
 func (s *serverTests) TestProxyDownloadFile() {


### PR DESCRIPTION
Marking this well known test proxy variable private to lower public api surface area.
