### PR TITLE
Add debug logging for recursive go.mod searches

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -103,7 +103,11 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
     $searchPath = Join-Path $searchPath $serviceDirectory
   }
 
-  $pkgFiles = Get-ChildItem -Path $searchPath -Include "go.mod" -Recurse
+  [array]$pkgFiles = Get-ChildItem -Path $searchPath -Include "go.mod" -Recurse
+
+  if ($pkgFiles) {
+    Write-Host "[Get-AllPackageInfoFromRepo] Mod count: $($pkgFiles.Count)"
+  }
 
   foreach ($pkgFile in $pkgFiles)
   {


### PR DESCRIPTION
I am not seeing any uses of the recurse function here actually needing to go down a directory level(s), but to be safe I want to run this for a week and do a search across our pipeline log db.
