### PR TITLE
Document AZURE_CLIENT_SEND_CERTIFICATE_CHAIN env var used by EnvironmentCredential

### DIFF
--- a/sdk/azidentity/README.md
+++ b/sdk/azidentity/README.md
@@ -178,7 +178,8 @@ client := armresources.NewResourceGroupsClient("subscription ID", chain, nil)
 |`AZURE_CLIENT_ID`|ID of a Microsoft Entra application
 |`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
 |`AZURE_CLIENT_CERTIFICATE_PATH`|path to a certificate file including private key
-|`AZURE_CLIENT_CERTIFICATE_PASSWORD`|password of the certificate file, if any
+|`AZURE_CLIENT_CERTIFICATE_PASSWORD`|(optional) password of the certificate file, if any
+|`AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`|(optional) send certificate chain in x5c header to support subject name / issuer based authentication
 
 #### Username and password
 

--- a/sdk/azidentity/README.md
+++ b/sdk/azidentity/README.md
@@ -179,7 +179,7 @@ client := armresources.NewResourceGroupsClient("subscription ID", chain, nil)
 |`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
 |`AZURE_CLIENT_CERTIFICATE_PATH`|path to a certificate file including private key
 |`AZURE_CLIENT_CERTIFICATE_PASSWORD`|(optional) password of the certificate file, if any
-|`AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`|(optional) send certificate chain in x5c header to support subject name / issuer based authentication
+|`AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`|(optional) send certificate chain in x5c header to support subject name/issuer-based authentication
 
 #### Username and password
 

--- a/sdk/azidentity/environment_credential.go
+++ b/sdk/azidentity/environment_credential.go
@@ -57,6 +57,8 @@ type EnvironmentCredentialOptions struct {
 //
 // AZURE_CLIENT_CERTIFICATE_PASSWORD: (optional) password for the certificate file.
 //
+// AZURE_CLIENT_SEND_CERTIFICATE_CHAIN: (optional) send certificate chain in x5c header to support subject name/issuer-based authentication
+//
 // # User with username and password
 //
 // AZURE_TENANT_ID: (optional) tenant to authenticate in. Defaults to "organizations".


### PR DESCRIPTION
If present, `EnvironmentCredential` can use the `AZURE_CLIENT_SEND_CERTIFICATE_CHAIN` environment variable to configure a `ClientCertificateCredential` instance. Add supporting docs to indicate that behavior.