### PR TITLE
Plumb TestRunTime parameter through job generation template

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -187,6 +187,7 @@ stages:
                   ServiceDirectory: ${{ parameters.ServiceDirectory }}
                   EnvVars: ${{ parameters.EnvVars }}
                   TimeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
+                  TestRunTime: ${{ parameters.TestRunTime }}
                   Location: ${{ parameters.Location }}
                   PreSteps:
                     - ${{ parameters.PreSteps }}


### PR DESCRIPTION
We missed a spot extending the `-timeout` argument to `go test` so overridden values aren't getting plumbed through.