### PR TITLE
Don't swallow error on Close()

### DIFF
--- a/sdk/ai/azopenai/CHANGELOG.md
+++ b/sdk/ai/azopenai/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 - ChatCompletionsOptions, CompletionsOptions, EmbeddingsOptions `DeploymentID` field renamed to `Deployment`.
+- Method `Close()` on `EventReader[T]` now returns an error.
 
 ### Bugs Fixed
 

--- a/sdk/ai/azopenai/event_reader.go
+++ b/sdk/ai/azopenai/event_reader.go
@@ -16,11 +16,11 @@ import (
 
 // EventReader streams events dynamically from an OpenAI endpoint.
 type EventReader[T any] struct {
-	reader  io.Reader // Required for Closing
+	reader  io.ReadCloser // Required for Closing
 	scanner *bufio.Scanner
 }
 
-func newEventReader[T any](r io.Reader) *EventReader[T] {
+func newEventReader[T any](r io.ReadCloser) *EventReader[T] {
 	return &EventReader[T]{reader: r, scanner: bufio.NewScanner(r)}
 }
 
@@ -56,8 +56,6 @@ func (er *EventReader[T]) Read() (T, error) {
 }
 
 // Close closes the EventReader and any applicable inner stream state.
-func (er *EventReader[T]) Close() {
-	if closer, ok := er.reader.(io.Closer); ok {
-		closer.Close()
-	}
+func (er *EventReader[T]) Close() error {
+	return er.reader.Close()
 }

--- a/sdk/ai/azopenai/event_reader_test.go
+++ b/sdk/ai/azopenai/event_reader_test.go
@@ -20,7 +20,7 @@ func TestEventReader_InvalidType(t *testing.T) {
 	}
 
 	text := strings.NewReader(strings.Join(data, "\n"))
-	eventReader := newEventReader[ChatCompletions](text)
+	eventReader := newEventReader[ChatCompletions](io.NopCloser(text))
 
 	firstEvent, err := eventReader.Read()
 	require.Empty(t, firstEvent)
@@ -34,7 +34,7 @@ func (br badReader) Read(p []byte) (n int, err error) {
 }
 
 func TestEventReader_BadReader(t *testing.T) {
-	eventReader := newEventReader[ChatCompletions](badReader{})
+	eventReader := newEventReader[ChatCompletions](io.NopCloser(badReader{}))
 
 	firstEvent, err := eventReader.Read()
 	require.Empty(t, firstEvent)


### PR DESCRIPTION
Return the result of reader.Close() to the caller.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
