### PR TITLE
runtime.Poller.Result won't be done on non-terminal error

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 * Pollers that use the `Location` header won't consider `http.StatusRequestTimeout` a terminal failure.
+* `runtime.Poller[T].Result` won't cache non-terminal error responses.
 
 ### Other Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 * Pollers that use the `Location` header won't consider `http.StatusRequestTimeout` a terminal failure.
-* `runtime.Poller[T].Result` won't cache non-terminal error responses.
+* `runtime.Poller[T].Result` won't consider non-terminal error responses as terminal.
 
 ### Other Changes
 

--- a/sdk/azcore/internal/pollers/loc/loc.go
+++ b/sdk/azcore/internal/pollers/loc/loc.go
@@ -103,7 +103,7 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 		} else if resp.StatusCode > 199 && resp.StatusCode < 300 {
 			// any 2xx other than a 202 indicates success
 			p.CurState = poller.StatusSucceeded
-		} else if resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests {
+		} else if pollers.IsNonTerminalHTTPStatusCode(resp) {
 			// the request timed out or is being throttled.
 			// DO NOT include this as a terminal failure. preserve
 			// the existing state and return the response.

--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -189,5 +189,12 @@ func ResultHelper[T any](resp *http.Response, failed bool, out *T) error {
 // IsNonTerminalHTTPStatusCode returns true if the HTTP status code should be
 // considered non-terminal thus eligible for retry.
 func IsNonTerminalHTTPStatusCode(resp *http.Response) bool {
-	return resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests
+	return exported.HasStatusCode(resp,
+		http.StatusRequestTimeout,      // 408
+		http.StatusTooManyRequests,     // 429
+		http.StatusInternalServerError, // 500
+		http.StatusBadGateway,          // 502
+		http.StatusServiceUnavailable,  // 503
+		http.StatusGatewayTimeout,      // 504
+	)
 }

--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -185,3 +185,9 @@ func ResultHelper[T any](resp *http.Response, failed bool, out *T) error {
 	}
 	return nil
 }
+
+// IsNonTerminalHTTPStatusCode returns true if the HTTP status code should be
+// considered non-terminal thus eligible for retry.
+func IsNonTerminalHTTPStatusCode(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests
+}

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -184,3 +184,9 @@ func TestResultHelper(t *testing.T) {
 	require.Equal(t, "happy", widgetResult.Result)
 	require.Equal(t, 123, widgetResult.Precalculated)
 }
+
+func TestIsNonTerminalHTTPStatusCode(t *testing.T) {
+	require.True(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusRequestTimeout}))
+	require.True(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusTooManyRequests}))
+	require.False(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusInternalServerError}))
+}

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -188,5 +188,10 @@ func TestResultHelper(t *testing.T) {
 func TestIsNonTerminalHTTPStatusCode(t *testing.T) {
 	require.True(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusRequestTimeout}))
 	require.True(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusTooManyRequests}))
-	require.False(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusInternalServerError}))
+	require.True(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusInternalServerError}))
+	require.True(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusBadGateway}))
+	require.True(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusServiceUnavailable}))
+	require.True(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusGatewayTimeout}))
+	require.False(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusBadRequest}))
+	require.False(t, IsNonTerminalHTTPStatusCode(&http.Response{StatusCode: http.StatusNotImplemented}))
 }

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -334,6 +334,11 @@ func (p *Poller[T]) Result(ctx context.Context) (res T, err error) {
 	err = p.op.Result(ctx, p.result)
 	var respErr *exported.ResponseError
 	if errors.As(err, &respErr) {
+		if pollers.IsNonTerminalHTTPStatusCode(respErr.RawResponse) {
+			// the request failed in a non-terminal way.
+			// don't cache the error or mark the Poller as done
+			return
+		}
 		// the LRO failed. record the error
 		p.err = err
 	} else if err != nil {


### PR DESCRIPTION
If the underlying error when retrieving the final result is non terminal, don't mark the poller as done so callers can retry.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
