### PR TITLE
Avoid throttling in azcontainerregistry live tests

### DIFF
--- a/sdk/containers/azcontainerregistry/assets.json
+++ b/sdk/containers/azcontainerregistry/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/containers/azcontainerregistry",
-  "Tag": "go/containers/azcontainerregistry_792985b1c1"
+  "Tag": "go/containers/azcontainerregistry_874036761a"
 }

--- a/sdk/containers/azcontainerregistry/client_test.go
+++ b/sdk/containers/azcontainerregistry/client_test.go
@@ -31,9 +31,9 @@ func TestClient_DeleteManifest(t *testing.T) {
 	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
 	require.NoError(t, err)
-	resp, err := client.GetTagProperties(ctx, "ubuntu", "20.04", nil)
+	resp, err := client.GetTagProperties(ctx, "busybox", "1.36.1-uclibc", nil)
 	require.NoError(t, err)
-	_, err = client.DeleteManifest(ctx, "ubuntu", *resp.Tag.Digest, nil)
+	_, err = client.DeleteManifest(ctx, "busybox", *resp.Tag.Digest, nil)
 	require.NoError(t, err)
 	_, err = client.DeleteManifest(ctx, "hello-world", "sha256:sha256:aa0cc8055b82dc2509bed2e19b275c8f463506616377219d9642221ab53cf9fe", nil)
 	require.NoError(t, err)
@@ -548,13 +548,13 @@ func TestClient_UpdateRepositoryProperties(t *testing.T) {
 	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
 	require.NoError(t, err)
-	res, err := client.UpdateRepositoryProperties(ctx, "ubuntu", &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{
+	res, err := client.UpdateRepositoryProperties(ctx, "busybox", &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{
 		CanWrite: to.Ptr(false),
 	},
 	})
 	require.NoError(t, err)
 	require.False(t, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
-	res, err = client.UpdateRepositoryProperties(ctx, "ubuntu", &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{
+	res, err = client.UpdateRepositoryProperties(ctx, "busybox", &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{
 		CanWrite: to.Ptr(true),
 	},
 	})

--- a/sdk/containers/azcontainerregistry/client_test.go
+++ b/sdk/containers/azcontainerregistry/client_test.go
@@ -301,20 +301,14 @@ func TestClient_NewListManifestsPager(t *testing.T) {
 	pager := client.NewListManifestsPager("alpine", &ClientListManifestsOptions{
 		MaxNum: to.Ptr[int32](1),
 	})
-	pages := 0
 	items := 0
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		require.NoError(t, err)
 		require.NotEmpty(t, page.Manifests.Attributes)
-		pages++
-		for i, v := range page.Manifests.Attributes {
-			fmt.Printf("page %d manifest %d: %s\n", pages, i+1, *v.Digest)
-			items++
-		}
+		items += len(page.Manifests.Attributes)
 	}
-	require.Equal(t, 32, pages)
-	require.Equal(t, 32, items)
+	require.NotZero(t, items)
 
 	pager = client.NewListManifestsPager("alpine", &ClientListManifestsOptions{
 		OrderBy: to.Ptr(ArtifactManifestOrderByLastUpdatedOnDescending),
@@ -427,21 +421,15 @@ func TestClient_NewListTagsPager(t *testing.T) {
 	pager := client.NewListTagsPager("alpine", &ClientListTagsOptions{
 		MaxNum: to.Ptr[int32](1),
 	})
-	pages := 0
 	items := 0
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		require.NoError(t, err)
 		require.NotEmpty(t, page.Tags)
-		pages++
 		require.Equal(t, 1, len(page.Tags))
-		for i, v := range page.Tags {
-			fmt.Printf("page %d tag %d: %s\n", pages, i+1, *v.Name)
-			items++
-		}
+		items += len(page.Tags)
 	}
-	require.Equal(t, 3, pages)
-	require.Equal(t, 3, items)
+	require.NotZero(t, items)
 
 	pager = client.NewListTagsPager("alpine", &ClientListTagsOptions{
 		OrderBy: to.Ptr(ArtifactTagOrderByLastUpdatedOnDescending),

--- a/sdk/containers/azcontainerregistry/utils_test.go
+++ b/sdk/containers/azcontainerregistry/utils_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -154,33 +153,22 @@ func importTestImages() error {
 	if err != nil {
 		return err
 	}
-	wg := &sync.WaitGroup{}
 	images := []string{"hello-world:latest", "alpine:3.17.1", "alpine:3.16.3", "alpine:3.15.6", "alpine:3.14.8", "ubuntu:20.04", "nginx:latest"}
-	ec := make(chan error, len(images))
-	for _, img := range images {
-		wg.Add(1)
-		go func(image string) {
-			poller, err := client.BeginImportImage(ctx, rg, registryName, armcontainerregistry.ImportImageParameters{
-				Source: &armcontainerregistry.ImportSource{
-					SourceImage: to.Ptr("library/" + image),
-					RegistryURI: to.Ptr("docker.io"),
-				},
-				TargetTags: []*string{to.Ptr(image)},
-				Mode:       to.Ptr(armcontainerregistry.ImportModeForce),
-			}, nil)
-			if err == nil {
-				_, err = poller.PollUntilDone(ctx, nil)
-			}
-			if err != nil {
-				ec <- err
-			}
-			wg.Done()
-		}(img)
-	}
-	wg.Wait()
-	select {
-	case err = <-ec:
-	default:
+	for _, image := range images {
+		poller, err := client.BeginImportImage(ctx, rg, registryName, armcontainerregistry.ImportImageParameters{
+			Source: &armcontainerregistry.ImportSource{
+				SourceImage: to.Ptr("library/" + image),
+				RegistryURI: to.Ptr("docker.io"),
+			},
+			TargetTags: []*string{to.Ptr(image)},
+			Mode:       to.Ptr(armcontainerregistry.ImportModeForce),
+		}, nil)
+		if err == nil {
+			_, err = poller.PollUntilDone(ctx, nil)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	return err
 }

--- a/sdk/containers/azcontainerregistry/utils_test.go
+++ b/sdk/containers/azcontainerregistry/utils_test.go
@@ -153,7 +153,7 @@ func importTestImages() error {
 	if err != nil {
 		return err
 	}
-	images := []string{"hello-world:latest", "alpine:3.17.1", "alpine:3.16.3", "alpine:3.14.8", "ubuntu:20.04", "nginx:latest"}
+	images := []string{"hello-world:latest", "alpine:3.17.1", "alpine:3.16.3", "alpine:3.14.8", "busybox:1.36.1-uclibc", "nginx:latest"}
 	for _, image := range images {
 		poller, err := client.BeginImportImage(ctx, rg, registryName, armcontainerregistry.ImportImageParameters{
 			Source: &armcontainerregistry.ImportSource{

--- a/sdk/containers/azcontainerregistry/utils_test.go
+++ b/sdk/containers/azcontainerregistry/utils_test.go
@@ -153,7 +153,7 @@ func importTestImages() error {
 	if err != nil {
 		return err
 	}
-	images := []string{"hello-world:latest", "alpine:3.17.1", "alpine:3.16.3", "alpine:3.15.6", "alpine:3.14.8", "ubuntu:20.04", "nginx:latest"}
+	images := []string{"hello-world:latest", "alpine:3.17.1", "alpine:3.16.3", "alpine:3.14.8", "ubuntu:20.04", "nginx:latest"}
 	for _, image := range images {
 		poller, err := client.BeginImportImage(ctx, rg, registryName, armcontainerregistry.ImportImageParameters{
 			Source: &armcontainerregistry.ImportSource{


### PR DESCRIPTION
Pipeline runs are failing due to rate limiting while importing images. I guess this is because I parallelized that step in #22920, so this PR reverts that change. Edit: that may have been part of the problem but it wasn't sufficient, so I also reduced the amount of imported data.