### PR TITLE
Add AzurePipelinesCredential parameters to its constructor

### DIFF
--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -134,6 +134,12 @@ func TestTenantID(t *testing.T) {
 			tenantOptional: true,
 		},
 		{
+			name: credNameAzurePipelines,
+			ctor: func(tenant string) (azcore.TokenCredential, error) {
+				return NewAzurePipelinesCredential(tenant, fakeClientID, "service-connection", tokenValue, nil)
+			},
+		},
+		{
 			name: credNameBrowser,
 			ctor: func(tenant string) (azcore.TokenCredential, error) {
 				return NewInteractiveBrowserCredential(&InteractiveBrowserCredentialOptions{
@@ -603,6 +609,14 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 				},
 			},
 			{
+				name: credNameAzurePipelines,
+				ctor: func(co azcore.ClientOptions) (azcore.TokenCredential, error) {
+					o := AzurePipelinesCredentialOptions{AdditionallyAllowedTenants: test.allowed, ClientOptions: co}
+					return NewAzurePipelinesCredential(fakeTenantID, fakeClientID, "service-connection", tokenValue, &o)
+				},
+				env: map[string]string{systemOIDCRequestURI: "https://localhost/instance"},
+			},
+			{
 				name: credNameCert,
 				ctor: func(co azcore.ClientOptions) (azcore.TokenCredential, error) {
 					o := ClientCertificateCredentialOptions{AdditionallyAllowedTenants: test.allowed, ClientOptions: co}
@@ -859,6 +873,7 @@ func TestClaims(t *testing.T) {
 	claim := `"test":"pass"`
 	for _, test := range []struct {
 		ctor func(azcore.ClientOptions) (azcore.TokenCredential, error)
+		env  map[string]string
 		name string
 	}{
 		{
@@ -867,6 +882,14 @@ func TestClaims(t *testing.T) {
 				o := ClientAssertionCredentialOptions{ClientOptions: co}
 				return NewClientAssertionCredential(fakeTenantID, fakeClientID, func(context.Context) (string, error) { return "...", nil }, &o)
 			},
+		},
+		{
+			name: credNameAzurePipelines,
+			ctor: func(co azcore.ClientOptions) (azcore.TokenCredential, error) {
+				o := AzurePipelinesCredentialOptions{ClientOptions: co}
+				return NewAzurePipelinesCredential(fakeTenantID, fakeClientID, "service-connection", tokenValue, &o)
+			},
+			env: map[string]string{systemOIDCRequestURI: "https://localhost/foo/UserRealm/foo"},
 		},
 		{
 			name: credNameCert,
@@ -924,6 +947,9 @@ func TestClaims(t *testing.T) {
 				name += " CAE"
 			}
 			t.Run(name, func(t *testing.T) {
+				for k, v := range test.env {
+					t.Setenv(k, v)
+				}
 				reqs := 0
 				sts := mockSTS{
 					tokenRequestCallback: func(r *http.Request) *http.Response {

--- a/sdk/azidentity/azure_pipelines_credential.go
+++ b/sdk/azidentity/azure_pipelines_credential.go
@@ -6,6 +6,7 @@ package azidentity
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -59,15 +60,18 @@ func NewAzurePipelinesCredential(tenantID, clientID, serviceConnectionID, system
 	if !validTenantID(tenantID) {
 		return nil, errInvalidTenantID
 	}
+	if clientID == "" {
+		return nil, errors.New("no client ID specified")
+	}
+	if serviceConnectionID == "" {
+		return nil, errors.New("no service connection ID specified")
+	}
+	if systemAccessToken == "" {
+		return nil, errors.New("no system access token specified")
+	}
 	u := os.Getenv(systemOIDCRequestURI)
 	if u == "" {
 		return nil, fmt.Errorf("no value for environment variable %s. This should be set by Azure Pipelines", systemOIDCRequestURI)
-	}
-	if clientID == "" {
-		return nil, fmt.Errorf("no client ID specified")
-	}
-	if serviceConnectionID == "" {
-		return nil, fmt.Errorf("no service connection ID specified")
 	}
 	a := AzurePipelinesCredential{
 		connectionID:      serviceConnectionID,


### PR DESCRIPTION
This is the planned final constructor API. I'll update markdown docs in another PR.