### PR TITLE
Add AzureCLICredentialOptions.Subscription

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.0-beta.3 (Unreleased)
 
 ### Features Added
+* Added `AzureCLICredentialOptions.Subscription`
 
 ### Breaking Changes
 

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -116,9 +116,13 @@ func resolveTenant(defaultTenant, specified, credName string, additionalTenants 
 	return "", fmt.Errorf(`%s isn't configured to acquire tokens for tenant %q. To enable acquiring tokens for this tenant add it to the AdditionallyAllowedTenants on the credential options, or add "*" to allow acquiring tokens for any tenant`, credName, specified)
 }
 
+func alphanumeric(r rune) bool {
+	return ('0' <= r && r <= '9') || ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z')
+}
+
 func validTenantID(tenantID string) bool {
 	for _, r := range tenantID {
-		if !(('0' <= r && r <= '9') || ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') || r == '.' || r == '-') {
+		if !(alphanumeric(r) || r == '.' || r == '-') {
 			return false
 		}
 	}

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -26,12 +26,18 @@ import (
 
 const credNameAzureCLI = "AzureCLICredential"
 
+type azTokenProvider func(ctx context.Context, scopes []string, tenant, subscription string) ([]byte, error)
+
 // AzureCLICredentialOptions contains optional parameters for AzureCLICredential.
 type AzureCLICredentialOptions struct {
 	// AdditionallyAllowedTenants specifies tenants for which the credential may acquire tokens, in addition
 	// to TenantID. Add the wildcard value "*" to allow the credential to acquire tokens for any tenant the
 	// logged in account can access.
 	AdditionallyAllowedTenants []string
+
+	// Subscription is the name or ID of a subscription. Set this to acquire tokens for an account other
+	// than the Azure CLI's current account.
+	Subscription string
 
 	// TenantID identifies the tenant the credential should authenticate in.
 	// Defaults to the CLI's default tenant, which is typically the home tenant of the logged in user.
@@ -40,7 +46,7 @@ type AzureCLICredentialOptions struct {
 	// inDefaultChain is true when the credential is part of DefaultAzureCredential
 	inDefaultChain bool
 	// tokenProvider is used by tests to fake invoking az
-	tokenProvider cliTokenProvider
+	tokenProvider azTokenProvider
 }
 
 // init returns an instance of AzureCLICredentialOptions initialized with default values.
@@ -78,9 +84,14 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequ
 	if err != nil {
 		return at, err
 	}
+	for _, r := range c.opts.Subscription {
+		if !(alphanumeric(r) || r == '-' || r == ' ') {
+			return at, fmt.Errorf("%s.GetToken(): invalid subscription %q", credNameAzureCLI, c.opts.Subscription)
+		}
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	b, err := c.opts.tokenProvider(ctx, opts.Scopes, tenant)
+	b, err := c.opts.tokenProvider(ctx, opts.Scopes, tenant, c.opts.Subscription)
 	if err == nil {
 		at, err = c.createAccessToken(b)
 	}
@@ -93,7 +104,7 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequ
 	return at, nil
 }
 
-var defaultAzTokenProvider cliTokenProvider = func(ctx context.Context, scopes []string, tenantID string) ([]byte, error) {
+var defaultAzTokenProvider azTokenProvider = func(ctx context.Context, scopes []string, tenantID, subscription string) ([]byte, error) {
 	if !validScope(scopes[0]) {
 		return nil, fmt.Errorf("%s.GetToken(): invalid scope %q", credNameAzureCLI, scopes[0])
 	}
@@ -108,6 +119,10 @@ var defaultAzTokenProvider cliTokenProvider = func(ctx context.Context, scopes [
 	commandLine := "az account get-access-token -o json --resource " + resource
 	if tenantID != "" {
 		commandLine += " --tenant " + tenantID
+	}
+	if subscription != "" {
+		// subscription needs quotes because it may contain spaces
+		commandLine += ` --subscription "` + subscription + `"`
 	}
 	var cliCmd *exec.Cmd
 	if runtime.GOOS == "windows" {

--- a/sdk/azidentity/azure_cli_credential_test.go
+++ b/sdk/azidentity/azure_cli_credential_test.go
@@ -9,22 +9,23 @@ package azidentity
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
 
 var (
-	mockAzTokenProviderSuccess = func(ctx context.Context, scopes []string, tenant string) ([]byte, error) {
-		return []byte(`{
+	mockAzTokenProviderSuccess = func(ctx context.Context, scopes []string, tenant, subscription string) ([]byte, error) {
+		return []byte(fmt.Sprintf(`{
   "accessToken": "mocktoken",
   "expiresOn": "2001-02-03 04:05:06.000007",
-  "subscription": "mocksub",
-  "tenant": "mocktenant",
+  "subscription": %q,
+  "tenant": %q,
   "tokenType": "Bearer"
 }
-`), nil
+`, subscription, tenant)), nil
 	}
-	mockAzTokenProviderFailure = func(ctx context.Context, scopes []string, tenant string) ([]byte, error) {
+	mockAzTokenProviderFailure = func(context.Context, []string, string, string) ([]byte, error) {
 		return nil, newAuthenticationFailedError(credNameAzureCLI, "mock provider error", nil, nil)
 	}
 )
@@ -49,7 +50,7 @@ func TestAzureCLICredential_Error(t *testing.T) {
 	authNs := 0
 	expected := newCredentialUnavailableError(credNameAzureCLI, "it didn't work")
 	o := AzureCLICredentialOptions{
-		tokenProvider: func(context.Context, []string, string) ([]byte, error) {
+		tokenProvider: func(context.Context, []string, string, string) ([]byte, error) {
 			authNs++
 			return nil, expected
 		},
@@ -103,17 +104,46 @@ func TestAzureCLICredential_GetTokenInvalidToken(t *testing.T) {
 	}
 }
 
+func TestAzureCLICredential_Subscription(t *testing.T) {
+	called := false
+	for _, want := range []string{"", "expected-subscription"} {
+		t.Run(fmt.Sprintf("subscription=%q", want), func(t *testing.T) {
+			options := AzureCLICredentialOptions{
+				Subscription: want,
+				tokenProvider: func(ctx context.Context, scopes []string, tenant, subscription string) ([]byte, error) {
+					called = true
+					if subscription != want {
+						t.Fatalf("wanted subscription %q, got %q", want, subscription)
+					}
+					return mockAzTokenProviderSuccess(ctx, scopes, tenant, subscription)
+				},
+			}
+			cred, err := NewAzureCLICredential(&options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = cred.GetToken(context.Background(), testTRO)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !called {
+				t.Fatal("token provider wasn't called")
+			}
+		})
+	}
+}
+
 func TestAzureCLICredential_TenantID(t *testing.T) {
 	expected := "expected-tenant-id"
 	called := false
 	options := AzureCLICredentialOptions{
 		TenantID: expected,
-		tokenProvider: func(ctx context.Context, scopes []string, tenantID string) ([]byte, error) {
+		tokenProvider: func(ctx context.Context, scopes []string, tenantID, subscription string) ([]byte, error) {
 			called = true
 			if tenantID != expected {
 				t.Fatal("Unexpected tenant ID: " + tenantID)
 			}
-			return mockAzTokenProviderSuccess(ctx, scopes, tenantID)
+			return mockAzTokenProviderSuccess(ctx, scopes, tenantID, subscription)
 		},
 	}
 	cred, err := NewAzureCLICredential(&options)

--- a/sdk/azidentity/azure_developer_cli_credential.go
+++ b/sdk/azidentity/azure_developer_cli_credential.go
@@ -26,6 +26,8 @@ import (
 
 const credNameAzureDeveloperCLI = "AzureDeveloperCLICredential"
 
+type azdTokenProvider func(ctx context.Context, scopes []string, tenant string) ([]byte, error)
+
 // AzureDeveloperCLICredentialOptions contains optional parameters for AzureDeveloperCLICredential.
 type AzureDeveloperCLICredentialOptions struct {
 	// AdditionallyAllowedTenants specifies tenants for which the credential may acquire tokens, in addition
@@ -40,7 +42,7 @@ type AzureDeveloperCLICredentialOptions struct {
 	// inDefaultChain is true when the credential is part of DefaultAzureCredential
 	inDefaultChain bool
 	// tokenProvider is used by tests to fake invoking azd
-	tokenProvider cliTokenProvider
+	tokenProvider azdTokenProvider
 }
 
 // AzureDeveloperCLICredential authenticates as the identity logged in to the [Azure Developer CLI].
@@ -92,7 +94,7 @@ func (c *AzureDeveloperCLICredential) GetToken(ctx context.Context, opts policy.
 	return at, nil
 }
 
-var defaultAzdTokenProvider cliTokenProvider = func(ctx context.Context, scopes []string, tenant string) ([]byte, error) {
+var defaultAzdTokenProvider azdTokenProvider = func(ctx context.Context, scopes []string, tenant string) ([]byte, error) {
 	// set a default timeout for this authentication iff the application hasn't done so already
 	var cancel context.CancelFunc
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {

--- a/sdk/azidentity/developer_credential_util.go
+++ b/sdk/azidentity/developer_credential_util.go
@@ -7,16 +7,12 @@
 package azidentity
 
 import (
-	"context"
 	"errors"
 	"time"
 )
 
 // cliTimeout is the default timeout for authentication attempts via CLI tools
 const cliTimeout = 10 * time.Second
-
-// cliTokenProvider is used by tests to fake invoking CLI authentication tools
-type cliTokenProvider func(ctx context.Context, scopes []string, tenant string) ([]byte, error)
 
 // unavailableIfInChain returns err or, if the credential was invoked by DefaultAzureCredential, a
 // credentialUnavailableError having the same message. This ensures DefaultAzureCredential will try
@@ -34,7 +30,7 @@ func unavailableIfInChain(err error, inDefaultChain bool) error {
 // validScope is for credentials authenticating via external tools. The authority validates scopes for all other credentials.
 func validScope(scope string) bool {
 	for _, r := range scope {
-		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '.' || r == '-' || r == '_' || r == '/' || r == ':') {
+		if !(alphanumeric(r) || r == '.' || r == '-' || r == '_' || r == '/' || r == ':') {
 			return false
 		}
 	}


### PR DESCRIPTION
This enables authenticating an account other than the CLI's configured default.