### PR TITLE
Add WithQueryParameters to policy package

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added `WithQueryParameters` to the `policy` package to facilitate adding custom query parameters to an API call.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/azcore/internal/shared/shared.go
+++ b/sdk/azcore/internal/shared/shared.go
@@ -33,6 +33,8 @@ type CtxWithTracingTracer struct{}
 // CtxAPINameKey is used as a context key for adding/retrieving the API name.
 type CtxAPINameKey struct{}
 
+type CtxWithQueryParametersKey struct{}
+
 // Delay waits for the duration to elapse or the context to be cancelled.
 func Delay(ctx context.Context, delay time.Duration) error {
 	select {

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -9,6 +9,7 @@ package policy
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -177,6 +178,13 @@ func WithCaptureResponse(parent context.Context, resp **http.Response) context.C
 // Any overlapping headers will have their values replaced with the values specified here.
 func WithHTTPHeader(parent context.Context, header http.Header) context.Context {
 	return context.WithValue(parent, shared.CtxWithHTTPHeaderKey{}, header)
+}
+
+// WithQueryParameters adds the specified url.Values to the parent context.
+// Use this to specify custom query parameters at the API-call level.
+// Any overlapping parameters will have their values replaced with the values specified here.
+func WithQueryParameters(parent context.Context, v url.Values) context.Context {
+	return context.WithValue(parent, shared.CtxWithQueryParametersKey{}, v)
 }
 
 // WithRetryOptions adds the specified RetryOptions to the parent context.

--- a/sdk/azcore/policy/policy_test.go
+++ b/sdk/azcore/policy/policy_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"math"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
@@ -39,6 +40,21 @@ func TestWithHTTPHeader(t *testing.T) {
 	header, ok := raw.(http.Header)
 	require.True(t, ok)
 	require.EqualValues(t, val, header.Get(key))
+}
+
+func TestWithQueryParameters(t *testing.T) {
+	const (
+		key = "some"
+		val = "thing"
+	)
+	input := url.Values{}
+	input.Set(key, val)
+	ctx := WithQueryParameters(context.Background(), input)
+	require.NotNil(t, ctx)
+	raw := ctx.Value(shared.CtxWithQueryParametersKey{})
+	qp, ok := raw.(url.Values)
+	require.True(t, ok)
+	require.EqualValues(t, val, qp.Get(key))
 }
 
 func TestWithRetryOptions(t *testing.T) {

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -77,6 +77,7 @@ func NewPipeline(module, version string, plOpts PipelineOptions, options *policy
 	policies = append(policies, plOpts.PerRetry...)
 	policies = append(policies, cp.PerRetryPolicies...)
 	policies = append(policies, exported.PolicyFunc(httpHeaderPolicy))
+	policies = append(policies, exported.PolicyFunc(queryParamsPolicy))
 	policies = append(policies, newHTTPTracePolicy(cp.Logging.AllowedQueryParams))
 	policies = append(policies, NewLogPolicy(&cp.Logging))
 	policies = append(policies, exported.PolicyFunc(bodyDownloadPolicy))

--- a/sdk/azcore/runtime/policy_query_params.go
+++ b/sdk/azcore/runtime/policy_query_params.go
@@ -1,0 +1,48 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// queryParamsPolicy is a policy that adds custom query parameters to a request
+func queryParamsPolicy(req *policy.Request) (*http.Response, error) {
+	// check if any custom query params have been specified
+	rawQP := req.Raw().Context().Value(shared.CtxWithQueryParametersKey{})
+	if rawQP == nil {
+		return req.Next()
+	}
+
+	// grab any existing query params
+	var allQP url.Values
+	if req.Raw().URL.RawQuery != "" {
+		var err error
+		allQP, err = url.ParseQuery(req.Raw().URL.RawQuery)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	newQP := rawQP.(url.Values)
+	if len(allQP) > 0 {
+		// merge the existing query params with the ones in the context.
+		// any overlapping values will be replaced with the context-provided values.
+		for qp := range newQP {
+			allQP[qp] = newQP[qp]
+		}
+	} else {
+		allQP = newQP
+	}
+
+	req.Raw().URL.RawQuery = allQP.Encode()
+	return req.Next()
+}

--- a/sdk/azcore/runtime/policy_query_params_test.go
+++ b/sdk/azcore/runtime/policy_query_params_test.go
@@ -1,0 +1,124 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithQueryParametersSuccess(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	const (
+		customQP         = "custom-qp"
+		customValue      = "custom-value"
+		preexistingQP    = "preexisting-qp"
+		preexistingValue = "preexisting-value"
+	)
+	srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
+		// ensure preexisting query param wasn't removed
+		qp, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			return false
+		}
+		return qp.Get(customQP) == customValue && qp.Get(preexistingQP) == preexistingValue
+	}), mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
+	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
+	req, err := NewRequest(policy.WithQueryParameters(context.Background(), url.Values{
+		customQP: []string{customValue},
+	}), http.MethodGet, srv.URL())
+	require.NoError(t, err)
+	qp := url.Values{}
+	qp.Set(preexistingQP, preexistingValue)
+	req.Raw().URL.RawQuery = qp.Encode()
+	resp, err := pl.Do(req)
+	require.NoError(t, err)
+	require.EqualValues(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestWithQueryParametersFail(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	const (
+		customQP    = "custom-qp"
+		customValue = "custom-value"
+	)
+	srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
+		qp, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			return false
+		}
+		return qp.Get(customQP) == customValue
+	}), mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
+	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	require.NoError(t, err)
+	resp, err := pl.Do(req)
+	require.NoError(t, err)
+	require.EqualValues(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestWithQueryParametersOverwrite(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	const (
+		customQP    = "custom-qp"
+		customValue = "custom-value"
+	)
+	srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
+		qp, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			return false
+		}
+		return qp.Get(customQP) == customValue
+	}), mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
+	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
+	req, err := NewRequest(policy.WithQueryParameters(context.Background(), url.Values{
+		customQP: []string{customValue},
+	}), http.MethodGet, srv.URL()+fmt.Sprintf("?%s=overwrite-me", customQP))
+	require.NoError(t, err)
+	resp, err := pl.Do(req)
+	require.NoError(t, err)
+	require.EqualValues(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestWithQueryParametersMultipleValues(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	const (
+		customQP     = "custom-qp"
+		customValue1 = "custom-value1"
+		customValue2 = "custom-value2"
+	)
+	srv.AppendResponse(mock.WithPredicate(func(r *http.Request) bool {
+		qp, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			return false
+		}
+		return qp[customQP][0] == customValue1 && qp[customQP][1] == customValue2
+	}), mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest))
+	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
+	req, err := NewRequest(policy.WithQueryParameters(context.Background(), url.Values{
+		customQP: []string{customValue1, customValue2},
+	}), http.MethodGet, srv.URL())
+	require.NoError(t, err)
+	resp, err := pl.Do(req)
+	require.NoError(t, err)
+	require.EqualValues(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
Enables custom query params for API calls.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/21704