### PR TITLE
[aznamespaces] Test cleanup

### DIFF
--- a/sdk/messaging/eventgrid/aznamespaces/assets.json
+++ b/sdk/messaging/eventgrid/aznamespaces/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/messaging/eventgrid/aznamespaces",
-  "Tag": "go/messaging/eventgrid/aznamespaces_345f27fa59"
+  "Tag": "go/messaging/eventgrid/aznamespaces_388e203c7a"
 }

--- a/sdk/messaging/eventgrid/aznamespaces/client_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/client_test.go
@@ -21,10 +21,6 @@ import (
 )
 
 func TestClients_UsingSASKey(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
-
 	sender, receiver := newClients(t, true)
 
 	ce, err := messaging.NewCloudEvent("source", "eventType", "hello world", nil)
@@ -51,10 +47,6 @@ func TestClients_UsingSASKey(t *testing.T) {
 }
 
 func TestFailedAck(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
-
 	ce, err := messaging.NewCloudEvent("TestFailedAck", "world", []byte("ack this one"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
 	})
@@ -101,10 +93,6 @@ func TestFailedAck(t *testing.T) {
 }
 
 func TestPartialAckFailure(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
-
 	ce, err := messaging.NewCloudEvent("TestPartialAckFailure", "world", []byte("event one"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
 	})
@@ -153,9 +141,6 @@ func TestPartialAckFailure(t *testing.T) {
 }
 
 func TestRejectEvents(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
 
 	ce, err := messaging.NewCloudEvent("TestAbandon", "world", []byte("event one"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
@@ -197,10 +182,6 @@ func TestRejectEvents(t *testing.T) {
 }
 
 func TestReleaseEvents(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
-
 	ce, err := messaging.NewCloudEvent("TestRelease", "world", []byte("event one"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
 	})
@@ -240,10 +221,6 @@ func TestReleaseEvents(t *testing.T) {
 }
 
 func TestPublishBytes(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
-
 	ce, err := messaging.NewCloudEvent("TestPublishBytes", "eventType", []byte("TestPublishBytes"), &messaging.CloudEventOptions{
 		DataContentType: to.Ptr("application/octet-stream"),
 	})
@@ -267,9 +244,6 @@ func TestPublishBytes(t *testing.T) {
 }
 
 func TestSendEventWithStringPayload(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
 	sender, receiver := newClients(t, false)
 
 	ce, err := messaging.NewCloudEvent("TestPublishString", "eventType", "TestPublishString", &messaging.CloudEventOptions{
@@ -293,9 +267,6 @@ func TestSendEventWithStringPayload(t *testing.T) {
 }
 
 func TestSendEventsAndReceiveEvents(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
 	sender, receiver := newClients(t, false)
 
 	testData := []struct {
@@ -366,10 +337,6 @@ func TestSendEventsAndReceiveEvents(t *testing.T) {
 }
 
 func TestSimpleErrors(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
-
 	sender, _ := newClients(t, false)
 
 	sendResp, err := sender.SendEvents(context.Background(), []*messaging.CloudEvent{
@@ -391,9 +358,6 @@ func TestSimpleErrors(t *testing.T) {
 }
 
 func TestRenewEventLocks(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
 	sender, receiver := newClients(t, false)
 
 	ce := mustCreateEvent(t, "TestRenewCloudEventLocks", "eventType", "hello world", nil)
@@ -412,9 +376,6 @@ func TestRenewEventLocks(t *testing.T) {
 }
 
 func TestReleaseWithDelay(t *testing.T) {
-	if recording.GetRecordMode() == recording.PlaybackMode {
-		t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22869")
-	}
 	sender, receiver := newClients(t, false)
 
 	ce := mustCreateEvent(t, "TestReleaseWithDelay", "eventType", "hello world", nil)

--- a/sdk/messaging/eventgrid/aznamespaces/example_publish_and_receive_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/example_publish_and_receive_test.go
@@ -102,8 +102,7 @@ func Example_publishAndReceiveCloudEvents() {
 	fmt.Fprintf(os.Stderr, "  Body: %#v\n", sampleData) // prints 'Body: &azeventgrid_test.SampleData{Name:"hello"}'
 	fmt.Fprintf(os.Stderr, "  Delivery count: %d\n", eventWithStruct.BrokerProperties.DeliveryCount)
 
-	// Disabled: WARNING: Forcing use of SASKey until https://github.com/Azure/azure-sdk-for-go/issues/22961 is resolved
-	// TempDisabledOutput:
+	// Output:
 }
 
 func sendAndReceiveEvent(sender *aznamespaces.SenderClient, receiver *aznamespaces.ReceiverClient, dataContentType string, payload any) (aznamespaces.ReceiveDetails, error) {

--- a/sdk/messaging/eventgrid/aznamespaces/main_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/main_test.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/test/credential"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces"
 	"github.com/joho/godotenv"
 )
@@ -60,26 +60,16 @@ func purgeEvents() {
 		panic(err)
 	}
 
-	// Disabled: Forcing use of SASKey until https://github.com/Azure/azure-sdk-for-go/issues/22961 is resolved
-	// cred, err := azidentity.NewDefaultAzureCredential(nil)
+	cred, err := credential.New(nil)
 
-	// if err != nil {
-	// 	panic(err)
-	// }
+	if err != nil {
+		panic(err)
+	}
 
-	// receiver, err := aznamespaces.NewReceiverClient(testVars.Endpoint, testVars.Topic, testVars.Subscription, cred, nil)
-
-	// if err != nil {
-	// 	panic(err)
-	// }
-
-	cred := azcore.NewKeyCredential(testVars.Key)
-
-	receiver, err := aznamespaces.NewReceiverClientWithSharedKeyCredential(testVars.Endpoint, testVars.Topic, testVars.Subscription, cred, &aznamespaces.ReceiverClientOptions{
+	receiver, err := aznamespaces.NewReceiverClient(testVars.Endpoint, testVars.Topic, testVars.Subscription, cred, &aznamespaces.ReceiverClientOptions{
 		ClientOptions: policy.ClientOptions{
 			Logging: policy.LogOptions{
 				IncludeBody:        true,
-				AllowedHeaders:     []string{"Authorization"},
 				AllowedQueryParams: []string{"maxWaitTime", "maxEvents"},
 			},
 		},

--- a/sdk/messaging/eventgrid/aznamespaces/shared_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/shared_test.go
@@ -261,7 +261,7 @@ func requireEqualCloudEvent(t *testing.T, expected messaging.CloudEvent, actual 
 	// just have to assume it's 'Sanitized'.
 
 	if recording.GetRecordMode() == recording.PlaybackMode {
-		expected.Source = "Sanitized"
+		expected.Source = recording.SanitizedValue
 	}
 
 	require.NotEmpty(t, actual.ID, "ID is not empty")

--- a/sdk/messaging/eventgrid/aznamespaces/shared_test.go
+++ b/sdk/messaging/eventgrid/aznamespaces/shared_test.go
@@ -141,11 +141,6 @@ func newClientOptions(t *testing.T) azcore.ClientOptions {
 }
 
 func newClients(t *testing.T, useSASKey bool) (*aznamespaces.SenderClient, *aznamespaces.ReceiverClient) {
-	if os.Getenv("FORCE_SASKEY") == "true" {
-		t.Logf("Switching from TokenCredential -> SAS Key because FORCE_SASKEY is true. See https://github.com/Azure/azure-sdk-for-go/issues/22961 for more details")
-		useSASKey = true
-	}
-
 	return newSenderClient(t, useSASKey), newReceiverClient(t, useSASKey)
 }
 


### PR DESCRIPTION
Fixing a few things:
- I had some workaround code for TokenCredential that's no longer necessary now that the service fix has been deployed.
- Using Charles's new test credential
- Fixing recordings to work again.

Fixes #22961