### PR TITLE
Enable tests to disable default sanitizers

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Features Added
 
+* `RemoveRegisteredSanitizers` selectively disables sanitizers the test proxy enables by
+  default since version 1.0.0-dev.20240422.1
+
 ### Breaking Changes
+
 * Deprecated the `go-vcr` based test recording API. Its methods now return errors or panic.
 
 ### Bugs Fixed

--- a/sdk/internal/recording/sanitizer.go
+++ b/sdk/internal/recording/sanitizer.go
@@ -389,6 +389,33 @@ func AddURISubscriptionIDSanitizer(value string, options *RecordingOptions) erro
 	return handleProxyResponse(client.Do(req))
 }
 
+// RemoveRegisteredSanitizers selectively disables sanitizers that are enabled by default such as "AZSDK1001"
+func RemoveRegisteredSanitizers(sanitizerIDs []string, options *RecordingOptions) error {
+	if recordMode == LiveMode {
+		return nil
+	}
+	if options == nil {
+		options = defaultOptions()
+	}
+	b, err := json.Marshal(struct {
+		Sanitizers []string `json:"Sanitizers"`
+	}{
+		Sanitizers: sanitizerIDs,
+	})
+	if err != nil {
+		return err
+	}
+	url := options.baseURL() + "/Admin/RemoveSanitizers"
+	req, err := http.NewRequest(http.MethodPost, url, io.NopCloser(bytes.NewReader(b)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(b))
+	handleTestLevelSanitizer(req, options)
+	return handleProxyResponse(client.Do(req))
+}
+
 // ResetProxy restores the proxy's default sanitizers, matchers, and transforms
 func ResetProxy(options *RecordingOptions) error {
 	if recordMode == LiveMode {

--- a/sdk/internal/recording/sanitizer_test.go
+++ b/sdk/internal/recording/sanitizer_test.go
@@ -78,6 +78,19 @@ func (e Entry) ResponseBodyByValue(k string) interface{} {
 	return m[k]
 }
 
+func (s *sanitizerTests) TestRemoveRegisteredSanitizers() {
+	s.T().Skip("this feature requires proxy version 1.0.0-dev.20240424.1 or later. Unskip this test after upgrading the proxy version specified in eng/target_proxy_version.txt")
+	require := require.New(s.T())
+	defer reset(s.T())
+
+	sanitizers := make([]string, 7)
+	for i := 0; i < len(sanitizers); i++ {
+		sanitizers[i] = fmt.Sprintf("AZSDK100%d", i)
+	}
+	require.NoError(RemoveRegisteredSanitizers(sanitizers, nil))
+	require.Error(RemoveRegisteredSanitizers([]string{"unknown ID"}, nil))
+}
+
 func (s *sanitizerTests) TestUriSanitizer() {
 	require := require.New(s.T())
 	defer reset(s.T())


### PR DESCRIPTION
The new test proxy version which includes the default sanitizers also includes a new API for disabling them. We'll probably want this while fixing tests, so I'd like to get it out in the next release.