### PR TITLE
Strip off package name for telemetry policy

### DIFF
--- a/sdk/azcore/runtime/policy_telemetry.go
+++ b/sdk/azcore/runtime/policy_telemetry.go
@@ -43,6 +43,10 @@ func NewTelemetryPolicy(mod, ver string, o *policy.TelemetryOptions) policy.Poli
 		b.WriteString(o.ApplicationID)
 		b.WriteRune(' ')
 	}
+	// mod might be the fully qualified name. in that case, we just want the package name
+	if i := strings.LastIndex(mod, "/"); i > -1 {
+		mod = mod[i+1:]
+	}
 	b.WriteString(formatTelemetry(mod, ver))
 	b.WriteRune(' ')
 	b.WriteString(platformInfo)

--- a/sdk/azcore/runtime/policy_telemetry_test.go
+++ b/sdk/azcore/runtime/policy_telemetry_test.go
@@ -36,6 +36,24 @@ func TestPolicyTelemetryDefault(t *testing.T) {
 	}
 }
 
+func TestPolicyTelemetryDefaultFullQualified(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse()
+	pl := exported.NewPipeline(srv, NewTelemetryPolicy("github.com/foo/bar/test", "v1.2.3", nil))
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp, err := pl.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v := resp.Request.Header.Get(shared.HeaderUserAgent); v != "azsdk-go-test/v1.2.3 "+platformInfo {
+		t.Fatalf("unexpected user agent value: %s", v)
+	}
+}
+
 func TestPolicyTelemetryPreserveExisting(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()


### PR DESCRIPTION
If a fully qualified module name is provided.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
