### PR TITLE
Updates for aztables metadata

### DIFF
--- a/sdk/data/aztables/CHANGELOG.md
+++ b/sdk/data/aztables/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Release History
 
-## 1.1.1 (Unreleased)
+## 1.2.0 (Unreleased)
 
 ### Features Added
+* Methods `Client.AddEntity` and `ServiceClient.NewListTablesPager` now include OData metadata in their responses.
+* The amount of OData metadata returned has been made configurable for the following methods:
+  * `Client.AddEntity`, `Client.GetEntity`, `Client.NewListEntitiesPager`, and `ServiceClient.NewListTablesPager`.
+  * Use one of the following constants to specify the amount: `MetadataFormatFull`, `MetadataFormatMinimal`, or `MetadataFormatNone`.
 
 ### Breaking Changes
 

--- a/sdk/data/aztables/assets.json
+++ b/sdk/data/aztables/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/data/aztables",
-  "Tag": "go/data/aztables_45893b48dc"
+  "Tag": "go/data/aztables_ec73894009"
 }

--- a/sdk/data/aztables/constants.go
+++ b/sdk/data/aztables/constants.go
@@ -56,6 +56,16 @@ func toGeneratedStatusType(g *generated.GeoReplicationStatusType) *GeoReplicatio
 	return nil
 }
 
+// MetadataFormat specifies the level of OData metadata returned with an entity.
+// https://learn.microsoft.com/rest/api/storageservices/payload-format-for-table-service-operations#json-format-applicationjson-versions-2013-08-15-and-later
+type MetadataFormat = generated.ODataMetadataFormat
+
+const (
+	MetadataFormatFull    MetadataFormat = generated.ODataMetadataFormatApplicationJSONODataFullmetadata
+	MetadataFormatMinimal MetadataFormat = generated.ODataMetadataFormatApplicationJSONODataMinimalmetadata
+	MetadataFormatNone    MetadataFormat = generated.ODataMetadataFormatApplicationJSONODataNometadata
+)
+
 // SASProtocol indicates the SAS protocol
 type SASProtocol string
 

--- a/sdk/data/aztables/internal/version.go
+++ b/sdk/data/aztables/internal/version.go
@@ -8,5 +8,5 @@ package internal
 
 const (
 	ModuleName = "github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
-	Version    = "v1.1.1"
+	Version    = "v1.2.0"
 )

--- a/sdk/data/aztables/models.go
+++ b/sdk/data/aztables/models.go
@@ -105,6 +105,9 @@ func (t *ServiceProperties) toGenerated() *generated.TableServiceProperties {
 type TableProperties struct {
 	// The name of the table.
 	Name *string `json:"TableName,omitempty"`
+
+	// The OData properties of the table in JSON format.
+	Value []byte
 }
 
 // RetentionPolicy - The retention policy.

--- a/sdk/data/aztables/options.go
+++ b/sdk/data/aztables/options.go
@@ -5,13 +5,14 @@ package aztables
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	generated "github.com/Azure/azure-sdk-for-go/sdk/data/aztables/internal"
 )
 
 // AddEntityOptions contains optional parameters for Client.AddEntity
 type AddEntityOptions struct {
-	// placeholder for future optional parameters
+	// Format specifies the amount of metadata returned.
+	// The default is MetadataFormatMinimal.
+	Format *MetadataFormat
 }
 
 // CreateTableOptions contains optional parameters for Client.Create and ServiceClient.CreateTable
@@ -52,11 +53,9 @@ func (g *GetAccessPolicyOptions) toGenerated() *generated.TableClientGetAccessPo
 
 // GetEntityOptions contains optional parameters for Client.GetEntity
 type GetEntityOptions struct {
-	// placeholder for future optional parameters
-}
-
-func (g *GetEntityOptions) toGenerated() (*generated.TableClientQueryEntityWithPartitionAndRowKeyOptions, *generated.QueryOptions) {
-	return &generated.TableClientQueryEntityWithPartitionAndRowKeyOptions{}, &generated.QueryOptions{Format: to.Ptr(generated.ODataMetadataFormatApplicationJSONODataMinimalmetadata)}
+	// Format specifies the amount of metadata returned.
+	// The default is MetadataFormatMinimal.
+	Format *MetadataFormat
 }
 
 // GetPropertiesOptions contains optional parameters for Client.GetProperties
@@ -94,6 +93,10 @@ type ListEntitiesOptions struct {
 
 	// The NextRowKey to start paging from
 	NextRowKey *string
+
+	// Format specifies the amount of metadata returned.
+	// The default is MetadataFormatMinimal.
+	Format *MetadataFormat
 }
 
 func (l *ListEntitiesOptions) toQueryOptions() *generated.QueryOptions {
@@ -103,7 +106,7 @@ func (l *ListEntitiesOptions) toQueryOptions() *generated.QueryOptions {
 
 	return &generated.QueryOptions{
 		Filter: l.Filter,
-		Format: to.Ptr(generated.ODataMetadataFormatApplicationJSONODataMinimalmetadata),
+		Format: l.Format,
 		Select: l.Select,
 		Top:    l.Top,
 	}
@@ -122,6 +125,10 @@ type ListTablesOptions struct {
 
 	// NextTableName is the continuation token for the next table to page from
 	NextTableName *string
+
+	// Format specifies the amount of metadata returned.
+	// The default is MetadataFormatMinimal.
+	Format *MetadataFormat
 }
 
 func (l *ListTablesOptions) toQueryOptions() *generated.QueryOptions {
@@ -131,7 +138,7 @@ func (l *ListTablesOptions) toQueryOptions() *generated.QueryOptions {
 
 	return &generated.QueryOptions{
 		Filter: l.Filter,
-		Format: to.Ptr(generated.ODataMetadataFormatApplicationJSONODataMinimalmetadata),
+		Format: l.Format,
 		Select: l.Select,
 		Top:    l.Top,
 	}

--- a/sdk/data/aztables/responses.go
+++ b/sdk/data/aztables/responses.go
@@ -7,7 +7,11 @@ import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 // AddEntityResponse contains response fields for Client.AddEntityResponse
 type AddEntityResponse struct {
+	// ETag contains the information returned from the ETag header response.
 	ETag azcore.ETag
+
+	// The OData properties of the table entity in JSON format.
+	Value []byte
 }
 
 // CreateTableResponse contains response fields for Client.Create and ServiceClient.CreateTable
@@ -36,7 +40,7 @@ type GetEntityResponse struct {
 	// ETag contains the information returned from the ETag header response.
 	ETag azcore.ETag
 
-	// The properties of the table entity.
+	// The OData properties of the table entity in JSON format.
 	Value []byte
 }
 

--- a/sdk/data/aztables/service_client.go
+++ b/sdk/data/aztables/service_client.go
@@ -5,6 +5,7 @@ package aztables
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -162,8 +163,26 @@ func (t *ServiceClient) NewListTablesPager(listOptions *ListTablesOptions) *runt
 
 			tableProps := make([]*TableProperties, len(resp.Value))
 			for i := range resp.Value {
+				odataValues := map[string]any{}
+				if resp.Value[i].ODataEditLink != nil {
+					odataValues["odata.editLink"] = *resp.Value[i].ODataEditLink
+				}
+				if resp.Value[i].ODataID != nil {
+					odataValues["odata.id"] = *resp.Value[i].ODataID
+				}
+				if resp.Value[i].ODataType != nil {
+					odataValues["odata.type"] = *resp.Value[i].ODataType
+				}
+				var odataJSON []byte
+				if len(odataValues) > 0 {
+					odataJSON, err = json.Marshal(odataValues)
+					if err != nil {
+						return ListTablesResponse{}, err
+					}
+				}
 				tableProps[i] = &TableProperties{
-					Name: resp.Value[i].TableName,
+					Name:  resp.Value[i].TableName,
+					Value: odataJSON,
 				}
 			}
 


### PR DESCRIPTION
Include returned metadata in more APIs.
Make the amount of returned metadata configurable.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/22438