### PR TITLE
ListHandles Return additional ClientName field

### DIFF
--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_bd5cdaec91"
+  "Tag": "go/storage/azfile_92541379dd"
 }

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -3362,6 +3362,25 @@ func (f *FileRecordedTestsSuite) TestFileListHandlesDefault() {
 	_require.Equal(*resp.NextMarker, "")
 }
 
+func (f *FileRecordedTestsSuite) TestFileListHandlesClientNameFieldCheck() {
+	if recording.GetRecordMode() == recording.LiveMode {
+		f.T().Skip("This test cannot be made live")
+	}
+	_require := require.New(f.T())
+	testName := f.T().Name()
+
+	svcClient, err := testcommon.GetServiceClient(f.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareClient := testcommon.GetShareClient(testcommon.GenerateShareName(testName), svcClient)
+
+	fClient := testcommon.GetFileClientFromShare(testcommon.GenerateFileName(testName), shareClient)
+	resp, err := fClient.ListHandles(context.Background(), nil)
+	_require.NoError(err)
+	_require.Len(resp.Handles, 1)
+	_require.NotNil(*resp.Handles[0].ClientName)
+}
+
 func (f *FileRecordedTestsSuite) TestFileForceCloseHandlesDefault() {
 	_require := require.New(f.T())
 	testName := f.T().Name()


### PR DESCRIPTION
ClientName field is returned by List Handle API currently in the codebase. This PR tests this functionality.

API - https://learn.microsoft.com/en-us/rest/api/storageservices/list-handles#response

Since the testing requires File shares to be created, open file handles, and execute the test while holding the handle, the test cannot be made Live in pipeline, and is playback only.
Though live testing was completed successfully as given below -
![image](https://github.com/Azure/azure-sdk-for-go/assets/124860586/e537d617-8011-49f2-b1e2-4f75199a9d94)


PS C:\Windows\System32> net use S: \\xxxx.file.core.windows.net\tanyafileshare The command completed successfully.

Holding file handle and executing the test -
![image](https://github.com/Azure/azure-sdk-for-go/assets/124860586/68384990-576d-400f-a5f9-8aaac1709ae4)

ClientName field is populated.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
