### PR TITLE
[keyvault] add sovereign cloud testing

### DIFF
--- a/sdk/security/keyvault/azcertificates/ci.yml
+++ b/sdk/security/keyvault/azcertificates/ci.yml
@@ -28,4 +28,5 @@ extends:
     ServiceDirectory: 'security/keyvault/azcertificates'
     RunLiveTests: true
     UsePipelineProxy: false
+    SupportedClouds: 'Public,UsGov,China'
     TestRunTime: '900s'

--- a/sdk/security/keyvault/azkeys/ci.yml
+++ b/sdk/security/keyvault/azkeys/ci.yml
@@ -29,9 +29,20 @@ extends:
     RunLiveTests: true
     UsePipelineProxy: false
     SupportedClouds: 'Public,UsGov,China'
+    CloudConfig:
+      Public:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+      UsGov:
+        SubscriptionConfiguration: $(sub-config-gov-test-resources)
+        MatrixFilters:
+         - ArmTemplateParameters=^(?!.*enableHsm.*true)
+      China:
+        SubscriptionConfiguration: $(sub-config-cn-test-resources)
+        MatrixFilters:
+         - ArmTemplateParameters=^(?!.*enableHsm.*true)
 
     # Due to the high cost of Managed HSMs, we only want to test using them weekly.
-    ${{ if and(contains(variables['Build.DefinitionName'], 'weekly'), eq(variables['Build.AzureCloud'], 'Public')) }}:
+    ${{ if contains(variables['Build.DefinitionName'], 'weekly') }}:
       AdditionalMatrixConfigs:
         - Name: keyvault_test_matrix_addons
           Path: sdk/security/keyvault/azkeys/platform-matrix.json

--- a/sdk/security/keyvault/azkeys/ci.yml
+++ b/sdk/security/keyvault/azkeys/ci.yml
@@ -31,7 +31,7 @@ extends:
     SupportedClouds: 'Public,UsGov,China'
 
     # Due to the high cost of Managed HSMs, we only want to test using them weekly.
-    ${{ if contains(variables['Build.DefinitionName'], 'weekly') }}:
+    ${{ if and(contains(variables['Build.DefinitionName'], 'weekly'), eq(variables['Build.AzureCloud'], 'Public')) }}:
       AdditionalMatrixConfigs:
         - Name: keyvault_test_matrix_addons
           Path: sdk/security/keyvault/azkeys/platform-matrix.json

--- a/sdk/security/keyvault/azkeys/ci.yml
+++ b/sdk/security/keyvault/azkeys/ci.yml
@@ -28,6 +28,7 @@ extends:
     ServiceDirectory: 'security/keyvault/azkeys'
     RunLiveTests: true
     UsePipelineProxy: false
+    SupportedClouds: 'Public,UsGov,China'
 
     # Due to the high cost of Managed HSMs, we only want to test using them weekly.
     ${{ if contains(variables['Build.DefinitionName'], 'weekly') }}:

--- a/sdk/security/keyvault/azsecrets/ci.yml
+++ b/sdk/security/keyvault/azsecrets/ci.yml
@@ -28,3 +28,4 @@ extends:
     ServiceDirectory: 'security/keyvault/azsecrets'
     RunLiveTests: true
     UsePipelineProxy: false
+    SupportedClouds: 'Public,UsGov,China'


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-go/issues/22854

Adds sovereign cloud testing to weekly live tests