### PR TITLE
azblob: Added support for getSASURL from specialized clients

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 * Fixed case in Blob Batch API when blob path has / in it. Fixes [#21649](https://github.com/Azure/azure-sdk-for-go/issues/21649).
+* Exposed GetSASURL from specialized clients
+* Fixed SharedKeyMissingError when using client.BlobClient() method
 
 ### Other Changes
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 ### Features Added
 
+* Exposed GetSASURL from specialized clients
+
 ### Breaking Changes
 
 ### Bugs Fixed
 
 * Fixed case in Blob Batch API when blob path has / in it. Fixes [#21649](https://github.com/Azure/azure-sdk-for-go/issues/21649).
-* Exposed GetSASURL from specialized clients
-* Fixed SharedKeyMissingError when using client.BlobClient() method
+* Fixed SharedKeyMissingError when using client.BlobClient().GetSASURL() method
 
 ### Other Changes
 

--- a/sdk/storage/azblob/appendblob/client.go
+++ b/sdk/storage/azblob/appendblob/client.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"io"
 	"os"
 	"time"
@@ -336,6 +337,12 @@ func (ab *Client) GetTags(ctx context.Context, o *blob.GetTagsOptions) (blob.Get
 // Deprecated: CopyFromURL works only with block blob
 func (ab *Client) CopyFromURL(ctx context.Context, copySource string, o *blob.CopyFromURLOptions) (blob.CopyFromURLResponse, error) {
 	return blob.CopyFromURLResponse{}, errors.New("operation will not work on this blob type. CopyFromURL works only with block blob")
+}
+
+// GetSASURL is a convenience method for generating a SAS token for the currently pointed at append blob.
+// It can only be used if the credential supplied during creation was a SharedKeyCredential.
+func (ab *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o *blob.GetSASURLOptions) (string, error) {
+	return ab.BlobClient().GetSASURL(permissions, expiry, o)
 }
 
 // Concurrent Download Functions -----------------------------------------------------------------------------------------

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -976,9 +976,10 @@ func (s *AppendBlobUnrecordedTestsSuite) TestGetSASURLAppendBlobClient() {
 	_require.NoError(err)
 
 	// Get new blob client with sasUrl and attempt GetProperties
-	client, err := blob.NewClientWithNoCredential(sasUrl, nil)
+	newClient, err := blob.NewClientWithNoCredential(sasUrl, nil)
+	_require.NoError(err)
 
-	_, err = client.GetProperties(context.Background(), nil)
+	_, err = newClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
 }
 

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -12,10 +12,12 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"hash/crc64"
 	"io"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -937,6 +939,47 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendBlockFromURLCopySourceAuthNegat
 	_, err = destABClient.AppendBlockFromURL(context.Background(), srcABClient.URL(), &options)
 	_require.Error(err)
 	_require.True(bloberror.HasCode(err, bloberror.CannotVerifyCopySource))
+}
+
+func (s *AppendBlobUnrecordedTestsSuite) TestGetSASURLAppendBlobClient() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	accountName := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME")
+	accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
+	cred, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	_require.NoError(err)
+
+	// Creating service client with credentials
+	serviceClient, err := service.NewClientWithSharedKeyCredential(fmt.Sprintf("https://%s.blob.core.windows.net/", accountName), cred, nil)
+	_require.NoError(err)
+
+	// Creating container client
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, serviceClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Creating append blob client with credentials
+	blockBlobName := testcommon.GenerateBlobName(testName)
+	apClient := testcommon.CreateNewAppendBlob(context.Background(), _require, blockBlobName, containerClient)
+
+	// Adding SAS and options
+	permissions := sas.BlobPermissions{
+		Read:   true,
+		Add:    true,
+		Write:  true,
+		Create: true,
+		Delete: true,
+	}
+	expiry := time.Now().Add(5 * time.Minute)
+
+	sasUrl, err := apClient.GetSASURL(permissions, expiry, nil)
+	_require.NoError(err)
+
+	// Get new blob client with sasUrl and attempt GetProperties
+	client, err := blob.NewClientWithNoCredential(sasUrl, nil)
+
+	_, err = client.GetProperties(context.Background(), nil)
+	_require.NoError(err)
 }
 
 func (s *AppendBlobRecordedTestsSuite) TestBlobCreateAppendMetadataNonEmpty() {

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3655,41 +3655,6 @@ func (s *BlobUnrecordedTestsSuite) TestSASURLBlobClient() {
 	_require.NoError(err)
 }
 
-//func (s *BlobUnrecordedTestsSuite) TestNoSharedKeyCredError() {
-//	_require := require.New(s.T())
-//	testName := s.T().Name()
-//
-//	// Creating service client
-//	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
-//	_require.NoError(err)
-//
-//	// Creating container client
-//	containerName := testcommon.GenerateContainerName(testName)
-//	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
-//	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
-//
-//	// Creating blob client without credentials
-//	blockBlobName := testcommon.GenerateBlobName(testName)
-//	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
-//
-//	// Adding SAS and options
-//	permissions := sas.BlobPermissions{
-//		Read:   true,
-//		Add:    true,
-//		Write:  true,
-//		Create: true,
-//		Delete: true,
-//	}
-//	start := time.Now().Add(-time.Hour)
-//	expiry := start.Add(time.Hour)
-//	opts := blob.GetSASURLOptions{StartTime: &start}
-//
-//	// GetSASURL fails with MissingSharedKeyCredential because blob client is created with credentials
-//	_, err = bbClient.BlobClient().GetSASURL(permissions, expiry, &opts)
-//	_require.NoError(err)
-//	_require.Equal(err, bloberror.MissingSharedKeyCredential)
-//}
-
 func (s *BlobRecordedTestsSuite) TestBlobGetAccountInfo() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3655,39 +3655,40 @@ func (s *BlobUnrecordedTestsSuite) TestSASURLBlobClient() {
 	_require.NoError(err)
 }
 
-func (s *BlobUnrecordedTestsSuite) TestNoSharedKeyCredError() {
-	_require := require.New(s.T())
-	testName := s.T().Name()
-
-	// Creating service client
-	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
-	_require.NoError(err)
-
-	// Creating container client
-	containerName := testcommon.GenerateContainerName(testName)
-	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
-	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
-
-	// Creating blob client without credentials
-	blockBlobName := testcommon.GenerateBlobName(testName)
-	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
-
-	// Adding SAS and options
-	permissions := sas.BlobPermissions{
-		Read:   true,
-		Add:    true,
-		Write:  true,
-		Create: true,
-		Delete: true,
-	}
-	start := time.Now().Add(-time.Hour)
-	expiry := start.Add(time.Hour)
-	opts := blob.GetSASURLOptions{StartTime: &start}
-
-	// GetSASURL fails (with MissingSharedKeyCredential) because blob client is created without credentials
-	_, err = bbClient.BlobClient().GetSASURL(permissions, expiry, &opts)
-	_require.Equal(err, bloberror.MissingSharedKeyCredential)
-}
+//func (s *BlobUnrecordedTestsSuite) TestNoSharedKeyCredError() {
+//	_require := require.New(s.T())
+//	testName := s.T().Name()
+//
+//	// Creating service client
+//	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+//	_require.NoError(err)
+//
+//	// Creating container client
+//	containerName := testcommon.GenerateContainerName(testName)
+//	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+//	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+//
+//	// Creating blob client without credentials
+//	blockBlobName := testcommon.GenerateBlobName(testName)
+//	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
+//
+//	// Adding SAS and options
+//	permissions := sas.BlobPermissions{
+//		Read:   true,
+//		Add:    true,
+//		Write:  true,
+//		Create: true,
+//		Delete: true,
+//	}
+//	start := time.Now().Add(-time.Hour)
+//	expiry := start.Add(time.Hour)
+//	opts := blob.GetSASURLOptions{StartTime: &start}
+//
+//	// GetSASURL fails with MissingSharedKeyCredential because blob client is created with credentials
+//	_, err = bbClient.BlobClient().GetSASURL(permissions, expiry, &opts)
+//	_require.NoError(err)
+//	_require.Equal(err, bloberror.MissingSharedKeyCredential)
+//}
 
 func (s *BlobRecordedTestsSuite) TestBlobGetAccountInfo() {
 	_require := require.New(s.T())

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"io"
 	"math"
 	"os"
@@ -129,7 +130,7 @@ func (bb *Client) URL() string {
 	return bb.generated().Endpoint()
 }
 
-// BlobClient returns the embedded blob client for this AppendBlob client.
+// BlobClient returns the embedded blob client for this BlockBlob client.
 func (bb *Client) BlobClient() *blob.Client {
 	blobClient, _ := base.InnerClients((*base.CompositeClient[generated.BlobClient, generated.BlockBlobClient])(bb))
 	return (*blob.Client)(blobClient)
@@ -408,6 +409,12 @@ func (bb *Client) GetTags(ctx context.Context, o *blob.GetTagsOptions) (blob.Get
 // For more information, see https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url.
 func (bb *Client) CopyFromURL(ctx context.Context, copySource string, o *blob.CopyFromURLOptions) (blob.CopyFromURLResponse, error) {
 	return bb.BlobClient().CopyFromURL(ctx, copySource, o)
+}
+
+// GetSASURL is a convenience method for generating a SAS token for the currently pointed at block blob.
+// It can only be used if the credential supplied during creation was a SharedKeyCredential.
+func (bb *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o *blob.GetSASURLOptions) (string, error) {
+	return bb.BlobClient().GetSASURL(permissions, expiry, o)
 }
 
 // Concurrent Upload Functions -----------------------------------------------------------------------------------------

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -2609,6 +2609,7 @@ func (s *BlockBlobUnrecordedTestsSuite) TestGetSASURLBlockBlobClient() {
 
 	// Get new blob client with sasUrl and attempt GetProperties
 	newClient, err := blob.NewClientWithNoCredential(sasUrl, nil)
+	_require.NoError(err)
 
 	_, err = newClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)

--- a/sdk/storage/azblob/internal/base/clients.go
+++ b/sdk/storage/azblob/internal/base/clients.go
@@ -71,7 +71,10 @@ type CompositeClient[T, U any] struct {
 }
 
 func InnerClients[T, U any](client *CompositeClient[T, U]) (*Client[T], *U) {
-	return &Client[T]{inner: client.innerT}, client.innerU
+	return &Client[T]{
+		inner:      client.innerT,
+		credential: client.sharedKey,
+	}, client.innerU
 }
 
 func NewAppendBlobClient(blobURL string, azClient *azcore.Client, sharedKey *exported.SharedKeyCredential) *CompositeClient[generated.BlobClient, generated.AppendBlobClient] {

--- a/sdk/storage/azblob/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azblob/internal/testcommon/clients_auth.go
@@ -253,7 +253,6 @@ func CreateNewBlockBlob(ctx context.Context, _require *require.Assertions, block
 
 	_, err := bbClient.Upload(ctx, streaming.NopCloser(strings.NewReader(BlockBlobDefaultData)), nil)
 	_require.NoError(err)
-	// _require.Equal(cResp.RawResponse.StatusCode, 201)
 	return bbClient
 }
 

--- a/sdk/storage/azblob/pageblob/client.go
+++ b/sdk/storage/azblob/pageblob/client.go
@@ -8,6 +8,7 @@ package pageblob
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"io"
 	"net/http"
 	"net/url"
@@ -424,6 +425,12 @@ func (pb *Client) GetTags(ctx context.Context, o *blob.GetTagsOptions) (blob.Get
 // For more information, see https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url.
 func (pb *Client) CopyFromURL(ctx context.Context, copySource string, o *blob.CopyFromURLOptions) (blob.CopyFromURLResponse, error) {
 	return pb.BlobClient().CopyFromURL(ctx, copySource, o)
+}
+
+// GetSASURL is a convenience method for generating a SAS token for the currently pointed at Page blob.
+// It can only be used if the credential supplied during creation was a SharedKeyCredential.
+func (pb *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o *blob.GetSASURLOptions) (string, error) {
+	return pb.BlobClient().GetSASURL(permissions, expiry, o)
 }
 
 // Concurrent Download Functions -----------------------------------------------------------------------------------------

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -2354,6 +2354,7 @@ func (s *PageBlobUnrecordedTestsSuite) TestGetSASURLPageBlobClient() {
 
 	// Get new blob client with sasUrl and attempt GetProperties
 	newClient, err := blob.NewClientWithNoCredential(sasUrl, nil)
+	_require.NoError(err)
 
 	_, err = newClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -13,9 +13,12 @@ import (
 	"encoding/binary"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
 	"hash/crc64"
 	"io"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -2313,6 +2316,47 @@ func (s *PageBlobRecordedTestsSuite) TestBlobClearPagesIfSequenceNumberEqualNegO
 	_require.Error(err)
 
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.InvalidInput)
+}
+
+func (s *PageBlobUnrecordedTestsSuite) TestGetSASURLPageBlobClient() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	accountName := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME")
+	accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
+	cred, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	_require.NoError(err)
+
+	// Creating service client with credentials
+	serviceClient, err := service.NewClientWithSharedKeyCredential(fmt.Sprintf("https://%s.blob.core.windows.net/", accountName), cred, nil)
+	_require.NoError(err)
+
+	// Creating container client
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, serviceClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Creating page blob client with credentials
+	blockBlobName := testcommon.GenerateBlobName(testName)
+	pbClient := createNewPageBlob(context.Background(), _require, blockBlobName, containerClient)
+
+	// Adding SAS and options
+	permissions := sas.BlobPermissions{
+		Read:   true,
+		Add:    true,
+		Write:  true,
+		Create: true,
+		Delete: true,
+	}
+	expiry := time.Now().Add(5 * time.Minute)
+
+	sasUrl, err := pbClient.GetSASURL(permissions, expiry, nil)
+	_require.NoError(err)
+
+	// Get new blob client with sasUrl and attempt GetProperties
+	newClient, err := blob.NewClientWithNoCredential(sasUrl, nil)
+
+	_, err = newClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
 }
 
 func setupGetPageRangesTest(t *testing.T, _require *require.Assertions, testName string) (containerClient *container.Client, pbClient *pageblob.Client) {


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go

This PR contains the following fixes/features - 
1. Expose GetSASURL on specialized clients - This will let customers call getSASUrl without creating outer BlobClient
2. client.BlobClient() should pass the credential as well.