### PR TITLE
Fix allowed tenants for InteractiveBrowserCredential

### DIFF
--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -634,6 +634,9 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 				// the specified tenant isn't allowed, so the error should be about that
 				require.ErrorContains(t, err, "AdditionallyAllowedTenants")
 			} else {
+				// tenant resolution should have succeeded because the specified tenant is allowed,
+				// however the credential should have returned a different error because automatic
+				// authentication is disabled
 				require.ErrorIs(t, ErrAuthenticationRequired, err)
 			}
 		})

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -619,6 +619,25 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run(credNameBrowser, func(t *testing.T) {
+			c, err := NewInteractiveBrowserCredential(&InteractiveBrowserCredentialOptions{
+				AdditionallyAllowedTenants: test.allowed,
+				// this enables testing the credential's tenant resolution without having to authenticate
+				DisableAutomaticAuthentication: true,
+			})
+			require.NoError(t, err)
+			_, err = c.GetToken(context.Background(), tro)
+			// GetToken should return an error in all cases because automatic authentication is disabled
+			require.Error(t, err)
+			if test.err {
+				// the specified tenant isn't allowed, so the error should be about that
+				require.ErrorContains(t, err, "AdditionallyAllowedTenants")
+			} else {
+				require.ErrorIs(t, ErrAuthenticationRequired, err)
+			}
+		})
+
 		for _, credName := range []string{credNameAzureCLI, credNameAzureDeveloperCLI} {
 			t.Run(fmt.Sprintf("DefaultAzureCredential/%s/%s", credName, test.desc), func(t *testing.T) {
 				typeName := fmt.Sprintf("%T", &AzureCLICredential{})

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -628,8 +628,6 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 			})
 			require.NoError(t, err)
 			_, err = c.GetToken(context.Background(), tro)
-			// GetToken should return an error in all cases because automatic authentication is disabled
-			require.Error(t, err)
 			if test.err {
 				// the specified tenant isn't allowed, so the error should be about that
 				require.ErrorContains(t, err, "AdditionallyAllowedTenants")

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -81,6 +81,7 @@ func NewInteractiveBrowserCredential(options *InteractiveBrowserCredentialOption
 	}
 	cp.init()
 	msalOpts := publicClientOptions{
+		AdditionallyAllowedTenants:     cp.AdditionallyAllowedTenants,
 		ClientOptions:                  cp.ClientOptions,
 		DisableAutomaticAuthentication: cp.DisableAutomaticAuthentication,
 		DisableInstanceDiscovery:       cp.DisableInstanceDiscovery,


### PR DESCRIPTION
Looks like I broke this in #21333 and since v1.4.0 it hasn't been possible to specify additional tenants for `InteractiveBrowserCredential` 😞 

There was a test gap here because at the time the feature could only be tested manually with live resources. The addition of `DisableAutomaticAuthentication` has since made an offline unit test possible because tenant resolution happens before authentication.