### PR TITLE
Don't error on empty time value

### DIFF
--- a/sdk/data/aztables/CHANGELOG.md
+++ b/sdk/data/aztables/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bugs Fixed
 * Fixed an issue that could cause `Client.NewListEntitiesPager` to skip pages in some cases.
+* Fixed an issue that could cause unmarshaling empty time values to fail.
 
 ### Other Changes
 

--- a/sdk/data/aztables/autorest.md
+++ b/sdk/data/aztables/autorest.md
@@ -21,7 +21,7 @@ modelerfour:
   seal-single-value-enum-by-default: true
 
 directive:
-  - from: source-file-go
+  - from: zz_table_client.go
     where: $
     transform: >-
       return $.
@@ -34,6 +34,14 @@ directive:
         replace(/= client\.mergeEntityCreateRequest\(/, `= client.MergeEntityCreateRequest(`).
         replace(/= client\.updateEntityCreateRequest\(/, `= client.UpdateEntityCreateRequest(`).
         replace(/if rowKey == "" \{\s*.*\s*\}\s*/g, ``);
+  - from:
+      - zz_time_rfc1123.go
+    where: $
+    transform: return $.replace(/UnmarshalText\(data\s+\[\]byte\)\s+error\s+\{\s/g, `UnmarshalText(data []byte) error {\n\tif len(data) == 0 {\n\t\treturn nil\n\t}\n`);
+  - from:
+      - zz_time_rfc3339.go
+    where: $
+    transform: return $.replace(/UnmarshalText\(data\s+\[\]byte\)\s+\(error\)\s+\{\s/g, `UnmarshalText(data []byte) error {\n\tif len(data) == 0 {\n\t\treturn nil\n\t}\n`);
 ```
 
 ### Go multi-api

--- a/sdk/data/aztables/autorest.md
+++ b/sdk/data/aztables/autorest.md
@@ -36,12 +36,9 @@ directive:
         replace(/if rowKey == "" \{\s*.*\s*\}\s*/g, ``);
   - from:
       - zz_time_rfc1123.go
-    where: $
-    transform: return $.replace(/UnmarshalText\(data\s+\[\]byte\)\s+error\s+\{\s/g, `UnmarshalText(data []byte) error {\n\tif len(data) == 0 {\n\t\treturn nil\n\t}\n`);
-  - from:
       - zz_time_rfc3339.go
     where: $
-    transform: return $.replace(/UnmarshalText\(data\s+\[\]byte\)\s+\(error\)\s+\{\s/g, `UnmarshalText(data []byte) error {\n\tif len(data) == 0 {\n\t\treturn nil\n\t}\n`);
+    transform: return $.replace(/UnmarshalText\(data\s+\[\]byte\)\s+(?:error|\(error\))\s+\{\s/g, `UnmarshalText(data []byte) error {\n\tif len(data) == 0 {\n\t\treturn nil\n\t}\n`);
 ```
 
 ### Go multi-api

--- a/sdk/data/aztables/internal/zz_time_rfc1123.go
+++ b/sdk/data/aztables/internal/zz_time_rfc1123.go
@@ -36,6 +36,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/sdk/data/aztables/internal/zz_time_rfc3339.go
+++ b/sdk/data/aztables/internal/zz_time_rfc3339.go
@@ -44,6 +44,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	layout := utcDateTime
 	if tzOffsetRegex.Match(data) {
 		layout = time.RFC3339Nano


### PR DESCRIPTION
Exit early if the value is empty.

This was observed in a test run. https://dev.azure.com/azure-sdk/590cfd2a-581c-4dcb-a12e-6568ce786175/_apis/build/builds/3530520/logs/449

Per the [docs](https://learn.microsoft.com/en-us/rest/api/storageservices/get-table-service-stats#response-body), `LastSyncTime` might be empty in some cases.

This will need to be fixed in codegen, but fixing it here for now.