### PR TITLE
Move the HMAC auth policy to an internal package

### DIFF
--- a/sdk/data/azappconfig/client.go
+++ b/sdk/data/azappconfig/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/internal/auth"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/internal/generated"
 )
 
@@ -46,12 +47,12 @@ func NewClient(endpoint string, cred azcore.TokenCredential, options *ClientOpti
 
 // NewClientFromConnectionString parses the connection string and returns a pointer to a Client object.
 func NewClientFromConnectionString(connectionString string, options *ClientOptions) (*Client, error) {
-	endpoint, credential, secret, err := parseConnectionString(connectionString)
+	endpoint, credential, secret, err := auth.ParseConnectionString(connectionString)
 	if err != nil {
 		return nil, err
 	}
 
-	return newClient(endpoint, newHmacAuthenticationPolicy(credential, secret), options)
+	return newClient(endpoint, auth.NewHMACPolicy(credential, secret), options)
 }
 
 func newClient(endpoint string, authPolicy policy.Policy, options *ClientOptions) (*Client, error) {

--- a/sdk/data/azappconfig/internal/auth/policy_hmac_auth.go
+++ b/sdk/data/azappconfig/internal/auth/policy_hmac_auth.go
@@ -4,7 +4,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-package azappconfig
+package auth
 
 import (
 	"bytes"
@@ -21,19 +21,23 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-type hmacAuthenticationPolicy struct {
+// HMACPolicy is a pipeline policy that implements HMAC authentication.
+// https://learn.microsoft.com/en-us/azure/azure-app-configuration/rest-api-authentication-hmac
+type HMACPolicy struct {
 	credential string
 	secret     []byte
 }
 
-func newHmacAuthenticationPolicy(credential string, secret []byte) *hmacAuthenticationPolicy {
-	return &hmacAuthenticationPolicy{
+// NewHMACPolicy creates a new instance of [HMACPolicy].
+func NewHMACPolicy(credential string, secret []byte) *HMACPolicy {
+	return &HMACPolicy{
 		credential: credential,
 		secret:     secret,
 	}
 }
 
-func (policy *hmacAuthenticationPolicy) Do(request *policy.Request) (*http.Response, error) {
+// Do implements the policy.Policy interface on the [HMACPolicy] type.
+func (policy *HMACPolicy) Do(request *policy.Request) (*http.Response, error) {
 	req := request.Raw()
 	id := policy.credential
 	key := policy.secret
@@ -97,7 +101,8 @@ func getHmac(content string, key []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(hmac.Sum(nil)), nil
 }
 
-func parseConnectionString(connectionString string) (endpoint string, credential string, secret []byte, err error) {
+// ParseConnectionString parses the provided connection string.
+func ParseConnectionString(connectionString string) (endpoint string, credential string, secret []byte, err error) {
 	const connectionStringEndpointPrefix = "Endpoint="
 	const connectionStringCredentialPrefix = "Id="
 	const connectionStringSecretPrefix = "Secret="

--- a/sdk/data/azappconfig/internal/auth/policy_hmac_auth_parse_test.go
+++ b/sdk/data/azappconfig/internal/auth/policy_hmac_auth_parse_test.go
@@ -4,7 +4,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package azappconfig
+package auth
 
 import (
 	"testing"
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHmacAuthParseConnectionString(t *testing.T) {
-	ep, id, sc, err := parseConnectionString("Endpoint=xX;Id=yY;Secret=ZmZm")
+	ep, id, sc, err := ParseConnectionString("Endpoint=xX;Id=yY;Secret=ZmZm")
 	require.NoError(t, err)
 	require.Equal(t, "xX", ep)
 	require.Equal(t, "yY", id)
@@ -25,7 +25,7 @@ func TestHmacAuthParseConnectionString(t *testing.T) {
 }
 
 func TestHmacAuthParseConnectionStringMixedOrder(t *testing.T) {
-	ep, id, sc, err := parseConnectionString("Id=yY;Secret=ZmZm;Endpoint=xX")
+	ep, id, sc, err := ParseConnectionString("Id=yY;Secret=ZmZm;Endpoint=xX")
 	require.NoError(t, err)
 	require.Equal(t, "xX", ep)
 	require.Equal(t, "yY", id)
@@ -37,7 +37,7 @@ func TestHmacAuthParseConnectionStringMixedOrder(t *testing.T) {
 }
 
 func TestHmacAuthParseConnectionStringExtraProperties(t *testing.T) {
-	ep, id, sc, err := parseConnectionString("A=aA;Endpoint=xX;B=bB;Id=yY;C=cC;Secret=ZmZm;D=dD;")
+	ep, id, sc, err := ParseConnectionString("A=aA;Endpoint=xX;B=bB;Id=yY;C=cC;Secret=ZmZm;D=dD;")
 	require.NoError(t, err)
 	require.Equal(t, "xX", ep)
 	require.Equal(t, "yY", id)
@@ -49,31 +49,31 @@ func TestHmacAuthParseConnectionStringExtraProperties(t *testing.T) {
 }
 
 func TestHmacAuthParseConnectionStringMissingEndoint(t *testing.T) {
-	_, _, _, err := parseConnectionString("Id=yY;Secret=ZmZm")
+	_, _, _, err := ParseConnectionString("Id=yY;Secret=ZmZm")
 	require.Error(t, err)
 }
 
 func TestHmacAuthParseConnectionStringMissingId(t *testing.T) {
-	_, _, _, err := parseConnectionString("Endpoint=xX;Secret=ZmZm")
+	_, _, _, err := ParseConnectionString("Endpoint=xX;Secret=ZmZm")
 	require.Error(t, err)
 }
 
 func TestHmacAuthParseConnectionStringMissingSecret(t *testing.T) {
-	_, _, _, err := parseConnectionString("Endpoint=xX;Id=yY")
+	_, _, _, err := ParseConnectionString("Endpoint=xX;Id=yY")
 	require.Error(t, err)
 }
 
 func TestHmacAuthParseConnectionStringDuplicateEndoint(t *testing.T) {
-	_, _, _, err := parseConnectionString("Endpoint=xX;Endpoint=xX;Id=yY;Secret=ZmZm")
+	_, _, _, err := ParseConnectionString("Endpoint=xX;Endpoint=xX;Id=yY;Secret=ZmZm")
 	require.Error(t, err)
 }
 
 func TestHmacAuthParseConnectionStringDuplicateId(t *testing.T) {
-	_, _, _, err := parseConnectionString("Endpoint=xX;Id=yY;Id=yY;Secret=ZmZm")
+	_, _, _, err := ParseConnectionString("Endpoint=xX;Id=yY;Id=yY;Secret=ZmZm")
 	require.Error(t, err)
 }
 
 func TestHmacAuthParseConnectionStringDuplicateSecret(t *testing.T) {
-	_, _, _, err := parseConnectionString("Endpoint=xX;Id=yY;Secret=ZmZm;Secret=zZ")
+	_, _, _, err := ParseConnectionString("Endpoint=xX;Id=yY;Secret=ZmZm;Secret=zZ")
 	require.Error(t, err)
 }


### PR DESCRIPTION
No functional changes.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
