### PR TITLE
Plumb EnvVars to subscription config builder to find duplicates

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -66,6 +66,7 @@ jobs:
         parameters:
           SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
           SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
+          EnvVars: ${{ parameters.EnvVars }}
 
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:


### PR DESCRIPTION
This will help avoid hard to diagnose issues where duplicate env var values are being defined in multiple places.
