### PR TITLE
Do not recursively search for go modules when service directory is known

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -64,6 +64,7 @@ stages:
                 - template: /eng/common/pipelines/templates/steps/retain-run.yml
                 - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                   parameters:
+                    ServiceDirectory: '${{parameters.ServiceDirectory}}'
                     ${{ if startsWith(parameters.ServiceDirectory, '../') }}:
                       PackageName: "${{replace(parameters.ServiceDirectory, '../', '')}}"
                     ${{ else }}:

--- a/eng/scripts/Create-ApiReview.ps1
+++ b/eng/scripts/Create-ApiReview.ps1
@@ -24,10 +24,6 @@ $createReviewScript = (Join-Path $PSScriptRoot .. common scripts Create-APIRevie
 $artifactList = @()
 foreach ($sdk in (Get-AllPackageInfoFromRepo $ServiceDirectory))
 {
-    if ($sdk.ServiceDirectory -ne $ServiceDirectory) {
-        Write-Host "Skipping nested package $($sdk.ServiceDirectory)"
-        continue
-    }
     Write-Host "Creating API review artifact for $($sdk.Name)"
     New-Item -ItemType Directory -Path $OutPath/$($sdk.Name) -force
     $fileName = Split-Path -Path $sdk.Name -Leaf

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -99,14 +99,14 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
 {
   $allPackageProps = @()
   $searchPath = Join-Path $RepoRoot "sdk"
+  $pkgFiles = @()
   if ($serviceDirectory) {
     $searchPath = Join-Path $searchPath $serviceDirectory
-  }
-
-  [array]$pkgFiles = Get-ChildItem -Path $searchPath -Include "go.mod" -Recurse
-
-  if ($pkgFiles) {
-    Write-Host "[Get-AllPackageInfoFromRepo] Mod count: $($pkgFiles.Count)"
+    # If we have a service directory only include the immediate match, no nested go.mod files
+    [array]$pkgFiles = Get-ChildItem -Path $searchPath -Include "go.mod" -Depth 1
+  } else {
+    # If service directory is not passed in, find all modules
+    [array]$pkgFiles = Get-ChildItem -Path $searchPath -Include "go.mod" -Recurse
   }
 
   foreach ($pkgFile in $pkgFiles)


### PR DESCRIPTION
Fixes #22881 

This PR fixes the issue we had with finding nested go modules when not intended, by making `Get-AllPackageInfoFromRepo` search recursively ONLY when service directory is not specified, otherwise we search with `-Depth 1`.

With #22950 I was able to trace instances where we picked up multiple modules via the scripts. There were three categories, two of which are updated here to no longer search recursively.

1. Dependency Check step in the analyze job. This seems to be intended and calls `Get-AllPackageInfoFromRepo` without passing in a service directory argument.
2. CI for core, security, data and template SDKs. All matches here were just picking up the nested `testdata/perf/go.mod` file which I think is not intended since we test perf specifically later in the pipeline.
3. Verify ChangeLog step specifically in the release job. This is solely due to us passing in the `PackageName` parameter and not the `ServiceDirectory` parameter. Under the hood we still filter on the match for `PackageName` so there is no need to be scanning the whole `sdk` directory recursively.

For posterity, I was able to track down offenders in our pipeline log db using the log message added from #22950 with the following query:

```
let _ago = ago(1d);
BuildLogLine
| where Timestamp > _ago
| where Message has "[Get-AllPackageInfoFromRepo] Mod count"
| where Message !has "count: 1" and Message !has "count: 2"  // count: 2 excludes perf/go.mod matches
| join kind=inner (
    BuildTimelineRecord
    | where FinishTime > _ago
    | where Type == "Task"
  ) on BuildDefinitionId, BuildId, LogId
| project BuildDefinitionName, BuildId, Message, RecordName
```