### PR TITLE
[azcore] Adding in a function create a policy.Request using an existing *http.Request

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added policy.NewRequestFromRequest(), allowing for a policy.Request to be created from an existing *http.Request.
+- Added runtime.NewRequestFromRequest(), allowing for a policy.Request to be created from an existing *http.Request.
 
 ### Breaking Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added policy.NewRequestFromRequest(), allowing for a policy.Request to be created from an existing *http.Request.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/azcore/internal/exported/exported_test.go
+++ b/sdk/azcore/internal/exported/exported_test.go
@@ -90,7 +90,46 @@ func TestNewRequestFromRequest(t *testing.T) {
 	req, err := NewRequestFromRequest(httpRequest)
 	require.NoError(t, err)
 
-	// this fails - we need to populate the .body stream when we create this.
+	// our stream has been drained - the func has to make a copy of the body so it can be seekable.
+	// so our stream should be at end.
+	currentPos, err := expectedData.Seek(0, io.SeekCurrent)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), currentPos)
+
+	actualData, err := io.ReadAll(req.Body())
+	require.NoError(t, err)
+	require.Equal(t, []byte{1, 2, 3, 4, 5}, actualData)
+
+	// now we change stuff in the policy.Request...
+	replacementBuff := bytes.NewReader([]byte{6})
+	err = req.SetBody(NopCloser(replacementBuff), "application/coolstuff")
+	require.NoError(t, err)
+
+	// and it's automatically reflected in the http.Request, which helps us with interop
+	// with other HTTP pipelines.
+	require.Equal(t, "application/coolstuff", httpRequest.Header.Get("Content-Type"))
+	newBytes, err := io.ReadAll(httpRequest.Body)
+	require.NoError(t, err)
+	require.Equal(t, []byte{6}, newBytes)
+}
+
+func TestNewRequestFromRequest_AvoidExtraCopyIfReadSeekCloser(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	expectedData := NopCloser(bytes.NewReader([]byte{1, 2, 3, 4, 5}))
+
+	httpRequest, err := http.NewRequestWithContext(ctx, "POST", "https://example.com", expectedData)
+	require.NoError(t, err)
+
+	req, err := NewRequestFromRequest(httpRequest)
+	require.NoError(t, err)
+
+	// our stream should _NOT_ get drained since it was already an io.ReadSeekCloser
+	currentPos, err := expectedData.Seek(0, io.SeekCurrent)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), currentPos)
+
 	actualData, err := io.ReadAll(req.Body())
 	require.NoError(t, err)
 	require.Equal(t, []byte{1, 2, 3, 4, 5}, actualData)

--- a/sdk/azcore/internal/exported/request.go
+++ b/sdk/azcore/internal/exported/request.go
@@ -80,7 +80,7 @@ func NewRequestFromRequest(req *http.Request) (*Request, error) {
 
 		if !isReadSeekCloser {
 			// since this is an already populated http.Request we want to copy
-			// over it's body, if it has one.
+			// over its body, if it has one.
 			bodyBytes, err := io.ReadAll(req.Body)
 
 			if err != nil {

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net/http"
 	"net/textproto"
 	"net/url"
 	"path"
@@ -43,6 +44,11 @@ const (
 // The endpoint MUST be properly encoded before calling this function.
 func NewRequest(ctx context.Context, httpMethod string, endpoint string) (*policy.Request, error) {
 	return exported.NewRequest(ctx, httpMethod, endpoint)
+}
+
+// NewRequestFromRequest creates a new policy.Request with an existing *http.Request
+func NewRequestFromRequest(req *http.Request) (*policy.Request, error) {
+	return exported.NewRequestFromRequest(req)
 }
 
 // EncodeQueryParams will parse and encode any query parameters in the specified URL.


### PR DESCRIPTION
Adds a new function (NewRequestFromRequest) which lets you pass in an already created *http.Request and get back a policy.Request. 

This is used in situations where we want to run a pipeline outside of an Azure generated client.