### PR TITLE
Updated cosmos_container.go: PatchItem function to respect enableContentResponseOnWrite 

### DIFF
--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -475,6 +475,8 @@ func (c *ContainerClient) PatchItem(
 
 	if o == nil {
 		o = &ItemOptions{}
+	} else {
+		h.enableContentResponseOnWrite = &o.EnableContentResponseOnWrite
 	}
 
 	operationContext := pipelineRequestOptions{


### PR DESCRIPTION

Updated `cosmos_container.go`: `PatchItem` function to respect `enableContentResponseOnWrite` option similar to how it is handled in `CreateItem`, `ReplaceItem`

Issue for this bugfix: https://github.com/Azure/azure-sdk-for-go/issues/21389

