### PR TITLE
[Cosmos] Adds global endpoint manager policy and links GEM to client

### DIFF
--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_policy.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_policy.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+type globalEndpointManagerPolicy struct {
+	gem *globalEndpointManager
+}
+
+func (p *globalEndpointManagerPolicy) Do(req *policy.Request) (*http.Response, error) {
+	shouldRefresh := p.gem.ShouldRefresh()
+	if shouldRefresh {
+		fmt.Println("should refresh true go routine")
+		go p.gem.Update(context.Background())
+	}
+	fmt.Println("policy done")
+	return req.Next()
+}


### PR DESCRIPTION
These changes add the global endpoint manager policy to the SDK and client, which will periodically run checks for updates in the user's Database Account information and keep the SDK updated to any changes in the account regions. This PR also links the GEM to the client, a link that had been previously missing.

One last thing missing is the merging of the preferred regions PR (https://github.com/Azure/azure-sdk-for-go/pull/22206) since that will also propagate the preferred regions to the global endpoint manager as opposed to it being an empty list.