### PR TITLE
[azopenai] Plumb `InsecureAllowCredentialWithHTTP` through every client constructor

### DIFF
--- a/sdk/ai/azopenai/CHANGELOG.md
+++ b/sdk/ai/azopenai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Ai sdk custom_client now respects `InsecureAllowCredentialWithHTTP` flag for allowing insecure connections. (PR#23188)
+- Client now respects the `InsecureAllowCredentialWithHTTP` flag for allowing non-HTTPS connections. Thank you @ukrocks007!  (PR#23188)
 
 ### Other Changes
 

--- a/sdk/ai/azopenai/client_test.go
+++ b/sdk/ai/azopenai/client_test.go
@@ -114,7 +114,7 @@ func TestClient_InsecureHTTPAllowed(t *testing.T) {
 		require.EqualError(t, err, "authenticated requests are not permitted for non TLS protected (https) endpoints")
 	})
 
-	t.Run("HTTPEnabled", func(t *testing.T) {
+	t.Run("InsecureAllowCredentialWithHTTP", func(t *testing.T) {
 		clientOptions := &azopenai.ClientOptions{
 			ClientOptions: policy.ClientOptions{
 				InsecureAllowCredentialWithHTTP: true,

--- a/sdk/ai/azopenai/client_test.go
+++ b/sdk/ai/azopenai/client_test.go
@@ -83,7 +83,7 @@ func TestClient_InsecureHTTPAllowed(t *testing.T) {
 	url := <-urlCh
 	t.Logf(url)
 
-	t.Run("MustBeExplicitlyConfigured", func(t *testing.T) {
+	t.Run("DefaultsToHTTPSOnly", func(t *testing.T) {
 		client, err := azopenai.NewClientForOpenAI(url, azcore.NewKeyCredential("fake-key"), nil)
 		require.NoError(t, err)
 

--- a/sdk/ai/azopenai/client_test.go
+++ b/sdk/ai/azopenai/client_test.go
@@ -8,14 +8,18 @@ package azopenai_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/test/credential"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,4 +60,94 @@ func TestClient_EmptyOptionsChecking(t *testing.T) {
 		fields := reflect.VisibleFields(reflect.TypeOf(v))
 		require.Emptyf(t, fields, "%T is ignored in our function signatures because it's empty", v)
 	}
+}
+
+func TestClient_InsecureHTTPAllowed(t *testing.T) {
+	const fakeID = "fake-id"
+
+	hf := func(resp http.ResponseWriter, req *http.Request) {
+		// _just_ enough of a response to prove we made it through the pipeline.
+		_, err := resp.Write([]byte(fmt.Sprintf("{ \"id\": \"%s\" }", fakeID)))
+		require.NoError(t, err)
+	}
+
+	urlCh := make(chan string)
+
+	go func() {
+		// start an HTTP service
+		server := httptest.NewServer(http.HandlerFunc(hf))
+		urlCh <- server.URL
+		t.Cleanup(server.Close)
+	}()
+
+	url := <-urlCh
+	t.Logf(url)
+
+	t.Run("MustBeExplicitlyConfigured", func(t *testing.T) {
+		client, err := azopenai.NewClientForOpenAI(url, azcore.NewKeyCredential("fake-key"), nil)
+		require.NoError(t, err)
+
+		resp, err := client.GetChatCompletions(context.Background(), azopenai.ChatCompletionsOptions{
+			Messages: []azopenai.ChatRequestMessageClassification{},
+		}, nil)
+		require.Empty(t, resp)
+		require.EqualError(t, err, "authenticated requests are not permitted for non TLS protected (https) endpoints")
+
+		client, err = azopenai.NewClientWithKeyCredential(url, azcore.NewKeyCredential("fake-key"), nil)
+		require.NoError(t, err)
+
+		resp, err = client.GetChatCompletions(context.Background(), azopenai.ChatCompletionsOptions{
+			Messages: []azopenai.ChatRequestMessageClassification{},
+		}, nil)
+		require.Empty(t, resp)
+		require.EqualError(t, err, "authenticated requests are not permitted for non TLS protected (https) endpoints")
+
+		fakeCred := &credential.Fake{}
+
+		client, err = azopenai.NewClient(url, fakeCred, nil)
+		require.NoError(t, err)
+
+		resp, err = client.GetChatCompletions(context.Background(), azopenai.ChatCompletionsOptions{
+			Messages: []azopenai.ChatRequestMessageClassification{},
+		}, nil)
+		require.Empty(t, resp)
+		require.EqualError(t, err, "authenticated requests are not permitted for non TLS protected (https) endpoints")
+	})
+
+	t.Run("HTTPEnabled", func(t *testing.T) {
+		clientOptions := &azopenai.ClientOptions{
+			ClientOptions: policy.ClientOptions{
+				InsecureAllowCredentialWithHTTP: true,
+			},
+		}
+
+		client, err := azopenai.NewClientForOpenAI(url, azcore.NewKeyCredential("fake-key"), clientOptions)
+		require.NoError(t, err)
+
+		resp, err := client.GetChatCompletions(context.Background(), azopenai.ChatCompletionsOptions{
+			Messages: []azopenai.ChatRequestMessageClassification{},
+		}, nil)
+		require.NoError(t, err)
+		require.Equal(t, fakeID, *resp.ID)
+
+		client, err = azopenai.NewClientWithKeyCredential(url, azcore.NewKeyCredential("fake-key"), clientOptions)
+		require.NoError(t, err)
+
+		resp, err = client.GetChatCompletions(context.Background(), azopenai.ChatCompletionsOptions{
+			Messages: []azopenai.ChatRequestMessageClassification{},
+		}, nil)
+		require.NoError(t, err)
+		require.Equal(t, fakeID, *resp.ID)
+
+		fakeCred := &credential.Fake{}
+
+		client, err = azopenai.NewClient(url, fakeCred, clientOptions)
+		require.NoError(t, err)
+
+		resp, err = client.GetChatCompletions(context.Background(), azopenai.ChatCompletionsOptions{
+			Messages: []azopenai.ChatRequestMessageClassification{},
+		}, nil)
+		require.NoError(t, err)
+		require.Equal(t, fakeID, *resp.ID)
+	})
 }


### PR DESCRIPTION
Just finishing up the work to plumb InsecureAllowCredentialWithHTTP through all the client constructors for the azopenai Client.