### PR TITLE
The EventReader buffer size is now configurable

### DIFF
--- a/sdk/ai/azopenai/CHANGELOG.md
+++ b/sdk/ai/azopenai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Updating to the `2024-03-01-preview` API version. This adds support for using Dimensions with Embeddings as well as the ability to choose the embeddings format. PR(#22603)
+- `EventReader` now has a `Buffer` method that controls the scanner buffer size when streaming Server-sent event's.
 
 ### Breaking Changes
 

--- a/sdk/ai/azopenai/event_reader.go
+++ b/sdk/ai/azopenai/event_reader.go
@@ -62,6 +62,13 @@ func (er *EventReader[T]) Read() (T, error) {
 	return *new(T), scannerErr
 }
 
+// Buffer sets the initial buffer to use when streaming the response, and
+// the maximum size of the buffer.  This must be called before Read(), or
+// a panic will occur.
+func (er *EventReader[T]) Buffer(buf []byte, max int) {
+	er.scanner.Buffer(buf, max)
+}
+
 // Close closes the EventReader and any applicable inner stream state.
 func (er *EventReader[T]) Close() error {
 	return er.reader.Close()

--- a/sdk/ai/azopenai/event_reader_test.go
+++ b/sdk/ai/azopenai/event_reader_test.go
@@ -75,3 +75,28 @@ func TestEventReader_SpacesAroundAreas(t *testing.T) {
 	require.NotEmpty(t, evt)
 	require.Equal(t, "without-spaces", *evt.Choices[0].Delta.Content)
 }
+
+func TestEventReader_BufferSize(t *testing.T) {
+	data := []struct {
+		size int
+		err  error
+	}{
+		{
+			size: 1,
+			err:  bufio.ErrTooLong,
+		},
+		{
+			size: 100,
+			err:  nil,
+		},
+	}
+
+	for _, i := range data {
+		buff := strings.NewReader("data: {}")
+		eventReader := newEventReader[ChatCompletions](io.NopCloser(buff))
+		eventReader.Buffer(make([]byte, 1), i.size)
+
+		_, err := eventReader.Read()
+		require.ErrorIs(t, err, i.err)
+	}
+}


### PR DESCRIPTION
When streaming answers with BYOD, it's possible for a Server-side event to be sent with a larger size than the `EventReader` scanner's default buffer size, and the user has no way to configure this.

This MR adds a `Buffer` function to `EventReader` so you can set the buffer to a custom size.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
