### PR TITLE
[CODEOWNERS] Remove automation section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,13 +57,6 @@
 # PRLabel: %Open Telemetry
 /sdk/tracing/azotel           @jhendrixMSFT @rickwinter
 
-################
-# Automation
-################
-
-# Git Hub integration and bot rules
-/.github/                    @benbp @jsquire @jhendrixMSFT @rickwinter @ronniegeraghty
-
 ###########
 # Eng Sys
 ###########


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the automation section, as CODEOWNERS changes no longer require manual syncing.