### PR TITLE
Fix unmarshalling usages value

### DIFF
--- a/sdk/resourcemanager/quota/armquota/models_serde.go
+++ b/sdk/resourcemanager/quota/armquota/models_serde.go
@@ -1015,10 +1015,10 @@ func (u *UsagesObject) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "usagesType":
+		case "UsagesType", "usagesType":
 			err = unpopulate(val, "UsagesType", &u.UsagesType)
 			delete(rawMsg, key)
-		case "value":
+		case "Value", "value":
 			err = unpopulate(val, "Value", &u.Value)
 			delete(rawMsg, key)
 		}


### PR DESCRIPTION
Recently I have noticed that when attempting to retrieve the `Usages` value, it consistently returns an empty result. In contrast, the Azure CLI provides a non-empty result for the same query.

I have also posted a related question (containing code snippets) on StackOverflow, for reference: [StackOverflow Question](https://stackoverflow.com/questions/77266498/how-to-get-network-usages-quotas-using-azure-sdk-for-golang).

During my investigation into this issue, I decided to explore how other SDKs handle it. To my surprise, I found that when using the SDK for Python, the correct approach to access the `Usages` value is not through `usagesResult.properties.usages.value` (where `usagesResult` is the result of the `AzureQuotaExtensionAPI.usages.get` call), but rather through `usagesResult.properties.usages.additional_properties["Value"]`.

In light of this discovery, I would like to propose a quick fix to address this discrepancy and enable the correct population of the `UsagesObject`. I understand that the root cause of this issue may lie elsewhere, and there may be a different intended structure for storing the `Usages` value. However, as a regular SDK user with limited knowledge of Azure's internal workings, I can only suggest this straightforward fix based on my observations.

I have tested this fix on my own account, but I assume that having others verify this issue should be a swift process.