### PR TITLE
Operation-Location poller checks result property

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bugs Fixed
 
+* Fixed an issue that prevented pollers using the `Operation-Location` strategy from unmarshaling the final result in some cases.
+
 ### Other Changes
 
 ## 1.11.1 (2024-04-02)

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.7.0
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/net v0.24.0
+	golang.org/x/net v0.25.0
 )
 
 require (

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -11,8 +11,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
-golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=
+golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
+golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/sdk/azcore/internal/pollers/async/async.go
+++ b/sdk/azcore/internal/pollers/async/async.go
@@ -155,5 +155,5 @@ func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 		p.resp = resp
 	}
 
-	return pollers.ResultHelper(p.resp, poller.Failed(p.CurState), out)
+	return pollers.ResultHelper(p.resp, poller.Failed(p.CurState), "", out)
 }

--- a/sdk/azcore/internal/pollers/body/body.go
+++ b/sdk/azcore/internal/pollers/body/body.go
@@ -131,5 +131,5 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 func (p *Poller[T]) Result(ctx context.Context, out *T) error {
-	return pollers.ResultHelper(p.resp, poller.Failed(p.CurState), out)
+	return pollers.ResultHelper(p.resp, poller.Failed(p.CurState), "", out)
 }

--- a/sdk/azcore/internal/pollers/fake/fake.go
+++ b/sdk/azcore/internal/pollers/fake/fake.go
@@ -124,7 +124,7 @@ func (p *Poller[T]) Result(ctx context.Context, out *T) error {
 		return exported.NewResponseError(p.resp)
 	}
 
-	return pollers.ResultHelper(p.resp, poller.Failed(p.FakeStatus), out)
+	return pollers.ResultHelper(p.resp, poller.Failed(p.FakeStatus), "", out)
 }
 
 // SanitizePollerPath removes any fake-appended suffix from a URL's path.

--- a/sdk/azcore/internal/pollers/loc/loc.go
+++ b/sdk/azcore/internal/pollers/loc/loc.go
@@ -119,5 +119,5 @@ func (p *Poller[T]) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 func (p *Poller[T]) Result(ctx context.Context, out *T) error {
-	return pollers.ResultHelper(p.resp, poller.Failed(p.CurState), out)
+	return pollers.ResultHelper(p.resp, poller.Failed(p.CurState), "", out)
 }

--- a/sdk/azcore/internal/pollers/op/op_test.go
+++ b/sdk/azcore/internal/pollers/op/op_test.go
@@ -127,7 +127,7 @@ func TestFinalStateViaOperationLocationWithPost(t *testing.T) {
 	poller, err := New[widget](exported.NewPipeline(shared.TransportFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{ "status": "succeeded", "shape": "rhombus" }`)),
+			Body:       io.NopCloser(strings.NewReader(`{ "status": "succeeded", "result": { "shape": "rhombus" } }`)),
 		}, nil
 	})), resp, pollers.FinalStateViaOpLocation)
 	require.NoError(t, err)

--- a/sdk/azcore/internal/pollers/util_test.go
+++ b/sdk/azcore/internal/pollers/util_test.go
@@ -159,13 +159,13 @@ func TestResultHelper(t *testing.T) {
 		Body:       http.NoBody,
 	}
 	var result string
-	err := ResultHelper(resp, false, &result)
+	err := ResultHelper(resp, false, "", &result)
 	require.NoError(t, err)
 	require.Empty(t, result)
 
 	resp.StatusCode = http.StatusBadRequest
 	resp.Body = io.NopCloser(strings.NewReader(`{ "code": "failed", "message": "bad stuff" }`))
-	err = ResultHelper(resp, false, &result)
+	err = ResultHelper(resp, false, "", &result)
 	var respErr *exported.ResponseError
 	require.ErrorAs(t, err, &respErr)
 	require.Equal(t, "failed", respErr.ErrorCode)
@@ -173,13 +173,20 @@ func TestResultHelper(t *testing.T) {
 
 	resp.StatusCode = http.StatusOK
 	resp.Body = http.NoBody
-	err = ResultHelper(resp, false, &result)
+	err = ResultHelper(resp, false, "", &result)
 	require.NoError(t, err)
 	require.Empty(t, result)
 
 	resp.Body = io.NopCloser(strings.NewReader(`{ "Result": "happy" }`))
 	widgetResult := widget{Precalculated: 123}
-	err = ResultHelper(resp, false, &widgetResult)
+	err = ResultHelper(resp, false, "", &widgetResult)
+	require.NoError(t, err)
+	require.Equal(t, "happy", widgetResult.Result)
+	require.Equal(t, 123, widgetResult.Precalculated)
+
+	resp.Body = io.NopCloser(strings.NewReader(`{ "subpath": { "Result": "happy" } }`))
+	widgetResult = widget{Precalculated: 123}
+	err = ResultHelper(resp, false, "subpath", &widgetResult)
 	require.NoError(t, err)
 	require.Equal(t, "happy", widgetResult.Result)
 	require.Equal(t, 123, widgetResult.Precalculated)

--- a/sdk/azcore/runtime/poller_test.go
+++ b/sdk/azcore/runtime/poller_test.go
@@ -493,7 +493,7 @@ func TestOpPollerWithWidgetPOST(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted), mock.WithBody([]byte(`{"status": "InProgress"}`)))
 	// POST with no location header means the success response returns the model
-	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"status": "Succeeded", "size": 2}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"status": "Succeeded", "result": {"size": 2} }`)))
 	defer close()
 
 	reqURL, err := url.Parse(srv.URL())

--- a/sdk/azcore/testdata/perf/go.mod
+++ b/sdk/azcore/testdata/perf/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 )
 

--- a/sdk/azcore/testdata/perf/go.sum
+++ b/sdk/azcore/testdata/perf/go.sum
@@ -3,8 +3,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.7.0/go.mod h1:4OG6tQ9EOP/MT0NM
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
-golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=
+golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
+golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
When a status monitor includes the "final response", it's found in a JSON property named "result". When making a "final GET", the JSON path isn't used.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/22433