### PR TITLE
Test List Blobs Fix for Invalid XML Characters 

### DIFF
--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_d0185a175d"
+  "Tag": "go/storage/azblob_7a25fb98e8"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_816342f61e"
+  "Tag": "go/storage/azblob_d0185a175d"
 }

--- a/sdk/storage/azblob/container/client_test.go
+++ b/sdk/storage/azblob/container/client_test.go
@@ -788,7 +788,7 @@ func (s *ContainerRecordedTestsSuite) TestContainerListBlobsDelimiterPrefixVersi
 	}
 }
 
-func (s *ContainerRecordedTestsSuite) TestContainerListBlobsInvalidPrefix() {
+func (s *ContainerRecordedTestsSuite) TestContainerListFlatBlobsInvalidBlobName() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
@@ -811,7 +811,7 @@ func (s *ContainerRecordedTestsSuite) TestContainerListBlobsInvalidPrefix() {
 	}
 }
 
-func (s *ContainerRecordedTestsSuite) TestContainerListHierarchyBlobsInvalidPrefix() {
+func (s *ContainerRecordedTestsSuite) TestContainerListHierarchyBlobsInvalidBlobName() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)

--- a/sdk/storage/azblob/container/client_test.go
+++ b/sdk/storage/azblob/container/client_test.go
@@ -788,6 +788,63 @@ func (s *ContainerRecordedTestsSuite) TestContainerListBlobsDelimiterPrefixVersi
 	}
 }
 
+func (s *ContainerRecordedTestsSuite) TestContainerListBlobsInvalidPrefix() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := "dir1/dir2/file\uFFFF.blob"
+	_ = testcommon.CreateNewBlockBlob(context.Background(), _require, blobName, containerClient)
+
+	pager := containerClient.NewListBlobsFlatPager(nil)
+	for pager.More() {
+		resp, err := pager.NextPage(context.Background())
+		_require.NoError(err)
+
+		_require.Equal(len(resp.Segment.BlobItems), 1)
+		_require.Equal(*resp.Segment.BlobItems[0].Name, blobName)
+	}
+}
+
+func (s *ContainerRecordedTestsSuite) TestContainerListHierarchyBlobsInvalidPrefix() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := "dir1/dir2/file\uFFFF.blob"
+	_ = testcommon.CreateNewBlockBlob(context.Background(), _require, blobName, containerClient)
+
+	pager := containerClient.NewListBlobsHierarchyPager(".b", nil)
+	for pager.More() {
+		resp, err := pager.NextPage(context.Background())
+		_require.NoError(err)
+
+		_require.Equal(len(resp.Segment.BlobItems), 0)
+		_require.Equal(len(resp.Segment.BlobPrefixes), 1)
+		_require.Equal(*resp.Segment.BlobPrefixes[0].Name, "dir1/dir2/file\uFFFF.b")
+	}
+
+	// empty delimiter
+	pager1 := containerClient.NewListBlobsHierarchyPager("", nil)
+	for pager1.More() {
+		resp, err := pager1.NextPage(context.Background())
+		_require.NoError(err)
+
+		_require.Equal(len(resp.Segment.BlobItems), 1)
+		_require.Equal(*resp.Segment.BlobItems[0].Name, blobName)
+	}
+}
+
 func (s *ContainerRecordedTestsSuite) TestContainerListBlobsWithSnapshots() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/internal/generated/models.go
+++ b/sdk/storage/azblob/internal/generated/models.go
@@ -7,9 +7,9 @@
 package generated
 
 import (
-	"encoding/base64"
 	"encoding/xml"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"net/url"
 )
 
 type TransactionalContentSetter interface {
@@ -94,7 +94,9 @@ func (b *BlobPrefix) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) erro
 	}
 	if aux.BlobName != nil {
 		if aux.BlobName.Encoded != nil && *aux.BlobName.Encoded {
-			name, err := base64.StdEncoding.DecodeString(*aux.BlobName.Content)
+			name, err := url.QueryUnescape(*aux.BlobName.Content)
+
+			// name, err := base64.StdEncoding.DecodeString(*aux.BlobName.Content)
 			if err != nil {
 				return err
 			}
@@ -124,7 +126,9 @@ func (b *BlobItem) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error 
 	b.OrMetadata = (map[string]*string)(aux.OrMetadata)
 	if aux.BlobName != nil {
 		if aux.BlobName.Encoded != nil && *aux.BlobName.Encoded {
-			name, err := base64.StdEncoding.DecodeString(*aux.BlobName.Content)
+			name, err := url.QueryUnescape(*aux.BlobName.Content)
+
+			// name, err := base64.StdEncoding.DecodeString(*aux.BlobName.Content)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- Test to check that invalid blob names are parsed correctly when List Flat & List Hierarchy 
- Changed decoding behavior from `base64.StdEncoding.DecodeString` to `url.QueryUnescape` because of error message `unmarshalling type *generated.ListBlobsFlatSegmentResponse: illegal base64 data at input byte 4`

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
