### PR TITLE
Add support for internal Azure App Configuration Snapshots

### DIFF
--- a/sdk/data/azappconfig/client.go
+++ b/sdk/data/azappconfig/client.go
@@ -141,7 +141,9 @@ func (c *Client) GetSetting(ctx context.Context, key string, options *GetSetting
 
 	var lastModified *time.Time
 	if resp.LastModified != nil {
-		tt, err := time.Parse(http.TimeFormat, *resp.LastModified)
+		slm := *resp.LastModified
+		tflm := slm.Format(http.TimeFormat)
+		tt, err := time.Parse(http.TimeFormat, tflm)
 		if err != nil {
 			return GetSettingResponse{}, err
 		}

--- a/sdk/data/azappconfig/client_test.go
+++ b/sdk/data/azappconfig/client_test.go
@@ -205,7 +205,7 @@ func TestClient(t *testing.T) {
 	revPgr := client.NewListRevisionsPager(azappconfig.SettingSelector{
 		KeyFilter:   &any,
 		LabelFilter: &any,
-		Fields:      azappconfig.AllSettingFields(),
+		Fields:      azappconfig.AllKeyValueFields(),
 	}, nil)
 	require.NotEmpty(t, revPgr)
 	hasMoreRevs := revPgr.More()
@@ -219,7 +219,7 @@ func TestClient(t *testing.T) {
 	settsPgr := client.NewListSettingsPager(azappconfig.SettingSelector{
 		KeyFilter:   &any,
 		LabelFilter: &any,
-		Fields:      azappconfig.AllSettingFields(),
+		Fields:      azappconfig.AllKeyValueFields(),
 	}, nil)
 	require.NotEmpty(t, settsPgr)
 	hasMoreSetts := settsPgr.More()

--- a/sdk/data/azappconfig/constants.go
+++ b/sdk/data/azappconfig/constants.go
@@ -8,7 +8,7 @@ package azappconfig
 
 import "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/internal/generated"
 
-// SettingFields are fields to retrieve from a configuration setting.
+// KeyValueFields are fields to retrieve from a configuration setting.
 type KeyValueFields = generated.KeyValueFields
 
 const (

--- a/sdk/data/azappconfig/constants.go
+++ b/sdk/data/azappconfig/constants.go
@@ -9,30 +9,30 @@ package azappconfig
 import "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/internal/generated"
 
 // SettingFields are fields to retrieve from a configuration setting.
-type SettingFields = generated.SettingFields
+type KeyValueFields = generated.KeyValueFields
 
 const (
 	// The primary identifier of a configuration setting.
-	SettingFieldsKey SettingFields = generated.SettingFieldsKey
+	KeyValueFieldsKey KeyValueFields = generated.KeyValueFieldsKey
 
 	// A label used to group configuration settings.
-	SettingFieldsLabel SettingFields = generated.SettingFieldsLabel
+	KeyValueFieldsLabel KeyValueFields = generated.KeyValueFieldsLabel
 
 	// The value of the configuration setting.
-	SettingFieldsValue SettingFields = generated.SettingFieldsValue
+	KeyValueFieldsValue KeyValueFields = generated.KeyValueFieldsValue
 
 	// The content type of the configuration setting's value.
-	SettingFieldsContentType SettingFields = generated.SettingFieldsContentType
+	KeyValueFieldsContentType KeyValueFields = generated.KeyValueFieldsContentType
 
 	// An ETag indicating the version of a configuration setting within a configuration store.
-	SettingFieldsETag SettingFields = generated.SettingFieldsEtag
+	KeyValueFieldsETag KeyValueFields = generated.KeyValueFieldsEtag
 
 	// The last time a modifying operation was performed on the given configuration setting.
-	SettingFieldsLastModified SettingFields = generated.SettingFieldsLastModified
+	KeyValueFieldsLastModified KeyValueFields = generated.KeyValueFieldsLastModified
 
 	// A value indicating whether the configuration setting is read-only.
-	SettingFieldsIsReadOnly SettingFields = generated.SettingFieldsLocked
+	KeyValueFieldsIsReadOnly KeyValueFields = generated.KeyValueFieldsLocked
 
 	// A list of tags that can help identify what a configuration setting may be applicable for.
-	SettingFieldsTags SettingFields = generated.SettingFieldsTags
+	KeyValueFieldsTags KeyValueFields = generated.KeyValueFieldsTags
 )

--- a/sdk/data/azappconfig/examples_test.go
+++ b/sdk/data/azappconfig/examples_test.go
@@ -194,7 +194,7 @@ func ExampleClient_NewListRevisionsPager() {
 	pager := client.NewListRevisionsPager(azappconfig.SettingSelector{
 		KeyFilter:   to.Ptr("*"),
 		LabelFilter: to.Ptr("*"),
-		Fields:      azappconfig.AllSettingFields(),
+		Fields:      azappconfig.AllKeyValueFields(),
 	}, nil)
 
 	for pager.More() {

--- a/sdk/data/azappconfig/internal/appconfiguration_ext.json
+++ b/sdk/data/azappconfig/internal/appconfiguration_ext.json
@@ -35,7 +35,7 @@
           "200": {
             "description": "Success",
             "schema": {
-                "$ref": "https://github.com/Azure/azure-rest-api-specs/blob/e01d8afe9be7633ed36db014af16d47fec01f737/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/1.0/appconfiguration.json#/definitions/KeyListResult"
+                "$ref": "https://github.com/Azure/azure-rest-api-specs/blob/1d5799e57a1bbe66a86afc246d363d8163625b45/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/2023-10-01/appconfiguration.json#/definitions/KeyListResult"
             },
             "headers": {
                 "Sync-Token": {
@@ -47,7 +47,7 @@
           "default": {
             "description": "Error response describing why the operation failed",
             "schema": {
-                "$ref": "https://github.com/Azure/azure-rest-api-specs/blob/e01d8afe9be7633ed36db014af16d47fec01f737/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/1.0/appconfiguration.json#/definitions/Error"
+                "$ref": "https://github.com/Azure/azure-rest-api-specs/blob/1d5799e57a1bbe66a86afc246d363d8163625b45/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/2023-10-01/appconfiguration.json#/definitions/Error"
             }
           }
         }

--- a/sdk/data/azappconfig/internal/autorest.md
+++ b/sdk/data/azappconfig/internal/autorest.md
@@ -6,7 +6,7 @@ These settings apply only when `--go` is specified on the command line.
 go: true
 version: "^3.0.0"
 input-file:
-- https://github.com/Azure/azure-rest-api-specs/blob/e01d8afe9be7633ed36db014af16d47fec01f737/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/1.0/appconfiguration.json
+- https://github.com/Azure/azure-rest-api-specs/blob/1d5799e57a1bbe66a86afc246d363d8163625b45/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/stable/2023-10-01/appconfiguration.json
 - appconfiguration_ext.json
 license-header: MICROSOFT_MIT_NO_VERSION
 clear-output-folder: false
@@ -15,56 +15,8 @@ output-folder: generated
 openapi-type: "data-plane"
 security: "AADToken"
 use: "@autorest/go@4.0.0-preview.51"
-```
-
-### Fix up enums
-
-``` yaml
-directive:
-- from: swagger-document
-  where: $.paths./kv
-  transform: >
-    $.get.parameters[6].items["x-ms-enum"] = {
-        "name": "SettingFields",
-        "modelAsString": true
-    };
-    $.head.parameters[6].items["x-ms-enum"] = {
-        "name": "SettingFields",
-        "modelAsString": true
-    };
-- from: swagger-document
-  where: $.paths./kv/{key}
-  transform: >
-    $.get.parameters[7].items["x-ms-enum"] = {
-        "name": "SettingFields",
-        "modelAsString": true
-    };
-    $.head.parameters[7].items["x-ms-enum"] = {
-        "name": "SettingFields",
-        "modelAsString": true
-    };
-- from: swagger-document
-  where: $.paths./labels
-  transform: >
-    $.get.parameters[5].items["x-ms-enum"] = {
-        "name": "LabelFields",
-        "modelAsString": true
-    };
-    $.head.parameters[5].items["x-ms-enum"] = {
-        "name": "LabelFields",
-        "modelAsString": true
-    };
-- from: swagger-document
-  where: $.paths./revisions
-  transform: >
-    $.get.parameters[6].items["x-ms-enum"] = {
-        "name": "SettingFields",
-        "modelAsString": true
-    };
-    $.head.parameters[6].items["x-ms-enum"] = {
-        "name": "SettingFields",
-        "modelAsString": true
-    };
+modelerfour:
+  lenient-model-deduplication: true
 ```
 
 ### Fix up pagers

--- a/sdk/data/azappconfig/internal/generated/zz_azureappconfiguration_client.go
+++ b/sdk/data/azappconfig/internal/generated/zz_azureappconfiguration_client.go
@@ -31,7 +31,7 @@ type AzureAppConfigurationClient struct {
 // CheckKeyValue - Requests the headers and status of the given resource.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - key - The key of the key-value to retrieve.
 //   - options - AzureAppConfigurationClientCheckKeyValueOptions contains the optional parameters for the AzureAppConfigurationClient.CheckKeyValue
 //     method.
@@ -68,7 +68,7 @@ func (client *AzureAppConfigurationClient) checkKeyValueCreateRequest(ctx contex
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.Select != nil {
 		reqQP.Set("$Select", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Select), "[]")), ","))
 	}
@@ -97,16 +97,13 @@ func (client *AzureAppConfigurationClient) checkKeyValueHandleResponse(resp *htt
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
-	if val := resp.Header.Get("Last-Modified"); val != "" {
-		result.LastModified = &val
-	}
 	return result, nil
 }
 
 // CheckKeyValues - Requests the headers and status of the given resource.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - options - AzureAppConfigurationClientCheckKeyValuesOptions contains the optional parameters for the AzureAppConfigurationClient.CheckKeyValues
 //     method.
 func (client *AzureAppConfigurationClient) CheckKeyValues(ctx context.Context, options *AzureAppConfigurationClientCheckKeyValuesOptions) (AzureAppConfigurationClientCheckKeyValuesResponse, error) {
@@ -141,12 +138,15 @@ func (client *AzureAppConfigurationClient) checkKeyValuesCreateRequest(ctx conte
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.After != nil {
 		reqQP.Set("After", *options.After)
 	}
 	if options != nil && options.Select != nil {
 		reqQP.Set("$Select", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Select), "[]")), ","))
+	}
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if client.syncToken != nil {
@@ -154,6 +154,12 @@ func (client *AzureAppConfigurationClient) checkKeyValuesCreateRequest(ctx conte
 	}
 	if options != nil && options.AcceptDatetime != nil {
 		req.Raw().Header["Accept-Datetime"] = []string{*options.AcceptDatetime}
+	}
+	if options != nil && options.IfMatch != nil {
+		req.Raw().Header["If-Match"] = []string{*options.IfMatch}
+	}
+	if options != nil && options.IfNoneMatch != nil {
+		req.Raw().Header["If-None-Match"] = []string{*options.IfNoneMatch}
 	}
 	return req, nil
 }
@@ -164,13 +170,16 @@ func (client *AzureAppConfigurationClient) checkKeyValuesHandleResponse(resp *ht
 	if val := resp.Header.Get("Sync-Token"); val != "" {
 		result.SyncToken = &val
 	}
+	if val := resp.Header.Get("ETag"); val != "" {
+		result.ETag = &val
+	}
 	return result, nil
 }
 
 // CheckKeys - Requests the headers and status of the given resource.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - options - AzureAppConfigurationClientCheckKeysOptions contains the optional parameters for the AzureAppConfigurationClient.CheckKeys
 //     method.
 func (client *AzureAppConfigurationClient) CheckKeys(ctx context.Context, options *AzureAppConfigurationClientCheckKeysOptions) (AzureAppConfigurationClientCheckKeysResponse, error) {
@@ -202,7 +211,7 @@ func (client *AzureAppConfigurationClient) checkKeysCreateRequest(ctx context.Co
 	if options != nil && options.Name != nil {
 		reqQP.Set("name", *options.Name)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.After != nil {
 		reqQP.Set("After", *options.After)
 	}
@@ -228,7 +237,7 @@ func (client *AzureAppConfigurationClient) checkKeysHandleResponse(resp *http.Re
 // CheckLabels - Requests the headers and status of the given resource.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - options - AzureAppConfigurationClientCheckLabelsOptions contains the optional parameters for the AzureAppConfigurationClient.CheckLabels
 //     method.
 func (client *AzureAppConfigurationClient) CheckLabels(ctx context.Context, options *AzureAppConfigurationClientCheckLabelsOptions) (AzureAppConfigurationClientCheckLabelsResponse, error) {
@@ -260,7 +269,7 @@ func (client *AzureAppConfigurationClient) checkLabelsCreateRequest(ctx context.
 	if options != nil && options.Name != nil {
 		reqQP.Set("name", *options.Name)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.After != nil {
 		reqQP.Set("After", *options.After)
 	}
@@ -289,7 +298,7 @@ func (client *AzureAppConfigurationClient) checkLabelsHandleResponse(resp *http.
 // CheckRevisions - Requests the headers and status of the given resource.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - options - AzureAppConfigurationClientCheckRevisionsOptions contains the optional parameters for the AzureAppConfigurationClient.CheckRevisions
 //     method.
 func (client *AzureAppConfigurationClient) CheckRevisions(ctx context.Context, options *AzureAppConfigurationClientCheckRevisionsOptions) (AzureAppConfigurationClientCheckRevisionsResponse, error) {
@@ -324,7 +333,7 @@ func (client *AzureAppConfigurationClient) checkRevisionsCreateRequest(ctx conte
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.After != nil {
 		reqQP.Set("After", *options.After)
 	}
@@ -347,13 +356,200 @@ func (client *AzureAppConfigurationClient) checkRevisionsHandleResponse(resp *ht
 	if val := resp.Header.Get("Sync-Token"); val != "" {
 		result.SyncToken = &val
 	}
+	if val := resp.Header.Get("ETag"); val != "" {
+		result.ETag = &val
+	}
 	return result, nil
+}
+
+// CheckSnapshot - Requests the headers and status of the given resource.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-10-01
+//   - name - The name of the key-value snapshot to check.
+//   - options - AzureAppConfigurationClientCheckSnapshotOptions contains the optional parameters for the AzureAppConfigurationClient.CheckSnapshot
+//     method.
+func (client *AzureAppConfigurationClient) CheckSnapshot(ctx context.Context, name string, options *AzureAppConfigurationClientCheckSnapshotOptions) (AzureAppConfigurationClientCheckSnapshotResponse, error) {
+	var err error
+	req, err := client.checkSnapshotCreateRequest(ctx, name, options)
+	if err != nil {
+		return AzureAppConfigurationClientCheckSnapshotResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return AzureAppConfigurationClientCheckSnapshotResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return AzureAppConfigurationClientCheckSnapshotResponse{}, err
+	}
+	resp, err := client.checkSnapshotHandleResponse(httpResp)
+	return resp, err
+}
+
+// checkSnapshotCreateRequest creates the CheckSnapshot request.
+func (client *AzureAppConfigurationClient) checkSnapshotCreateRequest(ctx context.Context, name string, options *AzureAppConfigurationClientCheckSnapshotOptions) (*policy.Request, error) {
+	urlPath := "/snapshots/{name}"
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
+	req, err := runtime.NewRequest(ctx, http.MethodHead, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2023-10-01")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	if client.syncToken != nil {
+		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
+	}
+	if options != nil && options.IfMatch != nil {
+		req.Raw().Header["If-Match"] = []string{*options.IfMatch}
+	}
+	if options != nil && options.IfNoneMatch != nil {
+		req.Raw().Header["If-None-Match"] = []string{*options.IfNoneMatch}
+	}
+	return req, nil
+}
+
+// checkSnapshotHandleResponse handles the CheckSnapshot response.
+func (client *AzureAppConfigurationClient) checkSnapshotHandleResponse(resp *http.Response) (AzureAppConfigurationClientCheckSnapshotResponse, error) {
+	result := AzureAppConfigurationClientCheckSnapshotResponse{}
+	if val := resp.Header.Get("Sync-Token"); val != "" {
+		result.SyncToken = &val
+	}
+	if val := resp.Header.Get("ETag"); val != "" {
+		result.ETag = &val
+	}
+	if val := resp.Header.Get("Link"); val != "" {
+		result.Link = &val
+	}
+	return result, nil
+}
+
+// CheckSnapshots - Requests the headers and status of the given resource.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-10-01
+//   - options - AzureAppConfigurationClientCheckSnapshotsOptions contains the optional parameters for the AzureAppConfigurationClient.CheckSnapshots
+//     method.
+func (client *AzureAppConfigurationClient) CheckSnapshots(ctx context.Context, options *AzureAppConfigurationClientCheckSnapshotsOptions) (AzureAppConfigurationClientCheckSnapshotsResponse, error) {
+	var err error
+	req, err := client.checkSnapshotsCreateRequest(ctx, options)
+	if err != nil {
+		return AzureAppConfigurationClientCheckSnapshotsResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return AzureAppConfigurationClientCheckSnapshotsResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return AzureAppConfigurationClientCheckSnapshotsResponse{}, err
+	}
+	resp, err := client.checkSnapshotsHandleResponse(httpResp)
+	return resp, err
+}
+
+// checkSnapshotsCreateRequest creates the CheckSnapshots request.
+func (client *AzureAppConfigurationClient) checkSnapshotsCreateRequest(ctx context.Context, options *AzureAppConfigurationClientCheckSnapshotsOptions) (*policy.Request, error) {
+	urlPath := "/snapshots"
+	req, err := runtime.NewRequest(ctx, http.MethodHead, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2023-10-01")
+	if options != nil && options.After != nil {
+		reqQP.Set("After", *options.After)
+	}
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	if client.syncToken != nil {
+		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
+	}
+	return req, nil
+}
+
+// checkSnapshotsHandleResponse handles the CheckSnapshots response.
+func (client *AzureAppConfigurationClient) checkSnapshotsHandleResponse(resp *http.Response) (AzureAppConfigurationClientCheckSnapshotsResponse, error) {
+	result := AzureAppConfigurationClientCheckSnapshotsResponse{}
+	if val := resp.Header.Get("Sync-Token"); val != "" {
+		result.SyncToken = &val
+	}
+	return result, nil
+}
+
+// BeginCreateSnapshot - Creates a key-value snapshot.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-10-01
+//   - name - The name of the key-value snapshot to create.
+//   - entity - The key-value snapshot to create.
+//   - options - AzureAppConfigurationClientBeginCreateSnapshotOptions contains the optional parameters for the AzureAppConfigurationClient.BeginCreateSnapshot
+//     method.
+func (client *AzureAppConfigurationClient) BeginCreateSnapshot(ctx context.Context, name string, entity Snapshot, options *AzureAppConfigurationClientBeginCreateSnapshotOptions) (*runtime.Poller[AzureAppConfigurationClientCreateSnapshotResponse], error) {
+	if options == nil || options.ResumeToken == "" {
+		resp, err := client.createSnapshot(ctx, name, entity, options)
+		if err != nil {
+			return nil, err
+		}
+		poller, err := runtime.NewPoller[AzureAppConfigurationClientCreateSnapshotResponse](resp, client.internal.Pipeline(), nil)
+		return poller, err
+	} else {
+		return runtime.NewPollerFromResumeToken[AzureAppConfigurationClientCreateSnapshotResponse](options.ResumeToken, client.internal.Pipeline(), nil)
+	}
+}
+
+// CreateSnapshot - Creates a key-value snapshot.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-10-01
+func (client *AzureAppConfigurationClient) createSnapshot(ctx context.Context, name string, entity Snapshot, options *AzureAppConfigurationClientBeginCreateSnapshotOptions) (*http.Response, error) {
+	var err error
+	req, err := client.createSnapshotCreateRequest(ctx, name, entity, options)
+	if err != nil {
+		return nil, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusCreated) {
+		err = runtime.NewResponseError(httpResp)
+		return nil, err
+	}
+	return httpResp, nil
+}
+
+// createSnapshotCreateRequest creates the CreateSnapshot request.
+func (client *AzureAppConfigurationClient) createSnapshotCreateRequest(ctx context.Context, name string, entity Snapshot, options *AzureAppConfigurationClientBeginCreateSnapshotOptions) (*policy.Request, error) {
+	urlPath := "/snapshots/{name}"
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2023-10-01")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	if client.syncToken != nil {
+		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
+	}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.snapshot+json, application/problem+json"}
+	if err := runtime.MarshalAsJSON(req, entity); err != nil {
+		return nil, err
+	}
+	return req, nil
 }
 
 // DeleteKeyValue - Deletes a key-value.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - key - The key of the key-value to delete.
 //   - options - AzureAppConfigurationClientDeleteKeyValueOptions contains the optional parameters for the AzureAppConfigurationClient.DeleteKeyValue
 //     method.
@@ -390,7 +586,7 @@ func (client *AzureAppConfigurationClient) deleteKeyValueCreateRequest(ctx conte
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if client.syncToken != nil {
 		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
@@ -398,7 +594,7 @@ func (client *AzureAppConfigurationClient) deleteKeyValueCreateRequest(ctx conte
 	if options != nil && options.IfMatch != nil {
 		req.Raw().Header["If-Match"] = []string{*options.IfMatch}
 	}
-	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/json, application/problem+json"}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/problem+json"}
 	return req, nil
 }
 
@@ -420,7 +616,7 @@ func (client *AzureAppConfigurationClient) deleteKeyValueHandleResponse(resp *ht
 // DeleteLock - Unlocks a key-value.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - key - The key of the key-value to unlock.
 //   - options - AzureAppConfigurationClientDeleteLockOptions contains the optional parameters for the AzureAppConfigurationClient.DeleteLock
 //     method.
@@ -457,7 +653,7 @@ func (client *AzureAppConfigurationClient) deleteLockCreateRequest(ctx context.C
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if client.syncToken != nil {
 		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
@@ -468,7 +664,7 @@ func (client *AzureAppConfigurationClient) deleteLockCreateRequest(ctx context.C
 	if options != nil && options.IfNoneMatch != nil {
 		req.Raw().Header["If-None-Match"] = []string{*options.IfNoneMatch}
 	}
-	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/json, application/problem+json"}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/problem+json"}
 	return req, nil
 }
 
@@ -490,7 +686,7 @@ func (client *AzureAppConfigurationClient) deleteLockHandleResponse(resp *http.R
 // GetKeyValue - Gets a single key-value.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - key - The key of the key-value to retrieve.
 //   - options - AzureAppConfigurationClientGetKeyValueOptions contains the optional parameters for the AzureAppConfigurationClient.GetKeyValue
 //     method.
@@ -527,7 +723,7 @@ func (client *AzureAppConfigurationClient) getKeyValueCreateRequest(ctx context.
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.Select != nil {
 		reqQP.Set("$Select", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Select), "[]")), ","))
 	}
@@ -544,7 +740,7 @@ func (client *AzureAppConfigurationClient) getKeyValueCreateRequest(ctx context.
 	if options != nil && options.IfNoneMatch != nil {
 		req.Raw().Header["If-None-Match"] = []string{*options.IfNoneMatch}
 	}
-	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/json, application/problem+json"}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/problem+json"}
 	return req, nil
 }
 
@@ -557,9 +753,6 @@ func (client *AzureAppConfigurationClient) getKeyValueHandleResponse(resp *http.
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
-	if val := resp.Header.Get("Last-Modified"); val != "" {
-		result.LastModified = &val
-	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyValue); err != nil {
 		return AzureAppConfigurationClientGetKeyValueResponse{}, err
 	}
@@ -568,7 +761,7 @@ func (client *AzureAppConfigurationClient) getKeyValueHandleResponse(resp *http.
 
 // NewGetKeyValuesPager - Gets a list of key-values.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - options - AzureAppConfigurationClientGetKeyValuesOptions contains the optional parameters for the AzureAppConfigurationClient.NewGetKeyValuesPager
 //     method.
 func (client *AzureAppConfigurationClient) NewGetKeyValuesPager(options *AzureAppConfigurationClientGetKeyValuesOptions) *runtime.Pager[AzureAppConfigurationClientGetKeyValuesResponse] {
@@ -613,12 +806,15 @@ func (client *AzureAppConfigurationClient) getKeyValuesCreateRequest(ctx context
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.After != nil {
 		reqQP.Set("After", *options.After)
 	}
 	if options != nil && options.Select != nil {
 		reqQP.Set("$Select", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Select), "[]")), ","))
+	}
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if client.syncToken != nil {
@@ -627,7 +823,13 @@ func (client *AzureAppConfigurationClient) getKeyValuesCreateRequest(ctx context
 	if options != nil && options.AcceptDatetime != nil {
 		req.Raw().Header["Accept-Datetime"] = []string{*options.AcceptDatetime}
 	}
-	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kvset+json, application/json, application/problem+json"}
+	if options != nil && options.IfMatch != nil {
+		req.Raw().Header["If-Match"] = []string{*options.IfMatch}
+	}
+	if options != nil && options.IfNoneMatch != nil {
+		req.Raw().Header["If-None-Match"] = []string{*options.IfNoneMatch}
+	}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kvset+json, application/problem+json"}
 	return req, nil
 }
 
@@ -637,6 +839,9 @@ func (client *AzureAppConfigurationClient) getKeyValuesHandleResponse(resp *http
 	if val := resp.Header.Get("Sync-Token"); val != "" {
 		result.SyncToken = &val
 	}
+	if val := resp.Header.Get("ETag"); val != "" {
+		result.ETag = &val
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyValueListResult); err != nil {
 		return AzureAppConfigurationClientGetKeyValuesResponse{}, err
 	}
@@ -645,7 +850,7 @@ func (client *AzureAppConfigurationClient) getKeyValuesHandleResponse(resp *http
 
 // NewGetKeysPager - Gets a list of keys.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - options - AzureAppConfigurationClientGetKeysOptions contains the optional parameters for the AzureAppConfigurationClient.NewGetKeysPager
 //     method.
 func (client *AzureAppConfigurationClient) NewGetKeysPager(options *AzureAppConfigurationClientGetKeysOptions) *runtime.Pager[AzureAppConfigurationClientGetKeysResponse] {
@@ -687,7 +892,7 @@ func (client *AzureAppConfigurationClient) getKeysCreateRequest(ctx context.Cont
 	if options != nil && options.Name != nil {
 		reqQP.Set("name", *options.Name)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.After != nil {
 		reqQP.Set("After", *options.After)
 	}
@@ -698,7 +903,7 @@ func (client *AzureAppConfigurationClient) getKeysCreateRequest(ctx context.Cont
 	if options != nil && options.AcceptDatetime != nil {
 		req.Raw().Header["Accept-Datetime"] = []string{*options.AcceptDatetime}
 	}
-	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.keyset+json, application/json, application/problem+json"}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.keyset+json, application/problem+json"}
 	return req, nil
 }
 
@@ -716,7 +921,7 @@ func (client *AzureAppConfigurationClient) getKeysHandleResponse(resp *http.Resp
 
 // NewGetLabelsPager - Gets a list of labels.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - options - AzureAppConfigurationClientGetLabelsOptions contains the optional parameters for the AzureAppConfigurationClient.NewGetLabelsPager
 //     method.
 func (client *AzureAppConfigurationClient) NewGetLabelsPager(options *AzureAppConfigurationClientGetLabelsOptions) *runtime.Pager[AzureAppConfigurationClientGetLabelsResponse] {
@@ -758,7 +963,7 @@ func (client *AzureAppConfigurationClient) getLabelsCreateRequest(ctx context.Co
 	if options != nil && options.Name != nil {
 		reqQP.Set("name", *options.Name)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.After != nil {
 		reqQP.Set("After", *options.After)
 	}
@@ -772,7 +977,7 @@ func (client *AzureAppConfigurationClient) getLabelsCreateRequest(ctx context.Co
 	if options != nil && options.AcceptDatetime != nil {
 		req.Raw().Header["Accept-Datetime"] = []string{*options.AcceptDatetime}
 	}
-	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.labelset+json, application/json, application/problem+json"}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.labelset+json, application/problem+json"}
 	return req, nil
 }
 
@@ -812,9 +1017,58 @@ func (client *AzureAppConfigurationClient) getNextPageHandleResponse(resp *http.
 	return result, nil
 }
 
+// GetOperationDetails - Gets the state of a long running operation.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-10-01
+//   - snapshot - Snapshot identifier for the long running operation.
+//   - options - AzureAppConfigurationClientGetOperationDetailsOptions contains the optional parameters for the AzureAppConfigurationClient.GetOperationDetails
+//     method.
+func (client *AzureAppConfigurationClient) GetOperationDetails(ctx context.Context, snapshot string, options *AzureAppConfigurationClientGetOperationDetailsOptions) (AzureAppConfigurationClientGetOperationDetailsResponse, error) {
+	var err error
+	req, err := client.getOperationDetailsCreateRequest(ctx, snapshot, options)
+	if err != nil {
+		return AzureAppConfigurationClientGetOperationDetailsResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return AzureAppConfigurationClientGetOperationDetailsResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return AzureAppConfigurationClientGetOperationDetailsResponse{}, err
+	}
+	resp, err := client.getOperationDetailsHandleResponse(httpResp)
+	return resp, err
+}
+
+// getOperationDetailsCreateRequest creates the GetOperationDetails request.
+func (client *AzureAppConfigurationClient) getOperationDetailsCreateRequest(ctx context.Context, snapshot string, options *AzureAppConfigurationClientGetOperationDetailsOptions) (*policy.Request, error) {
+	urlPath := "/operations"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2023-10-01")
+	reqQP.Set("snapshot", snapshot)
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// getOperationDetailsHandleResponse handles the GetOperationDetails response.
+func (client *AzureAppConfigurationClient) getOperationDetailsHandleResponse(resp *http.Response) (AzureAppConfigurationClientGetOperationDetailsResponse, error) {
+	result := AzureAppConfigurationClientGetOperationDetailsResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.OperationDetails); err != nil {
+		return AzureAppConfigurationClientGetOperationDetailsResponse{}, err
+	}
+	return result, nil
+}
+
 // NewGetRevisionsPager - Gets a list of key-value revisions.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - options - AzureAppConfigurationClientGetRevisionsOptions contains the optional parameters for the AzureAppConfigurationClient.NewGetRevisionsPager
 //     method.
 func (client *AzureAppConfigurationClient) NewGetRevisionsPager(options *AzureAppConfigurationClientGetRevisionsOptions) *runtime.Pager[AzureAppConfigurationClientGetRevisionsResponse] {
@@ -859,7 +1113,7 @@ func (client *AzureAppConfigurationClient) getRevisionsCreateRequest(ctx context
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	if options != nil && options.After != nil {
 		reqQP.Set("After", *options.After)
 	}
@@ -873,7 +1127,7 @@ func (client *AzureAppConfigurationClient) getRevisionsCreateRequest(ctx context
 	if options != nil && options.AcceptDatetime != nil {
 		req.Raw().Header["Accept-Datetime"] = []string{*options.AcceptDatetime}
 	}
-	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kvset+json, application/json, application/problem+json"}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kvset+json, application/problem+json"}
 	return req, nil
 }
 
@@ -883,8 +1137,158 @@ func (client *AzureAppConfigurationClient) getRevisionsHandleResponse(resp *http
 	if val := resp.Header.Get("Sync-Token"); val != "" {
 		result.SyncToken = &val
 	}
+	if val := resp.Header.Get("ETag"); val != "" {
+		result.ETag = &val
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyValueListResult); err != nil {
 		return AzureAppConfigurationClientGetRevisionsResponse{}, err
+	}
+	return result, nil
+}
+
+// GetSnapshot - Gets a single key-value snapshot.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-10-01
+//   - name - The name of the key-value snapshot to retrieve.
+//   - options - AzureAppConfigurationClientGetSnapshotOptions contains the optional parameters for the AzureAppConfigurationClient.GetSnapshot
+//     method.
+func (client *AzureAppConfigurationClient) GetSnapshot(ctx context.Context, name string, options *AzureAppConfigurationClientGetSnapshotOptions) (AzureAppConfigurationClientGetSnapshotResponse, error) {
+	var err error
+	req, err := client.getSnapshotCreateRequest(ctx, name, options)
+	if err != nil {
+		return AzureAppConfigurationClientGetSnapshotResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return AzureAppConfigurationClientGetSnapshotResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return AzureAppConfigurationClientGetSnapshotResponse{}, err
+	}
+	resp, err := client.getSnapshotHandleResponse(httpResp)
+	return resp, err
+}
+
+// getSnapshotCreateRequest creates the GetSnapshot request.
+func (client *AzureAppConfigurationClient) getSnapshotCreateRequest(ctx context.Context, name string, options *AzureAppConfigurationClientGetSnapshotOptions) (*policy.Request, error) {
+	urlPath := "/snapshots/{name}"
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2023-10-01")
+	if options != nil && options.Select != nil {
+		reqQP.Set("$Select", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Select), "[]")), ","))
+	}
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	if client.syncToken != nil {
+		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
+	}
+	if options != nil && options.IfMatch != nil {
+		req.Raw().Header["If-Match"] = []string{*options.IfMatch}
+	}
+	if options != nil && options.IfNoneMatch != nil {
+		req.Raw().Header["If-None-Match"] = []string{*options.IfNoneMatch}
+	}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.snapshot+json, application/problem+json"}
+	return req, nil
+}
+
+// getSnapshotHandleResponse handles the GetSnapshot response.
+func (client *AzureAppConfigurationClient) getSnapshotHandleResponse(resp *http.Response) (AzureAppConfigurationClientGetSnapshotResponse, error) {
+	result := AzureAppConfigurationClientGetSnapshotResponse{}
+	if val := resp.Header.Get("Sync-Token"); val != "" {
+		result.SyncToken = &val
+	}
+	if val := resp.Header.Get("ETag"); val != "" {
+		result.ETag = &val
+	}
+	if val := resp.Header.Get("Link"); val != "" {
+		result.Link = &val
+	}
+	if err := runtime.UnmarshalAsJSON(resp, &result.Snapshot); err != nil {
+		return AzureAppConfigurationClientGetSnapshotResponse{}, err
+	}
+	return result, nil
+}
+
+// NewGetSnapshotsPager - Gets a list of key-value snapshots.
+//
+// Generated from API version 2023-10-01
+//   - options - AzureAppConfigurationClientGetSnapshotsOptions contains the optional parameters for the AzureAppConfigurationClient.NewGetSnapshotsPager
+//     method.
+func (client *AzureAppConfigurationClient) NewGetSnapshotsPager(options *AzureAppConfigurationClientGetSnapshotsOptions) *runtime.Pager[AzureAppConfigurationClientGetSnapshotsResponse] {
+	return runtime.NewPager(runtime.PagingHandler[AzureAppConfigurationClientGetSnapshotsResponse]{
+		More: func(page AzureAppConfigurationClientGetSnapshotsResponse) bool {
+			return page.NextLink != nil && len(*page.NextLink) > 0
+		},
+		Fetcher: func(ctx context.Context, page *AzureAppConfigurationClientGetSnapshotsResponse) (AzureAppConfigurationClientGetSnapshotsResponse, error) {
+			var req *policy.Request
+			var err error
+			if page == nil {
+				req, err = client.getSnapshotsCreateRequest(ctx, options)
+			} else {
+				req, err = client.getNextPageCreateRequest(ctx, *page.NextLink)
+			}
+			if err != nil {
+				return AzureAppConfigurationClientGetSnapshotsResponse{}, err
+			}
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return AzureAppConfigurationClientGetSnapshotsResponse{}, err
+			}
+			if !runtime.HasStatusCode(resp, http.StatusOK) {
+				return AzureAppConfigurationClientGetSnapshotsResponse{}, runtime.NewResponseError(resp)
+			}
+			return client.getSnapshotsHandleResponse(resp)
+		},
+	})
+}
+
+// getSnapshotsCreateRequest creates the GetSnapshots request.
+func (client *AzureAppConfigurationClient) getSnapshotsCreateRequest(ctx context.Context, options *AzureAppConfigurationClientGetSnapshotsOptions) (*policy.Request, error) {
+	urlPath := "/snapshots"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	if options != nil && options.Name != nil {
+		reqQP.Set("name", *options.Name)
+	}
+	reqQP.Set("api-version", "2023-10-01")
+	if options != nil && options.After != nil {
+		reqQP.Set("After", *options.After)
+	}
+	if options != nil && options.Select != nil {
+		reqQP.Set("$Select", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Select), "[]")), ","))
+	}
+	if options != nil && options.Status != nil {
+		reqQP.Set("status", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Status), "[]")), ","))
+	}
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	if client.syncToken != nil {
+		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
+	}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.snapshotset+json, application/problem+json"}
+	return req, nil
+}
+
+// getSnapshotsHandleResponse handles the GetSnapshots response.
+func (client *AzureAppConfigurationClient) getSnapshotsHandleResponse(resp *http.Response) (AzureAppConfigurationClientGetSnapshotsResponse, error) {
+	result := AzureAppConfigurationClientGetSnapshotsResponse{}
+	if val := resp.Header.Get("Sync-Token"); val != "" {
+		result.SyncToken = &val
+	}
+	if err := runtime.UnmarshalAsJSON(resp, &result.SnapshotListResult); err != nil {
+		return AzureAppConfigurationClientGetSnapshotsResponse{}, err
 	}
 	return result, nil
 }
@@ -892,7 +1296,7 @@ func (client *AzureAppConfigurationClient) getRevisionsHandleResponse(resp *http
 // PutKeyValue - Creates a key-value.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - key - The key of the key-value to create.
 //   - entity - The key-value to create.
 //   - options - AzureAppConfigurationClientPutKeyValueOptions contains the optional parameters for the AzureAppConfigurationClient.PutKeyValue
@@ -930,7 +1334,7 @@ func (client *AzureAppConfigurationClient) putKeyValueCreateRequest(ctx context.
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if client.syncToken != nil {
 		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
@@ -941,7 +1345,7 @@ func (client *AzureAppConfigurationClient) putKeyValueCreateRequest(ctx context.
 	if options != nil && options.IfNoneMatch != nil {
 		req.Raw().Header["If-None-Match"] = []string{*options.IfNoneMatch}
 	}
-	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/json, application/problem+json"}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/problem+json"}
 	if err := runtime.MarshalAsJSON(req, entity); err != nil {
 		return nil, err
 	}
@@ -966,7 +1370,7 @@ func (client *AzureAppConfigurationClient) putKeyValueHandleResponse(resp *http.
 // PutLock - Locks a key-value.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 1.0
+// Generated from API version 2023-10-01
 //   - key - The key of the key-value to lock.
 //   - options - AzureAppConfigurationClientPutLockOptions contains the optional parameters for the AzureAppConfigurationClient.PutLock
 //     method.
@@ -1003,7 +1407,7 @@ func (client *AzureAppConfigurationClient) putLockCreateRequest(ctx context.Cont
 	if options != nil && options.Label != nil {
 		reqQP.Set("label", *options.Label)
 	}
-	reqQP.Set("api-version", "1.0")
+	reqQP.Set("api-version", "2023-10-01")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if client.syncToken != nil {
 		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
@@ -1014,7 +1418,7 @@ func (client *AzureAppConfigurationClient) putLockCreateRequest(ctx context.Cont
 	if options != nil && options.IfNoneMatch != nil {
 		req.Raw().Header["If-None-Match"] = []string{*options.IfNoneMatch}
 	}
-	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/json, application/problem+json"}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.kv+json, application/problem+json"}
 	return req, nil
 }
 
@@ -1029,6 +1433,80 @@ func (client *AzureAppConfigurationClient) putLockHandleResponse(resp *http.Resp
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyValue); err != nil {
 		return AzureAppConfigurationClientPutLockResponse{}, err
+	}
+	return result, nil
+}
+
+// UpdateSnapshot - Updates the state of a key-value snapshot.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-10-01
+//   - name - The name of the key-value snapshot to update.
+//   - entity - The parameters used to update the snapshot.
+//   - options - AzureAppConfigurationClientUpdateSnapshotOptions contains the optional parameters for the AzureAppConfigurationClient.UpdateSnapshot
+//     method.
+func (client *AzureAppConfigurationClient) UpdateSnapshot(ctx context.Context, name string, entity SnapshotUpdateParameters, options *AzureAppConfigurationClientUpdateSnapshotOptions) (AzureAppConfigurationClientUpdateSnapshotResponse, error) {
+	var err error
+	req, err := client.updateSnapshotCreateRequest(ctx, name, entity, options)
+	if err != nil {
+		return AzureAppConfigurationClientUpdateSnapshotResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return AzureAppConfigurationClientUpdateSnapshotResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return AzureAppConfigurationClientUpdateSnapshotResponse{}, err
+	}
+	resp, err := client.updateSnapshotHandleResponse(httpResp)
+	return resp, err
+}
+
+// updateSnapshotCreateRequest creates the UpdateSnapshot request.
+func (client *AzureAppConfigurationClient) updateSnapshotCreateRequest(ctx context.Context, name string, entity SnapshotUpdateParameters, options *AzureAppConfigurationClientUpdateSnapshotOptions) (*policy.Request, error) {
+	urlPath := "/snapshots/{name}"
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{name}", url.PathEscape(name))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2023-10-01")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	if client.syncToken != nil {
+		req.Raw().Header["Sync-Token"] = []string{*client.syncToken}
+	}
+	if options != nil && options.IfMatch != nil {
+		req.Raw().Header["If-Match"] = []string{*options.IfMatch}
+	}
+	if options != nil && options.IfNoneMatch != nil {
+		req.Raw().Header["If-None-Match"] = []string{*options.IfNoneMatch}
+	}
+	req.Raw().Header["Accept"] = []string{"application/vnd.microsoft.appconfig.snapshot+json, application/problem+json"}
+	if err := runtime.MarshalAsJSON(req, entity); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+// updateSnapshotHandleResponse handles the UpdateSnapshot response.
+func (client *AzureAppConfigurationClient) updateSnapshotHandleResponse(resp *http.Response) (AzureAppConfigurationClientUpdateSnapshotResponse, error) {
+	result := AzureAppConfigurationClientUpdateSnapshotResponse{}
+	if val := resp.Header.Get("Sync-Token"); val != "" {
+		result.SyncToken = &val
+	}
+	if val := resp.Header.Get("ETag"); val != "" {
+		result.ETag = &val
+	}
+	if val := resp.Header.Get("Link"); val != "" {
+		result.Link = &val
+	}
+	if err := runtime.UnmarshalAsJSON(resp, &result.Snapshot); err != nil {
+		return AzureAppConfigurationClientUpdateSnapshotResponse{}, err
 	}
 	return result, nil
 }

--- a/sdk/data/azappconfig/internal/generated/zz_constants.go
+++ b/sdk/data/azappconfig/internal/generated/zz_constants.go
@@ -8,6 +8,51 @@
 
 package generated
 
+// CompositionType - The composition type describes how the key-values within the snapshot are composed. The 'key' composition
+// type ensures there are no two key-values containing the same key. The 'key_label' composition
+// type ensures there are no two key-values containing the same key and label.
+type CompositionType string
+
+const (
+	CompositionTypeKey      CompositionType = "key"
+	CompositionTypeKeyLabel CompositionType = "key_label"
+)
+
+// PossibleCompositionTypeValues returns the possible values for the CompositionType const type.
+func PossibleCompositionTypeValues() []CompositionType {
+	return []CompositionType{
+		CompositionTypeKey,
+		CompositionTypeKeyLabel,
+	}
+}
+
+type KeyValueFields string
+
+const (
+	KeyValueFieldsContentType  KeyValueFields = "content_type"
+	KeyValueFieldsEtag         KeyValueFields = "etag"
+	KeyValueFieldsKey          KeyValueFields = "key"
+	KeyValueFieldsLabel        KeyValueFields = "label"
+	KeyValueFieldsLastModified KeyValueFields = "last_modified"
+	KeyValueFieldsLocked       KeyValueFields = "locked"
+	KeyValueFieldsTags         KeyValueFields = "tags"
+	KeyValueFieldsValue        KeyValueFields = "value"
+)
+
+// PossibleKeyValueFieldsValues returns the possible values for the KeyValueFields const type.
+func PossibleKeyValueFieldsValues() []KeyValueFields {
+	return []KeyValueFields{
+		KeyValueFieldsContentType,
+		KeyValueFieldsEtag,
+		KeyValueFieldsKey,
+		KeyValueFieldsLabel,
+		KeyValueFieldsLastModified,
+		KeyValueFieldsLocked,
+		KeyValueFieldsTags,
+		KeyValueFieldsValue,
+	}
+}
+
 type LabelFields string
 
 const (
@@ -21,29 +66,77 @@ func PossibleLabelFieldsValues() []LabelFields {
 	}
 }
 
-type SettingFields string
+type SnapshotFields string
 
 const (
-	SettingFieldsContentType  SettingFields = "content_type"
-	SettingFieldsEtag         SettingFields = "etag"
-	SettingFieldsKey          SettingFields = "key"
-	SettingFieldsLabel        SettingFields = "label"
-	SettingFieldsLastModified SettingFields = "last_modified"
-	SettingFieldsLocked       SettingFields = "locked"
-	SettingFieldsTags         SettingFields = "tags"
-	SettingFieldsValue        SettingFields = "value"
+	SnapshotFieldsCompositionType SnapshotFields = "composition_type"
+	SnapshotFieldsCreated         SnapshotFields = "created"
+	SnapshotFieldsEtag            SnapshotFields = "etag"
+	SnapshotFieldsExpires         SnapshotFields = "expires"
+	SnapshotFieldsFilters         SnapshotFields = "filters"
+	SnapshotFieldsItemsCount      SnapshotFields = "items_count"
+	SnapshotFieldsName            SnapshotFields = "name"
+	SnapshotFieldsRetentionPeriod SnapshotFields = "retention_period"
+	SnapshotFieldsSize            SnapshotFields = "size"
+	SnapshotFieldsStatus          SnapshotFields = "status"
+	SnapshotFieldsTags            SnapshotFields = "tags"
 )
 
-// PossibleSettingFieldsValues returns the possible values for the SettingFields const type.
-func PossibleSettingFieldsValues() []SettingFields {
-	return []SettingFields{
-		SettingFieldsContentType,
-		SettingFieldsEtag,
-		SettingFieldsKey,
-		SettingFieldsLabel,
-		SettingFieldsLastModified,
-		SettingFieldsLocked,
-		SettingFieldsTags,
-		SettingFieldsValue,
+// PossibleSnapshotFieldsValues returns the possible values for the SnapshotFields const type.
+func PossibleSnapshotFieldsValues() []SnapshotFields {
+	return []SnapshotFields{
+		SnapshotFieldsCompositionType,
+		SnapshotFieldsCreated,
+		SnapshotFieldsEtag,
+		SnapshotFieldsExpires,
+		SnapshotFieldsFilters,
+		SnapshotFieldsItemsCount,
+		SnapshotFieldsName,
+		SnapshotFieldsRetentionPeriod,
+		SnapshotFieldsSize,
+		SnapshotFieldsStatus,
+		SnapshotFieldsTags,
+	}
+}
+
+// SnapshotStatus - The current status of the snapshot.
+type SnapshotStatus string
+
+const (
+	SnapshotStatusArchived     SnapshotStatus = "archived"
+	SnapshotStatusFailed       SnapshotStatus = "failed"
+	SnapshotStatusProvisioning SnapshotStatus = "provisioning"
+	SnapshotStatusReady        SnapshotStatus = "ready"
+)
+
+// PossibleSnapshotStatusValues returns the possible values for the SnapshotStatus const type.
+func PossibleSnapshotStatusValues() []SnapshotStatus {
+	return []SnapshotStatus{
+		SnapshotStatusArchived,
+		SnapshotStatusFailed,
+		SnapshotStatusProvisioning,
+		SnapshotStatusReady,
+	}
+}
+
+// State - The current status of the operation
+type State string
+
+const (
+	StateCanceled   State = "Canceled"
+	StateFailed     State = "Failed"
+	StateNotStarted State = "NotStarted"
+	StateRunning    State = "Running"
+	StateSucceeded  State = "Succeeded"
+)
+
+// PossibleStateValues returns the possible values for the State const type.
+func PossibleStateValues() []State {
+	return []State{
+		StateCanceled,
+		StateFailed,
+		StateNotStarted,
+		StateRunning,
+		StateSucceeded,
 	}
 }

--- a/sdk/data/azappconfig/internal/generated/zz_models.go
+++ b/sdk/data/azappconfig/internal/generated/zz_models.go
@@ -10,6 +10,13 @@ package generated
 
 import "time"
 
+// AzureAppConfigurationClientBeginCreateSnapshotOptions contains the optional parameters for the AzureAppConfigurationClient.BeginCreateSnapshot
+// method.
+type AzureAppConfigurationClientBeginCreateSnapshotOptions struct {
+	// Resumes the LRO from the provided token.
+	ResumeToken string
+}
+
 // AzureAppConfigurationClientCheckKeyValueOptions contains the optional parameters for the AzureAppConfigurationClient.CheckKeyValue
 // method.
 type AzureAppConfigurationClientCheckKeyValueOptions struct {
@@ -22,7 +29,7 @@ type AzureAppConfigurationClientCheckKeyValueOptions struct {
 	// The label of the key-value to retrieve.
 	Label *string
 	// Used to select what fields are present in the returned resource(s).
-	Select []SettingFields
+	Select []KeyValueFields
 }
 
 // AzureAppConfigurationClientCheckKeyValuesOptions contains the optional parameters for the AzureAppConfigurationClient.CheckKeyValues
@@ -32,12 +39,18 @@ type AzureAppConfigurationClientCheckKeyValuesOptions struct {
 	AcceptDatetime *string
 	// Instructs the server to return elements that appear after the element referred to by the specified token.
 	After *string
+	// Used to perform an operation only if the targeted resource's etag matches the value provided.
+	IfMatch *string
+	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
+	IfNoneMatch *string
 	// A filter used to match keys.
 	Key *string
 	// A filter used to match labels
 	Label *string
 	// Used to select what fields are present in the returned resource(s).
-	Select []SettingFields
+	Select []KeyValueFields
+	// A filter used get key-values for a snapshot. Not valid when used with 'key' and 'label' filters.
+	Snapshot *string
 }
 
 // AzureAppConfigurationClientCheckKeysOptions contains the optional parameters for the AzureAppConfigurationClient.CheckKeys
@@ -76,7 +89,23 @@ type AzureAppConfigurationClientCheckRevisionsOptions struct {
 	// A filter used to match labels
 	Label *string
 	// Used to select what fields are present in the returned resource(s).
-	Select []SettingFields
+	Select []KeyValueFields
+}
+
+// AzureAppConfigurationClientCheckSnapshotOptions contains the optional parameters for the AzureAppConfigurationClient.CheckSnapshot
+// method.
+type AzureAppConfigurationClientCheckSnapshotOptions struct {
+	// Used to perform an operation only if the targeted resource's etag matches the value provided.
+	IfMatch *string
+	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
+	IfNoneMatch *string
+}
+
+// AzureAppConfigurationClientCheckSnapshotsOptions contains the optional parameters for the AzureAppConfigurationClient.CheckSnapshots
+// method.
+type AzureAppConfigurationClientCheckSnapshotsOptions struct {
+	// Instructs the server to return elements that appear after the element referred to by the specified token.
+	After *string
 }
 
 // AzureAppConfigurationClientDeleteKeyValueOptions contains the optional parameters for the AzureAppConfigurationClient.DeleteKeyValue
@@ -111,7 +140,7 @@ type AzureAppConfigurationClientGetKeyValueOptions struct {
 	// The label of the key-value to retrieve.
 	Label *string
 	// Used to select what fields are present in the returned resource(s).
-	Select []SettingFields
+	Select []KeyValueFields
 }
 
 // AzureAppConfigurationClientGetKeyValuesOptions contains the optional parameters for the AzureAppConfigurationClient.NewGetKeyValuesPager
@@ -121,12 +150,19 @@ type AzureAppConfigurationClientGetKeyValuesOptions struct {
 	AcceptDatetime *string
 	// Instructs the server to return elements that appear after the element referred to by the specified token.
 	After *string
+	// Used to perform an operation only if the targeted resource's etag matches the value provided.
+	IfMatch *string
+	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
+	IfNoneMatch *string
 	// A filter used to match keys.
 	Key *string
 	// A filter used to match labels
 	Label *string
 	// Used to select what fields are present in the returned resource(s).
-	Select []SettingFields
+	Select []KeyValueFields
+	// A filter used get key-values for a snapshot. The value should be the name of the snapshot. Not valid when used with 'key'
+	// and 'label' filters.
+	Snapshot *string
 }
 
 // AzureAppConfigurationClientGetKeysOptions contains the optional parameters for the AzureAppConfigurationClient.NewGetKeysPager
@@ -153,6 +189,12 @@ type AzureAppConfigurationClientGetLabelsOptions struct {
 	Select []LabelFields
 }
 
+// AzureAppConfigurationClientGetOperationDetailsOptions contains the optional parameters for the AzureAppConfigurationClient.GetOperationDetails
+// method.
+type AzureAppConfigurationClientGetOperationDetailsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // AzureAppConfigurationClientGetRevisionsOptions contains the optional parameters for the AzureAppConfigurationClient.NewGetRevisionsPager
 // method.
 type AzureAppConfigurationClientGetRevisionsOptions struct {
@@ -165,7 +207,31 @@ type AzureAppConfigurationClientGetRevisionsOptions struct {
 	// A filter used to match labels
 	Label *string
 	// Used to select what fields are present in the returned resource(s).
-	Select []SettingFields
+	Select []KeyValueFields
+}
+
+// AzureAppConfigurationClientGetSnapshotOptions contains the optional parameters for the AzureAppConfigurationClient.GetSnapshot
+// method.
+type AzureAppConfigurationClientGetSnapshotOptions struct {
+	// Used to perform an operation only if the targeted resource's etag matches the value provided.
+	IfMatch *string
+	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
+	IfNoneMatch *string
+	// Used to select what fields are present in the returned resource(s).
+	Select []SnapshotFields
+}
+
+// AzureAppConfigurationClientGetSnapshotsOptions contains the optional parameters for the AzureAppConfigurationClient.NewGetSnapshotsPager
+// method.
+type AzureAppConfigurationClientGetSnapshotsOptions struct {
+	// Instructs the server to return elements that appear after the element referred to by the specified token.
+	After *string
+	// A filter for the name of the returned snapshots.
+	Name *string
+	// Used to select what fields are present in the returned resource(s).
+	Select []SnapshotFields
+	// Used to filter returned snapshots by their status property.
+	Status []SnapshotStatus
 }
 
 // AzureAppConfigurationClientPutKeyValueOptions contains the optional parameters for the AzureAppConfigurationClient.PutKeyValue
@@ -190,6 +256,15 @@ type AzureAppConfigurationClientPutLockOptions struct {
 	Label *string
 }
 
+// AzureAppConfigurationClientUpdateSnapshotOptions contains the optional parameters for the AzureAppConfigurationClient.UpdateSnapshot
+// method.
+type AzureAppConfigurationClientUpdateSnapshotOptions struct {
+	// Used to perform an operation only if the targeted resource's etag matches the value provided.
+	IfMatch *string
+	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
+	IfNoneMatch *string
+}
+
 // Error - Azure App Configuration error object.
 type Error struct {
 	// A detailed description of the error.
@@ -208,8 +283,32 @@ type Error struct {
 	Type *string
 }
 
+// ErrorDetail - The details of an error.
+type ErrorDetail struct {
+	// REQUIRED; One of a server-defined set of error codes.
+	Code *string
+
+	// REQUIRED; A human-readable representation of the error.
+	Message *string
+
+	// An array of details about specific errors that led to this reported error.
+	Details []*ErrorDetail
+
+	// An object containing more specific information than the current object about the error.
+	Innererror *InnerError
+}
+
+// InnerError - An object containing specific information about an error.
+type InnerError struct {
+	// One of a server-defined set of error codes.
+	Code *string
+
+	// An object containing more specific information than the current object about the error.
+	Innererror *InnerError
+}
+
 type Key struct {
-	// READ-ONLY
+	// READ-ONLY; The name of the key.
 	Name *string
 }
 
@@ -223,20 +322,45 @@ type KeyListResult struct {
 }
 
 type KeyValue struct {
-	ContentType  *string
-	Etag         *string
-	Key          *string
-	Label        *string
-	LastModified *time.Time
-	Locked       *bool
+	// The content type of the value stored within the key-value.
+	ContentType *string
 
-	// Dictionary of
-	Tags  map[string]*string
+	// A value representing the current state of the resource.
+	Etag *string
+
+	// The key of the key-value.
+	Key *string
+
+	// The label the key-value belongs to.
+	Label *string
+
+	// A date representing the last time the key-value was modified.
+	LastModified *time.Time
+
+	// Indicates whether the key-value is locked.
+	Locked *bool
+
+	// The tags of the key-value
+	Tags map[string]*string
+
+	// The value of the key-value.
 	Value *string
+}
+
+// KeyValueFilter - Enables filtering of key-values.
+type KeyValueFilter struct {
+	// REQUIRED; Filters key-values by their key field.
+	Key *string
+
+	// Filters key-values by their label field.
+	Label *string
 }
 
 // KeyValueListResult - The result of a list request.
 type KeyValueListResult struct {
+	// An identifier representing the returned state of the resource.
+	Etag *string
+
 	// The collection value.
 	Items []*KeyValue
 
@@ -245,7 +369,7 @@ type KeyValueListResult struct {
 }
 
 type Label struct {
-	// READ-ONLY
+	// READ-ONLY; The name of the label.
 	Name *string
 }
 
@@ -256,4 +380,70 @@ type LabelListResult struct {
 
 	// The URI that can be used to request the next set of paged results.
 	NextLink *string
+}
+
+// OperationDetails - Details of a long running operation.
+type OperationDetails struct {
+	// REQUIRED; The unique id of the operation.
+	ID *string
+
+	// REQUIRED; The current status of the operation
+	Status *State
+
+	// An error, available when the status is Failed, describing why the operation failed.
+	Error *ErrorDetail
+}
+
+type Snapshot struct {
+	// REQUIRED; A list of filters used to filter the key-values included in the snapshot.
+	Filters []*KeyValueFilter
+
+	// The composition type describes how the key-values within the snapshot are composed. The 'key' composition type ensures
+	// there are no two key-values containing the same key. The 'key_label' composition
+	// type ensures there are no two key-values containing the same key and label.
+	CompositionType *CompositionType
+
+	// The amount of time, in seconds, that a snapshot will remain in the archived state before expiring. This property is only
+	// writable during the creation of a snapshot. If not specified, the default
+	// lifetime of key-value revisions will be used.
+	RetentionPeriod *int64
+
+	// The tags of the snapshot.
+	Tags map[string]*string
+
+	// READ-ONLY; The time that the snapshot was created.
+	Created *time.Time
+
+	// READ-ONLY; A value representing the current state of the snapshot.
+	Etag *string
+
+	// READ-ONLY; The time that the snapshot will expire.
+	Expires *time.Time
+
+	// READ-ONLY; The amount of key-values in the snapshot.
+	ItemsCount *int64
+
+	// READ-ONLY; The name of the snapshot.
+	Name *string
+
+	// READ-ONLY; The size in bytes of the snapshot.
+	Size *int64
+
+	// READ-ONLY; The current status of the snapshot.
+	Status *SnapshotStatus
+}
+
+// SnapshotListResult - The result of a snapshot list request.
+type SnapshotListResult struct {
+	// The collection value.
+	Items []*Snapshot
+
+	// The URI that can be used to request the next set of paged results.
+	NextLink *string
+}
+
+// SnapshotUpdateParameters - Parameters used to update a snapshot.
+type SnapshotUpdateParameters struct {
+	// The desired status of the snapshot.
+	Status *SnapshotStatus
 }

--- a/sdk/data/azappconfig/internal/generated/zz_models_serde.go
+++ b/sdk/data/azappconfig/internal/generated/zz_models_serde.go
@@ -58,6 +58,76 @@ func (e *Error) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ErrorDetail.
+func (e ErrorDetail) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "code", e.Code)
+	populate(objectMap, "details", e.Details)
+	populate(objectMap, "innererror", e.Innererror)
+	populate(objectMap, "message", e.Message)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ErrorDetail.
+func (e *ErrorDetail) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", e, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "code":
+			err = unpopulate(val, "Code", &e.Code)
+			delete(rawMsg, key)
+		case "details":
+			err = unpopulate(val, "Details", &e.Details)
+			delete(rawMsg, key)
+		case "innererror":
+			err = unpopulate(val, "Innererror", &e.Innererror)
+			delete(rawMsg, key)
+		case "message":
+			err = unpopulate(val, "Message", &e.Message)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", e, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InnerError.
+func (i InnerError) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "code", i.Code)
+	populate(objectMap, "innererror", i.Innererror)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type InnerError.
+func (i *InnerError) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", i, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "code":
+			err = unpopulate(val, "Code", &i.Code)
+			delete(rawMsg, key)
+		case "innererror":
+			err = unpopulate(val, "Innererror", &i.Innererror)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", i, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type Key.
 func (k Key) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -171,9 +241,41 @@ func (k *KeyValue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type KeyValueFilter.
+func (k KeyValueFilter) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "key", k.Key)
+	populate(objectMap, "label", k.Label)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeyValueFilter.
+func (k *KeyValueFilter) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", k, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "key":
+			err = unpopulate(val, "Key", &k.Key)
+			delete(rawMsg, key)
+		case "label":
+			err = unpopulate(val, "Label", &k.Label)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", k, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type KeyValueListResult.
 func (k KeyValueListResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "etag", k.Etag)
 	populate(objectMap, "items", k.Items)
 	populate(objectMap, "@nextLink", k.NextLink)
 	return json.Marshal(objectMap)
@@ -188,6 +290,9 @@ func (k *KeyValueListResult) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "etag":
+			err = unpopulate(val, "Etag", &k.Etag)
+			delete(rawMsg, key)
 		case "items":
 			err = unpopulate(val, "Items", &k.Items)
 			delete(rawMsg, key)
@@ -255,6 +360,166 @@ func (l *LabelListResult) UnmarshalJSON(data []byte) error {
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", l, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type OperationDetails.
+func (o OperationDetails) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "error", o.Error)
+	populate(objectMap, "id", o.ID)
+	populate(objectMap, "status", o.Status)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type OperationDetails.
+func (o *OperationDetails) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", o, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "error":
+			err = unpopulate(val, "Error", &o.Error)
+			delete(rawMsg, key)
+		case "id":
+			err = unpopulate(val, "ID", &o.ID)
+			delete(rawMsg, key)
+		case "status":
+			err = unpopulate(val, "Status", &o.Status)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", o, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Snapshot.
+func (s Snapshot) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "composition_type", s.CompositionType)
+	populateTimeRFC3339(objectMap, "created", s.Created)
+	populate(objectMap, "etag", s.Etag)
+	populateTimeRFC3339(objectMap, "expires", s.Expires)
+	populate(objectMap, "filters", s.Filters)
+	populate(objectMap, "items_count", s.ItemsCount)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "retention_period", s.RetentionPeriod)
+	populate(objectMap, "size", s.Size)
+	populate(objectMap, "status", s.Status)
+	populate(objectMap, "tags", s.Tags)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type Snapshot.
+func (s *Snapshot) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", s, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "composition_type":
+			err = unpopulate(val, "CompositionType", &s.CompositionType)
+			delete(rawMsg, key)
+		case "created":
+			err = unpopulateTimeRFC3339(val, "Created", &s.Created)
+			delete(rawMsg, key)
+		case "etag":
+			err = unpopulate(val, "Etag", &s.Etag)
+			delete(rawMsg, key)
+		case "expires":
+			err = unpopulateTimeRFC3339(val, "Expires", &s.Expires)
+			delete(rawMsg, key)
+		case "filters":
+			err = unpopulate(val, "Filters", &s.Filters)
+			delete(rawMsg, key)
+		case "items_count":
+			err = unpopulate(val, "ItemsCount", &s.ItemsCount)
+			delete(rawMsg, key)
+		case "name":
+			err = unpopulate(val, "Name", &s.Name)
+			delete(rawMsg, key)
+		case "retention_period":
+			err = unpopulate(val, "RetentionPeriod", &s.RetentionPeriod)
+			delete(rawMsg, key)
+		case "size":
+			err = unpopulate(val, "Size", &s.Size)
+			delete(rawMsg, key)
+		case "status":
+			err = unpopulate(val, "Status", &s.Status)
+			delete(rawMsg, key)
+		case "tags":
+			err = unpopulate(val, "Tags", &s.Tags)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", s, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SnapshotListResult.
+func (s SnapshotListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "items", s.Items)
+	populate(objectMap, "@nextLink", s.NextLink)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type SnapshotListResult.
+func (s *SnapshotListResult) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", s, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "items":
+			err = unpopulate(val, "Items", &s.Items)
+			delete(rawMsg, key)
+		case "@nextLink":
+			err = unpopulate(val, "NextLink", &s.NextLink)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", s, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SnapshotUpdateParameters.
+func (s SnapshotUpdateParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "status", s.Status)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type SnapshotUpdateParameters.
+func (s *SnapshotUpdateParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", s, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "status":
+			err = unpopulate(val, "Status", &s.Status)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", s, err)
 		}
 	}
 	return nil

--- a/sdk/data/azappconfig/internal/generated/zz_response_types.go
+++ b/sdk/data/azappconfig/internal/generated/zz_response_types.go
@@ -13,15 +13,15 @@ type AzureAppConfigurationClientCheckKeyValueResponse struct {
 	// ETag contains the information returned from the ETag header response.
 	ETag *string
 
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *string
-
 	// SyncToken contains the information returned from the Sync-Token header response.
 	SyncToken *string
 }
 
 // AzureAppConfigurationClientCheckKeyValuesResponse contains the response from method AzureAppConfigurationClient.CheckKeyValues.
 type AzureAppConfigurationClientCheckKeyValuesResponse struct {
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
 	// SyncToken contains the information returned from the Sync-Token header response.
 	SyncToken *string
 }
@@ -40,8 +40,34 @@ type AzureAppConfigurationClientCheckLabelsResponse struct {
 
 // AzureAppConfigurationClientCheckRevisionsResponse contains the response from method AzureAppConfigurationClient.CheckRevisions.
 type AzureAppConfigurationClientCheckRevisionsResponse struct {
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
 	// SyncToken contains the information returned from the Sync-Token header response.
 	SyncToken *string
+}
+
+// AzureAppConfigurationClientCheckSnapshotResponse contains the response from method AzureAppConfigurationClient.CheckSnapshot.
+type AzureAppConfigurationClientCheckSnapshotResponse struct {
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// Link contains the information returned from the Link header response.
+	Link *string
+
+	// SyncToken contains the information returned from the Sync-Token header response.
+	SyncToken *string
+}
+
+// AzureAppConfigurationClientCheckSnapshotsResponse contains the response from method AzureAppConfigurationClient.CheckSnapshots.
+type AzureAppConfigurationClientCheckSnapshotsResponse struct {
+	// SyncToken contains the information returned from the Sync-Token header response.
+	SyncToken *string
+}
+
+// AzureAppConfigurationClientCreateSnapshotResponse contains the response from method AzureAppConfigurationClient.BeginCreateSnapshot.
+type AzureAppConfigurationClientCreateSnapshotResponse struct {
+	Snapshot
 }
 
 // AzureAppConfigurationClientDeleteKeyValueResponse contains the response from method AzureAppConfigurationClient.DeleteKeyValue.
@@ -70,9 +96,6 @@ type AzureAppConfigurationClientGetKeyValueResponse struct {
 	// ETag contains the information returned from the ETag header response.
 	ETag *string
 
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *string
-
 	// SyncToken contains the information returned from the Sync-Token header response.
 	SyncToken *string
 }
@@ -80,6 +103,9 @@ type AzureAppConfigurationClientGetKeyValueResponse struct {
 // AzureAppConfigurationClientGetKeyValuesResponse contains the response from method AzureAppConfigurationClient.NewGetKeyValuesPager.
 type AzureAppConfigurationClientGetKeyValuesResponse struct {
 	KeyValueListResult
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
 	// SyncToken contains the information returned from the Sync-Token header response.
 	SyncToken *string
 }
@@ -105,9 +131,37 @@ type AzureAppConfigurationClientGetNextPageResponse struct {
 	SyncToken *string
 }
 
+// AzureAppConfigurationClientGetOperationDetailsResponse contains the response from method AzureAppConfigurationClient.GetOperationDetails.
+type AzureAppConfigurationClientGetOperationDetailsResponse struct {
+	OperationDetails
+}
+
 // AzureAppConfigurationClientGetRevisionsResponse contains the response from method AzureAppConfigurationClient.NewGetRevisionsPager.
 type AzureAppConfigurationClientGetRevisionsResponse struct {
 	KeyValueListResult
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// SyncToken contains the information returned from the Sync-Token header response.
+	SyncToken *string
+}
+
+// AzureAppConfigurationClientGetSnapshotResponse contains the response from method AzureAppConfigurationClient.GetSnapshot.
+type AzureAppConfigurationClientGetSnapshotResponse struct {
+	Snapshot
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// Link contains the information returned from the Link header response.
+	Link *string
+
+	// SyncToken contains the information returned from the Sync-Token header response.
+	SyncToken *string
+}
+
+// AzureAppConfigurationClientGetSnapshotsResponse contains the response from method AzureAppConfigurationClient.NewGetSnapshotsPager.
+type AzureAppConfigurationClientGetSnapshotsResponse struct {
+	SnapshotListResult
 	// SyncToken contains the information returned from the Sync-Token header response.
 	SyncToken *string
 }
@@ -127,6 +181,19 @@ type AzureAppConfigurationClientPutLockResponse struct {
 	KeyValue
 	// ETag contains the information returned from the ETag header response.
 	ETag *string
+
+	// SyncToken contains the information returned from the Sync-Token header response.
+	SyncToken *string
+}
+
+// AzureAppConfigurationClientUpdateSnapshotResponse contains the response from method AzureAppConfigurationClient.UpdateSnapshot.
+type AzureAppConfigurationClientUpdateSnapshotResponse struct {
+	Snapshot
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// Link contains the information returned from the Link header response.
+	Link *string
 
 	// SyncToken contains the information returned from the Sync-Token header response.
 	SyncToken *string

--- a/sdk/data/azappconfig/setting_selector.go
+++ b/sdk/data/azappconfig/setting_selector.go
@@ -26,20 +26,20 @@ type SettingSelector struct {
 	AcceptDateTime *time.Time
 
 	// The fields of the configuration setting to retrieve for each setting in the retrieved group.
-	Fields []SettingFields
+	Fields []KeyValueFields
 }
 
 // AllSettingFields returns a collection of all setting fields to use in SettingSelector.
-func AllSettingFields() []SettingFields {
-	return []SettingFields{
-		SettingFieldsKey,
-		SettingFieldsLabel,
-		SettingFieldsValue,
-		SettingFieldsContentType,
-		SettingFieldsETag,
-		SettingFieldsLastModified,
-		SettingFieldsIsReadOnly,
-		SettingFieldsTags,
+func AllSettingFields() []KeyValueFields {
+	return []KeyValueFields{
+		KeyValueFieldsKey,
+		KeyValueFieldsLabel,
+		KeyValueFieldsValue,
+		KeyValueFieldsContentType,
+		KeyValueFieldsETag,
+		KeyValueFieldsLastModified,
+		KeyValueFieldsIsReadOnly,
+		KeyValueFieldsTags,
 	}
 }
 
@@ -50,9 +50,9 @@ func (sc SettingSelector) toGeneratedGetRevisions() *generated.AzureAppConfigura
 		dt = &str
 	}
 
-	sf := make([]SettingFields, len(sc.Fields))
+	sf := make([]KeyValueFields, len(sc.Fields))
 	for i := range sc.Fields {
-		sf[i] = SettingFields(sc.Fields[i])
+		sf[i] = KeyValueFields(sc.Fields[i])
 	}
 
 	return &generated.AzureAppConfigurationClientGetRevisionsOptions{
@@ -70,9 +70,9 @@ func (sc SettingSelector) toGeneratedGetKeyValues() *generated.AzureAppConfigura
 		dt = &str
 	}
 
-	sf := make([]SettingFields, len(sc.Fields))
+	sf := make([]KeyValueFields, len(sc.Fields))
 	for i := range sc.Fields {
-		sf[i] = SettingFields(sc.Fields[i])
+		sf[i] = KeyValueFields(sc.Fields[i])
 	}
 
 	return &generated.AzureAppConfigurationClientGetKeyValuesOptions{

--- a/sdk/data/azappconfig/setting_selector.go
+++ b/sdk/data/azappconfig/setting_selector.go
@@ -29,8 +29,8 @@ type SettingSelector struct {
 	Fields []KeyValueFields
 }
 
-// AllSettingFields returns a collection of all setting fields to use in SettingSelector.
-func AllSettingFields() []KeyValueFields {
+// AllKeyValueFields returns a collection of all setting fields to use in SettingSelector.
+func AllKeyValueFields() []KeyValueFields {
 	return []KeyValueFields{
 		KeyValueFieldsKey,
 		KeyValueFieldsLabel,


### PR DESCRIPTION
- add generated code for snapshots (public facing methods will be added once this is released and we can target live resources)
- Renamed SettingFields => KeyValueFields to properly reflect the data which is stored

