### PR TITLE
Enable spans for aztables

### DIFF
--- a/sdk/data/aztables/CHANGELOG.md
+++ b/sdk/data/aztables/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Other Changes
 * Updated to latest version of `azcore`.
 * Clients now share the underlying `*azcore.Client`.
+* Enabled spans for distributed tracing.
 
 ## 1.0.2 (2023-07-20)
 

--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -125,6 +125,10 @@ func createTableResponseFromGen(g *generated.TableClientCreateResponse) CreateTa
 // NOTE: creating a table with the same name as a table that's in the process of being deleted will return an *azcore.ResponseError
 // with error code TableBeingDeleted and status code http.StatusConflict.
 func (t *Client) CreateTable(ctx context.Context, options *CreateTableOptions) (CreateTableResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "Client.CreateTable", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &CreateTableOptions{}
 	}
@@ -140,7 +144,12 @@ func (t *Client) CreateTable(ctx context.Context, options *CreateTableOptions) (
 // NOTE: deleting a table can take up to 40 seconds or more to complete.  If a table with the same name is created while the delete is still
 // in progress, an *azcore.ResponseError is returned with error code TableBeingDeleted and status code http.StatusConflict.
 func (t *Client) Delete(ctx context.Context, options *DeleteTableOptions) (DeleteTableResponse, error) {
-	return t.service.DeleteTable(ctx, t.name, options)
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "Client.Delete", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
+	resp, err := t.service.DeleteTable(ctx, t.name, options)
+	return resp, err
 }
 
 // ListEntitiesOptions contains optional parameters for Table.Query
@@ -255,6 +264,7 @@ func (t *Client) NewListEntitiesPager(listOptions *ListEntitiesOptions) *runtime
 			}
 			return newListEntitiesPage(resp)
 		},
+		Tracer: t.client.Tracer(),
 	})
 }
 
@@ -297,6 +307,10 @@ func newGetEntityResponse(g generated.TableClientQueryEntityWithPartitionAndRowK
 // no entity is available it returns an error. If the service returns a non-successful HTTP status code, the function
 // returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) GetEntity(ctx context.Context, partitionKey string, rowKey string, options *GetEntityOptions) (GetEntityResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "Client.GetEntity", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &GetEntityOptions{}
 	}
@@ -306,7 +320,8 @@ func (t *Client) GetEntity(ctx context.Context, partitionKey string, rowKey stri
 	if err != nil {
 		return GetEntityResponse{}, err
 	}
-	return newGetEntityResponse(resp)
+	entityResp, err := newGetEntityResponse(resp)
+	return entityResp, err
 }
 
 // AddEntityOptions contains optional parameters for Client.AddEntity
@@ -338,8 +353,12 @@ func addEntityResponseFromGenerated(g *generated.TableClientInsertEntityResponse
 // and a RowKey an error will be returned. If the service returns a non-successful HTTP status code, the function returns
 // an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) AddEntity(ctx context.Context, entity []byte, options *AddEntityOptions) (AddEntityResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "Client.AddEntity", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	var mapEntity map[string]interface{}
-	err := json.Unmarshal(entity, &mapEntity)
+	err = json.Unmarshal(entity, &mapEntity)
 	if err != nil {
 		return AddEntityResponse{}, err
 	}
@@ -372,6 +391,10 @@ func deleteEntityResponseFromGenerated(g *generated.TableClientDeleteEntityRespo
 // DeleteEntity deletes the entity with the specified partitionKey and rowKey from the table. If the service returns a non-successful HTTP
 // status code, the function returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) DeleteEntity(ctx context.Context, partitionKey string, rowKey string, options *DeleteEntityOptions) (DeleteEntityResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "Client.DeleteEntity", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &DeleteEntityOptions{}
 	}
@@ -452,6 +475,10 @@ func updateEntityResponseFromUpdateGenerated(g *generated.TableClientUpdateEntit
 // The response type will be TableEntityMergeResponse if updateMode is Merge and TableEntityUpdateResponse if updateMode is Replace.
 // If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *Client) UpdateEntity(ctx context.Context, entity []byte, options *UpdateEntityOptions) (UpdateEntityResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "Client.UpdateEntity", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &UpdateEntityOptions{
 			UpdateMode: UpdateModeMerge,
@@ -464,7 +491,7 @@ func (t *Client) UpdateEntity(ctx context.Context, entity []byte, options *Updat
 	}
 
 	var mapEntity map[string]interface{}
-	err := json.Unmarshal(entity, &mapEntity)
+	err = json.Unmarshal(entity, &mapEntity)
 	if err != nil {
 		return UpdateEntityResponse{}, err
 	}
@@ -477,7 +504,8 @@ func (t *Client) UpdateEntity(ctx context.Context, entity []byte, options *Updat
 
 	switch options.UpdateMode {
 	case UpdateModeMerge:
-		resp, err := t.client.MergeEntity(
+		var resp generated.TableClientMergeEntityResponse
+		resp, err = t.client.MergeEntity(
 			ctx,
 			t.name,
 			prepareKey(partKey),
@@ -490,7 +518,8 @@ func (t *Client) UpdateEntity(ctx context.Context, entity []byte, options *Updat
 		}
 		return updateEntityResponseFromMergeGenerated(&resp), err
 	case UpdateModeReplace:
-		resp, err := t.client.UpdateEntity(
+		var resp generated.TableClientUpdateEntityResponse
+		resp, err = t.client.UpdateEntity(
 			ctx,
 			t.name,
 			prepareKey(partKey),
@@ -504,9 +533,11 @@ func (t *Client) UpdateEntity(ctx context.Context, entity []byte, options *Updat
 		return updateEntityResponseFromUpdateGenerated(&resp), err
 	}
 	if pk == "" || rk == "" {
-		return UpdateEntityResponse{}, errPartitionKeyRowKeyError
+		err = errPartitionKeyRowKeyError
+	} else {
+		err = errInvalidUpdateMode
 	}
-	return UpdateEntityResponse{}, errInvalidUpdateMode
+	return UpdateEntityResponse{}, err
 }
 
 // UpsertEntityOptions contains optional parameters for Client.InsertEntity
@@ -559,13 +590,17 @@ func insertEntityFromGeneratedUpdate(g *generated.TableClientUpdateEntityRespons
 // If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
 // Specify nil for options if you want to use the default options.
 func (t *Client) UpsertEntity(ctx context.Context, entity []byte, options *UpsertEntityOptions) (UpsertEntityResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "Client.UpsertEntity", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &UpsertEntityOptions{
 			UpdateMode: UpdateModeMerge,
 		}
 	}
 	var mapEntity map[string]interface{}
-	err := json.Unmarshal(entity, &mapEntity)
+	err = json.Unmarshal(entity, &mapEntity)
 	if err != nil {
 		return UpsertEntityResponse{}, err
 	}
@@ -578,7 +613,8 @@ func (t *Client) UpsertEntity(ctx context.Context, entity []byte, options *Upser
 
 	switch options.UpdateMode {
 	case UpdateModeMerge:
-		resp, err := t.client.MergeEntity(
+		var resp generated.TableClientMergeEntityResponse
+		resp, err = t.client.MergeEntity(
 			ctx,
 			t.name,
 			prepareKey(partKey),
@@ -591,7 +627,8 @@ func (t *Client) UpsertEntity(ctx context.Context, entity []byte, options *Upser
 		}
 		return insertEntityFromGeneratedMerge(&resp), err
 	case UpdateModeReplace:
-		resp, err := t.client.UpdateEntity(
+		var resp generated.TableClientUpdateEntityResponse
+		resp, err = t.client.UpdateEntity(
 			ctx,
 			t.name,
 			prepareKey(partKey),
@@ -605,9 +642,11 @@ func (t *Client) UpsertEntity(ctx context.Context, entity []byte, options *Upser
 		return insertEntityFromGeneratedUpdate(&resp), err
 	}
 	if pk == "" || rk == "" {
-		return UpsertEntityResponse{}, errPartitionKeyRowKeyError
+		err = errPartitionKeyRowKeyError
+	} else {
+		err = errInvalidUpdateMode
 	}
-	return UpsertEntityResponse{}, errInvalidUpdateMode
+	return UpsertEntityResponse{}, err
 }
 
 // GetAccessPolicyOptions contains optional parameters for Client.GetAccessPolicy
@@ -642,6 +681,10 @@ func getAccessPolicyResponseFromGenerated(g *generated.TableClientGetAccessPolic
 // If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
 // Specify nil for options if you want to use the default options.
 func (t *Client) GetAccessPolicy(ctx context.Context, options *GetAccessPolicyOptions) (GetAccessPolicyResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "Client.GetAccessPolicy", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	resp, err := t.client.GetAccessPolicy(ctx, t.name, options.toGenerated())
 	if err != nil {
 		return GetAccessPolicyResponse{}, err
@@ -677,6 +720,10 @@ func (s *SetAccessPolicyOptions) toGenerated() *generated.TableClientSetAccessPo
 // If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
 // Specify nil for options if you want to use the default options.
 func (t *Client) SetAccessPolicy(ctx context.Context, options *SetAccessPolicyOptions) (SetAccessPolicyResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "Client.SetAccessPolicy", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &SetAccessPolicyOptions{}
 	}

--- a/sdk/data/aztables/internal/table_client.go
+++ b/sdk/data/aztables/internal/table_client.go
@@ -9,6 +9,7 @@ package internal
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 )
 
 func NewTableClient(endpoint string, client *azcore.Client) *TableClient {
@@ -24,4 +25,8 @@ func (t *TableClient) Endpoint() string {
 
 func (t *TableClient) Pipeline() runtime.Pipeline {
 	return t.internal.Pipeline()
+}
+
+func (t *TableClient) Tracer() tracing.Tracer {
+	return t.internal.Tracer()
 }

--- a/sdk/data/aztables/service_client.go
+++ b/sdk/data/aztables/service_client.go
@@ -78,6 +78,7 @@ func newClient(serviceURL string, plOpts runtime.PipelineOptions, options *Clien
 	if isCosmosEndpoint(serviceURL) {
 		plOpts.PerCall = append(plOpts.PerCall, cosmosPatchTransformPolicy{})
 	}
+	plOpts.Tracing.Namespace = "Microsoft.Tables"
 	return azcore.NewClient(generated.ModuleName, generated.Version, plOpts, &options.ClientOptions)
 }
 
@@ -103,6 +104,10 @@ func (c *CreateTableOptions) toGenerated() *generated.TableClientCreateOptions {
 // CreateTable creates a table with the specified name. If the service returns a non-successful HTTP status code,
 // the function returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *ServiceClient) CreateTable(ctx context.Context, name string, options *CreateTableOptions) (CreateTableResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ServiceClient.CreateTable", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &CreateTableOptions{}
 	}
@@ -112,7 +117,7 @@ func (t *ServiceClient) CreateTable(ctx context.Context, name string, options *C
 	}
 	return CreateTableResponse{
 		TableName: resp.TableName,
-	}, nil
+	}, err
 }
 
 // DeleteTableOptions contains optional parameters for Client.Delete and ServiceClient.DeleteTable
@@ -136,6 +141,10 @@ func deleteTableResponseFromGen(g generated.TableClientDeleteResponse) DeleteTab
 // DeleteTable deletes a table by name. If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
 // Specify nil for options if you want to use the default options.
 func (t *ServiceClient) DeleteTable(ctx context.Context, name string, options *DeleteTableOptions) (DeleteTableResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ServiceClient.DeleteTable", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	resp, err := t.client.Delete(ctx, name, options.toGenerated())
 	if err != nil {
 		return DeleteTableResponse{}, err
@@ -252,6 +261,7 @@ func (t *ServiceClient) NewListTablesPager(listOptions *ListTablesOptions) *runt
 			}
 			return fromGeneratedTableQueryResponseEnvelope(resp), nil
 		},
+		Tracer: t.client.Tracer(),
 	})
 }
 
@@ -278,6 +288,10 @@ func (g *GetStatisticsOptions) toGenerated() *generated.ServiceClientGetStatisti
 // GetStatistics retrieves all the statistics for an account with Geo-redundancy established. If the service returns a non-successful
 // HTTP status code, the function returns an *azcore.ResponseError type. Specify nil for options if you want to use the default options.
 func (t *ServiceClient) GetStatistics(ctx context.Context, options *GetStatisticsOptions) (GetStatisticsResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ServiceClient.GetStatistics", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &GetStatisticsOptions{}
 	}
@@ -321,6 +335,10 @@ func getPropertiesResponseFromGenerated(g *generated.ServiceClientGetPropertiesR
 // If the service returns a non-successful HTTP status code, the function returns an *azcore.ResponseError type.
 // Specify nil for options if you want to use the default options.
 func (t *ServiceClient) GetProperties(ctx context.Context, options *GetPropertiesOptions) (GetPropertiesResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ServiceClient.GetProperties", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &GetPropertiesOptions{}
 	}
@@ -361,6 +379,10 @@ func setPropertiesResponseFromGenerated(g *generated.ServiceClientSetPropertiesR
 // status code, the function returns an *azcore.ResponseError type.
 // Specify nil for options if you want to use the default options.
 func (t *ServiceClient) SetProperties(ctx context.Context, properties ServiceProperties, options *SetPropertiesOptions) (SetPropertiesResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ServiceClient.SetProperties", t.client.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if options == nil {
 		options = &SetPropertiesOptions{}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
