### PR TITLE
azidentity test cleanup

### DIFF
--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -284,7 +284,7 @@ func TestUserAuthentication(t *testing.T) {
 				_, err = cred.Authenticate(context.Background(), nil)
 				require.NoError(t, err)
 
-				os.Setenv(azureAuthorityHost, cc.ActiveDirectoryAuthorityHost)
+				t.Setenv(azureAuthorityHost, cc.ActiveDirectoryAuthorityHost)
 				cred, err = credential.new(nil, azcore.ClientOptions{Transport: &sts}, AuthenticationRecord{}, false)
 				require.NoError(t, err)
 				_, err = cred.Authenticate(context.Background(), nil)

--- a/sdk/azidentity/azure_cli_credential_test.go
+++ b/sdk/azidentity/azure_cli_credential_test.go
@@ -40,7 +40,7 @@ func mockAzTokenProviderFailure(context.Context, []string, string, string) ([]by
 	return nil, newAuthenticationFailedError(credNameAzureCLI, "mock provider error", nil, nil)
 }
 
-func mockAzTokenProviderSuccess(ctx context.Context, scopes []string, tenant, subscription string) ([]byte, error) {
+func mockAzTokenProviderSuccess(context.Context, []string, string, string) ([]byte, error) {
 	return azTokenOutput("2001-02-03 04:05:06.000007", 0), nil
 }
 

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -63,17 +63,6 @@ func TestParseCertificates_Error(t *testing.T) {
 	}
 }
 
-func TestClientCertificateCredential_InvalidTenantID(t *testing.T) {
-	test := allCertTests[0]
-	cred, err := NewClientCertificateCredential(badTenantID, fakeClientID, test.certs, test.key, nil)
-	if err == nil {
-		t.Fatal("Expected an error but received none")
-	}
-	if cred != nil {
-		t.Fatalf("Expected a nil credential value. Received: %v", cred)
-	}
-}
-
 func TestClientCertificateCredential_GetTokenSuccess(t *testing.T) {
 	for _, test := range allCertTests {
 		t.Run(test.name, func(t *testing.T) {

--- a/sdk/azidentity/client_certificate_credential_test.go
+++ b/sdk/azidentity/client_certificate_credential_test.go
@@ -63,22 +63,6 @@ func TestParseCertificates_Error(t *testing.T) {
 	}
 }
 
-func TestClientCertificateCredential_GetTokenSuccess(t *testing.T) {
-	for _, test := range allCertTests {
-		t.Run(test.name, func(t *testing.T) {
-			cred, err := NewClientCertificateCredential(fakeTenantID, fakeClientID, test.certs, test.key, nil)
-			if err != nil {
-				t.Fatalf("Expected an empty error but received: %s", err.Error())
-			}
-			cred.client.noCAE = fakeConfidentialClient{}
-			_, err = cred.GetToken(context.Background(), testTRO)
-			if err != nil {
-				t.Fatalf("Expected an empty error but received: %s", err.Error())
-			}
-		})
-	}
-}
-
 func TestClientCertificateCredential_SendCertificateChain(t *testing.T) {
 	for _, test := range allCertTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -100,19 +84,6 @@ func TestClientCertificateCredential_SendCertificateChain(t *testing.T) {
 				t.Fatalf("unexpected token: %s", tk.Token)
 			}
 		})
-	}
-}
-
-func TestClientCertificateCredential_GetTokenCheckPrivateKeyBlocks(t *testing.T) {
-	test := allCertTests[0]
-	cred, err := NewClientCertificateCredential(fakeTenantID, fakeClientID, test.certs, test.key, nil)
-	if err != nil {
-		t.Fatalf("Expected an empty error but received: %s", err.Error())
-	}
-	cred.client.noCAE = fakeConfidentialClient{}
-	_, err = cred.GetToken(context.Background(), testTRO)
-	if err != nil {
-		t.Fatalf("Expected an empty error but received: %s", err.Error())
 	}
 }
 

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -17,16 +17,6 @@ import (
 
 const fakeSecret = "secret"
 
-func TestClientSecretCredential_InvalidTenantID(t *testing.T) {
-	cred, err := NewClientSecretCredential(badTenantID, fakeClientID, fakeSecret, nil)
-	if err == nil {
-		t.Fatal("Expected an error but received none")
-	}
-	if cred != nil {
-		t.Fatalf("Expected a nil credential value. Received: %v", cred)
-	}
-}
-
 func TestClientSecretCredential_GetTokenSuccess(t *testing.T) {
 	cred, err := NewClientSecretCredential(fakeTenantID, fakeClientID, fakeSecret, nil)
 	if err != nil {

--- a/sdk/azidentity/client_secret_credential_test.go
+++ b/sdk/azidentity/client_secret_credential_test.go
@@ -17,18 +17,6 @@ import (
 
 const fakeSecret = "secret"
 
-func TestClientSecretCredential_GetTokenSuccess(t *testing.T) {
-	cred, err := NewClientSecretCredential(fakeTenantID, fakeClientID, fakeSecret, nil)
-	if err != nil {
-		t.Fatalf("Unable to create credential. Received: %v", err)
-	}
-	cred.client.noCAE = fakeConfidentialClient{}
-	_, err = cred.GetToken(context.Background(), testTRO)
-	if err != nil {
-		t.Fatalf("Expected an empty error but received: %v", err)
-	}
-}
-
 func TestClientSecretCredential_Live(t *testing.T) {
 	for _, disabledID := range []bool{true, false} {
 		name := "default options"

--- a/sdk/azidentity/confidential_client.go
+++ b/sdk/azidentity/confidential_client.go
@@ -91,7 +91,7 @@ func (c *confidentialClient) GetToken(ctx context.Context, tro policy.TokenReque
 		}
 		tro.TenantID = tenant
 	}
-	client, mu, err := c.client(ctx, tro)
+	client, mu, err := c.client(tro)
 	if err != nil {
 		return azcore.AccessToken{}, err
 	}
@@ -121,7 +121,7 @@ func (c *confidentialClient) GetToken(ctx context.Context, tro policy.TokenReque
 	return azcore.AccessToken{Token: ar.AccessToken, ExpiresOn: ar.ExpiresOn.UTC()}, err
 }
 
-func (c *confidentialClient) client(ctx context.Context, tro policy.TokenRequestOptions) (msalConfidentialClient, *sync.Mutex, error) {
+func (c *confidentialClient) client(tro policy.TokenRequestOptions) (msalConfidentialClient, *sync.Mutex, error) {
 	c.clientMu.Lock()
 	defer c.clientMu.Unlock()
 	if tro.EnableCAE {

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -16,18 +16,6 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
-func TestDeviceCodeCredential_InvalidTenantID(t *testing.T) {
-	options := DeviceCodeCredentialOptions{}
-	options.TenantID = badTenantID
-	cred, err := NewDeviceCodeCredential(&options)
-	if err == nil {
-		t.Fatal("Expected an error but received none")
-	}
-	if cred != nil {
-		t.Fatalf("Expected a nil credential value. Received: %v", cred)
-	}
-}
-
 func TestDeviceCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
 	cred, err := NewDeviceCodeCredential(nil)
 	if err != nil {

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -17,14 +17,22 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
+	"github.com/stretchr/testify/require"
 )
 
-func resetEnvironmentVarsForTest() {
-	clearEnvVars(azureTenantID, azureClientID, azureClientSecret, azureClientCertificatePath, azureUsername, azurePassword)
+func unsetEnvironmentVarsForTest(t *testing.T) {
+	for _, k := range []string{
+		azureClientCertificatePath, azureClientID, azureClientSecret, azurePassword, azureTenantID, azureUsername,
+	} {
+		if v, set := os.LookupEnv(k); set {
+			require.NoError(t, os.Unsetenv(k))
+			t.Cleanup(func() { require.NoError(t, os.Setenv(k, v)) })
+		}
+	}
 }
 
 func TestEnvironmentCredential_TenantIDNotSet(t *testing.T) {
-	resetEnvironmentVarsForTest()
+	unsetEnvironmentVarsForTest(t)
 	err := os.Setenv(azureClientID, fakeClientID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
@@ -40,7 +48,7 @@ func TestEnvironmentCredential_TenantIDNotSet(t *testing.T) {
 }
 
 func TestEnvironmentCredential_ClientIDNotSet(t *testing.T) {
-	resetEnvironmentVarsForTest()
+	unsetEnvironmentVarsForTest(t)
 	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
@@ -56,7 +64,7 @@ func TestEnvironmentCredential_ClientIDNotSet(t *testing.T) {
 }
 
 func TestEnvironmentCredential_ClientSecretNotSet(t *testing.T) {
-	resetEnvironmentVarsForTest()
+	unsetEnvironmentVarsForTest(t)
 	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
@@ -72,7 +80,7 @@ func TestEnvironmentCredential_ClientSecretNotSet(t *testing.T) {
 }
 
 func TestEnvironmentCredential_ClientSecretSet(t *testing.T) {
-	resetEnvironmentVarsForTest()
+	unsetEnvironmentVarsForTest(t)
 	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
@@ -95,7 +103,7 @@ func TestEnvironmentCredential_ClientSecretSet(t *testing.T) {
 }
 
 func TestEnvironmentCredential_CertificateErrors(t *testing.T) {
-	resetEnvironmentVarsForTest()
+	unsetEnvironmentVarsForTest(t)
 	for _, test := range []struct {
 		name, path string
 	}{
@@ -119,7 +127,7 @@ func TestEnvironmentCredential_CertificateErrors(t *testing.T) {
 }
 
 func TestEnvironmentCredential_ClientCertificatePathSet(t *testing.T) {
-	resetEnvironmentVarsForTest()
+	unsetEnvironmentVarsForTest(t)
 	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
@@ -172,7 +180,7 @@ func TestEnvironmentCredential_ClientCertificatePassword(t *testing.T) {
 }
 
 func TestEnvironmentCredential_UsernameOnlySet(t *testing.T) {
-	resetEnvironmentVarsForTest()
+	unsetEnvironmentVarsForTest(t)
 	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
@@ -192,7 +200,7 @@ func TestEnvironmentCredential_UsernameOnlySet(t *testing.T) {
 }
 
 func TestEnvironmentCredential_UsernamePasswordSet(t *testing.T) {
-	resetEnvironmentVarsForTest()
+	unsetEnvironmentVarsForTest(t)
 	err := os.Setenv(azureTenantID, fakeTenantID)
 	if err != nil {
 		t.Fatalf("Unexpected error when initializing environment variables: %v", err)
@@ -227,7 +235,7 @@ func TestEnvironmentCredential_SendCertificateChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resetEnvironmentVarsForTest()
+	unsetEnvironmentVarsForTest(t)
 	sts := mockSTS{tokenRequestCallback: validateX5C(t, certs)}
 	vars := map[string]string{
 		azureClientID:              liveSP.clientID,

--- a/sdk/azidentity/interactive_browser_credential_test.go
+++ b/sdk/azidentity/interactive_browser_credential_test.go
@@ -19,18 +19,6 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
-func TestInteractiveBrowserCredential_InvalidTenantID(t *testing.T) {
-	options := InteractiveBrowserCredentialOptions{}
-	options.TenantID = badTenantID
-	cred, err := NewInteractiveBrowserCredential(&options)
-	if err == nil {
-		t.Fatal("Expected an error but received none")
-	}
-	if cred != nil {
-		t.Fatalf("Expected a nil credential value. Received: %v", cred)
-	}
-}
-
 func TestInteractiveBrowserCredential_GetTokenSuccess(t *testing.T) {
 	cred, err := NewInteractiveBrowserCredential(nil)
 	if err != nil {

--- a/sdk/azidentity/managed_identity_credential_test.go
+++ b/sdk/azidentity/managed_identity_credential_test.go
@@ -30,13 +30,6 @@ const (
 	expiresOnNonStringIntResp = `{"access_token": "new_token", "refresh_token": "", "expires_in": "", "expires_on": 1560974028, "not_before": "1560970130", "resource": "https://vault.azure.net", "token_type": "Bearer"}`
 )
 
-// TODO: replace with 1.17's T.Setenv
-func clearEnvVars(envVars ...string) {
-	for _, ev := range envVars {
-		_ = os.Unsetenv(ev)
-	}
-}
-
 func TestManagedIdentityCredential_AzureArc(t *testing.T) {
 	file, err := os.Create(filepath.Join(t.TempDir(), "arc.key"))
 	if err != nil {
@@ -565,7 +558,6 @@ func TestManagedIdentityCredential_IMDSRetries(t *testing.T) {
 }
 
 func TestManagedIdentityCredential_ServiceFabric(t *testing.T) {
-	resetEnvironmentVarsForTest()
 	expectedSecret := "expected-secret"
 	pred := func(req *http.Request) bool {
 		if secret := req.Header.Get("Secret"); secret != expectedSecret {

--- a/sdk/azidentity/username_password_credential_test.go
+++ b/sdk/azidentity/username_password_credential_test.go
@@ -15,16 +15,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 )
 
-func TestUsernamePasswordCredential_InvalidTenantID(t *testing.T) {
-	cred, err := NewUsernamePasswordCredential(badTenantID, fakeClientID, "username", "password", nil)
-	if err == nil {
-		t.Fatal("Expected an error but received none")
-	}
-	if cred != nil {
-		t.Fatalf("Expected a nil credential value. Received: %v", cred)
-	}
-}
-
 func TestUsernamePasswordCredential_Live(t *testing.T) {
 	for _, disabledID := range []bool{true, false} {
 		name := "default options"


### PR DESCRIPTION
Tidying up the test suite:
- prevent side effects from setting environment variables
- consolidate test cases
- delete redundant tests

And this adds 0.3% more coverage 🍰 