### PR TITLE
Don't consider 408 as terminal failure for Location poller

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Pollers that use the `Location` header won't consider `http.StatusRequestTimeout` a terminal failure.
+
 ### Other Changes
 
 ## 1.11.0 (2024-04-01)

--- a/sdk/azcore/internal/pollers/loc/loc.go
+++ b/sdk/azcore/internal/pollers/loc/loc.go
@@ -103,10 +103,10 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 		} else if resp.StatusCode > 199 && resp.StatusCode < 300 {
 			// any 2xx other than a 202 indicates success
 			p.CurState = poller.StatusSucceeded
-		} else if resp.StatusCode == http.StatusTooManyRequests {
-			// the request is being throttled. DO NOT include
-			// this as a terminal failure. preserve the
-			// existing state and return the response.
+		} else if resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests {
+			// the request timed out or is being throttled.
+			// DO NOT include this as a terminal failure. preserve
+			// the existing state and return the response.
 		} else {
 			p.CurState = poller.StatusFailed
 		}


### PR DESCRIPTION
Treat 408 the same as 429, preserving state and returning the response.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
