### PR TITLE
Add KeyCredential and SASCredential types

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Features Added
 
+* Added types `KeyCredential` and `SASCredential` to the `azcore` package.
+  * Includes their respective constructor functions.
+* Added types `KeyCredentialPolicy` and `SASCredentialPolicy` to the `azcore/runtime` package.
+  * Includes their respective constructor functions and options types.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -27,7 +27,7 @@ type KeyCredential = exported.KeyCredential
 
 // NewKeyCredential creates a new instance of [KeyCredential] with the specified values.
 //   - key is the authentication key
-func NewKeyCredential(key string) (*KeyCredential, error) {
+func NewKeyCredential(key string) *KeyCredential {
 	return exported.NewKeyCredential(key)
 }
 
@@ -36,7 +36,7 @@ type SASCredential = exported.SASCredential
 
 // NewSASCredential creates a new instance of [SASCredential] with the specified values.
 //   - sas is the shared access signature
-func NewSASCredential(sas string) (*SASCredential, error) {
+func NewSASCredential(sas string) *SASCredential {
 	return exported.NewSASCredential(sas)
 }
 

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -22,6 +22,24 @@ type AccessToken = exported.AccessToken
 // TokenCredential represents a credential capable of providing an OAuth token.
 type TokenCredential = exported.TokenCredential
 
+// KeyCredential contains an authentication key used to authenticate to an Azure service.
+type KeyCredential = exported.KeyCredential
+
+// NewKeyCredential creates a new instance of [KeyCredential] with the specified values.
+//   - key is the authentication key
+func NewKeyCredential(key string) (*KeyCredential, error) {
+	return exported.NewKeyCredential(key)
+}
+
+// SASCredential contains a shared access signature used to authenticate to an Azure service.
+type SASCredential = exported.SASCredential
+
+// NewSASCredential creates a new instance of [SASCredential] with the specified values.
+//   - sas is the shared access signature
+func NewSASCredential(sas string) (*SASCredential, error) {
+	return exported.NewSASCredential(sas)
+}
+
 // holds sentinel values used to send nulls
 var nullables map[reflect.Type]interface{} = map[reflect.Type]interface{}{}
 

--- a/sdk/azcore/core_test.go
+++ b/sdk/azcore/core_test.go
@@ -221,3 +221,21 @@ func TestClientWithClientName(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, "az.namespace:Widget.Factory", attrString)
 }
+
+func TestNewKeyCredential(t *testing.T) {
+	cred, err := NewKeyCredential("")
+	require.Error(t, err)
+	require.Nil(t, cred)
+	cred, err = NewKeyCredential("foo")
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+}
+
+func TestNewSASCredential(t *testing.T) {
+	cred, err := NewSASCredential("")
+	require.Error(t, err)
+	require.Nil(t, cred)
+	cred, err = NewSASCredential("foo")
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+}

--- a/sdk/azcore/core_test.go
+++ b/sdk/azcore/core_test.go
@@ -223,19 +223,9 @@ func TestClientWithClientName(t *testing.T) {
 }
 
 func TestNewKeyCredential(t *testing.T) {
-	cred, err := NewKeyCredential("")
-	require.Error(t, err)
-	require.Nil(t, cred)
-	cred, err = NewKeyCredential("foo")
-	require.NoError(t, err)
-	require.NotNil(t, cred)
+	require.NotNil(t, NewKeyCredential("foo"))
 }
 
 func TestNewSASCredential(t *testing.T) {
-	cred, err := NewSASCredential("")
-	require.Error(t, err)
-	require.Nil(t, cred)
-	cred, err = NewSASCredential("foo")
-	require.NoError(t, err)
-	require.NotNil(t, cred)
+	require.NotNil(t, NewSASCredential("foo"))
 }

--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -121,12 +121,8 @@ type KeyCredential struct {
 
 // NewKeyCredential creates a new instance of [KeyCredential] with the specified values.
 //   - key is the authentication key
-func NewKeyCredential(key string) (*KeyCredential, error) {
-	cred, err := newKeyCredential(key)
-	if err != nil {
-		return nil, err
-	}
-	return &KeyCredential{cred: cred}, nil
+func NewKeyCredential(key string) *KeyCredential {
+	return &KeyCredential{cred: newKeyCredential(key)}
 }
 
 // Update replaces the existing key with the specified value.
@@ -142,12 +138,8 @@ type SASCredential struct {
 
 // NewSASCredential creates a new instance of [SASCredential] with the specified values.
 //   - sas is the shared access signature
-func NewSASCredential(sas string) (*SASCredential, error) {
-	cred, err := newKeyCredential(sas)
-	if err != nil {
-		return nil, err
-	}
-	return &SASCredential{cred: cred}, nil
+func NewSASCredential(sas string) *SASCredential {
+	return &SASCredential{cred: newKeyCredential(sas)}
 }
 
 // Update replaces the existing shared access signature with the specified value.
@@ -169,13 +161,10 @@ type keyCredential struct {
 	key atomic.Value // string
 }
 
-func newKeyCredential(key string) (*keyCredential, error) {
-	if key == "" {
-		return nil, errors.New("key cannot be empty")
-	}
+func newKeyCredential(key string) *keyCredential {
 	keyCred := keyCredential{}
 	keyCred.key.Store(key)
-	return &keyCred, nil
+	return &keyCred
 }
 
 func (k *keyCredential) Get() string {

--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -9,7 +9,6 @@ package exported
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -126,8 +125,8 @@ func NewKeyCredential(key string) *KeyCredential {
 }
 
 // Update replaces the existing key with the specified value.
-func (k *KeyCredential) Update(key string) error {
-	return k.cred.Update(key)
+func (k *KeyCredential) Update(key string) {
+	k.cred.Update(key)
 }
 
 // SASCredential contains a shared access signature used to authenticate to an Azure service.
@@ -143,8 +142,8 @@ func NewSASCredential(sas string) *SASCredential {
 }
 
 // Update replaces the existing shared access signature with the specified value.
-func (k *SASCredential) Update(sas string) error {
-	return k.cred.Update(sas)
+func (k *SASCredential) Update(sas string) {
+	k.cred.Update(sas)
 }
 
 // KeyCredentialGet returns the key for cred.
@@ -171,10 +170,6 @@ func (k *keyCredential) Get() string {
 	return k.key.Load().(string)
 }
 
-func (k *keyCredential) Update(key string) error {
-	if key == "" {
-		return errors.New("key cannot be empty")
-	}
+func (k *keyCredential) Update(key string) {
 	k.key.Store(key)
-	return nil
 }

--- a/sdk/azcore/internal/exported/exported_test.go
+++ b/sdk/azcore/internal/exported/exported_test.go
@@ -60,10 +60,8 @@ func TestNewKeyCredential(t *testing.T) {
 	cred := NewKeyCredential(val1)
 	require.NotNil(t, cred)
 	require.EqualValues(t, val1, KeyCredentialGet(cred))
-	require.Error(t, cred.Update(""))
-	require.EqualValues(t, val1, KeyCredentialGet(cred))
 	const val2 = "bar"
-	require.NoError(t, cred.Update(val2))
+	cred.Update(val2)
 	require.EqualValues(t, val2, KeyCredentialGet(cred))
 }
 
@@ -72,9 +70,7 @@ func TestNewSASCredential(t *testing.T) {
 	cred := NewSASCredential(val1)
 	require.NotNil(t, cred)
 	require.EqualValues(t, val1, SASCredentialGet(cred))
-	require.Error(t, cred.Update(""))
-	require.EqualValues(t, val1, SASCredentialGet(cred))
 	const val2 = "bar"
-	require.NoError(t, cred.Update(val2))
+	cred.Update(val2)
 	require.EqualValues(t, val2, SASCredentialGet(cred))
 }

--- a/sdk/azcore/internal/exported/exported_test.go
+++ b/sdk/azcore/internal/exported/exported_test.go
@@ -56,12 +56,8 @@ func TestDecodeByteArray(t *testing.T) {
 }
 
 func TestNewKeyCredential(t *testing.T) {
-	cred, err := NewKeyCredential("")
-	require.Error(t, err)
-	require.Nil(t, cred)
 	const val1 = "foo"
-	cred, err = NewKeyCredential(val1)
-	require.NoError(t, err)
+	cred := NewKeyCredential(val1)
 	require.NotNil(t, cred)
 	require.EqualValues(t, val1, KeyCredentialGet(cred))
 	require.Error(t, cred.Update(""))
@@ -72,12 +68,8 @@ func TestNewKeyCredential(t *testing.T) {
 }
 
 func TestNewSASCredential(t *testing.T) {
-	cred, err := NewSASCredential("")
-	require.Error(t, err)
-	require.Nil(t, cred)
 	const val1 = "foo"
-	cred, err = NewSASCredential(val1)
-	require.NoError(t, err)
+	cred := NewSASCredential(val1)
 	require.NotNil(t, cred)
 	require.EqualValues(t, val1, SASCredentialGet(cred))
 	require.Error(t, cred.Update(""))

--- a/sdk/azcore/runtime/policy_key_credential.go
+++ b/sdk/azcore/runtime/policy_key_credential.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// KeyCredentialPolicy authorizes requests with a [azcore.KeyCredential].
+type KeyCredentialPolicy struct {
+	cred   *exported.KeyCredential
+	header string
+	format func(string) string
+}
+
+// KeyCredentialPolicyOptions contains the optional values configuring [KeyCredentialPolicy].
+type KeyCredentialPolicyOptions struct {
+	// Format is used if the key needs special formatting (e.g. a prefix) before it's inserted into the HTTP request.
+	// The value passed to the callback is the raw key and the return value is the augmented key.
+	Format func(string) string
+}
+
+// NewKeyCredentialPolicy creates a new instance of [KeyCredentialPolicy].
+//   - cred is the [azcore.KeyCredential] used to authenticate with the service
+//   - header is the name of the HTTP request header in which the key is placed
+//   - options contains optional configuration, pass nil to accept the default values
+func NewKeyCredentialPolicy(cred *exported.KeyCredential, header string, options *KeyCredentialPolicyOptions) *KeyCredentialPolicy {
+	if options == nil {
+		options = &KeyCredentialPolicyOptions{}
+	}
+	return &KeyCredentialPolicy{
+		cred:   cred,
+		header: header,
+		format: options.Format,
+	}
+}
+
+// Do implementes the Do method on the [policy.Polilcy] interface.
+func (k *KeyCredentialPolicy) Do(req *policy.Request) (*http.Response, error) {
+	val := exported.KeyCredentialGet(k.cred)
+	if k.format != nil {
+		val = k.format(val)
+	}
+	req.Raw().Header.Add(k.header, val)
+	return req.Next()
+}

--- a/sdk/azcore/runtime/policy_key_credential.go
+++ b/sdk/azcore/runtime/policy_key_credential.go
@@ -14,14 +14,13 @@ import (
 type KeyCredentialPolicy struct {
 	cred   *exported.KeyCredential
 	header string
-	format func(string) string
+	prefix string
 }
 
 // KeyCredentialPolicyOptions contains the optional values configuring [KeyCredentialPolicy].
 type KeyCredentialPolicyOptions struct {
-	// Format is used if the key needs special formatting (e.g. a prefix) before it's inserted into the HTTP request.
-	// The value passed to the callback is the raw key and the return value is the augmented key.
-	Format func(string) string
+	// Prefix is used if the key requires a prefix before it's inserted into the HTTP request.
+	Prefix string
 }
 
 // NewKeyCredentialPolicy creates a new instance of [KeyCredentialPolicy].
@@ -35,15 +34,15 @@ func NewKeyCredentialPolicy(cred *exported.KeyCredential, header string, options
 	return &KeyCredentialPolicy{
 		cred:   cred,
 		header: header,
-		format: options.Format,
+		prefix: options.Prefix,
 	}
 }
 
 // Do implementes the Do method on the [policy.Polilcy] interface.
 func (k *KeyCredentialPolicy) Do(req *policy.Request) (*http.Response, error) {
 	val := exported.KeyCredentialGet(k.cred)
-	if k.format != nil {
-		val = k.format(val)
+	if k.prefix != "" {
+		val = k.prefix + val
 	}
 	req.Raw().Header.Add(k.header, val)
 	return req.Next()

--- a/sdk/azcore/runtime/policy_key_credential_test.go
+++ b/sdk/azcore/runtime/policy_key_credential_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyCredentialPolicy(t *testing.T) {
+	const key = "foo"
+	cred, err := exported.NewKeyCredential(key)
+	require.NoError(t, err)
+
+	const headerName = "fake-auth"
+	policy := NewKeyCredentialPolicy(cred, headerName, nil)
+	require.NotNil(t, policy)
+
+	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+		require.EqualValues(t, key, req.Header.Get(headerName))
+		return &http.Response{}, nil
+	}), policy)
+
+	req, err := NewRequest(context.Background(), http.MethodGet, "http://contoso.com")
+	require.NoError(t, err)
+
+	_, err = pl.Do(req)
+	require.NoError(t, err)
+
+	policy = NewKeyCredentialPolicy(cred, headerName, &KeyCredentialPolicyOptions{
+		Format: func(s string) string {
+			return "Prefix: " + s
+		},
+	})
+	require.NotNil(t, policy)
+
+	pl = exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+		require.EqualValues(t, "Prefix: "+key, req.Header.Get(headerName))
+		return &http.Response{}, nil
+	}), policy)
+
+	req, err = NewRequest(context.Background(), http.MethodGet, "http://contoso.com")
+	require.NoError(t, err)
+
+	_, err = pl.Do(req)
+	require.NoError(t, err)
+}

--- a/sdk/azcore/runtime/policy_key_credential_test.go
+++ b/sdk/azcore/runtime/policy_key_credential_test.go
@@ -34,9 +34,7 @@ func TestKeyCredentialPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	policy = NewKeyCredentialPolicy(cred, headerName, &KeyCredentialPolicyOptions{
-		Format: func(s string) string {
-			return "Prefix: " + s
-		},
+		Prefix: "Prefix: ",
 	})
 	require.NotNil(t, policy)
 

--- a/sdk/azcore/runtime/policy_key_credential_test.go
+++ b/sdk/azcore/runtime/policy_key_credential_test.go
@@ -15,8 +15,7 @@ import (
 
 func TestKeyCredentialPolicy(t *testing.T) {
 	const key = "foo"
-	cred, err := exported.NewKeyCredential(key)
-	require.NoError(t, err)
+	cred := exported.NewKeyCredential(key)
 
 	const headerName = "fake-auth"
 	policy := NewKeyCredentialPolicy(cred, headerName, nil)

--- a/sdk/azcore/runtime/policy_sas_credential.go
+++ b/sdk/azcore/runtime/policy_sas_credential.go
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// SASCredentialPolicy authorizes requests with a [azcore.SASCredential].
+type SASCredentialPolicy struct {
+	cred   *exported.SASCredential
+	header string
+}
+
+// SASCredentialPolicyOptions contains the optional values configuring [SASCredentialPolicy].
+type SASCredentialPolicyOptions struct {
+	// placeholder for future optional values
+}
+
+// NewSASCredentialPolicy creates a new instance of [SASCredentialPolicy].
+//   - cred is the [azcore.SASCredential] used to authenticate with the service
+//   - header is the name of the HTTP request header in which the shared access signature is placed
+//   - options contains optional configuration, pass nil to accept the default values
+func NewSASCredentialPolicy(cred *exported.SASCredential, header string, options *SASCredentialPolicyOptions) *SASCredentialPolicy {
+	return &SASCredentialPolicy{
+		cred:   cred,
+		header: header,
+	}
+}
+
+// Do implementes the Do method on the [policy.Polilcy] interface.
+func (k *SASCredentialPolicy) Do(req *policy.Request) (*http.Response, error) {
+	req.Raw().Header.Add(k.header, exported.SASCredentialGet(k.cred))
+	return req.Next()
+}

--- a/sdk/azcore/runtime/polilcy_sas_credential_test.go
+++ b/sdk/azcore/runtime/polilcy_sas_credential_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSASCredentialPolicy(t *testing.T) {
+	const key = "foo"
+	cred, err := exported.NewSASCredential(key)
+	require.NoError(t, err)
+
+	const headerName = "fake-auth"
+	policy := NewSASCredentialPolicy(cred, headerName, nil)
+	require.NotNil(t, policy)
+
+	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+		require.EqualValues(t, key, req.Header.Get(headerName))
+		return &http.Response{}, nil
+	}), policy)
+
+	req, err := NewRequest(context.Background(), http.MethodGet, "http://contoso.com")
+	require.NoError(t, err)
+
+	_, err = pl.Do(req)
+	require.NoError(t, err)
+}

--- a/sdk/azcore/runtime/polilcy_sas_credential_test.go
+++ b/sdk/azcore/runtime/polilcy_sas_credential_test.go
@@ -15,8 +15,7 @@ import (
 
 func TestSASCredentialPolicy(t *testing.T) {
 	const key = "foo"
-	cred, err := exported.NewSASCredential(key)
-	require.NoError(t, err)
+	cred := exported.NewSASCredential(key)
 
 	const headerName = "fake-auth"
 	policy := NewSASCredentialPolicy(cred, headerName, nil)


### PR DESCRIPTION
Includes supporting pipeline policies, config options, etc.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/20541