### PR TITLE
Prep azcore v1.7.2 for release

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.7.2 (Unreleased)
+## 1.7.2 (2023-09-06)
 
 ### Bugs Fixed
 

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -32,5 +32,5 @@ const (
 	Module = "azcore"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.7.1"
+	Version = "v1.7.2"
 )


### PR DESCRIPTION
The target branch was created by branching from tag `sdk/azcore/v1.7.1` and the following commits were cherry-picked.

https://github.com/Azure/azure-sdk-for-go/commit/68baa6f9cc9838b3ff5f4ab7661f4330947674c1
https://github.com/Azure/azure-sdk-for-go/commit/5b55febc172332cc903e396f5c6dedad7ad6a543