### PR TITLE
Service version upgrade for stg 93 storage

### DIFF
--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -22,7 +22,7 @@ export-clients: true
 use: "@autorest/go@4.0.0-preview.61"
 ```
 
-### Updating service version to 2023-11-03
+### Updating service version to 2024-05-04
 ```yaml
 directive:
 - from: 
@@ -36,7 +36,7 @@ directive:
   transform: >-
     return $.
       replaceAll(`[]string{"2021-12-02"}`, `[]string{ServiceVersion}`).
-      replaceAll(`2021-12-02`, `2023-11-03`);
+      replaceAll(`2021-12-02`, `2024-05-04`);
 ```
 
 ### Undo breaking change with BlobName 

--- a/sdk/storage/azblob/internal/generated/constants.go
+++ b/sdk/storage/azblob/internal/generated/constants.go
@@ -6,4 +6,4 @@
 
 package generated
 
-const ServiceVersion = "2023-11-03"
+const ServiceVersion = "2024-05-04"

--- a/sdk/storage/azdatalake/internal/generated/autorest.md
+++ b/sdk/storage/azdatalake/internal/generated/autorest.md
@@ -299,7 +299,7 @@ directive:
         replace(/err = unpopulate\((.*), "IsDirectory", &p\.IsDirectory\)/g, 'var rawVal string\nerr = unpopulate(val, "IsDirectory", &rawVal)\nboolVal, _ := strconv.ParseBool(rawVal)\np.IsDirectory = &boolVal');
 ```
 
-### Updating service version to 2023-11-03
+### Updating service version to 2024-05-04
 ```yaml
 directive:
 - from: 
@@ -310,5 +310,5 @@ directive:
   transform: >-
     return $.
       replaceAll(`[]string{"2023-05-03"}`, `[]string{ServiceVersion}`).
-      replaceAll(`2023-05-03`, `2023-11-03`);
+      replaceAll(`2023-05-03`, `2024-05-04`);
 ```

--- a/sdk/storage/azfile/internal/generated/autorest.md
+++ b/sdk/storage/azfile/internal/generated/autorest.md
@@ -22,7 +22,7 @@ export-clients: true
 use: "@autorest/go@4.0.0-preview.61"
 ```
 
-### Updating service version to 2023-11-03
+### Updating service version to 2024-05-04
 
 ```yaml
 directive:
@@ -35,7 +35,7 @@ directive:
   transform: >-
     return $.
       replaceAll(`[]string{"2023-08-03"}`, `[]string{ServiceVersion}`).
-      replaceAll(`2023-08-03`, `2023-11-03`);
+      replaceAll(`2023-08-03`, `2024-05-04`);
 ```
 
 ### Don't include share name, directory, or file name in path - we have direct URIs

--- a/sdk/storage/azfile/internal/generated/constants.go
+++ b/sdk/storage/azfile/internal/generated/constants.go
@@ -6,4 +6,4 @@
 
 package generated
 
-const ServiceVersion = "2023-11-03"
+const ServiceVersion = "2024-05-04"


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go

Azdatalake serviceVersion is already updated to 2024-05-04, updating only azblob and azfile in this PR
