### PR TITLE
[azservicebus] Updating templates so we use the same stuff for stress and normal integration testing

### DIFF
--- a/sdk/messaging/azservicebus/internal/stress/stress-test-resources.bicep
+++ b/sdk/messaging/azservicebus/internal/stress/stress-test-resources.bicep
@@ -7,108 +7,14 @@ param baseName string = resourceGroup().name
 @description('The client OID to grant access to test resources.')
 param testApplicationOid string
 
-var apiVersion = '2017-04-01'
-// Uncomment this if you want to test against the southeastasia nodes.
-//var location = 'southeastasia'
-var location = resourceGroup().location
-var serviceBusDataOwnerRoleId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/090c5cfd-751d-490a-894a-3ce6f1109419'
-
-resource servicebus 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
-  name: baseName
-  location: location
-  sku: {
-    name: 'Standard'
-    tier: 'Standard'
-  }
-  properties: {
-    zoneRedundant: false
+module sb '../../test-resources.bicep' = {
+  name: 'test_servicebus'
+  params: {
+    baseName: baseName
+    location: resourceGroup().location
+    testApplicationOid: testApplicationOid
+    enablePremium: false // we don't use/need Premium for our stress tests
   }
 }
 
-resource authorizationRuleName 'Microsoft.ServiceBus/namespaces/AuthorizationRules@2015-08-01' = {
-  name: '${baseName}/RootManageSharedAccessKey'
-  location: location
-  properties: {
-    rights: [
-      'Listen'
-      'Manage'
-      'Send'
-    ]
-  }
-  dependsOn: [
-    servicebus
-  ]
-}
-
-resource authorizationRuleNameNoManage 'Microsoft.ServiceBus/namespaces/AuthorizationRules@2015-08-01' = {
-  name: '${baseName}/NoManage'
-  location: location
-  properties: {
-    rights: [
-      'Listen'
-      'Send'
-    ]
-  }
-  dependsOn: [
-    servicebus
-  ]
-}
-
-resource dataOwnerRoleId 'Microsoft.Authorization/roleAssignments@2018-01-01-preview' = {
-  name: guid('dataOwnerRoleId${baseName}')
-  properties: {
-    roleDefinitionId: serviceBusDataOwnerRoleId
-    principalId: testApplicationOid
-  }
-  dependsOn: [
-    servicebus
-  ]
-}
-
-resource testQueue 'Microsoft.ServiceBus/namespaces/queues@2017-04-01' = {
-  parent: servicebus
-  name: 'testQueue'
-  properties: {
-    lockDuration: 'PT5M'
-    maxSizeInMegabytes: 1024
-    requiresDuplicateDetection: false
-    requiresSession: false
-    defaultMessageTimeToLive: 'P10675199DT2H48M5.4775807S'
-    deadLetteringOnMessageExpiration: false
-    duplicateDetectionHistoryTimeWindow: 'PT10M'
-    maxDeliveryCount: 10
-    autoDeleteOnIdle: 'P10675199DT2H48M5.4775807S'
-    enablePartitioning: false
-    enableExpress: false
-  }
-}
-
-resource testQueueWithSessions 'Microsoft.ServiceBus/namespaces/queues@2017-04-01' = {
-  parent: servicebus
-  name: 'testQueueWithSessions'
-  properties: {
-    lockDuration: 'PT5M'
-    maxSizeInMegabytes: 1024
-    requiresDuplicateDetection: false
-    requiresSession: true
-    defaultMessageTimeToLive: 'P10675199DT2H48M5.4775807S'
-    deadLetteringOnMessageExpiration: false
-    duplicateDetectionHistoryTimeWindow: 'PT10M'
-    maxDeliveryCount: 10
-    autoDeleteOnIdle: 'P10675199DT2H48M5.4775807S'
-    enablePartitioning: false
-    enableExpress: false
-  }
-}
-
-output SERVICEBUS_CONNECTION_STRING string = listKeys(
-  resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', baseName, 'RootManageSharedAccessKey'),
-  apiVersion
-).primaryConnectionString
-output SERVICEBUS_CONNECTION_STRING_NO_MANAGE string = listKeys(
-  resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', baseName, 'NoManage'),
-  apiVersion
-).primaryConnectionString
-output SERVICEBUS_ENDPOINT string = replace(servicebus.properties.serviceBusEndpoint, ':443/', '')
-output QUEUE_NAME string = 'testQueue'
-output QUEUE_NAME_WITH_SESSIONS string = 'testQueueWithSessions'
+output SERVICEBUS_ENDPOINT string = sb.outputs.SERVICEBUS_ENDPOINT


### PR DESCRIPTION
Deploying the main test-resources.bicep as a module, and parameterized the deployment of the Premium resource since we don't use that in stress testing.