### PR TITLE
Add option to use azcore from main in CI

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -9,7 +9,7 @@ stages:
       - template: /eng/pipelines/templates/variables/globals.yml
     displayName: 'Check Release: ${{ parameters.ServiceDirectory }}'
     dependsOn: ${{ parameters.DependsOn }}
-    condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-go-pr'))
+    condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-go-pr'), ne(variables['Use.AzcoreFromMain'], 'true'))
     jobs:
       - job: CheckReleaseJob
         displayName: "Check whether need to release"

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -20,6 +20,17 @@ parameters:
 
 steps:
   - task: Powershell@2
+    displayName: Use azcore from main
+    condition: eq(variables['Use.AzcoreFromMain'], 'true')
+    env:
+      GO111MODULE: 'on'
+    inputs:
+      targetType: filePath
+      pwsh: true
+      filePath: eng/scripts/Replace-azcore.ps1
+      arguments: '${{ parameters.ServiceDirectory }}'
+
+  - task: Powershell@2
     displayName: Build
     env:
       GO111MODULE: 'on'

--- a/eng/scripts/Replace-azcore.ps1
+++ b/eng/scripts/Replace-azcore.ps1
@@ -1,0 +1,38 @@
+Param(
+    [string] $ModuleDirectory
+)
+
+$goModFile = Join-Path $ModuleDirectory "go.mod"
+
+if (!(Test-Path $goModFile)) {
+    Write-Host "##[command]The file $goModFile doesn't exist"
+    exit 1
+}
+
+if (!$ModuleDirectory.Contains("$([IO.Path]::DirectorySeparatorChar)sdk$([IO.Path]::DirectorySeparatorChar)")) {
+    Write-Host "##[command]Directory $ModuleDirectory doesn't appear to be an SDK module"
+    exit 1
+}
+
+if ((Get-Content $goModFile -raw) -notmatch "github.com/Azure/azure-sdk-for-go/sdk/azcore") {
+    # no dependency on azcore, exit
+    Write-Host "##[command]No azcore dependency found in " $goModFile
+    return
+}
+
+# walk up the directory tree until we find the sdk directory, constructing the relative path as we go
+$relativePath = ""
+for ($parent = $ModuleDirectory; !$parent.EndsWith("$([IO.Path]::DirectorySeparatorChar)sdk"); $parent = (Split-Path $parent)) {
+    $relativePath += "../"
+}
+
+# add a replace directive to go.mod with a relative path to the azcore directory
+$replace = "replace github.com/Azure/azure-sdk-for-go/sdk/azcore => $($relativePath)azcore"
+Write-Host "##[command]Adding replace statement " $replace
+Add-Content -Path $goModFile -Value "`n$($replace)"
+
+## go mod tidy
+Write-Host "##[command]Executing go mod tidy in " $ModuleDirectory
+Set-Location $ModuleDirectory
+go mod tidy
+if ($LASTEXITCODE) { exit $LASTEXITCODE }


### PR DESCRIPTION
Off by default, set Use.AzcoreFromMain to true to enable.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
