### PR TITLE
[Cosmos] Add Global Endpoint Manager

### DIFF
--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager.go
@@ -73,8 +73,8 @@ func (gem *globalEndpointManager) RefreshStaleEndpoints() {
 	gem.locationCache.refreshStaleEndpoints()
 }
 
-func (gem *globalEndpointManager) Update() error {
-	accountProperties, err := gem.GetAccountProperties()
+func (gem *globalEndpointManager) Update(ctx context.Context) error {
+	accountProperties, err := gem.GetAccountProperties(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve account properties: %v", err)
 	}
@@ -91,7 +91,7 @@ func (gem *globalEndpointManager) Update() error {
 	return nil
 }
 
-func (gem *globalEndpointManager) GetAccountProperties() (accountProperties, error) {
+func (gem *globalEndpointManager) GetAccountProperties(ctx context.Context) (accountProperties, error) {
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabaseAccount,
 		resourceAddress: "",
@@ -102,7 +102,7 @@ func (gem *globalEndpointManager) GetAccountProperties() (accountProperties, err
 		return accountProperties{}, fmt.Errorf("failed to generate path for name-based request: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60 * time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	azResponse, err := gem.client.sendGetRequest(path, ctx, operationContext, nil, nil)
 	cancel()
 	if err != nil {

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager.go
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+const defaultUnavailableLocationRefreshInterval = 5 * time.Minute
+
+type globalEndpointManager struct {
+	client              *Client
+	preferredLocations  []string
+	locationCache       *locationCache
+	refreshTimeInterval time.Duration
+}
+
+func newGlobalEndpointManager(client *Client, preferredLocations []string, refreshTimeInterval time.Duration) (globalEndpointManager, error) {
+	endpoint, err := url.Parse(client.endpoint)
+	if err != nil {
+		return globalEndpointManager{}, err
+	}
+
+	if refreshTimeInterval == 0 {
+		refreshTimeInterval = defaultUnavailableLocationRefreshInterval
+	}
+
+	gem := globalEndpointManager{
+		client:              client,
+		preferredLocations:  preferredLocations,
+		locationCache:       newLocationCache(preferredLocations, *endpoint),
+		refreshTimeInterval: refreshTimeInterval}
+
+	return gem, nil
+}
+
+func (gem *globalEndpointManager) GetWriteEndpoints() ([]url.URL, error) {
+	return gem.locationCache.writeEndpoints()
+}
+
+func (gem *globalEndpointManager) GetReadEndpoints() ([]url.URL, error) {
+	return gem.locationCache.readEndpoints()
+}
+
+func (gem *globalEndpointManager) MarkEndpointUnavailableForWrite(endpoint url.URL) error {
+	return gem.locationCache.markEndpointUnavailableForWrite(endpoint)
+}
+
+func (gem *globalEndpointManager) MarkEndpointUnavailableForRead(endpoint url.URL) error {
+	return gem.locationCache.markEndpointUnavailableForRead(endpoint)
+}
+
+func (gem *globalEndpointManager) GetEndpointLocation(endpoint url.URL) string {
+	return gem.locationCache.getLocation(endpoint)
+}
+
+func (gem *globalEndpointManager) CanUseMultipleWriteLocations() bool {
+	return gem.locationCache.canUseMultipleWriteLocs()
+}
+
+func (gem *globalEndpointManager) IsEndpointUnavailable(endpoint url.URL, ops requestedOperations) bool {
+	return gem.locationCache.isEndpointUnavailable(endpoint, ops)
+}
+
+func (gem *globalEndpointManager) RefreshStaleEndpoints() {
+	gem.locationCache.refreshStaleEndpoints()
+}
+
+func (gem *globalEndpointManager) Update() error {
+	accountProperties, err := gem.GetAccountProperties()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve account properties: %v", err)
+	}
+
+	err = gem.locationCache.update(
+		accountProperties.WriteRegions,
+		accountProperties.ReadRegions,
+		gem.preferredLocations,
+		&accountProperties.EnableMultipleWriteLocations)
+	if err != nil {
+		return fmt.Errorf("failed to update location cache: %v", err)
+	}
+
+	return nil
+}
+
+func (gem *globalEndpointManager) GetAccountProperties() (accountProperties, error) {
+	operationContext := pipelineRequestOptions{
+		resourceType:    resourceTypeDatabaseAccount,
+		resourceAddress: "",
+	}
+
+	path, err := generatePathForNameBased(resourceTypeDatabaseAccount, "", false)
+	if err != nil {
+		return accountProperties{}, fmt.Errorf("failed to generate path for name-based request: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	azResponse, err := gem.client.sendGetRequest(path, ctx, operationContext, nil, nil)
+	cancel()
+	if err != nil {
+		return accountProperties{}, fmt.Errorf("failed to retrieve account properties: %v", err)
+	}
+
+	properties, err := newAccountProperties(azResponse)
+	if err != nil {
+		return accountProperties{}, fmt.Errorf("failed to parse account properties: %v", err)
+	}
+
+	return properties, nil
+}
+
+func newAccountProperties(azResponse *http.Response) (accountProperties, error) {
+	properties := accountProperties{}
+	err := azruntime.UnmarshalAsJSON(azResponse, &properties)
+	if err != nil {
+		return properties, err
+	}
+
+	return properties, nil
+}

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager.go
@@ -102,7 +102,7 @@ func (gem *globalEndpointManager) GetAccountProperties() (accountProperties, err
 		return accountProperties{}, fmt.Errorf("failed to generate path for name-based request: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60 * time.Second)
 	azResponse, err := gem.client.sendGetRequest(path, ctx, operationContext, nil, nil)
 	cancel()
 	if err != nil {

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -1,0 +1,407 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlobalEndpointManagerGetWriteEndpoints(t *testing.T) {
+	headerPolicy := &headerPolicies{}
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+
+	verifier := headerPoliciesVerify{}
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	assert.NoError(t, err)
+
+	req.SetOperationValue(pipelineRequestOptions{
+		isWriteOperation: true,
+	})
+
+	client := &Client{endpoint: srv.URL(), pipeline: pl}
+
+	preferredRegions := []string{"West US", "Central US"}
+
+	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
+	assert.NoError(t, err)
+
+	writeEndpoints, err := gem.GetWriteEndpoints()
+	assert.NoError(t, err)
+
+	serverEndpoint, err := url.Parse(srv.URL())
+	assert.NoError(t, err)
+
+	expectedWriteEndpoints := []url.URL{
+		*serverEndpoint,
+	}
+	assert.Equal(t, expectedWriteEndpoints, writeEndpoints)
+}
+
+func TestGlobalEndpointManagerGetReadEndpoints(t *testing.T) {
+	headerPolicy := &headerPolicies{}
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+
+	verifier := headerPoliciesVerify{}
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	assert.NoError(t, err)
+	req.SetOperationValue(pipelineRequestOptions{
+		isWriteOperation: true,
+	})
+
+	client := &Client{endpoint: srv.URL(), pipeline: pl}
+
+	preferredRegions := []string{"West US", "Central US"}
+
+	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
+	assert.NoError(t, err)
+
+	readEndpoints, err := gem.GetReadEndpoints()
+	assert.NoError(t, err)
+
+	serverEndpoint, err := url.Parse(srv.URL())
+	assert.NoError(t, err)
+
+	expectedReadEndpoints := []url.URL{
+		*serverEndpoint,
+	}
+	assert.Equal(t, expectedReadEndpoints, readEndpoints)
+}
+
+func TestGlobalEndpointManagerMarkEndpointUnavailableForRead(t *testing.T) {
+	headerPolicy := &headerPolicies{}
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+
+	verifier := headerPoliciesVerify{}
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	assert.NoError(t, err)
+
+	req.SetOperationValue(pipelineRequestOptions{
+		isWriteOperation: true,
+	})
+
+	client := &Client{endpoint: srv.URL(), pipeline: pl}
+
+	preferredRegions := []string{"West US", "Central US"}
+
+	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
+	assert.NoError(t, err)
+
+	endpoint, err := url.Parse(client.endpoint)
+	assert.NoError(t, err)
+
+	readEndpoints, err := gem.GetReadEndpoints()
+	assert.NoError(t, err)
+	print(readEndpoints)
+
+	err = gem.MarkEndpointUnavailableForRead(*endpoint)
+	assert.NoError(t, err)
+
+	unavailable := gem.IsEndpointUnavailable(*endpoint, 1)
+	assert.True(t, unavailable)
+}
+
+func TestGlobalEndpointManagerMarkEndpointUnavailableForWrite(t *testing.T) {
+	headerPolicy := &headerPolicies{}
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+
+	verifier := headerPoliciesVerify{}
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	assert.NoError(t, err)
+
+	req.SetOperationValue(pipelineRequestOptions{
+		isWriteOperation: true,
+	})
+
+	client := &Client{endpoint: srv.URL(), pipeline: pl}
+
+	preferredRegions := []string{"West US", "Central US"}
+
+	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
+	assert.NoError(t, err)
+
+	endpoint, err := url.Parse(client.endpoint)
+	assert.NoError(t, err)
+
+	err = gem.MarkEndpointUnavailableForWrite(*endpoint)
+	assert.NoError(t, err)
+
+	unavailable := gem.IsEndpointUnavailable(*endpoint, 2)
+	assert.True(t, unavailable)
+}
+
+func TestGlobalEndpointManagerGetEndpointLocation(t *testing.T) {
+	headerPolicy := &headerPolicies{}
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+
+	westRegion := accountRegion{
+		Name:     "West US",
+		Endpoint: srv.URL(),
+	}
+
+	properties := accountProperties{
+		ReadRegions:                  []accountRegion{westRegion},
+		WriteRegions:                 []accountRegion{westRegion},
+		EnableMultipleWriteLocations: false,
+	}
+
+	jsonString, err := json.Marshal(properties)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.SetResponse(mock.WithBody(jsonString))
+
+	verifier := headerPoliciesVerify{}
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	assert.NoError(t, err)
+
+	req.SetOperationValue(pipelineRequestOptions{
+		isWriteOperation: true,
+	})
+
+	client := &Client{endpoint: srv.URL(), pipeline: pl}
+
+	gem, err := newGlobalEndpointManager(client, []string{}, 5*time.Minute)
+	assert.NoError(t, err)
+
+	serverEndpoint, err := url.Parse(client.endpoint)
+	assert.NoError(t, err)
+
+	location := gem.GetEndpointLocation(*serverEndpoint)
+
+	expectedLocation := "West US"
+	assert.Equal(t, expectedLocation, location)
+}
+
+func TestGlobalEndpointManagerGetAccountProperties(t *testing.T) {
+	headerPolicy := &headerPolicies{}
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+
+	verifier := headerPoliciesVerify{}
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	if err != nil {
+		return
+	}
+	req.SetOperationValue(pipelineRequestOptions{
+		isWriteOperation: true,
+	})
+
+	client := &Client{endpoint: srv.URL(), pipeline: pl}
+
+	preferredRegions := []string{"West US", "Central US"}
+
+	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
+	assert.NoError(t, err)
+
+	accountProps, err := gem.GetAccountProperties()
+	assert.NoError(t, err)
+
+	expectedAccountProps := accountProperties{
+		ReadRegions:                  nil,
+		WriteRegions:                 nil,
+		EnableMultipleWriteLocations: false,
+	}
+	assert.Equal(t, expectedAccountProps, accountProps)
+}
+
+func TestGlobalEndpointManagerCanUseMultipleWriteLocations(t *testing.T) {
+	headerPolicy := &headerPolicies{}
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+
+	verifier := headerPoliciesVerify{}
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	assert.NoError(t, err)
+
+	req.SetOperationValue(pipelineRequestOptions{
+		isWriteOperation: true,
+	})
+
+	client := &Client{endpoint: srv.URL(), pipeline: pl}
+
+	preferredRegions := []string{"West US", "Central US"}
+
+	serverEndpoint, err := url.Parse(srv.URL())
+	assert.NoError(t, err)
+
+	mockLc := newLocationCache(preferredRegions, *serverEndpoint)
+	mockLc.enableMultipleWriteLocations = true
+	mockLc.useMultipleWriteLocations = true
+
+	mockGem := globalEndpointManager{
+		client:              client,
+		preferredLocations:  preferredRegions,
+		locationCache:       mockLc,
+		refreshTimeInterval: 5 * time.Minute,
+	}
+
+	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
+	assert.NoError(t, err)
+
+	// Multiple locations should be false for default GEM
+	canUseMultipleWriteLocs := gem.CanUseMultipleWriteLocations()
+	assert.False(t, canUseMultipleWriteLocs)
+
+	// Mock GEM with multiple write locations available should show true
+	canUseMultipleWriteLocs = mockGem.CanUseMultipleWriteLocations()
+	assert.True(t, canUseMultipleWriteLocs)
+}
+
+func TestGlobalEndpointManagerUpdate(t *testing.T) { //This test should be testing for the lock on the update/ refresh mechanism
+	// Create a mock client
+	headerPolicy := &headerPolicies{}
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+
+	westRegion := accountRegion{
+		Name:     "West US",
+		Endpoint: srv.URL(),
+	}
+
+	properties := accountProperties{
+		ReadRegions:                  []accountRegion{westRegion},
+		WriteRegions:                 []accountRegion{westRegion},
+		EnableMultipleWriteLocations: false,
+	}
+
+	jsonString, err := json.Marshal(properties)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.SetResponse(mock.WithBody(jsonString))
+
+	verifier := headerPoliciesVerify{}
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
+	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
+	assert.NoError(t, err)
+
+	req.SetOperationValue(pipelineRequestOptions{
+		isWriteOperation: true,
+	})
+
+	client := &Client{endpoint: srv.URL(), pipeline: pl}
+
+	gem, err := newGlobalEndpointManager(client, []string{}, 5*time.Minute)
+	assert.NoError(t, err)
+
+	// Update the location cache and client's default endpoint
+	err = gem.Update()
+	assert.NoError(t, err)
+
+	// Get the write endpoints after the update
+	writeEndpoints, err := gem.GetWriteEndpoints()
+	assert.NoError(t, err)
+
+	serverEndpoint, err := url.Parse(srv.URL())
+	assert.NoError(t, err)
+
+	// Assert the expected write endpoints after the update
+	expectedWriteEndpoints := []url.URL{
+		*serverEndpoint,
+	}
+	assert.Equal(t, expectedWriteEndpoints, writeEndpoints)
+
+	// Get the read endpoints after the update
+	readEndpoints, err := gem.GetReadEndpoints()
+	assert.NoError(t, err)
+
+	// Assert the expected read endpoints
+	expectedReadEndpoints := []url.URL{
+		*serverEndpoint,
+	}
+	assert.Equal(t, expectedReadEndpoints, readEndpoints)
+}
+
+// Emulator Test
+
+func TestGlobalEndpointManagerEmulator(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t)
+	emulatorRegionName := "South Central US"
+	preferredRegions := []string{}
+	emulatorRegion := accountRegion{Name: emulatorRegionName, Endpoint: "https://127.0.0.1:8081/"}
+
+	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
+	assert.NoError(t, err)
+
+	accountProps, err := gem.GetAccountProperties()
+	assert.NoError(t, err)
+
+	// Verify the expected account properties
+	expectedAccountProps := accountProperties{
+		ReadRegions:                  []accountRegion{emulatorRegion},
+		WriteRegions:                 []accountRegion{emulatorRegion},
+		EnableMultipleWriteLocations: false,
+	}
+	assert.Equal(t, expectedAccountProps, accountProps)
+
+	emulatorEndpoint, err := url.Parse("https://localhost:8081/")
+	assert.NoError(t, err)
+
+	// Verify the read endpoints
+	readEndpoints, err := gem.GetReadEndpoints()
+	assert.NoError(t, err)
+
+	expectedEndpoints := []url.URL{
+		*emulatorEndpoint,
+	}
+	assert.Equal(t, expectedEndpoints, readEndpoints)
+
+	// Verify the write endpoints
+	writeEndpoints, err := gem.GetWriteEndpoints()
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedEndpoints, writeEndpoints)
+
+	// Assert location cache is not populated until update() is called
+	locationInfo := gem.locationCache.locationInfo
+	availableLocation := []string{}
+	availableEndpointsByLocation := map[string]url.URL{}
+
+	assert.Equal(t, locationInfo.availReadLocations, availableLocation)
+	assert.Equal(t, locationInfo.availWriteLocations, availableLocation)
+	assert.Equal(t, locationInfo.availReadEndpointsByLocation, availableEndpointsByLocation)
+	assert.Equal(t, locationInfo.availWriteEndpointsByLocation, availableEndpointsByLocation)
+
+	//update and assert available locations are now populated in location cache
+	gem.Update()
+	locationInfo = gem.locationCache.locationInfo
+
+	assert.Equal(t, len(locationInfo.availReadLocations), len(availableLocation)+1)
+	assert.Equal(t, len(locationInfo.availWriteLocations), len(availableLocation)+1)
+	assert.Equal(t, locationInfo.availWriteLocations[0], emulatorRegionName)
+	assert.Equal(t, locationInfo.availReadLocations[0], emulatorRegionName)
+	assert.Equal(t, len(locationInfo.availReadEndpointsByLocation), len(availableEndpointsByLocation)+1)
+	assert.Equal(t, len(locationInfo.availWriteEndpointsByLocation), len(availableEndpointsByLocation)+1)
+}

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -6,7 +6,6 @@ package azcosmos
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -97,9 +96,6 @@ func TestGlobalEndpointManagerMarkEndpointUnavailableForRead(t *testing.T) {
 	endpoint, err := url.Parse(client.endpoint)
 	assert.NoError(t, err)
 
-	readEndpoints, err := gem.GetReadEndpoints()
-	assert.NoError(t, err)
-	print(readEndpoints)
 
 	err = gem.MarkEndpointUnavailableForRead(*endpoint)
 	assert.NoError(t, err)
@@ -267,7 +263,6 @@ func TestGlobalEndpointManagerConcurrentUpdate(t *testing.T) {
 	})
 
 	client := &Client{endpoint: srv.URL(), pipeline: pl}
-	fmt.Println(client.endpoint)
 
 	gem, err := newGlobalEndpointManager(client, []string{}, 5*time.Second)
 	assert.NoError(t, err)

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -395,7 +395,8 @@ func TestGlobalEndpointManagerEmulator(t *testing.T) {
 	assert.Equal(t, locationInfo.availWriteEndpointsByLocation, availableEndpointsByLocation)
 
 	//update and assert available locations are now populated in location cache
-	gem.Update()
+	err := gem.Update()
+	assert.NoError(t, err)
 	locationInfo = gem.locationCache.locationInfo
 
 	assert.Equal(t, len(locationInfo.availReadLocations), len(availableLocation)+1)

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -4,7 +4,6 @@
 package azcosmos
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -18,19 +17,11 @@ import (
 )
 
 func TestGlobalEndpointManagerGetWriteEndpoints(t *testing.T) {
-	headerPolicy := &headerPolicies{}
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 
-	verifier := headerPoliciesVerify{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
-	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
-	assert.NoError(t, err)
-
-	req.SetOperationValue(pipelineRequestOptions{
-		isWriteOperation: true,
-	})
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 
 	client := &Client{endpoint: srv.URL(), pipeline: pl}
 
@@ -52,18 +43,11 @@ func TestGlobalEndpointManagerGetWriteEndpoints(t *testing.T) {
 }
 
 func TestGlobalEndpointManagerGetReadEndpoints(t *testing.T) {
-	headerPolicy := &headerPolicies{}
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 
-	verifier := headerPoliciesVerify{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
-	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
-	assert.NoError(t, err)
-	req.SetOperationValue(pipelineRequestOptions{
-		isWriteOperation: true,
-	})
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 
 	client := &Client{endpoint: srv.URL(), pipeline: pl}
 
@@ -85,19 +69,11 @@ func TestGlobalEndpointManagerGetReadEndpoints(t *testing.T) {
 }
 
 func TestGlobalEndpointManagerMarkEndpointUnavailableForRead(t *testing.T) {
-	headerPolicy := &headerPolicies{}
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 
-	verifier := headerPoliciesVerify{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
-	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
-	assert.NoError(t, err)
-
-	req.SetOperationValue(pipelineRequestOptions{
-		isWriteOperation: true,
-	})
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 
 	client := &Client{endpoint: srv.URL(), pipeline: pl}
 
@@ -121,19 +97,11 @@ func TestGlobalEndpointManagerMarkEndpointUnavailableForRead(t *testing.T) {
 }
 
 func TestGlobalEndpointManagerMarkEndpointUnavailableForWrite(t *testing.T) {
-	headerPolicy := &headerPolicies{}
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 
-	verifier := headerPoliciesVerify{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
-	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
-	assert.NoError(t, err)
-
-	req.SetOperationValue(pipelineRequestOptions{
-		isWriteOperation: true,
-	})
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 
 	client := &Client{endpoint: srv.URL(), pipeline: pl}
 
@@ -153,7 +121,6 @@ func TestGlobalEndpointManagerMarkEndpointUnavailableForWrite(t *testing.T) {
 }
 
 func TestGlobalEndpointManagerGetEndpointLocation(t *testing.T) {
-	headerPolicy := &headerPolicies{}
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
@@ -175,21 +142,17 @@ func TestGlobalEndpointManagerGetEndpointLocation(t *testing.T) {
 	}
 	srv.SetResponse(mock.WithBody(jsonString))
 
-	verifier := headerPoliciesVerify{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
-	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
-	assert.NoError(t, err)
-
-	req.SetOperationValue(pipelineRequestOptions{
-		isWriteOperation: true,
-	})
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 
 	client := &Client{endpoint: srv.URL(), pipeline: pl}
 
 	gem, err := newGlobalEndpointManager(client, []string{}, 5*time.Minute)
 	assert.NoError(t, err)
 
-	serverEndpoint, err := url.Parse(client.endpoint)
+	serverEndpoint, err := url.Parse(srv.URL())
+	assert.NoError(t, err)
+
+	err = gem.Update()
 	assert.NoError(t, err)
 
 	location := gem.GetEndpointLocation(*serverEndpoint)
@@ -199,20 +162,11 @@ func TestGlobalEndpointManagerGetEndpointLocation(t *testing.T) {
 }
 
 func TestGlobalEndpointManagerGetAccountProperties(t *testing.T) {
-	headerPolicy := &headerPolicies{}
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 
-	verifier := headerPoliciesVerify{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
-	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
-	if err != nil {
-		return
-	}
-	req.SetOperationValue(pipelineRequestOptions{
-		isWriteOperation: true,
-	})
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 
 	client := &Client{endpoint: srv.URL(), pipeline: pl}
 
@@ -233,19 +187,11 @@ func TestGlobalEndpointManagerGetAccountProperties(t *testing.T) {
 }
 
 func TestGlobalEndpointManagerCanUseMultipleWriteLocations(t *testing.T) {
-	headerPolicy := &headerPolicies{}
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 
-	verifier := headerPoliciesVerify{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
-	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
-	assert.NoError(t, err)
-
-	req.SetOperationValue(pipelineRequestOptions{
-		isWriteOperation: true,
-	})
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 
 	client := &Client{endpoint: srv.URL(), pipeline: pl}
 
@@ -278,8 +224,6 @@ func TestGlobalEndpointManagerCanUseMultipleWriteLocations(t *testing.T) {
 }
 
 func TestGlobalEndpointManagerUpdate(t *testing.T) { //This test should be testing for the lock on the update/ refresh mechanism
-	// Create a mock client
-	headerPolicy := &headerPolicies{}
 	srv, close := mock.NewTLSServer()
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
@@ -301,14 +245,7 @@ func TestGlobalEndpointManagerUpdate(t *testing.T) { //This test should be testi
 	}
 	srv.SetResponse(mock.WithBody(jsonString))
 
-	verifier := headerPoliciesVerify{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{headerPolicy, &verifier}}, &policy.ClientOptions{Transport: srv})
-	req, err := azruntime.NewRequest(context.Background(), http.MethodGet, srv.URL())
-	assert.NoError(t, err)
-
-	req.SetOperationValue(pipelineRequestOptions{
-		isWriteOperation: true,
-	})
+	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 
 	client := &Client{endpoint: srv.URL(), pipeline: pl}
 
@@ -342,8 +279,6 @@ func TestGlobalEndpointManagerUpdate(t *testing.T) { //This test should be testi
 	}
 	assert.Equal(t, expectedReadEndpoints, readEndpoints)
 }
-
-// Emulator Test
 
 func TestGlobalEndpointManagerEmulator(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -4,6 +4,7 @@
 package azcosmos
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -152,7 +153,7 @@ func TestGlobalEndpointManagerGetEndpointLocation(t *testing.T) {
 	serverEndpoint, err := url.Parse(srv.URL())
 	assert.NoError(t, err)
 
-	err = gem.Update()
+	err = gem.Update(context.Background())
 	assert.NoError(t, err)
 
 	location := gem.GetEndpointLocation(*serverEndpoint)
@@ -175,7 +176,7 @@ func TestGlobalEndpointManagerGetAccountProperties(t *testing.T) {
 	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
 	assert.NoError(t, err)
 
-	accountProps, err := gem.GetAccountProperties()
+	accountProps, err := gem.GetAccountProperties(context.Background())
 	assert.NoError(t, err)
 
 	expectedAccountProps := accountProperties{
@@ -253,7 +254,7 @@ func TestGlobalEndpointManagerUpdate(t *testing.T) { //This test should be testi
 	assert.NoError(t, err)
 
 	// Update the location cache and client's default endpoint
-	err = gem.Update()
+	err = gem.Update(context.Background())
 	assert.NoError(t, err)
 
 	// Get the write endpoints after the update
@@ -290,7 +291,7 @@ func TestGlobalEndpointManagerEmulator(t *testing.T) {
 	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
 	assert.NoError(t, err)
 
-	accountProps, err := gem.GetAccountProperties()
+	accountProps, err := gem.GetAccountProperties(context.Background())
 	assert.NoError(t, err)
 
 	// Verify the expected account properties
@@ -330,7 +331,7 @@ func TestGlobalEndpointManagerEmulator(t *testing.T) {
 	assert.Equal(t, locationInfo.availWriteEndpointsByLocation, availableEndpointsByLocation)
 
 	//update and assert available locations are now populated in location cache
-	err = gem.Update()
+	err = gem.Update(context.Background())
 	assert.NoError(t, err)
 	locationInfo = gem.locationCache.locationInfo
 

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -395,7 +395,7 @@ func TestGlobalEndpointManagerEmulator(t *testing.T) {
 	assert.Equal(t, locationInfo.availWriteEndpointsByLocation, availableEndpointsByLocation)
 
 	//update and assert available locations are now populated in location cache
-	err := gem.Update()
+	err = gem.Update()
 	assert.NoError(t, err)
 	locationInfo = gem.locationCache.locationInfo
 

--- a/sdk/data/azcosmos/cosmos_location_cache.go
+++ b/sdk/data/azcosmos/cosmos_location_cache.go
@@ -36,13 +36,13 @@ type databaseAccountLocationsInfo struct {
 }
 
 type accountRegion struct {
-	name     string
-	endpoint string
+	Name     string `json:"name"`
+	Endpoint string `json:"databaseAccountEndpoint"`
 }
 
 type accountProperties struct {
-	ReadRegions                  []accountRegion `json:"readRegions"`
-	WriteRegions                 []accountRegion `json:"writeRegions"`
+	ReadRegions                  []accountRegion `json:"readableLocations"`
+	WriteRegions                 []accountRegion `json:"writableLocations"`
 	EnableMultipleWriteLocations bool            `json:"enableMultipleWriteLocations"`
 }
 
@@ -68,6 +68,8 @@ func newLocationCache(prefLocations []string, defaultEndpoint url.URL) *location
 }
 
 func (lc *locationCache) update(writeLocations []accountRegion, readLocations []accountRegion, prefList []string, enableMultipleWriteLocations *bool) error {
+	lc.mapMutex.Lock()
+	defer lc.mapMutex.Unlock()
 	nextLoc := copyDatabaseAccountLocationsInfo(lc.locationInfo)
 	if prefList != nil {
 		nextLoc.prefLocations = prefList
@@ -187,14 +189,12 @@ func (lc *locationCache) databaseAccountRead(dbAcct accountProperties) error {
 }
 
 func (lc *locationCache) refreshStaleEndpoints() {
-	lc.mapMutex.Lock()
 	for endpoint, info := range lc.locationUnavailabilityInfoMap {
 		t := time.Since(info.lastCheckTime)
 		if t > lc.unavailableLocationExpirationTime {
 			delete(lc.locationUnavailabilityInfoMap, endpoint)
 		}
 	}
-	lc.mapMutex.Unlock()
 }
 
 func (lc *locationCache) isEndpointUnavailable(endpoint url.URL, ops requestedOperations) bool {
@@ -241,13 +241,13 @@ func getEndpointsByLocation(locs []accountRegion) (map[string]url.URL, []string,
 	endpointsByLoc := make(map[string]url.URL)
 	parsedLocs := make([]string, 0)
 	for _, loc := range locs {
-		endpoint, err := url.Parse(loc.endpoint)
+		endpoint, err := url.Parse(loc.Endpoint)
 		if err != nil {
 			return nil, nil, err
 		}
-		if loc.name != "" {
-			endpointsByLoc[loc.name] = *endpoint
-			parsedLocs = append(parsedLocs, loc.name)
+		if loc.Name != "" {
+			endpointsByLoc[loc.Name] = *endpoint
+			parsedLocs = append(parsedLocs, loc.Name)
 		}
 		// TODO else: log
 	}

--- a/sdk/data/azcosmos/cosmos_location_cache.go
+++ b/sdk/data/azcosmos/cosmos_location_cache.go
@@ -68,8 +68,6 @@ func newLocationCache(prefLocations []string, defaultEndpoint url.URL) *location
 }
 
 func (lc *locationCache) update(writeLocations []accountRegion, readLocations []accountRegion, prefList []string, enableMultipleWriteLocations *bool) error {
-	lc.mapMutex.Lock()
-	defer lc.mapMutex.Unlock()
 	nextLoc := copyDatabaseAccountLocationsInfo(lc.locationInfo)
 	if prefList != nil {
 		nextLoc.prefLocations = prefList
@@ -189,6 +187,8 @@ func (lc *locationCache) databaseAccountRead(dbAcct accountProperties) error {
 }
 
 func (lc *locationCache) refreshStaleEndpoints() {
+	lc.mapMutex.Lock()
+	defer lc.mapMutex.Unlock()
 	for endpoint, info := range lc.locationUnavailabilityInfoMap {
 		t := time.Since(info.lastCheckTime)
 		if t > lc.unavailableLocationExpirationTime {

--- a/sdk/data/azcosmos/cosmos_location_cache_test.go
+++ b/sdk/data/azcosmos/cosmos_location_cache_test.go
@@ -52,10 +52,10 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	loc1 = accountRegion{name: "location1", endpoint: loc1Endpoint.String()}
-	loc2 = accountRegion{name: "location2", endpoint: loc2Endpoint.String()}
-	loc3 = accountRegion{name: "location3", endpoint: loc3Endpoint.String()}
-	loc4 = accountRegion{name: "location4", endpoint: loc4Endpoint.String()}
+	loc1 = accountRegion{Name: "location1", Endpoint: loc1Endpoint.String()}
+	loc2 = accountRegion{Name: "location2", Endpoint: loc2Endpoint.String()}
+	loc3 = accountRegion{Name: "location3", Endpoint: loc3Endpoint.String()}
+	loc4 = accountRegion{Name: "location4", Endpoint: loc4Endpoint.String()}
 
 	writeEndpoints = []url.URL{*loc1Endpoint, *loc2Endpoint, *loc3Endpoint}
 	readEndpoints = []url.URL{*loc1Endpoint, *loc2Endpoint, *loc4Endpoint}
@@ -191,24 +191,24 @@ func TestGetLocation(t *testing.T) {
 		t.Errorf("Expected GetLocation to return a valid location when provided the default endpoint, but it did not")
 	}
 	for _, region := range dbAcct.WriteRegions {
-		url, err := url.Parse(region.endpoint)
+		url, err := url.Parse(region.Endpoint)
 		if err != nil {
-			t.Errorf("Failed to parse endpoint %s, %s", region.endpoint, err)
+			t.Errorf("Failed to parse endpoint %s, %s", region.Endpoint, err)
 			continue
 		}
-		expected, actual := region.name, lc.getLocation(*url)
+		expected, actual := region.Name, lc.getLocation(*url)
 		if expected != actual {
 			t.Errorf("Expected GetLocation to return Write Region %s, but was %s", expected, actual)
 		}
 	}
 
 	for _, region := range dbAcct.ReadRegions {
-		url, err := url.Parse(region.endpoint)
+		url, err := url.Parse(region.Endpoint)
 		if err != nil {
-			t.Errorf("Failed to parse endpoint %s, %s", region.endpoint, err)
+			t.Errorf("Failed to parse endpoint %s, %s", region.Endpoint, err)
 			continue
 		}
-		expected, actual := region.name, lc.getLocation(*url)
+		expected, actual := region.Name, lc.getLocation(*url)
 		if expected != actual {
 			t.Errorf("Expected GetLocation to return Read Region %s, but was %s", expected, actual)
 		}
@@ -238,8 +238,8 @@ func TestGetEndpointsByLocation(t *testing.T) {
 		t.Errorf("Expected parsedLocs to contain %d locations, but it contained %d", len(locs), len(parsedLocs))
 	}
 	for i, loc := range locs {
-		if parsedLocs[i] != loc.name {
-			t.Errorf("Expected parsedLocs to contain location %s, but it did not", loc.name)
+		if parsedLocs[i] != loc.Name {
+			t.Errorf("Expected parsedLocs to contain location %s, but it did not", loc.Name)
 		}
 	}
 }
@@ -260,7 +260,7 @@ func TestGetPrefAvailableEndpoints(t *testing.T) {
 		t.Fatalf("Received error marking endpoint unavailable: %s", err.Error())
 	}
 	// loc1: unavailable, loc2: available, loc5: non-existent
-	lc.locationInfo.prefLocations = []string{loc1.name, loc2.name, "location5"}
+	lc.locationInfo.prefLocations = []string{loc1.Name, loc2.Name, "location5"}
 	prefWriteEndpoints := lc.getPrefAvailableEndpoints(lc.locationInfo.availWriteEndpointsByLocation, lc.locationInfo.availWriteLocations, write, lc.defaultEndpoint)
 	// loc2: preferred + available, default: fallback endpoint, loc1: unavailable + preferred
 	expectedWriteEndpoints := []*url.URL{loc2Endpoint, defaultEndpoint, loc1Endpoint}
@@ -274,7 +274,7 @@ func TestGetPrefAvailableEndpoints(t *testing.T) {
 
 func TestReadEndpoints(t *testing.T) {
 	lc := ResetLocationCache()
-	lc.locationInfo.prefLocations = []string{loc1.name, loc2.name, loc3.name, loc4.name}
+	lc.locationInfo.prefLocations = []string{loc1.Name, loc2.Name, loc3.Name, loc4.Name}
 	dbAcct := CreateDatabaseAccount(lc.enableMultipleWriteLocations, false)
 	err := lc.databaseAccountRead(dbAcct)
 	if err != nil {
@@ -323,7 +323,7 @@ func TestWriteEndpoints(t *testing.T) {
 	lc := ResetLocationCache()
 	lc.enableMultipleWriteLocations = true
 	lc.useMultipleWriteLocations = true
-	lc.locationInfo.prefLocations = []string{loc1.name, loc2.name, loc3.name, loc4.name}
+	lc.locationInfo.prefLocations = []string{loc1.Name, loc2.Name, loc3.Name, loc4.Name}
 	dbAcct := CreateDatabaseAccount(lc.enableMultipleWriteLocations, false)
 	err := lc.databaseAccountRead(dbAcct)
 	if err != nil {

--- a/sdk/data/azcosmos/cosmos_paths.go
+++ b/sdk/data/azcosmos/cosmos_paths.go
@@ -22,7 +22,7 @@ const (
 	pathSegmentDocument            string = "docs"
 	pathSegmentClientEncryptionKey string = "clientencryptionkeys"
 	pathSegmentOffer               string = "offers"
-	pathSegmentDatabaseAccount     string = "databaseaccount"
+	pathSegmentDatabaseAccount     string = ""
 	pathSegmentPartitionKeyRange   string = "pkranges"
 )
 

--- a/sdk/data/azcosmos/emulator_cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_global_endpoint_manager_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlobalEndpointManagerEmulator(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t)
+	emulatorRegionName := "South Central US"
+	preferredRegions := []string{}
+	emulatorRegion := accountRegion{Name: emulatorRegionName, Endpoint: "https://127.0.0.1:8081/"}
+
+	gem, err := newGlobalEndpointManager(client, preferredRegions, 5*time.Minute)
+	assert.NoError(t, err)
+
+	accountProps, err := gem.GetAccountProperties(context.Background())
+	assert.NoError(t, err)
+
+	// Verify the expected account properties
+	expectedAccountProps := accountProperties{
+		ReadRegions:                  []accountRegion{emulatorRegion},
+		WriteRegions:                 []accountRegion{emulatorRegion},
+		EnableMultipleWriteLocations: false,
+	}
+	assert.Equal(t, expectedAccountProps, accountProps)
+
+	emulatorEndpoint, err := url.Parse("https://localhost:8081/")
+	assert.NoError(t, err)
+
+	// Verify the read endpoints
+	readEndpoints, err := gem.GetReadEndpoints()
+	assert.NoError(t, err)
+
+	expectedEndpoints := []url.URL{
+		*emulatorEndpoint,
+	}
+	assert.Equal(t, expectedEndpoints, readEndpoints)
+
+	// Verify the write endpoints
+	writeEndpoints, err := gem.GetWriteEndpoints()
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedEndpoints, writeEndpoints)
+
+	// Assert location cache is not populated until update() is called
+	locationInfo := gem.locationCache.locationInfo
+	availableLocation := []string{}
+	availableEndpointsByLocation := map[string]url.URL{}
+
+	assert.Equal(t, locationInfo.availReadLocations, availableLocation)
+	assert.Equal(t, locationInfo.availWriteLocations, availableLocation)
+	assert.Equal(t, locationInfo.availReadEndpointsByLocation, availableEndpointsByLocation)
+	assert.Equal(t, locationInfo.availWriteEndpointsByLocation, availableEndpointsByLocation)
+
+	//update and assert available locations are now populated in location cache
+	err = gem.Update(context.Background())
+	assert.NoError(t, err)
+	locationInfo = gem.locationCache.locationInfo
+
+	assert.Equal(t, len(locationInfo.availReadLocations), len(availableLocation)+1)
+	assert.Equal(t, len(locationInfo.availWriteLocations), len(availableLocation)+1)
+	assert.Equal(t, locationInfo.availWriteLocations[0], emulatorRegionName)
+	assert.Equal(t, locationInfo.availReadLocations[0], emulatorRegionName)
+	assert.Equal(t, len(locationInfo.availReadEndpointsByLocation), len(availableEndpointsByLocation)+1)
+	assert.Equal(t, len(locationInfo.availWriteEndpointsByLocation), len(availableEndpointsByLocation)+1)
+}

--- a/sdk/data/azcosmos/shared_key_credential.go
+++ b/sdk/data/azcosmos/shared_key_credential.go
@@ -69,22 +69,24 @@ func (c *KeyCredential) buildCanonicalizedAuthHeaderFromRequest(req *policy.Requ
 			resourceAddress = strings.ToLower(resourceAddress)
 		}
 
-		value = c.buildCanonicalizedAuthHeader(req.Raw().Method, resourceTypePath, resourceAddress, req.Raw().Header.Get(headerXmsDate), "master", "1.0")
+		var isDatabaseAccount bool = opValues.resourceType == resourceTypeDatabaseAccount
+
+		value = c.buildCanonicalizedAuthHeader(isDatabaseAccount, req.Raw().Method, resourceTypePath, resourceAddress, req.Raw().Header.Get(headerXmsDate), "master", "1.0")
 	}
 
 	return value, nil
 }
 
 // where date is like time.RFC1123 but hard-codes GMT as the time zone
-func (c *KeyCredential) buildCanonicalizedAuthHeader(method, resourceType, resourceAddress, xmsDate, tokenType, version string) string {
-	if method == "" || resourceType == "" {
+func (c *KeyCredential) buildCanonicalizedAuthHeader(isDatabaseAccount bool, method, resourceTypePath, resourceAddress, xmsDate, tokenType, version string) string {
+	if method == "" || (resourceTypePath == "" && !isDatabaseAccount) {
 		return ""
 	}
 
 	resourceAddress, _ = url.PathUnescape(resourceAddress)
 
 	// https://docs.microsoft.com/en-us/rest/api/cosmos-db/access-control-on-cosmosdb-resources#constructkeytoken
-	stringToSign := join(strings.ToLower(method), "\n", strings.ToLower(resourceType), "\n", resourceAddress, "\n", strings.ToLower(xmsDate), "\n", "", "\n")
+	stringToSign := join(strings.ToLower(method), "\n", strings.ToLower(resourceTypePath), "\n", resourceAddress, "\n", strings.ToLower(xmsDate), "\n", "", "\n")
 	signature := c.computeHMACSHA256(stringToSign)
 
 	return url.QueryEscape(join("type=" + tokenType + "&ver=" + version + "&sig=" + signature))

--- a/sdk/data/azcosmos/shared_key_credential.go
+++ b/sdk/data/azcosmos/shared_key_credential.go
@@ -69,7 +69,7 @@ func (c *KeyCredential) buildCanonicalizedAuthHeaderFromRequest(req *policy.Requ
 			resourceAddress = strings.ToLower(resourceAddress)
 		}
 
-		var isDatabaseAccount bool = opValues.resourceType == resourceTypeDatabaseAccount
+		isDatabaseAccount := opValues.resourceType == resourceTypeDatabaseAccount
 
 		value = c.buildCanonicalizedAuthHeader(isDatabaseAccount, req.Raw().Method, resourceTypePath, resourceAddress, req.Raw().Header.Get(headerXmsDate), "master", "1.0")
 	}

--- a/sdk/data/azcosmos/shared_key_credential_test.go
+++ b/sdk/data/azcosmos/shared_key_credential_test.go
@@ -29,16 +29,16 @@ func Test_buildCanonicalizedAuthHeader(t *testing.T) {
 	tokenType := "master"
 	version := "1.0"
 
-	emptyAuthHeader := cred.buildCanonicalizedAuthHeader("", resourceType, resourceId, xmsDate, tokenType, version)
+	emptyAuthHeader := cred.buildCanonicalizedAuthHeader(false, "", resourceType, resourceId, xmsDate, tokenType, version)
 	assert.Equal(t, emptyAuthHeader, "")
-	emptyAuthHeader = cred.buildCanonicalizedAuthHeader(method, "", resourceId, xmsDate, tokenType, version)
+	emptyAuthHeader = cred.buildCanonicalizedAuthHeader(false, method, "", resourceId, xmsDate, tokenType, version)
 	assert.Equal(t, emptyAuthHeader, "")
 
 	stringToSign := join(strings.ToLower(method), "\n", strings.ToLower(resourceType), "\n", resourceId, "\n", strings.ToLower(xmsDate), "\n", "", "\n")
 	signature := cred.computeHMACSHA256(stringToSign)
 	expected := url.QueryEscape(fmt.Sprintf("type=%s&ver=%s&sig=%s", tokenType, version, signature))
 
-	authHeader := cred.buildCanonicalizedAuthHeader(method, resourceType, resourceId, xmsDate, tokenType, version)
+	authHeader := cred.buildCanonicalizedAuthHeader(false, method, resourceType, resourceId, xmsDate, tokenType, version)
 
 	assert.GreaterOrEqual(t, len(authHeader), 1)
 	assert.Equal(t, expected, authHeader)


### PR DESCRIPTION
Adds the global endpoint manager to the SDK. For now it's just the basic functionality, exposing the location cache methods to the GEM and adding the API request to fetch the database account information. Issue: https://github.com/Azure/azure-sdk-for-go/issues/18983

Next steps would be to develop the policy that uses the global endpoint manager to refresh account information every 5 minutes, as well as making changes to the first call to fetch the database account information in order to include retries to any preferred regions set.

Closes https://github.com/Azure/azure-sdk-for-go/issues/18983
