### PR TITLE
Handle errors in mod tidy script

### DIFF
--- a/eng/scripts/modtidy.ps1
+++ b/eng/scripts/modtidy.ps1
@@ -4,12 +4,20 @@ Param(
 
 $modFiles = Get-ChildItem -Path $searchPath -Include "go.mod" -Recurse
 
-$modFiles | ForEach-Object -Parallel {
-    Push-Location $_.Directory
+$tidyErrors = $modFiles | ForEach-Object -Parallel {
+    Set-Location $_.Directory
     Write-Host (Get-Location)
-    go mod tidy
-    Pop-Location
+    $output = go mod tidy 2>&1
     if ($LASTEXITCODE) {
-        exit 1
+        return @{ Directory = $_.Directory; Output = $output }
     }
+}
+
+if ($tidyErrors) {
+    Write-Error "Encountered the following tidy failures:" -ErrorAction 'Continue'
+    foreach ($err in $tidyErrors) {
+        Write-Host "=== $($err.Directory) ==="
+        $err.Output
+    }
+    exit 1
 }


### PR DESCRIPTION
Currently the script will not fail (due to exits being ignored in the parallel run context) which could present problems in the future if it is called in pipelines.
