### PR TITLE
Unexport unused sdk/internal constants

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.8.0 (2024-05-09)
 
+### Breaking Changes
+
+* Unexported `Module` and `Version` constants
+
 ### Other Changes
 
 * Removed default sanitizers added in v1.6.0 (the test proxy itself now includes these)

--- a/sdk/internal/version.go
+++ b/sdk/internal/version.go
@@ -7,9 +7,7 @@
 package internal
 
 const (
-	// Module is the name of the calling module used in telemetry data.
-	Module = "internal"
-
-	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.8.0"
+	// version is the semantic version (see http://semver.org) of this module.
+	//lint:ignore U1000 reason: "this constant is used by post-release automation"
+	version = "v1.8.0"
 )


### PR DESCRIPTION
This will stop requiring API approval for every release because changing the value of `Version` counts as a public API change. No module on main uses these constants and none has any reason to. Even `internal` itself doesn't use them, because it doesn't create a pipeline. I removed `Module` but kept `version` because our post-release automation updates that value.