### PR TITLE
Add FetcherForNextLinkOptions for extensibility

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-* Added function `FetcherForNextLink` to the `runtime` package to centralize creation of `Pager[T].Fetcher` from a next link URL.
+* Added function `FetcherForNextLink` and `FetcherForNextLinkOptions` to the `runtime` package to centralize creation of `Pager[T].Fetcher` from a next link URL.
 
 ### Breaking Changes
 

--- a/sdk/azcore/runtime/pager.go
+++ b/sdk/azcore/runtime/pager.go
@@ -91,14 +91,30 @@ func (p *Pager[T]) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &p.current)
 }
 
+// FetcherForNextLinkOptions contains the optional values for [FetcherForNextLink].
+type FetcherForNextLinkOptions struct {
+	// NextReq is the func to be called when requesting subsequent pages.
+	// Used for paged operations that have a custom next link operation.
+	NextReq func(context.Context, string) (*policy.Request, error)
+}
+
 // FetcherForNextLink is a helper containing boilerplate code to simplify creating a PagingHandler[T].Fetcher from a next link URL.
-func FetcherForNextLink(ctx context.Context, pl Pipeline, nextLink string, createReq func(context.Context) (*policy.Request, error)) (*http.Response, error) {
+//   - ctx is the [context.Context] controlling the lifetime of the HTTP operation
+//   - pl is the [Pipeline] used to dispatch the HTTP request
+//   - nextLink is the URL used to fetch the next page. the empty string indicates the first page is to be requested
+//   - firstReq is the func to be called when creating the request for the first page
+//   - options contains any optional parameters, pass nil to accept the default values
+func FetcherForNextLink(ctx context.Context, pl Pipeline, nextLink string, firstReq func(context.Context) (*policy.Request, error), options *FetcherForNextLinkOptions) (*http.Response, error) {
 	var req *policy.Request
 	var err error
 	if nextLink == "" {
-		req, err = createReq(ctx)
+		req, err = firstReq(ctx)
 	} else if nextLink, err = EncodeQueryParams(nextLink); err == nil {
-		req, err = NewRequest(ctx, http.MethodGet, nextLink)
+		if options != nil && options.NextReq != nil {
+			req, err = options.NextReq(ctx, nextLink)
+		} else {
+			req, err = NewRequest(ctx, http.MethodGet, nextLink)
+		}
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This includes support for paged operations that use next link method instead of a vanilla HTTP GET on the next link URL.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
[CHANGELOG.md]: https://github.com/Azure/azure-sdk-for-go/blob/main/CHANGELOG.md
