### PR TITLE
[azkeys] enable managed HSM's on weekly pipelines

### DIFF
--- a/sdk/security/keyvault/azkeys/ci.yml
+++ b/sdk/security/keyvault/azkeys/ci.yml
@@ -30,7 +30,7 @@ extends:
     UsePipelineProxy: false
 
     # Due to the high cost of Managed HSMs, we only want to test using them weekly.
-    ${{ contains(variables['Build.DefinitionName'], 'weekly') }}:
+    ${{ if contains(variables['Build.DefinitionName'], 'weekly') }}:
       AdditionalMatrixConfigs:
         - Name: keyvault_test_matrix_addons
           Path: sdk/security/keyvault/azadmin/platform-matrix.json

--- a/sdk/security/keyvault/azkeys/ci.yml
+++ b/sdk/security/keyvault/azkeys/ci.yml
@@ -33,6 +33,6 @@ extends:
     ${{ if contains(variables['Build.DefinitionName'], 'weekly') }}:
       AdditionalMatrixConfigs:
         - Name: keyvault_test_matrix_addons
-          Path: sdk/security/keyvault/azadmin/platform-matrix.json
+          Path: sdk/security/keyvault/azkeys/platform-matrix.json
           Selection: sparse
           GenerateVMJobs: true

--- a/sdk/security/keyvault/azkeys/ci.yml
+++ b/sdk/security/keyvault/azkeys/ci.yml
@@ -28,13 +28,11 @@ extends:
     ServiceDirectory: 'security/keyvault/azkeys'
     RunLiveTests: true
     UsePipelineProxy: false
-    AdditionalMatrixConfigs:
-      - Name: keyvault_test_matrix_addons
-        Path: sdk/security/keyvault/azkeys/platform-matrix.json
-        Selection: sparse
-        GenerateVMJobs: true
 
     # Due to the high cost of Managed HSMs, we only want to test using them weekly.
-    ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
-      MatrixFilters:
-        - ArmTemplateParameters=^(?!.*enableHsm.*true)
+    ${{ contains(variables['Build.DefinitionName'], 'weekly') }}:
+      AdditionalMatrixConfigs:
+        - Name: keyvault_test_matrix_addons
+          Path: sdk/security/keyvault/azadmin/platform-matrix.json
+          Selection: sparse
+          GenerateVMJobs: true


### PR DESCRIPTION
Part of [21934](https://github.com/Azure/azure-sdk-for-go/issues/21934)

Fix the ci.yml file to allow the tests to run live on managed HSM's weekly.
