### PR TITLE
Skip getting module properties for **/testdata/*

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -39,7 +39,7 @@ function Get-GoModuleProperties($goModPath)
   $goModPath = $goModPath -replace "\\", "/"
   # We should keep this regex in sync with what is in the azure-sdk repo at https://github.com/Azure/azure-sdk/blob/main/eng/scripts/Query-Azure-Packages.ps1#L227
   # The serviceName named capture group is unused but used in azure-sdk, so it's kept here for parity
-  if ($goModPath -match "(?<modPath>(sdk|profile)/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
+  if (!$goModPath.Contains("testdata") -and $goModPath -match "(?<modPath>(sdk|profile)/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
   {
     $modPath = $matches["modPath"]
     $modName = $matches["modName"] # We may need to start reading this from the go.mod file if the path and mod config start to differ

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -37,7 +37,7 @@ function Get-GoModuleVersionInfo($modPath)
 function Get-GoModuleProperties($goModPath)
 {
   $goModPath = $goModPath -replace "\\", "/"
-  # We should keep this regex in sync with what is in the azure-sdk repo at https://github.com/Azure/azure-sdk/blob/main/eng/scripts/Query-Azure-Packages.ps1#L227
+  # We should keep this regex in sync with what is in the azure-sdk repo at https://github.com/Azure/azure-sdk/blob/main/eng/scripts/Query-Azure-Packages.ps1#L238
   # The serviceName named capture group is unused but used in azure-sdk, so it's kept here for parity
   if (!$goModPath.Contains("testdata") -and $goModPath -match "(?<modPath>(sdk|profile)/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
   {


### PR DESCRIPTION
`Get-GoModuleVersionInfo` logs a warning for modules lacking version info, such as our perf test harnesses. This produces many irrelevant warnings:

![image](https://github.com/Azure/azure-sdk-for-go/assets/10964656/3515be7a-5a03-4d3e-81e2-6a67a04c0c48)

These are irrelevant because we don't ship anything in `**/testdata/*`. It seems excessive to add whatever artifacts are needed to satisfy the script(s), so how about having the script(s) simply skip over these modules?