### PR TITLE
[keyvault] fix doc comments

### DIFF
--- a/sdk/security/keyvault/azadmin/CHANGELOG.md
+++ b/sdk/security/keyvault/azadmin/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 1.0.1 (2023-08-21)
+### 1.0.1 (2023-08-22)
 
 #### Other Changes
 * Upgraded dependencies 

--- a/sdk/security/keyvault/azcertificates/autorest.md
+++ b/sdk/security/keyvault/azcertificates/autorest.md
@@ -172,7 +172,7 @@ directive:
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeyCurveName|JsonWebKeyCurveName/g, "CurveName");
+    transform: return $.replace(/JSONWebKeyCurveName/g, "CurveName");
   - from: 
       - models.go
       - constants.go
@@ -246,4 +246,11 @@ directive:
   - from: swagger-document
     where: $.definitions.X509CertificateProperties.properties.key_usage.items
     transform: $["description"] = "Defines how the certificate's key may be used."
+
+  # remove redundant section of doc comment
+  - from:
+      - models.go
+      - constants.go
+    where: $
+    transform: return $.replace(/For valid values, see JsonWebKeyCurveName./g, "");
 ```

--- a/sdk/security/keyvault/azcertificates/autorest.md
+++ b/sdk/security/keyvault/azcertificates/autorest.md
@@ -172,7 +172,7 @@ directive:
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeyCurveName/g, "CurveName");
+    transform: return $.replace(/JSONWebKeyCurveName|JsonWebKeyCurveName/g, "CurveName");
   - from: 
       - models.go
       - constants.go

--- a/sdk/security/keyvault/azcertificates/constants.go
+++ b/sdk/security/keyvault/azcertificates/constants.go
@@ -25,7 +25,7 @@ func PossibleCertificatePolicyActionValues() []CertificatePolicyAction {
 	}
 }
 
-// CurveName - Elliptic curve name. For valid values, see CurveName.
+// CurveName - Elliptic curve name.
 type CurveName string
 
 const (

--- a/sdk/security/keyvault/azcertificates/constants.go
+++ b/sdk/security/keyvault/azcertificates/constants.go
@@ -25,7 +25,7 @@ func PossibleCertificatePolicyActionValues() []CertificatePolicyAction {
 	}
 }
 
-// CurveName - Elliptic curve name. For valid values, see JsonWebKeyCurveName.
+// CurveName - Elliptic curve name. For valid values, see CurveName.
 type CurveName string
 
 const (

--- a/sdk/security/keyvault/azcertificates/models.go
+++ b/sdk/security/keyvault/azcertificates/models.go
@@ -505,7 +505,7 @@ type IssuerPropertiesListResult struct {
 
 // KeyProperties - Properties of the key pair backing a certificate.
 type KeyProperties struct {
-	// Elliptic curve name. For valid values, see CurveName.
+	// Elliptic curve name.
 	Curve *CurveName `json:"crv,omitempty"`
 
 	// Indicates if the private key can be exported. Release policy must be provided when creating the first version of an exportable

--- a/sdk/security/keyvault/azcertificates/models.go
+++ b/sdk/security/keyvault/azcertificates/models.go
@@ -505,7 +505,7 @@ type IssuerPropertiesListResult struct {
 
 // KeyProperties - Properties of the key pair backing a certificate.
 type KeyProperties struct {
-	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
+	// Elliptic curve name. For valid values, see CurveName.
 	Curve *CurveName `json:"crv,omitempty"`
 
 	// Indicates if the private key can be exported. Release policy must be provided when creating the first version of an exportable

--- a/sdk/security/keyvault/azkeys/CHANGELOG.md
+++ b/sdk/security/keyvault/azkeys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.1 (2023-08-21)
+## 1.0.1 (2023-08-22)
 
 ### Other Changes
 * Upgraded dependencies

--- a/sdk/security/keyvault/azkeys/autorest.md
+++ b/sdk/security/keyvault/azkeys/autorest.md
@@ -147,12 +147,12 @@ directive:
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeyOperation|JsonWebKeyOperation/g, "KeyOperation");
+    transform: return $.replace(/JSONWebKeyOperation/g, "KeyOperation");
   - from: 
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeyCurveName|JsonWebKeyCurveName/g, "CurveName");
+    transform: return $.replace(/JSONWebKeyCurveName/g, "CurveName");
   - from: 
       - models.go
       - constants.go
@@ -162,12 +162,12 @@ directive:
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeySignatureAlgorithm|JsonWebKeySignatureAlgorithm/g, "SignatureAlgorithm");
+    transform: return $.replace(/JSONWebKeySignatureAlgorithm/g, "SignatureAlgorithm");
   - from: 
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeyType|JsonWebKeyType/g, "KeyType");
+    transform: return $.replace(/JSONWebKeyType/g, "KeyType");
 
   # remove DeletionRecoveryLevel type
   - from: models.go
@@ -234,4 +234,11 @@ directive:
       - response_types.go
     where: $
     transform: return $.replace(/DeletedKeyBundle/g, "DeletedKey")
+
+  # remove redundant section of doc comment
+  - from:
+      - models.go
+      - constants.go
+    where: $
+    transform: return $.replace(/(For valid values, (.*)\.)|(For more information .*\.)|(For more information on possible algorithm\n\/\/ types, see JsonWebKeySignatureAlgorithm.)/g, "");
 ```

--- a/sdk/security/keyvault/azkeys/autorest.md
+++ b/sdk/security/keyvault/azkeys/autorest.md
@@ -147,12 +147,12 @@ directive:
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeyOperation/g, "KeyOperation");
+    transform: return $.replace(/JSONWebKeyOperation|JsonWebKeyOperation/g, "KeyOperation");
   - from: 
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeyCurveName/g, "CurveName");
+    transform: return $.replace(/JSONWebKeyCurveName|JsonWebKeyCurveName/g, "CurveName");
   - from: 
       - models.go
       - constants.go
@@ -162,12 +162,12 @@ directive:
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeySignatureAlgorithm/g, "SignatureAlgorithm");
+    transform: return $.replace(/JSONWebKeySignatureAlgorithm|JsonWebKeySignatureAlgorithm/g, "SignatureAlgorithm");
   - from: 
       - models.go
       - constants.go
     where: $
-    transform: return $.replace(/JSONWebKeyType/g, "KeyType");
+    transform: return $.replace(/JSONWebKeyType|JsonWebKeyType/g, "KeyType");
 
   # remove DeletionRecoveryLevel type
   - from: models.go
@@ -227,4 +227,11 @@ directive:
   - from: models.go
     where: $
     transform: return $.replace(/(KID \*)string(\s+.*)/g, "$1ID$2")
+
+  # edit doc comments to not contain DeletedKeyBundle
+  - from: 
+      - models.go
+      - response_types.go
+    where: $
+    transform: return $.replace(/DeletedKeyBundle/g, "DeletedKey")
 ```

--- a/sdk/security/keyvault/azkeys/constants.go
+++ b/sdk/security/keyvault/azkeys/constants.go
@@ -8,7 +8,7 @@
 
 package azkeys
 
-// CurveName - Elliptic curve name. For valid values, see JsonWebKeyCurveName.
+// CurveName - Elliptic curve name. For valid values, see CurveName.
 type CurveName string
 
 const (
@@ -74,7 +74,7 @@ func PossibleEncryptionAlgorithmValues() []EncryptionAlgorithm {
 	}
 }
 
-// KeyOperation - JSON web key operations. For more information, see JsonWebKeyOperation.
+// KeyOperation - JSON web key operations. For more information, see KeyOperation.
 type KeyOperation string
 
 const (
@@ -103,7 +103,7 @@ func PossibleKeyOperationValues() []KeyOperation {
 }
 
 // SignatureAlgorithm - The signing/verification algorithm identifier. For more information on possible algorithm
-// types, see JsonWebKeySignatureAlgorithm.
+// types, see SignatureAlgorithm.
 type SignatureAlgorithm string
 
 const (

--- a/sdk/security/keyvault/azkeys/constants.go
+++ b/sdk/security/keyvault/azkeys/constants.go
@@ -8,7 +8,7 @@
 
 package azkeys
 
-// CurveName - Elliptic curve name. For valid values, see CurveName.
+// CurveName - Elliptic curve name.
 type CurveName string
 
 const (
@@ -74,7 +74,7 @@ func PossibleEncryptionAlgorithmValues() []EncryptionAlgorithm {
 	}
 }
 
-// KeyOperation - JSON web key operations. For more information, see KeyOperation.
+// KeyOperation - JSON web key operations. For more information, see JsonWebKeyOperation.
 type KeyOperation string
 
 const (
@@ -102,8 +102,7 @@ func PossibleKeyOperationValues() []KeyOperation {
 	}
 }
 
-// SignatureAlgorithm - The signing/verification algorithm identifier. For more information on possible algorithm
-// types, see SignatureAlgorithm.
+// SignatureAlgorithm - The signing/verification algorithm identifier.
 type SignatureAlgorithm string
 
 const (

--- a/sdk/security/keyvault/azkeys/example_test.go
+++ b/sdk/security/keyvault/azkeys/example_test.go
@@ -119,7 +119,7 @@ func ExampleClient_UpdateKey() {
 // [Client.RotateKey] allows you to rotate a key on demand. See [Azure Key Vault documentation] for more information about key
 // rotation.
 //
-// [Azure Key Vault documentation]: https://docs.microsoft.com/azure/key-vault/keys/how-to-configure-key-rotation
+// [Azure Key Vault documentation]: https://learn.microsoft.com/azure/key-vault/keys/how-to-configure-key-rotation
 func ExampleClient_UpdateKeyRotationPolicy() {
 	// this policy rotates the key every 18 months
 	policy := azkeys.KeyRotationPolicy{

--- a/sdk/security/keyvault/azkeys/models.go
+++ b/sdk/security/keyvault/azkeys/models.go
@@ -18,10 +18,10 @@ type BackupKeyResult struct {
 
 // CreateKeyParameters - The key create parameters.
 type CreateKeyParameters struct {
-	// REQUIRED; The type of key to create. For valid values, see JsonWebKeyType.
+	// REQUIRED; The type of key to create. For valid values, see KeyType.
 	Kty *KeyType
 
-	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
+	// Elliptic curve name. For valid values, see CurveName.
 	Curve *CurveName
 
 	// The attributes of a key managed by the key vault service.
@@ -41,7 +41,7 @@ type CreateKeyParameters struct {
 	Tags map[string]*string
 }
 
-// DeletedKey - A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info
+// DeletedKey - A DeletedKey consisting of a WebKey plus its Attributes and deletion info
 type DeletedKey struct {
 	// The key management attributes.
 	Attributes *KeyAttributes
@@ -130,7 +130,7 @@ type ImportKeyParameters struct {
 
 // JSONWebKey - As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18
 type JSONWebKey struct {
-	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
+	// Elliptic curve name. For valid values, see CurveName.
 	Crv *CurveName
 
 	// RSA private exponent, or the D component of an EC private key.
@@ -390,7 +390,7 @@ type RestoreKeyParameters struct {
 
 // SignParameters - The key operations parameters.
 type SignParameters struct {
-	// REQUIRED; The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.
+	// REQUIRED; The signing/verification algorithm identifier. For more information on possible algorithm types, see SignatureAlgorithm.
 	Algorithm *SignatureAlgorithm
 
 	// REQUIRED
@@ -402,7 +402,7 @@ type UpdateKeyParameters struct {
 	// The attributes of a key managed by the key vault service.
 	KeyAttributes *KeyAttributes
 
-	// Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.
+	// Json web key operations. For more information on possible key operations, see KeyOperation.
 	KeyOps []*KeyOperation
 
 	// The policy rules under which the key can be exported.
@@ -414,7 +414,7 @@ type UpdateKeyParameters struct {
 
 // VerifyParameters - The key verify parameters.
 type VerifyParameters struct {
-	// REQUIRED; The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.
+	// REQUIRED; The signing/verification algorithm. For more information on possible algorithm types, see SignatureAlgorithm.
 	Algorithm *SignatureAlgorithm
 
 	// REQUIRED; The digest used for signing.

--- a/sdk/security/keyvault/azkeys/models.go
+++ b/sdk/security/keyvault/azkeys/models.go
@@ -18,10 +18,10 @@ type BackupKeyResult struct {
 
 // CreateKeyParameters - The key create parameters.
 type CreateKeyParameters struct {
-	// REQUIRED; The type of key to create. For valid values, see KeyType.
+	// REQUIRED; The type of key to create.
 	Kty *KeyType
 
-	// Elliptic curve name. For valid values, see CurveName.
+	// Elliptic curve name.
 	Curve *CurveName
 
 	// The attributes of a key managed by the key vault service.
@@ -130,7 +130,7 @@ type ImportKeyParameters struct {
 
 // JSONWebKey - As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18
 type JSONWebKey struct {
-	// Elliptic curve name. For valid values, see CurveName.
+	// Elliptic curve name.
 	Crv *CurveName
 
 	// RSA private exponent, or the D component of an EC private key.
@@ -390,7 +390,7 @@ type RestoreKeyParameters struct {
 
 // SignParameters - The key operations parameters.
 type SignParameters struct {
-	// REQUIRED; The signing/verification algorithm identifier. For more information on possible algorithm types, see SignatureAlgorithm.
+	// REQUIRED; The signing/verification algorithm identifier.
 	Algorithm *SignatureAlgorithm
 
 	// REQUIRED
@@ -402,7 +402,7 @@ type UpdateKeyParameters struct {
 	// The attributes of a key managed by the key vault service.
 	KeyAttributes *KeyAttributes
 
-	// Json web key operations. For more information on possible key operations, see KeyOperation.
+	// Json web key operations.
 	KeyOps []*KeyOperation
 
 	// The policy rules under which the key can be exported.
@@ -414,7 +414,7 @@ type UpdateKeyParameters struct {
 
 // VerifyParameters - The key verify parameters.
 type VerifyParameters struct {
-	// REQUIRED; The signing/verification algorithm. For more information on possible algorithm types, see SignatureAlgorithm.
+	// REQUIRED; The signing/verification algorithm.
 	Algorithm *SignatureAlgorithm
 
 	// REQUIRED; The digest used for signing.

--- a/sdk/security/keyvault/azkeys/response_types.go
+++ b/sdk/security/keyvault/azkeys/response_types.go
@@ -28,7 +28,7 @@ type DecryptResponse struct {
 
 // DeleteKeyResponse contains the response from method Client.DeleteKey.
 type DeleteKeyResponse struct {
-	// A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info
+	// A DeletedKey consisting of a WebKey plus its Attributes and deletion info
 	DeletedKey
 }
 
@@ -40,7 +40,7 @@ type EncryptResponse struct {
 
 // GetDeletedKeyResponse contains the response from method Client.GetDeletedKey.
 type GetDeletedKeyResponse struct {
-	// A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info
+	// A DeletedKey consisting of a WebKey plus its Attributes and deletion info
 	DeletedKey
 }
 

--- a/sdk/security/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/security/keyvault/azsecrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.1 (2023-08-21)
+## 1.0.1 (2023-08-22)
 
 ### Other Changes
 * Upgraded dependencies


### PR DESCRIPTION
When we changed some of the names, not all the doc comments were changed to match the new names. This pull request that issue and updates the doc comments