### PR TITLE
Allow the Key Vault client to access resources across tenants

### DIFF
--- a/sdk/security/keyvault/internal/CHANGELOG.md
+++ b/sdk/security/keyvault/internal/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Features Added
 * Added CAE support
 
+### Breaking Changes
+
+### Bugs Fixed
+* Allow the Key Vault client to access resources across tenants.
+
+### Other Changes
+
 ## 1.0.1 (2024-04-09)
 
 ### Other Changes

--- a/sdk/security/keyvault/internal/CHANGELOG.md
+++ b/sdk/security/keyvault/internal/CHANGELOG.md
@@ -5,12 +5,8 @@
 ### Features Added
 * Added CAE support
 
-### Breaking Changes
-
 ### Bugs Fixed
 * Allow the Key Vault client to access resources across tenants.
-
-### Other Changes
 
 ## 1.0.1 (2024-04-09)
 

--- a/sdk/security/keyvault/internal/CHANGELOG.md
+++ b/sdk/security/keyvault/internal/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### Features Added
 * Added CAE support
-
-### Bugs Fixed
-* Allow the Key Vault client to access resources across tenants.
+* `KeyVaultChallengePolicy` always requests tokens from the Vault's tenant, overriding any credential default
 
 ## 1.0.1 (2024-04-09)
 

--- a/sdk/security/keyvault/internal/challenge_policy.go
+++ b/sdk/security/keyvault/internal/challenge_policy.go
@@ -30,9 +30,7 @@ type KeyVaultChallengePolicyOptions struct {
 type keyVaultAuthorizer struct {
 	// tro is the policy's authentication parameters. These are discovered from an authentication challenge
 	// elicited ahead of the first client request.
-	tro policy.TokenRequestOptions
-	// TODO: move into tro once it has a tenant field (https://github.com/Azure/azure-sdk-for-go/issues/19841)
-	tenantID                string
+	tro                     policy.TokenRequestOptions
 	verifyChallengeResource bool
 }
 
@@ -57,7 +55,7 @@ func NewKeyVaultChallengePolicy(cred azcore.TokenCredential, opts *KeyVaultChall
 }
 
 func (k *keyVaultAuthorizer) authorize(req *policy.Request, authNZ func(policy.TokenRequestOptions) error) error {
-	if len(k.tro.Scopes) == 0 || k.tenantID == "" {
+	if len(k.tro.Scopes) == 0 || k.tro.TenantID == "" {
 		if body := req.Body(); body != nil {
 			// We don't know the scope or tenant ID because we haven't seen a challenge yet. We elicit one now by sending
 			// the request without authorization, first removing its body, if any. authorizeOnChallenge will reattach the
@@ -128,7 +126,7 @@ func (k *keyVaultAuthorizer) updateTokenRequestOptions(resp *http.Response, req 
 		}
 	}
 
-	k.tenantID = parseTenant(vals["authorization"])
+	k.tro.TenantID = parseTenant(vals["authorization"])
 	scope := ""
 	if v, ok := vals["scope"]; ok {
 		scope = v

--- a/sdk/security/keyvault/internal/challenge_policy_test.go
+++ b/sdk/security/keyvault/internal/challenge_policy_test.go
@@ -97,6 +97,7 @@ func TestChallengePolicy(t *testing.T) {
 			cred := credentialFunc(func(ctx context.Context, tro policy.TokenRequestOptions) (azcore.AccessToken, error) {
 				authenticated = true
 				require.Equal(t, []string{test.expectedScope}, tro.Scopes)
+				require.Equal(t, "{tenant}", tro.TenantID)
 				return azcore.AccessToken{Token: accessToken, ExpiresOn: time.Now().Add(time.Hour)}, nil
 			})
 			p := NewKeyVaultChallengePolicy(cred, &KeyVaultChallengePolicyOptions{DisableChallengeResourceVerification: test.disableVerify})


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

This fix allows the KeyVault client to access resources across tenants by correctly placing the tenant ID returned by the challenge into the `policy.TokenRequestOptions`.

Fixes #22928.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [X] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
