### PR TITLE
[azdatalake] HNS encryption scope

### DIFF
--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0-beta.2 (Unreleased)
 
 ### Features Added
+* HNS Encryption Scope support
 
 ### Breaking Changes
 

--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -8,7 +8,6 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-* Escape paths for NewDirectoryClient and NewFileClient in a file system. Fixes [#22281](https://github.com/Azure/azure-sdk-for-go/issues/22281).
 
 ### Other Changes
 

--- a/sdk/storage/azdatalake/assets.json
+++ b/sdk/storage/azdatalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azdatalake",
-  "Tag": "go/storage/azdatalake_56a4ed6196"
+  "Tag": "go/storage/azdatalake_9248522dce"
 }

--- a/sdk/storage/azdatalake/assets.json
+++ b/sdk/storage/azdatalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azdatalake",
-  "Tag": "go/storage/azdatalake_82ea48120e"
+  "Tag": "go/storage/azdatalake_56a4ed6196"
 }

--- a/sdk/storage/azdatalake/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azdatalake/internal/testcommon/clients_auth.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"testing"
 	"time"
 
@@ -62,6 +63,11 @@ var (
 		EncryptionKey:       &testEncryptedKey,
 		EncryptionKeySHA256: &testEncryptedHash,
 		EncryptionAlgorithm: &testEncryptionAlgorithm,
+	}
+	TestEncryptionScope = "datalaketestencryptionscope"
+	TestCPKScopeInfo    = container.CPKScopeInfo{
+		DefaultEncryptionScope:         &TestEncryptionScope,
+		PreventEncryptionScopeOverride: to.Ptr(false),
 	}
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
