### PR TITLE
Fix keyvault test recording options. Update docs

### DIFF
--- a/documentation/developer_setup.md
+++ b/documentation/developer_setup.md
@@ -275,19 +275,19 @@ func TestMain(m *testing.M) {
 func run(m *testing.M) int {
 	// Initialize
 	if recording.GetRecordMode() == recording.PlaybackMode || recording.GetRecordMode() == recording.RecordingMode {
-        proxy, err := recording.StartTestProxy(recordingDirectory, nil)
-        if err != nil {
-            panic(err)
-        }
+		proxy, err := recording.StartTestProxy(recordingDirectory, nil)
+		if err != nil {
+			panic(err)
+		}
 
-        // NOTE: defer should not be used directly within TestMain as it will not be executed due to os.Exit()
+		// NOTE: defer should not be used directly within TestMain as it will not be executed due to os.Exit()
 		defer func() {
 			err := recording.StopTestProxy(proxy)
 			if err != nil {
 				panic(err)
 			}
 		}()
-    }
+	}
 
     // Set sanitizers in record mode
 	if recording.GetRecordMode() == "record" {

--- a/sdk/security/keyvault/azcertificates/utils_test.go
+++ b/sdk/security/keyvault/azcertificates/utils_test.go
@@ -43,8 +43,10 @@ func TestMain(m *testing.M) {
 }
 
 func run(m *testing.M) int {
+	var proxy *recording.TestProxyInstance
 	if recording.GetRecordMode() == recording.PlaybackMode || recording.GetRecordMode() == recording.RecordingMode {
-		proxy, err := recording.StartTestProxy(recordingDirectory, nil)
+		var err error
+		proxy, err = recording.StartTestProxy(recordingDirectory, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -81,7 +83,9 @@ func run(m *testing.M) int {
 		if err != nil {
 			panic(err)
 		}
-		err = recording.AddHeaderRegexSanitizer("WWW-Authenticate", "https://local", `resource="(.*)"`, &recording.RecordingOptions{GroupForReplace: "1"})
+		opts := proxy.Options
+		opts.GroupForReplace = "1"
+		err = recording.AddHeaderRegexSanitizer("WWW-Authenticate", "https://local", `resource="(.*)"`, opts)
 		if err != nil {
 			panic(err)
 		}

--- a/sdk/security/keyvault/azkeys/utils_test.go
+++ b/sdk/security/keyvault/azkeys/utils_test.go
@@ -53,8 +53,10 @@ func TestMain(m *testing.M) {
 }
 
 func run(m *testing.M) int {
+	var proxy *recording.TestProxyInstance
 	if recording.GetRecordMode() == recording.PlaybackMode || recording.GetRecordMode() == recording.RecordingMode {
-		proxy, err := recording.StartTestProxy(recordingDirectory, nil)
+		var err error
+		proxy, err = recording.StartTestProxy(recordingDirectory, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -99,7 +101,9 @@ func run(m *testing.M) int {
 			if err != nil {
 				panic(err)
 			}
-			err = recording.AddHeaderRegexSanitizer("WWW-Authenticate", "https://local", `resource="(.*)"`, &recording.RecordingOptions{GroupForReplace: "1"})
+			opts := proxy.Options
+			opts.GroupForReplace = "1"
+			err = recording.AddHeaderRegexSanitizer("WWW-Authenticate", "https://local", `resource="(.*)"`, opts)
 			if err != nil {
 				panic(err)
 			}

--- a/sdk/security/keyvault/azsecrets/utils_test.go
+++ b/sdk/security/keyvault/azsecrets/utils_test.go
@@ -46,8 +46,10 @@ func TestMain(m *testing.M) {
 }
 
 func run(m *testing.M) int {
+	var proxy *recording.TestProxyInstance
 	if recording.GetRecordMode() == recording.PlaybackMode || recording.GetRecordMode() == recording.RecordingMode {
-		proxy, err := recording.StartTestProxy(recordingDirectory, nil)
+		var err error
+		proxy, err = recording.StartTestProxy(recordingDirectory, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -85,7 +87,9 @@ func run(m *testing.M) int {
 		if err != nil {
 			panic(err)
 		}
-		err = recording.AddHeaderRegexSanitizer("WWW-Authenticate", "https://local", `resource="(.*)"`, &recording.RecordingOptions{GroupForReplace: "1"})
+		opts := proxy.Options
+		opts.GroupForReplace = "1"
+		err = recording.AddHeaderRegexSanitizer("WWW-Authenticate", "https://local", `resource="(.*)"`, opts)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
- Fix keyvault tests using recording options with correct process port - we were using the default options which don't include the newly assigned proxy port
- Fix tabs in developer setup docs
