### PR TITLE
[azservicebus,azeventhubs] Adding in support for connecting to an emulator

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Add in ability to handle emulator connection strings. (PR#TBD)
+- Add in ability to handle emulator connection strings. (PR#22663)
 
 ### Breaking Changes
 

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 - Add in ability to handle emulator connection strings. (PR#22663)
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fixed a race condition between Processor.Run() and Processor.NextPartitionClient() where cancelling Run() quickly could lead to NextPartitionClient hanging indefinitely. (PR#22541)

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 - Fixed a race condition between Processor.Run() and Processor.NextPartitionClient() where cancelling Run() quickly could lead to NextPartitionClient hanging indefinitely. (PR#22541)
 
-### Other Changes
-
 ## 1.0.4 (2024-03-05)
 
 ### Bugs Fixed

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.0.5 (Unreleased)
+## 1.1.0 (2024-04-02)
 
 ### Features Added
+
+- Add in ability to handle emulator connection strings. (PR#TBD)
 
 ### Breaking Changes
 

--- a/sdk/messaging/azeventhubs/internal/constants.go
+++ b/sdk/messaging/azeventhubs/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.0.5"
+const Version = "v1.1.0"

--- a/sdk/messaging/azeventhubs/internal/exported/connection_string_properties.go
+++ b/sdk/messaging/azeventhubs/internal/exported/connection_string_properties.go
@@ -43,7 +43,9 @@ type ConnectionStringProperties struct {
 // parsed representation.
 //
 // There are two supported formats:
+//
 //  1. Connection strings generated from the portal (or elsewhere) that contain an embedded key and keyname.
+//
 //  2. A connection string with an embedded SharedAccessSignature:
 //     Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"
 func ParseConnectionString(connStr string) (ConnectionStringProperties, error) {
@@ -100,8 +102,16 @@ func ParseConnectionString(connStr string) (ConnectionStringProperties, error) {
 		}
 	}
 
-	if csp.Emulator && !strings.HasPrefix(csp.Endpoint, "sb://localhost:") {
-		return ConnectionStringProperties{}, fmt.Errorf("UseEmulator=true can only be used with sb://localhost:<port>, not %s", csp.Endpoint)
+	if csp.Emulator {
+		// check that they're only connecting to localhost
+		endpointParts := strings.SplitN(csp.Endpoint, ":", 3) // allow for a port, if it exists.
+
+		if len(endpointParts) < 2 || endpointParts[0] != "sb" || endpointParts[1] != "//localhost" {
+			// there should always be at least two parts "sb:" and "//localhost"
+			// with an optional 3rd piece that's the port "1111".
+			// (we don't need to validate it's a valid host since it's been through url.Parse() above)
+			return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not %s", csp.Endpoint)
+		}
 	}
 
 	if csp.FullyQualifiedNamespace == "" {

--- a/sdk/messaging/azeventhubs/internal/exported/connection_string_properties_test.go
+++ b/sdk/messaging/azeventhubs/internal/exported/connection_string_properties_test.go
@@ -109,6 +109,13 @@ func TestNewConnectionStringProperties(t *testing.T) {
 		require.True(t, parsed.Emulator)
 		require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
 
+		// also allowed _without_ a port.
+		cs = "Endpoint=sb://localhost;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
+		parsed, err = exported.ParseConnectionString(cs)
+		require.NoError(t, err)
+		require.True(t, parsed.Emulator)
+		require.Equal(t, "sb://localhost", parsed.Endpoint)
+
 		// emulator can give connection strings that have a trailing ';'
 		cs = "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true;"
 		parsed, err = exported.ParseConnectionString(cs)
@@ -119,7 +126,7 @@ func TestNewConnectionStringProperties(t *testing.T) {
 		// UseDevelopmentEmulator only works for localhost
 		cs = "Endpoint=sb://myserver.com:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
 		parsed, err = exported.ParseConnectionString(cs)
-		require.EqualError(t, err, "UseEmulator=true can only be used with sb://localhost:<port>, not sb://myserver.com:6765")
+		require.EqualError(t, err, "UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not sb://myserver.com:6765")
 
 		// there's no reason for a person to pass False, but it's allowed.
 		// If they're not using the dev emulator then there's no special behavior, it's like a normal connection string

--- a/sdk/messaging/azeventhubs/internal/namespace.go
+++ b/sdk/messaging/azeventhubs/internal/namespace.go
@@ -462,7 +462,11 @@ func (ns *Namespace) getWSSHostURI() string {
 }
 
 func (ns *Namespace) getAMQPHostURI() string {
-	return fmt.Sprintf("amqps://%s/", ns.FQDN)
+	if ns.TokenProvider.InsecureDisableTLS {
+		return fmt.Sprintf("amqp://%s/", ns.FQDN)
+	} else {
+		return fmt.Sprintf("amqps://%s/", ns.FQDN)
+	}
 }
 
 func (ns *Namespace) GetHTTPSHostURI() string {

--- a/sdk/messaging/azeventhubs/internal/namespace_test.go
+++ b/sdk/messaging/azeventhubs/internal/namespace_test.go
@@ -471,3 +471,31 @@ func TestNamespaceCantStopRecoverFromClosingConn(t *testing.T) {
 	require.Equal(t, 1, numCancels, "we cancelled a client creation")
 	require.False(t, ns.closedPermanently)
 }
+
+func TestNamespaceDisablingAMQPS(t *testing.T) {
+	t.Run("UseDevelopmentEmulator", func(t *testing.T) {
+		cs := "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + "MyKey" + ";SharedAccessKey=" + "MySecret" + ";UseDevelopmentEmulator=true"
+		ns, err := NewNamespace(NamespaceWithConnectionString(cs))
+		require.NoError(t, err)
+
+		audience := ns.GetEntityAudience("hub1")
+		require.Equal(t, "amqp://localhost:6765/hub1", audience)
+	})
+
+	t.Run("Normal", func(t *testing.T) {
+		cs := "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + "MyKey" + ";SharedAccessKey=" + "MySecret"
+		ns, err := NewNamespace(NamespaceWithConnectionString(cs))
+		require.NoError(t, err)
+
+		audience := ns.GetEntityAudience("hub1")
+		require.Equal(t, "amqps://localhost:6765/hub1", audience)
+	})
+
+	t.Run("TokenCredential", func(t *testing.T) {
+		ns, err := NewNamespace(NamespaceWithTokenCredential("localhost:6765", &fakeTokenCredential{}))
+		require.NoError(t, err)
+
+		audience := ns.GetEntityAudience("hub1")
+		require.Equal(t, "amqps://localhost:6765/hub1", audience)
+	})
+}

--- a/sdk/messaging/azeventhubs/internal/sbauth/token_provider.go
+++ b/sdk/messaging/azeventhubs/internal/sbauth/token_provider.go
@@ -20,6 +20,11 @@ import (
 type TokenProvider struct {
 	tokenCred        azcore.TokenCredential
 	sasTokenProvider *sas.TokenProvider
+
+	// InsecureDisableTLS disables TLS. This is only used if the user is connecting to localhost
+	// and is using an emulator connection string. See [ConnectionStringProperties.Emulator] for
+	// details.
+	InsecureDisableTLS bool
 }
 
 // NewTokenProvider creates a tokenProvider from azcore.TokenCredential.
@@ -46,7 +51,7 @@ func NewTokenProviderWithConnectionString(props exported.ConnectionStringPropert
 		return nil, err
 	}
 
-	return &TokenProvider{sasTokenProvider: provider}, nil
+	return &TokenProvider{sasTokenProvider: provider, InsecureDisableTLS: props.Emulator}, nil
 }
 
 // singleUseTokenProvider allows you to wrap an *auth.Token so it can be used

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Add in ability to handle emulator connection strings. (PR#TBD)
+- Add in ability to handle emulator connection strings. (PR#22663)
 
 ### Breaking Changes
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.6.2 (Unreleased)
+## 1.7.0 (2024-04-02)
 
 ### Features Added
+
+- Add in ability to handle emulator connection strings. (PR#TBD)
 
 ### Breaking Changes
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -6,12 +6,6 @@
 
 - Add in ability to handle emulator connection strings. (PR#22663)
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.6.1 (2024-03-05)
 
 ### Bugs Fixed

--- a/sdk/messaging/azservicebus/admin/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin/admin_client_test.go
@@ -752,9 +752,9 @@ func TestAdminClient_Forwarding(t *testing.T) {
 
 	defer deleteTopic(t, adminClient, topicName)
 
-	parsed, err := conn.ParsedConnectionFromStr(test.GetConnectionString(t))
+	parsed, err := conn.ParseConnectionString(test.GetConnectionString(t))
 	require.NoError(t, err)
-	forwardToName := to.Ptr(fmt.Sprintf("sb://%s/%s", parsed.Namespace, forwardToQueueName))
+	forwardToName := to.Ptr(fmt.Sprintf("sb://%s/%s", parsed.FullyQualifiedNamespace, forwardToQueueName))
 
 	_, err = adminClient.CreateSubscription(context.Background(), topicName, "sub1", &CreateSubscriptionOptions{
 		Properties: &SubscriptionProperties{

--- a/sdk/messaging/azservicebus/admin_client_test.go
+++ b/sdk/messaging/azservicebus/admin_client_test.go
@@ -32,10 +32,10 @@ func TestAdminClient_Queue_Forwarding(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	parsed, err := conn.ParsedConnectionFromStr(cs)
+	parsed, err := conn.ParseConnectionString(cs)
 	require.NoError(t, err)
 
-	formatted := fmt.Sprintf("%s%s", fmt.Sprintf("https://%s/", parsed.Namespace), forwardToQueueName)
+	formatted := fmt.Sprintf("%s%s", fmt.Sprintf("https://%s/", parsed.FullyQualifiedNamespace), forwardToQueueName)
 
 	createResp, err := adminClient.CreateQueue(context.Background(), queueName, &admin.CreateQueueOptions{
 		Properties: &admin.QueueProperties{

--- a/sdk/messaging/azservicebus/internal/atom/entity_manager.go
+++ b/sdk/messaging/azservicebus/internal/atom/entity_manager.go
@@ -99,7 +99,7 @@ func (m *ManagementError) String() string {
 // for the ATOM endpoint). This is typically wrapped by an entity specific client (like
 // TopicManager, QueueManager or , SubscriptionManager).
 func NewEntityManagerWithConnectionString(connectionString string, version string, options *azcore.ClientOptions) (EntityManager, error) {
-	parsed, err := conn.ParsedConnectionFromStr(connectionString)
+	parsed, err := conn.ParseConnectionString(connectionString)
 
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func NewEntityManagerWithConnectionString(connectionString string, version strin
 		return nil, err
 	}
 
-	return newEntityManagerImpl(provider, version, options, parsed.Namespace)
+	return newEntityManagerImpl(provider, version, options, parsed.FullyQualifiedNamespace)
 }
 
 // NewEntityManager creates an entity manager using a TokenCredential.

--- a/sdk/messaging/azservicebus/internal/conn/conn.go
+++ b/sdk/messaging/azservicebus/internal/conn/conn.go
@@ -6,44 +6,64 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
 type (
-	// ParsedConn is the structure of a parsed Service Bus or Event Hub connection string.
-	ParsedConn struct {
-		Namespace string
-		HubName   string
+	// ConnectionStringProperties are the properties of a connection string
+	// as returned by [ParseConnectionString].
+	ConnectionStringProperties struct {
+		// Endpoint is the Endpoint value in the connection string.
+		// Ex: sb://example.servicebus.windows.net
+		Endpoint string
 
-		KeyName string
-		Key     string
+		// EntityPath is EntityPath value in the connection string.
+		EntityPath *string
 
-		SAS string
+		// FullyQualifiedNamespace is the Endpoint value without the protocol scheme.
+		// Ex: example.servicebus.windows.net
+		FullyQualifiedNamespace string
+
+		// SharedAccessKey is the SharedAccessKey value in the connection string.
+		SharedAccessKey *string
+
+		// SharedAccessKeyName is the SharedAccessKeyName value in the connection string.
+		SharedAccessKeyName *string
+
+		// SharedAccessSignature is the SharedAccessSignature value in the connection string.
+		SharedAccessSignature *string
+
+		// Emulator indicates that the connection string is for an emulator:
+		// ex: Endpoint=localhost:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true
+		Emulator bool
 	}
 )
 
-// ParsedConnectionFromStr takes a string connection string from the Azure portal and returns the parsed representation.
+// ParseConnectionString takes a string connection string from the Azure portal and returns the parsed representation.
 // The method will return an error if the Endpoint, SharedAccessKeyName or SharedAccessKey is empty.
-func ParsedConnectionFromStr(connStr string) (*ParsedConn, error) {
+func ParseConnectionString(connStr string) (ConnectionStringProperties, error) {
 	const (
 		endpointKey              = "Endpoint"
 		sharedAccessKeyNameKey   = "SharedAccessKeyName"
 		sharedAccessKeyKey       = "SharedAccessKey"
 		entityPathKey            = "EntityPath"
 		sharedAccessSignatureKey = "SharedAccessSignature"
+		useEmulator              = "UseDevelopmentEmulator"
 	)
 
-	// We can parse two types of connection strings.
-	// 1. Connection strings generated from the portal (or elsewhere) that contain an embedded key and keyname.
-	// 2. A specially formatted connection string with an embedded SharedAccessSignature:
-	//   Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"
-	var namespace, hubName, keyName, secret, sas string
+	csp := ConnectionStringProperties{}
+
 	splits := strings.Split(connStr, ";")
 
 	for _, split := range splits {
+		if split == "" {
+			continue
+		}
+
 		keyAndValue := strings.SplitN(split, "=", 2)
 		if len(keyAndValue) < 2 {
-			return nil, errors.New("failed parsing connection string due to unmatched key value separated by '='")
+			return ConnectionStringProperties{}, errors.New("failed parsing connection string due to unmatched key value separated by '='")
 		}
 
 		// if a key value pair has `=` in the value, recombine them
@@ -53,39 +73,44 @@ func ParsedConnectionFromStr(connStr string) (*ParsedConn, error) {
 		case strings.EqualFold(endpointKey, key):
 			u, err := url.Parse(value)
 			if err != nil {
-				return nil, errors.New("failed parsing connection string due to an incorrectly formatted Endpoint value")
+				return ConnectionStringProperties{}, errors.New("failed parsing connection string due to an incorrectly formatted Endpoint value")
 			}
-			namespace = u.Host
+			csp.Endpoint = value
+			csp.FullyQualifiedNamespace = u.Host
 		case strings.EqualFold(sharedAccessKeyNameKey, key):
-			keyName = value
+			csp.SharedAccessKeyName = &value
 		case strings.EqualFold(sharedAccessKeyKey, key):
-			secret = value
+			csp.SharedAccessKey = &value
 		case strings.EqualFold(entityPathKey, key):
-			hubName = value
+			csp.EntityPath = &value
 		case strings.EqualFold(sharedAccessSignatureKey, key):
-			sas = value
+			csp.SharedAccessSignature = &value
+		case strings.EqualFold(useEmulator, key):
+			v, err := strconv.ParseBool(value)
+
+			if err != nil {
+				return ConnectionStringProperties{}, err
+			}
+
+			csp.Emulator = v
 		}
 	}
 
-	parsed := &ParsedConn{
-		Namespace: namespace,
-		KeyName:   keyName,
-		Key:       secret,
-		HubName:   hubName,
-		SAS:       sas,
+	if csp.Emulator && !strings.HasPrefix(csp.Endpoint, "sb://localhost:") {
+		return ConnectionStringProperties{}, fmt.Errorf("UseEmulator=true can only be used with sb://localhost:<port>, not %s", csp.Endpoint)
 	}
 
-	if namespace == "" {
-		return parsed, fmt.Errorf("key %q must not be empty", endpointKey)
+	if csp.FullyQualifiedNamespace == "" {
+		return ConnectionStringProperties{}, fmt.Errorf("key %q must not be empty", endpointKey)
 	}
 
-	if sas == "" && keyName == "" {
-		return parsed, fmt.Errorf("key %q must not be empty", sharedAccessKeyNameKey)
+	if csp.SharedAccessSignature == nil && csp.SharedAccessKeyName == nil {
+		return ConnectionStringProperties{}, fmt.Errorf("key %q must not be empty", sharedAccessKeyNameKey)
 	}
 
-	if secret == "" && sas == "" {
-		return parsed, fmt.Errorf("key %q or %q cannot both be empty", sharedAccessKeyKey, sharedAccessSignatureKey)
+	if csp.SharedAccessKey == nil && csp.SharedAccessSignature == nil {
+		return ConnectionStringProperties{}, fmt.Errorf("key %q or %q cannot both be empty", sharedAccessKeyKey, sharedAccessSignatureKey)
 	}
 
-	return parsed, nil
+	return csp, nil
 }

--- a/sdk/messaging/azservicebus/internal/conn/conn_test.go
+++ b/sdk/messaging/azservicebus/internal/conn/conn_test.go
@@ -97,6 +97,13 @@ func TestUseDevelopmentEmulatorProperty(t *testing.T) {
 	require.True(t, parsed.Emulator)
 	require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
 
+	// also allowed _without_ a port.
+	cs = "Endpoint=sb://localhost;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
+	parsed, err = ParseConnectionString(cs)
+	require.NoError(t, err)
+	require.True(t, parsed.Emulator)
+	require.Equal(t, "sb://localhost", parsed.Endpoint)
+
 	// emulator can give connection strings that have a trailing ';'
 	cs = "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true;"
 	parsed, err = ParseConnectionString(cs)
@@ -107,7 +114,7 @@ func TestUseDevelopmentEmulatorProperty(t *testing.T) {
 	// UseDevelopmentEmulator only works for localhost
 	cs = "Endpoint=sb://myserver.com:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
 	parsed, err = ParseConnectionString(cs)
-	require.EqualError(t, err, "UseEmulator=true can only be used with sb://localhost:<port>, not sb://myserver.com:6765")
+	require.EqualError(t, err, "UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not sb://myserver.com:6765")
 
 	// there's no reason for a person to pass False, but it's allowed.
 	// If they're not using the dev emulator then there's no special behavior, it's like a normal connection string
@@ -116,4 +123,5 @@ func TestUseDevelopmentEmulatorProperty(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, parsed.Emulator)
 	require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
+
 }

--- a/sdk/messaging/azservicebus/internal/conn/conn_test.go
+++ b/sdk/messaging/azservicebus/internal/conn/conn_test.go
@@ -25,6 +25,7 @@ package conn
 import (
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,47 +43,77 @@ const (
 )
 
 func TestParsedConnectionFromStr(t *testing.T) {
-	parsed, err := ParsedConnectionFromStr(happyConnStr)
+	parsed, err := ParseConnectionString(happyConnStr)
 	if assert.NoError(t, err) {
-		assert.Equal(t, namespace+".servicebus.windows.net", parsed.Namespace)
-		assert.Equal(t, keyName, parsed.KeyName)
-		assert.Equal(t, secret, parsed.Key)
-		assert.Equal(t, hubName, parsed.HubName)
+		assert.Equal(t, namespace+".servicebus.windows.net", parsed.FullyQualifiedNamespace)
+		assert.Equal(t, keyName, *parsed.SharedAccessKeyName)
+		assert.Equal(t, secret, *parsed.SharedAccessKey)
+		assert.Equal(t, hubName, *parsed.EntityPath)
+		require.False(t, parsed.Emulator)
 	}
 }
 
 func TestParsedConnectionFromStrCaseIndifference(t *testing.T) {
-	parsed, err := ParsedConnectionFromStr(lowerCase)
+	parsed, err := ParseConnectionString(lowerCase)
 	if assert.NoError(t, err) {
-		assert.Equal(t, namespace+".servicebus.windows.net", parsed.Namespace)
-		assert.Equal(t, keyName, parsed.KeyName)
-		assert.Equal(t, secret, parsed.Key)
-		assert.Equal(t, hubName, parsed.HubName)
+		assert.Equal(t, namespace+".servicebus.windows.net", parsed.FullyQualifiedNamespace)
+		assert.Equal(t, keyName, *parsed.SharedAccessKeyName)
+		assert.Equal(t, secret, *parsed.SharedAccessKey)
+		assert.Equal(t, hubName, *parsed.EntityPath)
 	}
 }
 
 func TestParsedConnectionFromStrWithoutEntityPath(t *testing.T) {
-	parsed, err := ParsedConnectionFromStr(noEntityPath)
+	parsed, err := ParseConnectionString(noEntityPath)
 	if assert.NoError(t, err) {
-		assert.Equal(t, namespace+".servicebus.windows.net", parsed.Namespace)
-		assert.Equal(t, keyName, parsed.KeyName)
-		assert.Equal(t, secret, parsed.Key)
-		assert.Equal(t, "", parsed.HubName)
+		assert.Equal(t, namespace+".servicebus.windows.net", parsed.FullyQualifiedNamespace)
+		assert.Equal(t, keyName, *parsed.SharedAccessKeyName)
+		assert.Equal(t, secret, *parsed.SharedAccessKey)
+		require.Nil(t, parsed.EntityPath)
 	}
 }
 
 func TestParsedConnectionFromStrWithEmbeddedSAS(t *testing.T) {
-	parsed, err := ParsedConnectionFromStr(withEmbeddedSAS)
+	parsed, err := ParseConnectionString(withEmbeddedSAS)
 	require.NoError(t, err)
 
-	require.Equal(t, &ParsedConn{
-		Namespace: namespace + ".servicebus.windows.net",
-		SAS:       "SharedAccessSignature sr=" + namespace + ".servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>",
+	require.Equal(t, ConnectionStringProperties{
+		Endpoint:                "sb://" + namespace + ".servicebus.windows.net/",
+		FullyQualifiedNamespace: namespace + ".servicebus.windows.net",
+		SharedAccessSignature:   to.Ptr("SharedAccessSignature sr=" + namespace + ".servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"),
 	}, parsed)
 
 }
 
 func TestFailedParsedConnectionFromStrWithoutEndpoint(t *testing.T) {
-	_, err := ParsedConnectionFromStr(noEndpoint)
+	_, err := ParseConnectionString(noEndpoint)
 	assert.Error(t, err)
+}
+
+func TestUseDevelopmentEmulatorProperty(t *testing.T) {
+	cs := "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
+	parsed, err := ParseConnectionString(cs)
+	require.NoError(t, err)
+	require.True(t, parsed.Emulator)
+	require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
+
+	// emulator can give connection strings that have a trailing ';'
+	cs = "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true;"
+	parsed, err = ParseConnectionString(cs)
+	require.NoError(t, err)
+	require.True(t, parsed.Emulator)
+	require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
+
+	// UseDevelopmentEmulator only works for localhost
+	cs = "Endpoint=sb://myserver.com:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
+	parsed, err = ParseConnectionString(cs)
+	require.EqualError(t, err, "UseEmulator=true can only be used with sb://localhost:<port>, not sb://myserver.com:6765")
+
+	// there's no reason for a person to pass False, but it's allowed.
+	// If they're not using the dev emulator then there's no special behavior, it's like a normal connection string
+	cs = "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=false"
+	parsed, err = ParseConnectionString(cs)
+	require.NoError(t, err)
+	require.False(t, parsed.Emulator)
+	require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
 }

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.6.2"
+const Version = "v1.7.0"

--- a/sdk/messaging/azservicebus/internal/namespace_test.go
+++ b/sdk/messaging/azservicebus/internal/namespace_test.go
@@ -407,3 +407,31 @@ func (f *fakeAMQPClient) Close() error {
 	f.closeCalled++
 	return nil
 }
+
+func TestNamespaceDisablingAMQPS(t *testing.T) {
+	t.Run("UseDevelopmentEmulator", func(t *testing.T) {
+		cs := "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + "MyKey" + ";SharedAccessKey=" + "MySecret" + ";UseDevelopmentEmulator=true"
+		ns, err := NewNamespace(NamespaceWithConnectionString(cs))
+		require.NoError(t, err)
+
+		audience := ns.GetEntityAudience("hub1")
+		require.Equal(t, "amqp://localhost:6765/hub1", audience)
+	})
+
+	t.Run("Normal", func(t *testing.T) {
+		cs := "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + "MyKey" + ";SharedAccessKey=" + "MySecret"
+		ns, err := NewNamespace(NamespaceWithConnectionString(cs))
+		require.NoError(t, err)
+
+		audience := ns.GetEntityAudience("hub1")
+		require.Equal(t, "amqps://localhost:6765/hub1", audience)
+	})
+
+	t.Run("TokenCredential", func(t *testing.T) {
+		ns, err := NewNamespace(NamespaceWithTokenCredential("localhost:6765", &fakeTokenCredential{}))
+		require.NoError(t, err)
+
+		audience := ns.GetEntityAudience("hub1")
+		require.Equal(t, "amqps://localhost:6765/hub1", audience)
+	})
+}

--- a/sdk/messaging/azservicebus/internal/sas/sas.go
+++ b/sdk/messaging/azservicebus/internal/sas/sas.go
@@ -139,21 +139,21 @@ func (s *Signer) SignWithExpiry(uri, expiry string) (string, error) {
 // an embedded SharedAccessSignature and expiration.
 // Ex: Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"
 func CreateConnectionStringWithSASUsingExpiry(connectionString string, expiry time.Time) (string, error) {
-	parsed, err := conn.ParsedConnectionFromStr(connectionString)
+	props, err := conn.ParseConnectionString(connectionString)
 
 	if err != nil {
 		return "", err
 	}
 
-	signer := NewSigner(parsed.KeyName, parsed.Key)
+	signer := NewSigner(*props.SharedAccessKeyName, *props.SharedAccessKey)
 
-	sig, err := signer.SignWithExpiry(parsed.Namespace, fmt.Sprintf("%d", expiry.Unix()))
+	sig, err := signer.SignWithExpiry(props.FullyQualifiedNamespace, fmt.Sprintf("%d", expiry.Unix()))
 
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("Endpoint=sb://%s;SharedAccessSignature=%s", parsed.Namespace, sig), nil
+	return fmt.Sprintf("Endpoint=sb://%s;SharedAccessSignature=%s", props.FullyQualifiedNamespace, sig), nil
 }
 
 func signatureExpiry(from time.Time, interval time.Duration) string {


### PR DESCRIPTION
Emulators are coming and the SDKs needed to allow non-TLS connections but it's restricted to localhost, and emulators _only_, which you signal with the new 'UseDevelopmentEmulator=true' property in your connection string.

Fixes #22370
Fixes #22371