### PR TITLE
Support Azure ML managed identity

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.0-beta.2 (Unreleased)
 
 ### Features Added
+* `DefaultAzureCredential` and `ManagedIdentityCredential` support Azure ML managed identity
 
 ### Breaking Changes
 

--- a/sdk/azidentity/assets.json
+++ b/sdk/azidentity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/azidentity",
-  "Tag": "go/azidentity_ae45facec3"
+  "Tag": "go/azidentity_db4a26f583"
 }

--- a/sdk/azidentity/live_test.go
+++ b/sdk/azidentity/live_test.go
@@ -59,12 +59,14 @@ var liveUser = struct {
 const (
 	azidentityRunManualTests = "AZIDENTITY_RUN_MANUAL_TESTS"
 	fakeClientID             = "fake-client-id"
+	fakeMIEndpoint           = "https://fake.local"
 	fakeResourceID           = "/fake/resource/ID"
 	fakeTenantID             = "fake-tenant"
 	fakeUsername             = "fake@user"
 	fakeAdfsAuthority        = "fake.adfs.local"
 	fakeAdfsScope            = "fake.adfs.local/fake-scope/.default"
 	liveTestScope            = "https://management.core.windows.net//.default"
+	redacted                 = "redacted"
 )
 
 var adfsLiveSP = struct {
@@ -157,6 +159,9 @@ func run(m *testing.M) int {
 			strings.TrimPrefix(adfsScope, "https://"):       fakeAdfsScope,
 			strings.TrimPrefix(adfsAuthority, "https://"):   fakeAdfsAuthority,
 		}
+		if id := os.Getenv(defaultIdentityClientID); id != "" {
+			pathVars[id] = fakeClientID
+		}
 		for target, replacement := range pathVars {
 			if target != "" {
 				err := recording.AddURISanitizer(replacement, target, nil)
@@ -181,6 +186,23 @@ func run(m *testing.M) int {
 		err := recording.AddBodyRegexSanitizer("{}", `^\S+=.*`, nil)
 		if err != nil {
 			panic(err)
+		}
+		// some managed identity requests include a "secret" header. It isn't dangerous
+		// to record the value, however it must be static for matching to work in playback
+		err = recording.AddHeaderRegexSanitizer("secret", redacted, "", nil)
+		if err != nil {
+			panic(err)
+		}
+		if url, ok := os.LookupEnv(msiEndpoint); ok {
+			err = recording.AddURISanitizer(fakeMIEndpoint, url, nil)
+			if err == nil {
+				if clientID, ok := os.LookupEnv(defaultIdentityClientID); ok {
+					err = recording.AddURISanitizer(fakeClientID, clientID, nil)
+				}
+			}
+			if err != nil {
+				panic(err)
+			}
 		}
 		// redact secrets returned by Microsoft Entra ID
 		for _, key := range []string{"access_token", "device_code", "message", "refresh_token", "user_code"} {


### PR DESCRIPTION
Though Azure ML doesn't directly support deploying Go, this support in the SDK will enable using Go tools in Azure ML compute environments, for example to move data (see #21396).