### PR TITLE
Add AuthenticationRecord to publicClientOptions

### DIFF
--- a/sdk/azidentity/assets.json
+++ b/sdk/azidentity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/azidentity",
-  "Tag": "go/azidentity_625e4cf3e9"
+  "Tag": "go/azidentity_ae45facec3"
 }

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -212,8 +212,8 @@ func TestUserAuthentication(t *testing.T) {
 		})
 
 		t.Run("PersistentCache_Live/"+credential.name, func(t *testing.T) {
-			if runtime.GOOS == "darwin" {
-				t.Skip("persistent caching requires interaction on macOS")
+			if runtime.GOOS != "windows" {
+				t.Skip("this test runs only on Windows")
 			}
 			if credential.name == credNameBrowser && !runManualTests {
 				t.Skipf("set %s to run this test", azidentityRunManualTests)

--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -104,6 +104,7 @@ func NewDeviceCodeCredential(options *DeviceCodeCredentialOptions) (*DeviceCodeC
 		DeviceCodePrompt:               cp.UserPrompt,
 		DisableAutomaticAuthentication: cp.DisableAutomaticAuthentication,
 		DisableInstanceDiscovery:       cp.DisableInstanceDiscovery,
+		Record:                         cp.AuthenticationRecord,
 		TokenCachePersistenceOptions:   cp.TokenCachePersistenceOptions,
 	}
 	c, err := newPublicClient(cp.TenantID, cp.ClientID, credNameDeviceCode, msalOpts)

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -84,6 +84,7 @@ func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOption
 		DisableAutomaticAuthentication: cp.DisableAutomaticAuthentication,
 		DisableInstanceDiscovery:       cp.DisableInstanceDiscovery,
 		LoginHint:                      cp.LoginHint,
+		Record:                         cp.AuthenticationRecord,
 		RedirectURL:                    cp.RedirectURL,
 		TokenCachePersistenceOptions:   cp.TokenCachePersistenceOptions,
 	}

--- a/sdk/azidentity/public_client.go
+++ b/sdk/azidentity/public_client.go
@@ -33,6 +33,7 @@ type publicClientOptions struct {
 	DisableAutomaticAuthentication bool
 	DisableInstanceDiscovery       bool
 	LoginHint, RedirectURL         string
+	Record                         AuthenticationRecord
 	TokenCachePersistenceOptions   *TokenCachePersistenceOptions
 	Username, Password             string
 }
@@ -90,6 +91,7 @@ func newPublicClient(tenantID, clientID, name string, o publicClientOptions) (*p
 		name:         name,
 		noCAEMu:      &sync.Mutex{},
 		opts:         o,
+		record:       o.Record,
 		tenantID:     tenantID,
 	}, nil
 }

--- a/sdk/azidentity/username_password_credential.go
+++ b/sdk/azidentity/username_password_credential.go
@@ -57,6 +57,7 @@ func NewUsernamePasswordCredential(tenantID string, clientID string, username st
 		ClientOptions:                options.ClientOptions,
 		DisableInstanceDiscovery:     options.DisableInstanceDiscovery,
 		Password:                     password,
+		Record:                       options.AuthenticationRecord,
 		TokenCachePersistenceOptions: options.TokenCachePersistenceOptions,
 		Username:                     username,
 	}


### PR DESCRIPTION
Credentials which authenticate users need to pass AuthenticationRecords to the public client so it can access previously cached data.