### PR TITLE
Add empty bicep file to azopenai

### DIFF
--- a/sdk/cognitiveservices/azopenai/test-resources.bicep
+++ b/sdk/cognitiveservices/azopenai/test-resources.bicep
@@ -1,0 +1,1 @@
+param baseName string


### PR DESCRIPTION
This will fix some variables not getting set from the subscription config.
