### PR TITLE
Add `OperationNotAllowedOnRootBlob` & `ImmutabilityPolicyDeleteOnLockedPolicy` to blob errors

### DIFF
--- a/sdk/storage/azblob/bloberror/error_codes.go
+++ b/sdk/storage/azblob/bloberror/error_codes.go
@@ -122,6 +122,7 @@ const (
 	NoAuthenticationInformation                       Code = "NoAuthenticationInformation"
 	NoPendingCopyOperation                            Code = "NoPendingCopyOperation"
 	OperationNotAllowedOnIncrementalCopyBlob          Code = "OperationNotAllowedOnIncrementalCopyBlob"
+	OperationNotAllowedOnRootBlob                     Code = "OperationNotAllowedOnRootBlob"
 	OperationTimedOut                                 Code = "OperationTimedOut"
 	OutOfRangeInput                                   Code = "OutOfRangeInput"
 	OutOfRangeQueryParameterValue                     Code = "OutOfRangeQueryParameterValue"

--- a/sdk/storage/azblob/bloberror/error_codes.go
+++ b/sdk/storage/azblob/bloberror/error_codes.go
@@ -69,6 +69,7 @@ const (
 	CopyIDMismatch                                    Code = "CopyIdMismatch"
 	EmptyMetadataKey                                  Code = "EmptyMetadataKey"
 	FeatureVersionMismatch                            Code = "FeatureVersionMismatch"
+	ImmutabilityPolicyDeleteOnLockedPolicy            Code = "ImmutabilityPolicyDeleteOnLockedPolicy"
 	IncrementalCopyBlobMismatch                       Code = "IncrementalCopyBlobMismatch"
 	IncrementalCopyOfEralierVersionSnapshotNotAllowed Code = "IncrementalCopyOfEralierVersionSnapshotNotAllowed"
 	IncrementalCopySourceMustBeSnapshot               Code = "IncrementalCopySourceMustBeSnapshot"


### PR DESCRIPTION
It is not listed in https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-error-codes but it occurs when you try to delete the "delete marker" version of a blob i.e. when `NewListBlobsFlatPager`->`ListBlobsInclude` has `DeletedWithVersions` and the blob version with `HasVersionsOnly=true` is attempted to be deleted.

Same with `ImmutabilityPolicyDeleteOnLockedPolicy` - which happens when trying to remove an immutability policy from a blob when it's a locked policy