### PR TITLE
Update azidentity/cache changelog and version

### DIFF
--- a/sdk/azidentity/cache/CHANGELOG.md
+++ b/sdk/azidentity/cache/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.1 (2024-05-07)
+## 0.2.2 (2024-05-07)
 
 ### Bugs Fixed
 * On Linux, prevent "permission denied" errors by linking the session keyring
@@ -8,6 +8,11 @@
 
 ### Other Changes
 * Upgraded dependencies
+
+## 0.2.1 (2023-11-07)
+
+### Other Changes
+* Upgraded dependencies and documentation
 
 ## 0.2.0 (2023-10-10)
 

--- a/sdk/azidentity/cache/version.go
+++ b/sdk/azidentity/cache/version.go
@@ -6,4 +6,4 @@
 
 package cache
 
-const version = "v0.2.1" // nolint
+const version = "v0.2.2" // nolint


### PR DESCRIPTION
v0.2.1 already published because of a bug in release scripts, and this bug also skipped its post-release automation.