### PR TITLE
Fix AzurePipelinesCredential options name

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -7,6 +7,8 @@
   that authenticates with client assertions such as federated credentials
 
 ### Breaking Changes
+> These changes affect only code written against a beta version such as v1.6.0-beta.4
+* Renamed `AzurePipelinesServiceConnectionCredentialOptions` to `AzurePipelinesCredentialOptions`
 
 ### Bugs Fixed
 

--- a/sdk/azidentity/azure_pipelines_credential.go
+++ b/sdk/azidentity/azure_pipelines_credential.go
@@ -32,8 +32,8 @@ type AzurePipelinesCredential struct {
 	cred                                     *ClientAssertionCredential
 }
 
-// AzurePipelinesServiceConnectionCredentialOptions contains optional parameters for AzurePipelinesServiceConnectionCredential.
-type AzurePipelinesServiceConnectionCredentialOptions struct {
+// AzurePipelinesCredentialOptions contains optional parameters for AzurePipelinesCredential.
+type AzurePipelinesCredentialOptions struct {
 	azcore.ClientOptions
 
 	// AdditionallyAllowedTenants specifies additional tenants for which the credential may acquire tokens.
@@ -54,9 +54,9 @@ type AzurePipelinesServiceConnectionCredentialOptions struct {
 // this variable in build job YAML.
 //
 // [Azure Pipelines documentation]: https://learn.microsoft.com/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#systemaccesstoken
-func NewAzurePipelinesCredential(tenantID, clientID, serviceConnectionID string, options *AzurePipelinesServiceConnectionCredentialOptions) (*AzurePipelinesCredential, error) {
+func NewAzurePipelinesCredential(tenantID, clientID, serviceConnectionID string, options *AzurePipelinesCredentialOptions) (*AzurePipelinesCredential, error) {
 	if options == nil {
-		options = &AzurePipelinesServiceConnectionCredentialOptions{}
+		options = &AzurePipelinesCredentialOptions{}
 	}
 	u := os.Getenv(systemOIDCRequestURI)
 	if u == "" {

--- a/sdk/azidentity/azure_pipelines_credential_test.go
+++ b/sdk/azidentity/azure_pipelines_credential_test.go
@@ -40,7 +40,7 @@ func TestAzurePipelinesCredential(t *testing.T) {
 			}),
 		)
 		srv.AppendResponse()
-		o := AzurePipelinesServiceConnectionCredentialOptions{
+		o := AzurePipelinesCredentialOptions{
 			ClientOptions: azcore.ClientOptions{
 				Transport: srv,
 			},


### PR DESCRIPTION
Whoops, overlooked this when I renamed the credential type.