### PR TITLE
Release non-retriable error wrapper. v1.5.0

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,20 +1,10 @@
 # Release History
 
-## 1.5.1 (Unreleased)
+## 1.5.0 (2023-11-02)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
-## 1.5.0 (2023-11-2)
-
-### Features Added
-
-* Added nonretriable error wrapper fr sdk error handling.
+* Added a new `NonRetriableError` func to the `errorinfo` package. New func serves as an error wrapper for non-retriable errors in the `azure-sdk-for-go/sdk` folder.
 
 ## 1.4.0 (2023-10-17)
 

--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.1 (Unreleased)
+## 1.5.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,12 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+## 1.5.0 (2023-11-2)
+
+### Features Added
+
+* Added nonretriable error wrapper fr sdk error handling.
 
 ## 1.4.0 (2023-10-17)
 

--- a/sdk/internal/version.go
+++ b/sdk/internal/version.go
@@ -11,5 +11,5 @@ const (
 	Module = "internal"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.4.1"
+	Version = "v1.5.0"
 )


### PR DESCRIPTION
Releases non-retriable error wrapper for /sdk