### PR TITLE
azfile: Support for invalid XML characters

### DIFF
--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_7cda641151"
+  "Tag": "go/storage/azfile_0fe0439957"
 }

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_0fe0439957"
+  "Tag": "go/storage/azfile_66b915bf67"
 }

--- a/sdk/storage/azfile/internal/generated/models.go
+++ b/sdk/storage/azfile/internal/generated/models.go
@@ -7,9 +7,9 @@
 package generated
 
 import (
-	"encoding/base64"
 	"encoding/xml"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"net/url"
 	"time"
 )
 
@@ -66,7 +66,7 @@ func (h *Handle) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	h.OpenTime = (*time.Time)(aux.OpenTime)
 	if aux.Path != nil {
 		if aux.Path.Encoded != nil && *aux.Path.Encoded {
-			name, err := base64.StdEncoding.DecodeString(*aux.Path.Content)
+			name, err := url.QueryUnescape(*aux.Path.Content)
 			if err != nil {
 				return err
 			}
@@ -92,7 +92,7 @@ func (d *Directory) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error
 	}
 	if aux.Name != nil {
 		if aux.Name.Encoded != nil && *aux.Name.Encoded {
-			name, err := base64.StdEncoding.DecodeString(*aux.Name.Content)
+			name, err := url.QueryUnescape(*aux.Name.Content)
 			if err != nil {
 				return err
 			}
@@ -104,7 +104,7 @@ func (d *Directory) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error
 	return nil
 }
 
-// UnmarshalXML implements the xml.Unmarshaller interface for type Directory.
+// UnmarshalXML implements the xml.Unmarshaller interface for type File.
 func (f *File) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias File
 	aux := &struct {
@@ -118,7 +118,7 @@ func (f *File) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	}
 	if aux.Name != nil {
 		if aux.Name.Encoded != nil && *aux.Name.Encoded {
-			name, err := base64.StdEncoding.DecodeString(*aux.Name.Content)
+			name, err := url.QueryUnescape(*aux.Name.Content)
 			if err != nil {
 				return err
 			}
@@ -130,7 +130,7 @@ func (f *File) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	return nil
 }
 
-// UnmarshalXML implements the xml.Unmarshaller interface for type Directory.
+// UnmarshalXML implements the xml.Unmarshaller interface for type ListFilesAndDirectoriesSegmentResponse.
 func (l *ListFilesAndDirectoriesSegmentResponse) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias ListFilesAndDirectoriesSegmentResponse
 	aux := &struct {
@@ -144,7 +144,7 @@ func (l *ListFilesAndDirectoriesSegmentResponse) UnmarshalXML(dec *xml.Decoder, 
 	}
 	if aux.Prefix != nil {
 		if aux.Prefix.Encoded != nil && *aux.Prefix.Encoded {
-			name, err := base64.StdEncoding.DecodeString(*aux.Prefix.Content)
+			name, err := url.QueryUnescape(*aux.Prefix.Content)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
