### PR TITLE
[aznamespaces] Adding in the ability to send events using BinaryMode.

### DIFF
--- a/sdk/messaging/eventgrid/aznamespaces/CHANGELOG.md
+++ b/sdk/messaging/eventgrid/aznamespaces/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 0.4.2 (Unreleased)
+## 0.5.0 (Unreleased)
 
 ### Features Added
+
+- Added in "binary mode" support, which can improve efficiency when sending a single event (PR#TBD)
 
 ### Breaking Changes
 

--- a/sdk/messaging/eventgrid/aznamespaces/CHANGELOG.md
+++ b/sdk/messaging/eventgrid/aznamespaces/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added in "binary mode" support, which can improve efficiency when sending a single event (PR#TBD)
+- Added in "binary mode" support, which can improve efficiency when sending a single event (PR#22582)
 
 ### Breaking Changes
 

--- a/sdk/messaging/eventgrid/aznamespaces/assets.json
+++ b/sdk/messaging/eventgrid/aznamespaces/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/messaging/eventgrid/aznamespaces",
-  "Tag": "go/messaging/eventgrid/aznamespaces_0001598cc4"
+  "Tag": "go/messaging/eventgrid/aznamespaces_345f27fa59"
 }

--- a/sdk/messaging/eventgrid/aznamespaces/assets.json
+++ b/sdk/messaging/eventgrid/aznamespaces/assets.json
@@ -1,0 +1,6 @@
+{
+  "AssetsRepo": "Azure/azure-sdk-assets",
+  "AssetsRepoPrefixPath": "go",
+  "TagPrefix": "go/messaging/eventgrid/aznamespaces",
+  "Tag": "go/messaging/eventgrid/aznamespaces_0001598cc4"
+}

--- a/sdk/messaging/eventgrid/aznamespaces/autorest.md
+++ b/sdk/messaging/eventgrid/aznamespaces/autorest.md
@@ -205,3 +205,17 @@ directive:
     where: $
     transform: return $.replace(/\RenewLockOptions\b/g, "renewLockOptions")
 ```
+
+# Binary mode support
+
+```yaml
+directive:
+  - from: options.go
+    where: $
+    transform: return $.replace(/\/\/ PublishCloudEventOptions.+?\n\}\n/s, "");
+  - from: client.go
+    where: $
+    transform: | 
+      return $.replace(/\/\/ publishCloudEventCreateRequest creates/, "// publishCloudEventCreateRequestUsingJSONEncoding creates")
+        .replace(/func \(client \*Client\) publishCloudEventCreateRequest/, "func (client *Client) publishCloudEventCreateRequestUsingJSONEncoding");
+```

--- a/sdk/messaging/eventgrid/aznamespaces/client.go
+++ b/sdk/messaging/eventgrid/aznamespaces/client.go
@@ -121,8 +121,8 @@ func (client *Client) PublishCloudEvent(ctx context.Context, topicName string, e
 	return PublishCloudEventResponse{}, nil
 }
 
-// publishCloudEventCreateRequest creates the PublishCloudEvent request.
-func (client *Client) publishCloudEventCreateRequest(ctx context.Context, topicName string, event messaging.CloudEvent, options *PublishCloudEventOptions) (*policy.Request, error) {
+// publishCloudEventCreateRequestUsingJSONEncoding creates the PublishCloudEvent request.
+func (client *Client) publishCloudEventCreateRequestUsingJSONEncoding(ctx context.Context, topicName string, event messaging.CloudEvent, options *PublishCloudEventOptions) (*policy.Request, error) {
 	urlPath := "/topics/{topicName}:publish"
 	if topicName == "" {
 		return nil, errors.New("parameter topicName cannot be empty")

--- a/sdk/messaging/eventgrid/aznamespaces/client_custom.go
+++ b/sdk/messaging/eventgrid/aznamespaces/client_custom.go
@@ -231,8 +231,6 @@ func stringize(tmpV any) (string, error) {
 
 	case []byte:
 		return base64.StdEncoding.EncodeToString(v), nil
-	case *url.URL:
-		return v.String(), nil
 	case string:
 		return v, nil
 

--- a/sdk/messaging/eventgrid/aznamespaces/client_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/client_test.go
@@ -9,11 +9,13 @@ package aznamespaces_test
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/messaging"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces"
@@ -21,7 +23,7 @@ import (
 )
 
 func TestFailedAck(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	ce, err := messaging.NewCloudEvent("hello-source", "world", []byte("ack this one"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
@@ -66,7 +68,7 @@ func TestFailedAck(t *testing.T) {
 }
 
 func TestPartialAckFailure(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	ce, err := messaging.NewCloudEvent("hello-source", "world", []byte("event one"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
@@ -113,7 +115,7 @@ func TestPartialAckFailure(t *testing.T) {
 }
 
 func TestReject(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	ce, err := messaging.NewCloudEvent("TestAbandon", "world", []byte("event one"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
@@ -153,7 +155,7 @@ func TestReject(t *testing.T) {
 }
 
 func TestRelease(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	ce, err := messaging.NewCloudEvent("TestAbandon", "world", []byte("event one"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
@@ -192,7 +194,7 @@ func TestRelease(t *testing.T) {
 }
 
 func TestPublishBytes(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	ce, err := messaging.NewCloudEvent("hello-source", "eventType", []byte("TestPublishBytes"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
@@ -215,7 +217,7 @@ func TestPublishBytes(t *testing.T) {
 }
 
 func TestPublishString(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	ce, err := messaging.NewCloudEvent("hello-source", "eventType", "TestPublishString", &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/json"),
@@ -238,7 +240,7 @@ func TestPublishString(t *testing.T) {
 }
 
 func TestPublishingAndReceivingMultipleCloudEvents(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	testData := []struct {
 		Send     messaging.CloudEvent
@@ -286,28 +288,8 @@ func TestPublishingAndReceivingMultipleCloudEvents(t *testing.T) {
 		batch = append(batch, td.Send)
 	}
 
-	// type simpleType struct {
-	// 	Name string
-	// }
-
-	// ce3, err := messaging.NewCloudEvent("hello-source", "eventType", simpleType{Name: "simple type name"}, &messaging.CloudEventOptions{
-	// 	DataContentType: to.Ptr("application/octet-stream"),
-	// })
-	// require.NoError(t, err)
-	// toSend = append(toSend, ce3)
-
-	// _, err := c.PublishCloudEvents(context.Background(), c.TestVars.Topic, batch, nil)
-	// require.NoError(t, err)
-
-	t.Logf("\n\n\n=====> starting our test, publishing\n\n\n")
-
-	// _, err := c.PublishCloudEvent(context.Background(), c.TestVars.Topic, batch[0], nil)
-	// require.NoError(t, err)
-
 	_, err := c.PublishCloudEvents(context.Background(), c.TestVars.Topic, batch, nil)
 	require.NoError(t, err)
-
-	t.Logf("\n\n\n=====> starting our test, receiving\n\n\n")
 
 	resp, err := c.ReceiveCloudEvents(context.Background(), c.TestVars.Topic, c.TestVars.Subscription, &aznamespaces.ReceiveCloudEventsOptions{
 		MaxEvents:   to.Ptr(int32(len(batch))),
@@ -322,20 +304,10 @@ func TestPublishingAndReceivingMultipleCloudEvents(t *testing.T) {
 
 		requireEqualCloudEvent(t, testData[i].Expected, resp.Value[i].Event)
 	}
-
-	// bytes, err := json.Marshal(simpleType{Name: "simple type name"})
-	// require.NoError(t, err)
-
-	// requireEqualCloudEvent(t, messaging.CloudEvent{
-	// 	SpecVersion: "1.0",
-	// 	Source:      "hello-source",
-	// 	Type:        "eventType",
-	// 	Data:        []byte(bytes),
-	// }, resp.Value[2].Event)
 }
 
 func TestSimpleErrors(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	_, err := c.PublishCloudEvents(context.Background(), c.TestVars.Topic, []messaging.CloudEvent{
 		{},
@@ -348,7 +320,7 @@ func TestSimpleErrors(t *testing.T) {
 }
 
 func TestRenewCloudEventLocks(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	ce := mustCreateEvent(t, "source", "eventType", "hello world", nil)
 	_, err := c.Client.PublishCloudEvent(context.Background(), c.TestVars.Topic, ce, nil)
@@ -366,7 +338,7 @@ func TestRenewCloudEventLocks(t *testing.T) {
 }
 
 func TestReleaseWithDelay(t *testing.T) {
-	c := newClientWrapper(t, nil)
+	c := newClientWrapper(t)
 
 	ce := mustCreateEvent(t, "source", "eventType", "hello world", nil)
 	_, err := c.Client.PublishCloudEvent(context.Background(), c.TestVars.Topic, ce, nil)
@@ -400,6 +372,237 @@ func TestReleaseWithDelay(t *testing.T) {
 	require.Empty(t, ackResp.FailedLockTokens)
 }
 
+func TestPublishCloudEvent_binaryMode(t *testing.T) {
+	client := newClientWrapper(t)
+
+	// you can send a variety of different payloads, all of which can be encoded by messaging.CloudEvent
+	binaryPayload := []byte{1, 2, 3}
+	customContentType := "application/customcontenttype"
+	eventToSend, err := messaging.NewCloudEvent("source", "eventType", binaryPayload, &messaging.CloudEventOptions{
+		// this will be used as the "Content-Type" for the request.
+		DataContentType: &customContentType,
+	})
+	require.NoError(t, err)
+
+	// want to validate that we're actually doing the binary mode encoding
+	var actualResp *http.Response
+	captureCtx := policy.WithCaptureResponse(context.Background(), &actualResp)
+
+	// binary mode publish (CloudEvent attributes encoded as headers, CloudEvent.Data used as the request body)
+	{
+		_, err = client.PublishCloudEvent(captureCtx, client.TestVars.Topic, eventToSend, &aznamespaces.PublishCloudEventOptions{
+			BinaryMode: true,
+		})
+		require.NoError(t, err)
+
+		require.NotNil(t, actualResp.Request)
+		// binary mode propagates the content type of the event itself.
+		// require.Equal(t, customContentType, actualResp.Request.Header["Content-Type"][0])
+
+		// (the body bytes stream is exhausted so we can't compare the contents but we can check that we only sent the body bytes.
+		require.Equal(t, int64(len(eventToSend.Data.([]byte))), actualResp.Request.ContentLength)
+	}
+
+	event := receiveAll(t, client, 1)[0]
+
+	// zero out needed fields
+	eventToSend.Time, event.Event.Time = nil, nil
+	require.Equal(t, eventToSend, event.Event)
+}
+
+// send an event using the two methods (binary and non-binary mode) and make sure they both
+// produce the same content, when received.
+func TestPublishCloudEvent_worksSameInBinaryVsNonBinaryMode(t *testing.T) {
+	client := newClientWrapper(t)
+
+	// you can send a variety of different payloads, all of which can be encoded by messaging.CloudEvent
+	binaryPayload := []byte{1, 2, 3}
+	customContentType := "application/customcontenttype"
+	eventToSend, err := messaging.NewCloudEvent("source", "eventType", binaryPayload, &messaging.CloudEventOptions{
+		// this will be used as the "Content-Type" for the request.
+		DataContentType: &customContentType,
+	})
+	require.NoError(t, err)
+
+	// want to validate that we're actually doing the binary mode encoding
+	var actualResp *http.Response
+	captureCtx := policy.WithCaptureResponse(context.Background(), &actualResp)
+
+	// binary mode publish (CloudEvent attributes encoded as headers, CloudEvent.Data used as the request body)
+	{
+		_, err = client.PublishCloudEvent(captureCtx, client.TestVars.Topic, eventToSend, &aznamespaces.PublishCloudEventOptions{
+			BinaryMode: true,
+		})
+		require.NoError(t, err)
+
+		require.NotNil(t, actualResp.Request)
+		// binary mode propagates the content type of the event itself.
+		require.Equal(t, customContentType, actualResp.Request.Header["Content-Type"][0])
+
+		// (the body bytes stream is exhausted so we can't compare the contents but we can check that we only sent the body bytes.
+		require.Equal(t, int64(len(eventToSend.Data.([]byte))), actualResp.Request.ContentLength)
+	}
+
+	// non-binary mode publish (ie, entire CloudEvent encoded as JSON as the body)
+	{
+		_, err = client.PublishCloudEvent(captureCtx, client.TestVars.Topic, eventToSend, &aznamespaces.PublishCloudEventOptions{
+			// Default is binary mode OFF.
+			//BinaryMode: true,
+		})
+		require.NoError(t, err)
+
+		require.NotNil(t, actualResp.Request)
+		require.Equal(t, "application/cloudevents+json; charset=utf-8", actualResp.Request.Header["Content-Type"][0])
+		require.Less(t, int64(len(eventToSend.Data.([]byte))), actualResp.Request.ContentLength, "the body is a JSON blob of the entire event, it will be larger than the payload I attempted to send")
+	}
+
+	// receive the two events
+	events := receiveAll(t, client, 2)
+
+	// events sent via binary content mode and non-binary-content-mode should be the same.
+	// it only affects transport, Event Grid should persist them the same.
+	require.NotEqual(t, events[0].Event.Time, events[1].Event.Time)
+
+	// scrub out fields that change no matter what.
+	for i := 0; i < len(events); i++ {
+		require.NotEmpty(t, events[i].BrokerProperties.LockToken)
+		events[i].BrokerProperties.LockToken = nil
+
+		require.NotZero(t, events[i].Event.Time)
+		events[i].Event.Time = &time.Time{}
+	}
+
+	require.Equal(t, events[0], events[1])
+}
+
+func TestPublishCloudEvent_binaryModeNonByteSlicePayloadFails(t *testing.T) {
+	client := newClientWrapper(t)
+
+	eventToSend, err := messaging.NewCloudEvent("source", "eventType", "you can't send strings (or any non []byte) using binary mode!", &messaging.CloudEventOptions{
+		// this will be used as the "Content-Type" for the request.
+		DataContentType: to.Ptr("application/octet-stream"),
+	})
+	require.NoError(t, err)
+
+	_, err = client.PublishCloudEvent(context.Background(), client.TestVars.Topic, eventToSend, &aznamespaces.PublishCloudEventOptions{
+		BinaryMode: true,
+	})
+	require.EqualError(t, err, "CloudEvent.Data must be of type []byte, was type string")
+}
+
+func TestPublishCloudEvent_binaryModeNoContentTypeFails(t *testing.T) {
+	client := newClientWrapper(t)
+
+	eventToSend, err := messaging.NewCloudEvent("source", "eventType", []byte{1, 2, 3}, nil)
+	require.NoError(t, err)
+
+	_, err = client.PublishCloudEvent(context.Background(), client.TestVars.Topic, eventToSend, &aznamespaces.PublishCloudEventOptions{
+		BinaryMode: true,
+	})
+	var respErr *azcore.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	require.Contains(t, err.Error(), "CONTENT-TYPE is not provided")
+	require.Equal(t, "BadRequest", respErr.ErrorCode)
+}
+
+func TestPublishCloudEvent_binaryModeUseOptionalValues(t *testing.T) {
+	client := newClientWrapper(t)
+
+	tm, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+	require.NoError(t, err)
+
+	arbitraryURL, err := url.Parse("https://microsoft.com/someschema")
+	require.NoError(t, err)
+
+	binaryPayload := []byte{1, 2, 3}
+	customContentType := "application/customcontenttype"
+
+	eventToSend, err := messaging.NewCloudEvent("source", "eventType", binaryPayload, &messaging.CloudEventOptions{
+		DataContentType: &customContentType,
+		Extensions: map[string]any{
+			"extensiondatastring":  "hello",
+			"extensiondatastring2": stringableType{},
+			"extensiondataint":     101,
+			"extensiondataurl":     arbitraryURL,
+			"extensiondatauint":    uint(202),
+			"extensiondatatime":    tm,
+			"extensiondatabytes":   []byte{4, 5, 6},
+		},
+		DataSchema: to.Ptr("https://microsoft.com"),
+		Subject:    to.Ptr("my subject"),
+	})
+	require.NoError(t, err)
+
+	// want to validate that we're actually doing the binary mode encoding
+	var actualResp *http.Response
+	captureCtx := policy.WithCaptureResponse(context.Background(), &actualResp)
+
+	// binary mode publish (CloudEvent attributes encoded as headers, CloudEvent.Data used as the request body)
+	_, err = client.PublishCloudEvent(captureCtx, client.TestVars.Topic, eventToSend, &aznamespaces.PublishCloudEventOptions{
+		BinaryMode: true,
+	})
+	require.NoError(t, err)
+
+	req := actualResp.Request
+	require.NotNil(t, req)
+
+	message := receiveAll(t, client, 1)[0]
+
+	require.Equal(t, customContentType, *message.Event.DataContentType)
+	require.Equal(t, []byte{1, 2, 3}, message.Event.Data)
+	require.Equal(t, "https://microsoft.com", *message.Event.DataSchema)
+	require.Equal(t, "source", message.Event.Source)
+	require.Equal(t, "1.0", message.Event.SpecVersion)
+	require.Equal(t, "my subject", *message.Event.Subject)
+
+	require.Equal(t, map[string]any{
+		"extensiondatastring":  "hello",
+		"extensiondatastring2": stringableType{}.String(),
+		"extensiondataint":     "101",
+		"extensiondataurl":     arbitraryURL.String(),
+		"extensiondatauint":    "202",
+		"extensiondatatime":    tm.Format(time.RFC3339),
+		"extensiondatabytes":   "BAUG", // byte data comes back as a base64 string
+	}, message.Event.Extensions)
+}
+
+func TestPublishCloudEvent_binaryModeNoContentType(t *testing.T) {
+	client := newClientWrapper(t)
+
+	binaryPayload := []byte{1, 2, 3}
+	eventToSend, err := messaging.NewCloudEvent("source", "eventType", binaryPayload, nil)
+	require.NoError(t, err)
+
+	// want to validate that we're actually doing the binary mode encoding
+	var actualResp *http.Response
+	captureCtx := policy.WithCaptureResponse(context.Background(), &actualResp)
+
+	_, err = client.PublishCloudEvent(captureCtx, client.TestVars.Topic, eventToSend, &aznamespaces.PublishCloudEventOptions{
+		BinaryMode: true,
+	})
+	var resp *azcore.ResponseError
+	require.ErrorAs(t, err, &resp)
+
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestPublishCloudEvent_binaryModeUnstringableExtension(t *testing.T) {
+	client := newClientWrapper(t)
+
+	binaryPayload := []byte{1, 2, 3}
+	eventToSend, err := messaging.NewCloudEvent("source", "eventType", binaryPayload, &messaging.CloudEventOptions{
+		Extensions: map[string]any{
+			"wontwork": aznamespaces.Client{},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = client.PublishCloudEvent(context.Background(), client.TestVars.Topic, eventToSend, &aznamespaces.PublishCloudEventOptions{
+		BinaryMode: true,
+	})
+	require.EqualError(t, err, "type aznamespaces.Client cannot be converted to a string")
+}
+
 func mustCreateEvent(t *testing.T, source string, eventType string, data any, options *messaging.CloudEventOptions) messaging.CloudEvent {
 	event, err := messaging.NewCloudEvent(source, eventType, data, options)
 	require.NoError(t, err)
@@ -414,4 +617,10 @@ func requireFailedLockTokens(t *testing.T, lockTokens []string, flts []aznamespa
 		require.Equal(t, flt.Error.Code, to.Ptr("TokenLost"))
 		require.EqualError(t, flt.Error, "Token has expired.")
 	}
+}
+
+type stringableType struct{}
+
+func (st stringableType) String() string {
+	return "hello"
 }

--- a/sdk/messaging/eventgrid/aznamespaces/client_unit_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/client_unit_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package aznamespaces
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringize(t *testing.T) {
+	require.Equal(t, "true", mustStringize(t, true))
+
+	require.Equal(t, "1", mustStringize(t, 1))
+	require.Equal(t, "1", mustStringize(t, int8(1)))
+	require.Equal(t, "1", mustStringize(t, int16(1)))
+	require.Equal(t, "1", mustStringize(t, int32(1)))
+	require.Equal(t, "1", mustStringize(t, int64(1)))
+
+	require.Equal(t, "1", mustStringize(t, uint8(1)))
+	require.Equal(t, "1", mustStringize(t, uint16(1)))
+	require.Equal(t, "1", mustStringize(t, uint32(1)))
+	require.Equal(t, "1", mustStringize(t, uint64(1)))
+
+	require.Equal(t, "AQID", mustStringize(t, []byte{1, 2, 3}))
+
+	u, err := url.Parse("https://microsoft.com/hello?query=1")
+	require.NoError(t, err)
+	require.Equal(t, "https://microsoft.com/hello?query=1", mustStringize(t, u))
+
+	require.Equal(t, "hello world", mustStringize(t, "hello world"))
+
+	require.Equal(t, "0001-01-01T00:00:00Z", mustStringize(t, time.Time{}))
+	require.Equal(t, "0001-01-01T00:00:00Z", mustStringize(t, &time.Time{}))
+
+	require.Equal(t, "hello", mustStringize(t, stringableType{}))
+
+	type customType struct{}
+	_, err = stringize(customType{})
+	require.EqualError(t, err, "type aznamespaces.customType cannot be converted to a string")
+}
+
+type stringableType struct{}
+
+func (st stringableType) String() string {
+	return "hello"
+}
+
+func mustStringize(t *testing.T, v any) string {
+	str, err := stringize(v)
+	require.NoError(t, err)
+	return str
+}

--- a/sdk/messaging/eventgrid/aznamespaces/example_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/example_test.go
@@ -124,6 +124,87 @@ func ExampleClient_ReceiveCloudEvents() {
 	// Output:
 }
 
+func ExampleClient_PublishCloudEvent() {
+	client := getEventGridClient()
+
+	if client == nil {
+		return
+	}
+
+	topic := os.Getenv("EVENTGRID_TOPIC")
+
+	// CloudEvent is in github.com/Azure/azure-sdk-for-go/azcore/messaging and can be
+	// used to transport
+
+	// you can send a variety of different payloads, all of which can be encoded by messaging.CloudEvent
+	payload := []byte{1, 2, 3}
+	eventToSend, err := messaging.NewCloudEvent("source", "eventType", payload, &messaging.CloudEventOptions{
+		DataContentType: to.Ptr("application/octet-stream"),
+	})
+
+	if err != nil {
+		//  TODO: Update the following line with your application specific error handling logic
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	_, err = client.PublishCloudEvent(context.TODO(), topic, eventToSend, nil)
+
+	if err != nil {
+		//  TODO: Update the following line with your application specific error handling logic
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	// Output:
+}
+
+// BinaryMode sends a CloudEvent more efficiently by avoiding unnecessary encoding of the Body.
+// There are some caveats to be aware of:
+//
+//   - CloudEvent.Data must be of type []byte.
+//   - CloudEvent.DataContentType will be used as the Content-Type for the HTTP request.
+//   - CloudEvent.Extensions fields are converted to strings.
+func ExampleClient_PublishCloudEvent_binaryMode() {
+	endpoint := os.Getenv("EVENTGRID_ENDPOINT")
+	key := os.Getenv("EVENTGRID_KEY")
+	topicName := os.Getenv("EVENTGRID_TOPIC")
+	subscriptionName := os.Getenv("EVENTGRID_SUBSCRIPTION")
+
+	if endpoint == "" || key == "" || topicName == "" || subscriptionName == "" {
+		return
+	}
+
+	client, err := aznamespaces.NewClientWithSharedKeyCredential(endpoint, azcore.NewKeyCredential(key), nil)
+
+	if err != nil {
+		panic(err)
+	}
+
+	event, err := messaging.NewCloudEvent("source", "eventType", []byte{1, 2, 3}, &messaging.CloudEventOptions{
+		DataContentType: to.Ptr("application/octet-stream"),
+	})
+
+	if err != nil {
+		//  TODO: Update the following line with your application specific error handling logic
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	// BinaryMode sends a CloudEvent more efficiently by avoiding unnecessary encoding of the Body.
+	// There are some caveats to be aware of:
+	// - [CloudEvent.Data] must be of type []byte.
+	// - [CloudEvent.DataContentType] will be used as the Content-Type for the HTTP request.
+	// - [CloudEvent.Extensions] fields are converted to strings.
+	_, err = client.PublishCloudEvent(context.TODO(), topicName, event, &aznamespaces.PublishCloudEventOptions{
+		BinaryMode: true,
+	})
+
+	if err != nil {
+		//  TODO: Update the following line with your application specific error handling logic
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	// Output:
+}
+
 func getEventGridClient() *aznamespaces.Client {
 	endpoint := os.Getenv("EVENTGRID_ENDPOINT")
 	sharedKey := os.Getenv("EVENTGRID_KEY")

--- a/sdk/messaging/eventgrid/aznamespaces/internal/version.go
+++ b/sdk/messaging/eventgrid/aznamespaces/internal/version.go
@@ -14,5 +14,5 @@ const (
 	ModuleName = "aznamespaces"
 
 	// ModuleVersion is the semantic version (see http://semver.org) of this module.
-	ModuleVersion = "v0.4.2"
+	ModuleVersion = "v0.5.0"
 )

--- a/sdk/messaging/eventgrid/aznamespaces/main_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/main_test.go
@@ -32,6 +32,7 @@ func TestMain(m *testing.M) {
 }
 
 func run(m *testing.M) int {
+	defer topicCleanup()
 	if recording.GetRecordMode() == recording.PlaybackMode || recording.GetRecordMode() == recording.RecordingMode {
 		proxy, err := recording.StartTestProxy(recordingDirectory, nil)
 		if err != nil {
@@ -48,9 +49,6 @@ func run(m *testing.M) int {
 	if err := godotenv.Load(); err != nil {
 		log.Printf("Failed to load .env file, no integration tests will run: %s", err)
 	}
-
-	cleanup := createTopicAndUpdateEnv()
-	defer cleanup()
 
 	return m.Run()
 }
@@ -140,6 +138,9 @@ func createTopicAndUpdateEnv() func() {
 	return func() {
 		if _, err = topicClient.BeginDelete(context.Background(), resGroup, nsHost, topicName, nil); err != nil {
 			fmt.Printf("Failed to start the delete for our test topic %s: %s", topicName, err)
+			return
 		}
+
+		fmt.Printf("Deleted topic %s\n", topicName)
 	}
 }

--- a/sdk/messaging/eventgrid/aznamespaces/main_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/main_test.go
@@ -70,11 +70,11 @@ func createTopicAndUpdateEnv(t *testing.T) func() {
 		return func() {}
 	}
 
-	azSubID := os.Getenv("AZEVENTGRID_SUBSCRIPTION_ID")
-	require.NotEmpty(t, azSubID, "AZEVENTGRID_SUBSCRIPTION_ID is defined")
+	azSubID := os.Getenv("AZNAMESPACES_SUBSCRIPTION_ID")
+	require.NotEmpty(t, azSubID, "AZNAMESPACES_SUBSCRIPTION_ID is defined")
 
-	resGroup := os.Getenv("AZEVENTGRID_RESOURCE_GROUP")
-	require.NotEmpty(t, resGroup, "AZEVENTGRID_RESOURCE_GROUP is defined")
+	resGroup := os.Getenv("AZNAMESPACES_RESOURCE_GROUP")
+	require.NotEmpty(t, resGroup, "AZNAMESPACES_RESOURCE_GROUP is defined")
 
 	nsURL, err := url.Parse(os.Getenv("EVENTGRID_ENDPOINT"))
 	require.NoError(t, err)

--- a/sdk/messaging/eventgrid/aznamespaces/main_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/main_test.go
@@ -22,9 +22,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
 	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
 )
 
-const recordingDirectory = "sdk/messaging/azeventgrid/testdata"
+const recordingDirectory = "sdk/messaging/eventgrid/aznamespaces/testdata"
 
 func TestMain(m *testing.M) {
 	code := run(m)
@@ -64,40 +65,30 @@ func PollUntilDone[T any](ctx context.Context, fn func() (*runtime.Poller[T], er
 	return err
 }
 
-func createTopicAndUpdateEnv() func() {
-	azSubID := os.Getenv("AZEVENTGRID_SUBSCRIPTION_ID")
-	resGroup := os.Getenv("AZEVENTGRID_RESOURCE_GROUP")
-
-	if azSubID == "" || resGroup == "" || recording.GetRecordMode() != recording.LiveMode {
-		// ie, these are unit tests.
+func createTopicAndUpdateEnv(t *testing.T) func() {
+	if recording.GetRecordMode() == recording.PlaybackMode {
 		return func() {}
 	}
 
-	nsURL, err := url.Parse(os.Getenv("EVENTGRID_ENDPOINT"))
+	azSubID := os.Getenv("AZEVENTGRID_SUBSCRIPTION_ID")
+	require.NotEmpty(t, azSubID, "AZEVENTGRID_SUBSCRIPTION_ID is defined")
 
-	if err != nil {
-		panic(err)
-	}
+	resGroup := os.Getenv("AZEVENTGRID_RESOURCE_GROUP")
+	require.NotEmpty(t, resGroup, "AZEVENTGRID_RESOURCE_GROUP is defined")
+
+	nsURL, err := url.Parse(os.Getenv("EVENTGRID_ENDPOINT"))
+	require.NoError(t, err)
 
 	nsHost := strings.Split(nsURL.Host, ".")[0]
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
-
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	topicClient, err := armeventgrid.NewNamespaceTopicsClient(azSubID, cred, nil)
-
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	subClient, err := armeventgrid.NewNamespaceTopicEventSubscriptionsClient(azSubID, cred, nil)
-
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	topicName := fmt.Sprintf("topic-%d", time.Now().UnixNano())
 
@@ -108,10 +99,7 @@ func createTopicAndUpdateEnv() func() {
 	err = PollUntilDone(context.Background(), func() (*runtime.Poller[armeventgrid.NamespaceTopicsClientCreateOrUpdateResponse], error) {
 		return topicClient.BeginCreateOrUpdate(context.Background(), resGroup, nsHost, topicName, armeventgrid.NamespaceTopic{}, nil)
 	})
-
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	err = PollUntilDone(context.Background(), func() (*runtime.Poller[armeventgrid.NamespaceTopicEventSubscriptionsClientCreateOrUpdateResponse], error) {
 		return subClient.BeginCreateOrUpdate(context.Background(),
@@ -128,14 +116,12 @@ func createTopicAndUpdateEnv() func() {
 			},
 			nil)
 	})
-
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	fmt.Printf("Created topic %s\n", topicName)
 
 	return func() {
+		// NOTE: this cleanup will happen after the entire test is complete - don't use 't'
 		if _, err = topicClient.BeginDelete(context.Background(), resGroup, nsHost, topicName, nil); err != nil {
 			fmt.Printf("Failed to start the delete for our test topic %s: %s", topicName, err)
 			return

--- a/sdk/messaging/eventgrid/aznamespaces/options.go
+++ b/sdk/messaging/eventgrid/aznamespaces/options.go
@@ -13,11 +13,6 @@ type AcknowledgeCloudEventsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// PublishCloudEventOptions contains the optional parameters for the Client.PublishCloudEvent method.
-type PublishCloudEventOptions struct {
-	// placeholder for future optional parameters
-}
-
 // PublishCloudEventsOptions contains the optional parameters for the Client.PublishCloudEvents method.
 type PublishCloudEventsOptions struct {
 	// placeholder for future optional parameters

--- a/sdk/messaging/eventgrid/aznamespaces/shared_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/shared_test.go
@@ -83,23 +83,19 @@ type clientWrapper struct {
 
 var initTopic sync.Once
 var topicCleanup = func() {}
+var tv testVars = fakeTestVars
 
 func newClientWrapper(t *testing.T) clientWrapper {
 	var client *aznamespaces.Client
-	var tv testVars
-
-	if recording.GetRecordMode() == recording.LiveMode {
-		initTopic.Do(func() {
-			topicCleanup = createTopicAndUpdateEnv()
-		})
-	}
 
 	if recording.GetRecordMode() != recording.PlaybackMode {
-		tmpTestVars, err := loadEnv()
-		require.NoError(t, err)
-		tv = tmpTestVars
-	} else {
-		tv = fakeTestVars
+		initTopic.Do(func() {
+			topicCleanup = createTopicAndUpdateEnv(t)
+
+			tmpTestVars, err := loadEnv()
+			require.NoError(t, err)
+			tv = tmpTestVars
+		})
 	}
 
 	options := &aznamespaces.ClientOptions{}


### PR DESCRIPTION
This is a more efficient way of sending CloudEvents as it avoids JSON serialization for the body. It has some restrictions/caveats, which are documented.

Fixes #22304