### PR TITLE
[azservicebus] Update some of the areas where we mention the DefaultAzureCredential

### DIFF
--- a/sdk/messaging/azeventhubs/example_consumerclient_test.go
+++ b/sdk/messaging/azeventhubs/example_consumerclient_test.go
@@ -15,6 +15,8 @@ var consumerClient *azeventhubs.ConsumerClient
 var err error
 
 func ExampleNewConsumerClient() {
+	// `DefaultAzureCredential` tries several common credential types. For more credential types
+	// see this link: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-credential-types.
 	defaultAzureCred, err := azidentity.NewDefaultAzureCredential(nil)
 
 	if err != nil {

--- a/sdk/messaging/azeventhubs/example_producerclient_test.go
+++ b/sdk/messaging/azeventhubs/example_producerclient_test.go
@@ -14,6 +14,8 @@ import (
 var producerClient *azeventhubs.ProducerClient
 
 func ExampleNewProducerClient() {
+	// `DefaultAzureCredential` tries several common credential types. For more credential types
+	// see this link: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-credential-types.
 	defaultAzureCred, err := azidentity.NewDefaultAzureCredential(nil)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/example_client_test.go
+++ b/sdk/messaging/azservicebus/example_client_test.go
@@ -16,8 +16,8 @@ func ExampleNewClient() {
 	// NOTE: If you'd like to authenticate using a Service Bus connection string
 	// look at `NewClientFromConnectionString` instead.
 
-	// For more information about the DefaultAzureCredential:
-	// https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#NewDefaultAzureCredential
+	// `DefaultAzureCredential` tries several common credential types. For more credential types
+	// see this link: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-credential-types.
 	credential, err := azidentity.NewDefaultAzureCredential(nil)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/migrationguide.md
+++ b/sdk/messaging/azservicebus/migrationguide.md
@@ -189,6 +189,8 @@ In `azservicebus`:
 ```go
 // import "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
+// `DefaultAzureCredential` tries several common credential types. For more credential types
+// see this link: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-credential-types.
 credential, err := azidentity.NewDefaultAzureCredential(nil)
 client, err := azservicebus.NewClient("<ex: myservicebus.servicebus.windows.net>", credential, nil)
 ```


### PR DESCRIPTION
DefaultAzureCredential is great for getting started but, ultimately, users are expected to look at other more specific credentials. I've added in some text to the spots in our examples (and migration guide) that mention it, with a pointer to the docs so they can figure out what the right credential type is.

Fixes #21504