### PR TITLE
Add support for proxied IMDS services

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Features Added
 * Restored `AzurePipelinesCredential` and persistent token caching API
+* Added support for a proxy IMDS client via the `IMDS_PROXY` environment variable
 
 ## Breaking Changes
 > These changes affect only code written against a beta version such as v1.6.0-beta.4

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -36,6 +36,7 @@ const (
 	identityServerThumbprint = "IDENTITY_SERVER_THUMBPRINT"
 	headerMetadata           = "Metadata"
 	imdsEndpoint             = "http://169.254.169.254/metadata/identity/oauth2/token"
+	imdsProxyEndpoint        = "IMDS_PROXY"
 	miResID                  = "mi_res_id"
 	msiEndpoint              = "MSI_ENDPOINT"
 	msiResID                 = "msi_res_id"
@@ -165,6 +166,8 @@ func newManagedIdentityClient(options *ManagedIdentityCredentialOptions) (*manag
 			env = "Cloud Shell"
 			c.msiType = msiTypeCloudShell
 		}
+	} else if endpoint, ok := os.LookupEnv(imdsProxyEndpoint); ok {
+		c.endpoint = endpoint
 	} else {
 		c.probeIMDS = options.dac
 		setIMDSRetryOptionDefaults(&cp.Retry)


### PR DESCRIPTION
Both AWS and GCP offer methods of altering their default IMDS endpoint in their clients without changing the type of client that is being created. This PR adds support to do the same for this client. 

My use case is that the default azure IMDS endpoint is not at the typical location, and as such, I'd like to be able to change the address. The current logic does not allow for this as setting either MSI_ENDPOINT or IDENTITY_ENDPOINT both cause changes to the type of client created. I have added a new environment variable rather than altering an existing one to prevent changes to existing applications


<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
