### PR TITLE
Adding cross partition query implementation

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 0.3.7 (Unreleased)
+## 0.3.7 (2023-11-15)
 
 ### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added support for cross partition queries
 
 ## 0.3.6 (2023-08-18)
 

--- a/sdk/data/azcosmos/cosmos_headers.go
+++ b/sdk/data/azcosmos/cosmos_headers.go
@@ -34,6 +34,7 @@ const (
 	cosmosHeaderIsBatchAtomic                      string = "x-ms-cosmos-batch-atomic"
 	cosmosHeaderIsBatchOrdered                     string = "x-ms-cosmos-batch-ordered"
 	cosmosHeaderSDKSupportedCapabilities           string = "x-ms-cosmos-sdk-supportedcapabilities"
+	cosmosHeaderCrossPartitionQuery                string = "x-ms-documentdb-query-enablecrosspartition"
 	headerXmsDate                                  string = "x-ms-date"
 	headerAuthorization                            string = "Authorization"
 	headerContentType                              string = "Content-Type"

--- a/sdk/data/azcosmos/cosmos_headers_policy.go
+++ b/sdk/data/azcosmos/cosmos_headers_policy.go
@@ -5,6 +5,7 @@ package azcosmos
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"
@@ -16,6 +17,7 @@ type headerPolicies struct {
 
 type headerOptionsOverride struct {
 	enableContentResponseOnWrite *bool
+	enableCrossPartitionQuery    *bool
 	partitionKey                 *PartitionKey
 	correlatedActivityId         *uuid.UUID
 }
@@ -40,6 +42,10 @@ func (p *headerPolicies) Do(req *policy.Request) (*http.Response, error) {
 
 			if o.headerOptionsOverride.correlatedActivityId != nil {
 				req.Raw().Header.Add(cosmosHeaderCorrelatedActivityId, (*o.headerOptionsOverride.correlatedActivityId).String())
+			}
+
+			if o.headerOptionsOverride.enableCrossPartitionQuery != nil {
+				req.Raw().Header.Add(cosmosHeaderCrossPartitionQuery, strconv.FormatBool(*o.headerOptionsOverride.enableCrossPartitionQuery))
 			}
 		}
 

--- a/sdk/data/azcosmos/example_test.go
+++ b/sdk/data/azcosmos/example_test.go
@@ -752,6 +752,108 @@ func ExampleContainerClient_NewQueryItemsPager_parametrizedQueries() {
 	}
 }
 
+func ExampleContainerClient_NewCrossPartitionQueryItemsPager() {
+	endpoint, ok := os.LookupEnv("AZURE_COSMOS_ENDPOINT")
+	if !ok {
+		panic("AZURE_COSMOS_ENDPOINT could not be found")
+	}
+
+	key, ok := os.LookupEnv("AZURE_COSMOS_KEY")
+	if !ok {
+		panic("AZURE_COSMOS_KEY could not be found")
+	}
+
+	cred, err := azcosmos.NewKeyCredential(key)
+	if err != nil {
+		panic(err)
+	}
+
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	container, err := client.NewContainer("databaseName", "aContainer")
+	if err != nil {
+		panic(err)
+	}
+
+	queryPager := container.NewCrossPartitionQueryItemsPager("select * from docs c", nil)
+	for queryPager.More() {
+		queryResponse, err := queryPager.NextPage(context.Background())
+		if err != nil {
+			var responseErr *azcore.ResponseError
+			errors.As(err, &responseErr)
+			panic(responseErr)
+		}
+
+		for _, item := range queryResponse.Items {
+			var itemResponseBody map[string]interface{}
+			err = json.Unmarshal(item, &itemResponseBody)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		fmt.Printf("Query page received with %v items. ActivityId %s consuming %v RU", len(queryResponse.Items), queryResponse.ActivityID, queryResponse.RequestCharge)
+	}
+}
+
+// Azure Cosmos DB supports queries with parameters expressed by the familiar @ notation.
+// Parameterized SQL provides robust handling and escaping of user input, and prevents accidental exposure of data through SQL injection.
+func ExampleContainerClient_NewCrossPartitionQueryItemsPager_parametrizedQueries() {
+	endpoint, ok := os.LookupEnv("AZURE_COSMOS_ENDPOINT")
+	if !ok {
+		panic("AZURE_COSMOS_ENDPOINT could not be found")
+	}
+
+	key, ok := os.LookupEnv("AZURE_COSMOS_KEY")
+	if !ok {
+		panic("AZURE_COSMOS_KEY could not be found")
+	}
+
+	cred, err := azcosmos.NewKeyCredential(key)
+	if err != nil {
+		panic(err)
+	}
+
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	container, err := client.NewContainer("databaseName", "aContainer")
+	if err != nil {
+		panic(err)
+	}
+
+	opt := &azcosmos.QueryOptions{
+		QueryParameters: []azcosmos.QueryParameter{
+			{"@value", "2"},
+		},
+	}
+
+	queryPager := container.NewCrossPartitionQueryItemsPager("select * from docs c where c.value = @value", opt)
+	for queryPager.More() {
+		queryResponse, err := queryPager.NextPage(context.Background())
+		if err != nil {
+			var responseErr *azcore.ResponseError
+			errors.As(err, &responseErr)
+			panic(responseErr)
+		}
+
+		for _, item := range queryResponse.Items {
+			var itemResponseBody map[string]interface{}
+			err = json.Unmarshal(item, &itemResponseBody)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		fmt.Printf("Query page received with %v items. ActivityId %s consuming %v RU", len(queryResponse.Items), queryResponse.ActivityID, queryResponse.RequestCharge)
+	}
+}
+
 func ExampleContainerClient_NewTransactionalBatch() {
 	endpoint, ok := os.LookupEnv("AZURE_COSMOS_ENDPOINT")
 	if !ok {


### PR DESCRIPTION
This PR allows the execution of cross partition queries using the CosmosDB REST API, allowing developers using the go SDK to run simple projections and filters, even though more complex queries are restricted by Gateway like TOP, ORDER  BY, OFFSET LIMIT, Aggregates, DISTINCT, and GROUP BY.
