### PR TITLE
[monitor ingestion] deprecate azingest

### DIFF
--- a/sdk/monitor/azingest/CHANGELOG.md
+++ b/sdk/monitor/azingest/CHANGELOG.md
@@ -1,16 +1,9 @@
 # Release History
 
-## 0.1.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 0.1.2 (2024-03-12)
 
 ### Other Changes
-* Updated to the latest version of `azcore`.
-* Enabled spans for distributed tracing.
+* This module is now DEPRECATED. The latest supported version of this module is at github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs
 
 ## 0.1.1 (2023-10-11)
 

--- a/sdk/monitor/azingest/CHANGELOG.md
+++ b/sdk/monitor/azingest/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Release History
 
-## 0.1.2 (2024-03-12)
+## 0.1.2 (2024-03-13)
 
 ### Other Changes
-* This module is now DEPRECATED. The latest supported version of this module is at github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs
+* This module is now DEPRECATED. The latest supported version of this module is at [github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs)
 
 ## 0.1.1 (2023-10-11)
 

--- a/sdk/monitor/azingest/README.md
+++ b/sdk/monitor/azingest/README.md
@@ -1,5 +1,5 @@
 # Azure Monitor Ingestion client module for Go
-> Deprecated: use github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs instead
+> Deprecated: use [github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs) instead
 
 The Azure Monitor Ingestion client module is used to send custom logs to [Azure Monitor][azure_monitor_overview] using the [Logs Ingestion API][ingestion_overview].
 

--- a/sdk/monitor/azingest/README.md
+++ b/sdk/monitor/azingest/README.md
@@ -1,4 +1,5 @@
 # Azure Monitor Ingestion client module for Go
+> Deprecated: use github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs instead
 
 The Azure Monitor Ingestion client module is used to send custom logs to [Azure Monitor][azure_monitor_overview] using the [Logs Ingestion API][ingestion_overview].
 

--- a/sdk/monitor/azingest/go.mod
+++ b/sdk/monitor/azingest/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs instead
 module github.com/Azure/azure-sdk-for-go/sdk/monitor/azingest
 
 go 1.18


### PR DESCRIPTION
The `azingest` module is being deprecated. Monitor Ingestion can now be found at `sdk/monitor/ingestion/azlogs`.

Part of https://github.com/Azure/azure-sdk-for-go/issues/22377