### PR TITLE
Add `ContentDisposition` and `ContentType` to blob.GetSASURLOptions

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Other Changes
 
 * Updated to the latest version of `azcore`.
+* Add `ContentDisposition` and `ContentType` to blob.GetSASURLOptions
 
 ## 1.2.0 (2023-10-11)
 

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -304,13 +304,14 @@ func (b *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o 
 	st := o.format()
 
 	qps, err := sas.BlobSignatureValues{
-		ContainerName: urlParts.ContainerName,
-		BlobName:      urlParts.BlobName,
-		SnapshotTime:  t,
-		Version:       sas.Version,
-		Permissions:   permissions.String(),
-		StartTime:     st,
-		ExpiryTime:    expiry.UTC(),
+		ContainerName:      urlParts.ContainerName,
+		BlobName:           urlParts.BlobName,
+		SnapshotTime:       t,
+		Version:            sas.Version,
+		Permissions:        permissions.String(),
+		StartTime:          st,
+		ExpiryTime:         expiry.UTC(),
+		ContentDisposition: o.ContentDisposition,
 	}.SignWithSharedKey(b.sharedKey())
 
 	if err != nil {

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -312,6 +312,7 @@ func (b *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o 
 		StartTime:          st,
 		ExpiryTime:         expiry.UTC(),
 		ContentDisposition: o.ContentDisposition,
+		ContentType:        o.ContentType,
 	}.SignWithSharedKey(b.sharedKey())
 
 	if err != nil {

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3644,10 +3644,25 @@ func (s *BlobUnrecordedTestsSuite) TestSASURLBlobClient() {
 		Create: true,
 		Delete: true,
 	}
-	expiry := time.Now().Add(5 * time.Minute)
+	start := time.Now()
+	expiry := start.Add(5 * time.Minute)
+	opts := blob.GetSASURLOptions{
+		StartTime:          &start,
+		ContentDisposition: "attachment; filename=\"test\"",
+		ContentType:        "application/octet-stream",
+	}
 
 	// BlobSASURL is created with GetSASURL
+	// Test with nil GetSASURLOptions
 	sasUrl, err := blobClient.GetSASURL(permissions, expiry, nil)
+	_require.NoError(err)
+
+	// Get new blob client with sasUrl and attempt GetProperties
+	_, err = blob.NewClientWithNoCredential(sasUrl, nil)
+	_require.NoError(err)
+
+	// Test with GetSASURLOptions
+	sasUrl, err = blobClient.GetSASURL(permissions, expiry, &opts)
 	_require.NoError(err)
 
 	// Get new blob client with sasUrl and attempt GetProperties

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -498,7 +498,8 @@ func (o *SetLegalHoldOptions) format() *generated.BlobClientSetLegalHoldOptions 
 
 // GetSASURLOptions contains the optional parameters for the Client.GetSASURL method.
 type GetSASURLOptions struct {
-	StartTime *time.Time
+	StartTime          *time.Time
+	ContentDisposition string
 }
 
 func (o *GetSASURLOptions) format() time.Time {

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -500,6 +500,7 @@ func (o *SetLegalHoldOptions) format() *generated.BlobClientSetLegalHoldOptions 
 type GetSASURLOptions struct {
 	StartTime          *time.Time
 	ContentDisposition string
+	ContentType        string
 }
 
 func (o *GetSASURLOptions) format() time.Time {


### PR DESCRIPTION
- Add `ContentDisposition` and `ContentType` to blob.GetSASURLOptions
In old version, users can set `Content-Disposition` header in `GetSASURLOptions` for customizing the filename.
https://github.com/Azure/azure-sdk-for-go/blob/2187aca40bbf6931ffac666977e5d29128d82585/storage/blob.go#L86-L109
But this is not supported in the latest version now.

- About the test
In #19945, all tests for `GetSASURLOptions` were removed.
I added a test for `blob.GetSASURLOptions`, maybe this is unnecessary? If it is unnecessary, I will remove it.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

