### PR TITLE
Restore scheme/host when recording HTTP(S)

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Recording will restore the original scheme/host after making a successful HTTP(s) call.
+
 ### Other Changes
 
 ## 1.5.0 (2023-11-02)

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -493,8 +493,8 @@ func (s *recordingTests) TestStartStopRecordingClient() {
 	require.NoError(err)
 	require.Equal("https://azsdkengsys.azurecr.io/acr/v1/some_registry/_tags",
 		data.Entries[0].RequestURI)
-	require.Equal(resp.Request.URL.String(),
-		fmt.Sprintf("%s/acr/v1/some_registry/_tags", defaultOptions().baseURL()))
+	require.Equal("https://azsdkengsys.azurecr.io/acr/v1/some_registry/_tags",
+		resp.Request.URL.String())
 }
 
 func (s *recordingTests) TestStopRecordingNoStart() {

--- a/sdk/internal/recording/testdata/recordings/TestRecording/TestGenerateAlphaNumericID.json
+++ b/sdk/internal/recording/testdata/recordings/TestRecording/TestGenerateAlphaNumericID.json
@@ -1,6 +1,6 @@
 {
   "Entries": [],
   "Variables": {
-    "randSeed": "1689722394"
+    "randSeed": "1701821574"
   }
 }


### PR DESCRIPTION
Things like LROs can use the original HTTP request when polling, so we must ensure that the *http.Request associated with a *http.Response has the correct scheme and host.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
