### PR TITLE
A few more yml updates

### DIFF
--- a/eng/tools/generator/template/rpName/packageName/ci.yml.tpl
+++ b/eng/tools/generator/template/rpName/packageName/ci.yml.tpl
@@ -21,8 +21,8 @@ pr:
     include:
     - sdk/resourcemanager/{{rpName}}/{{packageName}}/
 
-stages:
-- template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+extends:
+  template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     IncludeRelease: true
     ServiceDirectory: 'resourcemanager/{{rpName}}/{{packageName}}'

--- a/sdk/azidentity/cache/ci.azidentity.yml
+++ b/sdk/azidentity/cache/ci.azidentity.yml
@@ -21,7 +21,7 @@ pr:
     include:
     - sdk/azidentity/cache
 
-stages:
-- template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+extends:
+  template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: 'azidentity/cache'

--- a/sdk/cognitiveservices/azopenai/ci.cognitiveservices.yml
+++ b/sdk/cognitiveservices/azopenai/ci.cognitiveservices.yml
@@ -22,8 +22,8 @@ pr:
     include:
       - sdk/cognitiveservices/azopenai
 
-stages:
-  - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+extends:
+    template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
     parameters:
       ServiceDirectory: "cognitiveservices/azopenai"
       UsePipelineProxy: false

--- a/sdk/messaging/eventgrid/azeventgrid/ci.basic.yml
+++ b/sdk/messaging/eventgrid/azeventgrid/ci.basic.yml
@@ -21,8 +21,8 @@ pr:
     include:
       - sdk/messaging/eventgrid/azeventgrid
 
-stages:
-- template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+extends:
+  template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: "messaging/eventgrid/azeventgrid"
     RunLiveTests: true

--- a/sdk/monitor/ingestion/azlogs/ci.ingestion.yml
+++ b/sdk/monitor/ingestion/azlogs/ci.ingestion.yml
@@ -22,8 +22,8 @@ pr:
     - sdk/monitor/ingestion/azlogs
 
 
-stages:
-- template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+extends:
+  template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: 'monitor/ingestion/azlogs'
     RunLiveTests: true

--- a/sdk/resourcemanager/internal/ci.resourcemanager.yml
+++ b/sdk/resourcemanager/internal/ci.resourcemanager.yml
@@ -22,8 +22,8 @@ pr:
     - sdk/resourcemanager/internal/
     - eng/
 
-stages:
-- template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+extends:
+  template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     IncludeRelease: true
     ServiceDirectory: resourcemanager/internal

--- a/sdk/resourcemanager/resources/armmanagedapplications/ci.resources.yml
+++ b/sdk/resourcemanager/resources/armmanagedapplications/ci.resources.yml
@@ -21,8 +21,8 @@ pr:
     include:
     - sdk/resourcemanager/resources/armmanagedapplications/
 
-stages:
-- template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+extends:
+  template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     IncludeRelease: true
     ServiceDirectory: 'resourcemanager/resources/armmanagedapplications'

--- a/sdk/resourcemanager/solutions/armmanagedapplications/ci.solutions.yml
+++ b/sdk/resourcemanager/solutions/armmanagedapplications/ci.solutions.yml
@@ -21,8 +21,8 @@ pr:
     include:
     - sdk/resourcemanager/solutions/armmanagedapplications/
 
-stages:
-- template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+extends:
+  template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     IncludeRelease: true
     ServiceDirectory: 'resourcemanager/solutions/armmanagedapplications'

--- a/sdk/security/keyvault/internal/ci.keyvault.yml
+++ b/sdk/security/keyvault/internal/ci.keyvault.yml
@@ -21,8 +21,8 @@ pr:
     include:
     - sdk/security/keyvault/internal
 
-stages:
-- template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+extends:
+  template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: 'security/keyvault/internal'
     RunLiveTests: false


### PR DESCRIPTION
Swapping a few more `ci.yml` files to `extends` vs `stages` at their root.

Follow-up from #22590 and [the follow-up commit](https://github.com/Azure/azure-sdk-for-go/commit/88d8a7ebb55562f8b5fdc48644d31cc13d383c7d)

Not certain how it escaped the first ctrl-shift-f, but they did!