### PR TITLE
Remove fake.NewTokenCredential constructor

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 
 ### Breaking Changes
+> These changes affect only code written against previous beta versions of `v1.7.0` and `v1.8.0`
+* The function `NewTokenCredential` has been removed from the `fake` package. Use a literal `&fake.TokenCredential{}` instead.
 
 ### Bugs Fixed
 

--- a/sdk/azcore/fake/example_test.go
+++ b/sdk/azcore/fake/example_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 )
 
@@ -30,14 +29,8 @@ type WidgetListResponse struct {
 	Widgets []Widget
 }
 
-func ExampleNewTokenCredential() {
-	// create a fake azcore.TokenCredential
-	// the fake is used as the client credential during testing with fakes.
-	var _ azcore.TokenCredential = fake.NewTokenCredential()
-}
-
 func ExampleTokenCredential_SetError() {
-	cred := fake.NewTokenCredential()
+	cred := fake.TokenCredential{}
 
 	// set an error to be returned during authentication
 	cred.SetError(errors.New("failed to authenticate"))

--- a/sdk/azcore/fake/fake.go
+++ b/sdk/azcore/fake/fake.go
@@ -18,11 +18,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-// NewTokenCredential creates an instance of the TokenCredential type.
-func NewTokenCredential() *TokenCredential {
-	return &TokenCredential{}
-}
-
 // TokenCredential is a fake credential that implements the azcore.TokenCredential interface.
 type TokenCredential struct {
 	err error

--- a/sdk/azcore/fake/fake_test.go
+++ b/sdk/azcore/fake/fake_test.go
@@ -34,8 +34,7 @@ type widgets struct {
 }
 
 func TestNewTokenCredential(t *testing.T) {
-	cred := fake.NewTokenCredential()
-	require.NotNil(t, cred)
+	cred := fake.TokenCredential{}
 
 	tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
It doesn't add any value over using a literal fake.TokenCredential.
