### PR TITLE
[azopenai] Retract old congitiveservices/azopenai package.

### DIFF
--- a/sdk/cognitiveservices/azopenai/CHANGELOG.md
+++ b/sdk/cognitiveservices/azopenai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.1.2 (2023-08-10)
+
+### Breaking Changes
+
+* Retracting this module to delist it from pkg.go.dev. Use `github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai` instead.
+
 ## 0.1.1 (2023-07-26)
 
 ### Breaking Changes

--- a/sdk/cognitiveservices/azopenai/CHANGELOG.md
+++ b/sdk/cognitiveservices/azopenai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.1.2 (2023-08-10)
+## 0.1.2 (2023-08-14)
 
 ### Breaking Changes
 

--- a/sdk/cognitiveservices/azopenai/go.mod
+++ b/sdk/cognitiveservices/azopenai/go.mod
@@ -3,6 +3,8 @@ module github.com/Azure/azure-sdk-for-go/sdk/cognitiveservices/azopenai
 
 go 1.18
 
+retract [v0.1.0, v0.1.2] // use github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai instead.
+
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0

--- a/sdk/cognitiveservices/azopenai/version.go
+++ b/sdk/cognitiveservices/azopenai/version.go
@@ -7,5 +7,5 @@
 package azopenai
 
 const (
-	version = "v0.1.1"
+	version = "v0.1.2"
 )


### PR DESCRIPTION
Formally retract this package. Retracting the entire range (first to last release) will also delist it from pkg.go.dev.

Second to last part of #21260