### PR TITLE
Allow opt-in for Go race detector per SDK

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -83,6 +83,9 @@ parameters:
   - name: oneESTemplateTag
     type: string
     default: release
+  - name: EnableRaceDetector
+    type: boolean
+    default: false
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -109,6 +112,7 @@ extends:
                       Selection: all
                       GenerateVMJobs: true
               AdditionalParameters:
+                EnableRaceDetector: ${{ parameters.EnableRaceDetector }}
                 ServiceDirectory: ${{ parameters.ServiceDirectory }}
                 TestRunTime: ${{ parameters.TestRunTime }}
                 UsePipelineProxy: ${{ parameters.UsePipelineProxy }}

--- a/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
@@ -17,7 +17,9 @@ parameters:
   - name: ExcludeGoNMinus2
     type: boolean
     default: false
-
+  - name: EnableRaceDetector
+    type: boolean
+    default: false
 
 stages:
   - stage: Build
@@ -79,6 +81,7 @@ stages:
           GoVersion: $(go.version)
           TestProxy: true
           TestRunTime: ${{ parameters.TestRunTime }}
+          EnableRaceDetector: ${{ parameters.EnableRaceDetector }}
           EnvVars:
             AZURE_RECORD_MODE: 'playback'
 

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -21,6 +21,9 @@ parameters:
   - name: UsePlatformContainer
     type: boolean
     default: false
+  - name: EnableRaceDetector
+    type: boolean
+    default: false
 
 jobs:
 - job:
@@ -67,6 +70,7 @@ jobs:
       GoVersion: $(go.version)
       TestProxy: ${{ parameters.UsePipelineProxy }}
       TestRunTime: ${{ parameters.TestRunTime }}
+      EnableRaceDetector: ${{ parameters.EnableRaceDetector }}
       EnvVars:
         AZURE_RECORD_MODE: 'playback'
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -17,6 +17,9 @@ parameters:
   - name: TestRunTime
     type: string
     default: '600s'
+  - name: EnableRaceDetector
+    type: boolean
+    default: false
 
 steps:
   - task: Powershell@2
@@ -70,7 +73,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/run_tests.ps1
-      arguments: '${{ parameters.ServiceDirectory }} ${{ parameters.TestRunTime }}'
+      arguments: '${{ parameters.ServiceDirectory }} ${{ parameters.TestRunTime }} ${{ parameters.EnableRaceDetector }}'
       pwsh: true
     env:
       GO111MODULE: 'on'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -73,7 +73,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: ./eng/scripts/run_tests.ps1
-      arguments: '${{ parameters.ServiceDirectory }} ${{ parameters.TestRunTime }} ${{ parameters.EnableRaceDetector }}'
+      arguments: '${{ parameters.ServiceDirectory }} ${{ parameters.TestRunTime }} $${{ parameters.EnableRaceDetector }}'
       pwsh: true
     env:
       GO111MODULE: 'on'

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -3,15 +3,21 @@
 Param(
     [Parameter(Mandatory = $true)]
     [string] $serviceDirectory,
-    [string] $testTimeout = "10s"
+    [string] $testTimeout = "10s",
+    [bool] $enableRaceDetector = $false
 )
 
 $ErrorActionPreference = 'Stop'
 
-Push-Location sdk/$serviceDirectory
-Write-Host "##[command] Executing 'go test -timeout $testTimeout -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
+$raceDetector = ''
+if ($enableRaceDetector) {
+    $raceDetector = '-race'
+}
 
-go test -timeout $testTimeout -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
+Push-Location sdk/$serviceDirectory
+Write-Host "##[command] Executing 'go test -timeout $testTimeout $raceDetector -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
+
+go test -timeout $testTimeout $raceDetector -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
 # go test will return a non-zero exit code on test failures so don't skip generating the report in this case
 $GOTESTEXITCODE = $LASTEXITCODE
 

--- a/sdk/azcore/ci.yml
+++ b/sdk/azcore/ci.yml
@@ -27,4 +27,3 @@ extends:
   template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: azcore
-    EnableRaceDetector: true

--- a/sdk/azcore/ci.yml
+++ b/sdk/azcore/ci.yml
@@ -27,3 +27,4 @@ extends:
   template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: azcore
+    EnableRaceDetector: true

--- a/sdk/internal/ci.yml
+++ b/sdk/internal/ci.yml
@@ -28,3 +28,4 @@ extends:
   parameters:
     ServiceDirectory: internal
     LicenseCheck: false
+    EnableRaceDetector: true


### PR DESCRIPTION
This is a stop-gap until a more general solution is found. Some tests will cause an OOM when the race detector is enabled. For now, allow SDKs to opt in to the race detector if their tests don't cause an OOM.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
