### PR TITLE
Handle Docker Desktop 403 response from IMDS endpoint

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -12,6 +12,9 @@
   tokens by default or observe the environment variable "AZURE_IDENTITY_DISABLE_CP1".
 
 ### Bugs Fixed
+* Credential chains such as `DefaultAzureCredential` now try their next credential, if any, when
+  managed identity authentication fails in a Docker Desktop container
+  ([#21417](https://github.com/Azure/azure-sdk-for-go/issues/21417))
 
 ### Other Changes
 

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -175,15 +175,25 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
 		return c.createAccessToken(resp)
 	}
 
-	if c.msiType == msiTypeIMDS && resp.StatusCode == 400 {
-		if id != nil {
-			return azcore.AccessToken{}, newAuthenticationFailedError(credNameManagedIdentity, "the requested identity isn't assigned to this resource", resp, nil)
+	if c.msiType == msiTypeIMDS {
+		switch resp.StatusCode {
+		case http.StatusBadRequest:
+			if id != nil {
+				return azcore.AccessToken{}, newAuthenticationFailedError(credNameManagedIdentity, "the requested identity isn't assigned to this resource", resp, nil)
+			}
+			msg := "failed to authenticate a system assigned identity"
+			if body, err := runtime.Payload(resp); err == nil && len(body) > 0 {
+				msg += fmt.Sprintf(". The endpoint responded with %s", body)
+			}
+			return azcore.AccessToken{}, newCredentialUnavailableError(credNameManagedIdentity, msg)
+		case http.StatusForbidden:
+			// Docker Desktop runs a proxy that responds 403 to IMDS token requests. If we got that response,
+			// we return credentialUnavailableError so credential chains continue to their next credential
+			body, err := runtime.Payload(resp)
+			if err == nil && strings.HasSuffix(string(body), "connectex: A socket operation was attempted to an unreachable network.") {
+				return azcore.AccessToken{}, newCredentialUnavailableError(credNameManagedIdentity, fmt.Sprintf("unexpected response %q", string(body)))
+			}
 		}
-		msg := "failed to authenticate a system assigned identity"
-		if body, err := runtime.Payload(resp); err == nil && len(body) > 0 {
-			msg += fmt.Sprintf(". The endpoint responded with %s", body)
-		}
-		return azcore.AccessToken{}, newCredentialUnavailableError(credNameManagedIdentity, msg)
 	}
 
 	return azcore.AccessToken{}, newAuthenticationFailedError(credNameManagedIdentity, "authentication failed", resp, nil)

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -190,7 +190,7 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
 			// Docker Desktop runs a proxy that responds 403 to IMDS token requests. If we got that response,
 			// we return credentialUnavailableError so credential chains continue to their next credential
 			body, err := runtime.Payload(resp)
-			if err == nil && strings.HasSuffix(string(body), "connectex: A socket operation was attempted to an unreachable network.") {
+			if err == nil && strings.Contains(string(body), "A socket operation was attempted to an unreachable network") {
 				return azcore.AccessToken{}, newCredentialUnavailableError(credNameManagedIdentity, fmt.Sprintf("unexpected response %q", string(body)))
 			}
 		}

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -187,7 +187,7 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
 			}
 			return azcore.AccessToken{}, newCredentialUnavailableError(credNameManagedIdentity, msg)
 		case http.StatusForbidden:
-			// Docker Desktop runs a proxy that responds 403 to IMDS token requests. If we got that response,
+			// Docker Desktop runs a proxy that responds 403 to IMDS token requests. If we get that response,
 			// we return credentialUnavailableError so credential chains continue to their next credential
 			body, err := runtime.Payload(resp)
 			if err == nil && strings.Contains(string(body), "A socket operation was attempted to an unreachable network") {


### PR DESCRIPTION
We want credential chains to try their next credential, if any, when a managed identity isn't available i.e., we want `ManagedIdentityCredential` to return `credentialUnavailableError`. This requires a special case for Docker Desktop containers because some component of that infrastructure responds 403 Forbidden to IMDS token requests. Closes #21417 