### PR TITLE
Storage: Re-enable HTTP endpoints for shared key credential

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Re-enabled `SharedKeyCredential` authentication mode for non TLS protected endpoints.
+
 ### Other Changes
 
 ## 1.3.0 (2024-02-12)

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_9f40a5a13d"
+  "Tag": "go/storage/azblob_71b0a04c12"
 }

--- a/sdk/storage/azblob/internal/exported/shared_key_credential.go
+++ b/sdk/storage/azblob/internal/exported/shared_key_credential.go
@@ -11,9 +11,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 	"net/http"
 	"net/url"
 	"sort"
@@ -204,10 +202,6 @@ func (s *SharedKeyCredPolicy) Do(req *policy.Request) (*http.Response, error) {
 		return req.Next()
 	}
 
-	if err := checkHTTPSForAuth(req); err != nil {
-		return nil, err
-	}
-
 	if d := getHeader(shared.HeaderXmsDate, req.Raw().Header); d == "" {
 		req.Raw().Header.Set(shared.HeaderXmsDate, time.Now().UTC().Format(http.TimeFormat))
 	}
@@ -228,11 +222,4 @@ func (s *SharedKeyCredPolicy) Do(req *policy.Request) (*http.Response, error) {
 		log.Write(azlog.EventResponse, "===== HTTP Forbidden status, String-to-Sign:\n"+stringToSign+"\n===============================\n")
 	}
 	return response, err
-}
-
-func checkHTTPSForAuth(req *policy.Request) error {
-	if strings.ToLower(req.Raw().URL.Scheme) != "https" {
-		return errorinfo.NonRetriableError(errors.New("authenticated requests are not permitted for non TLS protected (https) endpoints"))
-	}
-	return nil
 }

--- a/sdk/storage/azblob/service/client_test.go
+++ b/sdk/storage/azblob/service/client_test.go
@@ -1847,7 +1847,7 @@ func (s *ServiceUnrecordedTestsSuite) TestServiceBlobBatchErrors() {
 	_require.Error(err)
 }
 
-func (s *ServiceRecordedTestsSuite) TestServiceClientRejectHTTP() {
+func (s *ServiceRecordedTestsSuite) TestServiceClientWithHTTP() {
 	_require := require.New(s.T())
 
 	cred, err := testcommon.GetGenericSharedKeyCredential(testcommon.TestAccountDefault)
@@ -1858,6 +1858,7 @@ func (s *ServiceRecordedTestsSuite) TestServiceClientRejectHTTP() {
 
 	_, err = svcClient.GetProperties(context.Background(), nil)
 	_require.Error(err)
+	testcommon.ValidateBlobErrorCode(_require, err, "AccountRequiresHttps")
 }
 
 func (s *ServiceRecordedTestsSuite) TestServiceClientWithNilSharedKey() {

--- a/sdk/storage/azblob/service/client_test.go
+++ b/sdk/storage/azblob/service/client_test.go
@@ -1847,7 +1847,7 @@ func (s *ServiceUnrecordedTestsSuite) TestServiceBlobBatchErrors() {
 	_require.Error(err)
 }
 
-func (s *ServiceRecordedTestsSuite) TestServiceClientWithHTTP() {
+func (s *ServiceUnrecordedTestsSuite) TestServiceClientWithHTTP() {
 	_require := require.New(s.T())
 
 	cred, err := testcommon.GetGenericSharedKeyCredential(testcommon.TestAccountDefault)

--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Re-enabled `SharedKeyCredential` authentication mode for non TLS protected endpoints.
+
 ### Other Changes
 
 ## 1.1.0 (2024-02-14)

--- a/sdk/storage/azdatalake/assets.json
+++ b/sdk/storage/azdatalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azdatalake",
-  "Tag": "go/storage/azdatalake_82ea48120e"
+  "Tag": "go/storage/azdatalake_6e4e5b7c87"
 }

--- a/sdk/storage/azdatalake/internal/exported/shared_key_credential.go
+++ b/sdk/storage/azdatalake/internal/exported/shared_key_credential.go
@@ -13,7 +13,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"net/http"
 	"net/url"
@@ -217,10 +216,6 @@ func (s *SharedKeyCredPolicy) Do(req *policy.Request) (*http.Response, error) {
 		return req.Next()
 	}
 
-	if err := checkHTTPSForAuth(req); err != nil {
-		return nil, err
-	}
-
 	if d := getHeader(shared.HeaderXmsDate, req.Raw().Header); d == "" {
 		req.Raw().Header.Set(shared.HeaderXmsDate, time.Now().UTC().Format(http.TimeFormat))
 	}
@@ -241,12 +236,4 @@ func (s *SharedKeyCredPolicy) Do(req *policy.Request) (*http.Response, error) {
 		log.Write(azlog.EventResponse, "===== HTTP Forbidden status, String-to-Sign:\n"+stringToSign+"\n===============================\n")
 	}
 	return response, err
-}
-
-// TODO: update the azblob dependency having checks for rejecting URLs that are not HTTPS
-func checkHTTPSForAuth(req *policy.Request) error {
-	if strings.ToLower(req.Raw().URL.Scheme) != "https" {
-		return errorinfo.NonRetriableError(errors.New("authenticated requests are not permitted for non TLS protected (https) endpoints"))
-	}
-	return nil
 }

--- a/sdk/storage/azdatalake/service/client_test.go
+++ b/sdk/storage/azdatalake/service/client_test.go
@@ -801,7 +801,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountListFilesystemsEmptyPrefix() {
 	_require.GreaterOrEqual(count, 2)
 }
 
-func (s *ServiceRecordedTestsSuite) TestServiceClientRejectHTTP() {
+func (s *ServiceRecordedTestsSuite) TestServiceClientWithHTTP() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 
@@ -818,6 +818,7 @@ func (s *ServiceRecordedTestsSuite) TestServiceClientRejectHTTP() {
 
 	_, err = fileClient.Create(context.Background(), nil)
 	_require.Error(err)
+	testcommon.ValidateErrorCode(_require, err, "AccountRequiresHttps")
 }
 
 func (s *ServiceRecordedTestsSuite) TestServiceClientWithNilSharedKey() {

--- a/sdk/storage/azdatalake/service/client_test.go
+++ b/sdk/storage/azdatalake/service/client_test.go
@@ -801,7 +801,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountListFilesystemsEmptyPrefix() {
 	_require.GreaterOrEqual(count, 2)
 }
 
-func (s *ServiceRecordedTestsSuite) TestServiceClientWithHTTP() {
+func (s *ServiceUnrecordedTestsSuite) TestServiceClientWithHTTP() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 

--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Re-enabled `SharedKeyCredential` authentication mode for non TLS protected endpoints.
+
 ### Other Changes
 
 ## 1.2.0 (2024-02-12)

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_8f8ed3dd66"
+  "Tag": "go/storage/azfile_e46f674336"
 }

--- a/sdk/storage/azfile/internal/exported/shared_key_credential.go
+++ b/sdk/storage/azfile/internal/exported/shared_key_credential.go
@@ -11,9 +11,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo"
 	"net/http"
 	"net/url"
 	"sort"
@@ -204,10 +202,6 @@ func (s *SharedKeyCredPolicy) Do(req *policy.Request) (*http.Response, error) {
 		return req.Next()
 	}
 
-	if err := checkHTTPSForAuth(req); err != nil {
-		return nil, err
-	}
-
 	if d := getHeader(shared.HeaderXmsDate, req.Raw().Header); d == "" {
 		req.Raw().Header.Set(shared.HeaderXmsDate, time.Now().UTC().Format(http.TimeFormat))
 	}
@@ -228,11 +222,4 @@ func (s *SharedKeyCredPolicy) Do(req *policy.Request) (*http.Response, error) {
 		log.Write(azlog.EventResponse, "===== HTTP Forbidden status, String-to-Sign:\n"+stringToSign+"\n===============================\n")
 	}
 	return response, err
-}
-
-func checkHTTPSForAuth(req *policy.Request) error {
-	if strings.ToLower(req.Raw().URL.Scheme) != "https" {
-		return errorinfo.NonRetriableError(errors.New("authenticated requests are not permitted for non TLS protected (https) endpoints"))
-	}
-	return nil
 }

--- a/sdk/storage/azfile/service/client_test.go
+++ b/sdk/storage/azfile/service/client_test.go
@@ -670,7 +670,7 @@ func (s *ServiceRecordedTestsSuite) TestPremiumAccountListShares() {
 	}
 }
 
-func (s *ServiceRecordedTestsSuite) TestServiceClientRejectHTTP() {
+func (s *ServiceRecordedTestsSuite) TestServiceClientWithHTTP() {
 	_require := require.New(s.T())
 
 	cred, err := testcommon.GetGenericSharedKeyCredential(testcommon.TestAccountDefault)
@@ -681,6 +681,7 @@ func (s *ServiceRecordedTestsSuite) TestServiceClientRejectHTTP() {
 
 	_, err = svcClient.GetProperties(context.Background(), nil)
 	_require.Error(err)
+	testcommon.ValidateFileErrorCode(_require, err, "AccountRequiresHttps")
 }
 
 func (s *ServiceRecordedTestsSuite) TestServiceClientWithNilSharedKey() {

--- a/sdk/storage/azfile/service/client_test.go
+++ b/sdk/storage/azfile/service/client_test.go
@@ -670,7 +670,7 @@ func (s *ServiceRecordedTestsSuite) TestPremiumAccountListShares() {
 	}
 }
 
-func (s *ServiceRecordedTestsSuite) TestServiceClientWithHTTP() {
+func (s *ServiceUnrecordedTestsSuite) TestServiceClientWithHTTP() {
 	_require := require.New(s.T())
 
 	cred, err := testcommon.GetGenericSharedKeyCredential(testcommon.TestAccountDefault)


### PR DESCRIPTION
Revert the change made in #22183 and #21841.

Discussion with PM and some concerns raised on github for this reveals that Azure Stack and Azurite users either prefer or in some cases forced to use HTTP. Not allowing HTTP from SDK side block their setup. Similar issues were faced by AzCopy and Blobfuse in their pipelines to test against Azurite. Hence reverting back the changes and allowing HTTP with key credentials.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
