### PR TITLE
Remove live SNI auth tests

### DIFF
--- a/sdk/azidentity/assets.json
+++ b/sdk/azidentity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/azidentity",
-  "Tag": "go/azidentity_0a700f9ea1"
+  "Tag": "go/azidentity_03176ee180"
 }

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -173,15 +173,12 @@ func TestClientCertificateCredential_Live(t *testing.T) {
 		path      string
 		sendChain bool
 	}{
-		{"PEM", liveSP.pemPath, false}, {"PKCS12", liveSP.pfxPath, false}, {"SNI", liveSP.sniPath, true},
+		{"PEM", liveSP.pemPath, false}, {"PKCS12", liveSP.pfxPath, false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.path == "" {
 				t.Skip("no certificate file specified")
-			}
-			if recording.GetRecordMode() == recording.LiveMode && test.name == "SNI" {
-				t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/21988")
 			}
 			certData, err := os.ReadFile(test.path)
 			if err != nil {
@@ -276,14 +273,14 @@ func TestClientCertificateCredential_InvalidCertLive(t *testing.T) {
 }
 
 func TestClientCertificateCredential_Regional(t *testing.T) {
-	if recording.GetRecordMode() == recording.LiveMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/21988")
+	if recording.GetRecordMode() != recording.PlaybackMode {
+		t.Skip("this test runs only in playback mode because it requires a production cert")
 	}
 	t.Setenv(azureRegionalAuthorityName, "westus2")
 	opts, stop := initRecording(t)
 	defer stop()
 
-	f, err := os.ReadFile(liveSP.sniPath)
+	f, err := os.ReadFile("testdata/certificate-with-chain.pem")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/azidentity/live_test.go
+++ b/sdk/azidentity/live_test.go
@@ -39,14 +39,12 @@ var liveSP = struct {
 	secret   string
 	pemPath  string
 	pfxPath  string
-	sniPath  string
 }{
 	tenantID: os.Getenv("IDENTITY_SP_TENANT_ID"),
 	clientID: os.Getenv("IDENTITY_SP_CLIENT_ID"),
 	secret:   os.Getenv("IDENTITY_SP_CLIENT_SECRET"),
 	pemPath:  os.Getenv("IDENTITY_SP_CERT_PEM"),
 	pfxPath:  os.Getenv("IDENTITY_SP_CERT_PFX"),
-	sniPath:  os.Getenv("IDENTITY_SP_CERT_SNI"),
 }
 
 var liveUser = struct {
@@ -111,7 +109,6 @@ func setFakeValues() {
 	liveSP.tenantID = fakeTenantID
 	liveSP.pemPath = "testdata/certificate.pem"
 	liveSP.pfxPath = "testdata/certificate.pfx"
-	liveSP.sniPath = "testdata/certificate-with-chain.pem"
 	liveUser.tenantID = fakeTenantID
 	liveUser.username = fakeUsername
 	liveUser.password = "fake-password"

--- a/sdk/azidentity/test-resources-pre.ps1
+++ b/sdk/azidentity/test-resources-pre.ps1
@@ -30,19 +30,15 @@ if ($null -eq $EnvironmentVariables -or $EnvironmentVariables.Count -eq 0) {
 $tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()
 $pfxPath = Join-Path $tmp "test.pfx"
 $pemPath = Join-Path $tmp "test.pem"
-$sniPath = Join-Path $tmp "testsni.pfx"
 
-Write-Host "Creating identity test files: $pfxPath $pemPath $sniPath"
+Write-Host "Creating identity test files: $pfxPath $pemPath"
 
 [System.Convert]::FromBase64String($EnvironmentVariables['PFX_CONTENTS']) | Set-Content -Path $pfxPath -AsByteStream
 Set-Content -Path $pemPath -Value $EnvironmentVariables['PEM_CONTENTS']
-[System.Convert]::FromBase64String($EnvironmentVariables['SNI_CONTENTS']) | Set-Content -Path $sniPath -AsByteStream
 
 # Set for pipeline
 Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_PFX;]$pfxPath"
 Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_PEM;]$pemPath"
-Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_SNI;]$sniPath"
 # Set for local
 $env:IDENTITY_SP_CERT_PFX = $pfxPath
 $env:IDENTITY_SP_CERT_PEM = $pemPath
-$env:IDENTITY_SP_CERT_SNI = $sniPath


### PR DESCRIPTION
The cert we used to test SNI auth has expired and we can't get another because requirements for issuing them have tightened (this is a 1P prod feature). Fortunately we don't need the live tests because this feature is straightforward to test with fakes and recordings, and we already do that. Closes #21988