### PR TITLE
[STG93][AzFiles] Adding Rename Support to List Ranges API 

### DIFF
--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_92541379dd"
+  "Tag": "go/storage/azfile_23ee391082"
 }

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -3091,6 +3091,64 @@ func (f *FileRecordedTestsSuite) TestFileGetRangeListSnapshot() {
 	_require.EqualValues(*resp2.Ranges[0], file.ShareFileRange{Start: to.Ptr(int64(0)), End: to.Ptr(fileSize - 1)})
 }
 
+func (f *FileRecordedTestsSuite) TestFileGetRangeListSupportRename() {
+	_require := require.New(f.T())
+	testName := f.T().Name()
+
+	svcClient, err := testcommon.GetServiceClient(f.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, testcommon.GenerateShareName(testName), svcClient)
+	defer func() {
+		_, err := shareClient.Delete(context.Background(), &share.DeleteOptions{DeleteSnapshots: to.Ptr(share.DeleteSnapshotsOptionTypeInclude)})
+		_require.NoError(err)
+	}()
+
+	fileSize := int64(512)
+	fClient := setupGetRangeListTest(_require, testName, fileSize, shareClient)
+
+	snapshotResponse1, err := shareClient.CreateSnapshot(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(snapshotResponse1.Snapshot)
+
+	rsc, _ := testcommon.GenerateData(int(fileSize))
+	_, err = fClient.UploadRange(context.Background(), 0, rsc, nil)
+
+	renameResponse, err := fClient.Rename(context.Background(), "file2", nil)
+	_require.NoError(err)
+
+	newFileClient := testcommon.GetFileClientFromShare("file2", shareClient)
+	_require.NoError(err)
+
+	snapshotResponse2, err := shareClient.CreateSnapshot(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(snapshotResponse2.Snapshot)
+
+	_, err = newFileClient.GetRangeList(context.Background(), &file.GetRangeListOptions{
+		PrevShareSnapshot: snapshotResponse1.Snapshot,
+		ShareSnapshot:     snapshotResponse2.Snapshot,
+		SupportRename:     to.Ptr(false),
+	})
+	_require.Error(err, "PreviousSnapshotNotFound")
+
+	_, err = newFileClient.GetRangeList(context.Background(), &file.GetRangeListOptions{
+		PrevShareSnapshot: snapshotResponse1.Snapshot,
+		ShareSnapshot:     snapshotResponse2.Snapshot,
+		SupportRename:     nil,
+	})
+	_require.Error(err, "PreviousSnapshotNotFound")
+
+	resp, err := newFileClient.GetRangeList(context.Background(), &file.GetRangeListOptions{
+		PrevShareSnapshot: snapshotResponse1.Snapshot,
+		ShareSnapshot:     snapshotResponse2.Snapshot,
+		SupportRename:     to.Ptr(true),
+	})
+	_require.NoError(err)
+	_require.Len(resp.Ranges, 1)
+	_require.EqualValues(*resp.Ranges[0], file.ShareFileRange{Start: to.Ptr(int64(0)), End: to.Ptr(fileSize - 1)})
+	_require.Equal(resp.ETag, renameResponse.ETag)
+}
+
 func (f *FileRecordedTestsSuite) TestFileUploadDownloadSmallBuffer() {
 	_require := require.New(f.T())
 	testName := f.T().Name()

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -691,6 +691,9 @@ type GetRangeListOptions struct {
 	ShareSnapshot *string
 	// LeaseAccessConditions contains optional parameters to access leased entity.
 	LeaseAccessConditions *LeaseAccessConditions
+	// SupportRename determines whether the changed ranges for a file should be listed when the file's location in the
+	// previous snapshot is different from the location in the Request URI, as a result of rename or move operations.
+	SupportRename *bool
 }
 
 func (o *GetRangeListOptions) format() (*generated.FileClientGetRangeListOptions, *generated.LeaseAccessConditions) {
@@ -702,6 +705,7 @@ func (o *GetRangeListOptions) format() (*generated.FileClientGetRangeListOptions
 		Prevsharesnapshot: o.PrevShareSnapshot,
 		Range:             exported.FormatHTTPRange(o.Range),
 		Sharesnapshot:     o.ShareSnapshot,
+		SupportRename:     o.SupportRename,
 	}, o.LeaseAccessConditions
 }
 

--- a/sdk/storage/azfile/internal/generated/autorest.md
+++ b/sdk/storage/azfile/internal/generated/autorest.md
@@ -7,7 +7,7 @@ go: true
 clear-output-folder: false
 version: "^3.0.0"
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/29ebfcffaddbbf8db7565a789ce19b5be3601748/specification/storage/data-plane/Microsoft.FileStorage/preview/2024-05-04/file.json"
+input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/70cfdba3d6acf2325fa5a9d264dfdf69c99fc0f9/specification/storage/data-plane/Microsoft.FileStorage/preview/2024-05-04/file.json"
 credential-scope: "https://storage.azure.com/.default"
 output-folder: ../generated
 file-prefix: "zz_"

--- a/sdk/storage/azfile/internal/generated/zz_constants.go
+++ b/sdk/storage/azfile/internal/generated/zz_constants.go
@@ -292,6 +292,7 @@ const (
 	StorageErrorCodeOutOfRangeInput                      StorageErrorCode = "OutOfRangeInput"
 	StorageErrorCodeOutOfRangeQueryParameterValue        StorageErrorCode = "OutOfRangeQueryParameterValue"
 	StorageErrorCodeParentNotFound                       StorageErrorCode = "ParentNotFound"
+	StorageErrorCodePreviousSnapshotNotFound             StorageErrorCode = "PreviousSnapshotNotFound"
 	StorageErrorCodeReadOnlyAttribute                    StorageErrorCode = "ReadOnlyAttribute"
 	StorageErrorCodeRequestBodyTooLarge                  StorageErrorCode = "RequestBodyTooLarge"
 	StorageErrorCodeRequestURLFailedToParse              StorageErrorCode = "RequestUrlFailedToParse"
@@ -363,6 +364,7 @@ func PossibleStorageErrorCodeValues() []StorageErrorCode {
 		StorageErrorCodeOutOfRangeInput,
 		StorageErrorCodeOutOfRangeQueryParameterValue,
 		StorageErrorCodeParentNotFound,
+		StorageErrorCodePreviousSnapshotNotFound,
 		StorageErrorCodeReadOnlyAttribute,
 		StorageErrorCodeRequestBodyTooLarge,
 		StorageErrorCodeRequestURLFailedToParse,

--- a/sdk/storage/azfile/internal/generated/zz_file_client.go
+++ b/sdk/storage/azfile/internal/generated/zz_file_client.go
@@ -1155,6 +1155,9 @@ func (client *FileClient) getRangeListCreateRequest(ctx context.Context, options
 	if client.fileRequestIntent != nil {
 		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
+	if options != nil && options.SupportRename != nil {
+		req.Raw().Header["x-ms-file-support-rename"] = []string{strconv.FormatBool(*options.SupportRename)}
+	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
 }

--- a/sdk/storage/azfile/internal/generated/zz_options.go
+++ b/sdk/storage/azfile/internal/generated/zz_options.go
@@ -383,6 +383,13 @@ type FileClientGetRangeListOptions struct {
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.
 	Sharesnapshot *string
 
+	// This header is allowed only when PrevShareSnapshot query parameter is set. Determines whether the changed ranges for a
+	// file that has been renamed or moved between the target snapshot (or the live
+	// file) and the previous snapshot should be listed. If the value is true, the valid changed ranges for the file will be returned.
+	// If the value is false, the operation will result in a failure with 409
+	// (Conflict) response. The default value is false.
+	SupportRename *bool
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for File Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN]
 	Timeout *int32


### PR DESCRIPTION
`x-ms-file-support-rename: { Boolean }`
Supported in version 2024-05-04 and above. This header is allowed only when prevsharesnapshot query parameter is present. The Boolean value determines whether the changed ranges for a file should be listed when the file's location in the previous snapshot is different from the location in the Request URI, as a result of rename or move operations. If the value is true, the valid changed ranges for the file will be returned. If the value is false, the operation will result in a failure with 409 (Conflict) response. The default value is false.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
