### PR TITLE
Add StatusCodes option to ARM RP registration policy

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.10.1 (Unreleased)
+## 1.11.0 (Unreleased)
 
 ### Features Added
+
+* Added `StatusCodes` to `arm/policy.RegistrationOptions` to allow supporting non-standard HTTP status codes during registration.
 
 ### Breaking Changes
 

--- a/sdk/azcore/arm/policy/policy.go
+++ b/sdk/azcore/arm/policy/policy.go
@@ -44,6 +44,11 @@ type RegistrationOptions struct {
 	// The default valule is 5 minutes.
 	// NOTE: Setting this to a small value might cause the policy to prematurely fail.
 	PollingDuration time.Duration
+
+	// StatusCodes contains the slice of custom HTTP status codes to use instead
+	// of the default http.StatusConflict. This should only be set if a service
+	// returns a non-standard HTTP status code when unregistered.
+	StatusCodes []int
 }
 
 // ClientOptions contains configuration settings for a client's pipeline.

--- a/sdk/azcore/arm/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/arm/runtime/policy_bearer_token_test.go
@@ -51,7 +51,7 @@ func newTestPipeline(opts *azpolicy.ClientOptions) runtime.Pipeline {
 	return runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, opts)
 }
 
-func defaultTestPipeline(srv azpolicy.Transporter, scope string) (runtime.Pipeline, error) {
+func defaultTestPipeline(srv azpolicy.Transporter) (runtime.Pipeline, error) {
 	retryOpts := azpolicy.RetryOptions{
 		MaxRetryDelay: 500 * time.Millisecond,
 		RetryDelay:    time.Millisecond,
@@ -74,7 +74,7 @@ func TestBearerPolicy_SuccessGetToken(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespSuccess)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	pipeline, err := defaultTestPipeline(srv, scope)
+	pipeline, err := defaultTestPipeline(srv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestBearerTokenPolicy_TokenExpired(t *testing.T) {
 	defer close()
 	srv.AppendResponse(mock.WithBody([]byte(accessTokenRespShortLived)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
-	pipeline, err := defaultTestPipeline(srv, scope)
+	pipeline, err := defaultTestPipeline(srv)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azcore/arm/runtime/policy_register_rp.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp.go
@@ -112,6 +112,7 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 		if err != nil {
 			return resp, err
 		}
+		rp = res.ResourceType.Namespace
 		logRegistrationExit := func(v any) {
 			log.Writef(LogRPRegistration, "END registration for %s: %v", rp, v)
 		}

--- a/sdk/azcore/arm/runtime/policy_register_rp.go
+++ b/sdk/azcore/arm/runtime/policy_register_rp.go
@@ -8,7 +8,6 @@ package runtime
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/internal/resource"
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
@@ -44,6 +44,9 @@ func setDefaults(r *armpolicy.RegistrationOptions) {
 	}
 	if r.PollingDuration == 0 {
 		r.PollingDuration = 5 * time.Minute
+	}
+	if len(r.StatusCodes) == 0 {
+		r.StatusCodes = []int{http.StatusConflict}
 	}
 }
 
@@ -88,7 +91,7 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 		// make the original request
 		resp, err = req.Next()
 		// getting a 409 is the first indication that the RP might need to be registered, check error response
-		if err != nil || resp.StatusCode != http.StatusConflict {
+		if err != nil || !runtime.HasStatusCode(resp, r.options.StatusCodes...) {
 			return resp, err
 		}
 		var reqErr requestError
@@ -105,13 +108,7 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 			// to the caller so its error unmarshalling will kick in
 			return resp, err
 		}
-		// RP needs to be registered.  start by getting the subscription ID from the original request
-		subID, err := getSubscription(req.Raw().URL.Path)
-		if err != nil {
-			return resp, err
-		}
-		// now get the RP from the error
-		rp, err = getProvider(reqErr)
+		res, err := resource.ParseResourceID(req.Raw().URL.Path)
 		if err != nil {
 			return resp, err
 		}
@@ -124,7 +121,7 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 		rpOps := &providersOperations{
 			p:     r.pipeline,
 			u:     r.endpoint,
-			subID: subID,
+			subID: res.SubscriptionID,
 		}
 		if _, err = rpOps.Register(&shared.ContextWithDeniedValues{Context: req.Raw().Context()}, rp); err != nil {
 			logRegistrationExit(err)
@@ -189,36 +186,13 @@ func isUnregisteredRPCode(errorCode string) bool {
 	return false
 }
 
-func getSubscription(path string) (string, error) {
-	parts := strings.Split(path, "/")
-	for i, v := range parts {
-		if v == "subscriptions" && (i+1) < len(parts) {
-			return parts[i+1], nil
-		}
-	}
-	return "", fmt.Errorf("failed to obtain subscription ID from %s", path)
-}
-
-func getProvider(re requestError) (string, error) {
-	if len(re.ServiceError.Details) > 0 {
-		return re.ServiceError.Details[0].Target, nil
-	}
-	return "", errors.New("unexpected empty Details")
-}
-
 // minimal error definitions to simplify detection
 type requestError struct {
 	ServiceError *serviceError `json:"error"`
 }
 
 type serviceError struct {
-	Code    string                `json:"code"`
-	Details []serviceErrorDetails `json:"details"`
-}
-
-type serviceErrorDetails struct {
-	Code   string `json:"code"`
-	Target string `json:"target"`
+	Code string `json:"code"`
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -40,5 +40,5 @@ const (
 	Module = "azcore"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.10.1"
+	Version = "v1.11.0"
 )


### PR DESCRIPTION
This lets customers work around services with non-conformant behavior. Replaced custom resource type parsing with in-box version.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/22563

I chose not to expose `StatusCodes` in `arm/policy.ClientOptions` as it should be very rare (not to mention temporal as the RP should fix their code). This does require one to disable the in-box registration policy and create their own version.

```go
regPol, err := armruntime.NewRPRegistrationPolicy(cred, &armpolicy.RegistrationOptions{
	StatusCodes: []int{http.StatusConflict, http.StatusNotFound},
})
if err != nil {
	// TODO: handle error
}

client, err := armmonitor.NewActivityLogsClient("subscription-id", cred, &arm.ClientOptions{
	ClientOptions: azcore.ClientOptions{
		PerCallPolicies: []policy.Policy{regPol},
	},
	DisableRPRegistration: true,
})
```