### PR TITLE
azfile: add create client using token credential

### DIFF
--- a/sdk/storage/azfile/directory/client_test.go
+++ b/sdk/storage/azfile/directory/client_test.go
@@ -108,6 +108,27 @@ func (d *DirectoryRecordedTestsSuite) TestDirCreateFileURL() {
 	_require.Equal(fileClient.URL(), correctURL)
 }
 
+func (d *DirectoryRecordedTestsSuite) TestServiceClientWithTokenCredential() {
+	_require := require.New(d.T())
+	testName := d.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	dirName := testcommon.GenerateDirectoryName(testName)
+	dirURL := "https://" + accountName + ".file.core.windows.net/" + shareName + "/" + dirName
+	dirClient, err := directory.NewClient(dirURL, cred, nil)
+	_require.NoError(err)
+
+	resp, err := dirClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(resp.RequestID)
+}
+
 func (d *DirectoryRecordedTestsSuite) TestDirectoryCreateUsingSharedKey() {
 	_require := require.New(d.T())
 	testName := d.T().Name()

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -101,6 +101,28 @@ func (f *FileRecordedTestsSuite) TestFileNewFileClient() {
 	_require.Equal(rootFileClient.URL(), correctURL)
 }
 
+func (f *FileRecordedTestsSuite) TestServiceClientWithTokenCredential() {
+	_require := require.New(f.T())
+	testName := f.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	dirName := testcommon.GenerateDirectoryName(testName)
+	fileName := testcommon.GenerateFileName(testName)
+	fileURL := "https://" + accountName + ".file.core.windows.net/" + shareName + "/" + dirName + "/" + fileName
+	dirClient, err := file.NewClient(fileURL, cred, nil)
+	_require.NoError(err)
+
+	resp, err := dirClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(resp.RequestID)
+}
+
 func (f *FileRecordedTestsSuite) TestFileCreateUsingSharedKey() {
 	_require := require.New(f.T())
 	testName := f.T().Name()

--- a/sdk/storage/azfile/internal/base/clients.go
+++ b/sdk/storage/azfile/internal/base/clients.go
@@ -19,8 +19,8 @@ type ClientOptions struct {
 }
 
 type Client[T any] struct {
-	inner     *T
-	sharedKey *exported.SharedKeyCredential
+	inner      *T
+	credential any
 }
 
 func InnerClient[T any](client *Client[T]) *T {
@@ -28,33 +28,42 @@ func InnerClient[T any](client *Client[T]) *T {
 }
 
 func SharedKey[T any](client *Client[T]) *exported.SharedKeyCredential {
-	return client.sharedKey
+	switch cred := client.credential.(type) {
+	case *exported.SharedKeyCredential:
+		return cred
+	default:
+		return nil
+	}
 }
 
-func NewServiceClient(serviceURL string, pipeline runtime.Pipeline, sharedKey *exported.SharedKeyCredential) *Client[generated.ServiceClient] {
+func Credential[T any](client *Client[T]) any {
+	return client.credential
+}
+
+func NewServiceClient(serviceURL string, pipeline runtime.Pipeline, credential any) *Client[generated.ServiceClient] {
 	return &Client[generated.ServiceClient]{
-		inner:     generated.NewServiceClient(serviceURL, pipeline),
-		sharedKey: sharedKey,
+		inner:      generated.NewServiceClient(serviceURL, pipeline),
+		credential: credential,
 	}
 }
 
-func NewShareClient(shareURL string, pipeline runtime.Pipeline, sharedKey *exported.SharedKeyCredential) *Client[generated.ShareClient] {
+func NewShareClient(shareURL string, pipeline runtime.Pipeline, credential any) *Client[generated.ShareClient] {
 	return &Client[generated.ShareClient]{
-		inner:     generated.NewShareClient(shareURL, pipeline),
-		sharedKey: sharedKey,
+		inner:      generated.NewShareClient(shareURL, pipeline),
+		credential: credential,
 	}
 }
 
-func NewDirectoryClient(directoryURL string, pipeline runtime.Pipeline, sharedKey *exported.SharedKeyCredential) *Client[generated.DirectoryClient] {
+func NewDirectoryClient(directoryURL string, pipeline runtime.Pipeline, credential any) *Client[generated.DirectoryClient] {
 	return &Client[generated.DirectoryClient]{
-		inner:     generated.NewDirectoryClient(directoryURL, pipeline),
-		sharedKey: sharedKey,
+		inner:      generated.NewDirectoryClient(directoryURL, pipeline),
+		credential: credential,
 	}
 }
 
-func NewFileClient(fileURL string, pipeline runtime.Pipeline, sharedKey *exported.SharedKeyCredential) *Client[generated.FileClient] {
+func NewFileClient(fileURL string, pipeline runtime.Pipeline, credential any) *Client[generated.FileClient] {
 	return &Client[generated.FileClient]{
-		inner:     generated.NewFileClient(fileURL, pipeline),
-		sharedKey: sharedKey,
+		inner:      generated.NewFileClient(fileURL, pipeline),
+		credential: credential,
 	}
 }

--- a/sdk/storage/azfile/service/client.go
+++ b/sdk/storage/azfile/service/client.go
@@ -8,6 +8,7 @@ package service
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
@@ -27,6 +28,19 @@ type ClientOptions base.ClientOptions
 
 // Client represents a URL to the Azure File Storage service allowing you to manipulate file shares.
 type Client base.Client[generated.ServiceClient]
+
+// NewClient creates an instance of Client with the specified values.
+//   - serviceURL - the URL of the storage account e.g. https://<account>.file.core.windows.net/
+//   - cred - an Azure AD credential, typically obtained via the azidentity module
+//   - options - client options; pass nil to accept the default values
+func NewClient(serviceURL string, cred azcore.TokenCredential, options *ClientOptions) (*Client, error) {
+	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{shared.TokenScope}, nil)
+	conOptions := shared.GetClientOptions(options)
+	conOptions.PerRetryPolicies = append(conOptions.PerRetryPolicies, authPolicy)
+	pl := runtime.NewPipeline(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+
+	return (*Client)(base.NewServiceClient(serviceURL, pl, &cred)), nil
+}
 
 // NewClientWithNoCredential creates an instance of Client with the specified values.
 // This is used to anonymously access a storage account or with a shared access signature (SAS) token.
@@ -80,6 +94,10 @@ func (s *Client) sharedKey() *SharedKeyCredential {
 	return base.SharedKey((*base.Client[generated.ServiceClient])(s))
 }
 
+func (s *Client) credential() any {
+	return base.Credential((*base.Client[generated.ServiceClient])(s))
+}
+
 // URL returns the URL endpoint used by the Client object.
 func (s *Client) URL() string {
 	return s.generated().Endpoint()
@@ -89,7 +107,7 @@ func (s *Client) URL() string {
 // The new share.Client uses the same request policy pipeline as the Client.
 func (s *Client) NewShareClient(shareName string) *share.Client {
 	shareURL := runtime.JoinPaths(s.generated().Endpoint(), shareName)
-	return (*share.Client)(base.NewShareClient(shareURL, s.generated().Pipeline(), s.sharedKey()))
+	return (*share.Client)(base.NewShareClient(shareURL, s.generated().Pipeline(), s.credential()))
 }
 
 // CreateShare is a lifecycle method to creates a new share under the specified account.

--- a/sdk/storage/azfile/service/client_test.go
+++ b/sdk/storage/azfile/service/client_test.go
@@ -91,6 +91,24 @@ func (s *ServiceRecordedTestsSuite) TestAccountNewShareURLValidName() {
 	_require.Equal(shareClient.URL(), correctURL)
 }
 
+func (s *ServiceRecordedTestsSuite) TestServiceClientWithTokenCredential() {
+	_require := require.New(s.T())
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	svcURL := "https://" + accountName + ".file.core.windows.net/"
+	svcClient, err := service.NewClient(svcURL, cred, nil)
+	_require.NoError(err)
+
+	resp, err := svcClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(resp.RequestID)
+}
+
 func (s *ServiceRecordedTestsSuite) TestServiceClientFromConnectionString() {
 	_require := require.New(s.T())
 

--- a/sdk/storage/azfile/share/client_test.go
+++ b/sdk/storage/azfile/share/client_test.go
@@ -94,6 +94,27 @@ func (s *ShareRecordedTestsSuite) TestShareCreateDirectoryURL() {
 	_require.Equal(dirClient.URL(), correctURL)
 }
 
+func (s *ShareRecordedTestsSuite) TestServiceClientWithTokenCredential() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	shareURL := "https://" + accountName + ".file.core.windows.net/" + shareName
+
+	shareClient, err := share.NewClient(shareURL, cred, nil)
+	_require.NoError(err)
+
+	resp, err := shareClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(resp.RequestID)
+}
+
 func (s *ShareRecordedTestsSuite) TestShareCreateUsingSharedKey() {
 	_require := require.New(s.T())
 	testName := s.T().Name()


### PR DESCRIPTION
According to [this](https://techcommunity.microsoft.com/t5/azure-storage-blog/general-availability-introducing-azure-ad-support-for-azure/ba-p/3826733), Azure file is now support AD authentication.

Therefore, added the option to create azure file clients (service, share, directory and file) with TokenCredential
