### PR TITLE
Use smaller image in ACR test

### DIFF
--- a/sdk/containers/azcontainerregistry/assets.json
+++ b/sdk/containers/azcontainerregistry/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/containers/azcontainerregistry",
-  "Tag": "go/containers/azcontainerregistry_874036761a"
+  "Tag": "go/containers/azcontainerregistry_b6bdd049bc"
 }

--- a/sdk/containers/azcontainerregistry/client_test.go
+++ b/sdk/containers/azcontainerregistry/client_test.go
@@ -10,6 +10,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -18,9 +22,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/stretchr/testify/require"
-	"io"
-	"net/http"
-	"testing"
 )
 
 const alpineManifestDigest = "sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a"
@@ -65,7 +66,7 @@ func TestClient_DeleteRepository(t *testing.T) {
 	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
 	require.NoError(t, err)
-	_, err = client.DeleteRepository(ctx, "nginx", nil)
+	_, err = client.DeleteRepository(ctx, "eclipse-mosquitto", nil)
 	require.NoError(t, err)
 }
 

--- a/sdk/containers/azcontainerregistry/utils_test.go
+++ b/sdk/containers/azcontainerregistry/utils_test.go
@@ -153,7 +153,7 @@ func importTestImages() error {
 	if err != nil {
 		return err
 	}
-	images := []string{"hello-world:latest", "alpine:3.17.1", "alpine:3.16.3", "alpine:3.14.8", "busybox:1.36.1-uclibc", "nginx:latest"}
+	images := []string{"hello-world:latest", "alpine:3.17.1", "alpine:3.16.3", "alpine:3.14.8", "busybox:1.36.1-uclibc", "eclipse-mosquitto:latest"}
 	for _, image := range images {
 		poller, err := client.BeginImportImage(ctx, rg, registryName, armcontainerregistry.ImportImageParameters{
 			Source: &armcontainerregistry.ImportSource{


### PR DESCRIPTION
Tests are still occasionally getting throttled while uploading images. This should help because eclipse-mosquitto is about 63MB smaller than nginx so, less I/O required. If this doesn't solve the problem, next step is to upgrade the ACR SKU from Basic to Premium, which has higher limits.