### PR TITLE
Update CODEOWNERS for eng/common

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,6 +93,7 @@
 # Eng Sys
 ###########
 /eng/                         @benbp @weshaggard
+/eng/common/                  @Azure/azure-sdk-eng
 
 # Add owners for notifications for specific pipelines
 /eng/common/pipelines/codeowners-linter.yml       @rickwinter


### PR DESCRIPTION
Add engsys team as owner for files under eng/common to enable engsys team to be able to approve and merge eng/common sync PRs.
