### PR TITLE
[azdatalake] Added ACL response headers

### DIFF
--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.3 (Unreleased)
 
 ### Features Added
+* Added ACL response headers in GetBlobProperties API for Files.
 
 ### Breaking Changes
 

--- a/sdk/storage/azdatalake/assets.json
+++ b/sdk/storage/azdatalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azdatalake",
-  "Tag": "go/storage/azdatalake_efc19e464c"
+  "Tag": "go/storage/azdatalake_3bd4a74b12"
 }

--- a/sdk/storage/azdatalake/assets.json
+++ b/sdk/storage/azdatalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azdatalake",
-  "Tag": "go/storage/azdatalake_3bd4a74b12"
+  "Tag": "go/storage/azdatalake_c3ee072ffa"
 }

--- a/sdk/storage/azdatalake/directory/client_test.go
+++ b/sdk/storage/azdatalake/directory/client_test.go
@@ -2523,11 +2523,8 @@ func (s *RecordedTestSuite) TestDirRenameNoOptions() {
 	_require.NoError(err)
 	_require.NotNil(resp)
 
-	//resp1, err := dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = dirClient.Rename(context.Background(), "newName", nil)
 	_require.NoError(err)
-	//_require.NotNil(resp1)
-	//_require.Contains(resp1.NewDirectoryClient.DFSURL(), "newName")
 }
 
 func (s *RecordedTestSuite) TestDirRenameRequestWithCPK() {
@@ -2586,11 +2583,8 @@ func (s *RecordedTestSuite) TestRenameDirWithNilAccessConditions() {
 		AccessConditions: nil,
 	}
 
-	//resp1, err := dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_require.NoError(err)
-	//_require.NotNil(resp1)
-	//_require.Contains(resp1.NewDirectoryClient.DFSURL(), "newName")
 }
 
 func (s *RecordedTestSuite) TestRenameDirIfModifiedSinceTrue() {
@@ -2622,11 +2616,8 @@ func (s *RecordedTestSuite) TestRenameDirIfModifiedSinceTrue() {
 			},
 		},
 	}
-	//resp1, err := dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_require.NoError(err)
-	//_require.NotNil(resp1)
-	//_require.Contains(resp1.NewDirectoryClient.DFSURL(), "newName")
 }
 
 func (s *RecordedTestSuite) TestRenameDirIfModifiedSinceFalse() {
@@ -2659,9 +2650,7 @@ func (s *RecordedTestSuite) TestRenameDirIfModifiedSinceFalse() {
 		},
 	}
 
-	//_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
-
 	_require.Error(err)
 	testcommon.ValidateErrorCode(_require, err, datalakeerror.SourceConditionNotMet)
 }
@@ -2696,11 +2685,8 @@ func (s *RecordedTestSuite) TestRenameDirIfUnmodifiedSinceTrue() {
 		},
 	}
 
-	//resp1, err := dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_require.NoError(err)
-	//_require.NotNil(resp1)
-	//_require.Contains(resp1.NewDirectoryClient.DFSURL(), "newName")
 }
 
 func (s *RecordedTestSuite) TestRenameDirIfUnmodifiedSinceFalse() {
@@ -2733,9 +2719,7 @@ func (s *RecordedTestSuite) TestRenameDirIfUnmodifiedSinceFalse() {
 		},
 	}
 
-	//_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
-
 	_require.Error(err)
 	testcommon.ValidateErrorCode(_require, err, datalakeerror.SourceConditionNotMet)
 }
@@ -2770,11 +2754,8 @@ func (s *RecordedTestSuite) TestRenameDirIfETagMatch() {
 		},
 	}
 
-	//resp1, err := dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_require.NoError(err)
-	//_require.NotNil(resp1)
-	//_require.Contains(resp1.NewDirectoryClient.DFSURL(), "newName")
 }
 
 func (s *RecordedTestSuite) TestRenameDirIfETagMatchFalse() {
@@ -2807,7 +2788,6 @@ func (s *RecordedTestSuite) TestRenameDirIfETagMatchFalse() {
 		},
 	}
 
-	//_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = dirClient.Rename(context.Background(), "newName", renameFileOpts)
 
 	_require.Error(err)

--- a/sdk/storage/azdatalake/file/client.go
+++ b/sdk/storage/azdatalake/file/client.go
@@ -296,11 +296,6 @@ func (f *Client) Rename(ctx context.Context, destinationPath string, options *Re
 	newFileClient := (*Client)(base.NewPathClient(newPathURL, newBlobURL, newBlobClient, f.generatedFileClientWithDFS().InternalClient().WithClientName(exported.ModuleName), f.sharedKey(), f.identityCredential(), f.getClientOptions()))
 	resp, err := newFileClient.generatedFileClientWithDFS().Create(ctx, createOpts, nil, lac, mac, smac, cpkOpts)
 
-	//return RenameResponse{
-	//	Response:      resp,
-	//	NewFileClient: newFileClient,
-	//}, exported.ConvertToDFSError(err)
-
 	return path.FormatRenameResponse(&resp), exported.ConvertToDFSError(err)
 }
 

--- a/sdk/storage/azdatalake/file/client_test.go
+++ b/sdk/storage/azdatalake/file/client_test.go
@@ -528,7 +528,7 @@ func (s *UnrecordedTestSuite) TestCreateFileWithExpiryAbsolute() {
 	resp1, err := fClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
 	_require.NotNil(resp1.ExpiresOn)
-	_require.Equal(expiryTimeAbsolute.UTC().Format(http.TimeFormat), (*resp1.ExpiresOn).UTC().Format(http.TimeFormat))
+	_require.Equal(expiryTimeAbsolute.UTC().Format(http.TimeFormat), resp1.ExpiresOn.UTC().Format(http.TimeFormat))
 }
 
 func (s *RecordedTestSuite) TestCreateFileWithExpiryNever() {
@@ -2459,11 +2459,8 @@ func (s *RecordedTestSuite) TestRenameFileWithNilAccessConditions() {
 		AccessConditions: nil,
 	}
 
-	//resp1, err := fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_require.NoError(err)
-	//_require.NotNil(resp1)
-	//_require.Contains(resp1.NewFileClient.DFSURL(), "newName")
 }
 
 func (s *RecordedTestSuite) TestRenameFileIfModifiedSinceTrue() {
@@ -2495,11 +2492,8 @@ func (s *RecordedTestSuite) TestRenameFileIfModifiedSinceTrue() {
 			},
 		},
 	}
-	//resp1, err := fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_require.NoError(err)
-	//_require.NotNil(resp1)
-	//_require.Contains(resp1.NewFileClient.DFSURL(), "newName")
 }
 
 func (s *RecordedTestSuite) TestRenameFileIfModifiedSinceFalse() {
@@ -2532,7 +2526,6 @@ func (s *RecordedTestSuite) TestRenameFileIfModifiedSinceFalse() {
 		},
 	}
 
-	//_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 
 	_require.Error(err)
@@ -2569,11 +2562,8 @@ func (s *RecordedTestSuite) TestRenameFileIfUnmodifiedSinceTrue() {
 		},
 	}
 
-	//resp1, err := fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_require.NoError(err)
-	//_require.NotNil(resp1)
-	//_require.Contains(resp1.NewFileClient.DFSURL(), "newName")
 }
 
 func (s *RecordedTestSuite) TestRenameFileIfUnmodifiedSinceFalse() {
@@ -2606,7 +2596,6 @@ func (s *RecordedTestSuite) TestRenameFileIfUnmodifiedSinceFalse() {
 		},
 	}
 
-	//_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 
 	_require.Error(err)
@@ -2643,11 +2632,8 @@ func (s *RecordedTestSuite) TestRenameFileIfETagMatch() {
 		},
 	}
 
-	//resp1, err := fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_require.NoError(err)
-	//_require.NotNil(resp1)
-	//_require.Contains(resp1.NewFileClient.DFSURL(), "newName")
 }
 
 func (s *RecordedTestSuite) TestRenameFileIfETagMatchFalse() {
@@ -2680,7 +2666,6 @@ func (s *RecordedTestSuite) TestRenameFileIfETagMatchFalse() {
 		},
 	}
 
-	//_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 	_, err = fClient.Rename(context.Background(), "newName", renameFileOpts)
 
 	_require.Error(err)
@@ -3770,7 +3755,7 @@ func (s *RecordedTestSuite) TestFileAppendDataWithAcquireLease() {
 
 	time.Sleep(time.Second * 15)
 
-	//Check if the lease was acquired for the right duration
+	// Check if the lease was acquired for the right duration
 	gResp, err := srcFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
 	_require.Equal(lease.StateTypeExpired, *gResp.LeaseState)
@@ -3806,7 +3791,7 @@ func (s *RecordedTestSuite) TestFileAppendDataWithRenewLease() {
 	_require.NoError(err)
 	_require.Equal(lease.StateTypeLeased, *gResp2.LeaseState)
 
-	//Wait for 15 seconds for lease to expire
+	// Wait for 15 seconds for lease to expire
 	time.Sleep(15 * time.Second)
 
 	gResp, err := srcFClient.GetProperties(context.Background(), nil)

--- a/sdk/storage/azdatalake/file/examples_test.go
+++ b/sdk/storage/azdatalake/file/examples_test.go
@@ -245,11 +245,11 @@ func generateData(sizeInBytes int) (io.ReadSeekCloser, []byte) {
 	if sizeInBytes > _len {
 		count := sizeInBytes / _len
 		if sizeInBytes%_len != 0 {
-			count = count + 1
+			count++
 		}
-		copy(data[:], strings.Repeat(random64BString, count))
+		copy(data, strings.Repeat(random64BString, count))
 	} else {
-		copy(data[:], random64BString)
+		copy(data, random64BString)
 	}
 	return streaming.NopCloser(bytes.NewReader(data)), data
 }

--- a/sdk/storage/azdatalake/file/models.go
+++ b/sdk/storage/azdatalake/file/models.go
@@ -113,7 +113,7 @@ func (o *CreateOptions) format() (*generated.LeaseAccessConditions, *generated.M
 
 // UpdateAccessControlOptions contains the optional parameters when calling the UpdateAccessControlRecursive operation.
 type UpdateAccessControlOptions struct {
-	//placeholder
+	// placeholder
 }
 
 func (o *UpdateAccessControlOptions) format(ACL string) (*generated.PathClientSetAccessControlRecursiveOptions, generated.PathSetAccessControlRecursiveMode) {
@@ -125,13 +125,13 @@ func (o *UpdateAccessControlOptions) format(ACL string) (*generated.PathClientSe
 
 // RemoveAccessControlOptions contains the optional parameters when calling the RemoveAccessControlRecursive operation.
 type RemoveAccessControlOptions struct {
-	//placeholder
+	// placeholder
 }
 
-func (o *RemoveAccessControlOptions) format(ACL string) (*generated.PathClientSetAccessControlRecursiveOptions, generated.PathSetAccessControlRecursiveMode) {
+func (o *RemoveAccessControlOptions) format(acl string) (*generated.PathClientSetAccessControlRecursiveOptions, generated.PathSetAccessControlRecursiveMode) {
 	mode := generated.PathSetAccessControlRecursiveModeRemove
 	return &generated.PathClientSetAccessControlRecursiveOptions{
-		ACL: &ACL,
+		ACL: &acl,
 	}, mode
 }
 
@@ -267,7 +267,7 @@ type AppendDataOptions struct {
 	ProposedLeaseID *string
 	// CPKInfo contains optional parameters to perform encryption using customer-provided key.
 	CPKInfo *CPKInfo
-	//Flush Optional. If true, the file will be flushed after append.
+	// Flush Optional. If true, the file will be flushed after append.
 	Flush *bool
 }
 

--- a/sdk/storage/azdatalake/file/responses.go
+++ b/sdk/storage/azdatalake/file/responses.go
@@ -73,6 +73,9 @@ type DownloadResponse struct {
 	// AcceptRanges contains the information returned from the Accept-Ranges header response.
 	AcceptRanges *string
 
+	// AccessControlList contains the combined list of access that are set for user, group and other on the file
+	AccessControlList *string
+
 	// Body contains the streaming response.
 	Body io.ReadCloser
 
@@ -244,6 +247,9 @@ func FormatDownloadStreamResponse(r *blob.DownloadStreamResponse, rawResponse *h
 	}
 	if val := rawResponse.Header.Get("x-ms-encryption-context"); val != "" {
 		newResp.EncryptionContext = &val
+	}
+	if val := rawResponse.Header.Get("x-ms-acl"); val != "" {
+		newResp.AccessControlList = &val
 	}
 	return newResp
 }

--- a/sdk/storage/azdatalake/file/retry_reader.go
+++ b/sdk/storage/azdatalake/file/retry_reader.go
@@ -101,7 +101,6 @@ func (s *RetryReader) setResponse(r io.ReadCloser) {
 // Read from retry reader
 func (s *RetryReader) Read(p []byte) (n int, err error) {
 	for try := int32(0); ; try++ {
-		//fmt.Println(try)       // Comment out for debugging.
 		if s.countWasBounded && s.info.Range.Count == CountToEnd {
 			// User specified an original count and the remaining bytes are 0, return 0, EOF
 			return 0, io.EOF

--- a/sdk/storage/azdatalake/filesystem/models.go
+++ b/sdk/storage/azdatalake/filesystem/models.go
@@ -201,17 +201,17 @@ func (o *GetSASURLOptions) format() time.Time {
 	return st
 }
 
-//// UndeletePathOptions contains the optional parameters for the FileSystem.UndeletePath operation.
-//type UndeletePathOptions struct {
+// UndeletePathOptions contains the optional parameters for the FileSystem.UndeletePath operation.
+// type UndeletePathOptions struct {
 //	// placeholder
-//}
+// }
 //
-//func (o *UndeletePathOptions) format() *UndeletePathOptions {
+// func (o *UndeletePathOptions) format() *UndeletePathOptions {
 //	if o == nil {
 //		return nil
 //	}
 //	return &UndeletePathOptions{}
-//}
+// }
 
 // CPKScopeInfo contains a group of parameters for the FileSystemClient.Create method.
 type CPKScopeInfo = container.CPKScopeInfo

--- a/sdk/storage/azdatalake/internal/exported/exported.go
+++ b/sdk/storage/azdatalake/internal/exported/exported.go
@@ -42,10 +42,10 @@ func ConvertToDFSError(err error) error {
 	var responseErr *azcore.ResponseError
 	isRespErr := errors.As(err, &responseErr)
 	if isRespErr {
-		responseErr.ErrorCode = strings.Replace(responseErr.ErrorCode, "blob", "path", -1)
-		responseErr.ErrorCode = strings.Replace(responseErr.ErrorCode, "Blob", "Path", -1)
-		responseErr.ErrorCode = strings.Replace(responseErr.ErrorCode, "container", "filesystem", -1)
-		responseErr.ErrorCode = strings.Replace(responseErr.ErrorCode, "Container", "FileSystem", -1)
+		responseErr.ErrorCode = strings.ReplaceAll(responseErr.ErrorCode, "blob", "path")
+		responseErr.ErrorCode = strings.ReplaceAll(responseErr.ErrorCode, "Blob", "Path")
+		responseErr.ErrorCode = strings.ReplaceAll(responseErr.ErrorCode, "container", "filesystem")
+		responseErr.ErrorCode = strings.ReplaceAll(responseErr.ErrorCode, "Container", "FileSystem")
 		return responseErr
 	}
 	return err

--- a/sdk/storage/azdatalake/internal/generated/zz_filesystem_client.go
+++ b/sdk/storage/azdatalake/internal/generated/zz_filesystem_client.go
@@ -28,7 +28,7 @@ type FileSystemClient struct {
 // operation does not support conditional HTTP requests.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - FileSystemClientCreateOptions contains the optional parameters for the FileSystemClient.Create method.
 func (client *FileSystemClient) Create(ctx context.Context, options *FileSystemClientCreateOptions) (FileSystemClientCreateResponse, error) {
 	var err error
@@ -113,7 +113,7 @@ func (client *FileSystemClient) createHandleResponse(resp *http.Response) (FileS
 // [https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations].
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - FileSystemClientDeleteOptions contains the optional parameters for the FileSystemClient.Delete method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the FileSystemClient.SetProperties
 //     method.
@@ -183,7 +183,7 @@ func (client *FileSystemClient) deleteHandleResponse(resp *http.Response) (FileS
 // GetProperties - All system and user-defined filesystem properties are specified in the response headers.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - FileSystemClientGetPropertiesOptions contains the optional parameters for the FileSystemClient.GetProperties
 //     method.
 func (client *FileSystemClient) GetProperties(ctx context.Context, options *FileSystemClientGetPropertiesOptions) (FileSystemClientGetPropertiesResponse, error) {
@@ -261,7 +261,7 @@ func (client *FileSystemClient) getPropertiesHandleResponse(resp *http.Response)
 
 // NewListBlobHierarchySegmentPager - The List Blobs operation returns a list of the blobs under the specified container
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - FileSystemClientListBlobHierarchySegmentOptions contains the optional parameters for the FileSystemClient.NewListBlobHierarchySegmentPager
 //     method.
 //
@@ -334,7 +334,7 @@ func (client *FileSystemClient) ListBlobHierarchySegmentHandleResponse(resp *htt
 
 // NewListPathsPager - List FileSystem paths and their properties.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - recursive - Required
 //   - options - FileSystemClientListPathsOptions contains the optional parameters for the FileSystemClient.NewListPathsPager
 //     method.
@@ -412,7 +412,7 @@ func (client *FileSystemClient) ListPathsHandleResponse(resp *http.Response) (Fi
 // [https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations].
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - FileSystemClientSetPropertiesOptions contains the optional parameters for the FileSystemClient.SetProperties
 //     method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the FileSystemClient.SetProperties

--- a/sdk/storage/azdatalake/internal/generated/zz_path_client.go
+++ b/sdk/storage/azdatalake/internal/generated/zz_path_client.go
@@ -28,7 +28,7 @@ type PathClient struct {
 // AppendData - Append data to the file.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - body - Initial data
 //   - options - PathClientAppendDataOptions contains the optional parameters for the PathClient.AppendData method.
 //   - PathHTTPHeaders - PathHTTPHeaders contains a group of parameters for the PathClient.Create method.
@@ -175,7 +175,7 @@ func (client *PathClient) appendDataHandleResponse(resp *http.Response) (PathCli
 // If-None-Match: "*".
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - PathClientCreateOptions contains the optional parameters for the PathClient.Create method.
 //   - PathHTTPHeaders - PathHTTPHeaders contains a group of parameters for the PathClient.Create method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the PathClient.Create method.
@@ -374,7 +374,7 @@ func (client *PathClient) createHandleResponse(resp *http.Response) (PathClientC
 // [https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations].
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - PathClientDeleteOptions contains the optional parameters for the PathClient.Delete method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the PathClient.Create method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the FileSystemClient.SetProperties
@@ -477,7 +477,7 @@ func (client *PathClient) deleteHandleResponse(resp *http.Response) (PathClientD
 // FlushData - Set the owner, group, permissions, or access control list for a path.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - PathClientFlushDataOptions contains the optional parameters for the PathClient.FlushData method.
 //   - PathHTTPHeaders - PathHTTPHeaders contains a group of parameters for the PathClient.Create method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the PathClient.Create method.
@@ -648,7 +648,7 @@ func (client *PathClient) flushDataHandleResponse(resp *http.Response) (PathClie
 // [https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations].
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - PathClientGetPropertiesOptions contains the optional parameters for the PathClient.GetProperties method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the PathClient.Create method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the FileSystemClient.SetProperties
@@ -803,7 +803,7 @@ func (client *PathClient) getPropertiesHandleResponse(resp *http.Response) (Path
 // Operations [https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations].
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - xmsLeaseAction - There are five lease actions: "acquire", "break", "change", "renew", and "release". Use "acquire" and
 //     specify the "x-ms-proposed-lease-id" and "x-ms-lease-duration" to acquire a new lease. Use "break"
 //     to break an existing lease. When a lease is broken, the lease break period is allowed to elapse, during which time no lease
@@ -917,7 +917,7 @@ func (client *PathClient) leaseHandleResponse(resp *http.Response) (PathClientLe
 // Service Operations [https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations].
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - PathClientReadOptions contains the optional parameters for the PathClient.Read method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the PathClient.Create method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the FileSystemClient.SetProperties
@@ -1082,7 +1082,7 @@ func (client *PathClient) readHandleResponse(resp *http.Response) (PathClientRea
 // SetAccessControl - Set the owner, group, permissions, or access control list for a path.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - PathClientSetAccessControlOptions contains the optional parameters for the PathClient.SetAccessControl method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the PathClient.Create method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the FileSystemClient.SetProperties
@@ -1187,7 +1187,7 @@ func (client *PathClient) setAccessControlHandleResponse(resp *http.Response) (P
 // SetAccessControlRecursive - Set the access control list for a path and sub-paths.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - mode - Mode "set" sets POSIX access control rights on files and directories, "modify" modifies one or more POSIX access
 //     control rights that pre-exist on files and directories, "remove" removes one or more
 //     POSIX access control rights that were present earlier on files and directories
@@ -1275,7 +1275,7 @@ func (client *PathClient) SetAccessControlRecursiveHandleResponse(resp *http.Res
 // SetExpiry - Sets the time a blob will expire and be deleted.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - expiryOptions - Required. Indicates mode of the expiry time
 //   - options - PathClientSetExpiryOptions contains the optional parameters for the PathClient.SetExpiry method.
 func (client *PathClient) SetExpiry(ctx context.Context, expiryOptions ExpiryOptions, options *PathClientSetExpiryOptions) (PathClientSetExpiryResponse, error) {
@@ -1355,7 +1355,7 @@ func (client *PathClient) setExpiryHandleResponse(resp *http.Response) (PathClie
 // Undelete - Undelete a path that was previously soft deleted
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - PathClientUndeleteOptions contains the optional parameters for the PathClient.Undelete method.
 func (client *PathClient) Undelete(ctx context.Context, options *PathClientUndeleteOptions) (PathClientUndeleteResponse, error) {
 	var err error
@@ -1430,7 +1430,7 @@ func (client *PathClient) undeleteHandleResponse(resp *http.Response) (PathClien
 // Headers for Blob Service Operations [https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations].
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - action - The action must be "append" to upload data to be appended to a file, "flush" to flush previously uploaded data
 //     to a file, "setProperties" to set the properties of a file or directory,
 //     "setAccessControl" to set the owner, group, permissions, or access control list for a file or directory, or "setAccessControlRecursive"

--- a/sdk/storage/azdatalake/internal/generated/zz_service_client.go
+++ b/sdk/storage/azdatalake/internal/generated/zz_service_client.go
@@ -25,7 +25,7 @@ type ServiceClient struct {
 
 // NewListFileSystemsPager - List filesystems and their properties in given account.
 //
-// Generated from API version 2023-11-03
+// Generated from API version 2024-05-04
 //   - options - ServiceClientListFileSystemsOptions contains the optional parameters for the ServiceClient.NewListFileSystemsPager
 //     method.
 //

--- a/sdk/storage/azdatalake/internal/path/responses.go
+++ b/sdk/storage/azdatalake/internal/path/responses.go
@@ -85,6 +85,9 @@ type GetPropertiesResponse struct {
 	// AcceptRanges contains the information returned from the Accept-Ranges header response.
 	AcceptRanges *string
 
+	// AccessControlList contains the combined list of access that are set for user, group and other on the file
+	AccessControlList *string
+
 	// AccessTier contains the information returned from the x-ms-access-tier header response.
 	AccessTier *string
 
@@ -292,6 +295,9 @@ func FormatGetPropertiesResponse(r *blob.GetPropertiesResponse, rawResponse *htt
 	}
 	if val := rawResponse.Header.Get("x-ms-permissions"); val != "" {
 		newResp.Permissions = &val
+	}
+	if val := rawResponse.Header.Get("x-ms-acl"); val != "" {
+		newResp.AccessControlList = &val
 	}
 	if val := rawResponse.Header.Get("x-ms-resource-type"); val != "" {
 		newResp.ResourceType = &val

--- a/sdk/storage/azdatalake/internal/testcommon/common.go
+++ b/sdk/storage/azdatalake/internal/testcommon/common.go
@@ -81,12 +81,8 @@ func BeforeTest(t *testing.T, suite string, test string) {
 	require.NoError(t, recording.AddHeaderRegexSanitizer("x-ms-copy-source-authorization", FakeToken, tokenRegex, nil))
 	// we freeze request IDs and timestamps to avoid creating noisy diffs
 	// NOTE: we can't freeze time stamps as that breaks some tests that use if-modified-since etc (maybe it can be fixed?)
-	//testframework.AddHeaderRegexSanitizer("X-Ms-Date", "Wed, 10 Aug 2022 23:34:14 GMT", "", nil)
 	require.NoError(t, recording.AddHeaderRegexSanitizer("x-ms-request-id", "00000000-0000-0000-0000-000000000000", "", nil))
-	//testframework.AddHeaderRegexSanitizer("Date", "Wed, 10 Aug 2022 23:34:14 GMT", "", nil)
 	// TODO: more freezing
-	//testframework.AddBodyRegexSanitizer("RequestId:00000000-0000-0000-0000-000000000000", `RequestId:\w{8}-\w{4}-\w{4}-\w{4}-\w{12}`, nil)
-	//testframework.AddBodyRegexSanitizer("Time:2022-08-11T00:21:56.4562741Z", `Time:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d*)?Z`, nil)
 	require.NoError(t, recording.Start(t, RecordingDirectory, nil))
 }
 
@@ -127,11 +123,11 @@ func GenerateData(sizeInBytes int) (io.ReadSeekCloser, []byte) {
 	if sizeInBytes > _len {
 		count := sizeInBytes / _len
 		if sizeInBytes%_len != 0 {
-			count = count + 1
+			count++
 		}
-		copy(data[:], strings.Repeat(random64BString, count))
+		copy(data, strings.Repeat(random64BString, count))
 	} else {
-		copy(data[:], random64BString)
+		copy(data, random64BString)
 	}
 	return streaming.NopCloser(bytes.NewReader(data)), data
 }

--- a/sdk/storage/azdatalake/lease/client_test.go
+++ b/sdk/storage/azdatalake/lease/client_test.go
@@ -72,7 +72,6 @@ var proposedLeaseIDs = []*string{to.Ptr("c820a799-76d7-4ee2-6e15-546f19325c2c"),
 func (s *LeaseRecordedTestsSuite) TestFilesystemAcquireLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
 
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
@@ -134,8 +133,6 @@ func (s *LeaseRecordedTestsSuite) TestFilesystemReleaseLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
-
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
 
@@ -167,8 +164,6 @@ func (s *LeaseRecordedTestsSuite) TestFilesystemRenewLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
-
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
 
@@ -196,8 +191,6 @@ func (s *LeaseRecordedTestsSuite) TestFilesystemRenewLease() {
 func (s *LeaseRecordedTestsSuite) TestFilesystemChangeLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
-
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
 
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
@@ -232,8 +225,6 @@ func (s *LeaseRecordedTestsSuite) TestFileAcquireLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
-
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
 
@@ -261,8 +252,6 @@ func (s *LeaseRecordedTestsSuite) TestFileAcquireLease() {
 func (s *LeaseRecordedTestsSuite) TestDeleteFileWithoutLeaseId() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
-
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
 
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
@@ -301,8 +290,6 @@ func (s *LeaseRecordedTestsSuite) TestDeleteFileWithoutLeaseId() {
 func (s *LeaseRecordedTestsSuite) TestFileReleaseLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
-
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
 
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
@@ -366,8 +353,6 @@ func (s *LeaseRecordedTestsSuite) TestFileChangeLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
-
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
 
@@ -402,8 +387,6 @@ func (s *LeaseRecordedTestsSuite) TestDirAcquireLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
-
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
 
@@ -431,8 +414,6 @@ func (s *LeaseRecordedTestsSuite) TestDirAcquireLease() {
 func (s *LeaseRecordedTestsSuite) TestDeleteDirWithoutLeaseId() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
-
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
 
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
@@ -471,8 +452,6 @@ func (s *LeaseRecordedTestsSuite) TestDeleteDirWithoutLeaseId() {
 func (s *LeaseRecordedTestsSuite) TestDirReleaseLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
-
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
 
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)
@@ -535,8 +514,6 @@ func (s *LeaseRecordedTestsSuite) TestDirRenewLease() {
 func (s *LeaseRecordedTestsSuite) TestDirChangeLease() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
-
-	//ignoreHeaders(_context.recording, headersToIgnoreForLease)
 
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDatalake, nil)
 	_require.NoError(err)

--- a/sdk/storage/azdatalake/sas/service.go
+++ b/sdk/storage/azdatalake/sas/service.go
@@ -60,7 +60,7 @@ func (v DatalakeSignatureValues) SignWithSharedKey(sharedKeyCredential *SharedKe
 		return QueryParameters{}, errors.New("service SAS is missing at least one of these: ExpiryTime or Permissions")
 	}
 
-	//Make sure the permission characters are in the correct order
+	// Make sure the permission characters are in the correct order
 	perms, err := parsePathPermissions(v.Permissions)
 	if err != nil {
 		return QueryParameters{}, err
@@ -95,7 +95,7 @@ func (v DatalakeSignatureValues) SignWithSharedKey(sharedKeyCredential *SharedKe
 		string(v.Protocol),
 		v.Version,
 		resource,
-		"", //snapshot not supported
+		"", // snapshot not supported
 		v.EncryptionScope,
 		v.CacheControl,       // rscc
 		v.ContentDisposition, // rscd
@@ -199,7 +199,7 @@ func (v DatalakeSignatureValues) SignWithUserDelegation(userDelegationCredential
 		string(v.Protocol),
 		v.Version,
 		resource,
-		"", //snapshot not supported
+		"", // snapshot not supported
 		v.EncryptionScope,
 		v.CacheControl,       // rscc
 		v.ContentDisposition, // rscd
@@ -239,7 +239,7 @@ func (v DatalakeSignatureValues) SignWithUserDelegation(userDelegationCredential
 		signature: signature,
 	}
 
-	//User delegation SAS specific parameters
+	// User delegation SAS specific parameters
 	p.signedOID = *udk.SignedOID
 	p.signedTID = *udk.SignedTID
 	p.signedStart = *udk.SignedStart
@@ -256,7 +256,7 @@ func getCanonicalName(account string, filesystemName string, fileName string, di
 	// Blob:      "/blob/account/containername/blobname"
 	elements := []string{"/blob/", account, "/", filesystemName}
 	if fileName != "" {
-		elements = append(elements, "/", strings.Replace(fileName, "\\", "/", -1))
+		elements = append(elements, "/", strings.ReplaceAll(fileName, "\\", "/"))
 	} else if directoryName != "" {
 		elements = append(elements, "/", directoryName)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
