### PR TITLE
recording.SanitizedValue matches test proxy

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 * Deprecated the `go-vcr` based test recording API. Its methods now return errors or panic.
+* Changed value of `recording.SanitizedValue` from "sanitized" to "Sanitized" to match the
+  test proxy
 
 ### Bugs Fixed
 

--- a/sdk/internal/recording/sanitizer.go
+++ b/sdk/internal/recording/sanitizer.go
@@ -27,7 +27,7 @@ type Sanitizer struct{}
 type StringSanitizer func(*string)
 
 // SanitizedValue is the default placeholder value to be used for sanitized strings.
-const SanitizedValue string = "sanitized"
+const SanitizedValue string = "Sanitized"
 
 // SanitizedBase64Value is the default placeholder value to be used for sanitized base-64 encoded strings.
 const SanitizedBase64Value string = "Kg=="


### PR DESCRIPTION
This constant isn't referenced on main. I anticipate using it to fix tests broken by the new test proxy's default sanitizers, which replace values with "**S**anitized".