### PR TITLE
Disable code coverage redesign in CI

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
@@ -35,10 +35,12 @@ stages:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
             go.version: '1.22.0'
+            GOEXPERIMENT: nocoverageredesign
           Windows_Go122:
             pool.name: azsdk-pool-mms-win-2022-general
             image.name: MMS2022
             go.version: '1.22.0'
+            GOEXPERIMENT: nocoverageredesign
       pool:
         name: $(pool.name)
         vmImage: $(image.name)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -110,10 +110,12 @@ stages:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
             go.version: '1.22.0'
+            GOEXPERIMENT: nocoverageredesign
           Windows_Go122:
             pool.name: azsdk-pool-mms-win-2022-general
             image.name: MMS2022
             go.version: '1.22.0'
+            GOEXPERIMENT: nocoverageredesign
             generate.bom: true
       pool:
         name: $(pool.name)

--- a/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
@@ -50,10 +50,12 @@ stages:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
             go.version: '1.22.0'
+            GOEXPERIMENT: nocoverageredesign
           Windows_Go122:
             pool.name: azsdk-pool-mms-win-2022-general
             image.name: MMS2022
             go.version: '1.22.0'
+            GOEXPERIMENT: nocoverageredesign
             generate.bom: true
       pool:
         name: $(pool.name)

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -24,13 +24,13 @@
         },
         "windows-2022": {
           "OSVmImage": "MMS2022",
-          "Pool": "azsdk-pool-mms-win-2022-general",
+          "Pool": "azsdk-pool-mms-win-2022-general"
         }
       },
-      "GOEXPERIMENT": "nocoverageredesign",
       "GoVersion": [
         "1.22.0"
-      ]
+      ],
+      "GOEXPERIMENT": "nocoverageredesign"
     }
   ]
 }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -12,8 +12,25 @@
     },
     "GoVersion": [
       "1.18.10",
-      "1.21.7",
-      "1.22.0"
+      "1.21.7"
     ]
-  }
+  },
+  "include": [
+    {
+      "Agent": {
+        "ubuntu-20.04": {
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general"
+        },
+        "windows-2022": {
+          "OSVmImage": "MMS2022",
+          "Pool": "azsdk-pool-mms-win-2022-general",
+        }
+      },
+      "GOEXPERIMENT": "nocoverageredesign",
+      "GoVersion": [
+        "1.22.0"
+      ]
+    }
+  ]
 }

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -80,7 +80,8 @@ steps:
       ${{ insert }}: ${{ parameters.EnvVars }}
       GOTRACEBACK: all
       AZURE_SDK_GO_LOGGING: all
-      GOEXPERIMENT: nocoverageredesign
+      - ${{ if eq(parameters.GoVersion, '1.22.0') }}:
+        GOEXPERIMENT: nocoverageredesign
 
   - task: PowerShell@2
     displayName: 'Build Performance Tests'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -80,8 +80,6 @@ steps:
       ${{ insert }}: ${{ parameters.EnvVars }}
       GOTRACEBACK: all
       AZURE_SDK_GO_LOGGING: all
-      ${{ if eq(parameters.GoVersion, '1.22.0') }}:
-        GOEXPERIMENT: nocoverageredesign
 
   - task: PowerShell@2
     displayName: 'Build Performance Tests'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -80,6 +80,7 @@ steps:
       ${{ insert }}: ${{ parameters.EnvVars }}
       GOTRACEBACK: all
       AZURE_SDK_GO_LOGGING: all
+      GOEXPERIMENT: nocoverageredesign
 
   - task: PowerShell@2
     displayName: 'Build Performance Tests'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -80,7 +80,7 @@ steps:
       ${{ insert }}: ${{ parameters.EnvVars }}
       GOTRACEBACK: all
       AZURE_SDK_GO_LOGGING: all
-      - ${{ if eq(parameters.GoVersion, '1.22.0') }}:
+      ${{ if eq(parameters.GoVersion, '1.22.0') }}:
         GOEXPERIMENT: nocoverageredesign
 
   - task: PowerShell@2

--- a/sdk/internal/telemetry/telemetry_test.go
+++ b/sdk/internal/telemetry/telemetry_test.go
@@ -16,13 +16,16 @@ func TestFormat(t *testing.T) {
 	// * azsdk-go-azservicebus/v1.0.0 (go1.19.3; linux)
 	// * azsdk-go-azservicebus/v1.0.0 (go1.19; Windows_NT)
 	// * azsdk-go-azservicebus/v1.0.0 (go1.21rc3; linux)
+	// * azsdk-go-azservicebus/v1.0.0 (go1.22.0 X:nocoverageredesign; linux)
 	//
 	// The OS varies based on the actual platform but it's a small set.
 	re := `^azsdk-go-azservicebus/v1.0.0` +
 		` ` +
 		`\(` +
-		`go\d+\.\d+(|\.\d+|rc\d+); (Windows_NT|linux|freebsd)` +
+		`go\d+\.\d+(?:|\.\d+|rc\d+)(?:\s[a-zA-Z0-9|:]+)?; (?:Windows_NT|linux|freebsd)` +
 		`\)$`
 
 	require.Regexp(t, re, userAgent)
+	require.Regexp(t, re, "azsdk-go-azservicebus/v1.0.0 (go1.21rc3; linux)")
+	require.Regexp(t, re, "azsdk-go-azservicebus/v1.0.0 (go1.22.0 X:nocoverageredesign; linux)")
 }


### PR DESCRIPTION
Go 1.22 changed some code coverage internals which is causing some cases to under-report coverage. Disabling for now until this is resolved.

See https://github.com/golang/go/issues/65570