### PR TITLE
[azopenai] Increasing test time to account for longer/slower API calls.

### DIFF
--- a/sdk/ai/azopenai/ci.yml
+++ b/sdk/ai/azopenai/ci.yml
@@ -25,15 +25,18 @@ pr:
 stages:
   - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
     parameters:
+      # We need to allow for longer retry times with tests that run against the public endpoint
+      # which throttles under load.
+      TimeoutInMinutes: 30
       ServiceDirectory: "ai/azopenai"
       RunLiveTests: true
       CloudConfig:
         Public:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
-            - $(sub-config-openai-test-resources)  # TestSecrets-openai
+            - $(sub-config-openai-test-resources) # TestSecrets-openai
       EnvVars:
-        AZURE_TEST_RUN_LIVE: 'true' # use when utilizing the New-TestResources Script
+        AZURE_TEST_RUN_LIVE: "true" # use when utilizing the New-TestResources Script
         AZURE_CLIENT_ID: $(AZOPENAI_CLIENT_ID)
         AZURE_CLIENT_SECRET: $(AZOPENAI_CLIENT_SECRET)
         AZURE_TENANT_ID: $(AZOPENAI_TENANT_ID)

--- a/sdk/ai/azopenai/ci.yml
+++ b/sdk/ai/azopenai/ci.yml
@@ -26,8 +26,10 @@ stages:
   - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
     parameters:
       # We need to allow for longer retry times with tests that run against the public endpoint
-      # which throttles under load.
-      TimeoutInMinutes: 30
+      # which throttles under load. Note, I left a little wiggle room since the TimeoutInMinutes
+      # controls the overall pipeline and TestRunTime configures the individual `go test -timeout` parameter.
+      TimeoutInMinutes: 35
+      TestRunTime: 30m
       ServiceDirectory: "ai/azopenai"
       RunLiveTests: true
       CloudConfig:

--- a/sdk/ai/azopenai/client_audio_test.go
+++ b/sdk/ai/azopenai/client_audio_test.go
@@ -22,7 +22,7 @@ func TestClient_GetAudioTranscription_AzureOpenAI(t *testing.T) {
 		t.Skipf("Recording needs to be revisited for multipart: https://github.com/Azure/azure-sdk-for-go/issues/21598")
 	}
 
-	client := newTestClient(t, azureWhisper)
+	client := newTestClient(t, azureWhisper, withForgivingRetryOption())
 	runTranscriptionTests(t, client, azureWhisperModel)
 }
 
@@ -54,7 +54,7 @@ func TestClient_GetAudioTranslation_AzureOpenAI(t *testing.T) {
 		t.Skipf("Recording needs to be revisited for multipart: https://github.com/Azure/azure-sdk-for-go/issues/21598")
 	}
 
-	client := newTestClient(t, azureWhisper)
+	client := newTestClient(t, azureWhisper, withForgivingRetryOption())
 	runTranslationTests(t, client, azureWhisperModel)
 }
 

--- a/sdk/ai/azopenai/client_shared_test.go
+++ b/sdk/ai/azopenai/client_shared_test.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -39,13 +38,29 @@ type endpoint struct {
 	Azure  bool
 }
 
+type testClientOption func(opt *azopenai.ClientOptions)
+
+func withForgivingRetryOption() testClientOption {
+	return func(opt *azopenai.ClientOptions) {
+		opt.Retry = policy.RetryOptions{
+			MaxRetries: 10,
+		}
+	}
+}
+
 // newTestClient creates a client enabled for HTTP recording, if needed.
 // See [newRecordingTransporter] for sanitization code.
-func newTestClient(t *testing.T, ep endpoint) *azopenai.Client {
+func newTestClient(t *testing.T, ep endpoint, options ...testClientOption) *azopenai.Client {
+	clientOptions := newClientOptionsForTest(t)
+
+	for _, opt := range options {
+		opt(clientOptions)
+	}
+
 	if ep.Azure {
 		cred := azcore.NewKeyCredential(ep.APIKey)
 
-		client, err := azopenai.NewClientWithKeyCredential(ep.URL, cred, newClientOptionsForTest(t))
+		client, err := azopenai.NewClientWithKeyCredential(ep.URL, cred, clientOptions)
 		require.NoError(t, err)
 
 		return client
@@ -60,14 +75,6 @@ func newTestClient(t *testing.T, ep endpoint) *azopenai.Client {
 
 		if options == nil {
 			options = &azopenai.ClientOptions{}
-		}
-
-		// We get rate limited quite a bit with OpenAI so we use this _very_ forgiving retry
-		// policy to make our tests pass consistently.
-		options.Retry = policy.RetryOptions{
-			MaxRetries:    60,
-			RetryDelay:    time.Second,
-			MaxRetryDelay: time.Second,
 		}
 
 		client, err := azopenai.NewClientForOpenAI(ep.URL, cred, options)
@@ -271,7 +278,7 @@ func newClientOptionsForTest(t *testing.T) *azopenai.ClientOptions {
 		keyLogPath := os.Getenv("SSLKEYLOGFILE")
 
 		if keyLogPath == "" {
-			return nil
+			return &azopenai.ClientOptions{}
 		}
 
 		keyLogWriter, err := os.OpenFile(keyLogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)

--- a/sdk/ai/azopenai/client_shared_test.go
+++ b/sdk/ai/azopenai/client_shared_test.go
@@ -71,13 +71,7 @@ func newTestClient(t *testing.T, ep endpoint, options ...testClientOption) *azop
 
 		cred := azcore.NewKeyCredential(ep.APIKey)
 
-		options := newClientOptionsForTest(t)
-
-		if options == nil {
-			options = &azopenai.ClientOptions{}
-		}
-
-		client, err := azopenai.NewClientForOpenAI(ep.URL, cred, options)
+		client, err := azopenai.NewClientForOpenAI(ep.URL, cred, clientOptions)
 		require.NoError(t, err)
 
 		return client


### PR DESCRIPTION
Raising the test timeout. We work across two APIs, both of which can be on the slower side and as I write more tests, push us over the default 15m limit.