### PR TITLE
[azmetrics] rename MetricValues to MetricData

### DIFF
--- a/sdk/monitor/query/azmetrics/CHANGELOG.md
+++ b/sdk/monitor/query/azmetrics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0 (2024-04-10)
+## 1.0.0 (2024-04-15)
 
 ### Breaking Changes
 * Removed pointers from slices

--- a/sdk/monitor/query/azmetrics/CHANGELOG.md
+++ b/sdk/monitor/query/azmetrics/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 * Removed pointers from slices
+* Renamed `MetricValues` to `MetricData`
 
 ### Other Changes
 * Updated to use API version 2024-02-01

--- a/sdk/monitor/query/azmetrics/autorest.md
+++ b/sdk/monitor/query/azmetrics/autorest.md
@@ -35,7 +35,7 @@ directive:
         - models.go
         - models_serde.go
     where: $
-    transform: return $.replace(/MetricResultsValuesItem/g, "MetricValues");
+    transform: return $.replace(/MetricResultsValuesItem/g, "MetricData");
   - from: swagger-document
     where: $.definitions.MetricResults.properties.values.items
     transform: $["description"] = "Metric data values."

--- a/sdk/monitor/query/azmetrics/models.go
+++ b/sdk/monitor/query/azmetrics/models.go
@@ -58,11 +58,11 @@ type Metric struct {
 // MetricResults - The metrics result for a resource.
 type MetricResults struct {
 	// The collection of metric data responses per resource, per metric.
-	Values []MetricValues
+	Values []MetricData
 }
 
-// MetricValues - Metric data values.
-type MetricValues struct {
+// MetricData - Metric data values.
+type MetricData struct {
 	// REQUIRED; The end time, in datetime format, for which the data was retrieved.
 	EndTime *string
 

--- a/sdk/monitor/query/azmetrics/models_serde.go
+++ b/sdk/monitor/query/azmetrics/models_serde.go
@@ -159,8 +159,8 @@ func (m *MetricResults) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type MetricValues.
-func (m MetricValues) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type MetricData.
+func (m MetricData) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "endtime", m.EndTime)
 	populate(objectMap, "interval", m.Interval)
@@ -172,8 +172,8 @@ func (m MetricValues) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type MetricValues.
-func (m *MetricValues) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type MetricData.
+func (m *MetricData) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", m, err)


### PR DESCRIPTION
Cleaning up names. Changing `MetricsValues` to `MetricData` to avoid confusion with the existing `MetricValue` struct.