### PR TITLE
NewListEntitiesPager fix

### DIFF
--- a/sdk/data/aztables/CHANGELOG.md
+++ b/sdk/data/aztables/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed an issue that could cause `Client.NewListEntitiesPager` to skip pages in some cases.
 
 ### Other Changes
 

--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -166,10 +166,7 @@ func (t *Client) NewListEntitiesPager(listOptions *ListEntitiesOptions) *runtime
 		More: func(page ListEntitiesResponse) bool {
 			// if there are no continuation header values, there are no more pages
 			// https://learn.microsoft.com/rest/api/storageservices/Query-Timeout-and-Pagination
-			if (page.NextPartitionKey == nil || len(*page.NextPartitionKey) == 0) && (page.NextRowKey == nil || len(*page.NextRowKey) == 0) {
-				return false
-			}
-			return true
+			return !((page.NextPartitionKey == nil || len(*page.NextPartitionKey) == 0) && (page.NextRowKey == nil || len(*page.NextRowKey) == 0))
 		},
 		Fetcher: func(ctx context.Context, page *ListEntitiesResponse) (ListEntitiesResponse, error) {
 			var partKey *string

--- a/sdk/data/aztables/client.go
+++ b/sdk/data/aztables/client.go
@@ -164,7 +164,9 @@ func (t *Client) NewListEntitiesPager(listOptions *ListEntitiesOptions) *runtime
 	}
 	return runtime.NewPager(runtime.PagingHandler[ListEntitiesResponse]{
 		More: func(page ListEntitiesResponse) bool {
-			if page.NextPartitionKey == nil || len(*page.NextPartitionKey) == 0 || page.NextRowKey == nil || len(*page.NextRowKey) == 0 {
+			// if there are no continuation header values, there are no more pages
+			// https://learn.microsoft.com/rest/api/storageservices/Query-Timeout-and-Pagination
+			if (page.NextPartitionKey == nil || len(*page.NextPartitionKey) == 0) && (page.NextRowKey == nil || len(*page.NextRowKey) == 0) {
 				return false
 			}
 			return true
@@ -173,12 +175,8 @@ func (t *Client) NewListEntitiesPager(listOptions *ListEntitiesOptions) *runtime
 			var partKey *string
 			var rowKey *string
 			if page != nil {
-				if page.NextPartitionKey != nil {
-					partKey = page.NextPartitionKey
-				}
-				if page.NextRowKey != nil {
-					rowKey = page.NextRowKey
-				}
+				partKey = page.NextPartitionKey
+				rowKey = page.NextRowKey
 			} else {
 				partKey = listOptions.NextPartitionKey
 				rowKey = listOptions.NextRowKey

--- a/sdk/data/aztables/service_client.go
+++ b/sdk/data/aztables/service_client.go
@@ -148,9 +148,7 @@ func (t *ServiceClient) NewListTablesPager(listOptions *ListTablesOptions) *runt
 		Fetcher: func(ctx context.Context, page *ListTablesResponse) (ListTablesResponse, error) {
 			var tableName *string
 			if page != nil {
-				if page.NextTableName != nil {
-					tableName = page.NextTableName
-				}
+				tableName = page.NextTableName
 			} else {
 				tableName = listOptions.NextTableName
 			}


### PR DESCRIPTION
Per the docs, if there are no continuation header values, there are no more entities to return.

Removed some superfluous if checks.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/22456