### PR TITLE
[azservicebus,azeventhubs] some more stress test fixes

### DIFF
--- a/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.3.1
-digest: sha256:28e374f8db5c46447b2a1491d4361ceb126536c425cbe54be49017120fe7b27d
-generated: "2024-03-01T17:51:06.962215142-08:00"
+  version: 0.3.2
+digest: sha256:6eee71a7e8a4c0dc06d5fbbce39ef63237a0db0b7fc2da66e98e96b68985b764
+generated: "2024-05-30T01:22:48.620817144Z"

--- a/sdk/messaging/azeventhubs/internal/eh/stress/stress-test-resources.json
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/stress-test-resources.json
@@ -142,20 +142,20 @@
           ]
         }
       ]
-    },
+    }
   ],
   "outputs": {
     "EVENTHUB_NAME_STRESS": {
       "type": "string",
       "value": "[variables('eventHubName')]"
     },
-    "EVENTHUB_CONNECTION_STRING": {
+    "EVENTHUB_NAMESPACE": {
       "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', variables('namespaceName'), 'RootManageSharedAccessKey'), variables('apiVersion')).primaryConnectionString]"
+      "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
     },
-    "CHECKPOINTSTORE_STORAGE_CONNECTION_STRING": {
+    "CHECKPOINTSTORE_STORAGE_ENDPOINT": {
       "type": "string",
-      "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), variables('storageApiVersion')).keys[0].value, ';EndpointSuffix=', parameters('storageEndpointSuffix'))]"
+      "value": "[reference(variables('storageAccountName')).primaryEndpoints.blob]"
     }
   }
 }

--- a/sdk/messaging/azservicebus/internal/stress/Chart.lock
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.3.1
-digest: sha256:28e374f8db5c46447b2a1491d4361ceb126536c425cbe54be49017120fe7b27d
-generated: "2024-02-05T17:21:31.510400504-08:00"
+  version: 0.3.2
+digest: sha256:6eee71a7e8a4c0dc06d5fbbce39ef63237a0db0b7fc2da66e98e96b68985b764
+generated: "2024-05-30T01:39:24.209525275Z"

--- a/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
+++ b/sdk/messaging/azservicebus/internal/stress/shared/stress_context.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	"github.com/microsoft/ApplicationInsights-Go/appinsights"
 )
@@ -94,16 +95,22 @@ type StressContextOptions struct {
 }
 
 func MustCreateStressContext(testName string, options *StressContextOptions) *StressContext {
-	cs := os.Getenv("SERVICEBUS_CONNECTION_STRING")
+	sbEndpoint := os.Getenv("SERVICEBUS_ENDPOINT")
 
-	if cs == "" {
-		log.Fatalf("missing SERVICEBUS_CONNECTION_STRING environment variable")
+	if sbEndpoint == "" {
+		log.Fatalf("missing SERVICEBUS_ENDPOINT environment variable")
 	}
 
 	aiKey := os.Getenv("APPINSIGHTS_INSTRUMENTATIONKEY")
 
 	if aiKey == "" {
 		log.Fatalf("missing APPINSIGHTS_INSTRUMENTATIONKEY environment variable")
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+
+	if err != nil {
+		log.Fatalf("failed to create DefaultAzureCredential: %s", err)
 	}
 
 	config := appinsights.NewTelemetryConfiguration(aiKey)
@@ -161,15 +168,14 @@ func MustCreateStressContext(testName string, options *StressContextOptions) *St
 	// })
 
 	sc := &StressContext{
-		TestRunID: testRunID,
-		Nano:      testRunID, // the same for now
-		TC:        telemetryClient,
-		// you could always change the interval here. A minute feels like often enough
-		// to know things are running, while not so often that you end up flooding logging
-		// with duplicate information.
-		logMessages: logMessages,
-		Context:     ctx,
 		cancel:      cancel,
+		Context:     ctx,
+		Cred:        cred,
+		Endpoint:    sbEndpoint,
+		logMessages: logMessages,
+		Nano:        testRunID, // the same for now
+		TC:          telemetryClient,
+		TestRunID:   testRunID,
 	}
 
 	if options != nil && options.EmitStartEvent {

--- a/sdk/messaging/azservicebus/internal/stress/stress-test-resources.bicep
+++ b/sdk/messaging/azservicebus/internal/stress/stress-test-resources.bicep
@@ -11,8 +11,6 @@ var apiVersion = '2017-04-01'
 // Uncomment this if you want to test against the southeastasia nodes.
 //var location = 'southeastasia'
 var location = resourceGroup().location
-var authorizationRuleName_var = '${baseName}/RootManageSharedAccessKey'
-var authorizationRuleNameNoManage_var = '${baseName}/NoManage'
 var serviceBusDataOwnerRoleId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/090c5cfd-751d-490a-894a-3ce6f1109419'
 
 resource servicebus 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
@@ -28,7 +26,7 @@ resource servicebus 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
 }
 
 resource authorizationRuleName 'Microsoft.ServiceBus/namespaces/AuthorizationRules@2015-08-01' = {
-  name: authorizationRuleName_var
+  name: '${baseName}/RootManageSharedAccessKey'
   location: location
   properties: {
     rights: [
@@ -43,7 +41,7 @@ resource authorizationRuleName 'Microsoft.ServiceBus/namespaces/AuthorizationRul
 }
 
 resource authorizationRuleNameNoManage 'Microsoft.ServiceBus/namespaces/AuthorizationRules@2015-08-01' = {
-  name: authorizationRuleNameNoManage_var
+  name: '${baseName}/NoManage'
   location: location
   properties: {
     rights: [
@@ -55,8 +53,6 @@ resource authorizationRuleNameNoManage 'Microsoft.ServiceBus/namespaces/Authoriz
     servicebus
   ]
 }
-
-
 
 resource dataOwnerRoleId 'Microsoft.Authorization/roleAssignments@2018-01-01-preview' = {
   name: guid('dataOwnerRoleId${baseName}')
@@ -105,8 +101,14 @@ resource testQueueWithSessions 'Microsoft.ServiceBus/namespaces/queues@2017-04-0
   }
 }
 
-output SERVICEBUS_CONNECTION_STRING string = listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', baseName, 'RootManageSharedAccessKey'), apiVersion).primaryConnectionString
-output SERVICEBUS_CONNECTION_STRING_NO_MANAGE string = listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', baseName, 'NoManage'), apiVersion).primaryConnectionString
+output SERVICEBUS_CONNECTION_STRING string = listKeys(
+  resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', baseName, 'RootManageSharedAccessKey'),
+  apiVersion
+).primaryConnectionString
+output SERVICEBUS_CONNECTION_STRING_NO_MANAGE string = listKeys(
+  resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', baseName, 'NoManage'),
+  apiVersion
+).primaryConnectionString
 output SERVICEBUS_ENDPOINT string = replace(servicebus.properties.serviceBusEndpoint, ':443/', '')
 output QUEUE_NAME string = 'testQueue'
 output QUEUE_NAME_WITH_SESSIONS string = 'testQueueWithSessions'


### PR DESCRIPTION
- Service Bus stress tests were using the wrong environment variables
- Event Hub stress-test-resources.json needed to output endpoints instead of connection strings.