### PR TITLE
fix: add AZURE_GO_SDK_DISABLE_HTTPS_CHECK to provide workaround to disable https auth check

### DIFF
--- a/sdk/azcore/runtime/policy_bearer_token.go
+++ b/sdk/azcore/runtime/policy_bearer_token.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"errors"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -114,6 +115,10 @@ func (b *BearerTokenPolicy) Do(req *policy.Request) (*http.Response, error) {
 }
 
 func checkHTTPSForAuth(req *policy.Request) error {
+	if strings.ToLower(os.Getenv("AZURE_GO_SDK_DISABLE_HTTPS_CHECK")) == "true" {
+		return nil
+	}
+
 	if strings.ToLower(req.Raw().URL.Scheme) != "https" {
 		return errorinfo.NonRetriableError(errors.New("authenticated requests are not permitted for non TLS protected (https) endpoints"))
 	}


### PR DESCRIPTION
add AZURE_GO_SDK_DISABLE_HTTPS_CHECK to provide workaround to disable https auth check
background: during our AKS CSI driver migration to track2, we found track2 has enforced https, and would return error if it's http request. In our AKS production, we have set cloud.resourceManagerEndpoint as `http://localhost` to a proxy inside AKS pod(container), and finally the proxy would send ARM https request (this is safe since http request is handled inside container). We have a critical fix to rollout a new CSI driver version in AKS production while we found this https auth check has blocked our new version rollout, and we are trying to add https support inside our aks proxy, while that would take long time to rollout in production since this is not a trivial change. And I believe adding an env var to disable such https check is also a reasonable workaround since track1 sdk does not enforce such https auth check, this is a like a breaking change.

This PR provides a env var to disable https auth check in such case, and does not change the default behavior of go sdk behavior.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
