### PR TITLE
Set confidential client region at construction

### DIFF
--- a/sdk/azidentity/confidential_client.go
+++ b/sdk/azidentity/confidential_client.go
@@ -50,7 +50,6 @@ func newConfidentialClient(tenantID, clientID, name string, cred confidential.Cr
 	if err != nil {
 		return nil, err
 	}
-	region := os.Getenv(azureRegionalAuthorityName)
 	opts.AdditionallyAllowedTenants = resolveAdditionalTenants(opts.AdditionallyAllowedTenants)
 	return &confidentialClient{
 		caeMu:    &sync.Mutex{},
@@ -61,7 +60,7 @@ func newConfidentialClient(tenantID, clientID, name string, cred confidential.Cr
 		name:     name,
 		noCAEMu:  &sync.Mutex{},
 		opts:     opts,
-		region:   region,
+		region:   os.Getenv(azureRegionalAuthorityName),
 		tenantID: tenantID,
 	}, nil
 }


### PR DESCRIPTION
#21333 made constructing MSAL clients and setting a credential's regional endpoint lazy. It's better to set the endpoint in the credential constructor so the value is predictable regardless of when the credential constructs MSAL clients.