### PR TITLE
Execute go mod tidy for perf tests when using live azcore

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -9,7 +9,7 @@ stages:
       - template: /eng/pipelines/templates/variables/globals.yml
     displayName: 'Check Release: ${{ parameters.ServiceDirectory }}'
     dependsOn: ${{ parameters.DependsOn }}
-    condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-go-pr'), ne(variables['Use.AzcoreFromMain'], 'true'))
+    condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-go-pr'), ne($(UseAzcoreFromMain), 'true'))
     jobs:
       - job: CheckReleaseJob
         displayName: "Check whether need to release"

--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -9,7 +9,7 @@ stages:
       - template: /eng/pipelines/templates/variables/globals.yml
     displayName: 'Check Release: ${{ parameters.ServiceDirectory }}'
     dependsOn: ${{ parameters.DependsOn }}
-    condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-go-pr'), ne($(UseAzcoreFromMain), 'true'))
+    condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-go-pr'), ne(variables.UseAzcoreFromMain, 'true'))
     jobs:
       - job: CheckReleaseJob
         displayName: "Check whether need to release"

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -83,12 +83,10 @@ steps:
 
   - task: PowerShell@2
     displayName: 'Build Performance Tests'
-    variables:
-      useAzcoreFromMain: eq(variables['Use.AzcoreFromMain'], 'true')
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/Build_Perf.ps1
-      arguments: '${{ parameters.ServiceDirectory }} $(useAzcoreFromMain)'
+      arguments: '${{ parameters.ServiceDirectory }} $(Use.AzcoreFromMain)'
       pwsh: true
 
   - ${{ if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -86,7 +86,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/Build_Perf.ps1
-      arguments: '${{ parameters.ServiceDirectory }} $$(Use.AzcoreFromMain)'
+      arguments: '${{ parameters.ServiceDirectory }} $[variables.Use.AzcoreFromMain]'
       pwsh: true
 
   - ${{ if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -86,7 +86,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/Build_Perf.ps1
-      arguments: '${{ parameters.ServiceDirectory }} ${{ variables['Use.AzcoreFromMain'] }}'
+      arguments: '${{ parameters.ServiceDirectory }} $$(Use.AzcoreFromMain)'
       pwsh: true
 
   - ${{ if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -86,7 +86,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/Build_Perf.ps1
-      arguments: '${{ parameters.ServiceDirectory }} $(UseAzcoreFromMain)'
+      arguments: '${{ parameters.ServiceDirectory }} $$(UseAzcoreFromMain)'
       pwsh: true
 
   - ${{ if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -83,10 +83,12 @@ steps:
 
   - task: PowerShell@2
     displayName: 'Build Performance Tests'
+    variables:
+      useAzcoreFromMain: eq(variables['Use.AzcoreFromMain'], 'true')
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/Build_Perf.ps1
-      arguments: '${{ parameters.ServiceDirectory }} variables['Use.AzcoreFromMain']'
+      arguments: '${{ parameters.ServiceDirectory }} $(useAzcoreFromMain)'
       pwsh: true
 
   - ${{ if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -86,7 +86,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/Build_Perf.ps1
-      arguments: '${{ parameters.ServiceDirectory }} $[variables.Use.AzcoreFromMain]'
+      arguments: '${{ parameters.ServiceDirectory }} variables['Use.AzcoreFromMain']'
       pwsh: true
 
   - ${{ if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -21,7 +21,7 @@ parameters:
 steps:
   - task: Powershell@2
     displayName: Use azcore from main
-    condition: eq(variables['Use.AzcoreFromMain'], 'true')
+    condition: eq($(UseAzcoreFromMain), 'true')
     env:
       GO111MODULE: 'on'
     inputs:
@@ -86,7 +86,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/Build_Perf.ps1
-      arguments: '${{ parameters.ServiceDirectory }} $(Use.AzcoreFromMain)'
+      arguments: '${{ parameters.ServiceDirectory }} $(UseAzcoreFromMain)'
       pwsh: true
 
   - ${{ if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -21,7 +21,7 @@ parameters:
 steps:
   - task: Powershell@2
     displayName: Use azcore from main
-    condition: eq($(UseAzcoreFromMain), 'true')
+    condition: eq(variables.UseAzcoreFromMain, 'true')
     env:
       GO111MODULE: 'on'
     inputs:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -86,7 +86,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/Build_Perf.ps1
-      arguments: '${{ parameters.ServiceDirectory }}'
+      arguments: '${{ parameters.ServiceDirectory }} ${{ variables['Use.AzcoreFromMain'] }}'
       pwsh: true
 
   - ${{ if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -8,3 +8,6 @@ variables:
   
   # Disable CodeQL injections except for where we specifically enable it
   Codeql.SkipTaskAutoInjection: true
+
+  # Set the default value so that 'Build Performance Tests' step can resolve it
+  UseAzcoreFromMain: $[eq(variables['Use.AzcoreFromMain'], 'true')]

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -8,3 +8,6 @@ variables:
   
   # Disable CodeQL injections except for where we specifically enable it
   Codeql.SkipTaskAutoInjection: true
+
+  # Set the default value so that 'Build Performance Tests' step can resolve it
+  Use.AzcoreFromMain: false

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -8,6 +8,3 @@ variables:
   
   # Disable CodeQL injections except for where we specifically enable it
   Codeql.SkipTaskAutoInjection: true
-
-  # Set the default value so that 'Build Performance Tests' step can resolve it
-  Use.AzcoreFromMain: false

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -11,7 +11,7 @@ Push-Location sdk/$serviceDirectory
 $perfDirectories = Get-ChildItem -Path . -Filter testdata -Recurse
 
 if ($perfDirectories.Length -eq 0) {
-    Write-Host "##[command] Did not find any performance tests in the directory $(pwd)"
+    Write-Host "##[command] Did not find any performance tests in the directory $(Get-Location)"
     exit 0
 }
 

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -11,7 +11,7 @@ Push-Location sdk/$serviceDirectory
 $perfDirectories = Get-ChildItem -Path . -Filter testdata -Recurse
 
 if ($perfDirectories.Length -eq 0) {
-    Write-Host "Did not find any performance tests in the directory $(pwd)"
+    Write-Host "##[command] Did not find any performance tests in the directory $(pwd)"
     exit 0
 }
 
@@ -24,7 +24,7 @@ foreach ($perfDir in $perfDirectories) {
         Push-Location perf
         Write-Host "##[command] Building and vetting performance tests in $perfDir/perf"
 
-        if ($useAzcoreFromMain) {
+        if ($useAzcoreFromMain -eq "true") {
             # using a live azcore might be dragging in updated dependencies
             Write-Host "##[command] Executing 'go mod tidy' in $perfDir/perf"
             go mod tidy

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -2,7 +2,7 @@
 
 Param(
     [string] $serviceDirectory,
-    [bool] $useAzcoreFromMain = $false
+    [string] $useAzcoreFromMain
 )
 
 Push-Location sdk/$serviceDirectory

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -17,6 +17,8 @@ if ($perfDirectories.Length -eq 0) {
 
 $failed = $false
 
+Write-Host "##[command] useAzcoreFromMain contains $useAzcoreFromMain"
+
 foreach ($perfDir in $perfDirectories) {
     Push-Location $perfDir
 

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -1,7 +1,8 @@
 #Requires -Version 7.0
 
 Param(
-    [string] $serviceDirectory
+    [string] $serviceDirectory,
+    [bool] $useAzcoreFromMain = $false
 )
 
 Push-Location sdk/$serviceDirectory
@@ -22,6 +23,15 @@ foreach ($perfDir in $perfDirectories) {
     if (Test-Path -Path perf) {
         Push-Location perf
         Write-Host "##[command] Building and vetting performance tests in $perfDir/perf"
+
+        if ($useAzcoreFromMain) {
+            # using a live azcore might be dragging in updated dependencies
+            Write-Host "##[command] Executing 'go mod tidy' in $perfDir/perf"
+            go mod tidy
+            if ($LASTEXITCODE) {
+                $failed = $true
+            }
+        }
 
         Write-Host "##[command] Executing 'go build .' in $perfDir/perf"
         go build .

--- a/eng/scripts/Build_Perf.ps1
+++ b/eng/scripts/Build_Perf.ps1
@@ -2,7 +2,7 @@
 
 Param(
     [string] $serviceDirectory,
-    [string] $useAzcoreFromMain
+    [bool] $useAzcoreFromMain
 )
 
 Push-Location sdk/$serviceDirectory
@@ -17,8 +17,6 @@ if ($perfDirectories.Length -eq 0) {
 
 $failed = $false
 
-Write-Host "##[command] useAzcoreFromMain contains $useAzcoreFromMain"
-
 foreach ($perfDir in $perfDirectories) {
     Push-Location $perfDir
 
@@ -26,7 +24,7 @@ foreach ($perfDir in $perfDirectories) {
         Push-Location perf
         Write-Host "##[command] Building and vetting performance tests in $perfDir/perf"
 
-        if ($useAzcoreFromMain -eq "true") {
+        if ($useAzcoreFromMain) {
             # using a live azcore might be dragging in updated dependencies
             Write-Host "##[command] Executing 'go mod tidy' in $perfDir/perf"
             go mod tidy


### PR DESCRIPTION
This ensures that any updated dependencies are propagated.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
