### PR TITLE
Fix go identity matrix/pool selection

### DIFF
--- a/sdk/azidentity/ci.yml
+++ b/sdk/azidentity/ci.yml
@@ -39,3 +39,6 @@ extends:
             GenerateVMJobs: true
             Path: sdk/azidentity/managed-identity-matrix.json
             Selection: sparse
+        MatrixReplace:
+          - Pool=.*LINUXPOOL.*/azsdk-pool-mms-ubuntu-2204-identitymsi
+          - OSVmImage=.*LINUXPOOL.*/azsdk-pool-mms-ubuntu-2204-1espt

--- a/sdk/azidentity/managed-identity-matrix.json
+++ b/sdk/azidentity/managed-identity-matrix.json
@@ -9,7 +9,7 @@
                 }
             },
             "GoVersion": [
-                "1.22"
+                "1.22.1"
             ],
             "IDENTITY_IMDS_AVAILABLE": "1"
         }

--- a/sdk/azidentity/managed-identity-matrix.json
+++ b/sdk/azidentity/managed-identity-matrix.json
@@ -4,8 +4,8 @@
             "Agent": {
                 "msi_image": {
                     "ArmTemplateParameters": "@{deployResources = $true}",
-                    "OSVmImage": "ubuntu-22.04",
-                    "Pool": "azsdk-pool-mms-ubuntu-2204-identitymsi"
+                    "OSVmImage": "env:LINUXNEXTVMIMAGE",
+                    "Pool": "env:LINUXPOOL"
                 }
             },
             "GoVersion": [


### PR DESCRIPTION
The matrix generation, due to 1es pt limitations, was changed to filter against OS variables and run one generation pass for each OS type. This had a mismatch with the identity matrix, so this PR updates the config to work with the generation jobs filters.
