### PR TITLE
Added RehydratePendingToCold to ArchiveStatus

### DIFF
--- a/sdk/storage/azblob/container/constants.go
+++ b/sdk/storage/azblob/container/constants.go
@@ -99,6 +99,7 @@ type ArchiveStatus = generated.ArchiveStatus
 const (
 	ArchiveStatusRehydratePendingToCool ArchiveStatus = generated.ArchiveStatusRehydratePendingToCool
 	ArchiveStatusRehydratePendingToHot  ArchiveStatus = generated.ArchiveStatusRehydratePendingToHot
+	ArchiveStatusRehydratePendingToCold ArchiveStatus = generated.ArchiveStatusRehydratePendingToCold
 )
 
 // PossibleArchiveStatusValues returns the possible values for the ArchiveStatus const type.

--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -7,7 +7,7 @@ go: true
 clear-output-folder: false
 version: "^3.0.0"
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/080b332b7572514a2e100dd2fa1fb86cb8edcb08/specification/storage/data-plane/Microsoft.BlobStorage/preview/2021-12-02/blob.json"
+input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a32d0b2423d19835246bb2ef92941503bfd5e734/specification/storage/data-plane/Microsoft.BlobStorage/preview/2021-12-02/blob.json"
 credential-scope: "https://storage.azure.com/.default"
 output-folder: ../generated
 file-prefix: "zz_"

--- a/sdk/storage/azblob/internal/generated/zz_blob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blob_client.go
@@ -956,6 +956,13 @@ func (client *BlobClient) downloadHandleResponse(resp *http.Response) (BlobClien
 		}
 		result.LastModified = &lastModified
 	}
+	if val := resp.Header.Get("x-ms-creation-time"); val != "" {
+		creationTime, err := time.Parse(time.RFC1123, val)
+		if err != nil {
+			return BlobClientDownloadResponse{}, err
+		}
+		result.CreationTime = &creationTime
+	}
 	for hh := range resp.Header {
 		if len(hh) > len("x-ms-meta-") && strings.EqualFold(hh[:len("x-ms-meta-")], "x-ms-meta-") {
 			if result.Metadata == nil {

--- a/sdk/storage/azblob/internal/generated/zz_constants.go
+++ b/sdk/storage/azblob/internal/generated/zz_constants.go
@@ -76,6 +76,7 @@ func PossibleAccountKindValues() []AccountKind {
 type ArchiveStatus string
 
 const (
+	ArchiveStatusRehydratePendingToCold ArchiveStatus = "rehydrate-pending-to-cold"
 	ArchiveStatusRehydratePendingToCool ArchiveStatus = "rehydrate-pending-to-cool"
 	ArchiveStatusRehydratePendingToHot  ArchiveStatus = "rehydrate-pending-to-hot"
 )
@@ -83,6 +84,7 @@ const (
 // PossibleArchiveStatusValues returns the possible values for the ArchiveStatus const type.
 func PossibleArchiveStatusValues() []ArchiveStatus {
 	return []ArchiveStatus{
+		ArchiveStatusRehydratePendingToCold,
 		ArchiveStatusRehydratePendingToCool,
 		ArchiveStatusRehydratePendingToHot,
 	}

--- a/sdk/storage/azblob/internal/generated/zz_response_types.go
+++ b/sdk/storage/azblob/internal/generated/zz_response_types.go
@@ -410,6 +410,9 @@ type BlobClientDownloadResponse struct {
 	// CopyStatusDescription contains the information returned from the x-ms-copy-status-description header response.
 	CopyStatusDescription *string
 
+	// CreationTime contains the information returned from the x-ms-creation-time header response.
+	CreationTime *time.Time
+
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 


### PR DESCRIPTION
HOLD OFF UNTIL STG 90 - Adding new rehydrate enum

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
