### PR TITLE
Fix persistent cache errors caused by Linux keyring permissions

### DIFF
--- a/eng/config.json
+++ b/eng/config.json
@@ -30,7 +30,7 @@
         },
         {
             "Name": "azidentity/cache",
-            "CoverageGoal": 0.35
+            "CoverageGoal": 0.70
         },
         {
             "Name": "azqueue",

--- a/sdk/azidentity/cache/CHANGELOG.md
+++ b/sdk/azidentity/cache/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Release History
 
-## 0.2.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.2.1 (2024-05-07)
 
 ### Bugs Fixed
+* On Linux, prevent "permission denied" errors by linking the session keyring
+  to the user keyring so the process possesses any keys it adds
 
 ### Other Changes
+* Upgraded dependencies
 
 ## 0.2.0 (2023-10-10)
 

--- a/sdk/azidentity/cache/internal/jwe/jwe_test.go
+++ b/sdk/azidentity/cache/internal/jwe/jwe_test.go
@@ -34,6 +34,10 @@ func TestEncryptParseDecrypt(t *testing.T) {
 	segments := strings.Split(s, ".")
 	require.Len(t, segments, 5, "compact format has 5 segments")
 
+	p, err := ParseCompactFormat([]byte(s))
+	require.NoError(t, err)
+	require.Equal(t, j, p)
+
 	h, err := base64.RawURLEncoding.DecodeString(segments[0])
 	require.NoError(t, err, segments[0])
 	hdr := Header{}

--- a/sdk/azidentity/cache/linux_test.go
+++ b/sdk/azidentity/cache/linux_test.go
@@ -18,22 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	ctx        = context.Background()
-	keyringErr error
-)
-
-func TestMain(m *testing.M) {
-	keyringErr = tryKeyring()
-	os.Exit(m.Run())
-}
+var ctx = context.Background()
 
 func TestKeyExistsButNotFile(t *testing.T) {
-	if keyringErr != nil {
-		t.Skip(keyringErr)
-	}
 	expected := []byte(t.Name())
-	a, err := newKeyring(t.Name())
+	a, err := storage(internal.TokenCachePersistenceOptions{Name: t.Name()})
 	require.NoError(t, err)
 	err = a.Write(ctx, append([]byte("not"), expected...))
 	require.NoError(t, err)
@@ -57,9 +46,6 @@ func TestKeyExistsButNotFile(t *testing.T) {
 }
 
 func TestReadWriteDelete(t *testing.T) {
-	if keyringErr != nil {
-		t.Skip(keyringErr)
-	}
 	for _, test := range []struct {
 		expected   []byte
 		desc, name string
@@ -115,9 +101,6 @@ func TestReadWriteDelete(t *testing.T) {
 }
 
 func TestTwoInstances(t *testing.T) {
-	if keyringErr != nil {
-		t.Skip(keyringErr)
-	}
 	for _, deleteFile := range []bool{false, true} {
 		s := "key and file exist"
 		if deleteFile {


### PR DESCRIPTION
This prevents the errors that made testing the Linux keyring storage implementation impossible in CI. These errors were caused by the `go test` process having permission to add keys to the user keyring but not to read those keys or find them in a search. This weird situation arose because the process was accessing the user keyring as its owner, not as a possessor, and the owner has lesser privilege. (Ownership doesn't imply possession in the keyring permissions model, I guess to enable processes running as the same UID to protect secrets from each other.) The fix is to link the session keyring possessed by the process to the user keyring, transitively granting the process possession of keys linked to the user keyring. Most systems do this automatically on login but apparently our CI runners either do not, or they replace the session keyring created at login before running `go test`. If this all seems too complicated to you, I agree 😅