### PR TITLE
Remove dead code in NewDefaultAzureCredential error handling

### DIFF
--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -117,9 +117,8 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		creds = append(creds, &defaultCredentialErrorReporter{credType: credNameAzureCLI, err: err})
 	}
 
-	err = defaultAzureCredentialConstructorErrorHandler(len(creds), errorMessages)
-	if err != nil {
-		return nil, err
+	if len(errorMessages) > 0 {
+		log.Writef(EventAuthentication, "NewDefaultAzureCredential failed to initialize some credentials:\n\t%s", strings.Join(errorMessages, "\n\t"))
 	}
 
 	chain, err := NewChainedTokenCredential(creds, nil)
@@ -136,20 +135,6 @@ func (c *DefaultAzureCredential) GetToken(ctx context.Context, opts policy.Token
 }
 
 var _ azcore.TokenCredential = (*DefaultAzureCredential)(nil)
-
-func defaultAzureCredentialConstructorErrorHandler(numberOfSuccessfulCredentials int, errorMessages []string) (err error) {
-	errorMessage := strings.Join(errorMessages, "\n\t")
-
-	if numberOfSuccessfulCredentials == 0 {
-		return errors.New(errorMessage)
-	}
-
-	if len(errorMessages) != 0 {
-		log.Writef(EventAuthentication, "NewDefaultAzureCredential failed to initialize some credentials:\n\t%s", errorMessage)
-	}
-
-	return nil
-}
 
 // defaultCredentialErrorReporter is a substitute for credentials that couldn't be constructed.
 // Its GetToken method always returns a credentialUnavailableError having the same message as


### PR DESCRIPTION
The helper I'm deleting implies that `NewDefaultAzureCredential` should return an error when all the constructors it calls return errors. That sounds good but never happens for a couple reasons:
1. the check for "all constructors returned errors" is whether the slice of constructed credentials is empty, but it never is because failed constructors are represented therein by instances of `defaultCredentialErrorReporter`
2. it isn't possible for all these constructors to return errors because `NewAzureCLICredential` never does

We could fix reason 1, but reason 2 means doing so would just preserve dead code.

Closes #21301 