### PR TITLE
[azeventgrid(old)] Officially deprecating this module

### DIFF
--- a/sdk/messaging/azeventgrid/CHANGELOG.md
+++ b/sdk/messaging/azeventgrid/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History
 
-## 0.4.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 0.5.0 (2024-03-27)
 
 ### Other Changes
+
+- This module has been split into two separate modules, one for each of the two different Event Grid products.
+  - The **Event Grid Basic** package in *`azeventgrid/publisher`* has been **replaced** 
+    with `github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azeventgrid`
+  - The **Event Grid Namespaces** package in *`azeventgrid`* has been **replaced**
+    with `github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces`
 
 ## 0.4.0 (2023-11-27)
 

--- a/sdk/messaging/azeventgrid/README.md
+++ b/sdk/messaging/azeventgrid/README.md
@@ -1,5 +1,7 @@
 # Azure Event Grid Client Module for Go
 
+**Please note this package has been moved to: [aznamespaces](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/eventgrid/aznamespaces).**
+
 [Azure Event Grid](https://learn.microsoft.com/azure/event-grid/overview) is a highly scalable, fully managed Pub Sub message distribution service that offers flexible message consumption patterns. For more information about Event Grid see: [link](https://learn.microsoft.com/azure/event-grid/overview).
 
 This client module allows you to publish events and receive events using the [Pull delivery](https://learn.microsoft.com/azure/event-grid/pull-delivery-overview) API.

--- a/sdk/messaging/azeventgrid/go.mod
+++ b/sdk/messaging/azeventgrid/go.mod
@@ -1,3 +1,5 @@
+// Deprecated: Event Grid Basic client has moved to github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azeventgrid
+// Deprecated: Event Grid Namespaces client has moved to use github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces
 module github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventgrid
 
 go 1.18

--- a/sdk/messaging/azeventgrid/go.mod
+++ b/sdk/messaging/azeventgrid/go.mod
@@ -1,5 +1,4 @@
-// Deprecated: Event Grid Basic client has moved to github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azeventgrid
-// Deprecated: Event Grid Namespaces client has moved to github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces
+// Deprecated: Event Grid Basic client has moved to github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azeventgrid and Event Grid Namespaces client has moved to github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces
 module github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventgrid
 
 go 1.18

--- a/sdk/messaging/azeventgrid/go.mod
+++ b/sdk/messaging/azeventgrid/go.mod
@@ -1,5 +1,5 @@
 // Deprecated: Event Grid Basic client has moved to github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azeventgrid
-// Deprecated: Event Grid Namespaces client has moved to use github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces
+// Deprecated: Event Grid Namespaces client has moved to github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces
 module github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventgrid
 
 go 1.18

--- a/sdk/messaging/azeventgrid/internal/version.go
+++ b/sdk/messaging/azeventgrid/internal/version.go
@@ -14,5 +14,5 @@ const (
 	ModuleName = "azeventgrid"
 
 	// ModuleVersion is the semantic version (see http://semver.org) of this module.
-	ModuleVersion = "v0.4.1"
+	ModuleVersion = "v0.5.0"
 )

--- a/sdk/messaging/azeventgrid/publisher/README.md
+++ b/sdk/messaging/azeventgrid/publisher/README.md
@@ -1,5 +1,7 @@
 # Azure Event Grid Publisher Client Module for Go
 
+**Please note this package has been moved to: [azeventgrid](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/eventgrid/azeventgrid).**
+
 [Azure Event Grid](https://learn.microsoft.com/azure/event-grid/overview) is a highly scalable, fully managed Pub Sub message distribution service that offers flexible message consumption patterns. For more information about Event Grid see: [link](https://learn.microsoft.com/azure/event-grid/overview).
 
 The client in this package can publish events to [Event Grid topics](https://learn.microsoft.com/azure/event-grid/concepts).


### PR DESCRIPTION
Both packages that were hosted in this module have moved and been published in their new places:

* Event Grid Basic client has moved to github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azeventgrid
* Event Grid Namespaces client has moved to github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces

We can deprecate this, publish it one more time and then scrub it from the repo.

Fixes #22554