### PR TITLE
[Cosmos] Use []json.RawMessage for cosmos list unmarshal to avoid MaxInt64 mishandling

### DIFF
--- a/sdk/data/azcosmos/cosmos_query_response.go
+++ b/sdk/data/azcosmos/cosmos_query_response.go
@@ -58,7 +58,7 @@ func newQueryResponse(resp *http.Response) (QueryItemsResponse, error) {
 }
 
 type queryServiceResponse struct {
-	Documents []any `json:"Documents,omitempty"`
+	Documents []json.RawMessage `json:"Documents,omitempty"`
 }
 
 // QueryContainersResponse contains response from the container query operation.


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-go/issues/22523

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
