### PR TITLE
More cleanup in aztables

### DIFF
--- a/sdk/data/aztables/constants.go
+++ b/sdk/data/aztables/constants.go
@@ -3,6 +3,11 @@
 
 package aztables
 
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	generated "github.com/Azure/azure-sdk-for-go/sdk/data/aztables/internal"
+)
+
 const (
 	headerXmsDate                 = "x-ms-date"
 	headerAuthorization           = "Authorization"
@@ -16,6 +21,83 @@ const (
 	partitionKey                  = "PartitionKey"
 	rowKey                        = "RowKey"
 )
+
+// GeoReplicationStatus - The status of the secondary location.
+type GeoReplicationStatus string
+
+const (
+	GeoReplicationStatusBootstrap   GeoReplicationStatus = "bootstrap"
+	GeoReplicationStatusLive        GeoReplicationStatus = "live"
+	GeoReplicationStatusUnavailable GeoReplicationStatus = "unavailable"
+)
+
+// PossibleGeoReplicationStatusValues returns the possible values for the GeoReplicationStatus const type.
+func PossibleGeoReplicationStatusValues() []GeoReplicationStatus {
+	return []GeoReplicationStatus{
+		GeoReplicationStatusBootstrap,
+		GeoReplicationStatusLive,
+		GeoReplicationStatusUnavailable,
+	}
+}
+
+func toGeneratedStatusType(g *generated.GeoReplicationStatusType) *GeoReplicationStatus {
+	if g == nil {
+		return nil
+	}
+	if *g == generated.GeoReplicationStatusTypeBootstrap {
+		return to.Ptr(GeoReplicationStatusBootstrap)
+	}
+	if *g == generated.GeoReplicationStatusTypeLive {
+		return to.Ptr(GeoReplicationStatusLive)
+	}
+	if *g == generated.GeoReplicationStatusTypeUnavailable {
+		return to.Ptr(GeoReplicationStatusUnavailable)
+	}
+	return nil
+}
+
+// SASProtocol indicates the SAS protocol
+type SASProtocol string
+
+const (
+	// SASProtocolHTTPS can be specified for a SAS protocol
+	SASProtocolHTTPS SASProtocol = "https"
+
+	// SASProtocolHTTPSandHTTP can be specified for a SAS protocol
+	SASProtocolHTTPSandHTTP SASProtocol = "https,http"
+)
+
+// PossibleSASProtocolValues returns the possible values for the SASProtocol const type.
+func PossibleSASProtocolValues() []SASProtocol {
+	return []SASProtocol{
+		SASProtocolHTTPS,
+		SASProtocolHTTPSandHTTP,
+	}
+}
+
+// TransactionType is the type for a specific transaction operation.
+type TransactionType string
+
+const (
+	TransactionTypeAdd           TransactionType = "add"
+	TransactionTypeUpdateMerge   TransactionType = "updatemerge"
+	TransactionTypeUpdateReplace TransactionType = "updatereplace"
+	TransactionTypeDelete        TransactionType = "delete"
+	TransactionTypeInsertMerge   TransactionType = "insertmerge"
+	TransactionTypeInsertReplace TransactionType = "insertreplace"
+)
+
+// PossibleTransactionTypeValues returns the possible values for the TransactionType const type.
+func PossibleTransactionTypeValues() []TransactionType {
+	return []TransactionType{
+		TransactionTypeAdd,
+		TransactionTypeUpdateMerge,
+		TransactionTypeUpdateReplace,
+		TransactionTypeDelete,
+		TransactionTypeInsertMerge,
+		TransactionTypeInsertReplace,
+	}
+}
 
 // UpdateMode specifies what type of update to do on UpsertEntity or UpdateEntity. UpdateModeReplace
 // will replace an existing entity, UpdateModeMerge will merge properties of the entities.

--- a/sdk/data/aztables/models.go
+++ b/sdk/data/aztables/models.go
@@ -62,6 +62,17 @@ func fromGeneratedCors(c *generated.CorsRule) *CorsRule {
 	}
 }
 
+func toGeneratedCorsRules(corsRules []*CorsRule) []*generated.CorsRule {
+	if len(corsRules) == 0 {
+		return nil
+	}
+	ret := make([]*generated.CorsRule, len(corsRules))
+	for i := range corsRules {
+		ret[i] = corsRules[i].toGenerated()
+	}
+	return ret
+}
+
 // ServiceProperties - Service Properties for a given table
 type ServiceProperties struct {
 	// The set of CORS rules.
@@ -90,15 +101,10 @@ func (t *ServiceProperties) toGenerated() *generated.TableServiceProperties {
 	}
 }
 
-func toGeneratedCorsRules(corsRules []*CorsRule) []*generated.CorsRule {
-	if len(corsRules) == 0 {
-		return nil
-	}
-	ret := make([]*generated.CorsRule, len(corsRules))
-	for i := range corsRules {
-		ret[i] = corsRules[i].toGenerated()
-	}
-	return ret
+// TableProperties contains the properties for a single Table
+type TableProperties struct {
+	// The name of the table.
+	Name *string `json:"TableName,omitempty"`
 }
 
 // RetentionPolicy - The retention policy.
@@ -317,38 +323,4 @@ func fromGeneratedGeoReplication(g *generated.GeoReplication) *GeoReplication {
 		LastSyncTime: g.LastSyncTime,
 		Status:       toGeneratedStatusType(g.Status),
 	}
-}
-
-// GeoReplicationStatus - The status of the secondary location.
-type GeoReplicationStatus string
-
-const (
-	GeoReplicationStatusBootstrap   GeoReplicationStatus = "bootstrap"
-	GeoReplicationStatusLive        GeoReplicationStatus = "live"
-	GeoReplicationStatusUnavailable GeoReplicationStatus = "unavailable"
-)
-
-// PossibleGeoReplicationStatusValues returns the possible values for the GeoReplicationStatus const type.
-func PossibleGeoReplicationStatusValues() []GeoReplicationStatus {
-	return []GeoReplicationStatus{
-		GeoReplicationStatusBootstrap,
-		GeoReplicationStatusLive,
-		GeoReplicationStatusUnavailable,
-	}
-}
-
-func toGeneratedStatusType(g *generated.GeoReplicationStatusType) *GeoReplicationStatus {
-	if g == nil {
-		return nil
-	}
-	if *g == generated.GeoReplicationStatusTypeBootstrap {
-		return to.Ptr(GeoReplicationStatusBootstrap)
-	}
-	if *g == generated.GeoReplicationStatusTypeLive {
-		return to.Ptr(GeoReplicationStatusLive)
-	}
-	if *g == generated.GeoReplicationStatusTypeUnavailable {
-		return to.Ptr(GeoReplicationStatusUnavailable)
-	}
-	return nil
 }

--- a/sdk/data/aztables/sas_query_params.go
+++ b/sdk/data/aztables/sas_query_params.go
@@ -9,25 +9,6 @@ import (
 	"time"
 )
 
-// SASProtocol indicates the SAS protocol
-type SASProtocol string
-
-const (
-	// SASProtocolHTTPS can be specified for a SAS protocol
-	SASProtocolHTTPS SASProtocol = "https"
-
-	// SASProtocolHTTPSandHTTP can be specified for a SAS protocol
-	SASProtocolHTTPSandHTTP SASProtocol = "https,http"
-)
-
-// PossibleSASProtocolValues returns the possible values for the SASProtocol const type.
-func PossibleSASProtocolValues() []SASProtocol {
-	return []SASProtocol{
-		SASProtocolHTTPS,
-		SASProtocolHTTPSandHTTP,
-	}
-}
-
 // FormatTimesForSASSigning converts a time.Time to a snapshotTimeFormat string suitable for a
 // SASField's StartTime or ExpiryTime fields. Returns "" if value.IsZero().
 func FormatTimesForSASSigning(startTime, expiryTime time.Time) (string, string) {

--- a/sdk/data/aztables/service_client.go
+++ b/sdk/data/aztables/service_client.go
@@ -121,12 +121,6 @@ func (t *ServiceClient) DeleteTable(ctx context.Context, name string, options *D
 	return DeleteTableResponse{}, err
 }
 
-// TableProperties contains the properties for a single Table
-type TableProperties struct {
-	// The name of the table.
-	Name *string `json:"TableName,omitempty"`
-}
-
 // NewListTablesPager queries the existing tables using the specified ListTablesOptions.
 // listOptions can specify the following properties to affect the query results returned:
 //

--- a/sdk/data/aztables/transactional_batch.go
+++ b/sdk/data/aztables/transactional_batch.go
@@ -24,30 +24,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"
 )
 
-// TransactionType is the type for a specific transaction operation.
-type TransactionType string
-
-const (
-	TransactionTypeAdd           TransactionType = "add"
-	TransactionTypeUpdateMerge   TransactionType = "updatemerge"
-	TransactionTypeUpdateReplace TransactionType = "updatereplace"
-	TransactionTypeDelete        TransactionType = "delete"
-	TransactionTypeInsertMerge   TransactionType = "insertmerge"
-	TransactionTypeInsertReplace TransactionType = "insertreplace"
-)
-
-// PossibleTransactionTypeValues returns the possible values for the TransactionType const type.
-func PossibleTransactionTypeValues() []TransactionType {
-	return []TransactionType{
-		TransactionTypeAdd,
-		TransactionTypeUpdateMerge,
-		TransactionTypeUpdateReplace,
-		TransactionTypeDelete,
-		TransactionTypeInsertMerge,
-		TransactionTypeInsertReplace,
-	}
-}
-
 // TransactionAction represents a single action within a Transaction
 type TransactionAction struct {
 	ActionType TransactionType


### PR DESCRIPTION
Moved constant definitions to constants.go.
Moved struct definitions to models.go.
Moved internal helper funcs next to their types.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
