### PR TITLE
[azservicebus] Fixing a memory leak when doing cross receiver settlement.

### DIFF
--- a/sdk/messaging/azservicebus/amqp_message.go
+++ b/sdk/messaging/azservicebus/amqp_message.go
@@ -57,8 +57,6 @@ type AMQPAnnotatedMessage struct {
 	// Properties corresponds to the properties section of an AMQP message.
 	Properties *AMQPAnnotatedMessageProperties
 
-	linkName string
-
 	// inner is the AMQP message we originally received, which contains some hidden
 	// data that's needed to settle with go-amqp. We strip out most of the underlying
 	// data so it's fairly minimal.
@@ -273,7 +271,6 @@ func newAMQPAnnotatedMessage(goAMQPMessage *amqp.Message, receivingLinkName stri
 		DeliveryTag:         goAMQPMessage.DeliveryTag,
 		Footer:              footer,
 		Header:              header,
-		linkName:            receivingLinkName,
 		Properties:          properties,
 		inner:               goAMQPMessage,
 	}

--- a/sdk/messaging/azservicebus/internal/mgmt.go
+++ b/sdk/messaging/azservicebus/internal/mgmt.go
@@ -374,10 +374,10 @@ func SetSessionState(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName str
 	return nil
 }
 
-// SendDisposition allows you settle a message using the management link, rather than via your
+// SettleOnMgmtLink allows you settle a message using the management link, rather than via your
 // *amqp.Receiver. Use this if the receiver has been closed/lost or if the message isn't associated
 // with a link (ex: deferred messages).
-func SendDisposition(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, lockToken *amqp.UUID, state Disposition, propertiesToModify map[string]any) error {
+func SettleOnMgmtLink(ctx context.Context, rpcLink amqpwrap.RPCLink, linkName string, lockToken *amqp.UUID, state Disposition, propertiesToModify map[string]any) error {
 	if lockToken == nil {
 		err := errors.New("lock token on the message is not set, thus cannot send disposition")
 		return err

--- a/sdk/messaging/azservicebus/internal/mock/emulation/events.go
+++ b/sdk/messaging/azservicebus/internal/mock/emulation/events.go
@@ -68,6 +68,7 @@ const (
 	DispositionTypeAccept  DispositionType = "accept"
 	DispositionTypeReject  DispositionType = "reject"
 	DispositionTypeRelease DispositionType = "release"
+	DispositionTypeModify  DispositionType = "modify" // used for abandoning a message
 )
 
 type DispositionEvent struct {

--- a/sdk/messaging/azservicebus/internal/stress/Chart.lock
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.3.0
-digest: sha256:3e21a7fdf5d6b37e871a6dd9f755888166fbb24802aa517f51d1d9223b47656e
-generated: "2023-09-26T11:43:56.706771668-07:00"
+  version: 0.3.1
+digest: sha256:28e374f8db5c46447b2a1491d4361ceb126536c425cbe54be49017120fe7b27d
+generated: "2024-02-05T17:21:31.510400504-08:00"

--- a/sdk/messaging/azservicebus/internal/stress/Dockerfile
+++ b/sdk/messaging/azservicebus/internal/stress/Dockerfile
@@ -6,6 +6,8 @@ ENV CGO_ENABLED=0
 ADD . /src
 WORKDIR /src/internal/stress
 RUN go build -o stress .
+WORKDIR /src/internal/stress/tests/benchmarks
+RUN go test -c
 
 # The first container is just for building the artifacts, and contains all the source, etc...
 # That container instance only ever lives on your local machine (or the build machine).
@@ -15,5 +17,6 @@ RUN go build -o stress .
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 WORKDIR /app
 COPY --from=build /src/internal/stress/stress /app/stress
+COPY --from=build /src/internal/stress/tests/benchmarks/benchmarks.test /app/benchmarks.test
 RUN yum update -y && yum install -y ca-certificates
 ENTRYPOINT ["/bin/bash"]

--- a/sdk/messaging/azservicebus/internal/stress/scenarios-matrix.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/scenarios-matrix.yaml
@@ -1,5 +1,5 @@
 displayNames:
-  # this makes it so these don't show up in the scenario names, 
+  # this makes it so these don't show up in the scenario names,
   # since they're just clutter.
   1.5Gi": ""
   4Gi": ""
@@ -23,7 +23,7 @@ matrix:
       testTarget: finitePeeks
       memory: "0.5Gi"
     finiteSendAndReceive:
-      testTarget: finiteSendAndReceive    
+      testTarget: finiteSendAndReceive
       memory: "0.5Gi"
     finiteSessions:
       testTarget: finiteSessions
@@ -52,10 +52,14 @@ matrix:
       memory: "0.5Gi"
     rapidOpenClose:
       testTarget: rapidOpenClose
-      memory: "0.5Gi"      
+      memory: "0.5Gi"
     receiveCancellation:
       testTarget: receiveCancellation
       memory: "0.5Gi"
     sendAndReceiveDrain:
       testTarget: sendAndReceiveDrain
       memory: "0.5Gi"
+    benchmarkBackupSettlementLeak:
+      benchmark: true
+      testTarget: "BenchmarkBackupSettlementLeakWhileOldReceiverStillAlive"
+      memory: "1.0Gi"

--- a/sdk/messaging/azservicebus/internal/stress/shared/utils.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/utils.go
@@ -30,7 +30,7 @@ func MustGenerateMessages(sc *StressContext, sender *TrackingSender, messageLimi
 
 	log.Printf("Sending %d messages", messageLimit)
 
-	streamingBatch, err := NewStreamingMessageBatch(ctx, &senderWrapper{inner: sender})
+	streamingBatch, err := NewStreamingMessageBatch(ctx, &senderWrapper{inner: sender}, messageLimit)
 	sc.PanicOnError("failed to create streaming batch", err)
 
 	extraBytes := make([]byte, numExtraBytes)

--- a/sdk/messaging/azservicebus/internal/stress/templates/stress-test-job.yaml
+++ b/sdk/messaging/azservicebus/internal/stress/templates/stress-test-job.yaml
@@ -17,7 +17,11 @@ spec:
         - >
           set -ex;
           mkdir -p "$DEBUG_SHARE";
+          {{ if ne .Stress.benchmark true }}
           /app/stress tests "{{ .Stress.testTarget }}" 2>&1 | tee -a "${DEBUG_SHARE}/{{ .Stress.Scenario }}-`date +%s`.log";
+          {{ else }}
+          /app/benchmarks.test -test.timeout 24h -test.bench {{ .Stress.testTarget }} 2>&1 | tee -a "${DEBUG_SHARE}/{{ .Stress.Scenario }}-`date +%s`.log";
+          {{ end }}
       # Pulls the image on pod start, always. We tend to push to the same image and tag over and over again
       # when iterating, so this is a must.
       imagePullPolicy: Always

--- a/sdk/messaging/azservicebus/internal/stress/tests/benchmarks/backup_settlement_leak_test.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/benchmarks/backup_settlement_leak_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package benchmarks
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/stress/shared"
+)
+
+// BackupSettlementLeak checks that, when we use backup settlement, that we're not
+// leaking memory. This came up in a couple of issues for a customer:
+// - https://github.com/Azure/azure-sdk-for-go/issues/22318
+// - https://github.com/Azure/azure-sdk-for-go/issues/22157
+//
+// The use case for backup settlement is for when the original link we've received
+// on has gone offline, so we need to settle via the management$ link instead. However,
+// the underlying go-amqp link is tracking several bits of state for the message which
+// will never get cleared. Since that receiver was dead it was going to get garbage
+// collected anyways, so this was non-issue.
+//
+// This customer's use case was slightly different - they were completing on a separate
+// receiver even when the original receiving link was still alive. This means the memory
+// leak is just accumulating and never gets garbage collected since there's no trigger
+// to know when to clear out any tracking state for the message.
+func BenchmarkBackupSettlementLeakWhileOldReceiverStillAlive(b *testing.B) {
+	b.StopTimer()
+
+	sc := shared.MustCreateStressContext("BenchmarkBackupSettlementLeak", nil)
+	defer sc.End()
+
+	sent := int64(100000)
+
+	client, queueName := mustInitBenchmarkBackupSettlementLeak(sc, b, int(sent))
+
+	oldReceiver, err := client.NewReceiverForQueue(queueName, nil)
+	sc.NoError(err)
+
+	newReceiver, err := client.NewReceiverForQueue(queueName, nil)
+	sc.NoError(err)
+
+	b.StartTimer()
+
+	var completed int64
+	expected := maxDeliveryCount * int64(sent)
+
+	for completed < expected {
+		// receive from the old receiver and...
+		receiveCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+
+		messages, err := oldReceiver.ReceiveMessages(receiveCtx, int(math.Min(float64(expected-completed), 5000)), &azservicebus.ReceiveMessagesOptions{
+			// not super scientific - mostly just want to get slightly fuller batches
+			TimeAfterFirstMessage: 30 * time.Second,
+		})
+		cancel()
+		sc.NoError(err)
+
+		wg := sync.WaitGroup{}
+		wg.Add(len(messages))
+
+		// ...completing on another receiver
+		for _, m := range messages {
+			m := m
+
+			go func() {
+				defer wg.Done()
+
+				// abandon it so we see the message a few times (until it's deadlettered after 10 tries)
+				err := newReceiver.AbandonMessage(context.Background(), m, nil)
+				sc.NoError(err)
+				atomic.AddInt64(&completed, 1)
+			}()
+		}
+
+		wg.Wait()
+
+		b.Logf("Settled %d/%d", completed, sent)
+	}
+
+	log.Printf("Forcing garbage collection\n")
+	runtime.GC()
+	log.Printf("Done with collection\n")
+	time.Sleep(1 * time.Minute)
+}
+
+func mustInitBenchmarkBackupSettlementLeak(sc *shared.StressContext, b *testing.B, numToSend int) (*azservicebus.Client, string) {
+	queueName := fmt.Sprintf("backup-settlement-tester-%s", sc.Nano)
+	shared.MustCreateAutoDeletingQueue(sc, queueName, &admin.QueueProperties{
+		MaxDeliveryCount: to.Ptr[int32](maxDeliveryCount),
+	})
+
+	client, err := azservicebus.NewClientFromConnectionString(sc.ConnectionString, nil)
+	sc.PanicOnError("failed to create client", err)
+
+	sender, err := shared.NewTrackingSender(sc.TC, client, queueName, nil)
+	sc.PanicOnError("create a sender", err)
+
+	shared.MustGenerateMessages(sc, sender, numToSend, 0)
+
+	return client, queueName
+}
+
+const maxDeliveryCount = 20

--- a/sdk/messaging/azservicebus/internal/stress/tests/benchmarks/main_test.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/benchmarks/main_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package benchmarks
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/stress/shared"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("ENV_FILE") == "" {
+		os.Setenv("ENV_FILE", "../../../../.env")
+	}
+
+	err := shared.LoadEnvironment()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(m.Run())
+}

--- a/sdk/messaging/azservicebus/internal/stress/tests/benchmarks/main_test.go
+++ b/sdk/messaging/azservicebus/internal/stress/tests/benchmarks/main_test.go
@@ -19,7 +19,8 @@ func TestMain(m *testing.M) {
 	err := shared.LoadEnvironment()
 
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("Failed to load env file, benchmarks will not run: %s", err)
+		return
 	}
 
 	os.Exit(m.Run())

--- a/sdk/messaging/azservicebus/internal/stress/tests/benchmarks/readme.md
+++ b/sdk/messaging/azservicebus/internal/stress/tests/benchmarks/readme.md
@@ -1,0 +1,9 @@
+## Generating
+
+`go test -memprofile mem.out -bench .`
+
+## Visualizing
+
+Run:
+* `sudo apt install graphviz`
+* `go tool pprof -http localhost:8000 -base mem.out.before_fix mem.out.after_fix`

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -5,6 +5,7 @@ package azservicebus
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/amqpwrap"
@@ -12,32 +13,22 @@ import (
 	"github.com/Azure/go-amqp"
 )
 
-type settler interface {
-	CompleteMessage(ctx context.Context, message *ReceivedMessage, options *CompleteMessageOptions) error
-	AbandonMessage(ctx context.Context, message *ReceivedMessage, options *AbandonMessageOptions) error
-	DeferMessage(ctx context.Context, message *ReceivedMessage, options *DeferMessageOptions) error
-	DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error
-}
-
 type messageSettler struct {
 	links        internal.AMQPLinks
 	retryOptions RetryOptions
 
-	// used only for tests
-	onlyDoBackupSettlement bool
+	// these are used for testing so we can tell which paths we tried to settle.
+	notifySettleOnLink       func(message *ReceivedMessage)
+	notifySettleOnManagement func(message *ReceivedMessage)
 }
 
-func newMessageSettler(links internal.AMQPLinks, retryOptions RetryOptions) settler {
+func newMessageSettler(links internal.AMQPLinks, retryOptions RetryOptions) *messageSettler {
 	return &messageSettler{
-		links:        links,
-		retryOptions: retryOptions,
+		links:                    links,
+		retryOptions:             retryOptions,
+		notifySettleOnLink:       func(message *ReceivedMessage) {},
+		notifySettleOnManagement: func(message *ReceivedMessage) {},
 	}
-}
-
-func (s *messageSettler) useManagementLink(m *ReceivedMessage, receiver amqpwrap.AMQPReceiver) bool {
-	return s.onlyDoBackupSettlement ||
-		m.deferred ||
-		m.RawAMQPMessage.linkName != receiver.LinkName()
 }
 
 func (s *messageSettler) settleWithRetries(ctx context.Context, message *ReceivedMessage, settleFn func(receiver amqpwrap.AMQPReceiver, rpcLink amqpwrap.RPCLink) error) error {
@@ -62,13 +53,22 @@ type CompleteMessageOptions struct {
 }
 
 // CompleteMessage completes a message, deleting it from the queue or subscription.
-func (s *messageSettler) CompleteMessage(ctx context.Context, message *ReceivedMessage, options *CompleteMessageOptions) error {
-	return s.settleWithRetries(ctx, message, func(receiver amqpwrap.AMQPReceiver, rpcLink amqpwrap.RPCLink) error {
-		if s.useManagementLink(message, receiver) {
-			return internal.SendDisposition(ctx, rpcLink, receiver.LinkName(), bytesToAMQPUUID(message.LockToken), internal.Disposition{Status: internal.CompletedDisposition}, nil)
-		} else {
-			return receiver.AcceptMessage(ctx, message.RawAMQPMessage.inner)
+func (ms *messageSettler) CompleteMessage(ctx context.Context, message *ReceivedMessage, options *CompleteMessageOptions) error {
+	return ms.settleWithRetries(ctx, message, func(receiver amqpwrap.AMQPReceiver, rpcLink amqpwrap.RPCLink) error {
+		var err error
+
+		if shouldSettleOnReceiver(message) {
+			ms.notifySettleOnLink(message)
+			err = receiver.AcceptMessage(ctx, message.RawAMQPMessage.inner)
 		}
+
+		if shouldSettleOnMgmtLink(err, message) {
+			ms.notifySettleOnManagement(message)
+			return internal.SettleOnMgmtLink(ctx, rpcLink, receiver.LinkName(),
+				bytesToAMQPUUID(message.LockToken), internal.Disposition{Status: internal.CompletedDisposition}, nil)
+		}
+
+		return err
 	})
 }
 
@@ -81,9 +81,29 @@ type AbandonMessageOptions struct {
 // AbandonMessage will cause a message to be returned to the queue or subscription.
 // This will increment its delivery count, and potentially cause it to be dead lettered
 // depending on your queue or subscription's configuration.
-func (s *messageSettler) AbandonMessage(ctx context.Context, message *ReceivedMessage, options *AbandonMessageOptions) error {
-	return s.settleWithRetries(ctx, message, func(receiver amqpwrap.AMQPReceiver, rpcLink amqpwrap.RPCLink) error {
-		if s.useManagementLink(message, receiver) {
+func (ms *messageSettler) AbandonMessage(ctx context.Context, message *ReceivedMessage, options *AbandonMessageOptions) error {
+	return ms.settleWithRetries(ctx, message, func(receiver amqpwrap.AMQPReceiver, rpcLink amqpwrap.RPCLink) error {
+		var err error
+
+		if shouldSettleOnReceiver(message) {
+			ms.notifySettleOnLink(message)
+
+			var annotations amqp.Annotations
+
+			if options != nil {
+				annotations = newAnnotations(options.PropertiesToModify)
+			}
+
+			err = receiver.ModifyMessage(ctx, message.RawAMQPMessage.inner, &amqp.ModifyMessageOptions{
+				DeliveryFailed:    false,
+				UndeliverableHere: false,
+				Annotations:       annotations,
+			})
+		}
+
+		if shouldSettleOnMgmtLink(err, message) {
+			ms.notifySettleOnManagement(message)
+
 			d := internal.Disposition{
 				Status: internal.AbandonedDisposition,
 			}
@@ -94,20 +114,10 @@ func (s *messageSettler) AbandonMessage(ctx context.Context, message *ReceivedMe
 				propertiesToModify = options.PropertiesToModify
 			}
 
-			return internal.SendDisposition(ctx, rpcLink, receiver.LinkName(), bytesToAMQPUUID(message.LockToken), d, propertiesToModify)
+			return internal.SettleOnMgmtLink(ctx, rpcLink, receiver.LinkName(), bytesToAMQPUUID(message.LockToken), d, propertiesToModify)
 		}
 
-		var annotations amqp.Annotations
-
-		if options != nil {
-			annotations = newAnnotations(options.PropertiesToModify)
-		}
-
-		return receiver.ModifyMessage(ctx, message.RawAMQPMessage.inner, &amqp.ModifyMessageOptions{
-			DeliveryFailed:    false,
-			UndeliverableHere: false,
-			Annotations:       annotations,
-		})
+		return err
 	})
 }
 
@@ -119,9 +129,30 @@ type DeferMessageOptions struct {
 
 // DeferMessage will cause a message to be deferred. Deferred messages
 // can be received using `Receiver.ReceiveDeferredMessages`.
-func (s *messageSettler) DeferMessage(ctx context.Context, message *ReceivedMessage, options *DeferMessageOptions) error {
-	return s.settleWithRetries(ctx, message, func(receiver amqpwrap.AMQPReceiver, rpcLink amqpwrap.RPCLink) error {
-		if s.useManagementLink(message, receiver) {
+func (ms *messageSettler) DeferMessage(ctx context.Context, message *ReceivedMessage, options *DeferMessageOptions) error {
+	return ms.settleWithRetries(ctx, message, func(receiver amqpwrap.AMQPReceiver, rpcLink amqpwrap.RPCLink) error {
+		var err error
+
+		if shouldSettleOnReceiver(message) {
+			ms.notifySettleOnLink(message)
+
+			var annotations amqp.Annotations
+
+			if options != nil {
+				annotations = newAnnotations(options.PropertiesToModify)
+			}
+
+			err = receiver.ModifyMessage(ctx, message.RawAMQPMessage.inner,
+				&amqp.ModifyMessageOptions{
+					DeliveryFailed:    false,
+					UndeliverableHere: true,
+					Annotations:       annotations,
+				})
+		}
+
+		if shouldSettleOnMgmtLink(err, message) {
+			ms.notifySettleOnManagement(message)
+
 			d := internal.Disposition{
 				Status: internal.DeferredDisposition,
 			}
@@ -132,21 +163,10 @@ func (s *messageSettler) DeferMessage(ctx context.Context, message *ReceivedMess
 				propertiesToModify = options.PropertiesToModify
 			}
 
-			return internal.SendDisposition(ctx, rpcLink, receiver.LinkName(), bytesToAMQPUUID(message.LockToken), d, propertiesToModify)
+			return internal.SettleOnMgmtLink(ctx, rpcLink, receiver.LinkName(), bytesToAMQPUUID(message.LockToken), d, propertiesToModify)
 		}
 
-		var annotations amqp.Annotations
-
-		if options != nil {
-			annotations = newAnnotations(options.PropertiesToModify)
-		}
-
-		return receiver.ModifyMessage(ctx, message.RawAMQPMessage.inner,
-			&amqp.ModifyMessageOptions{
-				DeliveryFailed:    false,
-				UndeliverableHere: true,
-				Annotations:       annotations,
-			})
+		return err
 	})
 }
 
@@ -166,8 +186,8 @@ type DeadLetterOptions struct {
 // DeadLetterMessage settles a message by moving it to the dead letter queue for a
 // queue or subscription. To receive these messages create a receiver with `Client.NewReceiver()`
 // using the `SubQueue` option.
-func (s *messageSettler) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
-	return s.settleWithRetries(ctx, message, func(receiver amqpwrap.AMQPReceiver, rpcLink amqpwrap.RPCLink) error {
+func (ms *messageSettler) DeadLetterMessage(ctx context.Context, message *ReceivedMessage, options *DeadLetterOptions) error {
+	return ms.settleWithRetries(ctx, message, func(receiver amqpwrap.AMQPReceiver, rpcLink amqpwrap.RPCLink) error {
 		reason := ""
 		description := ""
 
@@ -181,7 +201,33 @@ func (s *messageSettler) DeadLetterMessage(ctx context.Context, message *Receive
 			}
 		}
 
-		if s.useManagementLink(message, receiver) {
+		var err error
+
+		if shouldSettleOnReceiver(message) {
+			ms.notifySettleOnLink(message)
+
+			info := map[string]any{
+				"DeadLetterReason":           reason,
+				"DeadLetterErrorDescription": description,
+			}
+
+			if options != nil && options.PropertiesToModify != nil {
+				for key, val := range options.PropertiesToModify {
+					info[key] = val
+				}
+			}
+
+			amqpErr := amqp.Error{
+				Condition: "com.microsoft:dead-letter",
+				Info:      info,
+			}
+
+			err = receiver.RejectMessage(ctx, message.RawAMQPMessage.inner, &amqpErr)
+		}
+
+		if shouldSettleOnMgmtLink(err, message) {
+			ms.notifySettleOnManagement(message)
+
 			d := internal.Disposition{
 				Status:                internal.SuspendedDisposition,
 				DeadLetterDescription: &description,
@@ -194,26 +240,10 @@ func (s *messageSettler) DeadLetterMessage(ctx context.Context, message *Receive
 				propertiesToModify = options.PropertiesToModify
 			}
 
-			return internal.SendDisposition(ctx, rpcLink, receiver.LinkName(), bytesToAMQPUUID(message.LockToken), d, propertiesToModify)
+			return internal.SettleOnMgmtLink(ctx, rpcLink, receiver.LinkName(), bytesToAMQPUUID(message.LockToken), d, propertiesToModify)
 		}
 
-		info := map[string]any{
-			"DeadLetterReason":           reason,
-			"DeadLetterErrorDescription": description,
-		}
-
-		if options != nil && options.PropertiesToModify != nil {
-			for key, val := range options.PropertiesToModify {
-				info[key] = val
-			}
-		}
-
-		amqpErr := amqp.Error{
-			Condition: "com.microsoft:dead-letter",
-			Info:      info,
-		}
-
-		return receiver.RejectMessage(ctx, message.RawAMQPMessage.inner, &amqpErr)
+		return err
 	})
 }
 
@@ -234,4 +264,26 @@ func newAnnotations(propertiesToModify map[string]any) amqp.Annotations {
 	}
 
 	return annotations
+}
+
+func shouldSettleOnReceiver(message *ReceivedMessage) bool {
+	// deferred messages always go through the management link
+	return !message.settleOnMgmtLink
+}
+
+func shouldSettleOnMgmtLink(settlementErr error, message *ReceivedMessage) bool {
+	if message.settleOnMgmtLink {
+		// deferred messages always go through the management link
+		return true
+	}
+
+	if settlementErr == nil {
+		// we settled on the original receiver
+		return false
+	}
+
+	// if we got a connection or link error we can try settling against the mgmt link since
+	// our original receiver is gone.
+	var linkErr *amqp.LinkError
+	return errors.As(settlementErr, &linkErr)
 }

--- a/sdk/messaging/azservicebus/receiver_simulated_test.go
+++ b/sdk/messaging/azservicebus/receiver_simulated_test.go
@@ -361,8 +361,6 @@ func TestReceiver_UserFacingErrors(t *testing.T) {
 	messages, err = receiver.ReceiveMessages(context.Background(), 1, nil)
 	require.NoError(t, err)
 	require.Empty(t, messages)
-	// require.ErrorAs(t, err, &asSBError)
-	// require.Equal(t, CodeConnectionLost, asSBError.Code)
 
 	receiveErr = internal.RPCError{Resp: &amqpwrap.RPCResponse{Code: internal.RPCResponseCodeLockLost}}
 
@@ -372,8 +370,10 @@ func TestReceiver_UserFacingErrors(t *testing.T) {
 	msg := &ReceivedMessage{
 		LockToken: id,
 		RawAMQPMessage: &AMQPAnnotatedMessage{
-			linkName: "linkName",
+			inner: &amqp.Message{},
 		},
+		linkName:         "link-name",
+		settleOnMgmtLink: true,
 	}
 
 	err = receiver.AbandonMessage(context.Background(), msg, nil)

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -308,7 +308,7 @@ func TestReceiverDeferAndReceiveDeferredMessages(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, []string{"deferring a message"}, getSortedBodies(deferredMessages))
-	require.True(t, deferredMessages[0].deferred, "internal flag indicating it was from a deferred receiver method is set")
+	require.True(t, deferredMessages[0].settleOnMgmtLink, "deferred messages should always settle on the management link")
 
 	for _, m := range deferredMessages {
 		err = receiver.CompleteMessage(ctx, m, nil)

--- a/sdk/messaging/azservicebus/sender_test.go
+++ b/sdk/messaging/azservicebus/sender_test.go
@@ -550,8 +550,9 @@ func TestSender_SendAMQPMessageWithMultipleByteSlicesInData(t *testing.T) {
 	require.Nil(t, m.Body)
 	require.NotEmpty(t, m.RawAMQPMessage.DeliveryTag)
 
+	require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0], nil))
+
 	// kill some fields that aren't important for this comparison
-	m.RawAMQPMessage.linkName = ""
 	m.RawAMQPMessage.inner = nil
 
 	require.Equal(t, &AMQPAnnotatedMessage{
@@ -586,8 +587,6 @@ func TestSender_SendAMQPMessageWithMultipleByteSlicesInData(t *testing.T) {
 		// as we're not trying to test those necessarily
 		DeliveryTag: m.RawAMQPMessage.DeliveryTag,
 	}, messages[0].RawAMQPMessage)
-
-	require.NoError(t, receiver.CompleteMessage(context.Background(), messages[0], nil))
 }
 
 func TestSender_SendAMQPMessageWithValue(t *testing.T) {


### PR DESCRIPTION
go-amqp holds onto some tracking data that won't get cleared if we don't try to settle through the original Receiver. Our fix in here, combined with go-amqp's changes to route to the original receiver, should seal that up.

Benchmark added that also doubles as a stress test.

Fixes #22318 