### PR TITLE
Modified ARM template to built-in Files RBAC role

### DIFF
--- a/sdk/storage/azfile/test-resources.json
+++ b/sdk/storage/azfile/test-resources.json
@@ -25,7 +25,7 @@
       "blobDataContributorRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
       "contributorRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c')]",
       "blobDataOwnerRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b')]",
-      "fileElevatedContributorCustomRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/9276e164-dbbe-4f3f-b4db-cfdd87eebbe9')]",
+      "fileDataPrivilegedContributorRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/69566ab7-960f-475b-8e7c-b3118f30c6bd')]",
       "primaryAccountName": "[concat(parameters('baseName'), 'prim')]",
       "immutableAccountName": "[concat(parameters('baseName'), 'imm')]",
       "primaryEncryptionScopeName": "encryptionScope",
@@ -89,9 +89,9 @@
       {
         "type": "Microsoft.Authorization/roleAssignments",
         "apiVersion": "[variables('authorizationApiVersion')]",
-        "name": "[guid(concat('fileElevatedContributorCustomRoleId', resourceGroup().id))]",
+        "name": "[guid(concat('fileDataPrivilegedContributorRoleId', resourceGroup().id))]",
         "properties": {
-          "roleDefinitionId": "[variables('fileElevatedContributorCustomRoleId')]",
+          "roleDefinitionId": "[variables('fileDataPrivilegedContributorRoleId')]",
           "principalId": "[parameters('testApplicationOid')]"
         }
       },


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go

This PR Modifies the storage ARM template to point to built-in Files RBAC role