### PR TITLE
Don't canonicalize HTTP headers when logging

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Fixed an issue that could cause some allowed HTTP header values to not show up in logs.
+
 ### Other Changes
 
 ## 1.9.0-beta.1 (2023-10-05)

--- a/sdk/azcore/runtime/policy_logging.go
+++ b/sdk/azcore/runtime/policy_logging.go
@@ -191,7 +191,8 @@ func (p *logPolicy) writeHeader(b *bytes.Buffer, header http.Header) {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		value := header.Get(k)
+		// don't use Get() as it will canonicalize k which might cause a mismatch
+		value := header[k][0]
 		// redact all header values not in the allow-list
 		if _, ok := p.allowedHeaders[strings.ToLower(k)]; !ok {
 			value = redactedValue


### PR DESCRIPTION
Use the verbatim header key.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
