### PR TITLE
Default GetSASURL http+https for getsasurl

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed an issue where GetSASURL() was providing HTTPS SAS, instead of the default http+https SAS. Fixes [#22448](https://github.com/Azure/azure-sdk-for-go/issues/22448)
 
 ### Other Changes
 

--- a/sdk/storage/azblob/container/client.go
+++ b/sdk/storage/azblob/container/client.go
@@ -348,7 +348,6 @@ func (c *Client) GetSASURL(permissions sas.ContainerPermissions, expiry time.Tim
 	// Containers do not have snapshots, nor versions.
 	qps, err := sas.BlobSignatureValues{
 		Version:       sas.Version,
-		Protocol:      sas.ProtocolHTTPS,
 		ContainerName: urlParts.ContainerName,
 		Permissions:   permissions.String(),
 		StartTime:     st,

--- a/sdk/storage/azblob/service/client.go
+++ b/sdk/storage/azblob/service/client.go
@@ -280,7 +280,6 @@ func (s *Client) GetSASURL(resources sas.AccountResourceTypes, permissions sas.A
 	st := o.format()
 	qps, err := sas.AccountSignatureValues{
 		Version:       sas.Version,
-		Protocol:      sas.ProtocolHTTPS,
 		Permissions:   permissions.String(),
 		ResourceTypes: resources.String(),
 		StartTime:     st,

--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed an issue where GetSASURL() was providing HTTPS SAS, instead of the default http+https SAS. Fixes [#22448](https://github.com/Azure/azure-sdk-for-go/issues/22448)
 
 ### Other Changes
 

--- a/sdk/storage/azdatalake/filesystem/client.go
+++ b/sdk/storage/azdatalake/filesystem/client.go
@@ -356,7 +356,6 @@ func (fs *Client) GetSASURL(permissions sas.FileSystemPermissions, expiry time.T
 	}
 	qps, err := sas.DatalakeSignatureValues{
 		Version:        sas.Version,
-		Protocol:       sas.ProtocolHTTPS,
 		FileSystemName: urlParts.FileSystemName,
 		Permissions:    permissions.String(),
 		StartTime:      st,

--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed an issue where GetSASURL() was providing HTTPS SAS, instead of the default http+https SAS. Fixes [#22448](https://github.com/Azure/azure-sdk-for-go/issues/22448)
 
 ### Other Changes
 

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -338,7 +338,6 @@ func (f *Client) GetSASURL(permissions sas.FilePermissions, expiry time.Time, o 
 
 	qps, err := sas.SignatureValues{
 		Version:     sas.Version,
-		Protocol:    sas.ProtocolHTTPS,
 		ShareName:   urlParts.ShareName,
 		FilePath:    urlParts.DirectoryOrFilePath,
 		Permissions: permissions.String(),

--- a/sdk/storage/azfile/service/client.go
+++ b/sdk/storage/azfile/service/client.go
@@ -236,7 +236,6 @@ func (s *Client) GetSASURL(resources sas.AccountResourceTypes, permissions sas.A
 	st := o.format()
 	qps, err := sas.AccountSignatureValues{
 		Version:       sas.Version,
-		Protocol:      sas.ProtocolHTTPS,
 		Permissions:   permissions.String(),
 		ResourceTypes: resources.String(),
 		StartTime:     st,

--- a/sdk/storage/azfile/share/client.go
+++ b/sdk/storage/azfile/share/client.go
@@ -286,7 +286,6 @@ func (s *Client) GetSASURL(permissions sas.SharePermissions, expiry time.Time, o
 
 	qps, err := sas.SignatureValues{
 		Version:      sas.Version,
-		Protocol:     sas.ProtocolHTTPS,
 		ShareName:    urlParts.ShareName,
 		SnapshotTime: t,
 		Permissions:  permissions.String(),


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

As of version 2015-04-05, the optional signedProtocol (spr) field specifies the protocol that's permitted for a request made with the SAS. 
Possible values are both HTTPS and HTTP (https,http) or HTTPS only (https). _`The default value is https,http`_
Removed HTTPS protocol from GetSASURL() azfile, azblob and azdatalake in this PR to align with the default http+https behaviour.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
