### PR TITLE
Support federated credentials in on-behalf-of flow

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.6.0-beta.5 (Unreleased)
 
 ### Features Added
+* `NewOnBehalfOfCredentialWithClientAssertions` creates an on-behalf-of credential
+  that authenticates with client assertions such as federated credentials
 
 ### Breaking Changes
 

--- a/sdk/azidentity/example_test.go
+++ b/sdk/azidentity/example_test.go
@@ -64,7 +64,9 @@ func ExampleNewOnBehalfOfCredentialWithCertificate() {
 		// TODO: handle error
 	}
 
-	cred, err = azidentity.NewClientCertificateCredential(tenantID, clientID, certs, key, nil)
+	// userAssertion is the user's access token for the application. Typically it comes from a client request.
+	userAssertion := "TODO"
+	cred, err = azidentity.NewOnBehalfOfCredentialWithCertificate(tenantID, clientID, userAssertion, certs, key, nil)
 	if err != nil {
 		// TODO: handle error
 	}

--- a/sdk/azidentity/on_behalf_of_credential.go
+++ b/sdk/azidentity/on_behalf_of_credential.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
+	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -64,6 +65,9 @@ func NewOnBehalfOfCredentialWithCertificate(tenantID, clientID, userAssertion st
 // userAssertion is the user's access token for the application. The getAssertion function should return client assertions
 // that authenticate the application to Microsoft Entra ID, such as federated credentials.
 func NewOnBehalfOfCredentialWithClientAssertions(tenantID, clientID, userAssertion string, getAssertion func(context.Context) (string, error), options *OnBehalfOfCredentialOptions) (*OnBehalfOfCredential, error) {
+	if getAssertion == nil {
+		return nil, errors.New("getAssertion can't be nil. It must be a function that returns client assertions")
+	}
 	cred := confidential.NewCredFromAssertionCallback(func(ctx context.Context, _ confidential.AssertionRequestOptions) (string, error) {
 		return getAssertion(ctx)
 	})

--- a/sdk/azidentity/on_behalf_of_credential.go
+++ b/sdk/azidentity/on_behalf_of_credential.go
@@ -60,6 +60,16 @@ func NewOnBehalfOfCredentialWithCertificate(tenantID, clientID, userAssertion st
 	return newOnBehalfOfCredential(tenantID, clientID, userAssertion, cred, options)
 }
 
+// NewOnBehalfOfCredentialWithClientAssertions constructs an OnBehalfOfCredential that authenticates with client assertions.
+// userAssertion is the user's access token for the application. The getAssertion function should return client assertions
+// that authenticate the application to Microsoft Entra ID, such as federated credentials.
+func NewOnBehalfOfCredentialWithClientAssertions(tenantID, clientID, userAssertion string, getAssertion func(context.Context) (string, error), options *OnBehalfOfCredentialOptions) (*OnBehalfOfCredential, error) {
+	cred := confidential.NewCredFromAssertionCallback(func(ctx context.Context, _ confidential.AssertionRequestOptions) (string, error) {
+		return getAssertion(ctx)
+	})
+	return newOnBehalfOfCredential(tenantID, clientID, userAssertion, cred, options)
+}
+
 // NewOnBehalfOfCredentialWithSecret constructs an OnBehalfOfCredential that authenticates with a client secret.
 func NewOnBehalfOfCredentialWithSecret(tenantID, clientID, userAssertion, clientSecret string, options *OnBehalfOfCredentialOptions) (*OnBehalfOfCredential, error) {
 	cred, err := confidential.NewCredFromSecret(clientSecret)


### PR DESCRIPTION
Closes #22825 by adding an `OnBehalfOfCredential` constructor that takes a callback providing client assertions.