### PR TITLE
Improved support for multipart/form payloads

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 * Added `StatusCodes` to `arm/policy.RegistrationOptions` to allow supporting non-standard HTTP status codes during registration.
 * Added field `InsecureAllowCredentialWithHTTP` to `azcore.ClientOptions` and dependent authentication pipeline policies.
+* Added type `MultipartContent` to the `streaming` package to support multipart/form payloads with custom Content-Type and file name.
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
+* `runtime.SetMultipartFormData` won't try to stringify `[]byte` values.
 
 ### Other Changes
 

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -132,8 +132,6 @@ func MarshalAsXML(req *policy.Request, v any) error {
 	return req.SetBody(exported.NopCloser(bytes.NewReader(b)), shared.ContentTypeAppXML)
 }
 
-var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
-
 // SetMultipartFormData writes the specified keys/values as multi-part form
 // fields with the specified value.  File content must be specified as a ReadSeekCloser.
 // Byte slices will be treated as JSON. All other values are treated as string values.
@@ -165,6 +163,7 @@ func SetMultipartFormData(req *policy.Request, formData map[string]any) error {
 		}
 		// this is pretty much copied from multipart.Writer.CreateFormFile
 		// but lets us set the caller provided Content-Type and filename
+		quoteEscaper := strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 		h := make(textproto.MIMEHeader)
 		h.Set("Content-Disposition",
 			fmt.Sprintf(`form-data; name="%s"; filename="%s"`,

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -211,17 +211,19 @@ func SetMultipartFormData(req *policy.Request, formData map[string]any) error {
 			}
 			continue
 		}
+
+		var content string
 		if b, ok := v.([]byte); ok {
 			// JSON, don't quote it
-			writer.WriteField(k, string(b))
-			continue
+			content = string(b)
+		} else if s, ok := v.(string); ok {
+			content = s
+		} else {
+			// ensure the value is in string format
+			content = fmt.Sprintf("%v", v)
 		}
-		// ensure the value is in string format
-		s, ok := v.(string)
-		if !ok {
-			s = fmt.Sprintf("%v", v)
-		}
-		if err := writer.WriteField(k, s); err != nil {
+
+		if err := writer.WriteField(k, content); err != nil {
 			return err
 		}
 	}

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -151,6 +151,8 @@ func SetMultipartFormData(req *policy.Request, formData map[string]any) error {
 		return nil
 	}
 
+	quoteEscaper := strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
 	writeMultipartContent := func(fieldname, filename string, mpc streaming.MultipartContent) error {
 		if mpc.Body == nil {
 			return errors.New("streaming.MultipartContent.Body cannot be nil")
@@ -163,7 +165,6 @@ func SetMultipartFormData(req *policy.Request, formData map[string]any) error {
 		}
 		// this is pretty much copied from multipart.Writer.CreateFormFile
 		// but lets us set the caller provided Content-Type and filename
-		quoteEscaper := strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 		h := make(textproto.MIMEHeader)
 		h.Set("Content-Disposition",
 			fmt.Sprintf(`form-data; name="%s"; filename="%s"`,
@@ -186,7 +187,6 @@ func SetMultipartFormData(req *policy.Request, formData map[string]any) error {
 
 	// the same as multipart.Writer.WriteField but lets us specify the Content-Type
 	writeField := func(fieldname, contentType string, value string) error {
-		quoteEscaper := strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 		h := make(textproto.MIMEHeader)
 		h.Set("Content-Disposition",
 			fmt.Sprintf(`form-data; name="%s"`, quoteEscaper.Replace(fieldname)))

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -153,10 +153,14 @@ func SetMultipartFormData(req *policy.Request, formData map[string]any) error {
 
 	quoteEscaper := strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
-	writeMultipartContent := func(fieldname, filename string, mpc streaming.MultipartContent) error {
+	writeMultipartContent := func(fieldname string, mpc streaming.MultipartContent) error {
 		if mpc.Body == nil {
 			return errors.New("streaming.MultipartContent.Body cannot be nil")
 		}
+
+		// use fieldname for the file name when unspecified
+		filename := fieldname
+
 		if mpc.ContentType == "" && mpc.Filename == "" {
 			return writeContent(fieldname, filename, mpc.Body)
 		}
@@ -215,13 +219,13 @@ func SetMultipartFormData(req *policy.Request, formData map[string]any) error {
 			}
 			continue
 		} else if mpc, ok := v.(streaming.MultipartContent); ok {
-			if err := writeMultipartContent(k, k, mpc); err != nil {
+			if err := writeMultipartContent(k, mpc); err != nil {
 				return err
 			}
 			continue
 		} else if mpcs, ok := v.([]streaming.MultipartContent); ok {
 			for _, mpc := range mpcs {
-				if err := writeMultipartContent(k, k, mpc); err != nil {
+				if err := writeMultipartContent(k, mpc); err != nil {
 					return err
 				}
 			}

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -132,8 +132,8 @@ func MarshalAsXML(req *policy.Request, v any) error {
 	return req.SetBody(exported.NopCloser(bytes.NewReader(b)), shared.ContentTypeAppXML)
 }
 
-// SetMultipartFormData writes the specified keys/values as multi-part form
-// fields with the specified value.  File content must be specified as a ReadSeekCloser.
+// SetMultipartFormData writes the specified keys/values as multi-part form fields with the specified value.
+// File content must be specified as an [io.ReadSeekCloser] or [streaming.MultipartContent].
 // Byte slices will be treated as JSON. All other values are treated as string values.
 func SetMultipartFormData(req *policy.Request, formData map[string]any) error {
 	body := bytes.Buffer{}

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -212,12 +212,13 @@ func SetMultipartFormData(req *policy.Request, formData map[string]any) error {
 		}
 
 		var content string
-		if b, ok := v.([]byte); ok {
+		switch tt := v.(type) {
+		case []byte:
 			// JSON, don't quote it
-			content = string(b)
-		} else if s, ok := v.(string); ok {
-			content = s
-		} else {
+			content = string(tt)
+		case string:
+			content = tt
+		default:
 			// ensure the value is in string format
 			content = fmt.Sprintf("%v", v)
 		}

--- a/sdk/azcore/runtime/request_test.go
+++ b/sdk/azcore/runtime/request_test.go
@@ -285,18 +285,22 @@ func TestSetMultipartFormData(t *testing.T) {
 			thing1 := thing{}
 			require.NoError(t, json.Unmarshal(data, &thing1))
 			require.EqualValues(t, 123, thing1.ID)
+			require.EqualValues(t, "application/json", part.Header.Get(shared.HeaderContentType))
 		case "string":
 			strPart, err := io.ReadAll(part)
 			require.NoError(t, err)
 			require.EqualValues(t, "value", strPart)
+			require.EqualValues(t, "text/plain", part.Header.Get(shared.HeaderContentType))
 		case "int":
 			intPart, err := io.ReadAll(part)
 			require.NoError(t, err)
 			require.EqualValues(t, "1", intPart)
+			require.EqualValues(t, "text/plain", part.Header.Get(shared.HeaderContentType))
 		case "data":
 			dataPart, err := io.ReadAll(part)
 			require.NoError(t, err)
 			require.EqualValues(t, "some data", dataPart)
+			require.EqualValues(t, "application/octet-stream", part.Header.Get(shared.HeaderContentType))
 		case "datum":
 			content, err := io.ReadAll(part)
 			require.NoError(t, err)

--- a/sdk/azcore/runtime/request_test.go
+++ b/sdk/azcore/runtime/request_test.go
@@ -9,6 +9,8 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -19,6 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/stretchr/testify/require"
 )
 
@@ -246,10 +249,9 @@ func TestRequestValidFail(t *testing.T) {
 
 func TestSetMultipartFormData(t *testing.T) {
 	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = SetMultipartFormData(req, map[string]any{
+		"json":   []byte(`{"id":123}`),
 		"string": "value",
 		"int":    1,
 		"data":   exported.NopCloser(strings.NewReader("some data")),
@@ -259,53 +261,42 @@ func TestSetMultipartFormData(t *testing.T) {
 			exported.NopCloser(strings.NewReader("third part")),
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	mt, params, err := mime.ParseMediaType(req.Raw().Header.Get(shared.HeaderContentType))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if mt != "multipart/form-data" {
-		t.Fatalf("unexpected media type %s", mt)
-	}
+	require.NoError(t, err)
+	require.EqualValues(t, "multipart/form-data", mt)
 	reader := multipart.NewReader(req.Raw().Body, params["boundary"])
 	var datum []io.ReadSeekCloser
 	for {
 		part, err := reader.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			t.Fatal(err)
 		}
 		switch fn := part.FormName(); fn {
+		case "json":
+			data, err := io.ReadAll(part)
+			require.NoError(t, err)
+			require.EqualValues(t, '{', data[0])
+			type thing struct {
+				ID int `json:"id"`
+			}
+			thing1 := thing{}
+			require.NoError(t, json.Unmarshal(data, &thing1))
+			require.EqualValues(t, 123, thing1.ID)
 		case "string":
-			strPart := make([]byte, 16)
-			_, err = part.Read(strPart)
-			if err != io.EOF {
-				t.Fatal(err)
-			}
-			if tr := string(strPart[:5]); tr != "value" {
-				t.Fatalf("unexpected value %s", tr)
-			}
+			strPart, err := io.ReadAll(part)
+			require.NoError(t, err)
+			require.EqualValues(t, "value", strPart)
 		case "int":
-			intPart := make([]byte, 16)
-			_, err = part.Read(intPart)
-			if err != io.EOF {
-				t.Fatal(err)
-			}
-			if tr := string(intPart[:1]); tr != "1" {
-				t.Fatalf("unexpected value %s", tr)
-			}
+			intPart, err := io.ReadAll(part)
+			require.NoError(t, err)
+			require.EqualValues(t, "1", intPart)
 		case "data":
-			dataPart := make([]byte, 16)
-			_, err = part.Read(dataPart)
-			if err != io.EOF {
-				t.Fatal(err)
-			}
-			if tr := string(dataPart[:9]); tr != "some data" {
-				t.Fatalf("unexpected value %s", tr)
-			}
+			dataPart, err := io.ReadAll(part)
+			require.NoError(t, err)
+			require.EqualValues(t, "some data", dataPart)
 		case "datum":
 			content, err := io.ReadAll(part)
 			require.NoError(t, err)
@@ -324,6 +315,95 @@ func TestSetMultipartFormData(t *testing.T) {
 	require.Equal(t, "first part", string(first))
 	require.Equal(t, "second part", string(second))
 	require.Equal(t, "third part", string(third))
+}
+
+func TestSetMultipartContent(t *testing.T) {
+	req, err := NewRequest(context.Background(), http.MethodPost, "https://contoso.com")
+	require.NoError(t, err)
+	err = SetMultipartFormData(req, map[string]any{
+		"default": streaming.MultipartContent{
+			Body: exported.NopCloser(strings.NewReader("default body")),
+		},
+		"withContentType": streaming.MultipartContent{
+			Body:        exported.NopCloser(strings.NewReader("body with content type")),
+			ContentType: "text/plain",
+		},
+		"withFilename": streaming.MultipartContent{
+			Body:     exported.NopCloser(strings.NewReader("body with filename")),
+			Filename: "content.txt",
+		},
+		"allSet": streaming.MultipartContent{
+			Body:        exported.NopCloser(strings.NewReader("body with everything set")),
+			ContentType: "text/plain",
+			Filename:    "content.txt",
+		},
+		"multiple": []streaming.MultipartContent{
+			{
+				Body:     exported.NopCloser(bytes.NewReader([]byte{1, 2, 3, 4, 5})),
+				Filename: "data.bin",
+			},
+			{
+				Body:        exported.NopCloser(strings.NewReader("some text")),
+				ContentType: "text/plain",
+			},
+		},
+	})
+	require.NoError(t, err)
+	mt, params, err := mime.ParseMediaType(req.Raw().Header.Get(shared.HeaderContentType))
+	require.NoError(t, err)
+	require.EqualValues(t, "multipart/form-data", mt)
+	reader := multipart.NewReader(req.Raw().Body, params["boundary"])
+	countMultiple := 0
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		switch fn := part.FormName(); fn {
+		case "default":
+			require.EqualValues(t, "default", part.FileName())
+			require.EqualValues(t, "application/octet-stream", part.Header.Get(shared.HeaderContentType))
+			body, err := io.ReadAll(part)
+			require.NoError(t, err)
+			require.EqualValues(t, "default body", body)
+		case "withContentType":
+			require.EqualValues(t, "withContentType", part.FileName())
+			require.EqualValues(t, "text/plain", part.Header.Get(shared.HeaderContentType))
+			body, err := io.ReadAll(part)
+			require.NoError(t, err)
+			require.EqualValues(t, "body with content type", body)
+		case "withFilename":
+			require.EqualValues(t, "content.txt", part.FileName())
+			require.EqualValues(t, "application/octet-stream", part.Header.Get(shared.HeaderContentType))
+			body, err := io.ReadAll(part)
+			require.NoError(t, err)
+			require.EqualValues(t, "body with filename", body)
+		case "allSet":
+			require.EqualValues(t, "content.txt", part.FileName())
+			require.EqualValues(t, "text/plain", part.Header.Get(shared.HeaderContentType))
+			body, err := io.ReadAll(part)
+			require.NoError(t, err)
+			require.EqualValues(t, "body with everything set", body)
+		case "multiple":
+			body, err := io.ReadAll(part)
+			require.NoError(t, err)
+			if fn := part.FileName(); fn == "data.bin" {
+				require.EqualValues(t, "application/octet-stream", part.Header.Get(shared.HeaderContentType))
+				require.EqualValues(t, []byte{1, 2, 3, 4, 5}, body)
+			} else if fn == "multiple" {
+				require.EqualValues(t, "text/plain", part.Header.Get(shared.HeaderContentType))
+				require.EqualValues(t, "some text", body)
+			} else {
+				t.Fatalf("unexpected file %s", fn)
+			}
+			countMultiple++
+		default:
+			t.Fatalf("unexpected part %s", fn)
+		}
+	}
+	require.EqualValues(t, 2, countMultiple)
 }
 
 func TestEncodeQueryParams(t *testing.T) {

--- a/sdk/azcore/streaming/progress.go
+++ b/sdk/azcore/streaming/progress.go
@@ -73,3 +73,17 @@ func (p *progress) Seek(offset int64, whence int) (int64, error) {
 func (p *progress) Close() error {
 	return p.rc.Close()
 }
+
+// MultipartContent contains streaming content used in multipart/form payloads.
+type MultipartContent struct {
+	// Body contains the required content body.
+	Body io.ReadSeekCloser
+
+	// ContentType optionally specifies the HTTP Content-Type for this Body.
+	// The default value is application/octet-stream.
+	ContentType string
+
+	// Filename optionally specifies the filename for this Body.
+	// The default value is the field name for the multipart/form section.
+	Filename string
+}

--- a/sdk/azcore/streaming/progress_test.go
+++ b/sdk/azcore/streaming/progress_test.go
@@ -4,7 +4,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package streaming
+package streaming_test
 
 import (
 	"bytes"
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 )
 
@@ -36,7 +37,7 @@ func TestProgressReporting(t *testing.T) {
 	}
 	runtime.SkipBodyDownload(req)
 	var bytesSent int64
-	reqRpt := NewRequestProgress(NopCloser(body), func(bytesTransferred int64) {
+	reqRpt := streaming.NewRequestProgress(streaming.NopCloser(body), func(bytesTransferred int64) {
 		bytesSent = bytesTransferred
 	})
 	if err := req.SetBody(reqRpt, "application/octet-stream"); err != nil {
@@ -47,7 +48,7 @@ func TestProgressReporting(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	var bytesReceived int64
-	respRpt := NewResponseProgress(resp.Body, func(bytesTransferred int64) {
+	respRpt := streaming.NewResponseProgress(resp.Body, func(bytesTransferred int64) {
 		bytesReceived = bytesTransferred
 	})
 	defer respRpt.Close()
@@ -85,7 +86,7 @@ func TestProgressReportingSeek(t *testing.T) {
 	}
 	runtime.SkipBodyDownload(req)
 	var bytesSent int64
-	reqRpt := NewRequestProgress(NopCloser(body), func(bytesTransferred int64) {
+	reqRpt := streaming.NewRequestProgress(streaming.NopCloser(body), func(bytesTransferred int64) {
 		bytesSent = bytesTransferred
 	})
 	if err := req.SetBody(reqRpt, "application/octet-stream"); err != nil {


### PR DESCRIPTION
Added type MultipartContent to allow specifying Content-Type and file name for a payload.
Fixed an issue in SetMultipartFormData that would incorrectly quote raw JSON data.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
