### PR TITLE
Return specific errors when parsing connection strings

### DIFF
--- a/sdk/data/azappconfig/CHANGELOG.md
+++ b/sdk/data/azappconfig/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed an issue that could cause HTTP requests to fail with `http.StatusUnauthorized` in some cases.
 
 ### Other Changes
+* `NewClientFromConnectionString()` will return a more descriptive error message when parsing the connection string fails.
 
 ## 0.5.0 (2022-11-08)
 

--- a/sdk/data/azappconfig/internal/auth/policy_hmac_auth_test.go
+++ b/sdk/data/azappconfig/internal/auth/policy_hmac_auth_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHmacAuthParseConnectionString(t *testing.T) {
+func TestParseConnectionString(t *testing.T) {
 	ep, id, sc, err := ParseConnectionString("Endpoint=xX;Id=yY;Secret=ZmZm")
 	require.NoError(t, err)
 	require.Equal(t, "xX", ep)
@@ -24,7 +24,7 @@ func TestHmacAuthParseConnectionString(t *testing.T) {
 	require.Equal(t, byte('f'), sc[2])
 }
 
-func TestHmacAuthParseConnectionStringMixedOrder(t *testing.T) {
+func TestParseConnectionStringMixedOrder(t *testing.T) {
 	ep, id, sc, err := ParseConnectionString("Id=yY;Secret=ZmZm;Endpoint=xX")
 	require.NoError(t, err)
 	require.Equal(t, "xX", ep)
@@ -36,7 +36,7 @@ func TestHmacAuthParseConnectionStringMixedOrder(t *testing.T) {
 	require.Equal(t, byte('f'), sc[2])
 }
 
-func TestHmacAuthParseConnectionStringExtraProperties(t *testing.T) {
+func TestParseConnectionStringExtraProperties(t *testing.T) {
 	ep, id, sc, err := ParseConnectionString("A=aA;Endpoint=xX;B=bB;Id=yY;C=cC;Secret=ZmZm;D=dD;")
 	require.NoError(t, err)
 	require.Equal(t, "xX", ep)
@@ -48,32 +48,44 @@ func TestHmacAuthParseConnectionStringExtraProperties(t *testing.T) {
 	require.Equal(t, byte('f'), sc[2])
 }
 
-func TestHmacAuthParseConnectionStringMissingEndoint(t *testing.T) {
+func TestParseConnectionStringMissingEndoint(t *testing.T) {
 	_, _, _, err := ParseConnectionString("Id=yY;Secret=ZmZm")
 	require.Error(t, err)
+	require.ErrorContains(t, err, "missing Endpoint")
 }
 
-func TestHmacAuthParseConnectionStringMissingId(t *testing.T) {
+func TestParseConnectionStringMissingId(t *testing.T) {
 	_, _, _, err := ParseConnectionString("Endpoint=xX;Secret=ZmZm")
 	require.Error(t, err)
+	require.ErrorContains(t, err, "missing Id")
 }
 
-func TestHmacAuthParseConnectionStringMissingSecret(t *testing.T) {
+func TestParseConnectionStringMissingSecret(t *testing.T) {
 	_, _, _, err := ParseConnectionString("Endpoint=xX;Id=yY")
 	require.Error(t, err)
+	require.ErrorContains(t, err, "missing Secret")
 }
 
-func TestHmacAuthParseConnectionStringDuplicateEndoint(t *testing.T) {
+func TestParseConnectionStringDuplicateEndoint(t *testing.T) {
 	_, _, _, err := ParseConnectionString("Endpoint=xX;Endpoint=xX;Id=yY;Secret=ZmZm")
 	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate Endpoint")
 }
 
-func TestHmacAuthParseConnectionStringDuplicateId(t *testing.T) {
+func TestParseConnectionStringDuplicateId(t *testing.T) {
 	_, _, _, err := ParseConnectionString("Endpoint=xX;Id=yY;Id=yY;Secret=ZmZm")
 	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate Id")
 }
 
-func TestHmacAuthParseConnectionStringDuplicateSecret(t *testing.T) {
+func TestParseConnectionStringDuplicateSecret(t *testing.T) {
 	_, _, _, err := ParseConnectionString("Endpoint=xX;Id=yY;Secret=ZmZm;Secret=zZ")
 	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate Secret")
+}
+
+func TestParseConnectionStringInvalidEncoding(t *testing.T) {
+	_, _, _, err := ParseConnectionString("Endpoint=xX;Id=yY;Secret=badencoding")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "illegal base64 data")
 }


### PR DESCRIPTION
Include failure details instead of a generic error message. Some other minor cleanup.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
