### PR TITLE
[azmetrics] add sovereign cloud support

### DIFF
--- a/sdk/monitor/query/azmetrics/CHANGELOG.md
+++ b/sdk/monitor/query/azmetrics/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.1 (Unreleased)
 
 ### Features Added
+* Added sovereign cloud support
 
 ### Breaking Changes
 

--- a/sdk/monitor/query/azmetrics/README.md
+++ b/sdk/monitor/query/azmetrics/README.md
@@ -30,7 +30,7 @@ The [azidentity][azure_identity] module is used for client authentication.
 
 An authenticated client object is required to execute a query. The examples demonstrate using [azidentity.NewDefaultAzureCredential][default_cred_ref] to authenticate; however, the client accepts any [azidentity][azure_identity] credential. See the [azidentity][azure_identity] documentation for more information about other credential types.
 
-The clients default to the Azure public cloud. For other cloud configurations, see the [cloud][cloud_documentation] package documentation.
+The client defaults to the Azure public cloud. For other cloud configurations, see the [cloud][cloud_documentation] package documentation.
 
 #### Create a client
 

--- a/sdk/monitor/query/azmetrics/ci.yml
+++ b/sdk/monitor/query/azmetrics/ci.yml
@@ -28,4 +28,4 @@ extends:
     ServiceDirectory: 'monitor/query/azmetrics'
     RunLiveTests: true
     UsePipelineProxy: false
-    SupportedClouds: 'Public'
+    SupportedClouds: 'Public,UsGov,China'

--- a/sdk/monitor/query/azmetrics/cloud_config.go
+++ b/sdk/monitor/query/azmetrics/cloud_config.go
@@ -16,7 +16,7 @@ func init() {
 		Audience: "https://metrics.monitor.azure.cn",
 	}
 	cloud.AzureGovernment.Services[ServiceName] = cloud.ServiceConfiguration{
-		Audience: "https:/metrics.monitor.azure.us",
+		Audience: "https://metrics.monitor.azure.us",
 	}
 	cloud.AzurePublic.Services[ServiceName] = cloud.ServiceConfiguration{
 		Audience: "https://metrics.monitor.azure.com",

--- a/sdk/monitor/query/azmetrics/cloud_config.go
+++ b/sdk/monitor/query/azmetrics/cloud_config.go
@@ -1,0 +1,24 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azmetrics
+
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+
+// Cloud Service Names for Monitor Query Metrics, used to identify the respective cloud.ServiceConfiguration
+const ServiceName cloud.ServiceName = "query/azmetrics"
+
+func init() {
+	cloud.AzureChina.Services[ServiceName] = cloud.ServiceConfiguration{
+		Audience: "https://metrics.monitor.azure.cn",
+	}
+	cloud.AzureGovernment.Services[ServiceName] = cloud.ServiceConfiguration{
+		Audience: "https:/metrics.monitor.azure.us",
+	}
+	cloud.AzurePublic.Services[ServiceName] = cloud.ServiceConfiguration{
+		Audience: "https://metrics.monitor.azure.com",
+	}
+}

--- a/sdk/monitor/query/azmetrics/utils_test.go
+++ b/sdk/monitor/query/azmetrics/utils_test.go
@@ -25,10 +25,10 @@ import (
 )
 
 const (
-	recordingDirectory  = "sdk/monitor/query/azmetrics/testdata"
-	fakeResourceURI     = "/subscriptions/faa080af-c1d8-40ad-9cce-e1a451va7b87/resourceGroups/rg-example/providers/Microsoft.AppConfiguration/configurationStores/example"
-	fakeSubscrtiptionID = "faa080af-c1d8-40ad-9cce-e1a451va7b87"
-	fakeRegion          = "westus"
+	recordingDirectory = "sdk/monitor/query/azmetrics/testdata"
+	fakeResourceURI    = "/subscriptions/faa080af-c1d8-40ad-9cce-e1a451va7b87/resourceGroups/rg-example/providers/Microsoft.AppConfiguration/configurationStores/example"
+	fakeSubscriptionID = "faa080af-c1d8-40ad-9cce-e1a451va7b87"
+	fakeRegion         = "westus"
 )
 
 var (
@@ -60,7 +60,7 @@ func run(m *testing.M) int {
 	}
 
 	resourceURI = getEnvVar("RESOURCE_URI", fakeResourceURI)
-	subscriptionID = getEnvVar("AZMETRICS_SUBSCRIPTION_ID", fakeSubscrtiptionID)
+	subscriptionID = getEnvVar("AZMETRICS_SUBSCRIPTION_ID", fakeSubscriptionID)
 	region = getEnvVar("AZMETRICS_LOCATION", fakeRegion)
 
 	if recording.GetRecordMode() == recording.PlaybackMode {

--- a/sdk/monitor/query/azmetrics/utils_test.go
+++ b/sdk/monitor/query/azmetrics/utils_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
@@ -35,6 +36,8 @@ var (
 	resourceURI    string
 	subscriptionID string
 	region         string
+	endpoint       string
+	clientCloud    cloud.Configuration
 )
 
 func TestMain(m *testing.M) {
@@ -56,8 +59,13 @@ func run(m *testing.M) int {
 		}()
 	}
 
+	resourceURI = getEnvVar("RESOURCE_URI", fakeResourceURI)
+	subscriptionID = getEnvVar("AZMETRICS_SUBSCRIPTION_ID", fakeSubscrtiptionID)
+	region = getEnvVar("AZMETRICS_LOCATION", fakeRegion)
+
 	if recording.GetRecordMode() == recording.PlaybackMode {
 		credential = &FakeCredential{}
+		endpoint = "https://" + region + ".metrics.monitor.azure.com"
 	} else {
 		tenantID := getEnvVar("AZMETRICS_TENANT_ID", "")
 		clientID := getEnvVar("AZMETRICS_CLIENT_ID", "")
@@ -67,11 +75,21 @@ func run(m *testing.M) int {
 		if err != nil {
 			panic(err)
 		}
-	}
 
-	resourceURI = getEnvVar("RESOURCE_URI", fakeResourceURI)
-	subscriptionID = getEnvVar("AZMETRICS_SUBSCRIPTION_ID", fakeSubscrtiptionID)
-	region = getEnvVar("AZMETRICS_LOCATION", fakeRegion)
+		if cloudEnv, ok := os.LookupEnv("AZMETRICS_ENVIRONMENT"); ok {
+			if strings.EqualFold(cloudEnv, "AzureCloud") {
+				endpoint = "https://" + region + ".metrics.monitor.azure.com"
+			}
+			if strings.EqualFold(cloudEnv, "AzureUSGovernment") {
+				clientCloud = cloud.AzureGovernment
+				endpoint = "https://" + region + ".metrics.monitor.azure.us"
+			}
+			if strings.EqualFold(cloudEnv, "AzureChinaCloud") {
+				clientCloud = cloud.AzureChina
+				endpoint = "https://" + region + ".metrics.monitor.azure.cn"
+			}
+		}
+	}
 
 	return m.Run()
 }
@@ -90,7 +108,6 @@ func startTest(t *testing.T) *azmetrics.Client {
 	transport, err := recording.NewRecordingHTTPClient(t, nil)
 	require.NoError(t, err)
 	opts := &azmetrics.ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}}
-	endpoint := "https://" + region + ".metrics.monitor.azure.com"
 	client, err := azmetrics.NewClient(endpoint, credential, opts)
 	require.NoError(t, err)
 	return client

--- a/sdk/monitor/query/azmetrics/utils_test.go
+++ b/sdk/monitor/query/azmetrics/utils_test.go
@@ -107,7 +107,7 @@ func startTest(t *testing.T) *azmetrics.Client {
 	startRecording(t)
 	transport, err := recording.NewRecordingHTTPClient(t, nil)
 	require.NoError(t, err)
-	opts := &azmetrics.ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}}
+	opts := &azmetrics.ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport, Cloud: clientCloud}}
 	client, err := azmetrics.NewClient(endpoint, credential, opts)
 	require.NoError(t, err)
 	return client


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-for-go/issues/22547

* Adding sovereign cloud support to `azmetrics`
* Adding weekly live testing for the US Gov and China clouds