### PR TITLE
[azeventgrid(old)] Fixing a test error so we can deprecate this library

### DIFF
--- a/sdk/messaging/azeventgrid/client_test.go
+++ b/sdk/messaging/azeventgrid/client_test.go
@@ -330,13 +330,19 @@ func TestSimpleErrors(t *testing.T) {
 	_, err := c.PublishCloudEvents(context.Background(), c.TestVars.Topic, []messaging.CloudEvent{
 		{},
 	}, nil)
+
+	// this'll lead to an error message like this:
+	// "error": {
+	// 	"code":"BadRequest",
+	// 	"message":"`id` must be non-empty string",
+	// 	"timestamp_utc":"2024-03-22T21:53:04.035019068+00:00",
+	// 	"tracking_id":"<some tracking ID>"
+	// }
 	var respErr *azcore.ResponseError
-
 	require.ErrorAs(t, err, &respErr)
+	require.Equal(t, "BadRequest", respErr.ErrorCode)
 	require.Equal(t, http.StatusBadRequest, respErr.StatusCode)
-	require.Contains(t, respErr.Error(), "'data' attribute is required")
 }
-
 func TestRenewCloudEventLocks(t *testing.T) {
 	c := newClientWrapper(t, nil)
 


### PR DESCRIPTION
I needed to port this text fix over so the tests will pass so I can release the library once again to deprecate it.