### PR TITLE
Ensure modules are current and tidy in CI

### DIFF
--- a/eng/.golangci.yml
+++ b/eng/.golangci.yml
@@ -1,5 +1,7 @@
 #reference https://github.com/golangci/golangci-lint#config-file for more options
 run:
+  # ensure that go.mod files are current
+  modules-download-mode: readonly
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -77,10 +77,14 @@ steps:
       foreach ($md in $modDirs) {
         pushd $md
         Write-Host "##[command]Executing go mod tidy in $md"
-        go mod tidy | tee >&2
+        go mod tidy
+        $diff = (git diff -w .)
+        Write-Host ($diff -join "`n")
+        if ($diff.Length -gt 0) {
+          exit 1
+        }
       }
     displayName: 'go mod tidy'
-    failOnStderr: true
     workingDirectory: $(System.DefaultWorkingDirectory)
 
   - pwsh: |

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -75,6 +75,17 @@ steps:
   - pwsh: |
       $modDirs = ./eng/scripts/get_module_dirs.ps1 '${{ parameters.ServiceDirectory }}'
       foreach ($md in $modDirs) {
+        pushd $md
+        Write-Host "##[command]Executing go mod tidy in $md"
+        go mod tidy | tee >&2
+      }
+    displayName: 'go mod tidy'
+    failOnStderr: true
+    workingDirectory: $(System.DefaultWorkingDirectory)
+
+  - pwsh: |
+      $modDirs = ./eng/scripts/get_module_dirs.ps1 '${{ parameters.ServiceDirectory }}'
+      foreach ($md in $modDirs) {
         if (-Not $md -Match "/arm") {
           Get-ChildItem $md/doc.go
         }


### PR DESCRIPTION
Fails the build if go.mod or go.sum isn't current.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
