### PR TITLE
fix generator tool

### DIFF
--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -5,7 +5,10 @@ package common
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"io/ioutil"
 	"log"
@@ -510,33 +513,16 @@ func GetTag(path string) (string, error) {
 	return "", nil
 }
 
-func replaceModuleImport(path, rpName, namespaceName, previousVersion, currentVersion, subPath string, suffixes ...string) error {
-	previous, err := semver.NewVersion(previousVersion)
-	if err != nil {
-		return err
-	}
-
+func replaceModuleImport(path, rpName, namespaceName, currentVersion, subPath string, suffixes ...string) error {
 	current, err := semver.NewVersion(currentVersion)
 	if err != nil {
 		return err
 	}
 
-	if previous.Major() == current.Major() {
-		return nil
-	}
-
-	oldModule := fmt.Sprintf("github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/%s/%s", rpName, namespaceName)
-	if previous.Major() > 1 {
-		oldModule = fmt.Sprintf("%s/v%d", oldModule, previous.Major())
-	}
-
-	newModule := fmt.Sprintf("github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/%s/%s", rpName, namespaceName)
+	module := fmt.Sprintf("github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/%s/%s", rpName, namespaceName)
+	newModule := module
 	if current.Major() > 1 {
 		newModule = fmt.Sprintf("%s/v%d", newModule, current.Major())
-	}
-
-	if oldModule == newModule {
-		return nil
 	}
 
 	return filepath.Walk(filepath.Join(path, subPath), func(path string, info fs.FileInfo, err error) error {
@@ -554,12 +540,21 @@ func replaceModuleImport(path, rpName, namespaceName, previousVersion, currentVe
 		}
 
 		if suffix {
+			oldModule, err := getImportModule(path, module)
+			if err != nil {
+				return err
+			}
+
+			if oldModule == "" || oldModule == fmt.Sprintf("\"%s\"", newModule) {
+				return nil
+			}
+
 			b, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
 
-			newFile := strings.ReplaceAll(string(b), fmt.Sprintf("\"%s\"", oldModule), fmt.Sprintf("\"%s\"", newModule))
+			newFile := strings.ReplaceAll(string(b), oldModule, fmt.Sprintf("\"%s\"", newModule))
 			if newFile != string(b) {
 				if err = os.WriteFile(path, []byte(newFile), 0666); err != nil {
 					return err
@@ -569,6 +564,37 @@ func replaceModuleImport(path, rpName, namespaceName, previousVersion, currentVe
 
 		return nil
 	})
+}
+
+func getImportModule(filePath, modulePrefix string) (string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filePath, nil, parser.ImportsOnly)
+	if err != nil {
+		return "", err
+	}
+
+	for _, i := range f.Imports {
+		if strings.Contains(i.Path.Value, modulePrefix) {
+			return i.Path.Value, nil
+		}
+	}
+
+	return "", nil
+}
+
+func getModuleVersion(autorestPath string) (*semver.Version, error) {
+	data, err := os.ReadFile(autorestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, autorest_md_module_version_prefix) {
+			return semver.NewVersion(strings.TrimSpace(line[len(autorest_md_module_version_prefix):]))
+		}
+	}
+
+	return nil, errors.New("module-version does not exist in autorest.md")
 }
 
 func existSuffixFile(path, suffix string) bool {

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -7,8 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"go/parser"
-	"go/token"
 	"io/fs"
 	"io/ioutil"
 	"log"

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -315,7 +315,7 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 		if err = ReplaceVersion(packagePath, version.String()); err != nil {
 			return nil, err
 		}
- 
+
 		if _, err := os.Stat(filepath.Join(packagePath, "fake")); !os.IsNotExist(err) && oldModuleVersion.Major() != version.Major() {
 			log.Printf("Replace fake module v2+...")
 			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, version.String(),

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -318,7 +318,7 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 
 		if _, err := os.Stat(filepath.Join(packagePath, "fake")); !os.IsNotExist(err) && oldModuleVersion.Major() != version.Major() {
 			log.Printf("Replace fake module v2+...")
-			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, version.String(),
+			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, oldModuleVersion.String(), version.String(),
 				"fake", ".go"); err != nil {
 				return nil, err
 			}
@@ -327,7 +327,7 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 		// When sdk has major version bump, the live test needs to update the module referenced in the code.
 		if oldModuleVersion.Major() != version.Major() && existSuffixFile(packagePath, "_live_test.go") {
 			log.Printf("Replace live test module v2+...")
-			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, version.String(),
+			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, oldModuleVersion.String(), version.String(),
 				"", "_live_test.go"); err != nil {
 				return nil, err
 			}

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -306,23 +306,28 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 			return nil, err
 		}
 
+		oldModuleVersion, err := getModuleVersion(filepath.Join(packagePath, "autorest.md"))
+		if err != nil {
+			return nil, err
+		}
+
 		log.Printf("Replace version in autorest.md and constants...")
 		if err = ReplaceVersion(packagePath, version.String()); err != nil {
 			return nil, err
 		}
-
-		if _, err := os.Stat(filepath.Join(packagePath, "fake")); !os.IsNotExist(err) && changelog.HasBreakingChanges() {
+ 
+		if _, err := os.Stat(filepath.Join(packagePath, "fake")); !os.IsNotExist(err) && oldModuleVersion.Major() != version.Major() {
 			log.Printf("Replace fake module v2+...")
-			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, previousVersion, version.String(),
+			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, version.String(),
 				"fake", ".go"); err != nil {
 				return nil, err
 			}
 		}
 
 		// When sdk has major version bump, the live test needs to update the module referenced in the code.
-		if changelog.HasBreakingChanges() && existSuffixFile(packagePath, "_live_test.go") {
+		if oldModuleVersion.Major() != version.Major() && existSuffixFile(packagePath, "_live_test.go") {
 			log.Printf("Replace live test module v2+...")
-			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, previousVersion, version.String(),
+			if err = replaceModuleImport(packagePath, generateParam.RPName, generateParam.NamespaceName, version.String(),
 				"", "_live_test.go"); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
current version: v3.0.0-beta.1
to release: v2.7.0 (compare v2.6.0, not BreakingChange)

The above does not replace the import module in fake and live_test.
ref: https://github.com/Azure/azure-sdk-for-go/pull/22184/commits/b8368c704ce55b61adfc37894e6786d47b5aedac#diff-878839ecfc6b682d3adbdd34fdeff0178e7018301d85ea4dca7453563d9ca93c