### PR TITLE
Include HTTP verb and URL in retry logs

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+* Include the HTTP verb and URL in `log.EventRetryPolicy` log entries so it's clear which operation is being retried.
+
 ## 1.13.0 (2024-07-16)
 
 ### Features Added

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -102,7 +102,8 @@ func (p *retryPolicy) Do(req *policy.Request) (resp *http.Response, err error) {
 	try := int32(1)
 	for {
 		resp = nil // reset
-		log.Writef(log.EventRetryPolicy, "=====> Try=%d", try)
+		// unfortunately we don't have access to the custom allow-list of query params, so we'll redact everything but the default allowed QPs
+		log.Writef(log.EventRetryPolicy, "=====> Try=%d for %s %s", try, req.Raw().Method, getSanitizedURL(*req.Raw().URL, getAllowedQueryParams(nil)))
 
 		// For each try, seek to the beginning of the Body stream. We do this even for the 1st try because
 		// the stream may not be at offset 0 when we first get it and we want the same behavior for the


### PR DESCRIPTION
For each try, include the HTTP verb and URL in the log message so it's clear which operation is being retried.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/23232