### PR TITLE
Consolidate tracing options within pipeline options

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 > These changes affect only code written against previous beta versions of `v1.7.0` and `v1.8.0`
 * The function `NewTokenCredential` has been removed from the `fake` package. Use a literal `&fake.TokenCredential{}` instead.
+* The field `TracingNamespace` in `runtime.PipelineOptions` has been replaced by `TracingOptions`.
 
 ### Bugs Fixed
 

--- a/sdk/azcore/arm/runtime/policy_trace_namespace.go
+++ b/sdk/azcore/arm/runtime/policy_trace_namespace.go
@@ -23,7 +23,7 @@ func httpTraceNamespacePolicy(req *policy.Request) (resp *http.Response, err err
 		if err == nil {
 			// add the namespace attribute to the current span
 			span := tracer.SpanFromContext(req.Raw().Context())
-			span.SetAttributes(tracing.Attribute{Key: "az.namespace", Value: rt.Namespace})
+			span.SetAttributes(tracing.Attribute{Key: shared.TracingNamespaceAttrName, Value: rt.Namespace})
 		}
 	}
 	return req.Next()

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -125,8 +125,8 @@ func NewClient(clientName, moduleVersion string, plOpts runtime.PipelineOptions,
 	pl := runtime.NewPipeline(mod, moduleVersion, plOpts, options)
 
 	tr := options.TracingProvider.NewTracer(client, moduleVersion)
-	if tr.Enabled() && plOpts.TracingNamespace != "" {
-		tr.SetAttributes(tracing.Attribute{Key: "az.namespace", Value: plOpts.TracingNamespace})
+	if tr.Enabled() && plOpts.Tracing.Namespace != "" {
+		tr.SetAttributes(tracing.Attribute{Key: shared.TracingNamespaceAttrName, Value: plOpts.Tracing.Namespace})
 	}
 
 	return &Client{
@@ -134,7 +134,7 @@ func NewClient(clientName, moduleVersion string, plOpts runtime.PipelineOptions,
 		tr:        tr,
 		tp:        options.TracingProvider,
 		modVer:    moduleVersion,
-		namespace: plOpts.TracingNamespace,
+		namespace: plOpts.Tracing.Namespace,
 	}, nil
 }
 
@@ -154,7 +154,7 @@ func (c *Client) Tracer() tracing.Tracer {
 func (c *Client) WithClientName(clientName string) *Client {
 	tr := c.tp.NewTracer(clientName, c.modVer)
 	if tr.Enabled() && c.namespace != "" {
-		tr.SetAttributes(tracing.Attribute{Key: "az.namespace", Value: c.namespace})
+		tr.SetAttributes(tracing.Attribute{Key: shared.TracingNamespaceAttrName, Value: c.namespace})
 	}
 	return &Client{pl: c.pl, tr: tr, tp: c.tp, modVer: c.modVer, namespace: c.namespace}
 }

--- a/sdk/azcore/core_test.go
+++ b/sdk/azcore/core_test.go
@@ -143,12 +143,16 @@ func TestNewClientTracingEnabled(t *testing.T) {
 	defer close()
 
 	var attrString string
-	client, err := NewClient("package.Client", "v1.0.0", runtime.PipelineOptions{TracingNamespace: "Widget.Factory"}, &policy.ClientOptions{
+	client, err := NewClient("package.Client", "v1.0.0", runtime.PipelineOptions{
+		Tracing: runtime.TracingOptions{
+			Namespace: "Widget.Factory",
+		},
+	}, &policy.ClientOptions{
 		TracingProvider: tracing.NewProvider(func(name, version string) tracing.Tracer {
 			return tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {
 				require.NotNil(t, options)
 				for _, attr := range options.Attributes {
-					if attr.Key == "az.namespace" {
+					if attr.Key == shared.TracingNamespaceAttrName {
 						v, ok := attr.Value.(string)
 						require.True(t, ok)
 						attrString = attr.Key + ":" + v
@@ -180,14 +184,18 @@ func TestClientWithClientName(t *testing.T) {
 	var clientName string
 	var modVersion string
 	var attrString string
-	client, err := NewClient("module/package.Client", "v1.0.0", runtime.PipelineOptions{TracingNamespace: "Widget.Factory"}, &policy.ClientOptions{
+	client, err := NewClient("module/package.Client", "v1.0.0", runtime.PipelineOptions{
+		Tracing: runtime.TracingOptions{
+			Namespace: "Widget.Factory",
+		},
+	}, &policy.ClientOptions{
 		TracingProvider: tracing.NewProvider(func(name, version string) tracing.Tracer {
 			clientName = name
 			modVersion = version
 			return tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {
 				require.NotNil(t, options)
 				for _, attr := range options.Attributes {
-					if attr.Key == "az.namespace" {
+					if attr.Key == shared.TracingNamespaceAttrName {
 						v, ok := attr.Value.(string)
 						require.True(t, ok)
 						attrString = attr.Key + ":" + v

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -31,6 +31,8 @@ const (
 
 const BearerTokenPrefix = "Bearer "
 
+const TracingNamespaceAttrName = "az.namespace"
+
 const (
 	// Module is the name of the calling module used in telemetry data.
 	Module = "azcore"

--- a/sdk/azcore/runtime/pipeline.go
+++ b/sdk/azcore/runtime/pipeline.go
@@ -34,8 +34,14 @@ type PipelineOptions struct {
 	// Each policy is executed once per request, and for each retry of that request.
 	PerRetry []policy.Policy
 
-	// TracingNamespace contains the value to use for the az.namespace span attribute.
-	TracingNamespace string
+	// Tracing contains options used to configure distributed tracing.
+	Tracing TracingOptions
+}
+
+// TracingOptions contains tracing options for SDK developers.
+type TracingOptions struct {
+	// Namespace contains the value to use for the az.namespace span attribute.
+	Namespace string
 }
 
 // Pipeline represents a primitive for sending HTTP requests and receiving responses.


### PR DESCRIPTION
Use a shared constant for the tracing namespace attribute.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
