### PR TITLE
Clean up ETags in azappconfig

### DIFF
--- a/sdk/data/azappconfig/client.go
+++ b/sdk/data/azappconfig/client.go
@@ -300,8 +300,6 @@ func (c *Client) NewListSnapshotsPager(options *ListSnapshotsOptions) *runtime.P
 			for i := range page.Items {
 				snapshot := page.Items[i]
 
-				convertedETag := azcore.ETag(*snapshot.Etag)
-
 				convertedFilters := make([]SettingFilter, len(snapshot.Filters))
 				for j := range snapshot.Filters {
 					convertedFilters[j] = SettingFilter{
@@ -316,7 +314,7 @@ func (c *Client) NewListSnapshotsPager(options *ListSnapshotsOptions) *runtime.P
 					RetentionPeriod: snapshot.RetentionPeriod,
 					Tags:            snapshot.Tags,
 					Created:         snapshot.Created,
-					ETag:            &convertedETag,
+					ETag:            (*azcore.ETag)(snapshot.Etag),
 					Expires:         snapshot.Expires,
 					ItemsCount:      snapshot.ItemsCount,
 					Name:            snapshot.Name,
@@ -343,17 +341,16 @@ func (c *Client) NewListSettingsForSnapshotPager(snapshotName string, options *L
 		options = &ListSettingsForSnapshotOptions{}
 	}
 
-	opts := generated.AzureAppConfigurationClientGetKeyValuesOptions{
+	ssRespPager := c.appConfigClient.NewGetKeyValuesPager(&generated.AzureAppConfigurationClientGetKeyValuesOptions{
 		AcceptDatetime: options.AcceptDatetime,
 		After:          options.After,
-		IfMatch:        options.IfMatch,
-		IfNoneMatch:    options.IfNoneMatch,
+		IfMatch:        (*string)(options.IfMatch),
+		IfNoneMatch:    (*string)(options.IfNoneMatch),
 		Select:         options.Select,
 		Snapshot:       &snapshotName,
 		Key:            &options.Key,
 		Label:          &options.Label,
-	}
-	ssRespPager := c.appConfigClient.NewGetKeyValuesPager(&opts)
+	})
 
 	return runtime.NewPager(runtime.PagingHandler[ListSettingsForSnapshotResponse]{
 		More: func(ListSettingsForSnapshotResponse) bool {
@@ -445,15 +442,15 @@ func (c *Client) GetSnapshot(ctx context.Context, snapshotName string, options *
 		options = &GetSnapshotOptions{}
 	}
 
-	opts := (*generated.AzureAppConfigurationClientGetSnapshotOptions)(options)
-
-	getResp, err := c.appConfigClient.GetSnapshot(ctx, snapshotName, opts)
+	getResp, err := c.appConfigClient.GetSnapshot(ctx, snapshotName, &generated.AzureAppConfigurationClientGetSnapshotOptions{
+		IfMatch:     (*string)(options.IfMatch),
+		IfNoneMatch: options.IfNoneMatch,
+		Select:      options.Select,
+	})
 
 	if err != nil {
 		return GetSnapshotResponse{}, err
 	}
-
-	convertedETag := azcore.ETag(*getResp.Etag)
 
 	convertedFilters := make([]SettingFilter, len(getResp.Filters))
 	for i := range getResp.Filters {
@@ -470,7 +467,7 @@ func (c *Client) GetSnapshot(ctx context.Context, snapshotName string, options *
 			RetentionPeriod: getResp.RetentionPeriod,
 			Tags:            getResp.Tags,
 			Created:         getResp.Created,
-			ETag:            &convertedETag,
+			ETag:            (*azcore.ETag)(getResp.Etag),
 			Expires:         getResp.Expires,
 			ItemsCount:      getResp.ItemsCount,
 			Name:            getResp.Snapshot.Name,
@@ -541,15 +538,14 @@ func (c *Client) updateSnapshotStatus(ctx context.Context, snapshotName string, 
 		Status: &status,
 	}
 
-	opts := (*generated.AzureAppConfigurationClientUpdateSnapshotOptions)(options)
-
-	updateResp, err := c.appConfigClient.UpdateSnapshot(ctx, snapshotName, entity, opts)
+	updateResp, err := c.appConfigClient.UpdateSnapshot(ctx, snapshotName, entity, &generated.AzureAppConfigurationClientUpdateSnapshotOptions{
+		IfMatch:     (*string)(options.IfMatch),
+		IfNoneMatch: (*string)(options.IfNoneMatch),
+	})
 
 	if err != nil {
 		return updateSnapshotStatusResponse{}, err
 	}
-
-	convertedETag := azcore.ETag(*updateResp.Etag)
 
 	convertedFilters := make([]SettingFilter, len(updateResp.Filters))
 	for i := range updateResp.Filters {
@@ -566,7 +562,7 @@ func (c *Client) updateSnapshotStatus(ctx context.Context, snapshotName string, 
 			RetentionPeriod: updateResp.RetentionPeriod,
 			Tags:            updateResp.Tags,
 			Created:         updateResp.Created,
-			ETag:            &convertedETag,
+			ETag:            (*azcore.ETag)(updateResp.Etag),
 			Expires:         updateResp.Expires,
 			ItemsCount:      updateResp.ItemsCount,
 			Name:            updateResp.Snapshot.Name,

--- a/sdk/data/azappconfig/options.go
+++ b/sdk/data/azappconfig/options.go
@@ -28,6 +28,8 @@ type DeleteSettingOptions struct {
 
 	// If set, and the configuration setting exists in the configuration store,
 	// delete the setting if the passed-in ETag is the same as the setting's ETag in the configuration store.
+	//
+	// This has IfMatch semantics.
 	OnlyIfUnchanged *azcore.ETag
 }
 
@@ -41,6 +43,8 @@ type GetSettingOptions struct {
 
 	// If set, only retrieve the setting from the configuration store if setting has changed
 	// since the client last retrieved it with the ETag provided.
+	//
+	// This has IfNoneMatch semantics.
 	OnlyIfChanged *azcore.ETag
 }
 
@@ -61,6 +65,8 @@ type SetReadOnlyOptions struct {
 
 	// If set, and the configuration setting exists in the configuration store, update the setting
 	// if the passed-in configuration setting ETag is the same version as the one in the configuration store.
+	//
+	// This has IfMatch semantics.
 	OnlyIfUnchanged *azcore.ETag
 }
 
@@ -74,6 +80,8 @@ type SetSettingOptions struct {
 
 	// If set, and the configuration setting exists in the configuration store, overwrite the setting
 	// if the passed-in ETag is the same version as the one in the configuration store.
+	//
+	// This has IfMatch semantics.
 	OnlyIfUnchanged *azcore.ETag
 }
 
@@ -99,19 +107,19 @@ type CreateSnapshotOptions struct {
 // ArchiveSnapshotOptions contains the optional parameters for the ArchiveSnapshot method.
 type ArchiveSnapshotOptions struct {
 	// Used to perform an operation only if the targeted resource's etag matches the value provided.
-	IfMatch *string
+	IfMatch *azcore.ETag
 
 	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
-	IfNoneMatch *string
+	IfNoneMatch *azcore.ETag
 }
 
 // RestoreSnapshotOptions contains the optional parameters for the RestoreSnapshot method.
 type RestoreSnapshotOptions struct {
 	// Used to perform an operation only if the targeted resource's etag matches the value provided.
-	IfMatch *string
+	IfMatch *azcore.ETag
 
 	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
-	IfNoneMatch *string
+	IfNoneMatch *azcore.ETag
 }
 
 // ListSnapshotsOptions contains the optional parameters for the ListSnapshotsPager method.
@@ -138,10 +146,10 @@ type ListSettingsForSnapshotOptions struct {
 	After *string
 
 	// Used to perform an operation only if the targeted resource's etag matches the value provided.
-	IfMatch *string
+	IfMatch *azcore.ETag
 
 	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
-	IfNoneMatch *string
+	IfNoneMatch *azcore.ETag
 
 	// Used to select what fields are present in the returned resource(s).
 	Select []SettingFields
@@ -156,7 +164,7 @@ type ListSettingsForSnapshotOptions struct {
 // GetSnapshotOptions contains the optional parameters for the GetSnapshot method.
 type GetSnapshotOptions struct {
 	// Used to perform an operation only if the targeted resource's etag matches the value provided.
-	IfMatch *string
+	IfMatch *azcore.ETag
 
 	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
 	IfNoneMatch *string
@@ -168,17 +176,17 @@ type GetSnapshotOptions struct {
 // RecoverSnapshotOptions contains the optional parameters for the RecoverSnapshot method.
 type RecoverSnapshotOptions struct {
 	// Used to perform an operation only if the targeted resource's etag matches the value provided.
-	IfMatch *string
+	IfMatch *azcore.ETag
 
 	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
-	IfNoneMatch *string
+	IfNoneMatch *azcore.ETag
 }
 
 // UpdateSnapshotStatusOptions contains the optional parameters for the UpdateSnapshotStatus method.
 type updateSnapshotStatusOptions struct {
 	// Used to perform an operation only if the targeted resource's etag matches the value provided.
-	IfMatch *string
+	IfMatch *azcore.ETag
 
 	// Used to perform an operation only if the targeted resource's etag does not match the value provided.
-	IfNoneMatch *string
+	IfNoneMatch *azcore.ETag
 }


### PR DESCRIPTION
Use azcore.ETag instead of string for public surface area. Add doc comments for non-standard ETag option names.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
