### PR TITLE
Add AllowInsecureAuth to ClientOptions

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 * Added `StatusCodes` to `arm/policy.RegistrationOptions` to allow supporting non-standard HTTP status codes during registration.
+* Added field `AllowInsecureAuth` to `azcore.ClientOptions` and dependent authentication pipeline policies.
 
 ### Breaking Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 * Added `StatusCodes` to `arm/policy.RegistrationOptions` to allow supporting non-standard HTTP status codes during registration.
-* Added field `AllowInsecureAuth` to `azcore.ClientOptions` and dependent authentication pipeline policies.
+* Added field `InsecureAllowCredentialWithHTTP` to `azcore.ClientOptions` and dependent authentication pipeline policies.
 
 ### Breaking Changes
 

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -20,12 +20,12 @@ type BearerTokenOptions struct {
 	// policy's credential must support multitenant authentication.
 	AuxiliaryTenants []string
 
+	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
+	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
+	InsecureAllowCredentialWithHTTP bool
+
 	// Scopes contains the list of permission scopes required for the token.
 	Scopes []string
-
-	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
-	AllowInsecureAuth bool
 }
 
 // RegistrationOptions configures the registration policy's behavior.

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -24,7 +24,7 @@ type BearerTokenOptions struct {
 	Scopes []string
 
 	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will send the authentication key in clear text. Use with caution.
+	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
 	AllowInsecureAuth bool
 }
 

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -21,6 +21,7 @@ type BearerTokenOptions struct {
 	AuxiliaryTenants []string
 
 	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
+	// By default, authenticated requests to an HTTP endpoint are rejected by the client.
 	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
 	InsecureAllowCredentialWithHTTP bool
 

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -22,6 +22,10 @@ type BearerTokenOptions struct {
 
 	// Scopes contains the list of permission scopes required for the token.
 	Scopes []string
+
+	// AllowInsecureAuth enables authenticated requests over HTTP.
+	// WARNING: setting this to true will send the authentication key in clear text. Use with caution.
+	AllowInsecureAuth bool
 }
 
 // RegistrationOptions configures the registration policy's behavior.

--- a/sdk/azcore/arm/policy/policy_test.go
+++ b/sdk/azcore/arm/policy/policy_test.go
@@ -21,8 +21,8 @@ func TestClientOptions_Copy(t *testing.T) {
 	require.Nil(t, option.Clone())
 
 	option = &ClientOptions{ClientOptions: policy.ClientOptions{
-		AllowInsecureAuth: true,
-		Cloud:             cloud.AzurePublic,
+		InsecureAllowCredentialWithHTTP: true,
+		Cloud:                           cloud.AzurePublic,
 		Logging: policy.LogOptions{
 			AllowedHeaders:     []string{"test1", "test2"},
 			AllowedQueryParams: []string{"test1", "test2"},
@@ -33,7 +33,7 @@ func TestClientOptions_Copy(t *testing.T) {
 	}}
 	copiedOption := option.Clone()
 	require.Equal(t, option.APIVersion, copiedOption.APIVersion)
-	require.Equal(t, option.AllowInsecureAuth, copiedOption.AllowInsecureAuth)
+	require.Equal(t, option.InsecureAllowCredentialWithHTTP, copiedOption.InsecureAllowCredentialWithHTTP)
 	require.NotEqual(t, fmt.Sprintf("%p", &option.APIVersion), fmt.Sprintf("%p", &copiedOption.APIVersion))
 	require.Equal(t, option.Cloud.Services, copiedOption.Cloud.Services)
 	require.NotEqual(t, fmt.Sprintf("%p", option.Cloud.Services), fmt.Sprintf("%p", copiedOption.Cloud.Services))

--- a/sdk/azcore/arm/policy/policy_test.go
+++ b/sdk/azcore/arm/policy/policy_test.go
@@ -8,11 +8,12 @@ package policy
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestClientOptions_Copy(t *testing.T) {
@@ -20,7 +21,8 @@ func TestClientOptions_Copy(t *testing.T) {
 	require.Nil(t, option.Clone())
 
 	option = &ClientOptions{ClientOptions: policy.ClientOptions{
-		Cloud: cloud.AzurePublic,
+		AllowInsecureAuth: true,
+		Cloud:             cloud.AzurePublic,
 		Logging: policy.LogOptions{
 			AllowedHeaders:     []string{"test1", "test2"},
 			AllowedQueryParams: []string{"test1", "test2"},
@@ -31,6 +33,7 @@ func TestClientOptions_Copy(t *testing.T) {
 	}}
 	copiedOption := option.Clone()
 	require.Equal(t, option.APIVersion, copiedOption.APIVersion)
+	require.Equal(t, option.AllowInsecureAuth, copiedOption.AllowInsecureAuth)
 	require.NotEqual(t, fmt.Sprintf("%p", &option.APIVersion), fmt.Sprintf("%p", &copiedOption.APIVersion))
 	require.Equal(t, option.Cloud.Services, copiedOption.Cloud.Services)
 	require.NotEqual(t, fmt.Sprintf("%p", option.Cloud.Services), fmt.Sprintf("%p", copiedOption.Cloud.Services))

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -30,9 +30,9 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 		return azruntime.Pipeline{}, err
 	}
 	authPolicy := NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{
-		AllowInsecureAuth: options.AllowInsecureAuth,
-		AuxiliaryTenants:  options.AuxiliaryTenants,
-		Scopes:            []string{conf.Audience + "/.default"},
+		AuxiliaryTenants:                options.AuxiliaryTenants,
+		InsecureAllowCredentialWithHTTP: options.InsecureAllowCredentialWithHTTP,
+		Scopes:                          []string{conf.Audience + "/.default"},
 	})
 	perRetry := make([]azpolicy.Policy, len(plOpts.PerRetry), len(plOpts.PerRetry)+1)
 	copy(perRetry, plOpts.PerRetry)

--- a/sdk/azcore/arm/runtime/pipeline.go
+++ b/sdk/azcore/arm/runtime/pipeline.go
@@ -30,8 +30,9 @@ func NewPipeline(module, version string, cred azcore.TokenCredential, plOpts azr
 		return azruntime.Pipeline{}, err
 	}
 	authPolicy := NewBearerTokenPolicy(cred, &armpolicy.BearerTokenOptions{
-		AuxiliaryTenants: options.AuxiliaryTenants,
-		Scopes:           []string{conf.Audience + "/.default"},
+		AllowInsecureAuth: options.AllowInsecureAuth,
+		AuxiliaryTenants:  options.AuxiliaryTenants,
+		Scopes:            []string{conf.Audience + "/.default"},
 	})
 	perRetry := make([]azpolicy.Policy, len(plOpts.PerRetry), len(plOpts.PerRetry)+1)
 	copy(perRetry, plOpts.PerRetry)

--- a/sdk/azcore/arm/runtime/policy_bearer_token.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token.go
@@ -64,6 +64,7 @@ func NewBearerTokenPolicy(cred azcore.TokenCredential, opts *armpolicy.BearerTok
 	p.scopes = make([]string, len(opts.Scopes))
 	copy(p.scopes, opts.Scopes)
 	p.btp = azruntime.NewBearerTokenPolicy(cred, opts.Scopes, &azpolicy.BearerTokenOptions{
+		AllowInsecureAuth: opts.AllowInsecureAuth,
 		AuthorizationHandler: azpolicy.AuthorizationHandler{
 			OnChallenge: p.onChallenge,
 			OnRequest:   p.onRequest,

--- a/sdk/azcore/arm/runtime/policy_bearer_token.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token.go
@@ -64,7 +64,7 @@ func NewBearerTokenPolicy(cred azcore.TokenCredential, opts *armpolicy.BearerTok
 	p.scopes = make([]string, len(opts.Scopes))
 	copy(p.scopes, opts.Scopes)
 	p.btp = azruntime.NewBearerTokenPolicy(cred, opts.Scopes, &azpolicy.BearerTokenOptions{
-		AllowInsecureAuth: opts.AllowInsecureAuth,
+		InsecureAllowCredentialWithHTTP: opts.InsecureAllowCredentialWithHTTP,
 		AuthorizationHandler: azpolicy.AuthorizationHandler{
 			OnChallenge: p.onChallenge,
 			OnRequest:   p.onRequest,

--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -305,7 +305,7 @@ func TestBearerTokenPolicyAllowHTTP(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 	b := NewBearerTokenPolicy(mockCredential{}, &armpolicy.BearerTokenOptions{
-		AllowInsecureAuth: true,
+		InsecureAllowCredentialWithHTTP: true,
 	})
 	pl := newTestPipeline(&azpolicy.ClientOptions{Transport: srv, PerRetryPolicies: []azpolicy.Policy{b}})
 	req, err := runtime.NewRequest(context.Background(), "GET", srv.URL())

--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -299,3 +299,18 @@ func TestBearerTokenPolicyRequiresHTTPS(t *testing.T) {
 	var nre errorinfo.NonRetriable
 	require.ErrorAs(t, err, &nre)
 }
+
+func TestBearerTokenPolicyAllowHTTP(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
+	b := NewBearerTokenPolicy(mockCredential{}, &armpolicy.BearerTokenOptions{
+		AllowInsecureAuth: true,
+	})
+	pl := newTestPipeline(&azpolicy.ClientOptions{Transport: srv, PerRetryPolicies: []azpolicy.Policy{b}})
+	req, err := runtime.NewRequest(context.Background(), "GET", srv.URL())
+	require.NoError(t, err)
+	resp, err := pl.Do(req)
+	require.NoError(t, err)
+	require.EqualValues(t, http.StatusOK, resp.StatusCode)
+}

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -32,16 +32,16 @@ type Request = exported.Request
 // Instances can be shared across calls to SDK client constructors when uniform configuration is desired.
 // Zero-value fields will have their specified default values applied during use.
 type ClientOptions struct {
-	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will allow sending the credential in clear text. Use with caution.
-	AllowInsecureAuth bool
-
 	// APIVersion overrides the default version requested of the service.
 	// Set with caution as this package version has not been tested with arbitrary service versions.
 	APIVersion string
 
 	// Cloud specifies a cloud for the client. The default is Azure Public Cloud.
 	Cloud cloud.Configuration
+
+	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
+	// WARNING: setting this to true will allow sending the credential in clear text. Use with caution.
+	InsecureAllowCredentialWithHTTP bool
 
 	// Logging configures the built-in logging policy.
 	Logging LogOptions
@@ -152,9 +152,9 @@ type BearerTokenOptions struct {
 	// its given credential.
 	AuthorizationHandler AuthorizationHandler
 
-	// AllowInsecureAuth enables authenticated requests over HTTP.
+	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
 	// WARNING: setting this to true will allow sending the bearer token in clear text. Use with caution.
-	AllowInsecureAuth bool
+	InsecureAllowCredentialWithHTTP bool
 }
 
 // AuthorizationHandler allows SDK developers to insert custom logic that runs when BearerTokenPolicy must authorize a request.

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -40,6 +40,7 @@ type ClientOptions struct {
 	Cloud cloud.Configuration
 
 	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
+	// By default, authenticated requests to an HTTP endpoint are rejected by the client.
 	// WARNING: setting this to true will allow sending the credential in clear text. Use with caution.
 	InsecureAllowCredentialWithHTTP bool
 
@@ -153,6 +154,7 @@ type BearerTokenOptions struct {
 	AuthorizationHandler AuthorizationHandler
 
 	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
+	// By default, authenticated requests to an HTTP endpoint are rejected by the client.
 	// WARNING: setting this to true will allow sending the bearer token in clear text. Use with caution.
 	InsecureAllowCredentialWithHTTP bool
 }

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -33,7 +33,7 @@ type Request = exported.Request
 // Zero-value fields will have their specified default values applied during use.
 type ClientOptions struct {
 	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will send the authentication key in clear text. Use with caution.
+	// WARNING: setting this to true will send the credential in clear text. Use with caution.
 	AllowInsecureAuth bool
 
 	// APIVersion overrides the default version requested of the service.
@@ -153,7 +153,7 @@ type BearerTokenOptions struct {
 	AuthorizationHandler AuthorizationHandler
 
 	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will send the authentication key in clear text. Use with caution.
+	// WARNING: setting this to true will send the bearer token in clear text. Use with caution.
 	AllowInsecureAuth bool
 }
 

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -32,6 +32,10 @@ type Request = exported.Request
 // Instances can be shared across calls to SDK client constructors when uniform configuration is desired.
 // Zero-value fields will have their specified default values applied during use.
 type ClientOptions struct {
+	// AllowInsecureAuth enables authenticated requests over HTTP.
+	// WARNING: setting this to true will send the authentication key in clear text. Use with caution.
+	AllowInsecureAuth bool
+
 	// APIVersion overrides the default version requested of the service.
 	// Set with caution as this package version has not been tested with arbitrary service versions.
 	APIVersion string
@@ -147,6 +151,10 @@ type BearerTokenOptions struct {
 	// When this field isn't set, the policy follows its default behavior of authorizing every request with a bearer token from
 	// its given credential.
 	AuthorizationHandler AuthorizationHandler
+
+	// AllowInsecureAuth enables authenticated requests over HTTP.
+	// WARNING: setting this to true will send the authentication key in clear text. Use with caution.
+	AllowInsecureAuth bool
 }
 
 // AuthorizationHandler allows SDK developers to insert custom logic that runs when BearerTokenPolicy must authorize a request.

--- a/sdk/azcore/policy/policy.go
+++ b/sdk/azcore/policy/policy.go
@@ -33,7 +33,7 @@ type Request = exported.Request
 // Zero-value fields will have their specified default values applied during use.
 type ClientOptions struct {
 	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will send the credential in clear text. Use with caution.
+	// WARNING: setting this to true will allow sending the credential in clear text. Use with caution.
 	AllowInsecureAuth bool
 
 	// APIVersion overrides the default version requested of the service.
@@ -153,7 +153,7 @@ type BearerTokenOptions struct {
 	AuthorizationHandler AuthorizationHandler
 
 	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will send the bearer token in clear text. Use with caution.
+	// WARNING: setting this to true will allow sending the bearer token in clear text. Use with caution.
 	AllowInsecureAuth bool
 }
 

--- a/sdk/azcore/runtime/policy_bearer_token.go
+++ b/sdk/azcore/runtime/policy_bearer_token.go
@@ -24,6 +24,7 @@ type BearerTokenPolicy struct {
 	authzHandler policy.AuthorizationHandler
 	cred         exported.TokenCredential
 	scopes       []string
+	allowHTTP    bool
 }
 
 type acquiringResourceState struct {
@@ -55,6 +56,7 @@ func NewBearerTokenPolicy(cred exported.TokenCredential, scopes []string, opts *
 		cred:         cred,
 		scopes:       scopes,
 		mainResource: temporal.NewResource(acquire),
+		allowHTTP:    opts.AllowInsecureAuth,
 	}
 }
 
@@ -80,7 +82,7 @@ func (b *BearerTokenPolicy) Do(req *policy.Request) (*http.Response, error) {
 		return req.Next()
 	}
 
-	if err := checkHTTPSForAuth(req); err != nil {
+	if err := checkHTTPSForAuth(req, b.allowHTTP); err != nil {
 		return nil, err
 	}
 
@@ -113,8 +115,8 @@ func (b *BearerTokenPolicy) Do(req *policy.Request) (*http.Response, error) {
 	return res, err
 }
 
-func checkHTTPSForAuth(req *policy.Request) error {
-	if strings.ToLower(req.Raw().URL.Scheme) != "https" {
+func checkHTTPSForAuth(req *policy.Request, allowHTTP bool) error {
+	if strings.ToLower(req.Raw().URL.Scheme) != "https" && !allowHTTP {
 		return errorinfo.NonRetriableError(errors.New("authenticated requests are not permitted for non TLS protected (https) endpoints"))
 	}
 	return nil

--- a/sdk/azcore/runtime/policy_bearer_token.go
+++ b/sdk/azcore/runtime/policy_bearer_token.go
@@ -56,7 +56,7 @@ func NewBearerTokenPolicy(cred exported.TokenCredential, scopes []string, opts *
 		cred:         cred,
 		scopes:       scopes,
 		mainResource: temporal.NewResource(acquire),
-		allowHTTP:    opts.AllowInsecureAuth,
+		allowHTTP:    opts.InsecureAllowCredentialWithHTTP,
 	}
 }
 

--- a/sdk/azcore/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/runtime/policy_bearer_token_test.go
@@ -241,10 +241,16 @@ func TestBearerTokenPolicy_RequiresHTTPS(t *testing.T) {
 func TestCheckHTTPSForAuth(t *testing.T) {
 	req, err := NewRequest(context.Background(), http.MethodGet, "http://contoso.com")
 	require.NoError(t, err)
-	require.Error(t, checkHTTPSForAuth(req))
+	require.Error(t, checkHTTPSForAuth(req, false))
 	req, err = NewRequest(context.Background(), http.MethodGet, "https://contoso.com")
 	require.NoError(t, err)
-	require.NoError(t, checkHTTPSForAuth(req))
+	require.NoError(t, checkHTTPSForAuth(req, false))
+	req, err = NewRequest(context.Background(), http.MethodGet, "http://contoso.com")
+	require.NoError(t, err)
+	require.NoError(t, checkHTTPSForAuth(req, true))
+	req, err = NewRequest(context.Background(), http.MethodGet, "https://contoso.com")
+	require.NoError(t, err)
+	require.NoError(t, checkHTTPSForAuth(req, true))
 }
 
 func TestBearerTokenPolicy_NilCredential(t *testing.T) {

--- a/sdk/azcore/runtime/policy_key_credential.go
+++ b/sdk/azcore/runtime/policy_key_credential.go
@@ -21,6 +21,7 @@ type KeyCredentialPolicy struct {
 // KeyCredentialPolicyOptions contains the optional values configuring [KeyCredentialPolicy].
 type KeyCredentialPolicyOptions struct {
 	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
+	// By default, authenticated requests to an HTTP endpoint are rejected by the client.
 	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
 	InsecureAllowCredentialWithHTTP bool
 

--- a/sdk/azcore/runtime/policy_key_credential.go
+++ b/sdk/azcore/runtime/policy_key_credential.go
@@ -24,7 +24,7 @@ type KeyCredentialPolicyOptions struct {
 	Prefix string
 
 	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will send the authentication key in clear text. Use with caution.
+	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
 	AllowInsecureAuth bool
 }
 

--- a/sdk/azcore/runtime/policy_key_credential.go
+++ b/sdk/azcore/runtime/policy_key_credential.go
@@ -20,12 +20,12 @@ type KeyCredentialPolicy struct {
 
 // KeyCredentialPolicyOptions contains the optional values configuring [KeyCredentialPolicy].
 type KeyCredentialPolicyOptions struct {
+	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
+	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
+	InsecureAllowCredentialWithHTTP bool
+
 	// Prefix is used if the key requires a prefix before it's inserted into the HTTP request.
 	Prefix string
-
-	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
-	AllowInsecureAuth bool
 }
 
 // NewKeyCredentialPolicy creates a new instance of [KeyCredentialPolicy].
@@ -40,7 +40,7 @@ func NewKeyCredentialPolicy(cred *exported.KeyCredential, header string, options
 		cred:      cred,
 		header:    header,
 		prefix:    options.Prefix,
-		allowHTTP: options.AllowInsecureAuth,
+		allowHTTP: options.InsecureAllowCredentialWithHTTP,
 	}
 }
 

--- a/sdk/azcore/runtime/policy_key_credential_test.go
+++ b/sdk/azcore/runtime/policy_key_credential_test.go
@@ -82,3 +82,22 @@ func TestKeyCredentialPolicy_NilCredential(t *testing.T) {
 	_, err = pl.Do(req)
 	require.NoError(t, err)
 }
+
+func TestKeyCredentialPolicy_AllowInsecureAuth(t *testing.T) {
+	cred := exported.NewKeyCredential("foo")
+
+	policy := NewKeyCredentialPolicy(cred, "fake-auth", &KeyCredentialPolicyOptions{
+		AllowInsecureAuth: true,
+	})
+	require.NotNil(t, policy)
+
+	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{}, nil
+	}), policy)
+
+	req, err := NewRequest(context.Background(), http.MethodGet, "http://contoso.com")
+	require.NoError(t, err)
+
+	_, err = pl.Do(req)
+	require.NoError(t, err)
+}

--- a/sdk/azcore/runtime/policy_key_credential_test.go
+++ b/sdk/azcore/runtime/policy_key_credential_test.go
@@ -83,11 +83,11 @@ func TestKeyCredentialPolicy_NilCredential(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestKeyCredentialPolicy_AllowInsecureAuth(t *testing.T) {
+func TestKeyCredentialPolicy_InsecureAllowCredentialWithHTTP(t *testing.T) {
 	cred := exported.NewKeyCredential("foo")
 
 	policy := NewKeyCredentialPolicy(cred, "fake-auth", &KeyCredentialPolicyOptions{
-		AllowInsecureAuth: true,
+		InsecureAllowCredentialWithHTTP: true,
 	})
 	require.NotNil(t, policy)
 

--- a/sdk/azcore/runtime/policy_sas_credential.go
+++ b/sdk/azcore/runtime/policy_sas_credential.go
@@ -12,13 +12,16 @@ import (
 
 // SASCredentialPolicy authorizes requests with a [azcore.SASCredential].
 type SASCredentialPolicy struct {
-	cred   *exported.SASCredential
-	header string
+	cred      *exported.SASCredential
+	header    string
+	allowHTTP bool
 }
 
 // SASCredentialPolicyOptions contains the optional values configuring [SASCredentialPolicy].
 type SASCredentialPolicyOptions struct {
-	// placeholder for future optional values
+	// AllowInsecureAuth enables authenticated requests over HTTP.
+	// WARNING: setting this to true will send the authentication key in clear text. Use with caution.
+	AllowInsecureAuth bool
 }
 
 // NewSASCredentialPolicy creates a new instance of [SASCredentialPolicy].
@@ -26,9 +29,13 @@ type SASCredentialPolicyOptions struct {
 //   - header is the name of the HTTP request header in which the shared access signature is placed
 //   - options contains optional configuration, pass nil to accept the default values
 func NewSASCredentialPolicy(cred *exported.SASCredential, header string, options *SASCredentialPolicyOptions) *SASCredentialPolicy {
+	if options == nil {
+		options = &SASCredentialPolicyOptions{}
+	}
 	return &SASCredentialPolicy{
-		cred:   cred,
-		header: header,
+		cred:      cred,
+		header:    header,
+		allowHTTP: options.AllowInsecureAuth,
 	}
 }
 
@@ -38,7 +45,7 @@ func (k *SASCredentialPolicy) Do(req *policy.Request) (*http.Response, error) {
 	// this prevents a panic that might be hard to diagnose and allows testing
 	// against http endpoints that don't require authentication.
 	if k.cred != nil {
-		if err := checkHTTPSForAuth(req); err != nil {
+		if err := checkHTTPSForAuth(req, k.allowHTTP); err != nil {
 			return nil, err
 		}
 		req.Raw().Header.Add(k.header, exported.SASCredentialGet(k.cred))

--- a/sdk/azcore/runtime/policy_sas_credential.go
+++ b/sdk/azcore/runtime/policy_sas_credential.go
@@ -20,7 +20,7 @@ type SASCredentialPolicy struct {
 // SASCredentialPolicyOptions contains the optional values configuring [SASCredentialPolicy].
 type SASCredentialPolicyOptions struct {
 	// AllowInsecureAuth enables authenticated requests over HTTP.
-	// WARNING: setting this to true will send the authentication key in clear text. Use with caution.
+	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
 	AllowInsecureAuth bool
 }
 

--- a/sdk/azcore/runtime/policy_sas_credential.go
+++ b/sdk/azcore/runtime/policy_sas_credential.go
@@ -20,6 +20,7 @@ type SASCredentialPolicy struct {
 // SASCredentialPolicyOptions contains the optional values configuring [SASCredentialPolicy].
 type SASCredentialPolicyOptions struct {
 	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
+	// By default, authenticated requests to an HTTP endpoint are rejected by the client.
 	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
 	InsecureAllowCredentialWithHTTP bool
 }

--- a/sdk/azcore/runtime/policy_sas_credential.go
+++ b/sdk/azcore/runtime/policy_sas_credential.go
@@ -19,9 +19,9 @@ type SASCredentialPolicy struct {
 
 // SASCredentialPolicyOptions contains the optional values configuring [SASCredentialPolicy].
 type SASCredentialPolicyOptions struct {
-	// AllowInsecureAuth enables authenticated requests over HTTP.
+	// InsecureAllowCredentialWithHTTP enables authenticated requests over HTTP.
 	// WARNING: setting this to true will allow sending the authentication key in clear text. Use with caution.
-	AllowInsecureAuth bool
+	InsecureAllowCredentialWithHTTP bool
 }
 
 // NewSASCredentialPolicy creates a new instance of [SASCredentialPolicy].
@@ -35,7 +35,7 @@ func NewSASCredentialPolicy(cred *exported.SASCredential, header string, options
 	return &SASCredentialPolicy{
 		cred:      cred,
 		header:    header,
-		allowHTTP: options.AllowInsecureAuth,
+		allowHTTP: options.InsecureAllowCredentialWithHTTP,
 	}
 }
 

--- a/sdk/azcore/runtime/policy_sas_credential_test.go
+++ b/sdk/azcore/runtime/policy_sas_credential_test.go
@@ -50,6 +50,25 @@ func TestSASCredentialPolicy_RequiresHTTPS(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestSASCredentialPolicy_AllowHTTP(t *testing.T) {
+	cred := exported.NewSASCredential("foo")
+
+	policy := NewSASCredentialPolicy(cred, "fake-auth", &SASCredentialPolicyOptions{
+		AllowInsecureAuth: true,
+	})
+	require.NotNil(t, policy)
+
+	pl := exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{}, nil
+	}), policy)
+
+	req, err := NewRequest(context.Background(), http.MethodGet, "http://contoso.com")
+	require.NoError(t, err)
+
+	_, err = pl.Do(req)
+	require.NoError(t, err)
+}
+
 func TestSASCredentialPolicy_NilCredential(t *testing.T) {
 	const headerName = "fake-auth"
 	policy := NewSASCredentialPolicy(nil, headerName, nil)

--- a/sdk/azcore/runtime/policy_sas_credential_test.go
+++ b/sdk/azcore/runtime/policy_sas_credential_test.go
@@ -54,7 +54,7 @@ func TestSASCredentialPolicy_AllowHTTP(t *testing.T) {
 	cred := exported.NewSASCredential("foo")
 
 	policy := NewSASCredentialPolicy(cred, "fake-auth", &SASCredentialPolicyOptions{
-		AllowInsecureAuth: true,
+		InsecureAllowCredentialWithHTTP: true,
 	})
 	require.NotNil(t, policy)
 


### PR DESCRIPTION
When true, allows authenticated requests over HTTP.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/22482