### PR TITLE
fix(azidentity): do not strip away request headers in doForClient

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* `azidentity.doForClient` method no longer removes headers from the incoming request
 
 ### Other Changes
 

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -151,6 +151,17 @@ func doForClient(client *azcore.Client, r *http.Request) (*http.Response, error)
 			return nil, err
 		}
 	}
+
+	// copy headers to the new request, ignoring any for which the new request has a value
+	h := req.Raw().Header
+	for key, vals := range r.Header {
+		if _, has := h[key]; !has {
+			for _, val := range vals {
+				h.Add(key, val)
+			}
+		}
+	}
+
 	resp, err := client.Pipeline().Do(req)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -1075,6 +1075,10 @@ func TestDoForClient(t *testing.T) {
 					assert.Empty(t, rb)
 				}
 
+				for k, v := range tt.headers {
+					assert.Equal(t, v, req.Header[k])
+				}
+
 				assert.Equal(t, policyHeaderValue, req.Header.Get(policyHeaderName))
 
 				rw.Header().Set("content-type", "application/json")

--- a/sdk/azidentity/live_test.go
+++ b/sdk/azidentity/live_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 )
 
@@ -146,7 +147,19 @@ func run(m *testing.M) int {
 	switch recording.GetRecordMode() {
 	case recording.PlaybackMode:
 		setFakeValues()
-		err := recording.SetBodilessMatcher(nil, nil)
+		err := recording.SetDefaultMatcher(nil, &recording.SetDefaultMatcherOptions{
+			CompareBodies: to.Ptr(false),
+			// ignore the presence/absence/value of these headers because
+			// MSAL sets them and they don't affect azidentity behavior
+			ExcludedHeaders: []string{
+				"Client-Request-Id",
+				"Return-Client-Request-Id",
+				"X-Client-Cpu",
+				"X-Client-Os",
+				"X-Client-Sku",
+				"X-Client-Ver",
+			},
+		})
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

Some authorities might require certain headers to be passed.

For example, in our dSTS auth flow, the request form contains `client_info`, which needs to be accompanied by `X-Client-SKU=MSAL.Go` header, else the API call produces

```
AADSTS501791: Client_info is only supported for MSAL/ADAL,
please ensure that MSAL/ADAL custom headers are being sent.
```

The `doForClient` function creates new `runtime.Request` from the incoming request, but it fails to propagate the respective headers.

This PR is addressing that. It also adds a short unit test for the `doForClient` method, which was missing.

*I recommend not to squash the commits. Both of them work on their own and have concise message attached.*