### PR TITLE
azfile: Additional header support

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Create File/Directory
   * Set File/Directory Properties
   * Copy File
+* Added `x-ms-file-last-write-time` request header in Put Range and Put Range from URL.
 
 ### Breaking Changes
 

--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 ### Features Added
 
-* Updated service version to STG 87(2022-11-02).
+* Updated service version to `2022-11-02`.
 * Added OAuth support.
 * Added [Rename Directory API](https://learn.microsoft.com/rest/api/storageservices/rename-directory).
 * Added [Rename File API](https://learn.microsoft.com/rest/api/storageservices/rename-file).
+* Added `x-ms-file-change-time` request header in
+  * Create File/Directory
+  * Set File/Directory Properties
+  * Copy File
 
 ### Breaking Changes
 

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_a4fc259673"
+  "Tag": "go/storage/azfile_4a81e26d17"
 }

--- a/sdk/storage/azfile/directory/client_test.go
+++ b/sdk/storage/azfile/directory/client_test.go
@@ -315,6 +315,7 @@ func (d *DirectoryRecordedTestsSuite) TestDirSetPropertiesNonDefault() {
 	_require.NoError(err)
 	creationTime := currTime.Add(5 * time.Minute).Round(time.Microsecond)
 	lastWriteTime := currTime.Add(10 * time.Minute).Round(time.Millisecond)
+	changeTime := currTime.Add(15 * time.Minute).Round(time.Millisecond)
 
 	// Set the custom permissions
 	sResp, err := dirClient.SetProperties(context.Background(), &directory.SetPropertiesOptions{
@@ -325,6 +326,7 @@ func (d *DirectoryRecordedTestsSuite) TestDirSetPropertiesNonDefault() {
 			},
 			CreationTime:  &creationTime,
 			LastWriteTime: &lastWriteTime,
+			ChangeTime:    &changeTime,
 		},
 		FilePermissions: &file.Permissions{
 			Permission: &testcommon.SampleSDDL,
@@ -337,6 +339,7 @@ func (d *DirectoryRecordedTestsSuite) TestDirSetPropertiesNonDefault() {
 	_require.NotEqual(*sResp.FilePermissionKey, *cResp.FilePermissionKey)
 	_require.Equal(*sResp.FileCreationTime, creationTime.UTC())
 	_require.Equal(*sResp.FileLastWriteTime, lastWriteTime.UTC())
+	_require.Equal(*sResp.FileChangeTime, changeTime.UTC())
 
 	fileAttributes, err := file.ParseNTFSFileAttributes(sResp.FileAttributes)
 	_require.NoError(err)
@@ -353,6 +356,7 @@ func (d *DirectoryRecordedTestsSuite) TestDirSetPropertiesNonDefault() {
 	_require.Equal(*gResp.FilePermissionKey, *sResp.FilePermissionKey)
 	_require.Equal(*gResp.FileCreationTime, *sResp.FileCreationTime)
 	_require.Equal(*gResp.FileLastWriteTime, *sResp.FileLastWriteTime)
+	_require.Equal(*gResp.FileChangeTime, *sResp.FileChangeTime)
 	_require.Equal(*gResp.FileAttributes, *sResp.FileAttributes)
 
 	fileAttributes2, err := file.ParseNTFSFileAttributes(gResp.FileAttributes)
@@ -388,6 +392,7 @@ func (d *DirectoryUnrecordedTestsSuite) TestDirCreateDeleteNonDefault() {
 			Attributes:    &file.NTFSFileAttributes{None: true},
 			CreationTime:  to.Ptr(time.Now().Add(5 * time.Minute)),
 			LastWriteTime: to.Ptr(time.Now().Add(10 * time.Minute)),
+			ChangeTime:    to.Ptr(time.Now().Add(10 * time.Minute)),
 		},
 		FilePermissions: &file.Permissions{
 			Permission: &testcommon.SampleSDDL,
@@ -1259,6 +1264,7 @@ func (d *DirectoryRecordedTestsSuite) TestDirectorySetPropertiesUsingOAuth() {
 	_require.NoError(err)
 	creationTime := currTime.Add(5 * time.Minute).Round(time.Microsecond)
 	lastWriteTime := currTime.Add(10 * time.Minute).Round(time.Millisecond)
+	changeTime := currTime.Add(15 * time.Minute).Round(time.Millisecond)
 
 	// Set the custom permissions
 	sResp, err := dirClient.SetProperties(context.Background(), &directory.SetPropertiesOptions{
@@ -1269,6 +1275,7 @@ func (d *DirectoryRecordedTestsSuite) TestDirectorySetPropertiesUsingOAuth() {
 			},
 			CreationTime:  &creationTime,
 			LastWriteTime: &lastWriteTime,
+			ChangeTime:    &changeTime,
 		},
 		FilePermissions: &file.Permissions{
 			Permission: &testcommon.SampleSDDL,
@@ -1277,10 +1284,12 @@ func (d *DirectoryRecordedTestsSuite) TestDirectorySetPropertiesUsingOAuth() {
 	_require.NoError(err)
 	_require.NotNil(sResp.FileCreationTime)
 	_require.NotNil(sResp.FileLastWriteTime)
+	_require.NotNil(sResp.FileChangeTime)
 	_require.NotNil(sResp.FilePermissionKey)
 	_require.NotEqual(*sResp.FilePermissionKey, *cResp.FilePermissionKey)
 	_require.Equal(*sResp.FileCreationTime, creationTime.UTC())
 	_require.Equal(*sResp.FileLastWriteTime, lastWriteTime.UTC())
+	_require.Equal(*sResp.FileChangeTime, changeTime.UTC())
 
 	fileAttributes, err := file.ParseNTFSFileAttributes(sResp.FileAttributes)
 	_require.NoError(err)
@@ -1293,10 +1302,12 @@ func (d *DirectoryRecordedTestsSuite) TestDirectorySetPropertiesUsingOAuth() {
 	_require.NoError(err)
 	_require.NotNil(gResp.FileCreationTime)
 	_require.NotNil(gResp.FileLastWriteTime)
+	_require.NotNil(gResp.FileChangeTime)
 	_require.NotNil(gResp.FilePermissionKey)
 	_require.Equal(*gResp.FilePermissionKey, *sResp.FilePermissionKey)
 	_require.Equal(*gResp.FileCreationTime, *sResp.FileCreationTime)
 	_require.Equal(*gResp.FileLastWriteTime, *sResp.FileLastWriteTime)
+	_require.Equal(*gResp.FileChangeTime, *sResp.FileChangeTime)
 	_require.Equal(*gResp.FileAttributes, *sResp.FileAttributes)
 
 	fileAttributes2, err := file.ParseNTFSFileAttributes(gResp.FileAttributes)

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -396,6 +396,7 @@ func (f *FileUnrecordedTestsSuite) TestFileGetSetPropertiesNonDefault() {
 
 	creationTime := time.Now().Add(-time.Hour)
 	lastWriteTime := time.Now().Add(-time.Minute * 15)
+	changeTime := time.Now().Add(-time.Minute * 30)
 
 	options := &file.SetHTTPHeadersOptions{
 		Permissions: &file.Permissions{Permission: &testcommon.SampleSDDL},
@@ -403,6 +404,7 @@ func (f *FileUnrecordedTestsSuite) TestFileGetSetPropertiesNonDefault() {
 			Attributes:    &file.NTFSFileAttributes{Hidden: true},
 			CreationTime:  &creationTime,
 			LastWriteTime: &lastWriteTime,
+			ChangeTime:    &changeTime,
 		},
 		HTTPHeaders: &file.HTTPHeaders{
 			ContentType:        to.Ptr("text/html"),
@@ -451,6 +453,7 @@ func (f *FileUnrecordedTestsSuite) TestFileGetSetPropertiesNonDefault() {
 
 	_require.EqualValues((*getResp.FileCreationTime).Format(testcommon.ISO8601), creationTime.UTC().Format(testcommon.ISO8601))
 	_require.EqualValues((*getResp.FileLastWriteTime).Format(testcommon.ISO8601), lastWriteTime.UTC().Format(testcommon.ISO8601))
+	_require.EqualValues((*getResp.FileChangeTime).Format(testcommon.ISO8601), changeTime.UTC().Format(testcommon.ISO8601))
 
 	_require.NotNil(getResp.ETag)
 	_require.NotNil(getResp.RequestID)
@@ -535,6 +538,7 @@ func (f *FileRecordedTestsSuite) TestFilePreservePermissions() {
 	pKey := getResp.FilePermissionKey
 	cTime := getResp.FileCreationTime
 	lwTime := getResp.FileLastWriteTime
+	changeTime := getResp.FileChangeTime
 	attribs := getResp.FileAttributes
 
 	md5Str := "MDAwMDAwMDA="
@@ -579,6 +583,7 @@ func (f *FileRecordedTestsSuite) TestFilePreservePermissions() {
 	_require.EqualValues(getResp.FilePermissionKey, pKey)
 	_require.EqualValues(cTime, getResp.FileCreationTime)
 	_require.EqualValues(lwTime, getResp.FileLastWriteTime)
+	_require.NotEqualValues(changeTime, getResp.FileChangeTime) // default value is "now" for file change time
 	_require.EqualValues(attribs, getResp.FileAttributes)
 
 	_require.NotNil(getResp.ETag)
@@ -1037,11 +1042,13 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySourceCreationTime() {
 			Attributes:    &file.NTFSFileAttributes{ReadOnly: true, Hidden: true},
 			CreationTime:  to.Ptr(currTime.Add(5 * time.Minute)),
 			LastWriteTime: to.Ptr(currTime.Add(2 * time.Minute)),
+			ChangeTime:    to.Ptr(currTime.Add(8 * time.Minute)),
 		},
 	})
 	_require.NoError(err)
 	_require.NotNil(cResp.FileCreationTime)
 	_require.NotNil(cResp.FileLastWriteTime)
+	_require.NotNil(cResp.FileChangeTime)
 	_require.NotNil(cResp.FileAttributes)
 	_require.NotNil(cResp.FilePermissionKey)
 
@@ -1064,6 +1071,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySourceCreationTime() {
 	_require.NoError(err)
 	_require.EqualValues(resp2.FileCreationTime, cResp.FileCreationTime)
 	_require.NotEqualValues(resp2.FileLastWriteTime, cResp.FileLastWriteTime)
+	_require.NotEqualValues(resp2.FileChangeTime, cResp.FileChangeTime)
 	_require.NotEqualValues(resp2.FileAttributes, cResp.FileAttributes)
 }
 
@@ -1088,11 +1096,13 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySourceProperties() {
 			Attributes:    &file.NTFSFileAttributes{System: true},
 			CreationTime:  to.Ptr(currTime.Add(1 * time.Minute)),
 			LastWriteTime: to.Ptr(currTime.Add(2 * time.Minute)),
+			ChangeTime:    to.Ptr(currTime.Add(5 * time.Minute)),
 		},
 	})
 	_require.NoError(err)
 	_require.NotNil(cResp.FileCreationTime)
 	_require.NotNil(cResp.FileLastWriteTime)
+	_require.NotNil(cResp.FileChangeTime)
 	_require.NotNil(cResp.FileAttributes)
 	_require.NotNil(cResp.FilePermissionKey)
 
@@ -1105,6 +1115,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySourceProperties() {
 		CopyFileSMBInfo: &file.CopyFileSMBInfo{
 			CreationTime:       file.SourceCopyFileCreationTime{},
 			LastWriteTime:      file.SourceCopyFileLastWriteTime{},
+			ChangeTime:         file.SourceCopyFileChangeTime{},
 			Attributes:         file.SourceCopyFileAttributes{},
 			PermissionCopyMode: to.Ptr(file.PermissionCopyModeTypeSource),
 		},
@@ -1117,6 +1128,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySourceProperties() {
 	_require.NoError(err)
 	_require.EqualValues(resp2.FileCreationTime, cResp.FileCreationTime)
 	_require.EqualValues(resp2.FileLastWriteTime, cResp.FileLastWriteTime)
+	_require.EqualValues(resp2.FileChangeTime, cResp.FileChangeTime)
 	_require.EqualValues(resp2.FileAttributes, cResp.FileAttributes)
 	_require.EqualValues(resp2.FilePermissionKey, cResp.FilePermissionKey)
 
@@ -1148,20 +1160,24 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyDifferentProperties() {
 			Attributes:    &file.NTFSFileAttributes{System: true},
 			CreationTime:  to.Ptr(currTime.Add(1 * time.Minute)),
 			LastWriteTime: to.Ptr(currTime.Add(2 * time.Minute)),
+			ChangeTime:    to.Ptr(currTime.Add(3 * time.Minute)),
 		},
 	})
 	_require.NoError(err)
 	_require.NotNil(cResp.FileCreationTime)
 	_require.NotNil(cResp.FileLastWriteTime)
+	_require.NotNil(cResp.FileChangeTime)
 	_require.NotNil(cResp.FileAttributes)
 	_require.NotNil(cResp.FilePermissionKey)
 
 	destCreationTime := currTime.Add(5 * time.Minute)
 	destLastWriteTIme := currTime.Add(6 * time.Minute)
+	destChangeTime := currTime.Add(7 * time.Minute)
 	_, err = copyFClient.StartCopyFromURL(context.Background(), fClient.URL(), &file.StartCopyFromURLOptions{
 		CopyFileSMBInfo: &file.CopyFileSMBInfo{
 			CreationTime:  file.DestinationCopyFileCreationTime(destCreationTime),
 			LastWriteTime: file.DestinationCopyFileLastWriteTime(destLastWriteTIme),
+			ChangeTime:    file.DestinationCopyFileChangeTime(destChangeTime),
 			Attributes:    file.DestinationCopyFileAttributes{ReadOnly: true},
 		},
 	})
@@ -1175,6 +1191,8 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyDifferentProperties() {
 	_require.EqualValues(*resp2.FileCreationTime, destCreationTime.UTC())
 	_require.NotEqualValues(resp2.FileLastWriteTime, cResp.FileLastWriteTime)
 	_require.EqualValues(*resp2.FileLastWriteTime, destLastWriteTIme.UTC())
+	_require.NotEqualValues(resp2.FileChangeTime, cResp.FileChangeTime)
+	_require.EqualValues(*resp2.FileChangeTime, destChangeTime.UTC())
 	_require.NotEqualValues(resp2.FileAttributes, cResp.FileAttributes)
 	_require.EqualValues(resp2.FilePermissionKey, cResp.FilePermissionKey)
 }
@@ -1196,6 +1214,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyOverrideMode() {
 	_require.NoError(err)
 	_require.NotNil(cResp.FileCreationTime)
 	_require.NotNil(cResp.FileLastWriteTime)
+	_require.NotNil(cResp.FileChangeTime)
 	_require.NotNil(cResp.FileAttributes)
 	_require.NotNil(cResp.FilePermissionKey)
 
@@ -1215,6 +1234,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyOverrideMode() {
 	_require.NoError(err)
 	_require.NotEqualValues(resp2.FileCreationTime, cResp.FileCreationTime)
 	_require.NotEqualValues(resp2.FileLastWriteTime, cResp.FileLastWriteTime)
+	_require.NotEqualValues(resp2.FileChangeTime, cResp.FileChangeTime)
 	_require.NotEqualValues(resp2.FilePermissionKey, cResp.FilePermissionKey)
 }
 
@@ -1235,6 +1255,7 @@ func (f *FileRecordedTestsSuite) TestNegativeFileStartCopyOverrideMode() {
 	_require.NoError(err)
 	_require.NotNil(cResp.FileCreationTime)
 	_require.NotNil(cResp.FileLastWriteTime)
+	_require.NotNil(cResp.FileChangeTime)
 	_require.NotNil(cResp.FileAttributes)
 	_require.NotNil(cResp.FilePermissionKey)
 
@@ -1269,6 +1290,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySetArchiveAttributeTrue() {
 	_require.NoError(err)
 	_require.NotNil(cResp.FileCreationTime)
 	_require.NotNil(cResp.FileLastWriteTime)
+	_require.NotNil(cResp.FileChangeTime)
 	_require.NotNil(cResp.FileAttributes)
 	_require.NotNil(cResp.FilePermissionKey)
 
@@ -1286,6 +1308,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySetArchiveAttributeTrue() {
 	_require.NoError(err)
 	_require.NotEqualValues(resp2.FileCreationTime, cResp.FileCreationTime)
 	_require.NotEqualValues(resp2.FileLastWriteTime, cResp.FileLastWriteTime)
+	_require.NotEqualValues(resp2.FileChangeTime, cResp.FileChangeTime)
 	_require.Contains(*resp2.FileAttributes, "Archive")
 }
 
@@ -1310,6 +1333,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySetArchiveAttributeFalse() {
 	_require.NoError(err)
 	_require.NotNil(cResp.FileCreationTime)
 	_require.NotNil(cResp.FileLastWriteTime)
+	_require.NotNil(cResp.FileChangeTime)
 	_require.NotNil(cResp.FileAttributes)
 	_require.NotNil(cResp.FilePermissionKey)
 
@@ -1327,6 +1351,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySetArchiveAttributeFalse() {
 	_require.NoError(err)
 	_require.NotEqualValues(resp2.FileCreationTime, cResp.FileCreationTime)
 	_require.NotEqualValues(resp2.FileLastWriteTime, cResp.FileLastWriteTime)
+	_require.NotEqualValues(resp2.FileChangeTime, cResp.FileChangeTime)
 	_require.NotContains(*resp2.FileAttributes, "Archive")
 }
 
@@ -1347,6 +1372,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyDestReadOnly() {
 	_require.NoError(err)
 	_require.NotNil(cResp.FileCreationTime)
 	_require.NotNil(cResp.FileLastWriteTime)
+	_require.NotNil(cResp.FileChangeTime)
 	_require.NotNil(cResp.FileAttributes)
 	_require.NotNil(cResp.FilePermissionKey)
 
@@ -1370,6 +1396,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyDestReadOnly() {
 	_require.NoError(err)
 	_require.NotEqualValues(resp2.FileCreationTime, cResp.FileCreationTime)
 	_require.NotEqualValues(resp2.FileLastWriteTime, cResp.FileLastWriteTime)
+	_require.NotEqualValues(resp2.FileChangeTime, cResp.FileChangeTime)
 }
 
 func (f *FileRecordedTestsSuite) TestNegativeFileStartCopyDestReadOnly() {
@@ -1389,6 +1416,7 @@ func (f *FileRecordedTestsSuite) TestNegativeFileStartCopyDestReadOnly() {
 	_require.NoError(err)
 	_require.NotNil(cResp.FileCreationTime)
 	_require.NotNil(cResp.FileLastWriteTime)
+	_require.NotNil(cResp.FileChangeTime)
 	_require.NotNil(cResp.FileAttributes)
 	_require.NotNil(cResp.FilePermissionKey)
 

--- a/sdk/storage/azfile/file/constants.go
+++ b/sdk/storage/azfile/file/constants.go
@@ -77,7 +77,7 @@ type TransferValidationType = exported.TransferValidationType
 // TransferValidationTypeMD5 is a TransferValidationType used to provide a precomputed MD5.
 type TransferValidationTypeMD5 = exported.TransferValidationTypeMD5
 
-// ShareTokenIntent defines values for ShareTokenIntent
+// ShareTokenIntent is required if authorization header specifies an OAuth token.
 type ShareTokenIntent = generated.ShareTokenIntent
 
 const (
@@ -87,4 +87,17 @@ const (
 // PossibleShareTokenIntentValues returns the possible values for the ShareTokenIntent const type.
 func PossibleShareTokenIntentValues() []ShareTokenIntent {
 	return generated.PossibleShareTokenIntentValues()
+}
+
+// LastWrittenMode specifies if the file last write time should be preserved or overwritten
+type LastWrittenMode = generated.FileLastWrittenMode
+
+const (
+	LastWrittenModeNow      LastWrittenMode = generated.FileLastWrittenModeNow
+	LastWrittenModePreserve LastWrittenMode = generated.FileLastWrittenModePreserve
+)
+
+// PossibleLastWrittenModeValues returns the possible values for the LastWrittenMode const type.
+func PossibleLastWrittenModeValues() []LastWrittenMode {
+	return generated.PossibleFileLastWrittenModeValues()
 }

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -540,6 +540,8 @@ type UploadRangeOptions struct {
 	TransactionalValidation TransferValidationType
 	// LeaseAccessConditions contains optional parameters to access leased entity.
 	LeaseAccessConditions *LeaseAccessConditions
+	// LastWrittenMode specifies if the file last write time should be preserved or overwritten.
+	LastWrittenMode *LastWrittenMode
 }
 
 func (o *UploadRangeOptions) format(offset int64, body io.ReadSeekCloser) (string, int64, *generated.FileClientUploadRangeOptions, *generated.LeaseAccessConditions, error) {
@@ -570,6 +572,7 @@ func (o *UploadRangeOptions) format(offset int64, body io.ReadSeekCloser) (strin
 
 	if o != nil {
 		leaseAccessConditions = o.LeaseAccessConditions
+		uploadRangeOptions.FileLastWrittenMode = o.LastWrittenMode
 	}
 	if o != nil && o.TransactionalValidation != nil {
 		_, err = o.TransactionalValidation.Apply(body, uploadRangeOptions)
@@ -612,6 +615,8 @@ type UploadRangeFromURLOptions struct {
 	SourceContentCRC64             uint64
 	SourceModifiedAccessConditions *SourceModifiedAccessConditions
 	LeaseAccessConditions          *LeaseAccessConditions
+	// LastWrittenMode specifies if the file last write time should be preserved or overwritten.
+	LastWrittenMode *LastWrittenMode
 }
 
 func (o *UploadRangeFromURLOptions) format(sourceOffset int64, destinationOffset int64, count int64) (string, *generated.FileClientUploadRangeFromURLOptions, *generated.SourceModifiedAccessConditions, *generated.LeaseAccessConditions, error) {
@@ -635,6 +640,7 @@ func (o *UploadRangeFromURLOptions) format(sourceOffset int64, destinationOffset
 
 	if o != nil {
 		opts.CopySourceAuthorization = o.CopySourceAuthorization
+		opts.FileLastWrittenMode = o.LastWrittenMode
 		sourceModifiedAccessConditions = o.SourceModifiedAccessConditions
 		leaseAccessConditions = o.LeaseAccessConditions
 

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -295,6 +295,9 @@ type CopyFileSMBInfo struct {
 	// Specifies either the option to copy file attributes from a source file(source) to a target file or a list of attributes
 	// to set on a target file.
 	Attributes CopyFileAttributes
+	// Specifies either the option to copy file change time from a source file(source) to a target file or a time value in
+	// ISO 8601 format to set as change time on a target file.
+	ChangeTime CopyFileChangeTime
 	// Specifies either the option to copy file creation time from a source file(source) to a target file or a time value in ISO
 	// 8601 format to set as creation time on a target file.
 	CreationTime CopyFileCreationTime
@@ -331,6 +334,9 @@ func (c *CopyFileSMBInfo) format() *generated.CopyFileSMBInfo {
 	if c.LastWriteTime != nil {
 		opts.FileLastWriteTime = c.LastWriteTime.FormatLastWriteTime()
 	}
+	if c.ChangeTime != nil {
+		opts.FileChangeTime = c.ChangeTime.FormatChangeTime()
+	}
 
 	return opts
 }
@@ -344,6 +350,16 @@ type SourceCopyFileAttributes = exported.SourceCopyFileAttributes
 
 // DestinationCopyFileAttributes specifies a list of attributes to set on a target file.
 type DestinationCopyFileAttributes = exported.DestinationCopyFileAttributes
+
+// CopyFileChangeTime specifies either the option to copy file change time from a source file(source) to a target file or
+// a time value in ISO 8601 format to set as change time on a target file.
+type CopyFileChangeTime = exported.CopyFileChangeTime
+
+// SourceCopyFileChangeTime specifies to copy file change time from a source file(source) to a target file.
+type SourceCopyFileChangeTime = exported.SourceCopyFileChangeTime
+
+// DestinationCopyFileChangeTime specifies a time value in ISO 8601 format to set as change time on a target file.
+type DestinationCopyFileChangeTime = exported.DestinationCopyFileChangeTime
 
 // CopyFileCreationTime specifies either the option to copy file creation time from a source file(source) to a target file or
 // a time value in ISO 8601 format to set as creation time on a target file.

--- a/sdk/storage/azfile/internal/exported/copy_file_smb_options.go
+++ b/sdk/storage/azfile/internal/exported/copy_file_smb_options.go
@@ -68,6 +68,34 @@ func (d DestinationCopyFileLastWriteTime) notPubliclyImplementable() {}
 
 // ---------------------------------------------------------------------------------------------------------------------
 
+// CopyFileChangeTime specifies either the option to copy file change time from a source file(source) to a target file or
+// a time value in ISO 8601 format to set as change time on a target file.
+type CopyFileChangeTime interface {
+	FormatChangeTime() *string
+	notPubliclyImplementable()
+}
+
+// SourceCopyFileChangeTime specifies to copy file change time from a source file(source) to a target file.
+type SourceCopyFileChangeTime struct {
+}
+
+func (s SourceCopyFileChangeTime) FormatChangeTime() *string {
+	return to.Ptr("source")
+}
+
+func (s SourceCopyFileChangeTime) notPubliclyImplementable() {}
+
+// DestinationCopyFileChangeTime specifies a time value in ISO 8601 format to set as change time on a target file.
+type DestinationCopyFileChangeTime time.Time
+
+func (d DestinationCopyFileChangeTime) FormatChangeTime() *string {
+	return to.Ptr(time.Time(d).UTC().Format(generated.ISO8601))
+}
+
+func (d DestinationCopyFileChangeTime) notPubliclyImplementable() {}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
 // CopyFileAttributes specifies either the option to copy file attributes from a source file(source) to a target file or
 // a list of attributes to set on a target file.
 type CopyFileAttributes interface {


### PR DESCRIPTION
* Added `x-ms-file-change-time` request header in
  * Create File/Directory
  * Set File/Directory Properties
  * Copy File
* Added `x-ms-file-last-write-time` request header in Put Range and Put Range from URL.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
