### PR TITLE
Transport dialer: setting nil for wasm build

### DIFF
--- a/sdk/azcore/runtime/transport_default_dialer_other.go
+++ b/sdk/azcore/runtime/transport_default_dialer_other.go
@@ -1,0 +1,12 @@
+//go:build !wasm
+
+package runtime
+
+import (
+	"context"
+	"net"
+)
+
+func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return dialer.DialContext
+}

--- a/sdk/azcore/runtime/transport_default_dialer_wasm.go
+++ b/sdk/azcore/runtime/transport_default_dialer_wasm.go
@@ -1,0 +1,12 @@
+//go:build (js && wasm) || wasip1
+
+package runtime
+
+import (
+	"context"
+	"net"
+)
+
+func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return nil
+}

--- a/sdk/azcore/runtime/transport_default_http_client.go
+++ b/sdk/azcore/runtime/transport_default_http_client.go
@@ -18,10 +18,10 @@ var defaultHTTPClient *http.Client
 func init() {
 	defaultTransport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
+		DialContext: defaultTransportDialContext(&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).DialContext,
+		}),
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
This PR is to make this SDK to work as an WASM module. The implementation is refered from https://github.com/golang/go/blob/071aed2aaa0ed819582c5bff44b70d43c61f504a/src/net/http/transport.go#L45.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
