### PR TITLE
Deny context values from flowing across disjoint requests

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Passing a `nil` credential value will no longer cause a panic. Instead, the authentication is skipped.
 * Calling `Error` on a zero-value `azcore.ResponseError` will no longer panic.
 * Fixed an issue in `fake.PagerResponder[T]` that would cause a trailing error to be omitted when iterating over pages.
+* Context values created by `azcore` will no longer flow across disjoint HTTP requests.
 
 ### Other Changes
 

--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
@@ -292,7 +291,7 @@ func TestBearerTokenPolicyRequiresHTTPS(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()
 	b := NewBearerTokenPolicy(mockCredential{}, nil)
-	pl := newTestPipeline(&policy.ClientOptions{Transport: srv, PerRetryPolicies: []policy.Policy{b}})
+	pl := newTestPipeline(&azpolicy.ClientOptions{Transport: srv, PerRetryPolicies: []azpolicy.Policy{b}})
 	req, err := runtime.NewRequest(context.Background(), "GET", srv.URL())
 	require.NoError(t, err)
 	_, err = pl.Do(req)

--- a/sdk/azcore/arm/runtime/policy_register_rp.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp.go
@@ -126,12 +126,13 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 			u:     r.endpoint,
 			subID: subID,
 		}
-		if _, err = rpOps.Register(req.Raw().Context(), rp); err != nil {
+		if _, err = rpOps.Register(&shared.ContextWithDeniedValues{Context: req.Raw().Context()}, rp); err != nil {
 			logRegistrationExit(err)
 			return resp, err
 		}
+
 		// RP was registered, however we need to wait for the registration to complete
-		pollCtx, pollCancel := context.WithTimeout(req.Raw().Context(), r.options.PollingDuration)
+		pollCtx, pollCancel := context.WithTimeout(&shared.ContextWithDeniedValues{Context: req.Raw().Context()}, r.options.PollingDuration)
 		var lastRegState string
 		for {
 			// get the current registration state

--- a/sdk/azcore/internal/shared/shared_test.go
+++ b/sdk/azcore/internal/shared/shared_test.go
@@ -136,3 +136,23 @@ func TestExtractModuleName(t *testing.T) {
 	require.Empty(t, mod)
 	require.Empty(t, client)
 }
+
+func TestContextWithDeniedValues(t *testing.T) {
+	type testKey struct{}
+	const value = "value"
+
+	ctx := context.WithValue(context.Background(), testKey{}, value)
+	ctx = context.WithValue(ctx, CtxAPINameKey{}, value)
+	ctx = context.WithValue(ctx, CtxWithCaptureResponse{}, value)
+	ctx = context.WithValue(ctx, CtxWithHTTPHeaderKey{}, value)
+	ctx = context.WithValue(ctx, CtxWithRetryOptionsKey{}, value)
+	ctx = context.WithValue(ctx, CtxWithTracingTracer{}, value)
+	ctx = &ContextWithDeniedValues{Context: ctx}
+
+	require.Nil(t, ctx.Value(CtxAPINameKey{}))
+	require.Nil(t, ctx.Value(CtxWithCaptureResponse{}))
+	require.Nil(t, ctx.Value(CtxWithHTTPHeaderKey{}))
+	require.Nil(t, ctx.Value(CtxWithRetryOptionsKey{}))
+	require.Nil(t, ctx.Value(CtxWithTracingTracer{}))
+	require.NotNil(t, ctx.Value(testKey{}))
+}

--- a/sdk/azcore/runtime/policy_bearer_token.go
+++ b/sdk/azcore/runtime/policy_bearer_token.go
@@ -34,7 +34,7 @@ type acquiringResourceState struct {
 // acquire acquires or updates the resource; only one
 // thread/goroutine at a time ever calls this function
 func acquire(state acquiringResourceState) (newResource exported.AccessToken, newExpiration time.Time, err error) {
-	tk, err := state.p.cred.GetToken(state.req.Raw().Context(), state.tro)
+	tk, err := state.p.cred.GetToken(&shared.ContextWithDeniedValues{Context: state.req.Raw().Context()}, state.tro)
 	if err != nil {
 		return exported.AccessToken{}, time.Time{}, err
 	}

--- a/sdk/azcore/runtime/policy_http_trace_test.go
+++ b/sdk/azcore/runtime/policy_http_trace_test.go
@@ -205,7 +205,6 @@ func TestStartSpansDontNest(t *testing.T) {
 
 	barMethod := func(ctx context.Context) {
 		ourCtx, endSpan := StartSpan(ctx, "BarMethod", tr, nil)
-		require.Same(t, ctx, ourCtx)
 		defer endSpan(nil)
 		req, err := exported.NewRequest(ourCtx, http.MethodGet, srv.URL()+"/bar")
 		require.NoError(t, err)


### PR DESCRIPTION
This prevents things like custom HTTP headers from showing up in an authentication request.
Removed duplicate import from a test.

Fixes:
- https://github.com/Azure/azure-sdk-for-go/issues/21784
- https://github.com/Azure/azure-sdk-for-go/issues/21847