### PR TITLE
azblob: Random write in DownloadFile

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 * Re-enabled `SharedKeyCredential` authentication mode for non TLS protected endpoints.
+* Use random write in `DownloadFile` method. Fixes [#22426](https://github.com/Azure/azure-sdk-for-go/issues/22426).
 
 ### Other Changes
 

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -9,7 +9,6 @@ package blob
 import (
 	"context"
 	"io"
-	"math"
 	"os"
 	"sync"
 	"time"
@@ -359,7 +358,7 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 		OperationName: "downloadBlobToWriterAt",
 		TransferSize:  count,
 		ChunkSize:     o.BlockSize,
-		NumChunks:     uint16(((count - 1) / o.BlockSize) + 1),
+		NumChunks:     uint64(((count - 1) / o.BlockSize) + 1),
 		Concurrency:   o.Concurrency,
 		Operation: func(ctx context.Context, chunkStart int64, count int64) error {
 			downloadBlobOptions := o.getDownloadBlobOptions(HTTPRange{
@@ -396,165 +395,6 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 		return 0, err
 	}
 	return count, nil
-}
-
-// downloadFile downloads an Azure blob to a Writer. The blocks are downloaded parallely,
-// but written to file serially
-func (b *Client) downloadFile(ctx context.Context, writer io.Writer, o downloadOptions) (int64, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	if o.BlockSize == 0 {
-		o.BlockSize = DefaultDownloadBlockSize
-	}
-
-	if o.Concurrency == 0 {
-		o.Concurrency = DefaultConcurrency
-	}
-
-	count := o.Range.Count
-	if count == CountToEnd { //Calculate size if not specified
-		gr, err := b.GetProperties(ctx, o.getBlobPropertiesOptions())
-		if err != nil {
-			return 0, err
-		}
-		count = *gr.ContentLength - o.Range.Offset
-	}
-
-	if count <= 0 {
-		// The file is empty, there is nothing to download.
-		return 0, nil
-	}
-
-	progress := int64(0)
-	progressLock := &sync.Mutex{}
-
-	// helper routine to get body
-	getBodyForRange := func(ctx context.Context, chunkStart, size int64) (io.ReadCloser, error) {
-		downloadBlobOptions := o.getDownloadBlobOptions(HTTPRange{
-			Offset: chunkStart + o.Range.Offset,
-			Count:  size,
-		}, nil)
-		dr, err := b.DownloadStream(ctx, downloadBlobOptions)
-		if err != nil {
-			return nil, err
-		}
-
-		var body io.ReadCloser = dr.NewRetryReader(ctx, &o.RetryReaderOptionsPerBlock)
-		if o.Progress != nil {
-			rangeProgress := int64(0)
-			body = streaming.NewResponseProgress(
-				body,
-				func(bytesTransferred int64) {
-					diff := bytesTransferred - rangeProgress
-					rangeProgress = bytesTransferred
-					progressLock.Lock()
-					progress += diff
-					o.Progress(progress)
-					progressLock.Unlock()
-				})
-		}
-
-		return body, nil
-	}
-
-	// if file fits in a single buffer, we'll download here.
-	if count <= o.BlockSize {
-		body, err := getBodyForRange(ctx, int64(0), count)
-		if err != nil {
-			return 0, err
-		}
-		defer body.Close()
-
-		return io.Copy(writer, body)
-	}
-
-	buffers := shared.NewMMBPool(int(o.Concurrency), o.BlockSize)
-	defer buffers.Free()
-
-	numChunks := uint16((count-1)/o.BlockSize + 1)
-	for bufferCounter := float64(0); bufferCounter < math.Min(float64(numChunks), float64(o.Concurrency)); bufferCounter++ {
-		if _, err := buffers.Grow(); err != nil {
-			return 0, err
-		}
-	}
-
-	acquireBuffer := func() ([]byte, error) {
-		return <-buffers.Acquire(), nil
-	}
-
-	blocks := make([]chan []byte, numChunks)
-	for b := range blocks {
-		blocks[b] = make(chan []byte)
-	}
-
-	/*
-	 * We have created as many channels as the number of chunks we have.
-	 * Each downloaded block will be sent to the channel matching its
-	 * sequence number, i.e. 0th block is sent to 0th channel, 1st block
-	 * to 1st channel and likewise. The blocks are then read and written
-	 * to the file serially by below goroutine. Do note that the blocks
-	 * are still downloaded parallelly from n/w, only serialized
-	 * and written to file here.
-	 */
-	writerError := make(chan error)
-	writeSize := int64(0)
-	go func(ch chan error) {
-		for _, block := range blocks {
-			select {
-			case <-ctx.Done():
-				return
-			case block := <-block:
-				n, err := writer.Write(block)
-				writeSize += int64(n)
-				buffers.Release(block[:cap(block)])
-				if err != nil {
-					ch <- err
-					return
-				}
-			}
-		}
-		ch <- nil
-	}(writerError)
-
-	// Prepare and do parallel download.
-	err := shared.DoBatchTransfer(ctx, &shared.BatchTransferOptions{
-		OperationName: "downloadBlobToWriterAt",
-		TransferSize:  count,
-		ChunkSize:     o.BlockSize,
-		NumChunks:     numChunks,
-		Concurrency:   o.Concurrency,
-		Operation: func(ctx context.Context, chunkStart int64, count int64) error {
-			buff, err := acquireBuffer()
-			if err != nil {
-				return err
-			}
-
-			body, err := getBodyForRange(ctx, chunkStart, count)
-			if err != nil {
-				buffers.Release(buff)
-				return nil
-			}
-
-			_, err = io.ReadFull(body, buff[:count])
-			body.Close()
-			if err != nil {
-				return err
-			}
-
-			blockIndex := chunkStart / o.BlockSize
-			blocks[blockIndex] <- buff[:count]
-			return nil
-		},
-	})
-
-	if err != nil {
-		return 0, err
-	}
-	// error from writer thread.
-	if err = <-writerError; err != nil {
-		return 0, err
-	}
-	return writeSize, nil
 }
 
 // DownloadStream reads a range of bytes from a blob. The response also includes the blob's properties and metadata.
@@ -596,11 +436,6 @@ func (b *Client) DownloadFile(ctx context.Context, file *os.File, o *DownloadFil
 	}
 	do := (*downloadOptions)(o)
 
-	filePointer, err := file.Seek(0, io.SeekCurrent)
-	if err != nil {
-		return 0, err
-	}
-
 	// 1. Calculate the size of the destination file
 	var size int64
 
@@ -629,15 +464,7 @@ func (b *Client) DownloadFile(ctx context.Context, file *os.File, o *DownloadFil
 	}
 
 	if size > 0 {
-		writeSize, err := b.downloadFile(ctx, file, *do)
-		if err != nil {
-			return 0, err
-		}
-		_, err = file.Seek(filePointer, io.SeekStart)
-		if err != nil {
-			return 0, err
-		}
-		return writeSize, nil
+		return b.downloadBuffer(ctx, file, *do)
 	} else { // if the blob's size is 0, there is no need in downloading it
 		return 0, nil
 	}

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -13,11 +13,14 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3744,4 +3747,60 @@ func (s *BlobRecordedTestsSuite) TestBlobClientCustomAudience() {
 
 	_, err = blobClientAudience.GetProperties(context.Background(), nil)
 	_require.NoError(err)
+}
+
+type fakeDownloadBlob struct {
+	contentSize int64
+	numChunks   atomic.Uint64
+}
+
+func (f *fakeDownloadBlob) Do(req *http.Request) (*http.Response, error) {
+	// check how many times range based get blob is called
+	if _, ok := req.Header["x-ms-range"]; ok {
+		f.numChunks.Add(1)
+	}
+	return &http.Response{
+		Request:    req,
+		Status:     "Created",
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Length": []string{fmt.Sprintf("%v", f.contentSize)}},
+		Body:       http.NoBody,
+	}, nil
+}
+
+func TestDownloadSmallBlockSize(t *testing.T) {
+	_require := require.New(t)
+
+	fileSize := int64(100 * 1024 * 1024)
+	blockSize := int64(1024)
+	numChunks := uint64(((fileSize - 1) / blockSize) + 1)
+	fbb := &fakeDownloadBlob{
+		contentSize: fileSize,
+	}
+	blobClient, err := blockblob.NewClientWithNoCredential("https://fake/blob/path", &blockblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: fbb,
+		},
+	})
+	_require.NoError(err)
+	_require.NotNil(blobClient)
+
+	// download to a temp file and verify contents
+	tmp, err := os.CreateTemp("", "")
+	_require.NoError(err)
+	defer tmp.Close()
+
+	_, err = blobClient.DownloadFile(context.Background(), tmp, &blob.DownloadFileOptions{BlockSize: blockSize})
+	_require.NoError(err)
+
+	_require.Equal(fbb.numChunks.Load(), numChunks)
+
+	// reset counter
+	fbb.numChunks.Store(0)
+
+	buff := make([]byte, fileSize)
+	_, err = blobClient.DownloadBuffer(context.Background(), buff, &blob.DownloadBufferOptions{BlockSize: blockSize})
+	_require.NoError(err)
+
+	_require.Equal(fbb.numChunks.Load(), numChunks)
 }

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -474,7 +474,7 @@ func (bb *Client) uploadFromReader(ctx context.Context, reader io.ReaderAt, actu
 		OperationName: "uploadFromReader",
 		TransferSize:  actualSize,
 		ChunkSize:     o.BlockSize,
-		NumChunks:     uint16(((actualSize - 1) / o.BlockSize) + 1),
+		NumChunks:     uint64(((actualSize - 1) / o.BlockSize) + 1),
 		Concurrency:   o.Concurrency,
 		Operation: func(ctx context.Context, offset int64, chunkSize int64) error {
 			// This function is called once per block.

--- a/sdk/storage/azblob/client_test.go
+++ b/sdk/storage/azblob/client_test.go
@@ -449,7 +449,6 @@ func performUploadAndDownloadFileTest(t *testing.T, _require *require.Assertions
 		destBuffer = make([]byte, downloadCount)
 	}
 
-	_require.NoError(err)
 	n, err := destFile.Read(destBuffer)
 	_require.NoError(err)
 
@@ -708,9 +707,9 @@ func (s *AZBlobUnrecordedTestsSuite) TestBasicDoBatchTransfer() {
 		totalSizeCount := int64(0)
 		runCount := int64(0)
 
-		numChunks := uint16(0)
+		numChunks := uint64(0)
 		if test.chunkSize != 0 {
-			numChunks = uint16(((test.transferSize - 1) / test.chunkSize) + 1)
+			numChunks = uint64(((test.transferSize - 1) / test.chunkSize) + 1)
 		}
 
 		err := shared.DoBatchTransfer(ctx, &shared.BatchTransferOptions{

--- a/sdk/storage/azblob/internal/shared/batch_transfer.go
+++ b/sdk/storage/azblob/internal/shared/batch_transfer.go
@@ -19,7 +19,7 @@ const (
 type BatchTransferOptions struct {
 	TransferSize  int64
 	ChunkSize     int64
-	NumChunks     uint16
+	NumChunks     uint64
 	Concurrency   uint16
 	Operation     func(ctx context.Context, offset int64, chunkSize int64) error
 	OperationName string
@@ -54,7 +54,7 @@ func DoBatchTransfer(ctx context.Context, o *BatchTransferOptions) error {
 	}
 
 	// Add each chunk's operation to the channel.
-	for chunkNum := uint16(0); chunkNum < o.NumChunks; chunkNum++ {
+	for chunkNum := uint64(0); chunkNum < o.NumChunks; chunkNum++ {
 		curChunkSize := o.ChunkSize
 
 		if chunkNum == o.NumChunks-1 { // Last chunk
@@ -69,7 +69,7 @@ func DoBatchTransfer(ctx context.Context, o *BatchTransferOptions) error {
 
 	// Wait for the operations to complete.
 	var firstErr error = nil
-	for chunkNum := uint16(0); chunkNum < o.NumChunks; chunkNum++ {
+	for chunkNum := uint64(0); chunkNum < o.NumChunks; chunkNum++ {
 		responseError := <-operationResponseChannel
 		// record the first error (the original error which should cause the other chunks to fail with canceled context)
 		if responseError != nil && firstErr == nil {


### PR DESCRIPTION
Fixes #22426 
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go

Evaluated perf of random vs sequential write when DownloadFile method is used to download 10GB blob. Saw similar perf numbers in both cases for premium SSD as well as standard HDD. Current sequential write logic also has some sync issues. So, reverting the code back to use random write logic.

Time taken to download 10GB blob in premium SSD.
```
Concurrency  |  Sequential  |  Random
      5      |      42.42s  |    42.02s
      8      |      42.16s  |    42.09s
      16     |     42.02s   |    42.66s
```

Time taken to download 10GB blob in standard HDD.
```
Concurrency  |  Sequential  |  Random
      5      |      1m26s   |   1m29s
      8      |      1m29s   |    1m30s
      16     |     1m30s    |    1m28s
```


