### PR TITLE
[azopenai] Re-enable tests that were temporarily disabled

### DIFF
--- a/eng/config.json
+++ b/eng/config.json
@@ -46,7 +46,7 @@
         },
         {
             "Name": "azopenai",
-            "CoverageGoal": 0.24
+            "CoverageGoal": 0.32
         },
         {
             "Name": "aztemplate",

--- a/sdk/ai/azopenai/assets.json
+++ b/sdk/ai/azopenai/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/ai/azopenai",
-  "Tag": "go/ai/azopenai_d4fd4783ec"
+  "Tag": "go/ai/azopenai_b42da78821"
 }

--- a/sdk/ai/azopenai/client_audio_test.go
+++ b/sdk/ai/azopenai/client_audio_test.go
@@ -13,24 +13,15 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/stretchr/testify/require"
 )
 
 func TestClient_GetAudioTranscription_AzureOpenAI(t *testing.T) {
-	if recording.GetRecordMode() != recording.LiveMode {
-		t.Skipf("Recording needs to be revisited for multipart: https://github.com/Azure/azure-sdk-for-go/issues/21598")
-	}
-
 	client := newTestClient(t, azureOpenAI.Whisper.Endpoint, withForgivingRetryOption())
 	runTranscriptionTests(t, client, azureOpenAI.Whisper.Model)
 }
 
 func TestClient_GetAudioTranscription_OpenAI(t *testing.T) {
-	if recording.GetRecordMode() != recording.LiveMode {
-		t.Skipf("Recording needs to be revisited for multipart: https://github.com/Azure/azure-sdk-for-go/issues/21598")
-	}
-
 	client := newOpenAIClientForTest(t)
 
 	mp3Bytes, err := os.ReadFile(`testdata/sampledata_audiofiles_myVoiceIsMyPassportVerifyMe01.mp3`)
@@ -50,19 +41,11 @@ func TestClient_GetAudioTranscription_OpenAI(t *testing.T) {
 }
 
 func TestClient_GetAudioTranslation_AzureOpenAI(t *testing.T) {
-	if recording.GetRecordMode() != recording.LiveMode {
-		t.Skipf("Recording needs to be revisited for multipart: https://github.com/Azure/azure-sdk-for-go/issues/21598")
-	}
-
 	client := newTestClient(t, azureOpenAI.Whisper.Endpoint, withForgivingRetryOption())
 	runTranslationTests(t, client, azureOpenAI.Whisper.Model)
 }
 
 func TestClient_GetAudioTranslation_OpenAI(t *testing.T) {
-	if recording.GetRecordMode() != recording.LiveMode {
-		t.Skipf("Recording needs to be revisited for multipart: https://github.com/Azure/azure-sdk-for-go/issues/21598")
-	}
-
 	client := newOpenAIClientForTest(t)
 
 	mp3Bytes, err := os.ReadFile(`testdata/sampledata_audiofiles_myVoiceIsMyPassportVerifyMe01.mp3`)


### PR DESCRIPTION
- Do proper test recordings for audio so we can enable those.
- Bring back vision, and also target Azure.

Overall, this brings our test coverage back up to 32% from 24%.

Fixes #21598