### PR TITLE
Added spec location verification to the release pipeline

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -56,6 +56,8 @@ stages:
             deploy:
               steps:
                 - checkout: self
+                - download: current
+                  artifact: 'PackageInfo'
                 - template: /eng/common/pipelines/templates/steps/retain-run.yml
                 - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                   parameters:
@@ -64,6 +66,14 @@ stages:
                     ${{ else }}:
                       PackageName: 'sdk/${{parameters.ServiceDirectory}}'
                     ForRelease: true
+                - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
+                  parameters:
+                    ${{ if startsWith(parameters.ServiceDirectory, '../') }}:
+                      PackageName: "${{replace(parameters.ServiceDirectory, '../', '')}}"
+                    ${{ else }}:
+                      PackageName: 'sdk/${{parameters.ServiceDirectory}}'
+                    ServiceDirectory: ${{parameters.ServiceDirectory}}
+                    ArtifactLocation: $(Pipeline.Workspace)
                 - task: PowerShell@2
                   displayName: 'Verify no replace directives in go.mod file'
                   inputs:

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -18,7 +18,10 @@ steps:
       workingDirectory: $(Pipeline.Workspace)
     displayName: Dump Package properties
     condition: and(succeeded(), ${{ parameters.IsSdkLibrary }})
-
+  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+    parameters:
+      ArtifactPath: $(Build.ArtifactStagingDirectory)/PackageInfo
+      ArtifactName: 'PackageInfo'
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
 
   - task: Powershell@2

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -18,10 +18,12 @@ steps:
       workingDirectory: $(Pipeline.Workspace)
     displayName: Dump Package properties
     condition: and(succeeded(), ${{ parameters.IsSdkLibrary }})
-  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
-    parameters:
-      ArtifactPath: $(Build.ArtifactStagingDirectory)/PackageInfo
-      ArtifactName: 'PackageInfo'
+  - task: PublishPipelineArtifact@1
+    condition: and(succeeded(), ${{ parameters.IsSdkLibrary }})
+    displayName: 'Publish PackageInfo Artifacts'
+    inputs:
+      artifactName: 'PackageInfo'
+      path: $(Build.ArtifactStagingDirectory)/PackageInfo
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
 
   - task: Powershell@2


### PR DESCRIPTION
## Purpose of this PR
The purpose is to gate on the REST API specifications used to release SDK are from the main branch of Azure/azure-rest-api-specs repository.

## Linked PRs
The common script and pipeline are merged by another PR.
https://github.com/Azure/azure-sdk-tools/pull/7451

FYI - The same change has been added to the other four tier 1 language release pipelines.
https://github.com/Azure/azure-sdk-for-net/pull/40783

Because Go SDK doesn't have package generated, it needs to add a step to publish the `PackageInfo` as artifact. `PackageInfo` will be used in downstream step to get the sdk directory and the version info.

This PR should hold on the merge until below PR is merged.
https://github.com/Azure/azure-sdk-tools/pull/7585

## Test PR
[aztemplate test pipeline run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3441736&view=logs&j=6a8552c2-2ada-5ee5-a4d2-6fcf45f87c55)

@weshaggard @benbp , can you please review this PR?


