### PR TITLE
DataLake encryption context

### DIFF
--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -6,6 +6,7 @@
 * HNS Encryption Scope support
 * Append API with acquire lease, release lease and renewal of lease support.
 * Flush API bundled with release lease option.
+* HNS Encryption Context support
 
 ### Breaking Changes
 

--- a/sdk/storage/azdatalake/assets.json
+++ b/sdk/storage/azdatalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azdatalake",
-  "Tag": "go/storage/azdatalake_9d160e2359"
+  "Tag": "go/storage/azdatalake_63d8313459"
 }

--- a/sdk/storage/azdatalake/file/client.go
+++ b/sdk/storage/azdatalake/file/client.go
@@ -490,9 +490,11 @@ func (f *Client) uploadFromReader(ctx context.Context, reader io.ReaderAt, actua
 	})
 
 	if err != nil {
-		_, err2 := f.Delete(ctx, nil)
-		if err2 != nil {
-			return exported.ConvertToDFSError(err2)
+		if o.EncryptionContext != nil {
+			_, err2 := f.Delete(ctx, nil)
+			if err2 != nil {
+				return exported.ConvertToDFSError(err2)
+			}
 		}
 		return exported.ConvertToDFSError(err)
 	}

--- a/sdk/storage/azdatalake/file/client.go
+++ b/sdk/storage/azdatalake/file/client.go
@@ -490,7 +490,10 @@ func (f *Client) uploadFromReader(ctx context.Context, reader io.ReaderAt, actua
 	})
 
 	if err != nil {
-		_, err = f.Delete(ctx, nil)
+		_, err2 := f.Delete(ctx, nil)
+		if err2 != nil {
+			return exported.ConvertToDFSError(err2)
+		}
 		return exported.ConvertToDFSError(err)
 	}
 	// All appends were successful, call to flush

--- a/sdk/storage/azdatalake/file/client_test.go
+++ b/sdk/storage/azdatalake/file/client_test.go
@@ -2984,7 +2984,7 @@ func (s *UnrecordedTestSuite) TestFileUploadFile() {
 	_require.EqualValues(downloadedContentMD5, contentMD5)
 }
 
-func (s *RecordedTestSuite) TestFileUploadBufferEncryptionContext() {
+func (s *UnrecordedTestSuite) TestFileUploadBufferEncryptionContext() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 
@@ -3034,7 +3034,7 @@ func (s *RecordedTestSuite) TestFileUploadBufferEncryptionContext() {
 
 }
 
-func (s *RecordedTestSuite) TestFileUploadFileEncryptionContext() {
+func (s *UnrecordedTestSuite) TestFileUploadFileEncryptionContext() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 
@@ -3087,7 +3087,7 @@ func (s *RecordedTestSuite) TestFileUploadFileEncryptionContext() {
 	_require.Equal(testcommon.TestEncryptionContext, *dResp.EncryptionContext)
 }
 
-func (s *RecordedTestSuite) TestFileDownloadStreamEncryptionContext() {
+func (s *UnrecordedTestSuite) TestFileDownloadStreamEncryptionContext() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 
@@ -5301,7 +5301,7 @@ func (s *RecordedTestSuite) TestFileGetPropertiesWithCPK() {
 	_require.Equal(testcommon.TestCPKByValue.EncryptionKeySHA256, response.EncryptionKeySHA256)
 }
 
-func (s *RecordedTestSuite) TestFileGetPropertiesWithEncryptionContext() {
+func (s *UnecordedTestSuite) TestFileGetPropertiesWithEncryptionContext() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 

--- a/sdk/storage/azdatalake/file/client_test.go
+++ b/sdk/storage/azdatalake/file/client_test.go
@@ -5335,7 +5335,7 @@ func (s *RecordedTestSuite) TestFileGetPropertiesWithCPK() {
 	_require.Equal(testcommon.TestCPKByValue.EncryptionKeySHA256, response.EncryptionKeySHA256)
 }
 
-func (s *UnecordedTestSuite) TestFileGetPropertiesWithEncryptionContext() {
+func (s *UnrecordedTestSuite) TestFileGetPropertiesWithEncryptionContext() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 

--- a/sdk/storage/azdatalake/file/client_test.go
+++ b/sdk/storage/azdatalake/file/client_test.go
@@ -2984,6 +2984,156 @@ func (s *UnrecordedTestSuite) TestFileUploadFile() {
 	_require.EqualValues(downloadedContentMD5, contentMD5)
 }
 
+func (s *RecordedTestSuite) TestFileUploadBufferEncryptionContext() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	filesystemName := testcommon.GenerateFileSystemName(testName)
+	fsClient, err := testcommon.GetFileSystemClient(filesystemName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+	defer testcommon.DeleteFileSystem(context.Background(), _require, fsClient)
+
+	_, err = fsClient.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	var fileSize int64 = 100 * 1024 * 1024
+	fileName := testcommon.GenerateFileName(testName)
+	fClient, err := testcommon.GetFileClient(filesystemName, fileName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+
+	// create local file
+	content := make([]byte, fileSize)
+	_, err = rand.Read(content)
+	_require.NoError(err)
+	err = os.WriteFile("testFile", content, 0644)
+	_require.NoError(err)
+
+	defer func() {
+		err = os.Remove("testFile")
+		_require.NoError(err)
+	}()
+
+	fh, err := os.Open("testFile")
+	_require.NoError(err)
+
+	defer func(fh *os.File) {
+		err := fh.Close()
+		_require.NoError(err)
+	}(fh)
+
+	err = fClient.UploadBuffer(context.Background(), content, &file.UploadBufferOptions{
+		Concurrency:       5,
+		ChunkSize:         4 * 1024 * 1024,
+		EncryptionContext: &testcommon.TestEncryptionContext,
+	})
+	_require.NoError(err)
+
+	gResp2, err := fClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.Equal(testcommon.TestEncryptionContext, *gResp2.EncryptionContext)
+
+}
+
+func (s *RecordedTestSuite) TestFileUploadFileEncryptionContext() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	filesystemName := testcommon.GenerateFileSystemName(testName)
+	fsClient, err := testcommon.GetFileSystemClient(filesystemName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+	defer testcommon.DeleteFileSystem(context.Background(), _require, fsClient)
+
+	_, err = fsClient.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	var fileSize int64 = 100 * 1024 * 1024
+	fileName := testcommon.GenerateFileName(testName)
+	fClient, err := testcommon.GetFileClient(filesystemName, fileName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+
+	// create local file
+	content := make([]byte, fileSize)
+	_, err = rand.Read(content)
+	_require.NoError(err)
+	err = os.WriteFile("testFile", content, 0644)
+	_require.NoError(err)
+
+	defer func() {
+		err = os.Remove("testFile")
+		_require.NoError(err)
+	}()
+
+	fh, err := os.Open("testFile")
+	_require.NoError(err)
+
+	defer func(fh *os.File) {
+		err := fh.Close()
+		_require.NoError(err)
+	}(fh)
+
+	err = fClient.UploadFile(context.Background(), fh, &file.UploadFileOptions{
+		Concurrency:       5,
+		ChunkSize:         4 * 1024 * 1024,
+		EncryptionContext: &testcommon.TestEncryptionContext,
+	})
+	_require.NoError(err)
+
+	gResp2, err := fClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.Equal(testcommon.TestEncryptionContext, *gResp2.EncryptionContext)
+
+	dResp, err := fClient.DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+	_require.Equal(testcommon.TestEncryptionContext, *dResp.EncryptionContext)
+}
+
+func (s *RecordedTestSuite) TestFileDownloadStreamEncryptionContext() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	filesystemName := testcommon.GenerateFileSystemName(testName)
+	fsClient, err := testcommon.GetFileSystemClient(filesystemName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+	defer testcommon.DeleteFileSystem(context.Background(), _require, fsClient)
+
+	_, err = fsClient.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	var fileSize int64 = 1 * 1024 * 1024
+	fileName := testcommon.GenerateFileName(testName)
+	fClient, err := testcommon.GetFileClient(filesystemName, fileName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+
+	resp, err := fClient.Create(context.Background(), &file.CreateOptions{EncryptionContext: &testcommon.TestEncryptionContext})
+	_require.NoError(err)
+	_require.NotNil(resp)
+
+	content := make([]byte, fileSize)
+	_, err = rand.Read(content)
+	_require.NoError(err)
+	md5Value := md5.Sum(content)
+	contentMD5 := md5Value[:]
+
+	err = fClient.UploadStream(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+	_require.NoError(err)
+
+	gResp2, err := fClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.Equal(*gResp2.ContentLength, fileSize)
+
+	dResp, err := fClient.DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	data, err := io.ReadAll(dResp.Body)
+	_require.NoError(err)
+
+	downloadedMD5Value := md5.Sum(data)
+	downloadedContentMD5 := downloadedMD5Value[:]
+
+	_require.EqualValues(downloadedContentMD5, contentMD5)
+	_require.Equal(testcommon.TestEncryptionContext, *dResp.EncryptionContext)
+}
+
 func (s *RecordedTestSuite) TestSmallFileUploadFile() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
@@ -5149,6 +5299,48 @@ func (s *RecordedTestSuite) TestFileGetPropertiesWithCPK() {
 	_require.NotNil(response)
 	_require.NotNil(respFromCtxFile.Header.Get("x-ms-encryption-key-sha256")) // validate that the x-ms-encryption-key-sha256 is actually populated
 	_require.Equal(testcommon.TestCPKByValue.EncryptionKeySHA256, response.EncryptionKeySHA256)
+}
+
+func (s *RecordedTestSuite) TestFileGetPropertiesWithEncryptionContext() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	filesystemName := testcommon.GenerateFileSystemName(testName)
+	fsClient, err := testcommon.GetFileSystemClient(filesystemName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+	defer testcommon.DeleteFileSystem(context.Background(), _require, fsClient)
+
+	_, err = fsClient.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	fileName := testcommon.GenerateFileName(testName)
+	fClient, err := testcommon.GetFileClient(filesystemName, fileName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+
+	createFileOpts := &file.CreateOptions{
+		EncryptionContext: &testcommon.TestEncryptionContext,
+	}
+
+	resp, err := fClient.Create(context.Background(), createFileOpts)
+	_require.NoError(err)
+	_require.NotNil(resp)
+
+	response, err := fClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(response)
+	_require.Equal(testcommon.TestEncryptionContext, *response.EncryptionContext)
+
+	fileClient, err := testcommon.GetFileClient(filesystemName, fileName+"test", s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+
+	resp2, err := fileClient.Create(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(resp2)
+
+	response2, err := fileClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(response)
+	_require.Nil(response2.EncryptionContext)
 }
 
 func (s *UnrecordedTestSuite) TestFileCreateDeleteUsingOAuth() {

--- a/sdk/storage/azdatalake/file/models.go
+++ b/sdk/storage/azdatalake/file/models.go
@@ -309,7 +309,7 @@ func (o *AppendDataOptions) format(offset int64, body io.ReadSeekCloser) (*gener
 		_, err = o.TransactionalValidation.Apply(body, appendDataOptions)
 		if err != nil {
 			return nil, nil, nil, err
-
+		}
 		appendDataOptions.LeaseAction = o.LeaseAction
 		appendDataOptions.LeaseDuration = o.LeaseDuration
 		appendDataOptions.ProposedLeaseID = o.ProposedLeaseID

--- a/sdk/storage/azdatalake/file/models.go
+++ b/sdk/storage/azdatalake/file/models.go
@@ -55,6 +55,8 @@ type CreateOptions struct {
 	Group *string
 	// ACL is the access control list for the file.
 	ACL *string
+	// EncryptionContext stores non-encrypted data that can be used to derive the customer-provided key for a file.
+	EncryptionContext *string
 }
 
 // CreateExpiryValues describes when a newly created file should expire.
@@ -91,6 +93,7 @@ func (o *CreateOptions) format() (*generated.LeaseAccessConditions, *generated.M
 	createOpts.Permissions = o.Permissions
 	createOpts.ProposedLeaseID = o.ProposedLeaseID
 	createOpts.LeaseDuration = o.LeaseDuration
+	createOpts.EncryptionContext = o.EncryptionContext
 
 	var httpHeaders *generated.PathHTTPHeaders
 	var cpkOpts *generated.CPKInfo
@@ -149,6 +152,8 @@ type uploadFromReaderOptions struct {
 	HTTPHeaders *HTTPHeaders
 	// CPKInfo contains optional parameters to perform encryption using customer-provided key.
 	CPKInfo *CPKInfo
+	// EncryptionContext contains the information returned from the x-ms-encryption-context header response.
+	EncryptionContext *string
 }
 
 // UploadStreamOptions provides set of configurations for Client.UploadStream operation.

--- a/sdk/storage/azdatalake/file/models.go
+++ b/sdk/storage/azdatalake/file/models.go
@@ -312,7 +312,7 @@ func (o *AppendDataOptions) format(offset int64, body io.ReadSeekCloser) (*gener
 		if err != nil {
 			return nil, nil, nil, err
 		}
-    
+
 		appendDataOptions.LeaseAction = o.LeaseAction
 		appendDataOptions.LeaseDuration = o.LeaseDuration
 		appendDataOptions.ProposedLeaseID = o.ProposedLeaseID

--- a/sdk/storage/azdatalake/file/responses.go
+++ b/sdk/storage/azdatalake/file/responses.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/internal/generated_blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/internal/path"
 	"io"
+	"net/http"
 	"time"
 )
 
@@ -135,6 +136,9 @@ type DownloadResponse struct {
 	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
 	EncryptionScope *string
 
+	// EncryptionContext contains the information returned from the x-ms-encryption-context header response.
+	EncryptionContext *string
+
 	// ErrorCode contains the information returned from the x-ms-error-code header response.
 	ErrorCode *string
 
@@ -193,7 +197,7 @@ type DownloadResponse struct {
 	VersionID *string
 }
 
-func FormatDownloadStreamResponse(r *blob.DownloadStreamResponse) DownloadResponse {
+func FormatDownloadStreamResponse(r *blob.DownloadStreamResponse, rawResponse *http.Response) DownloadResponse {
 	newResp := DownloadResponse{}
 	if r != nil {
 		newResp.AcceptRanges = r.AcceptRanges
@@ -237,6 +241,9 @@ func FormatDownloadStreamResponse(r *blob.DownloadStreamResponse) DownloadRespon
 		newResp.TagCount = r.TagCount
 		newResp.Version = r.Version
 		newResp.VersionID = r.VersionID
+	}
+	if val := rawResponse.Header.Get("x-ms-encryption-context"); val != "" {
+		newResp.EncryptionContext = &val
 	}
 	return newResp
 }

--- a/sdk/storage/azdatalake/filesystem/client_test.go
+++ b/sdk/storage/azdatalake/filesystem/client_test.go
@@ -1670,6 +1670,46 @@ func (s *RecordedTestSuite) TestFilesystemListPathsWithContinuation() {
 	_require.Nil(resp.Continuation)
 }
 
+func (s *RecordedTestSuite) TestFilesystemListPathsWithEncryptionContext() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	filesystemName := testcommon.GenerateFileSystemName(testName)
+	fsClient, err := testcommon.GetFileSystemClient(filesystemName, s.T(), testcommon.TestAccountDatalake, nil)
+	_require.NoError(err)
+	defer testcommon.DeleteFileSystem(context.Background(), _require, fsClient)
+
+	_, err = fsClient.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	client := fsClient.NewFileClient(testName + "file1")
+	_, err = client.Create(context.Background(), &file.CreateOptions{EncryptionContext: &testcommon.TestEncryptionContext})
+	_require.NoError(err)
+	client = fsClient.NewFileClient(testName + "file2")
+	_, err = client.Create(context.Background(), &file.CreateOptions{EncryptionContext: &testcommon.TestEncryptionContext})
+	_require.NoError(err)
+	dirClient := fsClient.NewDirectoryClient(testName + "dir1")
+	_, err = dirClient.Create(context.Background(), nil)
+	_require.NoError(err)
+	dirClient = fsClient.NewDirectoryClient(testName + "dir2")
+	_, err = dirClient.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	pager := fsClient.NewListPathsPager(true, nil)
+	for pager.More() {
+		resp, err := pager.NextPage(context.Background())
+		_require.NoError(err)
+		_require.Equal(5, len(resp.Paths))
+		_require.Equal(resp.PathList.Paths[2].IsDirectory, to.Ptr(true))
+		// Encryption context is only applicable on files, not directories.
+		_require.Equal(resp.PathList.Paths[3].EncryptionContext, &testcommon.TestEncryptionContext)
+
+		if err != nil {
+			break
+		}
+	}
+}
+
 func (s *RecordedTestSuite) TestFilesystemListDeletedPaths() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azdatalake/internal/path/responses.go
+++ b/sdk/storage/azdatalake/internal/path/responses.go
@@ -157,6 +157,9 @@ type GetPropertiesResponse struct {
 	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
 	EncryptionScope *string
 
+	// EncryptionContext contains the information returned from the x-ms-encryption-context header response.
+	EncryptionContext *string
+
 	// ExpiresOn contains the information returned from the x-ms-expiry-time header response.
 	ExpiresOn *time.Time
 
@@ -292,6 +295,9 @@ func FormatGetPropertiesResponse(r *blob.GetPropertiesResponse, rawResponse *htt
 	}
 	if val := rawResponse.Header.Get("x-ms-resource-type"); val != "" {
 		newResp.ResourceType = &val
+	}
+	if val := rawResponse.Header.Get("x-ms-encryption-context"); val != "" {
+		newResp.EncryptionContext = &val
 	}
 	return newResp
 }

--- a/sdk/storage/azdatalake/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azdatalake/internal/testcommon/clients_auth.go
@@ -59,6 +59,7 @@ var (
 	testEncryptedKey        = "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc="
 	testEncryptedHash       = "3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE="
 	testEncryptionAlgorithm = file.EncryptionAlgorithmTypeAES256
+	TestEncryptionContext   = "test_encryption_context"
 	TestCPKByValue          = file.CPKInfo{
 		EncryptionKey:       &testEncryptedKey,
 		EncryptionKeySHA256: &testEncryptedHash,


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x]  Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go


This PR contains the following features - 
STG87 : Data Lake Encryption Context 
STG88 : Add Encryption Context to File Upload Options 