### PR TITLE
Add selective component governance step

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -151,11 +151,16 @@ stages:
           Codeql.Enabled: true
           Codeql.BuildIdentifier: ${{ parameters.ServiceDirectory }}
           Codeql.SkipTaskAutoInjection: false
+          skipComponentGovernanceDetection: true
       pool:
         name: azsdk-pool-mms-ubuntu-2004-general
 
       steps:
       - template: /eng/common/pipelines/templates/steps/check-spelling.yml
+
+      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+        displayName: "Component Detection"
+        condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
 
       - task: GoTool@0
         inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -148,10 +148,12 @@ stages:
     - job: Analyze
       displayName: Analyze
       variables:
-          Codeql.Enabled: true
-          Codeql.BuildIdentifier: ${{ parameters.ServiceDirectory }}
-          Codeql.SkipTaskAutoInjection: false
-          skipComponentGovernanceDetection: true
+        - name: Codeql.Enabled
+          value: true
+        - name: Codeql.BuildIdentifier
+          value: ${{ parameters.ServiceDirectory }}
+        - name: Codeql.SkipTaskAutoInjection
+          value: false
       pool:
         name: azsdk-pool-mms-ubuntu-2004-general
 

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -5,9 +5,12 @@ variables:
   # https://docs.opensource.microsoft.com/tools/cg/index.html
   # https://github.com/microsoft/component-detection/blob/main/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
   EnableGoCliScan: true
-  
+
   # Disable CodeQL injections except for where we specifically enable it
   Codeql.SkipTaskAutoInjection: true
 
   # Set the default value so that 'Build Performance Tests' step can resolve it
   UseAzcoreFromMain: $[eq(variables['Use.AzcoreFromMain'], 'true')]
+
+  # We enable this selectively to avoid overloading CG scanning/reporting on PR pipelines
+  skipComponentGovernanceDetection: true


### PR DESCRIPTION
Selectively turning on component governance checks for scheduled CI. Turning CG off explicitly for PR builds to hopefully reduce scanning cost on the CG team side of things.
