### PR TITLE
Add tracing.Tracer to requests instead of context

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Features Added
 
+* Added type `TracingOptions` to the `runtime` package for configuring tracing during pipeline construction.
+* Added method `Tracer` to `runtime.Pipeline` which returns the `tracing.Tracer` for that pipeline.
+
 ### Breaking Changes
 > These changes affect only code written against previous beta versions of `v1.7.0` and `v1.8.0`
 * The function `NewTokenCredential` has been removed from the `fake` package. Use a literal `&fake.TokenCredential{}` instead.
+* The field `TracingNamespace` in `runtime.PipelineOptions` has been replaced by `TracingOptions`.
 
 ### Bugs Fixed
 
@@ -17,6 +21,7 @@
 * Passing a `nil` credential value will no longer cause a panic. Instead, the authentication is skipped.
 * Calling `Error` on a zero-value `azcore.ResponseError` will no longer panic.
 * Fixed an issue in `fake.PagerResponder[T]` that would cause a trailing error to be omitted when iterating over pages.
+* Pipelines created with a non zero-value `tracing.Provider` are now capable of creating traces.
 
 ### Other Changes
 

--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
@@ -292,7 +291,7 @@ func TestBearerTokenPolicyRequiresHTTPS(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	b := NewBearerTokenPolicy(mockCredential{}, nil)
-	pl := newTestPipeline(&policy.ClientOptions{Transport: srv, PerRetryPolicies: []policy.Policy{b}})
+	pl := newTestPipeline(&azpolicy.ClientOptions{Transport: srv, PerRetryPolicies: []azpolicy.Policy{b}})
 	req, err := runtime.NewRequest(context.Background(), "GET", srv.URL())
 	require.NoError(t, err)
 	_, err = pl.Do(req)

--- a/sdk/azcore/arm/runtime/policy_trace_namespace.go
+++ b/sdk/azcore/arm/runtime/policy_trace_namespace.go
@@ -17,13 +17,13 @@ import (
 
 // httpTraceNamespacePolicy is a policy that adds the az.namespace attribute to the current Span
 func httpTraceNamespacePolicy(req *policy.Request) (resp *http.Response, err error) {
-	rawTracer := req.Raw().Context().Value(shared.CtxWithTracingTracer{})
-	if tracer, ok := rawTracer.(tracing.Tracer); ok && tracer.Enabled() {
+	var tracer tracing.Tracer
+	if req.OperationValue(&tracer) && tracer.Enabled() {
 		rt, err := resource.ParseResourceType(req.Raw().URL.Path)
 		if err == nil {
 			// add the namespace attribute to the current span
 			span := tracer.SpanFromContext(req.Raw().Context())
-			span.SetAttributes(tracing.Attribute{Key: "az.namespace", Value: rt.Namespace})
+			span.SetAttributes(tracing.Attribute{Key: shared.TracingNamespaceAttrName, Value: rt.Namespace})
 		}
 	}
 	return req.Next()

--- a/sdk/azcore/arm/runtime/policy_trace_namespace_test.go
+++ b/sdk/azcore/arm/runtime/policy_trace_namespace_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/stretchr/testify/require"
@@ -22,17 +21,10 @@ func TestHTTPTraceNamespacePolicy(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 
-	pl := exported.NewPipeline(srv, exported.PolicyFunc(httpTraceNamespacePolicy))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, exported.PolicyFunc(httpTraceNamespacePolicy))
 
 	// no tracer
 	req, err := exported.NewRequest(context.Background(), http.MethodGet, srv.URL())
-	require.NoError(t, err)
-	srv.AppendResponse()
-	_, err = pl.Do(req)
-	require.NoError(t, err)
-
-	// wrong tracer type
-	req, err = exported.NewRequest(context.WithValue(context.Background(), shared.CtxWithTracingTracer{}, 0), http.MethodGet, srv.URL())
 	require.NoError(t, err)
 	srv.AppendResponse()
 	_, err = pl.Do(req)
@@ -42,7 +34,8 @@ func TestHTTPTraceNamespacePolicy(t *testing.T) {
 	tr := tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {
 		return ctx, tracing.Span{}
 	}, nil)
-	req, err = exported.NewRequest(context.WithValue(context.Background(), shared.CtxWithTracingTracer{}, tr), http.MethodGet, srv.URL())
+	exported.SetTracer(&pl, tr)
+	req, err = exported.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	require.NoError(t, err)
 	srv.AppendResponse()
 	_, err = pl.Do(req)
@@ -65,7 +58,8 @@ func TestHTTPTraceNamespacePolicy(t *testing.T) {
 			return tracing.NewSpan(spanImpl)
 		},
 	})
-	req, err = exported.NewRequest(context.WithValue(context.Background(), shared.CtxWithTracingTracer{}, tr), http.MethodGet, srv.URL())
+	exported.SetTracer(&pl, tr)
+	req, err = exported.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	require.NoError(t, err)
 	srv.AppendResponse()
 	_, err = pl.Do(req)
@@ -88,7 +82,8 @@ func TestHTTPTraceNamespacePolicy(t *testing.T) {
 			return tracing.NewSpan(spanImpl)
 		},
 	})
-	req, err = exported.NewRequest(context.WithValue(context.Background(), shared.CtxWithTracingTracer{}, tr), http.MethodGet, srv.URL()+requestEndpoint)
+	exported.SetTracer(&pl, tr)
+	req, err = exported.NewRequest(context.Background(), http.MethodGet, srv.URL()+requestEndpoint)
 	require.NoError(t, err)
 	srv.AppendResponse()
 	_, err = pl.Do(req)

--- a/sdk/azcore/internal/exported/pipeline_test.go
+++ b/sdk/azcore/internal/exported/pipeline_test.go
@@ -11,10 +11,12 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 )
 
 func TestPipelineErrors(t *testing.T) {
-	pl := NewPipeline(nil)
+	pl := NewPipeline(tracing.Tracer{}, nil)
 	resp, err := pl.Do(nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -76,7 +78,7 @@ func TestPipelineDo(t *testing.T) {
 		t.Fatal(err)
 	}
 	tp := mockTransport{succeed: true}
-	pl := NewPipeline(&tp)
+	pl := NewPipeline(tracing.Tracer{}, &tp)
 	resp, err := pl.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azcore/internal/pollers/async/async_test.go
+++ b/sdk/azcore/internal/pollers/async/async_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/poller"
 	"github.com/stretchr/testify/require"
 )
@@ -110,7 +111,7 @@ func TestFinalGetLocation(t *testing.T) {
 	resp := initialResponse(http.MethodPost, http.NoBody)
 	resp.Header.Set(shared.HeaderAzureAsync, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, locURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		if surl := req.URL.String(); surl == fakePollingURL {
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -140,7 +141,7 @@ func TestFinalGetLocation(t *testing.T) {
 func TestFinalGetOrigin(t *testing.T) {
 	resp := initialResponse(http.MethodPost, http.NoBody)
 	resp.Header.Set(shared.HeaderAzureAsync, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		if surl := req.URL.String(); surl == fakePollingURL {
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -170,7 +171,7 @@ func TestFinalGetOrigin(t *testing.T) {
 func TestNoFinalGet(t *testing.T) {
 	resp := initialResponse(http.MethodPost, http.NoBody)
 	resp.Header.Set(shared.HeaderAzureAsync, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(`{ "status": "succeeded", "shape": "circle" }`)),
@@ -191,7 +192,7 @@ func TestNoFinalGet(t *testing.T) {
 func TestPatchNoFinalGet(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, http.NoBody)
 	resp.Header.Set(shared.HeaderAzureAsync, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(`{ "status": "succeeded", "shape": "circle" }`)),
@@ -212,7 +213,7 @@ func TestPatchNoFinalGet(t *testing.T) {
 func TestPollFailed(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, http.NoBody)
 	resp.Header.Set(shared.HeaderAzureAsync, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{},
@@ -235,7 +236,7 @@ func TestPollFailed(t *testing.T) {
 func TestPollError(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, http.NoBody)
 	resp.Header.Set(shared.HeaderAzureAsync, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
 			Header:     http.Header{},
@@ -260,7 +261,7 @@ func TestPollError(t *testing.T) {
 func TestPollFailedError(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, http.NoBody)
 	resp.Header.Set(shared.HeaderAzureAsync, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("failed")
 	})), resp, "")
 	require.NoError(t, err)

--- a/sdk/azcore/internal/pollers/body/body_test.go
+++ b/sdk/azcore/internal/pollers/body/body_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/poller"
 	"github.com/stretchr/testify/require"
 )
@@ -98,7 +99,7 @@ type widget struct {
 func TestUpdateNoProvStateFail(t *testing.T) {
 	resp := initialResponse(http.MethodPut, strings.NewReader(`{ "properties": { "provisioningState": "Started" } }`))
 	resp.StatusCode = http.StatusOK
-	bp, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	bp, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       http.NoBody,
@@ -115,7 +116,7 @@ func TestUpdateNoProvStateFail(t *testing.T) {
 func TestUpdateNoProvStateSuccess(t *testing.T) {
 	resp := initialResponse(http.MethodPut, strings.NewReader(`{ "properties": { "provisioningState": "Started" } }`))
 	resp.StatusCode = http.StatusOK
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(`{ "shape": "rectangle" }`)),
@@ -136,7 +137,7 @@ func TestUpdateNoProvStateSuccess(t *testing.T) {
 func TestUpdateNoProvState204(t *testing.T) {
 	resp := initialResponse(http.MethodPut, strings.NewReader(`{ "properties": { "provisioningState": "Started" } }`))
 	resp.StatusCode = http.StatusOK
-	poller, err := New[struct{}](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[struct{}](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNoContent,
 			Body:       http.NoBody,
@@ -154,7 +155,7 @@ func TestUpdateNoProvState204(t *testing.T) {
 
 func TestPollFailed(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, strings.NewReader(`{ "properties": { "provisioningState": "Started" } }`))
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{},
@@ -176,7 +177,7 @@ func TestPollFailed(t *testing.T) {
 
 func TestPollFailedError(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, strings.NewReader(`{ "properties": { "provisioningState": "Started" } }`))
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("failed")
 	})), resp)
 	require.NoError(t, err)
@@ -188,7 +189,7 @@ func TestPollFailedError(t *testing.T) {
 
 func TestPollError(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, strings.NewReader(`{ "properties": { "provisioningState": "Started" } }`))
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
 			Header:     http.Header{},

--- a/sdk/azcore/internal/pollers/fake/fake_test.go
+++ b/sdk/azcore/internal/pollers/fake/fake_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/poller"
 	"github.com/stretchr/testify/require"
 )
@@ -100,7 +101,7 @@ func TestPollSucceeded(t *testing.T) {
 	pollCtx := context.WithValue(context.Background(), shared.CtxAPINameKey{}, "FakeAPI")
 	resp := initialResponse(pollCtx, http.MethodPatch, http.NoBody)
 	resp.Header.Set(shared.HeaderFakePollerStatus, poller.StatusInProgress)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{shared.HeaderFakePollerStatus: []string{"Succeeded"}},
@@ -126,7 +127,7 @@ func TestPollError(t *testing.T) {
 	pollCtx := context.WithValue(context.Background(), shared.CtxAPINameKey{}, "FakeAPI")
 	resp := initialResponse(pollCtx, http.MethodPatch, http.NoBody)
 	resp.Header.Set(shared.HeaderFakePollerStatus, poller.StatusInProgress)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
 			Header:     http.Header{shared.HeaderFakePollerStatus: []string{poller.StatusFailed}},
@@ -151,7 +152,7 @@ func TestPollFailed(t *testing.T) {
 	pollCtx := context.WithValue(context.Background(), shared.CtxAPINameKey{}, "FakeAPI")
 	resp := initialResponse(pollCtx, http.MethodPatch, http.NoBody)
 	resp.Header.Set(shared.HeaderFakePollerStatus, poller.StatusInProgress)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{shared.HeaderFakePollerStatus: []string{poller.StatusFailed}},
@@ -175,7 +176,7 @@ func TestPollErrorNoHeader(t *testing.T) {
 	pollCtx := context.WithValue(context.Background(), shared.CtxAPINameKey{}, "FakeAPI")
 	resp := initialResponse(pollCtx, http.MethodPatch, http.NoBody)
 	resp.Header.Set(shared.HeaderFakePollerStatus, poller.StatusInProgress)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
 			Body:       io.NopCloser(strings.NewReader(`{ "error": { "code": "NotFound", "message": "the item doesn't exist" } }`)),

--- a/sdk/azcore/internal/pollers/loc/loc_test.go
+++ b/sdk/azcore/internal/pollers/loc/loc_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/poller"
 	"github.com/stretchr/testify/require"
 )
@@ -78,7 +79,7 @@ func TestNew(t *testing.T) {
 func TestUpdateSucceeded(t *testing.T) {
 	resp := initialResponse()
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New[struct{}](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[struct{}](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNoContent,
 			Body:       http.NoBody,
@@ -96,7 +97,7 @@ func TestUpdateSucceeded(t *testing.T) {
 func TestUpdateFailed(t *testing.T) {
 	resp := initialResponse()
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New[struct{}](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[struct{}](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		if surl := req.URL.String(); surl == fakeLocationURL {
 			resp := &http.Response{
 				StatusCode: http.StatusAccepted,
@@ -130,7 +131,7 @@ func TestUpdateFailed(t *testing.T) {
 func TestUpdateFailedWithProvisioningState(t *testing.T) {
 	resp := initialResponse()
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New[struct{}](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[struct{}](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		if surl := req.URL.String(); surl == fakeLocationURL {
 			resp := &http.Response{
 				StatusCode: http.StatusAccepted,

--- a/sdk/azcore/internal/pollers/op/op_test.go
+++ b/sdk/azcore/internal/pollers/op/op_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/pollers"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,7 +95,7 @@ func TestFinalStateViaLocation(t *testing.T) {
 	resp := initialResponse(http.MethodPut, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		if surl := req.URL.String(); surl == fakePollingURL {
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -124,7 +125,7 @@ func TestFinalStateViaLocation(t *testing.T) {
 func TestFinalStateViaOperationLocationWithPost(t *testing.T) {
 	resp := initialResponse(http.MethodPost, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(`{ "status": "succeeded", "shape": "rhombus" }`)),
@@ -145,7 +146,7 @@ func TestFinalStateViaOperationLocationWithPost(t *testing.T) {
 func TestFinalStateViaResourceLocation(t *testing.T) {
 	resp := initialResponse(http.MethodPut, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		if surl := req.URL.String(); surl == fakePollingURL {
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -175,7 +176,7 @@ func TestFinalStateViaResourceLocation(t *testing.T) {
 func TestResultForPatch(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		if surl := req.URL.String(); surl == fakePollingURL {
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -206,7 +207,7 @@ func TestPostWithLocation(t *testing.T) {
 	resp := initialResponse(http.MethodPost, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
 	resp.Header.Set(shared.HeaderLocation, fakeLocationURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		if surl := req.URL.String(); surl == fakePollingURL {
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -236,7 +237,7 @@ func TestPostWithLocation(t *testing.T) {
 func TestOperationFailed(t *testing.T) {
 	resp := initialResponse(http.MethodPut, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(`{ "status": "Failed", "error": { "code": "InvalidSomething" } }`)),
@@ -259,7 +260,7 @@ func TestOperationFailed(t *testing.T) {
 func TestPollFailed(t *testing.T) {
 	resp := initialResponse(http.MethodPut, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("failed")
 	})), resp, pollers.FinalStateViaLocation)
 	require.NoError(t, err)
@@ -273,7 +274,7 @@ func TestPollFailed(t *testing.T) {
 func TestPollError(t *testing.T) {
 	resp := initialResponse(http.MethodPut, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
 			Header:     http.Header{},
@@ -294,7 +295,7 @@ func TestPollError(t *testing.T) {
 func TestMissingStatus(t *testing.T) {
 	resp := initialResponse(http.MethodPatch, strings.NewReader(`{ "status": "Updating" }`))
 	resp.Header.Set(shared.HeaderOperationLocation, fakePollingURL)
-	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	poller, err := New[widget](exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(`{ "shape": "square" }`)),

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -114,7 +115,7 @@ func TestPollHelper(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	pl := exported.NewPipeline(shared.TransportFunc(func(*http.Request) (*http.Response, error) {
+	pl := exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("failed")
 	}))
 	err = PollHelper(context.Background(), fakeEndpoint, pl, func(*http.Response) (string, error) {
@@ -124,7 +125,7 @@ func TestPollHelper(t *testing.T) {
 	require.Error(t, err)
 
 	require.Error(t, err)
-	pl = exported.NewPipeline(shared.TransportFunc(func(*http.Request) (*http.Response, error) {
+	pl = exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
 			Body:       http.NoBody,
@@ -136,7 +137,7 @@ func TestPollHelper(t *testing.T) {
 	require.Error(t, err)
 
 	require.Error(t, err)
-	pl = exported.NewPipeline(shared.TransportFunc(func(*http.Request) (*http.Response, error) {
+	pl = exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       http.NoBody,

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -31,6 +31,8 @@ const (
 
 const BearerTokenPrefix = "Bearer "
 
+const TracingNamespaceAttrName = "az.namespace"
+
 const (
 	// Module is the name of the calling module used in telemetry data.
 	Module = "azcore"

--- a/sdk/azcore/internal/shared/shared.go
+++ b/sdk/azcore/internal/shared/shared.go
@@ -27,9 +27,6 @@ type CtxWithRetryOptionsKey struct{}
 // CtxWithCaptureResponse is used as a context key for retrieving the raw response.
 type CtxWithCaptureResponse struct{}
 
-// CtxWithTracingTracer is used as a context key for adding/retrieving tracing.Tracer.
-type CtxWithTracingTracer struct{}
-
 // CtxAPINameKey is used as a context key for adding/retrieving the API name.
 type CtxAPINameKey struct{}
 

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +48,7 @@ func TestPagerSinglePage(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [1, 2, 3, 4, 5]}`)))
-	pl := exported.NewPipeline(srv)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv)
 
 	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
@@ -79,7 +80,7 @@ func TestPagerMultiplePages(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [1, 2, 3, 4, 5], "next": true}`)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [6, 7, 8], "next": true}`)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [9, 0, 1, 2]}`)))
-	pl := exported.NewPipeline(srv)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv)
 
 	pageCount := 0
 	pager := NewPager(PagingHandler[PageResponse]{
@@ -123,7 +124,7 @@ func TestPagerLROMultiplePages(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [6, 7, 8]}`)))
-	pl := exported.NewPipeline(srv)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv)
 
 	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
@@ -177,7 +178,7 @@ func TestPagerPipelineError(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetError(errors.New("pipeline failed"))
-	pl := exported.NewPipeline(srv)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv)
 
 	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
@@ -199,7 +200,7 @@ func TestPagerSecondPageError(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [1, 2, 3, 4, 5], "next": true}`)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest), mock.WithBody([]byte(`{"message": "didn't work", "code": "PageError"}`)))
-	pl := exported.NewPipeline(srv)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv)
 
 	pageCount := 0
 	pager := NewPager(PagingHandler[PageResponse]{
@@ -241,7 +242,7 @@ func TestPagerResponderError(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`incorrect JSON response`)))
-	pl := exported.NewPipeline(srv)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv)
 
 	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
@@ -261,7 +262,7 @@ func TestPagerResponderError(t *testing.T) {
 func TestFetcherForNextLink(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
-	pl := exported.NewPipeline(srv)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv)
 
 	srv.AppendResponse()
 	firstReqCalled := false

--- a/sdk/azcore/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/runtime/policy_bearer_token_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/stretchr/testify/require"
@@ -249,7 +250,7 @@ func TestCheckHTTPSForAuth(t *testing.T) {
 
 func TestBearerTokenPolicy_NilCredential(t *testing.T) {
 	policy := NewBearerTokenPolicy(nil, nil, nil)
-	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	pl := exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		require.Zero(t, req.Header.Get(shared.HeaderAuthorization))
 		return &http.Response{}, nil
 	}), policy)

--- a/sdk/azcore/runtime/policy_key_credential_test.go
+++ b/sdk/azcore/runtime/policy_key_credential_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +22,7 @@ func TestKeyCredentialPolicy(t *testing.T) {
 	policy := NewKeyCredentialPolicy(cred, headerName, nil)
 	require.NotNil(t, policy)
 
-	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	pl := exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		require.EqualValues(t, key, req.Header.Get(headerName))
 		return &http.Response{}, nil
 	}), policy)
@@ -37,7 +38,7 @@ func TestKeyCredentialPolicy(t *testing.T) {
 	})
 	require.NotNil(t, policy)
 
-	pl = exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	pl = exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		require.EqualValues(t, "Prefix: "+key, req.Header.Get(headerName))
 		return &http.Response{}, nil
 	}), policy)
@@ -55,7 +56,7 @@ func TestKeyCredentialPolicy_RequiresHTTPS(t *testing.T) {
 	policy := NewKeyCredentialPolicy(cred, "fake-auth", nil)
 	require.NotNil(t, policy)
 
-	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	pl := exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{}, nil
 	}), policy)
 
@@ -71,7 +72,7 @@ func TestKeyCredentialPolicy_NilCredential(t *testing.T) {
 	policy := NewKeyCredentialPolicy(nil, headerName, nil)
 	require.NotNil(t, policy)
 
-	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	pl := exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		require.Zero(t, req.Header.Get(headerName))
 		return &http.Response{}, nil
 	}), policy)

--- a/sdk/azcore/runtime/policy_logging_test.go
+++ b/sdk/azcore/runtime/policy_logging_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func TestPolicyLoggingSuccess(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse()
-	pl := exported.NewPipeline(srv, NewLogPolicy(nil))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewLogPolicy(nil))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -87,7 +88,7 @@ func TestPolicyLoggingError(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetError(errors.New("bogus error"))
-	pl := exported.NewPipeline(srv, NewLogPolicy(nil))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewLogPolicy(nil))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/stretchr/testify/require"
@@ -35,7 +36,7 @@ func TestRetryPolicySuccess(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
-	pl := exported.NewPipeline(srv, NewRetryPolicy(nil))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(nil))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -63,7 +64,7 @@ func TestRetryPolicyFailOnStatusCode(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusInternalServerError))
-	pl := exported.NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(testRetryOptions()))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -97,7 +98,7 @@ func TestRetryPolicyFailOnStatusCodeRespBodyPreserved(t *testing.T) {
 	srv.SetResponse(mock.WithStatusCode(http.StatusInternalServerError), mock.WithBody([]byte(respBody)))
 	// add a per-request policy that reads and restores the request body.
 	// this is to simulate how something like httputil.DumpRequest works.
-	pl := exported.NewPipeline(srv, exported.PolicyFunc(func(r *policy.Request) (*http.Response, error) {
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, exported.PolicyFunc(func(r *policy.Request) (*http.Response, error) {
 		b, err := io.ReadAll(r.Raw().Body)
 		if err != nil {
 			t.Fatal(err)
@@ -145,7 +146,7 @@ func TestRetryPolicySuccessWithRetry(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 	srv.AppendResponse()
-	pl := exported.NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(testRetryOptions()))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -182,7 +183,7 @@ func TestRetryPolicySuccessRetryWithNilResponse(t *testing.T) {
 		t: srv,
 		r: []int{2}, // send a nil on the second request
 	}
-	pl := exported.NewPipeline(nilInjector, NewRetryPolicy(testRetryOptions()))
+	pl := exported.NewPipeline(tracing.Tracer{}, nilInjector, NewRetryPolicy(testRetryOptions()))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -215,7 +216,7 @@ func TestRetryPolicyNoRetries(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 	srv.AppendResponse()
-	pl := exported.NewPipeline(srv, NewRetryPolicy(&policy.RetryOptions{MaxRetries: -1}))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(&policy.RetryOptions{MaxRetries: -1}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -240,7 +241,7 @@ func TestRetryPolicyUnlimitedRetryDelay(t *testing.T) {
 	srv.AppendResponse()
 	opt := testRetryOptions()
 	opt.MaxRetryDelay = -1
-	pl := exported.NewPipeline(srv, NewRetryPolicy(opt))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(opt))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -262,7 +263,7 @@ func TestRetryPolicyFailOnError(t *testing.T) {
 	defer close()
 	fakeErr := errors.New("bogus error")
 	srv.SetError(fakeErr)
-	pl := exported.NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(testRetryOptions()))
 	req, err := NewRequest(context.Background(), http.MethodPost, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -296,7 +297,7 @@ func TestRetryPolicySuccessWithRetryComplex(t *testing.T) {
 	srv.AppendError(errors.New("bogus error"))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
-	pl := exported.NewPipeline(srv, exported.PolicyFunc(includeResponsePolicy), NewRetryPolicy(testRetryOptions()))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, exported.PolicyFunc(includeResponsePolicy), NewRetryPolicy(testRetryOptions()))
 	var respFromCtx *http.Response
 	ctxWithResp := WithCaptureResponse(context.Background(), &respFromCtx)
 	req, err := NewRequest(ctxWithResp, http.MethodGet, srv.URL())
@@ -332,7 +333,7 @@ func TestRetryPolicyRequestTimedOut(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetError(errors.New("bogus error"))
-	pl := exported.NewPipeline(srv, NewRetryPolicy(nil))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(nil))
 	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
 	defer cancel()
 	req, err := NewRequest(ctx, http.MethodPost, srv.URL())
@@ -378,7 +379,7 @@ func TestRetryPolicyIsNotRetriable(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
 	srv.AppendError(theErr)
-	pl := exported.NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(testRetryOptions()))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -418,7 +419,7 @@ func TestWithRetryOptionsE2E(t *testing.T) {
 	srv.RepeatResponse(9, mock.WithStatusCode(http.StatusRequestTimeout))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	defaultOptions := testRetryOptions()
-	pl := exported.NewPipeline(srv, NewRetryPolicy(defaultOptions))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(defaultOptions))
 	customOptions := *defaultOptions
 	customOptions.MaxRetries = 10
 	customOptions.MaxRetryDelay = 200 * time.Millisecond
@@ -451,7 +452,7 @@ func TestRetryPolicyFailOnErrorNoDownload(t *testing.T) {
 	defer close()
 	fakeErr := errors.New("bogus error")
 	srv.SetError(fakeErr)
-	pl := exported.NewPipeline(srv, NewRetryPolicy(testRetryOptions()))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(testRetryOptions()))
 	req, err := NewRequest(context.Background(), http.MethodPost, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -473,7 +474,7 @@ func TestRetryPolicySuccessNoDownload(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte("response body")))
-	pl := exported.NewPipeline(srv, NewRetryPolicy(nil))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(nil))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -493,7 +494,7 @@ func TestRetryPolicySuccessNoDownloadNoBody(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
-	pl := exported.NewPipeline(srv, NewRetryPolicy(nil))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(nil))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -546,7 +547,7 @@ func TestRetryPolicyRequestTimedOutTooSlow(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse(mock.WithSlowResponse(5 * time.Second))
-	pl := exported.NewPipeline(srv, NewRetryPolicy(nil))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(nil))
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	req, err := NewRequest(ctx, http.MethodPost, srv.URL())
@@ -579,7 +580,7 @@ func TestRetryPolicySuccessWithPerTryTimeout(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 	opt := testRetryOptions()
 	opt.TryTimeout = 1 * time.Second
-	pl := exported.NewPipeline(srv, NewRetryPolicy(opt))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(opt))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -618,7 +619,7 @@ func TestRetryPolicySuccessWithPerTryTimeoutNoRetry(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody(largeBody))
 	opt := testRetryOptions()
 	opt.TryTimeout = 10 * time.Second
-	pl := exported.NewPipeline(srv, NewRetryPolicy(opt))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(opt))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -652,7 +653,7 @@ func TestRetryPolicySuccessWithPerTryTimeoutNoRetryWithBodyDownload(t *testing.T
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody(largeBody))
 	opt := testRetryOptions()
 	opt.TryTimeout = 10 * time.Second
-	pl := exported.NewPipeline(srv, NewRetryPolicy(opt), exported.PolicyFunc(bodyDownloadPolicy))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(opt), exported.PolicyFunc(bodyDownloadPolicy))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -677,7 +678,7 @@ func TestRetryPolicyWithShouldRetryNoRetry(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
 
-	pl := exported.NewPipeline(srv, NewRetryPolicy(&policy.RetryOptions{
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(&policy.RetryOptions{
 		RetryDelay: time.Millisecond,
 		ShouldRetry: func(r *http.Response, err error) bool {
 			return r.StatusCode != http.StatusRequestTimeout
@@ -698,7 +699,7 @@ func TestRetryPolicyWithShouldRetryRetry(t *testing.T) {
 	srv.AppendResponse()
 
 	shouldRetryCalled := false
-	pl := exported.NewPipeline(srv, NewRetryPolicy(&policy.RetryOptions{
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(&policy.RetryOptions{
 		RetryDelay: time.Millisecond,
 		ShouldRetry: func(r *http.Response, err error) bool {
 			shouldRetryCalled = true
@@ -722,7 +723,7 @@ func TestPipelineNoRetryOn429(t *testing.T) {
 	perRetryPolicy := countingPolicy{}
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	require.NoError(t, err)
-	pl := exported.NewPipeline(srv, NewRetryPolicy(nil), &perRetryPolicy)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(nil), &perRetryPolicy)
 	resp, err := pl.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
@@ -739,7 +740,7 @@ func TestPipelineRetryOn429(t *testing.T) {
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	require.NoError(t, err)
 	opt := testRetryOptions()
-	pl := exported.NewPipeline(srv, NewRetryPolicy(opt), &perRetryPolicy)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(opt), &perRetryPolicy)
 	resp, err := pl.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -815,7 +816,7 @@ func TestRetryPolicySuccessWithRetryPreserveHeaders(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusRequestTimeout))
 	srv.AppendResponse()
-	pl := exported.NewPipeline(srv, NewRetryPolicy(testRetryOptions()), exported.PolicyFunc(challengeLikePolicy))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewRetryPolicy(testRetryOptions()), exported.PolicyFunc(challengeLikePolicy))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	require.NoError(t, err)
 	body := newRewindTrackingBody("stuff")

--- a/sdk/azcore/runtime/policy_sas_credential_test.go
+++ b/sdk/azcore/runtime/policy_sas_credential_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +22,7 @@ func TestSASCredentialPolicy(t *testing.T) {
 	policy := NewSASCredentialPolicy(cred, headerName, nil)
 	require.NotNil(t, policy)
 
-	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	pl := exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		require.EqualValues(t, key, req.Header.Get(headerName))
 		return &http.Response{}, nil
 	}), policy)
@@ -39,7 +40,7 @@ func TestSASCredentialPolicy_RequiresHTTPS(t *testing.T) {
 	policy := NewSASCredentialPolicy(cred, "fake-auth", nil)
 	require.NotNil(t, policy)
 
-	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	pl := exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{}, nil
 	}), policy)
 
@@ -55,7 +56,7 @@ func TestSASCredentialPolicy_NilCredential(t *testing.T) {
 	policy := NewSASCredentialPolicy(nil, headerName, nil)
 	require.NotNil(t, policy)
 
-	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+	pl := exported.NewPipeline(tracing.Tracer{}, shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		require.Zero(t, req.Header.Get(headerName))
 		return &http.Response{}, nil
 	}), policy)

--- a/sdk/azcore/runtime/policy_telemetry_test.go
+++ b/sdk/azcore/runtime/policy_telemetry_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
 
@@ -22,7 +23,7 @@ func TestPolicyTelemetryDefault(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse()
-	pl := exported.NewPipeline(srv, NewTelemetryPolicy("test", "v1.2.3", nil))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewTelemetryPolicy("test", "v1.2.3", nil))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -40,7 +41,7 @@ func TestPolicyTelemetryPreserveExisting(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse()
-	pl := exported.NewPipeline(srv, NewTelemetryPolicy("test", "v1.2.3", nil))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewTelemetryPolicy("test", "v1.2.3", nil))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -61,7 +62,7 @@ func TestPolicyTelemetryWithAppID(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const appID = "my_application"
-	pl := exported.NewPipeline(srv, NewTelemetryPolicy("test", "v1.2.3", &policy.TelemetryOptions{ApplicationID: appID}))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewTelemetryPolicy("test", "v1.2.3", &policy.TelemetryOptions{ApplicationID: appID}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -80,7 +81,7 @@ func TestPolicyTelemetryWithAppIDSanitized(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const appID = "This will get the spaces removed and truncated."
-	pl := exported.NewPipeline(srv, NewTelemetryPolicy("test", "v1.2.3", &policy.TelemetryOptions{ApplicationID: appID}))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewTelemetryPolicy("test", "v1.2.3", &policy.TelemetryOptions{ApplicationID: appID}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -100,7 +101,7 @@ func TestPolicyTelemetryPreserveExistingWithAppID(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const appID = "my_application"
-	pl := exported.NewPipeline(srv, NewTelemetryPolicy("test", "v1.2.3", &policy.TelemetryOptions{ApplicationID: appID}))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewTelemetryPolicy("test", "v1.2.3", &policy.TelemetryOptions{ApplicationID: appID}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -121,7 +122,7 @@ func TestPolicyTelemetryDisabled(t *testing.T) {
 	defer close()
 	srv.SetResponse()
 	const appID = "my_application"
-	pl := exported.NewPipeline(srv, NewTelemetryPolicy("test", "v1.2.3", &policy.TelemetryOptions{ApplicationID: appID, Disabled: true}))
+	pl := exported.NewPipeline(tracing.Tracer{}, srv, NewTelemetryPolicy("test", "v1.2.3", &policy.TelemetryOptions{ApplicationID: appID, Disabled: true}))
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/sdk/azcore/runtime/request_test.go
+++ b/sdk/azcore/runtime/request_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -224,7 +225,7 @@ func TestRequestValidFail(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Raw().Header.Add("inval d", "header")
-	p := exported.NewPipeline(nil)
+	p := exported.NewPipeline(tracing.Tracer{}, nil)
 	resp, err := p.Do(req)
 	if err == nil {
 		t.Fatal("unexpected nil error")

--- a/sdk/azcore/streaming/progress_test.go
+++ b/sdk/azcore/streaming/progress_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
 
@@ -29,7 +30,7 @@ func TestProgressReporting(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse(mock.WithBody(content))
-	pl := exported.NewPipeline(srv)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv)
 	req, err := runtime.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -78,7 +79,7 @@ func TestProgressReportingSeek(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	srv.SetResponse(mock.WithBody(content))
-	pl := exported.NewPipeline(srv)
+	pl := exported.NewPipeline(tracing.Tracer{}, srv)
 	req, err := runtime.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
This prevents traces from showing up for clients that didn't explicitly enable tracing via their ClientOptions. This required moving the tracer into the pipeline and out of the client.
Added TracingOptions type for configuring tracing via pipeline options. Creating a raw pipeline with a tracing provider will now create traces. Don't create a HTTP span if a SDK span hasn't been created. This prevents HTTP spans from showing up when tracing is enabled but a SDK hasn't yet incorporated spans.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/21784