### PR TITLE
Enable health checks for HTTP/2 connections

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fixed an issue that could cause some allowed HTTP header values to not show up in logs.
 * Include error text instead of error type in traces when the transport returns an error.
+* Fixed an issue that could cause an HTTP/2 request to hang when the TCP connection becomes unresponsive.
 
 ### Other Changes
 
@@ -43,7 +44,6 @@
 
 * Fixed an issue that could cause some ARM RPs to not be automatically registered.
 * Block bearer token authentication for non TLS protected endpoints.
-* Fixed an issue that could cause an HTTP/2 request to hang when the TCP connection becomes unresponsive.
 
 ### Other Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 * Suppress creating spans for nested SDK API calls. The HTTP span will be a child of the outer API span.
 * Fix default HTTP transport to work in WASM modules.
-* Enable HTTP connection health checks for HTTP/2 connections.
+* Fixed an issue that could cause an HTTP/2 request to hang when the TCP connection becomes unresponsive.
 
 ### Other Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 * Fixed an issue that could cause some ARM RPs to not be automatically registered.
 * Block bearer token authentication for non TLS protected endpoints.
+* Fixed an issue that could cause an HTTP/2 request to hang when the TCP connection becomes unresponsive.
 
 ### Other Changes
 
@@ -57,8 +58,6 @@
 ### Bugs Fixed
 
 * Suppress creating spans for nested SDK API calls. The HTTP span will be a child of the outer API span.
-* Fix default HTTP transport to work in WASM modules.
-* Fixed an issue that could cause an HTTP/2 request to hang when the TCP connection becomes unresponsive.
 
 ### Other Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -57,6 +57,8 @@
 ### Bugs Fixed
 
 * Suppress creating spans for nested SDK API calls. The HTTP span will be a child of the outer API span.
+* Fix default HTTP transport to work in WASM modules.
+* Enable HTTP connection health checks for HTTP/2 connections.
 
 ### Other Changes
 

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -5,11 +5,12 @@ go 1.18
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/net v0.15.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.15.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -10,6 +10,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
 golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
+golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sdk/azcore/runtime/transport_default_http_client.go
+++ b/sdk/azcore/runtime/transport_default_http_client.go
@@ -39,8 +39,8 @@ func init() {
 	if http2Transport, err := http2.ConfigureTransports(defaultTransport); err == nil {
 		// if the connection has been idle for 10 seconds, send a ping frame for a health check
 		http2Transport.ReadIdleTimeout = 10 * time.Second
-		// if there's no response to the ping within 2 seconds, close the connection
-		http2Transport.PingTimeout = 2 * time.Second
+		// if there's no response to the ping within the timeout, the connection will be closed
+		http2Transport.PingTimeout = 5 * time.Second
 	}
 	defaultHTTPClient = &http.Client{
 		Transport: defaultTransport,

--- a/sdk/azcore/runtime/transport_default_http_client.go
+++ b/sdk/azcore/runtime/transport_default_http_client.go
@@ -11,6 +11,8 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"golang.org/x/net/http2"
 )
 
 var defaultHTTPClient *http.Client
@@ -31,6 +33,12 @@ func init() {
 			MinVersion:    tls.VersionTLS12,
 			Renegotiation: tls.RenegotiateFreelyAsClient,
 		},
+	}
+	if http2Transport, err := http2.ConfigureTransports(defaultTransport); err == nil {
+		// if the connection has been idle for 10 seconds, send a ping frame for a health check
+		http2Transport.ReadIdleTimeout = 10 * time.Second
+		// if there's no response to the ping within 2 seconds, close the connection
+		http2Transport.PingTimeout = 2 * time.Second
 	}
 	defaultHTTPClient = &http.Client{
 		Transport: defaultTransport,

--- a/sdk/azcore/runtime/transport_default_http_client.go
+++ b/sdk/azcore/runtime/transport_default_http_client.go
@@ -26,6 +26,7 @@ func init() {
 		}),
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/sdk/azcore/runtime/transport_default_http_client.go
+++ b/sdk/azcore/runtime/transport_default_http_client.go
@@ -35,6 +35,7 @@ func init() {
 			Renegotiation: tls.RenegotiateFreelyAsClient,
 		},
 	}
+	// TODO: evaluate removing this once https://github.com/golang/go/issues/59690 has been fixed
 	if http2Transport, err := http2.ConfigureTransports(defaultTransport); err == nil {
 		// if the connection has been idle for 10 seconds, send a ping frame for a health check
 		http2Transport.ReadIdleTimeout = 10 * time.Second

--- a/sdk/azcore/testdata/perf/go.mod
+++ b/sdk/azcore/testdata/perf/go.mod
@@ -7,6 +7,9 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0
 )
 
-require golang.org/x/text v0.13.0 // indirect
+require (
+	golang.org/x/net v0.15.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
+)
 
 replace github.com/Azure/azure-sdk-for-go/sdk/azcore => ../../

--- a/sdk/azcore/testdata/perf/go.sum
+++ b/sdk/azcore/testdata/perf/go.sum
@@ -3,6 +3,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aov
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
+golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
If the health check fails, the connection will be closed and a new one created.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/21346