### PR TITLE
Check for Sync-Token before updating the cache

### DIFF
--- a/sdk/data/azappconfig/CHANGELOG.md
+++ b/sdk/data/azappconfig/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Check for a `Sync-Token` value before updating the cache.
 
 ### Other Changes
 

--- a/sdk/data/azappconfig/internal/synctoken/policy.go
+++ b/sdk/data/azappconfig/internal/synctoken/policy.go
@@ -39,9 +39,12 @@ func (p *Policy) Do(req *policy.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	// update the cache from the response
-	if err := p.cache.Set(exported.SyncToken(resp.Header.Get(syncTokenHeader))); err != nil {
-		return nil, &nonRetriableError{err}
+	// update the cache from the response if available.
+	// e.g. a 404 will include a Sync-Token but a 400 will not.
+	if st := resp.Header.Get(syncTokenHeader); st != "" {
+		if err := p.cache.Set(exported.SyncToken(st)); err != nil {
+			return nil, &nonRetriableError{err}
+		}
 	}
 
 	return resp, err

--- a/sdk/data/azappconfig/internal/synctoken/policy_test.go
+++ b/sdk/data/azappconfig/internal/synctoken/policy_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestPolicy(t *testing.T) {
 	srv, close := mock.NewServer()
-	srv.AppendResponse()
 	defer close()
 
 	cache := NewCache()
@@ -36,9 +35,11 @@ func TestPolicy(t *testing.T) {
 
 	req, err := runtime.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	require.NoError(t, err)
+
+	srv.AppendResponse()
 	resp, err := pl.Do(req)
-	require.Error(t, err) // missing Sync-Token response header
-	require.Nil(t, resp)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
 
 	srv.AppendResponse(mock.WithHeader(syncTokenHeader, "id=val"))
 	resp, err = pl.Do(req)


### PR DESCRIPTION
Some responses, e.g. http.StatusBadRequest, won't return a Sync-Token.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
