### PR TITLE
Fix string-to-sign when path contains URL-encoded values

### DIFF
--- a/sdk/data/azappconfig/CHANGELOG.md
+++ b/sdk/data/azappconfig/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Response types `ListRevisionsPage` and `ListSettingsPage` now have the suffix `Response` in their names.
 
 ### Bugs Fixed
+* Fixed an issue that could cause HTTP requests to fail with `http.StatusUnauthorized` in some cases.
 
 ### Other Changes
 

--- a/sdk/data/azappconfig/assets.json
+++ b/sdk/data/azappconfig/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/data/azappconfig",
-  "Tag": "go/data/azappconfig_cc0b6e27f2"
+  "Tag": "go/data/azappconfig_560d04663e"
 }

--- a/sdk/data/azappconfig/client_test.go
+++ b/sdk/data/azappconfig/client_test.go
@@ -324,3 +324,27 @@ func TestSettingNilValue(t *testing.T) {
 	require.NotNil(t, resp.Key)
 	require.EqualValues(t, key, *resp.Key)
 }
+
+func TestSettingWithEscaping(t *testing.T) {
+	const (
+		key         = ".appconfig.featureflag/TestSettingWithEscaping"
+		contentType = "application/vnd.microsoft.appconfig.ff+json;charset=utf-8"
+	)
+	client := NewClientFromConnectionString(t)
+
+	addResp, err := client.AddSetting(context.Background(), key, nil, &azappconfig.AddSettingOptions{
+		ContentType: to.Ptr(contentType),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, addResp)
+
+	getResp, err := client.GetSetting(context.Background(), key, nil)
+	require.NoError(t, err)
+	require.NotNil(t, getResp.Key)
+	require.EqualValues(t, key, *getResp.Key)
+
+	resp, err := client.DeleteSetting(context.Background(), key, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Key)
+	require.EqualValues(t, key, *resp.Key)
+}

--- a/sdk/data/azappconfig/policy_hmac_auth.go
+++ b/sdk/data/azappconfig/policy_hmac_auth.go
@@ -40,7 +40,7 @@ func (policy *hmacAuthenticationPolicy) Do(request *policy.Request) (*http.Respo
 
 	method := req.Method
 	host := req.URL.Host
-	pathAndQuery := req.URL.Path
+	pathAndQuery := req.URL.EscapedPath()
 	if req.URL.RawQuery != "" {
 		pathAndQuery = pathAndQuery + "?" + req.URL.RawQuery
 	}


### PR DESCRIPTION
URL.Path contains the decoded path which can be different from the path used in the HTTP request.  As a result, the string-to-sign doesn't match the request, causing it to fail with a 401 unauthorized.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/19874