### PR TITLE
Some refactoring of azappconfig

### DIFF
--- a/sdk/data/azappconfig/CHANGELOG.md
+++ b/sdk/data/azappconfig/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Release History
 
-## 0.5.1 (Unreleased)
+## 0.6.0 (Unreleased)
 
 ### Features Added
 * Handle setting content type in `AddSetting` and `SetSetting` ([#19797](https://github.com/Azure/azure-sdk-for-go/issues/19797))
 
 ### Breaking Changes
+* Response types `ListRevisionsPage` and `ListSettingsPage` now have the suffix `Response` in their names.
 
 ### Bugs Fixed
 

--- a/sdk/data/azappconfig/client.go
+++ b/sdk/data/azappconfig/client.go
@@ -9,6 +9,7 @@ package azappconfig
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -94,38 +95,6 @@ func toGeneratedETagString(etag *azcore.ETag) *string {
 	return &str
 }
 
-func (cs Setting) toGeneratedPutOptions(ifMatch *azcore.ETag, ifNoneMatch *azcore.ETag) (generated.KeyValue, generated.AzureAppConfigurationClientPutKeyValueOptions) {
-	return cs.toGenerated(), generated.AzureAppConfigurationClientPutKeyValueOptions{
-		IfMatch:     toGeneratedETagString(ifMatch),
-		IfNoneMatch: toGeneratedETagString(ifNoneMatch),
-		Label:       cs.Label,
-	}
-}
-
-// AddSettingResponse contains the response from AddSetting method.
-type AddSettingResponse struct {
-	Setting
-
-	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
-	SyncToken *string
-}
-
-func fromGeneratedAdd(g generated.AzureAppConfigurationClientPutKeyValueResponse) AddSettingResponse {
-	return AddSettingResponse{
-		Setting:   settingFromGenerated(g.KeyValue),
-		SyncToken: g.SyncToken,
-	}
-}
-
-// AddSettingOptions contains the optional parameters for the AddSetting method.
-type AddSettingOptions struct {
-	// Configuration setting label.
-	Label *string
-
-	// Configuration setting content type.
-	ContentType *string
-}
-
 // AddSetting creates a configuration setting only if the setting does not already exist in the configuration store.
 func (c *Client) AddSetting(ctx context.Context, key string, value *string, options *AddSettingOptions) (AddSettingResponse, error) {
 	var label *string
@@ -144,32 +113,10 @@ func (c *Client) AddSetting(ctx context.Context, key string, value *string, opti
 		return AddSettingResponse{}, err
 	}
 
-	return (AddSettingResponse)(fromGeneratedAdd(resp)), nil
-}
-
-// DeleteSettingResponse contains the response from DeleteSetting method.
-type DeleteSettingResponse struct {
-	Setting
-
-	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
-	SyncToken *string
-}
-
-func fromGeneratedDelete(g generated.AzureAppConfigurationClientDeleteKeyValueResponse) DeleteSettingResponse {
-	return DeleteSettingResponse{
-		Setting:   settingFromGenerated(g.KeyValue),
-		SyncToken: g.SyncToken,
-	}
-}
-
-// DeleteSettingOptions contains the optional parameters for the DeleteSetting method.
-type DeleteSettingOptions struct {
-	// Configuration setting label.
-	Label *string
-
-	// If set, and the configuration setting exists in the configuration store,
-	// delete the setting if the passed-in ETag is the same as the setting's ETag in the configuration store.
-	OnlyIfUnchanged *azcore.ETag
+	return AddSettingResponse{
+		Setting:   settingFromGenerated(resp.KeyValue),
+		SyncToken: resp.SyncToken,
+	}, nil
 }
 
 func (cs Setting) toGeneratedDeleteOptions(ifMatch *azcore.ETag) *generated.AzureAppConfigurationClientDeleteKeyValueOptions {
@@ -196,60 +143,10 @@ func (c *Client) DeleteSetting(ctx context.Context, key string, options *DeleteS
 		return DeleteSettingResponse{}, err
 	}
 
-	return fromGeneratedDelete(resp), nil
-}
-
-// GetSettingResponse contains the configuration setting retrieved by GetSetting method.
-type GetSettingResponse struct {
-	Setting
-
-	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
-	SyncToken *string
-
-	// Contains the timestamp of when the configuration setting was last modified.
-	LastModified *time.Time
-}
-
-func fromGeneratedGet(g generated.AzureAppConfigurationClientGetKeyValueResponse) GetSettingResponse {
-	var t *time.Time
-	if g.LastModified != nil {
-		if tt, err := time.Parse(timeFormat, *g.LastModified); err == nil {
-			t = &tt
-		}
-	}
-
-	return GetSettingResponse{
-		Setting:      settingFromGenerated(g.KeyValue),
-		SyncToken:    g.SyncToken,
-		LastModified: t,
-	}
-}
-
-// GetSettingOptions contains the optional parameters for the GetSetting method.
-type GetSettingOptions struct {
-	// Configuration setting label.
-	Label *string
-
-	// If set, only retrieve the setting from the configuration store if setting has changed
-	// since the client last retrieved it with the ETag provided.
-	OnlyIfChanged *azcore.ETag
-
-	// The setting will be retrieved exactly as it existed at the provided time.
-	AcceptDateTime *time.Time
-}
-
-func (cs Setting) toGeneratedGetOptions(ifNoneMatch *azcore.ETag, acceptDateTime *time.Time) *generated.AzureAppConfigurationClientGetKeyValueOptions {
-	var dt *string
-	if acceptDateTime != nil {
-		str := acceptDateTime.Format(timeFormat)
-		dt = &str
-	}
-
-	return &generated.AzureAppConfigurationClientGetKeyValueOptions{
-		AcceptDatetime: dt,
-		IfNoneMatch:    toGeneratedETagString(ifNoneMatch),
-		Label:          cs.Label,
-	}
+	return DeleteSettingResponse{
+		Setting:   settingFromGenerated(resp.KeyValue),
+		SyncToken: resp.SyncToken,
+	}, nil
 }
 
 // GetSetting retrieves an existing configuration setting from the configuration store.
@@ -271,53 +168,20 @@ func (c *Client) GetSetting(ctx context.Context, key string, options *GetSetting
 		return GetSettingResponse{}, err
 	}
 
-	return fromGeneratedGet(resp), nil
-}
-
-// SetReadOnlyResponse contains the response from SetReadOnly method.
-type SetReadOnlyResponse struct {
-	Setting
-
-	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
-	SyncToken *string
-}
-
-func fromGeneratedPutLock(g generated.AzureAppConfigurationClientPutLockResponse) SetReadOnlyResponse {
-	return SetReadOnlyResponse{
-		Setting:   settingFromGenerated(g.KeyValue),
-		SyncToken: g.SyncToken,
+	var lastModified *time.Time
+	if resp.LastModified != nil {
+		tt, err := time.Parse(http.TimeFormat, *resp.LastModified)
+		if err != nil {
+			return GetSettingResponse{}, err
+		}
+		lastModified = &tt
 	}
-}
 
-func fromGeneratedDeleteLock(g generated.AzureAppConfigurationClientDeleteLockResponse) SetReadOnlyResponse {
-	return SetReadOnlyResponse{
-		Setting:   settingFromGenerated(g.KeyValue),
-		SyncToken: g.SyncToken,
-	}
-}
-
-// SetReadOnlyOptions contains the optional parameters for the SetReadOnly method.
-type SetReadOnlyOptions struct {
-	// Configuration setting label.
-	Label *string
-
-	// If set, and the configuration setting exists in the configuration store, update the setting
-	// if the passed-in configuration setting ETag is the same version as the one in the configuration store.
-	OnlyIfUnchanged *azcore.ETag
-}
-
-func (cs Setting) toGeneratedPutLockOptions(ifMatch *azcore.ETag) *generated.AzureAppConfigurationClientPutLockOptions {
-	return &generated.AzureAppConfigurationClientPutLockOptions{
-		IfMatch: toGeneratedETagString(ifMatch),
-		Label:   cs.Label,
-	}
-}
-
-func (cs Setting) toGeneratedDeleteLockOptions(ifMatch *azcore.ETag) *generated.AzureAppConfigurationClientDeleteLockOptions {
-	return &generated.AzureAppConfigurationClientDeleteLockOptions{
-		IfMatch: toGeneratedETagString(ifMatch),
-		Label:   cs.Label,
-	}
+	return GetSettingResponse{
+		Setting:      settingFromGenerated(resp.KeyValue),
+		SyncToken:    resp.SyncToken,
+		LastModified: lastModified,
+	}, nil
 }
 
 // SetReadOnly sets an existing configuration setting to read only or read write state in the configuration store.
@@ -337,45 +201,23 @@ func (c *Client) SetReadOnly(ctx context.Context, key string, isReadOnly bool, o
 		var resp generated.AzureAppConfigurationClientPutLockResponse
 		resp, err = c.appConfigClient.PutLock(ctx, *setting.Key, setting.toGeneratedPutLockOptions(ifMatch))
 		if err == nil {
-			return fromGeneratedPutLock(resp), nil
+			return SetReadOnlyResponse{
+				Setting:   settingFromGenerated(resp.KeyValue),
+				SyncToken: resp.SyncToken,
+			}, nil
 		}
 	} else {
 		var resp generated.AzureAppConfigurationClientDeleteLockResponse
 		resp, err = c.appConfigClient.DeleteLock(ctx, *setting.Key, setting.toGeneratedDeleteLockOptions(ifMatch))
 		if err == nil {
-			return fromGeneratedDeleteLock(resp), nil
+			return SetReadOnlyResponse{
+				Setting:   settingFromGenerated(resp.KeyValue),
+				SyncToken: resp.SyncToken,
+			}, nil
 		}
 	}
 
 	return SetReadOnlyResponse{}, err
-}
-
-// SetSettingResponse contains the response from SetSetting method.
-type SetSettingResponse struct {
-	Setting
-
-	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
-	SyncToken *string
-}
-
-func fromGeneratedSet(g generated.AzureAppConfigurationClientPutKeyValueResponse) SetSettingResponse {
-	return SetSettingResponse{
-		Setting:   settingFromGenerated(g.KeyValue),
-		SyncToken: g.SyncToken,
-	}
-}
-
-// SetSettingOptions contains the optional parameters for the SetSetting method.
-type SetSettingOptions struct {
-	// Configuration setting label.
-	Label *string
-
-	// Configuration setting content type.
-	ContentType *string
-
-	// If set, and the configuration setting exists in the configuration store, overwrite the setting
-	// if the passed-in ETag is the same version as the one in the configuration store.
-	OnlyIfUnchanged *azcore.ETag
 }
 
 // SetSetting creates a configuration setting if it doesn't exist or overwrites the existing setting in the configuration store.
@@ -398,96 +240,63 @@ func (c *Client) SetSetting(ctx context.Context, key string, value *string, opti
 		return SetSettingResponse{}, err
 	}
 
-	return (SetSettingResponse)(fromGeneratedSet(resp)), nil
-}
-
-// ListRevisionsPage contains the configuration settings returned by ListRevisionsPager.
-type ListRevisionsPage struct {
-	// Contains the configuration settings returned that match the setting selector provided.
-	Settings []Setting
-
-	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
-	SyncToken *string
-}
-
-func fromGeneratedGetRevisionsPage(g generated.AzureAppConfigurationClientGetRevisionsResponse) ListRevisionsPage {
-	var css []Setting
-	for _, cs := range g.Items {
-		if cs != nil {
-			css = append(css, settingFromGenerated(*cs))
-		}
-	}
-
-	return ListRevisionsPage{
-		Settings:  css,
-		SyncToken: g.SyncToken,
-	}
-}
-
-// ListRevisionsOptions contains the optional parameters for the NewListRevisionsPager method.
-type ListRevisionsOptions struct {
-	// placeholder for future options
+	return SetSettingResponse{
+		Setting:   settingFromGenerated(resp.KeyValue),
+		SyncToken: resp.SyncToken,
+	}, nil
 }
 
 // NewListRevisionsPager creates a pager that retrieves the revisions of one or more
 // configuration setting entities that match the specified setting selector.
-func (c *Client) NewListRevisionsPager(selector SettingSelector, options *ListRevisionsOptions) *runtime.Pager[ListRevisionsPage] {
+func (c *Client) NewListRevisionsPager(selector SettingSelector, options *ListRevisionsOptions) *runtime.Pager[ListRevisionsPageResponse] {
 	pagerInternal := c.appConfigClient.NewGetRevisionsPager(selector.toGeneratedGetRevisions())
-	return runtime.NewPager(runtime.PagingHandler[ListRevisionsPage]{
-		More: func(ListRevisionsPage) bool {
+	return runtime.NewPager(runtime.PagingHandler[ListRevisionsPageResponse]{
+		More: func(ListRevisionsPageResponse) bool {
 			return pagerInternal.More()
 		},
-		Fetcher: func(ctx context.Context, cur *ListRevisionsPage) (ListRevisionsPage, error) {
+		Fetcher: func(ctx context.Context, cur *ListRevisionsPageResponse) (ListRevisionsPageResponse, error) {
 			page, err := pagerInternal.NextPage(ctx)
 			if err != nil {
-				return ListRevisionsPage{}, err
+				return ListRevisionsPageResponse{}, err
 			}
-			return fromGeneratedGetRevisionsPage(page), nil
+			var css []Setting
+			for _, cs := range page.Items {
+				if cs != nil {
+					css = append(css, settingFromGenerated(*cs))
+				}
+			}
+
+			return ListRevisionsPageResponse{
+				Settings:  css,
+				SyncToken: page.SyncToken,
+			}, nil
 		},
 	})
 }
 
-// ListSettingsPage contains the configuration settings returned by ListRevisionsPager.
-type ListSettingsPage struct {
-	// Contains the configuration settings returned that match the setting selector provided.
-	Settings []Setting
-
-	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
-	SyncToken *string
-}
-
-func fromGeneratedGetSettingsPage(g generated.AzureAppConfigurationClientGetKeyValuesResponse) ListSettingsPage {
-	var css []Setting
-	for _, cs := range g.Items {
-		if cs != nil {
-			css = append(css, settingFromGenerated(*cs))
-		}
-	}
-
-	return ListSettingsPage{
-		Settings:  css,
-		SyncToken: g.SyncToken,
-	}
-}
-
-// ListSettingsOptions contains the optional parameters for the NewListSettingsPager method.
-type ListSettingsOptions struct {
-	// placeholder for future options
-}
-
 // NewListSettingsPager creates a pager that retrieves setting entities that match the specified setting selector.
-func (c *Client) NewListSettingsPager(selector SettingSelector, options *ListSettingsOptions) *runtime.Pager[ListSettingsPage] {
+func (c *Client) NewListSettingsPager(selector SettingSelector, options *ListSettingsOptions) *runtime.Pager[ListSettingsPageResponse] {
 	pagerInternal := c.appConfigClient.NewGetKeyValuesPager(selector.toGeneratedGetKeyValues())
-	return runtime.NewPager(runtime.PagingHandler[ListSettingsPage]{
-		More: func(ListSettingsPage) bool {
+	return runtime.NewPager(runtime.PagingHandler[ListSettingsPageResponse]{
+		More: func(ListSettingsPageResponse) bool {
 			return pagerInternal.More()
 		},
-		Fetcher: func(ctx context.Context, cur *ListSettingsPage) (ListSettingsPage, error) {
+		Fetcher: func(ctx context.Context, cur *ListSettingsPageResponse) (ListSettingsPageResponse, error) {
 			page, err := pagerInternal.NextPage(ctx)
 			if err != nil {
-				return ListSettingsPage{}, err
+				return ListSettingsPageResponse{}, err
 			}
-			return fromGeneratedGetSettingsPage(page), nil
+			var css []Setting
+			for _, cs := range page.Items {
+				if cs != nil {
+					css = append(css, settingFromGenerated(*cs))
+				}
+			}
+
+			return ListSettingsPageResponse{
+				Settings:  css,
+				SyncToken: page.SyncToken,
+			}, nil
 		},
 	})
 }

--- a/sdk/data/azappconfig/constants.go
+++ b/sdk/data/azappconfig/constants.go
@@ -1,0 +1,38 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azappconfig
+
+import "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/internal/generated"
+
+// SettingFields are fields to retrieve from a configuration setting.
+type SettingFields = generated.SettingFields
+
+const (
+	// The primary identifier of a configuration setting.
+	SettingFieldsKey SettingFields = generated.SettingFieldsKey
+
+	// A label used to group configuration settings.
+	SettingFieldsLabel SettingFields = generated.SettingFieldsLabel
+
+	// The value of the configuration setting.
+	SettingFieldsValue SettingFields = generated.SettingFieldsValue
+
+	// The content type of the configuration setting's value.
+	SettingFieldsContentType SettingFields = generated.SettingFieldsContentType
+
+	// An ETag indicating the version of a configuration setting within a configuration store.
+	SettingFieldsETag SettingFields = generated.SettingFieldsEtag
+
+	// The last time a modifying operation was performed on the given configuration setting.
+	SettingFieldsLastModified SettingFields = generated.SettingFieldsLastModified
+
+	// A value indicating whether the configuration setting is read-only.
+	SettingFieldsIsReadOnly SettingFields = generated.SettingFieldsLocked
+
+	// A list of tags that can help identify what a configuration setting may be applicable for.
+	SettingFieldsTags SettingFields = generated.SettingFieldsTags
+)

--- a/sdk/data/azappconfig/options.go
+++ b/sdk/data/azappconfig/options.go
@@ -1,0 +1,78 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azappconfig
+
+import (
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// AddSettingOptions contains the optional parameters for the AddSetting method.
+type AddSettingOptions struct {
+	// Configuration setting label.
+	Label *string
+
+	// Configuration setting content type.
+	ContentType *string
+}
+
+// DeleteSettingOptions contains the optional parameters for the DeleteSetting method.
+type DeleteSettingOptions struct {
+	// Configuration setting label.
+	Label *string
+
+	// If set, and the configuration setting exists in the configuration store,
+	// delete the setting if the passed-in ETag is the same as the setting's ETag in the configuration store.
+	OnlyIfUnchanged *azcore.ETag
+}
+
+// GetSettingOptions contains the optional parameters for the GetSetting method.
+type GetSettingOptions struct {
+	// Configuration setting label.
+	Label *string
+
+	// If set, only retrieve the setting from the configuration store if setting has changed
+	// since the client last retrieved it with the ETag provided.
+	OnlyIfChanged *azcore.ETag
+
+	// The setting will be retrieved exactly as it existed at the provided time.
+	AcceptDateTime *time.Time
+}
+
+// ListRevisionsOptions contains the optional parameters for the NewListRevisionsPager method.
+type ListRevisionsOptions struct {
+	// placeholder for future options
+}
+
+// ListSettingsOptions contains the optional parameters for the NewListSettingsPager method.
+type ListSettingsOptions struct {
+	// placeholder for future options
+}
+
+// SetReadOnlyOptions contains the optional parameters for the SetReadOnly method.
+type SetReadOnlyOptions struct {
+	// Configuration setting label.
+	Label *string
+
+	// If set, and the configuration setting exists in the configuration store, update the setting
+	// if the passed-in configuration setting ETag is the same version as the one in the configuration store.
+	OnlyIfUnchanged *azcore.ETag
+}
+
+// SetSettingOptions contains the optional parameters for the SetSetting method.
+type SetSettingOptions struct {
+	// Configuration setting label.
+	Label *string
+
+	// Configuration setting content type.
+	ContentType *string
+
+	// If set, and the configuration setting exists in the configuration store, overwrite the setting
+	// if the passed-in ETag is the same version as the one in the configuration store.
+	OnlyIfUnchanged *azcore.ETag
+}

--- a/sdk/data/azappconfig/response_types.go
+++ b/sdk/data/azappconfig/response_types.go
@@ -1,0 +1,70 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azappconfig
+
+import "time"
+
+// AddSettingResponse contains the response from AddSetting method.
+type AddSettingResponse struct {
+	Setting
+
+	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
+	SyncToken *string
+}
+
+// DeleteSettingResponse contains the response from DeleteSetting method.
+type DeleteSettingResponse struct {
+	Setting
+
+	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
+	SyncToken *string
+}
+
+// GetSettingResponse contains the configuration setting retrieved by GetSetting method.
+type GetSettingResponse struct {
+	Setting
+
+	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
+	SyncToken *string
+
+	// Contains the timestamp of when the configuration setting was last modified.
+	LastModified *time.Time
+}
+
+// ListRevisionsPageResponse contains the configuration settings returned by ListRevisionsPager.
+type ListRevisionsPageResponse struct {
+	// Contains the configuration settings returned that match the setting selector provided.
+	Settings []Setting
+
+	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
+	SyncToken *string
+}
+
+// ListSettingsPageResponse contains the configuration settings returned by ListRevisionsPager.
+type ListSettingsPageResponse struct {
+	// Contains the configuration settings returned that match the setting selector provided.
+	Settings []Setting
+
+	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
+	SyncToken *string
+}
+
+// SetReadOnlyResponse contains the response from SetReadOnly method.
+type SetReadOnlyResponse struct {
+	Setting
+
+	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
+	SyncToken *string
+}
+
+// SetSettingResponse contains the response from SetSetting method.
+type SetSettingResponse struct {
+	Setting
+
+	// Sync token for the Azure App Configuration client, corresponding to the current state of the client.
+	SyncToken *string
+}

--- a/sdk/data/azappconfig/setting.go
+++ b/sdk/data/azappconfig/setting.go
@@ -83,3 +83,39 @@ func (cs Setting) toGenerated() generated.KeyValue {
 		Value:        cs.Value,
 	}
 }
+
+func (cs Setting) toGeneratedDeleteLockOptions(ifMatch *azcore.ETag) *generated.AzureAppConfigurationClientDeleteLockOptions {
+	return &generated.AzureAppConfigurationClientDeleteLockOptions{
+		IfMatch: toGeneratedETagString(ifMatch),
+		Label:   cs.Label,
+	}
+}
+
+func (cs Setting) toGeneratedGetOptions(ifNoneMatch *azcore.ETag, acceptDateTime *time.Time) *generated.AzureAppConfigurationClientGetKeyValueOptions {
+	var dt *string
+	if acceptDateTime != nil {
+		str := acceptDateTime.Format(timeFormat)
+		dt = &str
+	}
+
+	return &generated.AzureAppConfigurationClientGetKeyValueOptions{
+		AcceptDatetime: dt,
+		IfNoneMatch:    toGeneratedETagString(ifNoneMatch),
+		Label:          cs.Label,
+	}
+}
+
+func (cs Setting) toGeneratedPutLockOptions(ifMatch *azcore.ETag) *generated.AzureAppConfigurationClientPutLockOptions {
+	return &generated.AzureAppConfigurationClientPutLockOptions{
+		IfMatch: toGeneratedETagString(ifMatch),
+		Label:   cs.Label,
+	}
+}
+
+func (cs Setting) toGeneratedPutOptions(ifMatch *azcore.ETag, ifNoneMatch *azcore.ETag) (generated.KeyValue, generated.AzureAppConfigurationClientPutKeyValueOptions) {
+	return cs.toGenerated(), generated.AzureAppConfigurationClientPutKeyValueOptions{
+		IfMatch:     toGeneratedETagString(ifMatch),
+		IfNoneMatch: toGeneratedETagString(ifNoneMatch),
+		Label:       cs.Label,
+	}
+}

--- a/sdk/data/azappconfig/setting.go
+++ b/sdk/data/azappconfig/setting.go
@@ -66,6 +66,15 @@ func settingFromGenerated(kv generated.KeyValue) Setting {
 	}
 }
 
+func toGeneratedETagString(etag *azcore.ETag) *string {
+	if etag == nil || *etag == azcore.ETagAny {
+		return (*string)(etag)
+	}
+
+	str := "\"" + (string)(*etag) + "\""
+	return &str
+}
+
 func (cs Setting) toGenerated() generated.KeyValue {
 	tags := make(map[string]*string)
 	for k, v := range cs.Tags {
@@ -86,6 +95,13 @@ func (cs Setting) toGenerated() generated.KeyValue {
 
 func (cs Setting) toGeneratedDeleteLockOptions(ifMatch *azcore.ETag) *generated.AzureAppConfigurationClientDeleteLockOptions {
 	return &generated.AzureAppConfigurationClientDeleteLockOptions{
+		IfMatch: toGeneratedETagString(ifMatch),
+		Label:   cs.Label,
+	}
+}
+
+func (cs Setting) toGeneratedDeleteOptions(ifMatch *azcore.ETag) *generated.AzureAppConfigurationClientDeleteKeyValueOptions {
+	return &generated.AzureAppConfigurationClientDeleteKeyValueOptions{
 		IfMatch: toGeneratedETagString(ifMatch),
 		Label:   cs.Label,
 	}

--- a/sdk/data/azappconfig/setting_selector.go
+++ b/sdk/data/azappconfig/setting_selector.go
@@ -12,35 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/internal/generated"
 )
 
-// SettingFields are fields to retrieve from a configuration setting.
-type SettingFields = generated.SettingFields
-
-const (
-	// The primary identifier of a configuration setting.
-	SettingFieldsKey SettingFields = generated.SettingFieldsKey
-
-	// A label used to group configuration settings.
-	SettingFieldsLabel SettingFields = generated.SettingFieldsLabel
-
-	// The value of the configuration setting.
-	SettingFieldsValue SettingFields = generated.SettingFieldsValue
-
-	// The content type of the configuration setting's value.
-	SettingFieldsContentType SettingFields = generated.SettingFieldsContentType
-
-	// An ETag indicating the version of a configuration setting within a configuration store.
-	SettingFieldsETag SettingFields = generated.SettingFieldsEtag
-
-	// The last time a modifying operation was performed on the given configuration setting.
-	SettingFieldsLastModified SettingFields = generated.SettingFieldsLastModified
-
-	// A value indicating whether the configuration setting is read-only.
-	SettingFieldsIsReadOnly SettingFields = generated.SettingFieldsLocked
-
-	// A list of tags that can help identify what a configuration setting may be applicable for.
-	SettingFieldsTags SettingFields = generated.SettingFieldsTags
-)
-
 // SettingSelector is a set of options that allows selecting a filtered set of configuration setting entities
 // from the configuration store, and optionally allows indicating which fields of each setting to retrieve.
 type SettingSelector struct {

--- a/sdk/data/azappconfig/version.go
+++ b/sdk/data/azappconfig/version.go
@@ -8,5 +8,5 @@ package azappconfig
 
 const (
 	moduleName    = "azappconfig"
-	moduleVersion = "v0.5.1"
+	moduleVersion = "v0.6.0"
 )


### PR DESCRIPTION
Moved options and response types to their respective files. Moved methods on Setting to its respective file.
Inlined various from* conversion funcs to their call sites. Renamed paged response types to have the Response suffix per guidelines. Fixed an issue parsing the time value returned in the Last-Modified header. The expected format was incorrect and the error was previously silently dropped.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
