### PR TITLE
[azservicebus] Fixing a long-standing bug where we wouldn't recover (inline) on amqp.Receiver.Receive() failures

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Fixed behavior in ReceiveMessages() that could lead to cases where it would not retry on retryable failures. (PR#TBD)
+- Fixed behavior in ReceiveMessages() that could lead to cases where it would not retry on retryable failures. (PR#22653)
 
 ## 1.6.1 (2024-03-05)
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Fixed behavior in ReceiveMessages() that could lead to cases where it would not retry on retryable failures. (PR#TBD)
+
 ## 1.6.1 (2024-03-05)
 
 ### Bugs Fixed


### PR DESCRIPTION
Fixing a long-standing bug where the retry loop didn't cover the entire ReceiveMessage() function, making it so we wouldn't retry if a retryable failure came from amqp.Receiver.Receive().

