### PR TITLE
ARM auth policy opts in to CAE

### DIFF
--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -34,6 +34,9 @@ type mockCredential struct {
 }
 
 func (mc mockCredential) GetToken(ctx context.Context, options azpolicy.TokenRequestOptions) (azcore.AccessToken, error) {
+	if !options.EnableCAE {
+		return azcore.AccessToken{}, errors.New("ARM clients should set EnableCAE to true")
+	}
 	if mc.getTokenImpl != nil {
 		return mc.getTokenImpl(ctx, options)
 	}


### PR DESCRIPTION
CAE is now disabled by default, so clients for RPs like ARM which support CAE must declare explicitly opt in. I renamed `acquire` to clarify that it's called only for auxiliary tenants. This would be an important distinction if it turns out we shouldn't request CAE tokens from auxiliary tenants.