### PR TITLE
[azeventgrid] Use CE instead of EG (otherwise we're generating a SAS based on a separate topic)

### DIFF
--- a/sdk/messaging/azeventgrid/publisher/client_test.go
+++ b/sdk/messaging/azeventgrid/publisher/client_test.go
@@ -90,7 +90,7 @@ func TestPublishCloudEvent(t *testing.T) {
 	})
 
 	t.Run("sharedkey", func(t *testing.T) {
-		client, err := publisher.NewClientWithSharedKeyCredential(vars.CE.Endpoint, azcore.NewKeyCredential(vars.EG.Key), newClientOptionsForTest(t, vars.CE))
+		client, err := publisher.NewClientWithSharedKeyCredential(vars.CE.Endpoint, azcore.NewKeyCredential(vars.CE.Key), newClientOptionsForTest(t, vars.CE))
 		require.NoError(t, err)
 		testPublish(t, client)
 	})


### PR DESCRIPTION
Copy/paste error from another PR.