### PR TITLE
Use identity subscription config and pre script for live test variables

### DIFF
--- a/sdk/azidentity/ci.yml
+++ b/sdk/azidentity/ci.yml
@@ -26,16 +26,9 @@ stages:
   parameters:
     RunLiveTests: true
     ServiceDirectory: 'azidentity'
-    PreSteps:
-      - pwsh: |
-          [System.Convert]::FromBase64String($env:PFX_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/test.pfx -AsByteStream
-          Set-Content -Path $(Agent.TempDirectory)/test.pem -Value $env:PEM_CONTENTS
-          [System.Convert]::FromBase64String($env:SNI_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/testsni.pfx -AsByteStream
-        env:
-          PFX_CONTENTS: $(net-identity-spcert-pfx)
-          PEM_CONTENTS: $(net-identity-spcert-pem)
-          SNI_CONTENTS: $(net-identity-spcert-sni)
-    EnvVars:
-      IDENTITY_SP_CERT_PEM: $(Agent.TempDirectory)/test.pem
-      IDENTITY_SP_CERT_PFX: $(Agent.TempDirectory)/test.pfx
-      IDENTITY_SP_CERT_SNI: $(Agent.TempDirectory)/testsni.pfx
+    CloudConfig:
+      Public:
+        SubscriptionConfigurations:
+          - $(sub-config-azure-cloud-test-resources)
+          # Contains alternate tenant, AAD app and cert info for testing
+          - $(sub-config-identity-test-resources)

--- a/sdk/azidentity/test-resources-pre.ps1
+++ b/sdk/azidentity/test-resources-pre.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param (
+    # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $RemainingArguments
+)
+
+if (!$CI) {
+    # TODO: Remove this once auto-cloud config downloads are supported locally
+    Write-Host "Skipping cert setup in local testing mode"
+    return
+}
+
+if ($EnvironmentVariables -eq $null -or $EnvironmentVariables.Count -eq 0) {
+    throw "EnvironmentVariables must be set in the calling script New-TestResources.ps1"
+}
+
+$tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()
+$pfxPath = Join-Path $tmp "test.pfx"
+$pemPath = Join-Path $tmp "test.pem"
+$sniPath = Join-Path $tmp "testsni.pfx"
+
+Write-Host "Creating identity test files: $pfxPath $pemPath $sniPath"
+
+[System.Convert]::FromBase64String($EnvironmentVariables['PFX_CONTENTS']) | Set-Content -Path $pfxPath -AsByteStream
+Set-Content -Path $pemPath -Value $EnvironmentVariables['PEM_CONTENTS']
+[System.Convert]::FromBase64String($EnvironmentVariables['SNI_CONTENTS']) | Set-Content -Path $sniPath -AsByteStream
+
+# Set for pipeline
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_PFX;]$pfxPath"
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_PEM;]$pemPath"
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_SNI;]$sniPath"
+# Set for local
+$env:IDENTITY_SP_CERT_PFX = $pfxPath
+$env:IDENTITY_SP_CERT_PEM = $pemPath
+$env:IDENTITY_SP_CERT_SNI = $sniPath


### PR DESCRIPTION
Updating the identity live tests to remove logic and env setting from yaml in favor of a dedicated keyvault config. This will make it possible to improve local and sovereign cloud testing, and make cross-language config updates more easily.

Related: https://github.com/Azure/azure-sdk-for-net/pull/38473

