### PR TITLE
Some cleanup in aztables

### DIFF
--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -190,13 +190,17 @@ func (t *Client) NewListEntitiesPager(listOptions *ListEntitiesOptions) *runtime
 			if err != nil {
 				return ListEntitiesResponse{}, err
 			}
-			marshalledValue := make([][]byte, 0)
-			for _, e := range resp.TableEntityQueryResponse.Value {
-				m, err := json.Marshal(e)
-				if err != nil {
-					return ListEntitiesResponse{}, err
+
+			var marshalledValue [][]byte
+			if len(resp.TableEntityQueryResponse.Value) > 0 {
+				marshalledValue = make([][]byte, len(resp.TableEntityQueryResponse.Value))
+				for i := range resp.TableEntityQueryResponse.Value {
+					m, err := json.Marshal(resp.TableEntityQueryResponse.Value[i])
+					if err != nil {
+						return ListEntitiesResponse{}, err
+					}
+					marshalledValue[i] = m
 				}
-				marshalledValue = append(marshalledValue, m)
 			}
 
 			return ListEntitiesResponse{

--- a/sdk/data/aztables/models.go
+++ b/sdk/data/aztables/models.go
@@ -91,9 +91,12 @@ func (t *ServiceProperties) toGenerated() *generated.TableServiceProperties {
 }
 
 func toGeneratedCorsRules(corsRules []*CorsRule) []*generated.CorsRule {
-	var ret []*generated.CorsRule
-	for _, c := range corsRules {
-		ret = append(ret, c.toGenerated())
+	if len(corsRules) == 0 {
+		return nil
+	}
+	ret := make([]*generated.CorsRule, len(corsRules))
+	for i := range corsRules {
+		ret[i] = corsRules[i].toGenerated()
 	}
 	return ret
 }

--- a/sdk/data/aztables/options.go
+++ b/sdk/data/aztables/options.go
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package aztables
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	generated "github.com/Azure/azure-sdk-for-go/sdk/data/aztables/internal"
+)
+
+// AddEntityOptions contains optional parameters for Client.AddEntity
+type AddEntityOptions struct {
+	// placeholder for future optional parameters
+}
+
+// CreateTableOptions contains optional parameters for Client.Create and ServiceClient.CreateTable
+type CreateTableOptions struct {
+	// placeholder for future optional parameters
+}
+
+func (c *CreateTableOptions) toGenerated() *generated.TableClientCreateOptions {
+	return &generated.TableClientCreateOptions{}
+}
+
+// DeleteEntityOptions contains optional parameters for Client.DeleteEntity
+type DeleteEntityOptions struct {
+	IfMatch *azcore.ETag
+}
+
+func (d *DeleteEntityOptions) toGenerated() *generated.TableClientDeleteEntityOptions {
+	return &generated.TableClientDeleteEntityOptions{}
+}
+
+// DeleteTableOptions contains optional parameters for Client.Delete and ServiceClient.DeleteTable
+type DeleteTableOptions struct {
+	// placeholder for future optional parameters
+}
+
+func (c *DeleteTableOptions) toGenerated() *generated.TableClientDeleteOptions {
+	return &generated.TableClientDeleteOptions{}
+}
+
+// GetAccessPolicyOptions contains optional parameters for Client.GetAccessPolicy
+type GetAccessPolicyOptions struct {
+	// placeholder for future optional parameters
+}
+
+func (g *GetAccessPolicyOptions) toGenerated() *generated.TableClientGetAccessPolicyOptions {
+	return &generated.TableClientGetAccessPolicyOptions{}
+}
+
+// GetEntityOptions contains optional parameters for Client.GetEntity
+type GetEntityOptions struct {
+	// placeholder for future optional parameters
+}
+
+func (g *GetEntityOptions) toGenerated() (*generated.TableClientQueryEntityWithPartitionAndRowKeyOptions, *generated.QueryOptions) {
+	return &generated.TableClientQueryEntityWithPartitionAndRowKeyOptions{}, &generated.QueryOptions{Format: to.Ptr(generated.ODataMetadataFormatApplicationJSONODataMinimalmetadata)}
+}
+
+// GetPropertiesOptions contains optional parameters for Client.GetProperties
+type GetPropertiesOptions struct {
+	// placeholder for future optional parameters
+}
+
+func (g *GetPropertiesOptions) toGenerated() *generated.ServiceClientGetPropertiesOptions {
+	return &generated.ServiceClientGetPropertiesOptions{}
+}
+
+// GetStatisticsOptions contains optional parameters for ServiceClient.GetStatistics
+type GetStatisticsOptions struct {
+	// placeholder for future optional parameters
+}
+
+func (g *GetStatisticsOptions) toGenerated() *generated.ServiceClientGetStatisticsOptions {
+	return &generated.ServiceClientGetStatisticsOptions{}
+}
+
+// ListEntitiesOptions contains optional parameters for Table.Query
+type ListEntitiesOptions struct {
+	// OData filter expression.
+	Filter *string
+
+	// Select expression using OData notation. Limits the columns on each record
+	// to just those requested, e.g. "$select=PolicyAssignmentId, ResourceId".
+	Select *string
+
+	// Maximum number of records to return.
+	Top *int32
+
+	// The NextPartitionKey to start paging from
+	NextPartitionKey *string
+
+	// The NextRowKey to start paging from
+	NextRowKey *string
+}
+
+func (l *ListEntitiesOptions) toQueryOptions() *generated.QueryOptions {
+	if l == nil {
+		return &generated.QueryOptions{}
+	}
+
+	return &generated.QueryOptions{
+		Filter: l.Filter,
+		Format: to.Ptr(generated.ODataMetadataFormatApplicationJSONODataMinimalmetadata),
+		Select: l.Select,
+		Top:    l.Top,
+	}
+}
+
+// ListTablesOptions contains optional parameters for ServiceClient.QueryTables
+type ListTablesOptions struct {
+	// OData filter expression.
+	Filter *string
+
+	// Select expression using OData notation. Limits the columns on each record to just those requested, e.g. "$select=PolicyAssignmentId, ResourceId".
+	Select *string
+
+	// Maximum number of records to return.
+	Top *int32
+
+	// NextTableName is the continuation token for the next table to page from
+	NextTableName *string
+}
+
+func (l *ListTablesOptions) toQueryOptions() *generated.QueryOptions {
+	if l == nil {
+		return &generated.QueryOptions{}
+	}
+
+	return &generated.QueryOptions{
+		Filter: l.Filter,
+		Format: to.Ptr(generated.ODataMetadataFormatApplicationJSONODataMinimalmetadata),
+		Select: l.Select,
+		Top:    l.Top,
+	}
+}
+
+// SetAccessPolicyOptions contains optional parameters for Client.SetAccessPolicy
+type SetAccessPolicyOptions struct {
+	TableACL []*SignedIdentifier
+}
+
+func (s *SetAccessPolicyOptions) toGenerated() *generated.TableClientSetAccessPolicyOptions {
+	if len(s.TableACL) == 0 {
+		return &generated.TableClientSetAccessPolicyOptions{}
+	}
+	sis := make([]*generated.SignedIdentifier, len(s.TableACL))
+	for i := range s.TableACL {
+		sis[i] = toGeneratedSignedIdentifier(s.TableACL[i])
+	}
+	return &generated.TableClientSetAccessPolicyOptions{
+		TableACL: sis,
+	}
+}
+
+// SetPropertiesOptions contains optional parameters for Client.SetProperties
+type SetPropertiesOptions struct {
+	// placeholder for future optional parameters
+}
+
+func (s *SetPropertiesOptions) toGenerated() *generated.ServiceClientSetPropertiesOptions {
+	return &generated.ServiceClientSetPropertiesOptions{}
+}
+
+// SubmitTransactionOptions contains optional parameters for Client.SubmitTransaction
+type SubmitTransactionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// UpdateEntityOptions contains optional parameters for Client.UpdateEntity
+type UpdateEntityOptions struct {
+	IfMatch    *azcore.ETag
+	UpdateMode UpdateMode
+}
+
+func (u *UpdateEntityOptions) toGeneratedMergeEntity(m map[string]any) *generated.TableClientMergeEntityOptions {
+	if u == nil {
+		return &generated.TableClientMergeEntityOptions{}
+	}
+	return &generated.TableClientMergeEntityOptions{
+		IfMatch:               (*string)(u.IfMatch),
+		TableEntityProperties: m,
+	}
+}
+
+func (u *UpdateEntityOptions) toGeneratedUpdateEntity(m map[string]any) *generated.TableClientUpdateEntityOptions {
+	if u == nil {
+		return &generated.TableClientUpdateEntityOptions{}
+	}
+	return &generated.TableClientUpdateEntityOptions{
+		IfMatch:               (*string)(u.IfMatch),
+		TableEntityProperties: m,
+	}
+}
+
+// UpsertEntityOptions contains optional parameters for Client.InsertEntity
+type UpsertEntityOptions struct {
+	// ETag is the optional etag for the Table
+	ETag azcore.ETag
+
+	// UpdateMode is the desired mode for the Update. Use UpdateModeReplace to replace fields on
+	// the entity, use UpdateModeMerge to merge fields of the entity.
+	UpdateMode UpdateMode
+}

--- a/sdk/data/aztables/responses.go
+++ b/sdk/data/aztables/responses.go
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package aztables
+
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+// AddEntityResponse contains response fields for Client.AddEntityResponse
+type AddEntityResponse struct {
+	ETag azcore.ETag
+}
+
+// CreateTableResponse contains response fields for Client.Create and ServiceClient.CreateTable
+type CreateTableResponse struct {
+	// The name of the table.
+	TableName *string `json:"TableName,omitempty"`
+}
+
+// DeleteEntityResponse contains response fields for Client.DeleteEntity
+type DeleteEntityResponse struct {
+	// placeholder for future optional response fields
+}
+
+// DeleteTableResponse contains response fields for ServiceClient.DeleteTable and Client.Delete
+type DeleteTableResponse struct {
+	// placeholder for future optional response fields
+}
+
+// GetAccessPolicyResponse contains response fields for Client.GetAccessPolicy
+type GetAccessPolicyResponse struct {
+	SignedIdentifiers []*SignedIdentifier
+}
+
+// GetEntityResponse contains response fields for Client.GetEntity
+type GetEntityResponse struct {
+	// ETag contains the information returned from the ETag header response.
+	ETag azcore.ETag
+
+	// The properties of the table entity.
+	Value []byte
+}
+
+// GetPropertiesResponse contains response fields for Client.GetProperties
+type GetPropertiesResponse struct {
+	ServiceProperties
+}
+
+// GetStatisticsResponse contains response fields for Client.GetStatistics
+type GetStatisticsResponse struct {
+	GeoReplication *GeoReplication `xml:"GeoReplication"`
+}
+
+// ListEntitiesResponse contains response fields for ListEntitiesPager.NextPage
+type ListEntitiesResponse struct {
+	// NextPartitionKey contains the information returned from the x-ms-continuation-NextPartitionKey header response.
+	NextPartitionKey *string
+
+	// NextRowKey contains the information returned from the x-ms-continuation-NextRowKey header response.
+	NextRowKey *string
+
+	// List of table entities.
+	Entities [][]byte
+}
+
+// ListTablesResponse contains response fields for ListTablesPager.NextPage
+type ListTablesResponse struct {
+	// NextTableName contains the information returned from the x-ms-continuation-NextTableName header response.
+	NextTableName *string
+
+	// List of tables.
+	Tables []*TableProperties `json:"value,omitempty"`
+}
+
+// SetAccessPolicyResponse contains response fields for Client.SetAccessPolicy
+type SetAccessPolicyResponse struct {
+	// placeholder for future optional parameters
+}
+
+// SetPropertiesResponse contains response fields for Client.SetProperties
+type SetPropertiesResponse struct {
+	// placeholder for future response fields
+}
+
+// TransactionResponse contains response fields for Client.TransactionResponse
+type TransactionResponse struct {
+	// placeholder for future response fields
+}
+
+// UpdateEntityResponse contains response fields for Client.UpdateEntity
+type UpdateEntityResponse struct {
+	ETag azcore.ETag
+}
+
+// UpsertEntityResponse contains response fields for Client.InsertEntity
+type UpsertEntityResponse struct {
+	ETag azcore.ETag
+}

--- a/sdk/data/aztables/transactional_batch.go
+++ b/sdk/data/aztables/transactional_batch.go
@@ -55,16 +55,6 @@ type TransactionAction struct {
 	IfMatch    *azcore.ETag
 }
 
-// TransactionResponse contains response fields for Client.TransactionResponse
-type TransactionResponse struct {
-	// placeholder for future response fields
-}
-
-// SubmitTransactionOptions contains optional parameters for Client.SubmitTransaction
-type SubmitTransactionOptions struct {
-	// placeholder for future optional parameters
-}
-
 // SubmitTransaction submits the table transactional batch according to the slice of TransactionActions provided.
 // All transactionActions must be for entities with the same PartitionKey. There can only be one transaction action
 // for a RowKey, a duplicated row key will return an error. A storage account will return a 202 Accepted response


### PR DESCRIPTION
Moved options and response types to their respective files. Helper funcs that were used in one place have been removed, their contents made inline.
Replaced appending to slices with making the correct size and populating them in place.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
