### PR TITLE
Do not create or block on api review for nested packages

### DIFF
--- a/eng/scripts/Create-ApiReview.ps1
+++ b/eng/scripts/Create-ApiReview.ps1
@@ -24,6 +24,10 @@ $createReviewScript = (Join-Path $PSScriptRoot .. common scripts Create-APIRevie
 $artifactList = @()
 foreach ($sdk in (Get-AllPackageInfoFromRepo $ServiceDirectory))
 {
+    if ($sdk.ServiceDirectory -ne $ServiceDirectory) {
+        Write-Host "Skipping nested package $($sdk.ServiceDirectory)"
+        continue
+    }
     Write-Host "Creating API review artifact for $($sdk.Name)"
     New-Item -ItemType Directory -Path $OutPath/$($sdk.Name) -force
     $fileName = Split-Path -Path $sdk.Name -Leaf


### PR DESCRIPTION
I do not think there are any pipelines where we need/want to be recursing on packages, as we keep to a one pipeline per package convention in go data plane. Currently nested packages, i.e. azidentity/cache are blocking parent packages from releasing if they don't have an api review approval.
