### PR TITLE
Better handling cosmos regions

### DIFF
--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -45,7 +45,7 @@ func NewClientWithKey(endpoint string, cred KeyCredential, o *ClientOptions) (*C
 	preferredRegions := []string{}
 	enableCrossRegionRetries := true
 	if o != nil {
-		preferredRegions = o.PreferredRegions
+		preferredRegions = o.PreferredRegionsAsStringArray()
 	}
 	gem, err := newGlobalEndpointManager(endpoint, newInternalPipeline(newSharedKeyCredPolicy(cred), o), preferredRegions, 0, enableCrossRegionRetries)
 	if err != nil {
@@ -66,7 +66,7 @@ func NewClient(endpoint string, cred azcore.TokenCredential, o *ClientOptions) (
 	preferredRegions := []string{}
 	enableCrossRegionRetries := true
 	if o != nil {
-		preferredRegions = o.PreferredRegions
+		preferredRegions = o.PreferredRegionsAsStringArray()
 	}
 	gem, err := newGlobalEndpointManager(endpoint, newInternalPipeline(newCosmosBearerTokenPolicy(cred, scope, nil), o), preferredRegions, 0, enableCrossRegionRetries)
 	if err != nil {

--- a/sdk/data/azcosmos/cosmos_client_options.go
+++ b/sdk/data/azcosmos/cosmos_client_options.go
@@ -14,5 +14,101 @@ type ClientOptions struct {
 	// The default is false.
 	EnableContentResponseOnWrite bool
 	// PreferredRegions is a list of regions to be used when initializing the client in case the default region fails.
-	PreferredRegions []string
+	PreferredRegions ClientRegions
 }
+
+// PreferredRegionsAsStringArray returns the preferred regions as a string array.
+func (co *ClientOptions) PreferredRegionsAsStringArray() []string {
+	regions := make([]string, len(co.PreferredRegions))
+	for i, region := range co.PreferredRegions {
+		regions[i] = string(region)
+	}
+	return regions
+}
+
+type ClientRegions []ClientRegion
+type ClientRegion string
+
+const (
+	ClientRegionEastUS              ClientRegion = "East US"
+	ClientRegionEastUS2             ClientRegion = "East US 2"
+	ClientRegionSouthCentralUS      ClientRegion = "South Central US"
+	ClientRegionWestUS              ClientRegion = "West US"
+	ClientRegionWestUS2             ClientRegion = "West US 2"
+	ClientRegionWestUS3             ClientRegion = "West US 3"
+	ClientRegionAustraliaEast       ClientRegion = "Australia East"
+	ClientRegionSoutheastAsia       ClientRegion = "Southeast Asia"
+	ClientRegionNorthEurope         ClientRegion = "North Europe"
+	ClientRegionSwedenCentral       ClientRegion = "Sweden Central"
+	ClientRegionUKSouth             ClientRegion = "UK South"
+	ClientRegionWestEurope          ClientRegion = "West Europe"
+	ClientRegionCentralUS           ClientRegion = "Central US"
+	ClientRegionSouthAfricaNorth    ClientRegion = "South Africa North"
+	ClientRegionCentralIndia        ClientRegion = "Central India"
+	ClientRegionEastAsia            ClientRegion = "East Asia"
+	ClientRegionJapanEast           ClientRegion = "Japan East"
+	ClientRegionKoreaCentral        ClientRegion = "Korea Central"
+	ClientRegionCanadaCentral       ClientRegion = "Canada Central"
+	ClientRegionFranceCentral       ClientRegion = "France Central"
+	ClientRegionGermanyWestCentral  ClientRegion = "Germany West Central"
+	ClientRegionNorwayEast          ClientRegion = "Norway East"
+	ClientRegionPolandCentral       ClientRegion = "Poland Central"
+	ClientRegionSwitzerlandNorth    ClientRegion = "Switzerland North"
+	ClientRegionUAENorth            ClientRegion = "UAE North"
+	ClientRegionBrazilSouth         ClientRegion = "Brazil South"
+	ClientRegionCentralUSEUAP       ClientRegion = "Central US EUAP"
+	ClientRegionQatarCentral        ClientRegion = "Qatar Central"
+	ClientRegionCentralUSStage      ClientRegion = "Central US (Stage)"
+	ClientRegionEastUSStage         ClientRegion = "East US (Stage)"
+	ClientRegionEastUS2Stage        ClientRegion = "East US 2 (Stage)"
+	ClientRegionNorthCentralUSStage ClientRegion = "North Central US (Stage)"
+	ClientRegionSouthCentralUSStage ClientRegion = "South Central US (Stage)"
+	ClientRegionWestUSStage         ClientRegion = "West US (Stage)"
+	ClientRegionWestUS2Stage        ClientRegion = "West US 2 (Stage)"
+	ClientRegionAsia                ClientRegion = "Asia"
+	ClientRegionAsiaPacific         ClientRegion = "Asia Pacific"
+	ClientRegionAustralia           ClientRegion = "Australia"
+	ClientRegionBrazil              ClientRegion = "Brazil"
+	ClientRegionCanada              ClientRegion = "Canada"
+	ClientRegionEurope              ClientRegion = "Europe"
+	ClientRegionFrance              ClientRegion = "France"
+	ClientRegionGermany             ClientRegion = "Germany"
+	ClientRegionGlobal              ClientRegion = "Global"
+	ClientRegionIndia               ClientRegion = "India"
+	ClientRegionJapan               ClientRegion = "Japan"
+	ClientRegionKorea               ClientRegion = "Korea"
+	ClientRegionNorway              ClientRegion = "Norway"
+	ClientRegionSingapore           ClientRegion = "Singapore"
+	ClientRegionSouthAfrica         ClientRegion = "South Africa"
+	ClientRegionSwitzerland         ClientRegion = "Switzerland"
+	ClientRegionUnitedArabEmirates  ClientRegion = "United Arab Emirates"
+	ClientRegionUnitedKingdom       ClientRegion = "United Kingdom"
+	ClientRegionUnitedStates        ClientRegion = "United States"
+	ClientRegionUnitedStatesEUAP    ClientRegion = "United States EUAP"
+	ClientRegionEastAsiaStage       ClientRegion = "East Asia (Stage)"
+	ClientRegionSoutheastAsiaStage  ClientRegion = "Southeast Asia (Stage)"
+	ClientRegionBrazilUS            ClientRegion = "Brazil US"
+	ClientRegionEastUSSTG           ClientRegion = "East US STG"
+	ClientRegionNorthCentralUS      ClientRegion = "North Central US"
+	ClientRegionJioIndiaWest        ClientRegion = "Jio India West"
+	ClientRegionEastUS2EUAP         ClientRegion = "East US 2 EUAP"
+	ClientRegionSouthCentralUSSTG   ClientRegion = "South Central US STG"
+	ClientRegionWestCentralUS       ClientRegion = "West Central US"
+	ClientRegionSouthAfricaWest     ClientRegion = "South Africa West"
+	ClientRegionAustraliaCentral    ClientRegion = "Australia Central"
+	ClientRegionAustraliaCentral2   ClientRegion = "Australia Central 2"
+	ClientRegionAustraliaSoutheast  ClientRegion = "Australia Southeast"
+	ClientRegionJapanWest           ClientRegion = "Japan West"
+	ClientRegionJioIndiaCentral     ClientRegion = "Jio India Central"
+	ClientRegionKoreaSouth          ClientRegion = "Korea South"
+	ClientRegionSouthIndia          ClientRegion = "South India"
+	ClientRegionWestIndia           ClientRegion = "West India"
+	ClientRegionCanadaEast          ClientRegion = "Canada East"
+	ClientRegionFranceSouth         ClientRegion = "France South"
+	ClientRegionGermanyNorth        ClientRegion = "Germany North"
+	ClientRegionNorwayWest          ClientRegion = "Norway West"
+	ClientRegionSwitzerlandWest     ClientRegion = "Switzerland West"
+	ClientRegionUKWest              ClientRegion = "UK West"
+	ClientRegionUAECentral          ClientRegion = "UAE Central"
+	ClientRegionBrazilSoutheast     ClientRegion = "Brazil Southeast"
+)

--- a/sdk/data/azcosmos/cosmos_client_options.go
+++ b/sdk/data/azcosmos/cosmos_client_options.go
@@ -26,7 +26,10 @@ func (co *ClientOptions) PreferredRegionsAsStringArray() []string {
 	return regions
 }
 
+// ClientRegions is a list of regions to be used when initializing the client in case the default region fails.
 type ClientRegions []ClientRegion
+
+// ClientRegion type defines the region to be used when initializing the client in case the default region fails.
 type ClientRegion string
 
 const (

--- a/sdk/data/azcosmos/example_test.go
+++ b/sdk/data/azcosmos/example_test.go
@@ -79,7 +79,7 @@ func ExampleNewClientFromConnectionString() {
 }
 
 func ExampleClientOptions_PreferredRegions() {
-	clientOptions := azcosmos.ClientOptions{PreferredRegions: []string{"West US", "Central US"}}
+	clientOptions := azcosmos.ClientOptions{PreferredRegions: azcosmos.ClientRegions{azcosmos.ClientRegionWestUS, azcosmos.ClientRegionCentralUS}}
 
 	endpoint, ok := os.LookupEnv("AZURE_COSMOS_ENDPOINT")
 	if !ok {


### PR DESCRIPTION
PR updates the preferred regions handling in the CosmosDB client options. It adds support for preferred regions in the CosmosDB client options and provides a method to convert the preferred regions to a string array. The preferred regions can now be specified using the new `ClientRegions` type, which includes a list of predefined region constants. This change improves the flexibility and usability of the CosmosDB client options.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
