### PR TITLE
azfile: Add support for AAD audience

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### Features Added
 
+* Updated service version to `2023-11-03`.
+* Added support for Audience when OAuth is used.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_f1d39931a0"
+  "Tag": "go/storage/azfile_f80b868396"
 }

--- a/sdk/storage/azfile/directory/client.go
+++ b/sdk/storage/azfile/directory/client.go
@@ -36,7 +36,8 @@ type Client base.Client[generated.DirectoryClient]
 //
 // Note that ClientOptions.FileRequestIntent is currently required for token authentication.
 func NewClient(directoryURL string, cred azcore.TokenCredential, options *ClientOptions) (*Client, error) {
-	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{shared.TokenScope}, nil)
+	audience := base.GetAudience((*base.ClientOptions)(options))
+	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{audience}, nil)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{
 		PerRetry: []policy.Policy{authPolicy},

--- a/sdk/storage/azfile/directory/client_test.go
+++ b/sdk/storage/azfile/directory/client_test.go
@@ -39,27 +39,27 @@ func Test(t *testing.T) {
 	}
 }
 
-func (s *DirectoryRecordedTestsSuite) SetupSuite() {
-	s.proxy = testcommon.SetupSuite(&s.Suite)
+func (d *DirectoryRecordedTestsSuite) SetupSuite() {
+	d.proxy = testcommon.SetupSuite(&d.Suite)
 }
 
-func (s *DirectoryRecordedTestsSuite) TearDownSuite() {
-	testcommon.TearDownSuite(&s.Suite, s.proxy)
+func (d *DirectoryRecordedTestsSuite) TearDownSuite() {
+	testcommon.TearDownSuite(&d.Suite, d.proxy)
 }
 
-func (s *DirectoryRecordedTestsSuite) BeforeTest(suite string, test string) {
-	testcommon.BeforeTest(s.T(), suite, test)
+func (d *DirectoryRecordedTestsSuite) BeforeTest(suite string, test string) {
+	testcommon.BeforeTest(d.T(), suite, test)
 }
 
-func (s *DirectoryRecordedTestsSuite) AfterTest(suite string, test string) {
-	testcommon.AfterTest(s.T(), suite, test)
+func (d *DirectoryRecordedTestsSuite) AfterTest(suite string, test string) {
+	testcommon.AfterTest(d.T(), suite, test)
 }
 
-func (s *DirectoryUnrecordedTestsSuite) BeforeTest(suite string, test string) {
+func (d *DirectoryUnrecordedTestsSuite) BeforeTest(suite string, test string) {
 
 }
 
-func (s *DirectoryUnrecordedTestsSuite) AfterTest(suite string, test string) {
+func (d *DirectoryUnrecordedTestsSuite) AfterTest(suite string, test string) {
 
 }
 
@@ -2263,4 +2263,107 @@ func (d *DirectoryRecordedTestsSuite) TestListFileDirEncodedPrefix() {
 		_require.NotNil(resp.Prefix)
 		_require.Equal(*resp.Prefix, dirName)
 	}
+}
+
+func (d *DirectoryRecordedTestsSuite) TestDirectoryClientDefaultAudience() {
+	_require := require.New(d.T())
+	testName := d.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	svcClient, err := testcommon.GetServiceClient(d.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	dirName := testcommon.GenerateDirectoryName(testName)
+	dirURL := "https://" + accountName + ".file.core.windows.net/" + shareName + "/" + dirName
+
+	options := &directory.ClientOptions{
+		FileRequestIntent: to.Ptr(directory.ShareTokenIntentBackup),
+		Audience:          to.Ptr("https://storage.azure.com/"),
+	}
+	testcommon.SetClientOptions(d.T(), &options.ClientOptions)
+	dirClientAudience, err := directory.NewClient(dirURL, cred, options)
+	_require.NoError(err)
+
+	_, err = dirClientAudience.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	_, err = dirClientAudience.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+}
+
+func (d *DirectoryRecordedTestsSuite) TestDirectoryClientCustomAudience() {
+	_require := require.New(d.T())
+	testName := d.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	svcClient, err := testcommon.GetServiceClient(d.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	dirName := testcommon.GenerateDirectoryName(testName)
+	dirURL := "https://" + accountName + ".file.core.windows.net/" + shareName + "/" + dirName
+
+	options := &directory.ClientOptions{
+		FileRequestIntent: to.Ptr(directory.ShareTokenIntentBackup),
+		Audience:          to.Ptr("https://" + accountName + ".file.core.windows.net"),
+	}
+	testcommon.SetClientOptions(d.T(), &options.ClientOptions)
+	dirClientAudience, err := directory.NewClient(dirURL, cred, options)
+	_require.NoError(err)
+
+	_, err = dirClientAudience.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	_, err = dirClientAudience.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+}
+
+func (d *DirectoryRecordedTestsSuite) TestDirectoryAudienceNegative() {
+	_require := require.New(d.T())
+	testName := d.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	svcClient, err := testcommon.GetServiceClient(d.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	dirName := testcommon.GenerateDirectoryName(testName)
+	dirURL := "https://" + accountName + ".file.core.windows.net/" + shareName + "/" + dirName
+
+	options := &directory.ClientOptions{
+		FileRequestIntent: to.Ptr(directory.ShareTokenIntentBackup),
+		Audience:          to.Ptr("https://badaudience.file.core.windows.net"),
+	}
+	testcommon.SetClientOptions(d.T(), &options.ClientOptions)
+	dirClientAudience, err := directory.NewClient(dirURL, cred, options)
+	_require.NoError(err)
+
+	_, err = dirClientAudience.Create(context.Background(), nil)
+	_require.Error(err)
+	testcommon.ValidateFileErrorCode(_require, err, fileerror.AuthenticationFailed)
 }

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -41,7 +41,8 @@ type Client base.Client[generated.FileClient]
 //
 // Note that ClientOptions.FileRequestIntent is currently required for token authentication.
 func NewClient(fileURL string, cred azcore.TokenCredential, options *ClientOptions) (*Client, error) {
-	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{shared.TokenScope}, nil)
+	audience := base.GetAudience((*base.ClientOptions)(options))
+	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{audience}, nil)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{
 		PerRetry: []policy.Policy{authPolicy},

--- a/sdk/storage/azfile/internal/base/clients.go
+++ b/sdk/storage/azfile/internal/base/clients.go
@@ -67,7 +67,7 @@ func GetAudience(clOpts *ClientOptions) string {
 	if clOpts == nil || clOpts.Audience == nil {
 		return shared.TokenScope
 	} else {
-		return strings.TrimRight(*clOpts.Audience, "/") + shared.DefaultOAuthScope
+		return strings.TrimRight(*clOpts.Audience, "/") + "/.default"
 	}
 }
 

--- a/sdk/storage/azfile/internal/base/clients.go
+++ b/sdk/storage/azfile/internal/base/clients.go
@@ -11,15 +11,30 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/generated"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/shared"
+	"strings"
 )
 
 // ClientOptions contains the optional parameters when creating a Client.
 type ClientOptions struct {
 	azcore.ClientOptions
-	AllowTrailingDot       *bool
-	FileRequestIntent      *generated.ShareTokenIntent
+
+	// AllowTrailingDot specifies if a trailing dot present in request url should be trimmed or not.
+	AllowTrailingDot *bool
+
+	// FileRequestIntent is required when using TokenCredential for authentication.
+	// Acceptable value is backup.
+	FileRequestIntent *generated.ShareTokenIntent
+
+	// AllowSourceTrailingDot specifies if a trailing dot present in source url should be trimmed or not.
 	AllowSourceTrailingDot *bool
-	pipelineOptions        *runtime.PipelineOptions
+
+	// Audience to use when requesting tokens for Azure Active Directory authentication.
+	// Only has an effect when credential is of type TokenCredential. The value could be
+	// https://storage.azure.com/ (default) or https://<account>.file.core.windows.net.
+	Audience *string
+
+	pipelineOptions *runtime.PipelineOptions
 }
 
 type Client[T any] struct {
@@ -46,6 +61,14 @@ func GetPipelineOptions(clOpts *ClientOptions) *runtime.PipelineOptions {
 
 func SetPipelineOptions(clOpts *ClientOptions, plOpts *runtime.PipelineOptions) {
 	clOpts.pipelineOptions = plOpts
+}
+
+func GetAudience(clOpts *ClientOptions) string {
+	if clOpts == nil || clOpts.Audience == nil {
+		return shared.TokenScope
+	} else {
+		return strings.TrimRight(*clOpts.Audience, "/") + shared.DefaultOAuthScope
+	}
 }
 
 func NewServiceClient(serviceURL string, azClient *azcore.Client, sharedKey *exported.SharedKeyCredential, options *ClientOptions) *Client[generated.ServiceClient] {

--- a/sdk/storage/azfile/internal/shared/shared.go
+++ b/sdk/storage/azfile/internal/shared/shared.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	TokenScope = "https://storage.azure.com/.default"
+	TokenScope        = "https://storage.azure.com/.default"
+	DefaultOAuthScope = "/.default"
 )
 
 const (

--- a/sdk/storage/azfile/internal/shared/shared.go
+++ b/sdk/storage/azfile/internal/shared/shared.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	TokenScope        = "https://storage.azure.com/.default"
-	DefaultOAuthScope = "/.default"
+	TokenScope = "https://storage.azure.com/.default"
 )
 
 const (

--- a/sdk/storage/azfile/service/client.go
+++ b/sdk/storage/azfile/service/client.go
@@ -38,7 +38,8 @@ type Client base.Client[generated.ServiceClient]
 // This constructor exists to allow the construction of a share.Client that has token credential authentication.
 // Also note that ClientOptions.FileRequestIntent is currently required for token authentication.
 func NewClient(serviceURL string, cred azcore.TokenCredential, options *ClientOptions) (*Client, error) {
-	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{shared.TokenScope}, nil)
+	audience := base.GetAudience((*base.ClientOptions)(options))
+	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{audience}, nil)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{
 		PerRetry: []policy.Policy{authPolicy},

--- a/sdk/storage/azfile/service/client_test.go
+++ b/sdk/storage/azfile/service/client_test.go
@@ -629,3 +629,38 @@ func (s *ServiceRecordedTestsSuite) TestPremiumAccountListShares() {
 		}
 	}
 }
+
+func (s *ServiceRecordedTestsSuite) TestServiceClientCustomAudience() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	// create service client using token credential
+	options := &service.ClientOptions{
+		FileRequestIntent: to.Ptr(service.ShareTokenIntentBackup),
+		Audience:          to.Ptr("https://" + accountName + ".file.core.windows.net"),
+	}
+	testcommon.SetClientOptions(s.T(), &options.ClientOptions)
+	svcClientAudience, err := service.NewClient("https://"+accountName+".file.core.windows.net/", cred, options)
+	_require.NoError(err)
+
+	dirClientAudience := svcClientAudience.NewShareClient(shareName).NewDirectoryClient(testcommon.GenerateDirectoryName(testName))
+
+	_, err = dirClientAudience.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	_, err = dirClientAudience.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+}

--- a/sdk/storage/azfile/share/client.go
+++ b/sdk/storage/azfile/share/client.go
@@ -37,7 +37,8 @@ type Client base.Client[generated.ShareClient]
 // Note that the only share-level operations that support token credential authentication are CreatePermission and GetPermission.
 // Also note that ClientOptions.FileRequestIntent is currently required for token authentication.
 func NewClient(shareURL string, cred azcore.TokenCredential, options *ClientOptions) (*Client, error) {
-	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{shared.TokenScope}, nil)
+	audience := base.GetAudience((*base.ClientOptions)(options))
+	authPolicy := runtime.NewBearerTokenPolicy(cred, []string{audience}, nil)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{
 		PerRetry: []policy.Policy{authPolicy},

--- a/sdk/storage/azfile/share/client_test.go
+++ b/sdk/storage/azfile/share/client_test.go
@@ -1627,3 +1627,108 @@ func (s *ShareRecordedTestsSuite) TestPremiumShareBandwidth() {
 	_require.NotNil(response.NextAllowedQuotaDowngradeTime)
 	_require.Greater(*response.ProvisionedBandwidthMiBps, (int32)(0))
 }
+
+func (s *ShareRecordedTestsSuite) TestShareClientDefaultAudience() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	options := &share.ClientOptions{
+		FileRequestIntent: to.Ptr(share.TokenIntentBackup),
+		Audience:          to.Ptr("https://storage.azure.com/"),
+	}
+	testcommon.SetClientOptions(s.T(), &options.ClientOptions)
+	shareClientAudience, err := share.NewClient("https://"+accountName+".file.core.windows.net/"+shareName, cred, options)
+	_require.NoError(err)
+
+	// Create a permission and check that it's not empty.
+	createResp, err := shareClientAudience.CreatePermission(context.Background(), testcommon.SampleSDDL, nil)
+	_require.NoError(err)
+	_require.NotNil(createResp.FilePermissionKey)
+	_require.NotEmpty(*createResp.FilePermissionKey)
+
+	getResp, err := shareClientAudience.GetPermission(context.Background(), *createResp.FilePermissionKey, nil)
+	_require.NoError(err)
+	_require.NotNil(getResp.Permission)
+	_require.NotEmpty(*getResp.Permission)
+}
+
+func (s *ShareRecordedTestsSuite) TestShareClientCustomAudience() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	options := &share.ClientOptions{
+		FileRequestIntent: to.Ptr(share.TokenIntentBackup),
+		Audience:          to.Ptr("https://" + accountName + ".file.core.windows.net"),
+	}
+	testcommon.SetClientOptions(s.T(), &options.ClientOptions)
+	shareClientAudience, err := share.NewClient("https://"+accountName+".file.core.windows.net/"+shareName, cred, options)
+	_require.NoError(err)
+
+	// Create a permission and check that it's not empty.
+	createResp, err := shareClientAudience.CreatePermission(context.Background(), testcommon.SampleSDDL, nil)
+	_require.NoError(err)
+	_require.NotNil(createResp.FilePermissionKey)
+	_require.NotEmpty(*createResp.FilePermissionKey)
+
+	getResp, err := shareClientAudience.GetPermission(context.Background(), *createResp.FilePermissionKey, nil)
+	_require.NoError(err)
+	_require.NotNil(getResp.Permission)
+	_require.NotEmpty(*getResp.Permission)
+}
+
+func (s *ShareRecordedTestsSuite) TestShareClientAudienceNegative() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	accountName, _ := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	_require.Greater(len(accountName), 0)
+
+	cred, err := testcommon.GetGenericTokenCredential()
+	_require.NoError(err)
+
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	options := &share.ClientOptions{
+		FileRequestIntent: to.Ptr(share.TokenIntentBackup),
+		Audience:          to.Ptr("https://badaudience.file.core.windows.net"),
+	}
+	testcommon.SetClientOptions(s.T(), &options.ClientOptions)
+	shareClientAudience, err := share.NewClient("https://"+accountName+".file.core.windows.net/"+shareName, cred, options)
+	_require.NoError(err)
+
+	// Create a permission and check that it's not empty.
+	_, err = shareClientAudience.CreatePermission(context.Background(), testcommon.SampleSDDL, nil)
+	_require.Error(err)
+	testcommon.ValidateFileErrorCode(_require, err, fileerror.AuthenticationFailed)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
