### PR TITLE
[azservicebus] Fixing issue where the body was populated incorrectly, making it empty on retries since it can't be rewound.

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- admin.Client properly populates the request body when retrying operations. PR#21496
+
 ### Other Changes
 
 ## 1.4.0 (2023-06-06)

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/auth"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/conn"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/sbauth"
@@ -159,15 +160,6 @@ type ExecuteOptions struct {
 	ForwardToDeadLetter *string
 }
 
-// nopCloser copied from azblob.
-type nopCloser struct {
-	io.ReadSeeker
-}
-
-func (n nopCloser) Close() error {
-	return nil
-}
-
 func (em *entityManager) execute(ctx context.Context, method string, entityPath string, body io.ReadSeeker, options *ExecuteOptions) (*http.Response, error) {
 	url := em.Host + strings.TrimPrefix(entityPath, "/")
 
@@ -184,7 +176,7 @@ func (em *entityManager) execute(ctx context.Context, method string, entityPath 
 	req.Raw().URL.RawQuery = q.Encode()
 
 	if body != nil {
-		if err := req.SetBody(nopCloser{ReadSeeker: body}, "application/atom+xml;type=entry;charset=utf-8"); err != nil {
+		if err := req.SetBody(streaming.NopCloser(body), "application/atom+xml;type=entry;charset=utf-8"); err != nil {
 			return nil, err
 		}
 	}

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -121,7 +121,7 @@ func NewEntityManager(ns string, tokenCredential azcore.TokenCredential, version
 
 // Get performs an HTTP Get for a given entity path, deserializing the returned XML into `respObj`
 func (em *entityManager) Get(ctx context.Context, entityPath string, respObj any) (*http.Response, error) {
-	resp, err := em.execute(ctx, http.MethodGet, entityPath, http.NoBody, nil)
+	resp, err := em.execute(ctx, http.MethodGet, entityPath, nil, nil)
 	defer CloseRes(ctx, resp)
 
 	if err != nil {
@@ -151,7 +151,7 @@ func (em *entityManager) Put(ctx context.Context, entityPath string, body any, r
 
 // Delete performs an HTTP DELETE for a given entity path
 func (em *entityManager) Delete(ctx context.Context, entityPath string) (*http.Response, error) {
-	return em.execute(ctx, http.MethodDelete, entityPath, http.NoBody, nil)
+	return em.execute(ctx, http.MethodDelete, entityPath, nil, nil)
 }
 
 type ExecuteOptions struct {
@@ -159,7 +159,16 @@ type ExecuteOptions struct {
 	ForwardToDeadLetter *string
 }
 
-func (em *entityManager) execute(ctx context.Context, method string, entityPath string, body io.Reader, options *ExecuteOptions) (*http.Response, error) {
+// nopCloser copied from azblob.
+type nopCloser struct {
+	io.ReadSeeker
+}
+
+func (n nopCloser) Close() error {
+	return nil
+}
+
+func (em *entityManager) execute(ctx context.Context, method string, entityPath string, body io.ReadSeeker, options *ExecuteOptions) (*http.Response, error) {
 	url := em.Host + strings.TrimPrefix(entityPath, "/")
 
 	ctx = context.WithValue(ctx, ctxWithAuthKey{}, options)
@@ -174,9 +183,10 @@ func (em *entityManager) execute(ctx context.Context, method string, entityPath 
 	q.Add("api-version", "2021-05")
 	req.Raw().URL.RawQuery = q.Encode()
 
-	if body != nil && body != http.NoBody {
-		req.Raw().Body = io.NopCloser(body)
-		req.Raw().Header.Add("Content-Type", "application/atom+xml;type=entry;charset=utf-8")
+	if body != nil {
+		if err := req.SetBody(nopCloser{ReadSeeker: body}, "application/atom+xml;type=entry;charset=utf-8"); err != nil {
+			return nil, err
+		}
 	}
 
 	resp, err := em.pl.Do(req)

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager_test.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package atom
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+type fakePolicy struct {
+	t *testing.T
+}
+
+func (p *fakePolicy) Do(req *policy.Request) (*http.Response, error) {
+	require.NotNil(p.t, req.Body())
+
+	reqBytes, err := io.ReadAll(req.Body())
+	require.NoError(p.t, err)
+	require.Equal(p.t, "<string>hello</string>", string(reqBytes))
+
+	// now rewind it, and try again - this is what the retry policy does.
+	err = req.RewindBody()
+	require.NoError(p.t, err)
+
+	reqBytes, err = io.ReadAll(req.Body())
+	require.NoError(p.t, err)
+	require.Equal(p.t, "<string>hello</string>", string(reqBytes))
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("<string>response body</string>")),
+	}, nil
+}
+
+func TestEntityManagerRewindable(t *testing.T) {
+	// prior to this I was populating the .Raw().Body field which works for first
+	// requests but will fail if there is a retry since the body can't be rewound.
+	pl := runtime.NewPipeline("module", "version", runtime.PipelineOptions{
+		PerCall: []policy.Policy{
+			&fakePolicy{t: t},
+		},
+	}, nil)
+
+	em := entityManager{
+		pl:   pl,
+		Host: "https://localhost",
+	}
+
+	var respBody *string
+	resp, err := em.Put(context.Background(), "entityPath", "hello", &respBody, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, "response body", *respBody)
+}


### PR DESCRIPTION
Previously we were setting request.Raw().Body directly, instead of using the request.SetBody() function. 

This made it so the request body itself was no longer rewindable, which made subsequent requests send an empty body instead.

Fixes #21489