### PR TITLE
[azopenai] Make sure we defer close the eventreader in our examples.

### DIFF
--- a/sdk/ai/azopenai/example_client_getchatcompletions_test.go
+++ b/sdk/ai/azopenai/example_client_getchatcompletions_test.go
@@ -229,11 +229,12 @@ func ExampleClient_GetChatCompletionsStream() {
 		// TODO: handle error
 	}
 
-	streamReader := resp.ChatCompletionsStream
+	defer resp.ChatCompletionsStream.Close()
+
 	gotReply := false
 
 	for {
-		chatCompletions, err := streamReader.Read()
+		chatCompletions, err := resp.ChatCompletionsStream.Read()
 
 		if errors.Is(err, io.EOF) {
 			break

--- a/sdk/ai/azopenai/example_client_getcompletions_test.go
+++ b/sdk/ai/azopenai/example_client_getcompletions_test.go
@@ -95,6 +95,8 @@ func ExampleClient_GetCompletionsStream() {
 		// TODO: handle error
 	}
 
+	defer resp.CompletionsStream.Close()
+
 	for {
 		entry, err := resp.CompletionsStream.Read()
 


### PR DESCRIPTION
The EventReader is the reader for the body when streaming results. Not closing it leaks resources.