### PR TITLE
Fix azblob/download data race

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fix concurrency issue while Downloading File. Fixes [#22156](https://github.com/Azure/azure-sdk-for-go/issues/22156). 
 
 ### Other Changes
 

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -471,7 +471,7 @@ func (b *Client) downloadFile(ctx context.Context, writer io.Writer, o downloadO
 	buffers := shared.NewMMBPool(int(o.Concurrency), o.BlockSize)
 	defer buffers.Free()
 
-	numChunks := (count-1)/o.BlockSize + 1
+	numChunks := uint16((count-1)/o.BlockSize + 1)
 	for bufferCounter := float64(0); bufferCounter < math.Min(float64(numChunks), float64(o.Concurrency)); bufferCounter++ {
 		if _, err := buffers.Grow(); err != nil {
 			return 0, err
@@ -521,7 +521,7 @@ func (b *Client) downloadFile(ctx context.Context, writer io.Writer, o downloadO
 		OperationName: "downloadBlobToWriterAt",
 		TransferSize:  count,
 		ChunkSize:     o.BlockSize,
-		NumChunks:     uint16(numChunks),
+		NumChunks:     numChunks,
 		Concurrency:   o.Concurrency,
 		Operation: func(ctx context.Context, chunkStart int64, count int64) error {
 			buff, err := acquireBuffer()


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go. 

Please verify the following before submitting your PR, thank you!
-->

In Download File API, method aquireBuffer() in https://github.com/Azure/azure-sdk-for-go/commit/1dc804a987bde7cc943c339b0b374f98c99d30e1 is not thread safe. 
If 2 threads acquire the buffer and both try to increment the _count_ of buffers allocated at the same time, this leads to a Data Race.  

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
