### PR TITLE
azfile: Add encryption scope in account SAS

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added OAuth support.
 * Added [Rename Directory API](https://learn.microsoft.com/rest/api/storageservices/rename-directory).
 * Added [Rename File API](https://learn.microsoft.com/rest/api/storageservices/rename-file).
+* Updated the SAS Version to `2022-11-02` and added `Encryption Scope` to Account SAS.
 
 ### Breaking Changes
 

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -2930,7 +2930,8 @@ func (f *FileRecordedTestsSuite) TestFileGetRangeListSnapshot() {
 	fileSize := int64(512)
 	fClient := setupGetRangeListTest(_require, testName, fileSize, shareClient)
 
-	resp, _ := shareClient.CreateSnapshot(context.Background(), nil)
+	resp, err := shareClient.CreateSnapshot(context.Background(), nil)
+	_require.NoError(err)
 	_require.NotNil(resp.Snapshot)
 
 	resp2, err := fClient.GetRangeList(context.Background(), &file.GetRangeListOptions{

--- a/sdk/storage/azfile/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azfile/internal/testcommon/clients_auth.go
@@ -42,6 +42,7 @@ const (
 	AccountNameEnvVar           = "AZURE_STORAGE_ACCOUNT_NAME"
 	AccountKeyEnvVar            = "AZURE_STORAGE_ACCOUNT_KEY"
 	DefaultEndpointSuffixEnvVar = "AZURE_STORAGE_ENDPOINT_SUFFIX"
+	EncryptionScopeEnvVar       = "AZURE_STORAGE_ENCRYPTION_SCOPE"
 )
 
 const (

--- a/sdk/storage/azfile/lease/client_test.go
+++ b/sdk/storage/azfile/lease/client_test.go
@@ -70,9 +70,10 @@ func (l *LeaseRecordedTestsSuite) TestShareAcquireLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
+	_require.NoError(err)
 
 	ctx := context.Background()
 	acquireLeaseResponse, err := shareLeaseClient.Acquire(ctx, int32(60), nil)
@@ -98,13 +99,15 @@ func (l *LeaseRecordedTestsSuite) TestNegativeShareAcquireMultipleLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient0, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient0, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
+	_require.NoError(err)
 
-	shareLeaseClient1, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient1, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[1],
 	})
+	_require.NoError(err)
 
 	ctx := context.Background()
 	acquireLeaseResponse0, err := shareLeaseClient0.Acquire(ctx, int32(60), nil)
@@ -131,9 +134,10 @@ func (l *LeaseRecordedTestsSuite) TestShareDeleteShareWithoutLeaseId() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
+	_require.NoError(err)
 
 	ctx := context.Background()
 	acquireLeaseResponse, err := shareLeaseClient.Acquire(ctx, int32(60), nil)
@@ -162,9 +166,10 @@ func (l *LeaseRecordedTestsSuite) TestShareReleaseLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
+	_require.NoError(err)
 
 	ctx := context.Background()
 	acquireLeaseResponse, err := shareLeaseClient.Acquire(ctx, int32(60), nil)
@@ -193,9 +198,10 @@ func (l *LeaseRecordedTestsSuite) TestShareRenewLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
+	_require.NoError(err)
 
 	ctx := context.Background()
 	acquireLeaseResponse, err := shareLeaseClient.Acquire(ctx, int32(15), nil)
@@ -221,9 +227,10 @@ func (l *LeaseRecordedTestsSuite) TestShareBreakLeaseDefault() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
+	_require.NoError(err)
 
 	ctx := context.Background()
 	acquireLeaseResponse, err := shareLeaseClient.Acquire(ctx, int32(60), nil)
@@ -253,9 +260,10 @@ func (l *LeaseRecordedTestsSuite) TestShareBreakLeaseNonDefault() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
+	_require.NoError(err)
 
 	ctx := context.Background()
 	acquireLeaseResponse, err := shareLeaseClient.Acquire(ctx, int32(60), nil)
@@ -290,9 +298,10 @@ func (l *LeaseRecordedTestsSuite) TestNegativeShareBreakRenewLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
+	_require.NoError(err)
 
 	ctx := context.Background()
 	acquireLeaseResponse, err := shareLeaseClient.Acquire(ctx, int32(60), nil)
@@ -325,9 +334,10 @@ func (l *LeaseRecordedTestsSuite) TestShareChangeLease() {
 	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
 	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
 
-	shareLeaseClient, _ := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
+	shareLeaseClient, err := lease.NewShareClient(shareClient, &lease.ShareClientOptions{
 		LeaseID: proposedLeaseIDs[0],
 	})
+	_require.NoError(err)
 
 	ctx := context.Background()
 	acquireLeaseResponse, err := shareLeaseClient.Acquire(ctx, int32(60), nil)

--- a/sdk/storage/azfile/sas/account.go
+++ b/sdk/storage/azfile/sas/account.go
@@ -22,13 +22,14 @@ type SharedKeyCredential = exported.SharedKeyCredential
 // AccountSignatureValues is used to generate a Shared Access Signature (SAS) for an Azure Storage account.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/constructing-an-account-sas
 type AccountSignatureValues struct {
-	Version       string    `param:"sv"`  // If not specified, this format to SASVersion
-	Protocol      Protocol  `param:"spr"` // See the SASProtocol* constants
-	StartTime     time.Time `param:"st"`  // Not specified if IsZero
-	ExpiryTime    time.Time `param:"se"`  // Not specified if IsZero
-	Permissions   string    `param:"sp"`  // Create by initializing AccountPermissions and then call String()
-	IPRange       IPRange   `param:"sip"`
-	ResourceTypes string    `param:"srt"` // Create by initializing AccountResourceTypes and then call String()
+	Version         string    `param:"sv"`  // If not specified, this format to SASVersion
+	Protocol        Protocol  `param:"spr"` // See the SASProtocol* constants
+	StartTime       time.Time `param:"st"`  // Not specified if IsZero
+	ExpiryTime      time.Time `param:"se"`  // Not specified if IsZero
+	Permissions     string    `param:"sp"`  // Create by initializing AccountPermissions and then call String()
+	IPRange         IPRange   `param:"sip"`
+	ResourceTypes   string    `param:"srt"` // Create by initializing AccountResourceTypes and then call String()
+	EncryptionScope string    `param:"ses"`
 }
 
 // SignWithSharedKey uses an account's shared key credential to sign this signature values to produce
@@ -65,6 +66,7 @@ func (v AccountSignatureValues) SignWithSharedKey(sharedKeyCredential *SharedKey
 		v.IPRange.String(),
 		string(v.Protocol),
 		v.Version,
+		v.EncryptionScope,
 		""}, // That is right, the account SAS requires a terminating extra newline
 		"\n")
 
@@ -74,12 +76,13 @@ func (v AccountSignatureValues) SignWithSharedKey(sharedKeyCredential *SharedKey
 	}
 	p := QueryParameters{
 		// Common SAS parameters
-		version:     v.Version,
-		protocol:    v.Protocol,
-		startTime:   v.StartTime,
-		expiryTime:  v.ExpiryTime,
-		permissions: v.Permissions,
-		ipRange:     v.IPRange,
+		version:         v.Version,
+		protocol:        v.Protocol,
+		startTime:       v.StartTime,
+		expiryTime:      v.ExpiryTime,
+		permissions:     v.Permissions,
+		ipRange:         v.IPRange,
+		encryptionScope: v.EncryptionScope,
 
 		// Account-specific SAS parameters
 		services:      "f", // will always be "f" for Azure File

--- a/sdk/storage/azfile/sas/query_params.go
+++ b/sdk/storage/azfile/sas/query_params.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	// Version is the default version encoded in the SAS token.
-	Version = "2020-02-10"
+	Version = "2022-11-02"
 )
 
 // TimeFormats ISO 8601 format.
@@ -127,6 +127,7 @@ type QueryParameters struct {
 	resource           string    `param:"sr"`
 	permissions        string    `param:"sp"`
 	signature          string    `param:"sig"`
+	encryptionScope    string    `param:"ses"`
 	cacheControl       string    `param:"rscc"`
 	contentDisposition string    `param:"rscd"`
 	contentEncoding    string    `param:"rsce"`
@@ -197,6 +198,11 @@ func (p *QueryParameters) Signature() string {
 	return p.signature
 }
 
+// EncryptionScope returns encryption scope.
+func (p *QueryParameters) EncryptionScope() string {
+	return p.encryptionScope
+}
+
 // CacheControl returns cacheControl.
 func (p *QueryParameters) CacheControl() string {
 	return p.cacheControl
@@ -259,6 +265,9 @@ func (p *QueryParameters) Encode() string {
 	if p.signature != "" {
 		v.Add("sig", p.signature)
 	}
+	if p.encryptionScope != "" {
+		v.Add("ses", p.encryptionScope)
+	}
 	if p.cacheControl != "" {
 		v.Add("rscc", p.cacheControl)
 	}
@@ -318,6 +327,8 @@ func NewQueryParameters(values url.Values, deleteSASParametersFromValues bool) Q
 			p.permissions = val
 		case "sig":
 			p.signature = val
+		case "ses":
+			p.encryptionScope = val
 		case "rscc":
 			p.cacheControl = val
 		case "rscd":

--- a/sdk/storage/azfile/sas/query_params_test.go
+++ b/sdk/storage/azfile/sas/query_params_test.go
@@ -132,7 +132,7 @@ func TestIPRange_String(t *testing.T) {
 
 func TestSAS(t *testing.T) {
 	// Note: This is a totally invalid fake SAS, this is just testing our ability to parse different query parameters on a SAS
-	const sas = "sv=2019-12-12&sr=b&st=2111-01-09T01:42:34.936Z&se=2222-03-09T01:42:34.936Z&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https,http&si=myIdentifier&ss=bf&srt=s&rscc=cc&rscd=cd&rsce=ce&rscl=cl&rsct=ct&sig=clNxbtnkKSHw7f3KMEVVc4agaszoRFdbZr%2FWBmPNsrw%3D"
+	const sas = "sv=2019-12-12&sr=b&st=2111-01-09T01:42:34.936Z&se=2222-03-09T01:42:34.936Z&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https,http&si=myIdentifier&ss=bf&srt=s&rscc=cc&rscd=cd&rsce=ce&rscl=cl&rsct=ct&ses=test&sig=clNxbtnkKSHw7f3KMEVVc4agaszoRFdbZr%2FWBmPNsrw%3D"
 	_url := fmt.Sprintf("https://teststorageaccount.file.core.windows.net/testshare/testpath?%s", sas)
 	_uri, err := url.Parse(_url)
 	require.NoError(t, err)
@@ -177,6 +177,7 @@ func validateSAS(t *testing.T, sas string, parameters QueryParameters) {
 	require.NoError(t, err)
 
 	require.Equal(t, parameters.Signature(), sign)
+	require.Equal(t, parameters.EncryptionScope(), sasCompMap["ses"])
 	require.Equal(t, parameters.CacheControl(), sasCompMap["rscc"])
 	require.Equal(t, parameters.ContentDisposition(), sasCompMap["rscd"])
 	require.Equal(t, parameters.ContentEncoding(), sasCompMap["rsce"])

--- a/sdk/storage/azfile/service/client_test.go
+++ b/sdk/storage/azfile/service/client_test.go
@@ -524,10 +524,8 @@ func (s *ServiceUnrecordedTestsSuite) TestAccountSASEncryptionScope() {
 	cred, err := testcommon.GetGenericSharedKeyCredential(testcommon.TestAccountDefault)
 	_require.NoError(err)
 
-	//encryptionScope, err := testcommon.GetRequiredEnv(testcommon.EncryptionScopeEnvVar)
-	//_require.NoError(err)
-
-	encryptionScope := "blobgokeytestscope"
+	encryptionScope, err := testcommon.GetRequiredEnv(testcommon.EncryptionScopeEnvVar)
+	_require.NoError(err)
 
 	resources := sas.AccountResourceTypes{
 		Object:    true,
@@ -577,4 +575,13 @@ func (s *ServiceUnrecordedTestsSuite) TestAccountSASEncryptionScope() {
 		_require.NotNil(resp.Shares[0].Name)
 		_require.Equal(*resp.Shares[0].Name, shareName)
 	}
+
+	shareClient := svcClient.NewShareClient(shareName)
+	fileClient := shareClient.NewRootDirectoryClient().NewFileClient(testcommon.GenerateFileName(testName))
+
+	_, err = fileClient.Create(context.Background(), 2048, nil)
+	_require.NoError(err)
+
+	_, err = fileClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
 }


### PR DESCRIPTION
Updated the SAS Version to `2022-11-02` and added `Encryption Scope` to Account SAS.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
