### PR TITLE
Escape semicolons in query params before parsing

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugs Fixed
 
 * Fixed a potential race condition between `NullValue` and `IsNullValue`.
+* `runtime.EncodeQueryParams` will escape semicolons before calling `url.ParseQuery`.
 
 ### Other Changes
 

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -42,12 +42,19 @@ func NewRequest(ctx context.Context, httpMethod string, endpoint string) (*polic
 }
 
 // EncodeQueryParams will parse and encode any query parameters in the specified URL.
+// Any semicolons will automatically be escaped.
 func EncodeQueryParams(u string) (string, error) {
 	before, after, found := strings.Cut(u, "?")
 	if !found {
 		return u, nil
 	}
-	qp, err := url.ParseQuery(after)
+	// staring in Go 1.17, url.ParseQuery will reject semicolons in query params.
+	// so, we must escape them first. note that this assumes that semicolons aren't
+	// being used as query param separators which is per the current RFC.
+	// for more info:
+	// https://github.com/golang/go/issues/25192
+	// https://github.com/golang/go/issues/50034
+	qp, err := url.ParseQuery(strings.ReplaceAll(after, ";", "%3B"))
 	if err != nil {
 		return "", err
 	}

--- a/sdk/azcore/runtime/request_test.go
+++ b/sdk/azcore/runtime/request_test.go
@@ -340,7 +340,7 @@ func TestEncodeQueryParams(t *testing.T) {
 	nextLink, err = EncodeQueryParams(testURL)
 	require.NoError(t, err)
 	require.EqualValues(t, testURL, nextLink)
-	nextLink, err = EncodeQueryParams(testURL + "query?invalid=;semicolon")
-	require.Error(t, err)
-	require.Empty(t, nextLink)
+	nextLink, err = EncodeQueryParams(testURL + "query?compound=thing1;thing2;thing3")
+	require.NoError(t, err)
+	require.EqualValues(t, testURL+"query?compound=thing1%3Bthing2%3Bthing3", nextLink)
 }


### PR DESCRIPTION
For compat reasons, url.ParseQuery will reject semicolons within query params. So, we must escape them first.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/22408