### PR TITLE
[azservicebus, azeventhubs] emulators should allow for non-localhost as well

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Emulator strings should allow for hosts other than localhost (PR#TBD)
+
 ### Other Changes
 
 ## 1.2.0 (2024-05-07)

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Emulator strings should allow for hosts other than localhost (PR#TBD)
+- Emulator strings should allow for hosts other than localhost (PR#22898)
 
 ### Other Changes
 

--- a/sdk/messaging/azeventhubs/internal/exported/connection_string_properties.go
+++ b/sdk/messaging/azeventhubs/internal/exported/connection_string_properties.go
@@ -103,7 +103,6 @@ func ParseConnectionString(connStr string) (ConnectionStringProperties, error) {
 	}
 
 	if csp.Emulator {
-		// check that they're only connecting to localhost
 		endpointParts := strings.SplitN(csp.Endpoint, ":", 3) // allow for a port, if it exists.
 
 		if len(endpointParts) < 2 || endpointParts[0] != "sb" {

--- a/sdk/messaging/azeventhubs/internal/exported/connection_string_properties.go
+++ b/sdk/messaging/azeventhubs/internal/exported/connection_string_properties.go
@@ -106,11 +106,11 @@ func ParseConnectionString(connStr string) (ConnectionStringProperties, error) {
 		// check that they're only connecting to localhost
 		endpointParts := strings.SplitN(csp.Endpoint, ":", 3) // allow for a port, if it exists.
 
-		if len(endpointParts) < 2 || endpointParts[0] != "sb" || endpointParts[1] != "//localhost" {
-			// there should always be at least two parts "sb:" and "//localhost"
+		if len(endpointParts) < 2 || endpointParts[0] != "sb" {
+			// there should always be at least two parts "sb:" and "//<emulator hostname>"
 			// with an optional 3rd piece that's the port "1111".
 			// (we don't need to validate it's a valid host since it's been through url.Parse() above)
-			return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not %s", csp.Endpoint)
+			return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://<emulator hostname> or sb://<emulator hostname>:<port number>, not %s", csp.Endpoint)
 		}
 	}
 

--- a/sdk/messaging/azeventhubs/internal/exported/connection_string_properties_test.go
+++ b/sdk/messaging/azeventhubs/internal/exported/connection_string_properties_test.go
@@ -123,10 +123,12 @@ func TestNewConnectionStringProperties(t *testing.T) {
 		require.True(t, parsed.Emulator)
 		require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
 
-		// UseDevelopmentEmulator only works for localhost
+		// UseDevelopmentEmulator works for any hostname. This allows for cases where the emulator is used
+		// in testing with multiple containers, where the hostname will not be localhost but development
+		// will still be local.
 		cs = "Endpoint=sb://myserver.com:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
 		parsed, err = exported.ParseConnectionString(cs)
-		require.EqualError(t, err, "UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not sb://myserver.com:6765")
+		require.NoError(t, err)
 
 		// there's no reason for a person to pass False, but it's allowed.
 		// If they're not using the dev emulator then there's no special behavior, it's like a normal connection string

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Emulator strings should allow for hosts other than localhost (PR#TBD)
+
 ### Other Changes
 
 ## 1.7.0 (2024-04-02)

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Emulator strings should allow for hosts other than localhost (PR#TBD)
+- Emulator strings should allow for hosts other than localhost (PR#22898)
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/internal/conn/conn.go
+++ b/sdk/messaging/azservicebus/internal/conn/conn.go
@@ -103,11 +103,11 @@ func ParseConnectionString(connStr string) (ConnectionStringProperties, error) {
 		// check that they're only connecting to localhost
 		endpointParts := strings.SplitN(csp.Endpoint, ":", 3) // allow for a port, if it exists.
 
-		if len(endpointParts) < 2 || endpointParts[0] != "sb" || endpointParts[1] != "//localhost" {
-			// there should always be at least two parts "sb:" and "//localhost"
+		if len(endpointParts) < 2 || endpointParts[0] != "sb" {
+			// there should always be at least two parts "sb:" and "//<emulator hostname>"
 			// with an optional 3rd piece that's the port "1111".
 			// (we don't need to validate it's a valid host since it's been through url.Parse() above)
-			return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not %s", csp.Endpoint)
+			return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://<emulator hostname> or sb://<emulator hostname>:<port number>, not %s", csp.Endpoint)
 		}
 	}
 

--- a/sdk/messaging/azservicebus/internal/conn/conn.go
+++ b/sdk/messaging/azservicebus/internal/conn/conn.go
@@ -100,7 +100,6 @@ func ParseConnectionString(connStr string) (ConnectionStringProperties, error) {
 	}
 
 	if csp.Emulator {
-		// check that they're only connecting to localhost
 		endpointParts := strings.SplitN(csp.Endpoint, ":", 3) // allow for a port, if it exists.
 
 		if len(endpointParts) < 2 || endpointParts[0] != "sb" {

--- a/sdk/messaging/azservicebus/internal/conn/conn_test.go
+++ b/sdk/messaging/azservicebus/internal/conn/conn_test.go
@@ -111,10 +111,12 @@ func TestUseDevelopmentEmulatorProperty(t *testing.T) {
 	require.True(t, parsed.Emulator)
 	require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
 
-	// UseDevelopmentEmulator only works for localhost
+	// UseDevelopmentEmulator works for any hostname. This allows for cases where the emulator is used
+	// in testing with multiple containers, where the hostname will not be localhost but development
+	// will still be local.
 	cs = "Endpoint=sb://myserver.com:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
 	parsed, err = ParseConnectionString(cs)
-	require.EqualError(t, err, "UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not sb://myserver.com:6765")
+	require.NoError(t, err)
 
 	// there's no reason for a person to pass False, but it's allowed.
 	// If they're not using the dev emulator then there's no special behavior, it's like a normal connection string


### PR DESCRIPTION
Removing the restriction that emulator behavior is only available on localhost. 

This supports scenarios where you're using Docker's private networking, where each container has an individual hostname that is _NOT_ localhost.