### PR TITLE
Defensively trim suffix and prefix of | to prevent invalid attributes

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed a bug where the `x-ms-file-attributes` header could be set to contain invalid trailing or leading | characters.
 
 ### Other Changes
 

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_66b915bf67"
+  "Tag": "go/storage/azfile_aafef7262b"
 }

--- a/sdk/storage/azfile/internal/exported/smb_property.go
+++ b/sdk/storage/azfile/internal/exported/smb_property.go
@@ -46,6 +46,8 @@ func FormatSMBProperties(sp *SMBProperties, isDir bool) (fileAttributes *string,
 			// Directories need to have this attribute included, if setting any attributes.
 			*fileAttributes += "|Directory"
 		}
+		*fileAttributes = strings.TrimPrefix(*fileAttributes, "|")
+		*fileAttributes = strings.TrimSuffix(*fileAttributes, "|")
 	}
 
 	creationTime = nil


### PR DESCRIPTION
This is fixing a bug introduced in this PR. https://github.com/Azure/azure-sdk-for-go/commit/0c1dfe5e2c8f27f557e67b39ba8d74618533634d#diff-b94011e17ec4244b354bbf2cdfdec36490abd7480e993f4879e3b4a649b46705R42
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
