### PR TITLE
Fix azidentity/cache CI

### DIFF
--- a/eng/config.json
+++ b/eng/config.json
@@ -30,7 +30,7 @@
         },
         {
             "Name": "azidentity/cache",
-            "CoverageGoal": 0.42
+            "CoverageGoal": 0.35
         },
         {
             "Name": "azqueue",

--- a/eng/config.json
+++ b/eng/config.json
@@ -29,6 +29,10 @@
             "CoverageGoal": 0.87
         },
         {
+            "Name": "azidentity/cache",
+            "CoverageGoal": 0.42
+        },
+        {
             "Name": "azqueue",
             "CoverageGoal": 0.60
         },

--- a/sdk/azidentity/cache/CHANGELOG.md
+++ b/sdk/azidentity/cache/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Release History
+
+## 0.1.0 (Unreleased)
+
+### Features Added
+* Initial release

--- a/sdk/azidentity/cache/LICENSE.txt
+++ b/sdk/azidentity/cache/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/sdk/azidentity/cache/README.md
+++ b/sdk/azidentity/cache/README.md
@@ -1,6 +1,6 @@
 # Azure Identity Cache Module for Go
 
-This module implements a cross-platform persistent token cache for [azidentity][https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity] credentials. See that module's [examples](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#pkg-examples) for sample code showing how to configure persistent caching for a credential.
+This module implements a cross-platform persistent token cache for [azidentity](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity) credentials. See that module's [examples](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#pkg-examples) for sample code showing how to configure persistent caching for a credential.
 
 ## Provide Feedback
 

--- a/sdk/azidentity/cache/README.md
+++ b/sdk/azidentity/cache/README.md
@@ -1,0 +1,29 @@
+# Azure Identity Cache Module for Go
+
+This module implements a cross-platform persistent token cache for [azidentity][https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity] credentials. See that module's [examples](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#pkg-examples) for sample code showing how to configure persistent caching for a credential.
+
+## Provide Feedback
+
+If you encounter bugs or have suggestions, please
+[open an issue](https://github.com/Azure/azure-sdk-for-go/issues).
+
+## Contributing
+
+This project welcomes contributions and suggestions. Most contributions require
+you to agree to a Contributor License Agreement (CLA) declaring that you have
+the right to, and actually do, grant us the rights to use your contribution.
+For details, visit [https://cla.microsoft.com](https://cla.microsoft.com).
+
+When you submit a pull request, a CLA-bot will automatically determine whether
+you need to provide a CLA and decorate the PR appropriately (e.g., label,
+comment). Simply follow the instructions provided by the bot. You will only
+need to do this once across all repos using our CLA.
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
+additional questions or comments.
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fazidentity%2Fcache%2FREADME.png)

--- a/sdk/azidentity/cache/linux_test.go
+++ b/sdk/azidentity/cache/linux_test.go
@@ -19,19 +19,18 @@ import (
 )
 
 var (
-	ctx              = context.Background()
-	storageAvailable = false
+	ctx        = context.Background()
+	keyringErr error
 )
 
 func TestMain(m *testing.M) {
-	err := tryKeyring()
-	storageAvailable = err == nil
+	keyringErr = tryKeyring()
 	os.Exit(m.Run())
 }
 
 func TestKeyExistsButNotFile(t *testing.T) {
-	if !storageAvailable {
-		t.Skip("storage isn't available")
+	if keyringErr != nil {
+		t.Skip(keyringErr)
 	}
 	expected := []byte(t.Name())
 	a, err := newKeyring(t.Name())
@@ -58,8 +57,8 @@ func TestKeyExistsButNotFile(t *testing.T) {
 }
 
 func TestReadWriteDelete(t *testing.T) {
-	if !storageAvailable {
-		t.Skip("storage isn't available")
+	if keyringErr != nil {
+		t.Skip(keyringErr)
 	}
 	for _, test := range []struct {
 		expected   []byte
@@ -116,8 +115,8 @@ func TestReadWriteDelete(t *testing.T) {
 }
 
 func TestTwoInstances(t *testing.T) {
-	if !storageAvailable {
-		t.Skip("storage isn't available")
+	if keyringErr != nil {
+		t.Skip(keyringErr)
 	}
 	for _, deleteFile := range []bool{false, true} {
 		s := "key and file exist"
@@ -159,9 +158,6 @@ func TestTwoInstances(t *testing.T) {
 }
 
 func TestUnencryptedFallback(t *testing.T) {
-	if !storageAvailable {
-		t.Skip("storage isn't available")
-	}
 	before := tryKeyring
 	t.Cleanup(func() { tryKeyring = before })
 	tryKeyring = func() error { return errors.New("it didn't work") }

--- a/sdk/azidentity/cache/linux_test.go
+++ b/sdk/azidentity/cache/linux_test.go
@@ -21,6 +21,10 @@ import (
 var ctx = context.Background()
 
 func TestKeyExistsButNotFile(t *testing.T) {
+	before := cacheDir
+	t.Cleanup(func() { cacheDir = before })
+	tmpdir := t.TempDir()
+	cacheDir = func() (string, error) { return tmpdir, nil }
 	expected := []byte(t.Name())
 	a, err := newKeyring(t.Name())
 	require.NoError(t, err)
@@ -46,6 +50,10 @@ func TestKeyExistsButNotFile(t *testing.T) {
 }
 
 func TestReadWriteDelete(t *testing.T) {
+	before := cacheDir
+	t.Cleanup(func() { cacheDir = before })
+	tmpdir := t.TempDir()
+	cacheDir = func() (string, error) { return tmpdir, nil }
 	for _, test := range []struct {
 		expected   []byte
 		desc, name string
@@ -101,6 +109,10 @@ func TestReadWriteDelete(t *testing.T) {
 }
 
 func TestTwoInstances(t *testing.T) {
+	before := cacheDir
+	t.Cleanup(func() { cacheDir = before })
+	tmpdir := t.TempDir()
+	cacheDir = func() (string, error) { return tmpdir, nil }
 	for _, deleteFile := range []bool{false, true} {
 		s := "key and file exist"
 		if deleteFile {
@@ -141,9 +153,11 @@ func TestTwoInstances(t *testing.T) {
 }
 
 func TestUnencryptedFallback(t *testing.T) {
-	before := tryKeyring
-	t.Cleanup(func() { tryKeyring = before })
+	tryKeyringBefore := tryKeyring
+	t.Cleanup(func() { tryKeyring = tryKeyringBefore })
 	tryKeyring = func() error { return errors.New("it didn't work") }
+	cacheDirBefore := cacheDir
+	t.Cleanup(func() { cacheDir = cacheDirBefore })
 
 	o := internal.TokenCachePersistenceOptions{Name: t.Name()}
 	_, err := storage(internal.TokenCachePersistenceOptions{})

--- a/sdk/azidentity/cache/mock_test.go
+++ b/sdk/azidentity/cache/mock_test.go
@@ -1,0 +1,169 @@
+//go:build go1.18 && windows
+// +build go1.18,windows
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cache
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	mockClientInfo = "eyJ1aWQiOiJjNzNjNmYyOC1hZTVmLTQxM2QtYTlhMi1lMTFlNWFmNjY4ZjgiLCJ1dGlkIjoiZTBiZDIzMjEtMDdmYS00Y2YwLTg3YjgtMDBhYTJhNzQ3MzI5In0"
+	mockIDT        = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Imwzc1EtNTBjQ0g0eEJWWkxIVEd3blNSNzY4MCJ9.eyJhdWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE2MzcxOTEyMTIsIm5iZiI6MTYzNzE5MTIxMiwiZXhwIjoxNjM3MTk1MTEyLCJhaW8iOiJBVVFBdS84VEFBQUFQMExOZGNRUXQxNmJoSkFreXlBdjFoUGJuQVhtT0o3RXJDVHV4N0hNTjhHd2VMb2FYMWR1cDJhQ2Y0a0p5bDFzNmovSzF5R05DZmVIQlBXM21QUWlDdz09IiwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvZTBiZDIzMjEtMDdmYS00Y2YwLTg3YjgtMDBhYTJhNzQ3MzI5LyIsIm5hbWUiOiJJZGVudGl0eSBUZXN0IFVzZXIiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJpZGVudGl0eXRlc3R1c2VyQGF6dXJlc2Rrb3V0bG9vay5vbm1pY3Jvc29mdC5jb20iLCJyaCI6IjAuQVMwQWlLeFB4ZE05SDBhbnhJbzJqZ05BczVWM3NBVGJqUnBHdS00Qy1lR19lMFl0QUxFLiIsInN1YiI6ImMxYTBsY2xtbWxCYW9wc0MwVmlaLVpPMjFCT2dSUXE3SG9HRUtOOXloZnMiLCJ0aWQiOiJjNTRmYWM4OC0zZGQzLTQ2MWYtYTdjNC04YTM2OGUwMzQwYjMiLCJ1dGkiOiI5TXFOSWI5WjdrQy1QVHRtai11X0FBIiwidmVyIjoiMi4wIn0.hh5Exz9MBjTXrTuTZnz7vceiuQjcC_oRSTeBIC9tYgSO2c2sqQRpZi91qBZFQD9okayLPPKcwqXgEJD9p0-c4nUR5UQN7YSeDLmYtZUYMG79EsA7IMiQaiy94AyIe2E-oBDcLwFycGwh1iIOwwOwjbanmu2Dx3HfQx831lH9uVjagf0Aow0wTkTVCsedGSZvG-cRUceFLj-kFN-feFH3NuScuOfLR2Magf541pJda7X7oStwL_RNUFqjJFTdsiFV4e-VHK5qo--3oPU06z0rS9bosj0pFSATIVHrrS4gY7jiSvgMbG837CDBQkz5b08GUN5GlLN9jlygl1plBmbgww"
+)
+
+var accessTokenRespSuccess = []byte(fmt.Sprintf(`{"access_token": "%s", "expires_in": 3600}`, "tokenValue"))
+
+// mockSTS returns mock Azure AD responses so tests don't have to account for
+// MSAL metadata requests. By default, all responses are success responses
+// having a token which expires in 1 hour and whose value is the "tokenValue"
+// constant. Set tokenRequestCallback to return a different *http.Response.
+type mockSTS struct {
+	// tenant to include in metadata responses. This value must match a test's
+	// expected tenant because metadata tells MSAL where to send token requests.
+	// Defaults to the "fakeTenantID" constant.
+	tenant string
+	// tokenRequestCallback is called for every token request. Return nil to
+	// send a generic success response.
+	tokenRequestCallback func(*http.Request) *http.Response
+}
+
+func (m *mockSTS) Do(req *http.Request) (*http.Response, error) {
+	res := &http.Response{StatusCode: http.StatusOK}
+	tenant := m.tenant
+	if tenant == "" {
+		tenant = "fake-tenant"
+	}
+	switch s := strings.Split(req.URL.Path, "/"); s[len(s)-1] {
+	case "instance":
+		res.Body = io.NopCloser(bytes.NewReader(instanceMetadata(tenant)))
+	case "openid-configuration":
+		res.Body = io.NopCloser(bytes.NewReader(tenantMetadata(tenant)))
+	case "devicecode":
+		res.Body = io.NopCloser(strings.NewReader(`{"device_code":"...","expires_in":600,"interval":60}`))
+	case "token":
+		if err := req.ParseForm(); err != nil {
+			return nil, fmt.Errorf("mockSTS failed to parse a request body: %w", err)
+		}
+		if grant := req.FormValue("grant_type"); grant == "device_code" || grant == "password" {
+			// include account info because we're authenticating a user
+			res.Body = io.NopCloser(bytes.NewReader(
+				[]byte(fmt.Sprintf(`{"access_token":"at","expires_in": 3600,"refresh_token":"rt","client_info":%q,"id_token":%q}`, mockClientInfo, mockIDT)),
+			))
+		} else {
+			res.Body = io.NopCloser(bytes.NewReader(accessTokenRespSuccess))
+		}
+		if m.tokenRequestCallback != nil {
+			if r := m.tokenRequestCallback(req); r != nil {
+				res = r
+			}
+		}
+	default:
+		// User realm metadata request paths look like "/common/UserRealm/user@domain".
+		// Matching on the UserRealm segment avoids having to know the UPN.
+		if s[len(s)-2] == "UserRealm" {
+			res.Body = io.NopCloser(
+				strings.NewReader(`{"account_type":"Managed","cloud_audience_urn":"urn","cloud_instance_name":"...","domain_name":"..."}`),
+			)
+		} else {
+			return nil, fmt.Errorf("mockSTS received an unexpected request for %s", req.URL.String())
+		}
+	}
+	return res, nil
+}
+
+func instanceMetadata(tenant string) []byte {
+	return []byte(strings.ReplaceAll(`{
+		"tenant_discovery_endpoint": "https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration",
+		"api-version": "1.1",
+		"metadata": [
+			{
+				"preferred_network": "login.microsoftonline.com",
+				"preferred_cache": "login.windows.net",
+				"aliases": [
+					"login.microsoftonline.com",
+					"login.windows.net",
+					"login.microsoft.com",
+					"sts.windows.net"
+				]
+			}
+		]
+	}`, "{tenant}", tenant))
+}
+
+func tenantMetadata(tenant string) []byte {
+	return []byte(strings.ReplaceAll(`{
+		"token_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
+		"token_endpoint_auth_methods_supported": [
+			"client_secret_post",
+			"private_key_jwt",
+			"client_secret_basic"
+		],
+		"jwks_uri": "https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys",
+		"response_modes_supported": [
+			"query",
+			"fragment",
+			"form_post"
+		],
+		"subject_types_supported": [
+			"pairwise"
+		],
+		"id_token_signing_alg_values_supported": [
+			"RS256"
+		],
+		"response_types_supported": [
+			"code",
+			"id_token",
+			"code id_token",
+			"id_token token"
+		],
+		"scopes_supported": [
+			"openid",
+			"profile",
+			"email",
+			"offline_access"
+		],
+		"issuer": "https://login.microsoftonline.com/{tenant}/v2.0",
+		"request_uri_parameter_supported": false,
+		"userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+		"authorization_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize",
+		"device_authorization_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/devicecode",
+		"http_logout_supported": true,
+		"frontchannel_logout_supported": true,
+		"end_session_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/logout",
+		"claims_supported": [
+			"sub",
+			"iss",
+			"cloud_instance_name",
+			"cloud_instance_host_name",
+			"cloud_graph_host_name",
+			"msgraph_host",
+			"aud",
+			"exp",
+			"iat",
+			"auth_time",
+			"acr",
+			"nonce",
+			"preferred_username",
+			"name",
+			"tid",
+			"ver",
+			"at_hash",
+			"c_hash",
+			"email"
+		],
+		"kerberos_endpoint": "https://login.microsoftonline.com/{tenant}/kerberos",
+		"tenant_region_scope": "NA",
+		"cloud_instance_name": "microsoftonline.com",
+		"cloud_graph_host_name": "graph.windows.net",
+		"msgraph_host": "graph.microsoft.com",
+		"rbac_url": "https://pas.windows.net"
+	}`, "{tenant}", tenant))
+}

--- a/sdk/azidentity/cache/windows_test.go
+++ b/sdk/azidentity/cache/windows_test.go
@@ -1,0 +1,69 @@
+//go:build go1.18 && windows
+// +build go1.18,windows
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cache
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/stretchr/testify/require"
+)
+
+var ctx = context.Background()
+
+func TestCaching(t *testing.T) {
+	for _, test := range []struct {
+		ctor func(azidentity.TokenCachePersistenceOptions) (azcore.TokenCredential, error)
+		name string
+	}{
+		{
+			func(tcpo azidentity.TokenCachePersistenceOptions) (azcore.TokenCredential, error) {
+				opts := azidentity.ClientSecretCredentialOptions{
+					ClientOptions:                policy.ClientOptions{Transport: &mockSTS{}},
+					TokenCachePersistenceOptions: &tcpo,
+				}
+				return azidentity.NewClientSecretCredential("tenantID", "clientID", "secret", &opts)
+			},
+			"confidential",
+		},
+		{
+			func(tcpo azidentity.TokenCachePersistenceOptions) (azcore.TokenCredential, error) {
+				opts := azidentity.DeviceCodeCredentialOptions{
+					ClientOptions:                policy.ClientOptions{Transport: &mockSTS{}},
+					TokenCachePersistenceOptions: &tcpo,
+				}
+				return azidentity.NewDeviceCodeCredential(&opts)
+			},
+			"public",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tcpo := azidentity.TokenCachePersistenceOptions{
+				Name: strings.ReplaceAll(t.Name(), string(filepath.Separator), "_"),
+			}
+			if a, e := storage(azidentity.TokenCachePersistenceOptions{Name: tcpo.Name + ".nocae"}); e == nil {
+				defer func() { a.Delete(ctx) }()
+			}
+			cred, err := test.ctor(tcpo)
+			require.NoError(t, err)
+			tro := policy.TokenRequestOptions{Scopes: []string{"scope"}}
+			tk, err := cred.GetToken(ctx, tro)
+			require.NoError(t, err)
+
+			cred2, err := test.ctor(tcpo)
+			require.NoError(t, err)
+			tk2, err := cred2.GetToken(ctx, tro)
+			require.NoError(t, err)
+			require.Equal(t, tk.Token, tk2.Token)
+		})
+	}
+}


### PR DESCRIPTION
This skips testing the Linux persistent cache implementation when it isn't useable, as in our CI where the user who executes tests apparently isn't allowed to write files. Skipping those tests requires setting a low coverage bar. I also added a changelog, readme and license file to get the analyze job passing.