### PR TITLE
Include response body in IMDS 400 error message

### DIFF
--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -181,10 +180,9 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
 			return azcore.AccessToken{}, newAuthenticationFailedError(credNameManagedIdentity, "the requested identity isn't assigned to this resource", resp, nil)
 		}
 		msg := "failed to authenticate a system assigned identity"
-		if body, err := io.ReadAll(resp.Body); err == nil && len(body) > 0 {
+		if body, err := runtime.Payload(resp); err == nil && len(body) > 0 {
 			msg += fmt.Sprintf(". The endpoint responded with %s", body)
 		}
-		resp.Body.Close()
 		return azcore.AccessToken{}, newCredentialUnavailableError(credNameManagedIdentity, msg)
 	}
 

--- a/sdk/azidentity/managed_identity_client_test.go
+++ b/sdk/azidentity/managed_identity_client_test.go
@@ -87,11 +87,11 @@ func TestManagedIdentityClient_IMDS400(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = client.authenticate(context.Background(), nil, []string{liveTestScope})
+	_, err = client.authenticate(context.Background(), nil, testTRO.Scopes)
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if actual := err.Error(); !strings.Contains(err.Error(), body) {
+	if actual := err.Error(); !strings.Contains(actual, body) {
 		t.Fatalf("expected response body in error, got %q", actual)
 	}
 }


### PR DESCRIPTION
This makes the message more helpful, especially when the client gets a response from something other than IMDS. Closes #19510