### PR TITLE
Update app registration guide link

### DIFF
--- a/sdk/azidentity/device_code_credential.go
+++ b/sdk/azidentity/device_code_credential.go
@@ -37,7 +37,7 @@ type DeviceCodeCredentialOptions struct {
 	// ClientID is the ID of the application to which users will authenticate. When not set, users
 	// will authenticate to an Azure development application, which isn't recommended for production
 	// scenarios. In production, developers should instead register their applications and assign
-	// appropriate roles. See https://aka.ms/identity/AppRegistrationAndRoleAssignment for more
+	// appropriate roles. See https://aka.ms/azsdk/identity/AppRegistrationAndRoleAssignment for more
 	// information.
 	ClientID string
 

--- a/sdk/azidentity/interactive_browser_credential.go
+++ b/sdk/azidentity/interactive_browser_credential.go
@@ -36,7 +36,7 @@ type InteractiveBrowserCredentialOptions struct {
 	// ClientID is the ID of the application to which users will authenticate. When not set, users
 	// will authenticate to an Azure development application, which isn't recommended for production
 	// scenarios. In production, developers should instead register their applications and assign
-	// appropriate roles. See https://aka.ms/identity/AppRegistrationAndRoleAssignment for more
+	// appropriate roles. See https://aka.ms/azsdk/identity/AppRegistrationAndRoleAssignment for more
 	// information.
 	ClientID string
 


### PR DESCRIPTION
The old link is still active and lands at the same page, so our published package docs are okay for now.