### PR TITLE
[azadmin] change managed hsm region 

### DIFF
--- a/sdk/security/keyvault/azadmin/test-resources.json
+++ b/sdk/security/keyvault/azadmin/test-resources.json
@@ -37,7 +37,7 @@
         },
         "hsmLocation": {
             "type": "string",
-            "defaultValue": "uksouth",
+            "defaultValue": "australiaeast",
             "allowedValues": [
                 "australiacentral",
                 "australiaeast",


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-go/issues/20750

Changing the region for azadmin to a region with more capacity.
