### PR TITLE
azcosmos - Fix continuations types

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -8,8 +8,8 @@
 * Added extended logging for requests, responses, and client configuration
 
 ### Breaking Changes
-* ItemOptions.SessionToken, QueryOptions.SessionToken, QueryOptions.ContinuationToken are now `*string`
-* ItemResponse.SessionToken, QueryItemsResponse.ContinuationToken are now `*string`
+* ItemOptions.SessionToken, QueryOptions.SessionToken, QueryOptions.ContinuationToken, QueryDatabasesOptions.ContinuationToken, QueryContainersOptions.ContinuationToken are now `*string`
+* ItemResponse.SessionToken, QueryItemsResponse.ContinuationToken, QueryContainersResponse.ContinuationToken, QueryDatabasesResponse.ContinuationToken are now `*string`
 
 ## 0.3.6 (2023-08-18)
 

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -246,11 +246,11 @@ func (c *Client) NewQueryDatabasesPager(query string, o *QueryDatabasesOptions) 
 
 	return azruntime.NewPager(azruntime.PagingHandler[QueryDatabasesResponse]{
 		More: func(page QueryDatabasesResponse) bool {
-			return page.ContinuationToken != ""
+			return page.ContinuationToken != nil
 		},
 		Fetcher: func(ctx context.Context, page *QueryDatabasesResponse) (QueryDatabasesResponse, error) {
 			if page != nil {
-				if page.ContinuationToken != "" {
+				if page.ContinuationToken != nil {
 					// Use the previous page continuation if available
 					queryOptions.ContinuationToken = page.ContinuationToken
 				}

--- a/sdk/data/azcosmos/cosmos_client_test.go
+++ b/sdk/data/azcosmos/cosmos_client_test.go
@@ -623,8 +623,8 @@ func TestQueryDatabases(t *testing.T) {
 			receivedIds = append(receivedIds, dbs.ID)
 		}
 
-		if queryPager.More() && queryResponse.ContinuationToken != "someContinuationToken" {
-			t.Errorf("Expected ContinuationToken to be %s, but got %s", "someContinuationToken", queryResponse.ContinuationToken)
+		if queryPager.More() && *queryResponse.ContinuationToken != "someContinuationToken" {
+			t.Errorf("Expected ContinuationToken to be %s, but got %s", "someContinuationToken", *queryResponse.ContinuationToken)
 		}
 
 		if queryResponse.ActivityID == "" {

--- a/sdk/data/azcosmos/cosmos_container_request_options.go
+++ b/sdk/data/azcosmos/cosmos_container_request_options.go
@@ -55,7 +55,7 @@ type QueryContainersOptions struct {
 func (options *QueryContainersOptions) toHeaders() *map[string]string {
 	headers := make(map[string]string)
 
-	if options.ContinuationToken != nill {
+	if options.ContinuationToken != nil {
 		headers[cosmosHeaderContinuationToken] = *options.ContinuationToken
 	}
 

--- a/sdk/data/azcosmos/cosmos_container_request_options.go
+++ b/sdk/data/azcosmos/cosmos_container_request_options.go
@@ -44,8 +44,8 @@ func (options *DeleteContainerOptions) toHeaders() *map[string]string {
 // QueryContainersOptions are options to query containers
 type QueryContainersOptions struct {
 	// ContinuationToken to be used to continue a previous query execution.
-	// Obtained from QueryItemsResponse.ContinuationToken.
-	ContinuationToken string
+	// Obtained from QueryContainersResponse.ContinuationToken.
+	ContinuationToken *string
 
 	// QueryParameters allows execution of parametrized queries.
 	// See https://docs.microsoft.com/azure/cosmos-db/sql/sql-query-parameterized-queries
@@ -55,8 +55,8 @@ type QueryContainersOptions struct {
 func (options *QueryContainersOptions) toHeaders() *map[string]string {
 	headers := make(map[string]string)
 
-	if options.ContinuationToken != "" {
-		headers[cosmosHeaderContinuationToken] = options.ContinuationToken
+	if options.ContinuationToken != nill {
+		headers[cosmosHeaderContinuationToken] = *options.ContinuationToken
 	}
 
 	return &headers

--- a/sdk/data/azcosmos/cosmos_container_request_options_test.go
+++ b/sdk/data/azcosmos/cosmos_container_request_options_test.go
@@ -42,7 +42,8 @@ func TestContainerRequestOptionsToHeaders(t *testing.T) {
 
 func TestQueryContainersRequestOptionsToHeaders(t *testing.T) {
 	options := &QueryContainersOptions{}
-	options.ContinuationToken = "continuationToken"
+	continuation := "continuationToken"
+	options.ContinuationToken = &continuation
 	header := options.toHeaders()
 	if header == nil {
 		t.Fatal("toHeaders should return non-nil")

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -103,7 +103,7 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 
 	return runtime.NewPager(runtime.PagingHandler[QueryContainersResponse]{
 		More: func(page QueryContainersResponse) bool {
-			return page.ContinuationToken != ""
+			return page.ContinuationToken != nil
 		},
 		Fetcher: func(ctx context.Context, page *QueryContainersResponse) (QueryContainersResponse, error) {
 			if page != nil {

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -107,7 +107,7 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 		},
 		Fetcher: func(ctx context.Context, page *QueryContainersResponse) (QueryContainersResponse, error) {
 			if page != nil {
-				if page.ContinuationToken != "" {
+				if page.ContinuationToken != nil {
 					// Use the previous page continuation if available
 					queryOptions.ContinuationToken = page.ContinuationToken
 				}

--- a/sdk/data/azcosmos/cosmos_database_request_options.go
+++ b/sdk/data/azcosmos/cosmos_database_request_options.go
@@ -58,8 +58,8 @@ type CreateDatabaseOptions struct {
 // QueryDatabasesOptions are options to query databases
 type QueryDatabasesOptions struct {
 	// ContinuationToken to be used to continue a previous query execution.
-	// Obtained from QueryItemsResponse.ContinuationToken.
-	ContinuationToken string
+	// Obtained from QueryDatabasesResponse.ContinuationToken.
+	ContinuationToken *string
 
 	// QueryParameters allows execution of parametrized queries.
 	// See https://docs.microsoft.com/azure/cosmos-db/sql/sql-query-parameterized-queries
@@ -69,8 +69,8 @@ type QueryDatabasesOptions struct {
 func (options *QueryDatabasesOptions) toHeaders() *map[string]string {
 	headers := make(map[string]string)
 
-	if options.ContinuationToken != "" {
-		headers[cosmosHeaderContinuationToken] = options.ContinuationToken
+	if options.ContinuationToken != nil {
+		headers[cosmosHeaderContinuationToken] = *options.ContinuationToken
 	}
 
 	return &headers

--- a/sdk/data/azcosmos/cosmos_database_request_options_test.go
+++ b/sdk/data/azcosmos/cosmos_database_request_options_test.go
@@ -59,7 +59,8 @@ func TestDeleteDatabaseOptionsToHeaders(t *testing.T) {
 
 func TestQueryDatabasesRequestOptionsToHeaders(t *testing.T) {
 	options := &QueryDatabasesOptions{}
-	options.ContinuationToken = "continuationToken"
+	continuation := "continuationToken"
+	options.ContinuationToken = &continuation
 	header := options.toHeaders()
 	if header == nil {
 		t.Fatal("toHeaders should return non-nil")

--- a/sdk/data/azcosmos/cosmos_database_test.go
+++ b/sdk/data/azcosmos/cosmos_database_test.go
@@ -54,8 +54,8 @@ func TestDatabaseQueryContainers(t *testing.T) {
 			receivedIds = append(receivedIds, container.ID)
 		}
 
-		if queryPager.More() && queryResponse.ContinuationToken != "someContinuationToken" {
-			t.Errorf("Expected ContinuationToken to be %s, but got %s", "someContinuationToken", queryResponse.ContinuationToken)
+		if queryPager.More() && *queryResponse.ContinuationToken != "someContinuationToken" {
+			t.Errorf("Expected ContinuationToken to be %s, but got %s", "someContinuationToken", *queryResponse.ContinuationToken)
 		}
 
 		if queryResponse.ActivityID == "" {

--- a/sdk/data/azcosmos/cosmos_query_response.go
+++ b/sdk/data/azcosmos/cosmos_query_response.go
@@ -69,7 +69,7 @@ type QueryContainersResponse struct {
 	Response
 	// ContinuationToken contains the value of the x-ms-continuation header in the response.
 	// It can be used to stop a query and resume it later.
-	ContinuationToken string
+	ContinuationToken *string
 	// List of containers.
 	Containers []ContainerProperties
 }
@@ -79,8 +79,10 @@ func newContainersQueryResponse(resp *http.Response) (QueryContainersResponse, e
 		Response: newResponse(resp),
 	}
 
-	response.ContinuationToken = resp.Header.Get(cosmosHeaderContinuationToken)
-
+	continuationToken = resp.Header.Get(cosmosHeaderContinuationToken)
+	if continuationToken != "" {
+		response.ContinuationToken = &continuationToken
+	}
 	result := queryContainersServiceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return QueryContainersResponse{}, err
@@ -100,7 +102,7 @@ type QueryDatabasesResponse struct {
 	Response
 	// ContinuationToken contains the value of the x-ms-continuation header in the response.
 	// It can be used to stop a query and resume it later.
-	ContinuationToken string
+	ContinuationToken *string
 	// List of databases.
 	Databases []DatabaseProperties
 }
@@ -110,7 +112,10 @@ func newDatabasesQueryResponse(resp *http.Response) (QueryDatabasesResponse, err
 		Response: newResponse(resp),
 	}
 
-	response.ContinuationToken = resp.Header.Get(cosmosHeaderContinuationToken)
+	continuationToken = resp.Header.Get(cosmosHeaderContinuationToken)
+	if continuationToken != "" {
+		response.ContinuationToken = &continuationToken
+	}
 
 	result := queryDatabasesServiceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {

--- a/sdk/data/azcosmos/cosmos_query_response.go
+++ b/sdk/data/azcosmos/cosmos_query_response.go
@@ -79,7 +79,7 @@ func newContainersQueryResponse(resp *http.Response) (QueryContainersResponse, e
 		Response: newResponse(resp),
 	}
 
-	continuationToken = resp.Header.Get(cosmosHeaderContinuationToken)
+	continuationToken := resp.Header.Get(cosmosHeaderContinuationToken)
 	if continuationToken != "" {
 		response.ContinuationToken = &continuationToken
 	}
@@ -112,7 +112,7 @@ func newDatabasesQueryResponse(resp *http.Response) (QueryDatabasesResponse, err
 		Response: newResponse(resp),
 	}
 
-	continuationToken = resp.Header.Get(cosmosHeaderContinuationToken)
+	continuationToken := resp.Header.Get(cosmosHeaderContinuationToken)
 	if continuationToken != "" {
 		response.ContinuationToken = &continuationToken
 	}


### PR DESCRIPTION
During https://github.com/Azure/azure-sdk-for-go/pull/22623 we fixed `ContinuationToken` to be `*string` but we missed some other places.

* QueryContainersOptions
* QueryDatabasesOptions
* QueryContainersResponse
* QueryDatabasesResponse