### PR TITLE
Don't omit trailing error response for fake pages

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Block key and SAS authentication for non TLS protected endpoints.
 * Passing a `nil` credential value will no longer cause a panic. Instead, the authentication is skipped.
 * Calling `Error` on a zero-value `azcore.ResponseError` will no longer panic.
+* Fixed an issue in `fake.PagerResponder[T]` that would cause a trailing error to be omitted when iterating over pages.
 
 ### Other Changes
 

--- a/sdk/azcore/fake/fake.go
+++ b/sdk/azcore/fake/fake.go
@@ -74,7 +74,9 @@ func (e *ErrorResponder) SetResponseError(httpStatus int, errorCode string) {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // PagerResponder represents a sequence of paged responses.
-// Responses are replayed in the order in which they were added.
+// Responses are consumed in the order in which they were added.
+// If no pages or errors have been added, calls to Pager[T].NextPage
+// will return an error.
 type PagerResponder[T any] exported.PagerResponder[T]
 
 // AddPage adds a page to the sequence of respones.
@@ -102,8 +104,10 @@ type AddPageOptions = exported.AddPageOptions
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // PollerResponder represents a sequence of responses for a long-running operation.
-// Any non-terminal responses are replayed in the order in which they were added.
+// Any non-terminal responses are consumed in the order in which they were added.
 // The terminal response, success or error, is always the final response.
+// If no responses or errors have been added, the following method calls on Poller[T]
+// will return an error: PollUntilDone, Poll, Result.
 type PollerResponder[T any] exported.PollerResponder[T]
 
 // AddNonTerminalResponse adds a non-terminal response to the sequence of responses.

--- a/sdk/azcore/fake/fake_test.go
+++ b/sdk/azcore/fake/fake_test.go
@@ -161,7 +161,7 @@ func TestPagerResponder(t *testing.T) {
 			require.NotNil(t, resp)
 			page, err := unmarshal[widgets](resp)
 			require.NoError(t, err)
-			require.Nil(t, page.NextPage)
+			require.NotNil(t, page.NextPage)
 			require.Equal(t, []widget{{Name: "baz"}}, page.Widgets)
 		case 4:
 			require.Error(t, err)


### PR DESCRIPTION
Fetching the next page, or an error, is predicated on the page response's next link field being populated.
Always set the next link field even if the next "page" is an error response.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
