### PR TITLE
[Cosmos DB] Fixing Cosmos emulator CI

### DIFF
--- a/sdk/data/azcosmos/ci.yml
+++ b/sdk/data/azcosmos/ci.yml
@@ -26,16 +26,18 @@ stages:
     ServiceDirectory: 'data/azcosmos'
 - stage: Emulator
   displayName: 'Cosmos Emulator'
+  variables:
+  - template: /eng/pipelines/templates/variables/globals.yml
   jobs:
   - job: DownloadAndRunCosmosEmulator
     displayName: Download and run Cosmos Emulator
 
     strategy:
       matrix:
-        Windows_Go118:
+        Windows_Go120:
           pool.name: azsdk-pool-mms-win-2022-general
           image.name: MMS2022
-          go.version: '1.18'
+          go.version: '1.20.7'
     pool:
       name: $(pool.name)
       vmImage: $(image.name)


### PR DESCRIPTION
Emulator CI started to fail on 8/31 with:

```
"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command ". 'D:\a\_work\_temp\71e34255-01cf-49e5-b060-8a3f2ac8beaf.ps1'"
UseAzcoreFromMain : The term 'UseAzcoreFromMain' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At D:\a\_work\_temp\71e34255-01cf-49e5-b060-8a3f2ac8beaf.ps1:4 char:64
+ … k\1\s\eng\scripts\Build_Perf.ps1' data/azcosmos $$(UseAzcoreFromMain)
+                                                      ~~~~~~~~~~~~~~~~~
+ CategoryInfo          : ObjectNotFound: (UseAzcoreFromMain:String) [], ParentContainsErrorRecordException
+ FullyQualifiedErrorId : CommandNotFoundException
##[error]PowerShell exited with code '1'.
Finishing: Build Performance Tests
```

Apparently this is due to a missing global variable.