### PR TITLE
SetBodilessMatcher & SetDefaultMatcher take RecordingOptions

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
-## 1.5.3 (Unreleased)
+## 1.6.0 (Unreleased)
 
 ### Features Added
+* Options types for `SetBodilessMatcher` and `SetDefaultMatcher` now embed `RecordingOptions`
 
 ### Breaking Changes
 

--- a/sdk/internal/recording/matchers_test.go
+++ b/sdk/internal/recording/matchers_test.go
@@ -9,12 +9,34 @@ package recording
 import (
 	"bytes"
 	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+func TestSetMatcherRecordingOptions(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+	parsed, err := url.Parse(srv.URL())
+	require.NoError(t, err)
+	port, err := strconv.ParseInt(parsed.Port(), 10, 0)
+	require.NoError(t, err)
+	ro := RecordingOptions{ProxyPort: int(port)}
+	t.Run("SetBodilessMatcher", func(t *testing.T) {
+		err := SetBodilessMatcher(t, &MatcherOptions{RecordingOptions: ro})
+		require.NoError(t, err)
+	})
+	t.Run("SetDefaultMatcher", func(t *testing.T) {
+		err = SetDefaultMatcher(nil, &SetDefaultMatcherOptions{RecordingOptions: ro})
+		require.NoError(t, err)
+	})
+}
 
 type matchersTests struct {
 	suite.Suite

--- a/sdk/internal/version.go
+++ b/sdk/internal/version.go
@@ -11,5 +11,5 @@ const (
 	Module = "internal"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.5.3"
+	Version = "v1.6.0"
 )


### PR DESCRIPTION
#21168 changed the default port for `Set*Matcher()` to a non-deterministic value. That prevents configuring matchers on a test proxy not started by `recording.StartTestProxy` because the default port can't be known before `go test` starts. This PR adds proxy configuration options to these functions, which enables overriding the default port and aligns these functions with the rest of the API e.g. `Add*Sanitizer()`.