### PR TITLE
CRC64 not optional in UploadRangeFromURL

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Breaking Changes
 
+* Changed type of SourceContentCRC64 header from uint64 to a generic interface implementation, so that it is considered 
+  optional. These changes impact:
+  * `file.UploadRangeFromURL()`
+
 ### Bugs Fixed
 
 * Fixed a bug where Optional fields which were mandatory earlier create a failure when passed an older service version
@@ -21,6 +25,8 @@
 ### Bugs Fixed
 
 * Fixed a bug where the `x-ms-file-attributes` header could be set to contain invalid trailing or leading | characters.
+
+### Breaking Changes
 
 ## 1.1.0-beta.1 (2023-09-12)
 

--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -6,13 +6,11 @@
 
 ### Breaking Changes
 
-* Changed type of SourceContentCRC64 header from uint64 to a generic interface implementation, so that it is considered 
-  optional. These changes impact:
-  * `file.UploadRangeFromURL()`
-
 ### Bugs Fixed
 
 * Fixed a bug where Optional fields which were mandatory earlier create a failure when passed an older service version
+* Made SourceContentCRC64 header as optional. Changed the type from uint64 to a generic interface implementation. 
+  These changes impact: `file.UploadRangeFromURL()`
 
 ### Other Changes
 
@@ -25,8 +23,6 @@
 ### Bugs Fixed
 
 * Fixed a bug where the `x-ms-file-attributes` header could be set to contain invalid trailing or leading | characters.
-
-### Breaking Changes
 
 ## 1.1.0-beta.1 (2023-09-12)
 

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_249bf38076"
+  "Tag": "go/storage/azfile_8ffdf7bb69"
 }

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_8ffdf7bb69"
+  "Tag": "go/storage/azfile_f1d39931a0"
 }

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -1773,9 +1773,8 @@ func (f *FileUnrecordedTestsSuite) TestFileUploadRangeFromURL() {
 	destFClient := shareClient.NewRootDirectoryClient().NewFileClient("dest" + testcommon.GenerateFileName(testName))
 	_, err = destFClient.Create(context.Background(), fileSize, nil)
 	_require.NoError(err)
-
 	uResp, err := destFClient.UploadRangeFromURL(context.Background(), srcFileSAS, 0, 0, int64(contentSize), &file.UploadRangeFromURLOptions{
-		SourceContentCRC64: contentCRC64,
+		SourceContentValidation: file.SourceContentValidationTypeCRC64(contentCRC64),
 	})
 	_require.NoError(err)
 	_require.NotNil(uResp.XMSContentCRC64)
@@ -1825,7 +1824,7 @@ func (f *FileRecordedTestsSuite) TestFileUploadRangeFromURLNegative() {
 	destFClient := testcommon.CreateNewFileFromShare(context.Background(), _require, "dest"+testcommon.GenerateFileName(testName), fileSize, shareClient)
 
 	_, err = destFClient.UploadRangeFromURL(context.Background(), srcFClient.URL(), 0, 0, int64(contentSize), &file.UploadRangeFromURLOptions{
-		SourceContentCRC64: contentCRC64,
+		SourceContentValidation: file.SourceContentValidationTypeCRC64(contentCRC64),
 	})
 	_require.Error(err)
 }
@@ -1906,7 +1905,7 @@ func (f *FileUnrecordedTestsSuite) TestFileUploadRangeFromURLCopySourceAuthBlob(
 
 	blobURL := blobClient.ServiceClient().NewContainerClient(containerName).NewBlockBlobClient(blobName).URL()
 	uResp, err := destFClient.UploadRangeFromURL(context.Background(), blobURL, 0, 0, int64(contentSize), &file.UploadRangeFromURLOptions{
-		SourceContentCRC64:      contentCRC64,
+		SourceContentValidation: file.SourceContentValidationTypeCRC64(contentCRC64),
 		CopySourceAuthorization: to.Ptr("Bearer " + accessToken.Token),
 	})
 	_require.NoError(err)
@@ -4065,7 +4064,7 @@ func (f *FileUnrecordedTestsSuite) TestFileUploadRangeFromURLTrailingDot() {
 	destFClient := testcommon.CreateNewFileFromShare(context.Background(), _require, "destFile..", fileSize, shareClient)
 
 	uResp, err := destFClient.UploadRangeFromURL(context.Background(), srcFileSAS, 0, 0, int64(contentSize), &file.UploadRangeFromURLOptions{
-		SourceContentCRC64: contentCRC64,
+		SourceContentValidation: file.SourceContentValidationTypeCRC64(contentCRC64),
 	})
 	_require.NoError(err)
 	_require.NotNil(uResp.XMSContentCRC64)
@@ -4201,8 +4200,8 @@ func (f *FileUnrecordedTestsSuite) TestFileUploadRangeFromURLPreserve() {
 	_require.NotNil(cResp.FileLastWriteTime)
 
 	uResp, err := destFClient.UploadRangeFromURL(context.Background(), srcFileSAS, 0, 0, int64(contentSize), &file.UploadRangeFromURLOptions{
-		SourceContentCRC64: contentCRC64,
-		LastWrittenMode:    to.Ptr(file.LastWrittenModePreserve),
+		SourceContentValidation: file.SourceContentValidationTypeCRC64(contentCRC64),
+		LastWrittenMode:         to.Ptr(file.LastWrittenModePreserve),
 	})
 	_require.NoError(err)
 	_require.NotNil(uResp.XMSContentCRC64)
@@ -4256,8 +4255,8 @@ func (f *FileUnrecordedTestsSuite) TestFileUploadRangeFromURLNow() {
 	_require.NotNil(cResp.FileLastWriteTime)
 
 	uResp, err := destFClient.UploadRangeFromURL(context.Background(), srcFileSAS, 0, 0, int64(contentSize), &file.UploadRangeFromURLOptions{
-		SourceContentCRC64: contentCRC64,
-		LastWrittenMode:    to.Ptr(file.LastWrittenModeNow),
+		SourceContentValidation: file.SourceContentValidationTypeCRC64(contentCRC64),
+		LastWrittenMode:         to.Ptr(file.LastWrittenModeNow),
 	})
 	_require.NoError(err)
 	_require.NotNil(uResp.XMSContentCRC64)

--- a/sdk/storage/azfile/file/constants.go
+++ b/sdk/storage/azfile/file/constants.go
@@ -78,8 +78,10 @@ type SourceContentValidationType interface {
 	notPubliclyImplementable()
 }
 
+// SourceContentValidationTypeCRC64 is a SourceContentValidationType used to provide a precomputed CRC64.
 type SourceContentValidationTypeCRC64 uint64
 
+// Apply implements the SourceContentValidationType interface for type SourceContentValidationTypeCRC64.
 func (s SourceContentValidationTypeCRC64) Apply(cfg generated.SourceContentSetter) error {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, uint64(s))

--- a/sdk/storage/azfile/file/constants.go
+++ b/sdk/storage/azfile/file/constants.go
@@ -7,6 +7,7 @@
 package file
 
 import (
+	"encoding/binary"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/generated"
 )
@@ -70,6 +71,23 @@ const (
 func PossibleRangeWriteTypeValues() []RangeWriteType {
 	return generated.PossibleFileRangeWriteTypeValues()
 }
+
+// SourceContentValidationType abstracts mechanisms used to validate source content
+type SourceContentValidationType interface {
+	Apply(generated.SourceContentSetter) error
+	notPubliclyImplementable()
+}
+
+type SourceContentValidationTypeCRC64 uint64
+
+func (s SourceContentValidationTypeCRC64) Apply(cfg generated.SourceContentSetter) error {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, uint64(s))
+	cfg.SetSourceContentCRC64(buf)
+	return nil
+}
+
+func (SourceContentValidationTypeCRC64) notPubliclyImplementable() {}
 
 // TransferValidationType abstracts the various mechanisms used to verify a transfer.
 type TransferValidationType = exported.TransferValidationType


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
