### PR TITLE
Exposing x-ms-resource-type response header 

### DIFF
--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Exposing x-ms-resource-type response header in GetProperties API for file and directory.
 
 ### Other Changes
 

--- a/sdk/storage/azdatalake/directory/client_test.go
+++ b/sdk/storage/azdatalake/directory/client_test.go
@@ -2765,7 +2765,7 @@ func (s *RecordedTestSuite) TestDirGetPropertiesResponseCapture() {
 	_require.NoError(err)
 	_require.NotNil(resp2)
 	_require.NotNil(respFromCtxDir) // validate that the respFromCtx is actually populated
-	_require.Equal("directory", respFromCtxDir.Header.Get("x-ms-resource-type"))
+	_require.Equal("directory", *resp2.ResourceType)
 
 	// This tests filesystem.NewClient
 	dirClient = fsClient.NewDirectoryClient(dirName)
@@ -2775,7 +2775,7 @@ func (s *RecordedTestSuite) TestDirGetPropertiesResponseCapture() {
 	_require.NoError(err)
 	_require.NotNil(resp2)
 	_require.NotNil(respFromCtxFs) // validate that the respFromCtx is actually populated
-	_require.Equal("directory", respFromCtxFs.Header.Get("x-ms-resource-type"))
+	_require.Equal("directory", *resp2.ResourceType)
 
 	// This tests service.NewClient
 	serviceClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
@@ -2788,7 +2788,7 @@ func (s *RecordedTestSuite) TestDirGetPropertiesResponseCapture() {
 	_require.NoError(err)
 	_require.NotNil(resp2)
 	_require.NotNil(respFromCtxService) // validate that the respFromCtx is actually populated
-	_require.Equal("directory", respFromCtxService.Header.Get("x-ms-resource-type"))
+	_require.Equal("directory", *resp2.ResourceType)
 }
 
 func (s *RecordedTestSuite) TestDirGetPropertiesWithCPK() {

--- a/sdk/storage/azdatalake/file/client_test.go
+++ b/sdk/storage/azdatalake/file/client_test.go
@@ -12,9 +12,6 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/internal/exported"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/service"
 	"hash/crc64"
 	"io"
 	"math/rand"
@@ -24,6 +21,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/service"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -3180,6 +3181,7 @@ func (s *RecordedTestSuite) TestTinyFileUploadFile() {
 	gResp2, err := fClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
 	_require.Equal(*gResp2.ContentLength, fileSize)
+	_require.Equal(*gResp2.ResourceType, "file")
 
 	dResp, err := fClient.DownloadStream(context.Background(), nil)
 	_require.NoError(err)
@@ -4867,7 +4869,7 @@ func (s *RecordedTestSuite) TestFileGetPropertiesResponseCapture() {
 	_require.NoError(err)
 	_require.NotNil(resp2)
 	_require.NotNil(respFromCtxFile) // validate that the respFromCtx is actually populated
-	_require.Equal("file", respFromCtxFile.Header.Get("x-ms-resource-type"))
+	_require.Equal("file", *resp2.ResourceType)
 
 	// This tests filesystem.NewClient
 	fClient = fsClient.NewFileClient(dirName + "/" + fileName)
@@ -4877,7 +4879,7 @@ func (s *RecordedTestSuite) TestFileGetPropertiesResponseCapture() {
 	_require.NoError(err)
 	_require.NotNil(resp2)
 	_require.NotNil(respFromCtxFs) // validate that the respFromCtx is actually populated
-	_require.Equal("file", respFromCtxFs.Header.Get("x-ms-resource-type"))
+	_require.Equal("file", *resp2.ResourceType)
 
 	// This tests service.NewClient
 	serviceClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
@@ -4892,7 +4894,7 @@ func (s *RecordedTestSuite) TestFileGetPropertiesResponseCapture() {
 	_require.NoError(err)
 	_require.NotNil(resp2)
 	_require.NotNil(respFromCtxService) // validate that the respFromCtx is actually populated
-	_require.Equal("file", respFromCtxService.Header.Get("x-ms-resource-type"))
+	_require.Equal("file", *resp2.ResourceType)
 
 	// This tests directory.NewClient
 	var respFromCtxDir *http.Response
@@ -4905,7 +4907,7 @@ func (s *RecordedTestSuite) TestFileGetPropertiesResponseCapture() {
 	_require.NoError(err)
 	_require.NotNil(resp2)
 	_require.NotNil(respFromCtxDir) // validate that the respFromCtx is actually populated
-	_require.Equal("file", respFromCtxDir.Header.Get("x-ms-resource-type"))
+	_require.Equal("file", *resp2.ResourceType)
 }
 
 func (s *RecordedTestSuite) TestFileGetPropertiesWithCPK() {

--- a/sdk/storage/azdatalake/internal/path/responses.go
+++ b/sdk/storage/azdatalake/internal/path/responses.go
@@ -7,11 +7,12 @@
 package path
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/internal/generated"
-	"net/http"
-	"time"
 )
 
 // SetAccessControlResponse contains the response fields for the SetAccessControl operation.
@@ -227,6 +228,9 @@ type GetPropertiesResponse struct {
 
 	// Permissions contains the information returned from the x-ms-permissions header response.
 	Permissions *string
+
+	// ResourceType contains the information returned from the x-ms-resource-type header response.
+	ResourceType *string
 }
 
 func FormatGetPropertiesResponse(r *blob.GetPropertiesResponse, rawResponse *http.Response) GetPropertiesResponse {
@@ -285,6 +289,9 @@ func FormatGetPropertiesResponse(r *blob.GetPropertiesResponse, rawResponse *htt
 	}
 	if val := rawResponse.Header.Get("x-ms-permissions"); val != "" {
 		newResp.Permissions = &val
+	}
+	if val := rawResponse.Header.Get("x-ms-resource-type"); val != "" {
+		newResp.ResourceType = &val
 	}
 	return newResp
 }


### PR DESCRIPTION
Exposing x-ms-resource-type response header in GetProperties API for file and directory

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
