### PR TITLE
Correct IMDS resource ID query parameter

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* `ManagedIdentityCredential` now specifies resource IDs correctly for Azure Container Instances
 
 ### Other Changes
 

--- a/sdk/azidentity/assets.json
+++ b/sdk/azidentity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/azidentity",
-  "Tag": "go/azidentity_03176ee180"
+  "Tag": "go/azidentity_4d7934c64a"
 }

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -34,14 +34,14 @@ const (
 	identityServerThumbprint = "IDENTITY_SERVER_THUMBPRINT"
 	headerMetadata           = "Metadata"
 	imdsEndpoint             = "http://169.254.169.254/metadata/identity/oauth2/token"
+	miResID                  = "mi_res_id"
 	msiEndpoint              = "MSI_ENDPOINT"
+	msiResID                 = "msi_res_id"
 	msiSecret                = "MSI_SECRET"
 	imdsAPIVersion           = "2018-02-01"
 	azureArcAPIVersion       = "2019-08-15"
+	qpClientID               = "client_id"
 	serviceFabricAPIVersion  = "2019-07-01-preview"
-
-	qpClientID = "client_id"
-	qpResID    = "mi_res_id"
 )
 
 type msiType int
@@ -286,7 +286,7 @@ func (c *managedIdentityClient) createIMDSAuthRequest(ctx context.Context, id Ma
 	q.Add("resource", strings.Join(scopes, " "))
 	if id != nil {
 		if id.idKind() == miResourceID {
-			q.Add(qpResID, id.String())
+			q.Add(msiResID, id.String())
 		} else {
 			q.Add(qpClientID, id.String())
 		}
@@ -306,7 +306,7 @@ func (c *managedIdentityClient) createAppServiceAuthRequest(ctx context.Context,
 	q.Add("resource", scopes[0])
 	if id != nil {
 		if id.idKind() == miResourceID {
-			q.Add(qpResID, id.String())
+			q.Add(miResID, id.String())
 		} else {
 			q.Add(qpClientID, id.String())
 		}
@@ -329,7 +329,7 @@ func (c *managedIdentityClient) createAzureMLAuthRequest(ctx context.Context, id
 		if id.idKind() == miResourceID {
 			log.Write(EventAuthentication, "WARNING: Azure ML doesn't support specifying a managed identity by resource ID")
 			q.Set("clientid", "")
-			q.Set(qpResID, id.String())
+			q.Set(miResID, id.String())
 		} else {
 			q.Set("clientid", id.String())
 		}
@@ -351,7 +351,7 @@ func (c *managedIdentityClient) createServiceFabricAuthRequest(ctx context.Conte
 	if id != nil {
 		log.Write(EventAuthentication, "WARNING: Service Fabric doesn't support selecting a user-assigned identity at runtime")
 		if id.idKind() == miResourceID {
-			q.Add(qpResID, id.String())
+			q.Add(miResID, id.String())
 		} else {
 			q.Add(qpClientID, id.String())
 		}
@@ -411,7 +411,7 @@ func (c *managedIdentityClient) createAzureArcAuthRequest(ctx context.Context, i
 	if id != nil {
 		log.Write(EventAuthentication, "WARNING: Azure Arc doesn't support user-assigned managed identities")
 		if id.idKind() == miResourceID {
-			q.Add(qpResID, id.String())
+			q.Add(miResID, id.String())
 		} else {
 			q.Add(qpClientID, id.String())
 		}
@@ -437,7 +437,7 @@ func (c *managedIdentityClient) createCloudShellAuthRequest(ctx context.Context,
 		log.Write(EventAuthentication, "WARNING: Cloud Shell doesn't support user-assigned managed identities")
 		q := request.Raw().URL.Query()
 		if id.idKind() == miResourceID {
-			q.Add(qpResID, id.String())
+			q.Add(miResID, id.String())
 		} else {
 			q.Add(qpClientID, id.String())
 		}

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -242,18 +242,18 @@ func TestManagedIdentityCredential_AppService(t *testing.T) {
 				t.Fatalf(`unexpected resource "%s"`, v)
 			}
 			if id == nil {
-				if q.Get(qpClientID) != "" || q.Get(qpResID) != "" {
+				if q.Get(qpClientID) != "" || q.Get(miResID) != "" {
 					t.Fatal("request shouldn't include a user-assigned ID")
 				}
 			} else {
-				if q.Get(qpClientID) != "" && q.Get(qpResID) != "" {
+				if q.Get(qpClientID) != "" && q.Get(miResID) != "" {
 					t.Fatal("request includes two IDs")
 				}
 				var v string
 				if _, ok := id.(ClientID); ok {
 					v = q.Get(qpClientID)
 				} else if _, ok := id.(ResourceID); ok {
-					v = q.Get(qpResID)
+					v = q.Get(miResID)
 				}
 				if v != id.String() {
 					t.Fatalf(`unexpected id "%s"`, v)
@@ -450,7 +450,7 @@ func TestManagedIdentityCredential_ResourceID_IMDS(t *testing.T) {
 	if reqQueryParams["resource"][0] != liveTestScope {
 		t.Fatalf("Unexpected resource in resource query param")
 	}
-	if reqQueryParams[qpResID][0] != resID {
+	if reqQueryParams[msiResID][0] != resID {
 		t.Fatalf("Unexpected resource ID in resource query param")
 	}
 }

--- a/sdk/azidentity/test-resources-post.ps1
+++ b/sdk/azidentity/test-resources-post.ps1
@@ -27,6 +27,7 @@ FROM mcr.microsoft.com/oss/go/microsoft/golang:latest as builder
 ENV GOARCH=amd64 GOWORK=off
 COPY . /azidentity
 WORKDIR /azidentity/testdata/managed-id-test
+RUN go mod tidy
 RUN go build -o /build/managed-id-test .
 RUN GOOS=windows go build -o /build/managed-id-test.exe .
 


### PR DESCRIPTION
IMDS observes both `msi_res_id` and `mi_res_id` as the query parameter specifying an identity by its resource ID. We should prefer `msi_res_id` because it's the [documented parameter](https://github.com/Azure/azure-rest-api-specs/blob/dba6ed1f03bda88ac6884c0a883246446cc72495/specification/imds/data-plane/Microsoft.InstanceMetadataService/stable/2018-10-01/imds.json#L233-L239) and because Azure Container Instances, which has a different implementation based on the IMDS API, observes only `msi_res_id`.