### PR TITLE
Disable retries for DefaultAzureCredential's IMDS probe

### DIFF
--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -187,6 +187,7 @@ func (c *managedIdentityClient) authenticate(ctx context.Context, id ManagedIDKi
 	if c.probeIMDS {
 		cx, cancel := context.WithTimeout(ctx, imdsProbeTimeout)
 		defer cancel()
+		cx = policy.WithRetryOptions(cx, policy.RetryOptions{MaxRetries: -1})
 		req, err := runtime.NewRequest(cx, http.MethodGet, c.endpoint)
 		if err == nil {
 			_, err = c.azClient.Pipeline().Do(req)


### PR DESCRIPTION
Whoops, I overlooked this in #22676