### PR TITLE
[azeventhubs] Fix race condition between Processor.Run being cancelled and NextPartitionClient

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a race condition between Processor.Run() and Processor.NextPartitionClient() where cancelling Run() quickly could lead to NextPartitionClient hanging indefinitely. (PR#TBD)
+
 ### Other Changes
 
 ## 1.0.4 (2024-03-05)

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed a race condition between Processor.Run() and Processor.NextPartitionClient() where cancelling Run() quickly could lead to NextPartitionClient hanging indefinitely. (PR#TBD)
+- Fixed a race condition between Processor.Run() and Processor.NextPartitionClient() where cancelling Run() quickly could lead to NextPartitionClient hanging indefinitely. (PR#22541)
 
 ### Other Changes
 

--- a/sdk/messaging/azeventhubs/internal/test/test_helpers.go
+++ b/sdk/messaging/azeventhubs/internal/test/test_helpers.go
@@ -113,8 +113,6 @@ func GetConnectionParamsForTest(t *testing.T) ConnectionParamsForTest {
 	}
 
 	envVars := mustGetEnvironmentVars(t, []string{
-		"AZURE_TENANT_ID",
-		"AZURE_CLIENT_ID",
 		"AZURE_SUBSCRIPTION_ID",
 		"CHECKPOINTSTORE_STORAGE_CONNECTION_STRING",
 		"EVENTHUB_CONNECTION_STRING_LISTEN_ONLY",

--- a/sdk/messaging/azeventhubs/processor.go
+++ b/sdk/messaging/azeventhubs/processor.go
@@ -193,7 +193,11 @@ func newProcessorImpl(consumerClient consumerClientForProcessor, checkpointStore
 //
 // [example_consuming_with_checkpoints_test.go]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/example_consuming_with_checkpoints_test.go
 func (p *Processor) NextPartitionClient(ctx context.Context) *ProcessorPartitionClient {
-	<-p.runCalled
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-p.runCalled:
+	}
 
 	select {
 	case nextClient := <-p.nextClients:


### PR DESCRIPTION
Fixed a race condition between Processor.Run() and Processor.NextPartitionClient() where cancelling Run() quickly could lead to NextPartitionClient hanging indefinitely, waiting for a channel that would never be closed.

Fixes #22539