### PR TITLE
chore: Update instructions on how to get SDK version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ Thank you for opening a bug report. For faster processing, please include:
 - import path of package in question, e.g. `.../services/compute/mgmt/2018-06-01/compute`
 - SDK version e.g. `master`, `latest`, `18.1.0`
   - Specify the exact commit if possible; one way to get this is the REVISION
-    column output by `go list -m all | grep "github.com/Azure/azure-sdk-for-go/sdk"`.
+    column output by `go list -m <module>`, for example `go list -m github.com/Azure/azure-sdk-for-go/sdk/azcore`.
 - output of `go version`
 
 <!--

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ Thank you for opening a bug report. For faster processing, please include:
 - import path of package in question, e.g. `.../services/compute/mgmt/2018-06-01/compute`
 - SDK version e.g. `master`, `latest`, `18.1.0`
   - Specify the exact commit if possible; one way to get this is the REVISION
-    column output by `dep status "github.com/Azure/azure-sdk-for-go`.
+    column output by `go list -m all | grep "github.com/Azure/azure-sdk-for-go/sdk"`.
 - output of `go version`
 
 <!--


### PR DESCRIPTION
The issue template seems to be referencing https://github.com/golang/dep which is deprecated. Also the command was missing a closing double quotes `"`.

This PR updates the issue template to use `go list -m <module>`

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
