### PR TITLE
Fixed issue where customers could not capture response of directory and file GetProperties calls

### DIFF
--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed an issue where customers could not capture the raw HTTP response of directory and file GetProperties operations.
 
 ### Other Changes
 

--- a/sdk/storage/azdatalake/assets.json
+++ b/sdk/storage/azdatalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azdatalake",
-  "Tag": "go/storage/azdatalake_c3c16cffab"
+  "Tag": "go/storage/azdatalake_080efc14e8"
 }

--- a/sdk/storage/azdatalake/assets.json
+++ b/sdk/storage/azdatalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azdatalake",
-  "Tag": "go/storage/azdatalake_080efc14e8"
+  "Tag": "go/storage/azdatalake_93ff4d0fca"
 }

--- a/sdk/storage/azdatalake/directory/client.go
+++ b/sdk/storage/azdatalake/directory/client.go
@@ -56,6 +56,11 @@ func NewClient(directoryURL string, cred azcore.TokenCredential, options *Client
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	blobClientOpts := blockblob.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -84,6 +89,12 @@ func NewClientWithNoCredential(directoryURL string, options *ClientOptions) (*Cl
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
+
 	blobClientOpts := blockblob.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -115,6 +126,11 @@ func NewClientWithSharedKeyCredential(directoryURL string, cred *SharedKeyCreden
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	blobClientOpts := blockblob.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -230,7 +246,7 @@ func (d *Client) Delete(ctx context.Context, options *DeleteOptions) (DeleteResp
 func (d *Client) GetProperties(ctx context.Context, options *GetPropertiesOptions) (GetPropertiesResponse, error) {
 	opts := path.FormatGetPropertiesOptions(options)
 	var respFromCtx *http.Response
-	ctxWithResp := runtime.WithCaptureResponse(ctx, &respFromCtx)
+	ctxWithResp := shared.WithCaptureBlobResponse(ctx, &respFromCtx)
 	resp, err := d.blobClient().GetProperties(ctxWithResp, opts)
 	newResp := path.FormatGetPropertiesResponse(&resp, respFromCtx)
 	err = exported.ConvertToDFSError(err)

--- a/sdk/storage/azdatalake/directory/client.go
+++ b/sdk/storage/azdatalake/directory/client.go
@@ -211,14 +211,15 @@ func (d *Client) NewFileClient(fileName string) (*file.Client, error) {
 	fileURL := runtime.JoinPaths(d.DFSURL(), fileName)
 	newBlobURL, fileURL := shared.GetURLs(fileURL)
 	var newBlobClient *blockblob.Client
+	clientOptions := &blockblob.ClientOptions{ClientOptions: d.getClientOptions().ClientOptions}
 	var err error
 	if d.identityCredential() != nil {
-		newBlobClient, err = blockblob.NewClient(newBlobURL, *d.identityCredential(), nil)
+		newBlobClient, err = blockblob.NewClient(newBlobURL, *d.identityCredential(), clientOptions)
 	} else if d.sharedKey() != nil {
 		blobSharedKey, _ := exported.ConvertToBlobSharedKey(d.sharedKey())
-		newBlobClient, err = blockblob.NewClientWithSharedKeyCredential(newBlobURL, blobSharedKey, nil)
+		newBlobClient, err = blockblob.NewClientWithSharedKeyCredential(newBlobURL, blobSharedKey, clientOptions)
 	} else {
-		newBlobClient, err = blockblob.NewClientWithNoCredential(newBlobURL, nil)
+		newBlobClient, err = blockblob.NewClientWithNoCredential(newBlobURL, clientOptions)
 	}
 	if err != nil {
 		return nil, exported.ConvertToDFSError(err)

--- a/sdk/storage/azdatalake/directory/client_test.go
+++ b/sdk/storage/azdatalake/directory/client_test.go
@@ -2485,6 +2485,7 @@ func (s *RecordedTestSuite) TestDirGetPropertiesResponseCapture() {
 
 	// This tests service.NewClient
 	serviceClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
+	_require.Nil(err)
 	fsClient = serviceClient.NewFileSystemClient(filesystemName)
 	dirClient = fsClient.NewDirectoryClient(dirName)
 	var respFromCtxService *http.Response

--- a/sdk/storage/azdatalake/directory/client_test.go
+++ b/sdk/storage/azdatalake/directory/client_test.go
@@ -2464,13 +2464,36 @@ func (s *RecordedTestSuite) TestDirGetPropertiesResponseCapture() {
 	_require.Nil(err)
 	_require.NotNil(resp)
 
-	var respFromCtx *http.Response
-	ctxWithResp := runtime.WithCaptureResponse(context.Background(), &respFromCtx)
-	resp2, err := dirClient.GetProperties(ctxWithResp, nil)
+	// This tests directory.NewClient
+	var respFromCtxDir *http.Response
+	ctxWithRespDir := runtime.WithCaptureResponse(context.Background(), &respFromCtxDir)
+	resp2, err := dirClient.GetProperties(ctxWithRespDir, nil)
 	_require.Nil(err)
 	_require.NotNil(resp2)
-	_require.NotNil(respFromCtx) // validate that the respFromCtx is actually populated
-	_require.Equal("directory", respFromCtx.Header.Get("x-ms-resource-type"))
+	_require.NotNil(respFromCtxDir) // validate that the respFromCtx is actually populated
+	_require.Equal("directory", respFromCtxDir.Header.Get("x-ms-resource-type"))
+
+	// This tests filesystem.NewClient
+	dirClient = fsClient.NewDirectoryClient(dirName)
+	var respFromCtxFs *http.Response
+	ctxWithRespFs := runtime.WithCaptureResponse(context.Background(), &respFromCtxFs)
+	resp2, err = dirClient.GetProperties(ctxWithRespFs, nil)
+	_require.Nil(err)
+	_require.NotNil(resp2)
+	_require.NotNil(respFromCtxFs) // validate that the respFromCtx is actually populated
+	_require.Equal("directory", respFromCtxFs.Header.Get("x-ms-resource-type"))
+
+	// This tests service.NewClient
+	serviceClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
+	fsClient = serviceClient.NewFileSystemClient(filesystemName)
+	dirClient = fsClient.NewDirectoryClient(dirName)
+	var respFromCtxService *http.Response
+	ctxWithRespService := runtime.WithCaptureResponse(context.Background(), &respFromCtxService)
+	resp2, err = dirClient.GetProperties(ctxWithRespService, nil)
+	_require.Nil(err)
+	_require.NotNil(resp2)
+	_require.NotNil(respFromCtxService) // validate that the respFromCtx is actually populated
+	_require.Equal("directory", respFromCtxService.Header.Get("x-ms-resource-type"))
 }
 
 // TODO: more tests for acls

--- a/sdk/storage/azdatalake/file/client.go
+++ b/sdk/storage/azdatalake/file/client.go
@@ -63,6 +63,11 @@ func NewClient(fileURL string, cred azcore.TokenCredential, options *ClientOptio
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	blobClientOpts := blockblob.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -91,6 +96,11 @@ func NewClientWithNoCredential(fileURL string, options *ClientOptions) (*Client,
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	blobClientOpts := blockblob.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -122,6 +132,11 @@ func NewClientWithSharedKeyCredential(fileURL string, cred *SharedKeyCredential,
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	blobClientOpts := blockblob.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -216,7 +231,7 @@ func (f *Client) Delete(ctx context.Context, options *DeleteOptions) (DeleteResp
 func (f *Client) GetProperties(ctx context.Context, options *GetPropertiesOptions) (GetPropertiesResponse, error) {
 	opts := path.FormatGetPropertiesOptions(options)
 	var respFromCtx *http.Response
-	ctxWithResp := runtime.WithCaptureResponse(ctx, &respFromCtx)
+	ctxWithResp := shared.WithCaptureBlobResponse(ctx, &respFromCtx)
 	resp, err := f.blobClient().GetProperties(ctxWithResp, opts)
 	newResp := path.FormatGetPropertiesResponse(&resp, respFromCtx)
 	err = exported.ConvertToDFSError(err)

--- a/sdk/storage/azdatalake/file/client_test.go
+++ b/sdk/storage/azdatalake/file/client_test.go
@@ -3935,9 +3935,11 @@ func (s *RecordedTestSuite) TestFileGetPropertiesResponseCapture() {
 
 	// This tests service.NewClient
 	serviceClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
+	_require.Nil(err)
 	fsClient = serviceClient.NewFileSystemClient(filesystemName)
 	dirClient = fsClient.NewDirectoryClient(dirName)
 	fClient, err = dirClient.NewFileClient(fileName)
+	_require.Nil(err)
 	var respFromCtxService *http.Response
 	ctxWithRespService := runtime.WithCaptureResponse(context.Background(), &respFromCtxService)
 	resp2, err = fClient.GetProperties(ctxWithRespService, nil)
@@ -3950,7 +3952,9 @@ func (s *RecordedTestSuite) TestFileGetPropertiesResponseCapture() {
 	var respFromCtxDir *http.Response
 	ctxWithRespDir := runtime.WithCaptureResponse(context.Background(), &respFromCtxDir)
 	dirClient, err = testcommon.GetDirClient(filesystemName, dirName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.Nil(err)
 	fClient, err = dirClient.NewFileClient(fileName)
+	_require.Nil(err)
 	resp2, err = fClient.GetProperties(ctxWithRespDir, nil)
 	_require.Nil(err)
 	_require.NotNil(resp2)

--- a/sdk/storage/azdatalake/filesystem/client.go
+++ b/sdk/storage/azdatalake/filesystem/client.go
@@ -55,6 +55,11 @@ func NewClient(filesystemURL string, cred azcore.TokenCredential, options *Clien
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	containerClientOpts := container.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -82,6 +87,11 @@ func NewClientWithNoCredential(filesystemURL string, options *ClientOptions) (*C
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	containerClientOpts := container.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -112,6 +122,11 @@ func NewClientWithSharedKeyCredential(filesystemURL string, cred *SharedKeyCrede
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	containerClientOpts := container.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}

--- a/sdk/storage/azdatalake/internal/shared/policy_include_blob_response.go
+++ b/sdk/storage/azdatalake/internal/shared/policy_include_blob_response.go
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package shared
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// NOTE: This is duplication of the azcore includeResponsePolicy, this is necessary for some APIs like directory/file
+// 		 GetProperties. Under the hood, these APIs grab the raw response to construct the datalake properties
+//		 (owner, group, permission) in addition to the blob properties. If we use the includeResponsePolicy, this can
+//		 result in the customer not being able to retrieve the response themselves.
+
+// CtxIncludeBlobResponseKey is used as a context key for retrieving the raw response.
+type CtxIncludeBlobResponseKey struct{}
+
+type includeBlobResponsePolicy struct {
+}
+
+// NewIncludeBlobResponsePolicy creates a policy that retrieves the raw HTTP response upon request
+func NewIncludeBlobResponsePolicy() policy.Policy {
+	return &includeBlobResponsePolicy{}
+}
+
+func (p *includeBlobResponsePolicy) Do(req *policy.Request) (*http.Response, error) {
+	resp, err := req.Next()
+	if resp == nil {
+		return resp, err
+	}
+	if httpOutRaw := req.Raw().Context().Value(CtxIncludeBlobResponseKey{}); httpOutRaw != nil {
+		httpOut := httpOutRaw.(**http.Response)
+		*httpOut = resp
+	}
+	return resp, err
+}
+
+// WithCaptureBlobResponse applies the HTTP response retrieval annotation to the parent context.
+// The resp parameter will contain the HTTP response after the request has completed.
+func WithCaptureBlobResponse(parent context.Context, resp **http.Response) context.Context {
+	return context.WithValue(parent, CtxIncludeBlobResponseKey{}, resp)
+}

--- a/sdk/storage/azdatalake/service/client.go
+++ b/sdk/storage/azdatalake/service/client.go
@@ -54,6 +54,11 @@ func NewClient(serviceURL string, cred azcore.TokenCredential, options *ClientOp
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	blobServiceClientOpts := service.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -80,6 +85,11 @@ func NewClientWithNoCredential(serviceURL string, options *ClientOptions) (*Clie
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	blobServiceClientOpts := service.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}
@@ -110,6 +120,11 @@ func NewClientWithSharedKeyCredential(serviceURL string, cred *SharedKeyCredenti
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	perCallPolicies := []policy.Policy{shared.NewIncludeBlobResponsePolicy()}
+	if options.ClientOptions.PerCallPolicies != nil {
+		perCallPolicies = append(perCallPolicies, options.ClientOptions.PerCallPolicies...)
+	}
+	options.ClientOptions.PerCallPolicies = perCallPolicies
 	blobServiceClientOpts := service.ClientOptions{
 		ClientOptions: options.ClientOptions,
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->
This is duplication of the azcore includeResponsePolicy, this is necessary for some APIs like directory/file
GetProperties. Under the hood, these APIs grab the raw response to construct the datalake properties
(owner, group, permission) in addition to the blob properties. If we use the includeResponsePolicy, this can
result in the customer not being able to retrieve the response themselves.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
