### PR TITLE
fix sdk/resourcemanager/connectedvmware/armconnectedvmware README

### DIFF
--- a/sdk/resourcemanager/connectedvmware/armconnectedvmware/CHANGELOG.md
+++ b/sdk/resourcemanager/connectedvmware/armconnectedvmware/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.1.1 (2023-12-22)
+### Others Change
+
+- Fixed README.md
+
+
 ## 1.1.0 (2023-11-24)
 ### Features Added
 

--- a/sdk/resourcemanager/connectedvmware/armconnectedvmware/README.md
+++ b/sdk/resourcemanager/connectedvmware/armconnectedvmware/README.md
@@ -57,7 +57,7 @@ clientFactory, err := armconnectedvmware.NewClientFactory(<subscription ID>, cre
 A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
 
 ```go
-client := clientFactory.NewVirtualMachinesClient()
+client := clientFactory.NewVCentersClient()
 ```
 
 ## Fakes

--- a/sdk/resourcemanager/connectedvmware/armconnectedvmware/autorest.md
+++ b/sdk/resourcemanager/connectedvmware/armconnectedvmware/autorest.md
@@ -8,6 +8,6 @@ require:
 - https://github.com/Azure/azure-rest-api-specs/blob/3066a973f4baf2e2bf072a013b585a820bb10146/specification/connectedvmware/resource-manager/readme.md
 - https://github.com/Azure/azure-rest-api-specs/blob/3066a973f4baf2e2bf072a013b585a820bb10146/specification/connectedvmware/resource-manager/readme.go.md
 license-header: MICROSOFT_MIT_NO_VERSION
-module-version: 1.1.0
+module-version: 1.1.1
 tag: package-2023-10
 ```

--- a/sdk/resourcemanager/connectedvmware/armconnectedvmware/constants.go
+++ b/sdk/resourcemanager/connectedvmware/armconnectedvmware/constants.go
@@ -19,7 +19,7 @@ package armconnectedvmware
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/connectedvmware/armconnectedvmware"
-	moduleVersion = "v1.1.0"
+	moduleVersion = "v1.1.1"
 )
 
 // CreatedByType - The type of identity that created the resource.


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-go/issues/22158

The `NewVirtualMachinesClient` function was removed in v1.0.0.