### PR TITLE
[azkeys] change managed hsm region

### DIFF
--- a/sdk/security/keyvault/azkeys/test-resources.json
+++ b/sdk/security/keyvault/azkeys/test-resources.json
@@ -37,7 +37,7 @@
         },
         "hsmLocation": {
             "type": "string",
-            "defaultValue": "uksouth",
+            "defaultValue": "australiaeast",
             "allowedValues": [
                 "australiacentral",
                 "australiaeast",


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-go/issues/20750

Changing region for azkeys to region with more capacity.