### PR TITLE
Cosmos DB: Add support for Span

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-* Adds support for tracing. See [PR 23268](https://github.com/Azure/azure-sdk-for-go/pull/23268)
+* Added support for tracing. See [PR 23268](https://github.com/Azure/azure-sdk-for-go/pull/23268)
 
 ### Breaking Changes
 

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Adds support for tracing. See [PR 23268](https://github.com/Azure/azure-sdk-for-go/pull/23268)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 1.0.4 (Unreleased)
 
 ### Features Added
-
 * Added support for tracing. See [PR 23268](https://github.com/Azure/azure-sdk-for-go/pull/23268)
 
 ### Breaking Changes

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -212,7 +212,7 @@ func (c *Client) CreateDatabase(
 	if err != nil {
 		return DatabaseResponse{}, err
 	}
-	ctx, endSpan := azruntime.StartSpan(ctx, spanName.name, c.internal.Tracer(), nil)
+	ctx, endSpan := azruntime.StartSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 
 	if o == nil {
@@ -278,7 +278,7 @@ func (c *Client) NewQueryDatabasesPager(query string, o *QueryDatabasesOptions) 
 			if err != nil {
 				return QueryDatabasesResponse{}, err
 			}
-			ctx, endSpan := azruntime.StartSpan(ctx, spanName.name, c.internal.Tracer(), nil)
+			ctx, endSpan := azruntime.StartSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -272,6 +272,13 @@ func (c *Client) NewQueryDatabasesPager(query string, o *QueryDatabasesOptions) 
 			return page.ContinuationToken != nil
 		},
 		Fetcher: func(ctx context.Context, page *QueryDatabasesResponse) (QueryDatabasesResponse, error) {
+			var err error
+			spanName, err := getSpanNameForDatabases(operationTypeQuery, resourceTypeDatabase, c.gem.locationCache.defaultEndpoint.Hostname())
+			if err != nil {
+				return QueryDatabasesResponse{}, err
+			}
+			ctx, endSpan := azruntime.StartSpan(ctx, spanName, c.internal.Tracer(), nil)
+			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
 					// Use the previous page continuation if available

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -273,6 +273,7 @@ func (c *Client) NewQueryDatabasesPager(query string, o *QueryDatabasesOptions) 
 		},
 		Fetcher: func(ctx context.Context, page *QueryDatabasesResponse) (QueryDatabasesResponse, error) {
 			var err error
+			// Move the span to the pager once https://github.com/Azure/azure-sdk-for-go/issues/23294 is fixed
 			spanName, err := getSpanNameForDatabases(operationTypeQuery, resourceTypeDatabase, c.gem.locationCache.defaultEndpoint.Hostname())
 			if err != nil {
 				return QueryDatabasesResponse{}, err

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -208,7 +208,11 @@ func (c *Client) CreateDatabase(
 	databaseProperties DatabaseProperties,
 	o *CreateDatabaseOptions) (DatabaseResponse, error) {
 	var err error
-	ctx, endSpan := azruntime.StartSpan(ctx, "Client.CreateDatabase", c.internal.Tracer(), nil)
+	spanName, err := getSpanNameForDatabases(operationTypeCreate, resourceTypeDatabase, databaseProperties.ID)
+	if err != nil {
+		return DatabaseResponse{}, err
+	}
+	ctx, endSpan := azruntime.StartSpan(ctx, spanName, c.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 
 	if o == nil {
@@ -290,6 +294,7 @@ func (c *Client) NewQueryDatabasesPager(query string, o *QueryDatabasesOptions) 
 
 			return newDatabasesQueryResponse(azResponse)
 		},
+		Tracer: c.internal.Tracer(),
 	})
 }
 

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -47,6 +47,7 @@ func NewClientWithKey(endpoint string, cred KeyCredential, o *ClientOptions) (*C
 	if o != nil {
 		preferredRegions = o.PreferredRegions
 	}
+
 	gem, err := newGlobalEndpointManager(endpoint, newInternalPipeline(newSharedKeyCredPolicy(cred), o), preferredRegions, 0, enableCrossRegionRetries)
 	if err != nil {
 		return nil, err
@@ -137,6 +138,9 @@ func newClient(authPolicy policy.Policy, gem *globalEndpointManager, options *Cl
 			PerRetry: []policy.Policy{
 				authPolicy,
 				&clientRetryPolicy{gem: gem},
+			},
+			Tracing: azruntime.TracingOptions{
+				Namespace: "Microsoft.DocumentDB",
 			},
 		},
 		&options.ClientOptions)

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -203,6 +203,10 @@ func (c *Client) CreateDatabase(
 	ctx context.Context,
 	databaseProperties DatabaseProperties,
 	o *CreateDatabaseOptions) (DatabaseResponse, error) {
+	var err error
+	ctx, endSpan := azruntime.StartSpan(ctx, "Client.CreateDatabase", c.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+
 	if o == nil {
 		o = &CreateDatabaseOptions{}
 	}
@@ -234,7 +238,8 @@ func (c *Client) CreateDatabase(
 		return DatabaseResponse{}, err
 	}
 
-	return newDatabaseResponse(azResponse)
+	response, err := newDatabaseResponse(azResponse)
+	return response, err
 }
 
 // NewQueryDatabasesPager executes query for databases.

--- a/sdk/data/azcosmos/cosmos_client_retry_policy_test.go
+++ b/sdk/data/azcosmos/cosmos_client_retry_policy_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
@@ -43,7 +44,7 @@ func TestSessionNotAvailableSingleMaster(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
 	// Setting up responses for consistent failures
 	srv.AppendResponse(
@@ -53,7 +54,7 @@ func TestSessionNotAvailableSingleMaster(t *testing.T) {
 		mock.WithHeader("x-ms-substatus", "1002"),
 		mock.WithStatusCode(404))
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 	_, err = container.ReadItem(context.TODO(), NewPartitionKeyString("1"), "doc1", nil)
@@ -130,7 +131,7 @@ func TestSessionNotAvailableMultiMaster(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
 	// Setting up responses for using all retries and failing
 	srv.AppendResponse(
@@ -146,7 +147,7 @@ func TestSessionNotAvailableMultiMaster(t *testing.T) {
 		mock.WithHeader("x-ms-substatus", "1002"),
 		mock.WithStatusCode(404))
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 	_, err = container.ReadItem(context.TODO(), NewPartitionKeyString("1"), "doc1", nil)
@@ -238,7 +239,7 @@ func TestReadEndpointFailure(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
 	// Setting up responses for retrying twice
 	srv.AppendResponse(
@@ -250,7 +251,7 @@ func TestReadEndpointFailure(t *testing.T) {
 	srv.AppendResponse(
 		mock.WithStatusCode(200))
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 	_, err = container.ReadItem(context.TODO(), NewPartitionKeyString("1"), "doc1", nil)
@@ -291,9 +292,9 @@ func TestWriteEndpointFailure(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 
@@ -354,9 +355,9 @@ func TestReadServiceUnavailable(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 
@@ -427,9 +428,9 @@ func TestWriteServiceUnavailable(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 
@@ -506,9 +507,9 @@ func TestDnsErrorRetry(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 

--- a/sdk/data/azcosmos/cosmos_client_retry_policy_test.go
+++ b/sdk/data/azcosmos/cosmos_client_retry_policy_test.go
@@ -54,7 +54,7 @@ func TestSessionNotAvailableSingleMaster(t *testing.T) {
 		mock.WithHeader("x-ms-substatus", "1002"),
 		mock.WithStatusCode(404))
 
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 	_, err = container.ReadItem(context.TODO(), NewPartitionKeyString("1"), "doc1", nil)
@@ -147,7 +147,7 @@ func TestSessionNotAvailableMultiMaster(t *testing.T) {
 		mock.WithHeader("x-ms-substatus", "1002"),
 		mock.WithStatusCode(404))
 
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 	_, err = container.ReadItem(context.TODO(), NewPartitionKeyString("1"), "doc1", nil)
@@ -251,7 +251,7 @@ func TestReadEndpointFailure(t *testing.T) {
 	srv.AppendResponse(
 		mock.WithStatusCode(200))
 
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 	_, err = container.ReadItem(context.TODO(), NewPartitionKeyString("1"), "doc1", nil)
@@ -294,7 +294,7 @@ func TestWriteEndpointFailure(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 
@@ -357,7 +357,7 @@ func TestReadServiceUnavailable(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 
@@ -430,7 +430,7 @@ func TestWriteServiceUnavailable(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 
@@ -509,7 +509,7 @@ func TestDnsErrorRetry(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 

--- a/sdk/data/azcosmos/cosmos_client_test.go
+++ b/sdk/data/azcosmos/cosmos_client_test.go
@@ -89,9 +89,9 @@ func TestEnsureErrorIsGeneratedOnResponse(t *testing.T) {
 		mock.WithBody(jsonString),
 		mock.WithStatusCode(404))
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -128,9 +128,9 @@ func TestEnsureErrorIsNotGeneratedOnResponse(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -147,9 +147,9 @@ func TestRequestEnricherIsCalled(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -175,9 +175,9 @@ func TestNoOptionsIsCalled(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -193,9 +193,9 @@ func TestAttachContent(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -245,9 +245,9 @@ func TestAttachContent(t *testing.T) {
 func TestCreateRequest(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -290,9 +290,9 @@ func TestSendDelete(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 	verifier := pipelineVerifier{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -314,9 +314,9 @@ func TestSendGet(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 	verifier := pipelineVerifier{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -338,9 +338,9 @@ func TestSendPut(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 	verifier := pipelineVerifier{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -372,9 +372,9 @@ func TestSendPost(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 	verifier := pipelineVerifier{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -406,9 +406,9 @@ func TestSendQuery(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 	verifier := pipelineVerifier{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -442,9 +442,9 @@ func TestSendQueryWithParameters(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 	verifier := pipelineVerifier{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -485,9 +485,9 @@ func TestSendBatch(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 	verifier := pipelineVerifier{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDocument,
 		resourceAddress: "",
@@ -530,9 +530,9 @@ func TestSendPatch(t *testing.T) {
 	srv.SetResponse(
 		mock.WithStatusCode(200))
 	verifier := pipelineVerifier{}
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypeDatabase,
 		resourceAddress: "",
@@ -607,9 +607,9 @@ func TestQueryDatabases(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	receivedIds := []string{}
 	queryPager := client.NewQueryDatabasesPager("select * from c", nil)

--- a/sdk/data/azcosmos/cosmos_client_test.go
+++ b/sdk/data/azcosmos/cosmos_client_test.go
@@ -570,7 +570,7 @@ func TestSendPatch(t *testing.T) {
 }
 
 func TestCreateScopeFromEndpoint(t *testing.T) {
-	url := "https://foo.documents.azure.com:443/"
+	url, _ := url.Parse("https://foo.documents.azure.com:443/")
 	scope, err := createScopeFromEndpoint(url)
 	if err != nil {
 		t.Fatal(err)
@@ -613,7 +613,7 @@ func TestQueryDatabases(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}, locationCache: mockLocationCache}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	receivedIds := []string{}
 	queryPager := client.NewQueryDatabasesPager("select * from c", nil)

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -514,6 +514,13 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 			return page.ContinuationToken != nil
 		},
 		Fetcher: func(ctx context.Context, page *QueryItemsResponse) (QueryItemsResponse, error) {
+			var err error
+			spanName, err := getSpanNameForItems(operationTypeQuery, c.id)
+			if err != nil {
+				return QueryItemsResponse{}, err
+			}
+			ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
 					// Use the previous page continuation if available

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -42,11 +42,11 @@ func (c *ContainerClient) Read(
 	ctx context.Context,
 	o *ReadContainerOptions) (ContainerResponse, error) {
 	var err error
-	spanName, err := getSpanNameForContainers(operationTypeRead, resourceTypeCollection, c.id)
+	spanName, err := c.getSpanForContainer(operationTypeRead, resourceTypeCollection, c.id)
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadContainerOptions{}
@@ -84,11 +84,11 @@ func (c *ContainerClient) Replace(
 	containerProperties ContainerProperties,
 	o *ReplaceContainerOptions) (ContainerResponse, error) {
 	var err error
-	spanName, err := getSpanNameForContainers(operationTypeReplace, resourceTypeCollection, c.id)
+	spanName, err := c.getSpanForContainer(operationTypeReplace, resourceTypeCollection, c.id)
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReplaceContainerOptions{}
@@ -127,11 +127,11 @@ func (c *ContainerClient) Delete(
 	ctx context.Context,
 	o *DeleteContainerOptions) (ContainerResponse, error) {
 	var err error
-	spanName, err := getSpanNameForContainers(operationTypeDelete, resourceTypeCollection, c.id)
+	spanName, err := c.getSpanForContainer(operationTypeDelete, resourceTypeCollection, c.id)
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteContainerOptions{}
@@ -169,11 +169,11 @@ func (c *ContainerClient) ReadThroughput(
 	ctx context.Context,
 	o *ThroughputOptions) (ThroughputResponse, error) {
 	var err error
-	spanName, err := getSpanNameForContainers(operationTypeRead, resourceTypeOffer, c.id)
+	spanName, err := c.getSpanForContainer(operationTypeRead, resourceTypeOffer, c.id)
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -198,11 +198,11 @@ func (c *ContainerClient) ReplaceThroughput(
 	throughputProperties ThroughputProperties,
 	o *ThroughputOptions) (ThroughputResponse, error) {
 	var err error
-	spanName, err := getSpanNameForContainers(operationTypeReplace, resourceTypeOffer, c.id)
+	spanName, err := c.getSpanForContainer(operationTypeReplace, resourceTypeOffer, c.id)
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -229,11 +229,11 @@ func (c *ContainerClient) CreateItem(
 	item []byte,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	spanName, err := getSpanNameForItems(operationTypeCreate, c.id)
+	spanName, err := c.getSpanForItems(operationTypeCreate)
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -282,11 +282,11 @@ func (c *ContainerClient) UpsertItem(
 	item []byte,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	spanName, err := getSpanNameForItems(operationTypeUpsert, c.id)
+	spanName, err := c.getSpanForItems(operationTypeUpsert)
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -341,11 +341,11 @@ func (c *ContainerClient) ReplaceItem(
 	item []byte,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	spanName, err := getSpanNameForItems(operationTypeReplace, c.id)
+	spanName, err := c.getSpanForItems(operationTypeReplace)
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -394,11 +394,11 @@ func (c *ContainerClient) ReadItem(
 	itemId string,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	spanName, err := getSpanNameForItems(operationTypeRead, c.id)
+	spanName, err := c.getSpanForItems(operationTypeRead)
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -443,11 +443,11 @@ func (c *ContainerClient) DeleteItem(
 	itemId string,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	spanName, err := getSpanNameForItems(operationTypeDelete, c.id)
+	spanName, err := c.getSpanForItems(operationTypeDelete)
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -516,11 +516,11 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 		Fetcher: func(ctx context.Context, page *QueryItemsResponse) (QueryItemsResponse, error) {
 			var err error
 			// Move the span to the pager once https://github.com/Azure/azure-sdk-for-go/issues/23294 is fixed
-			spanName, err := getSpanNameForItems(operationTypeQuery, c.id)
+			spanName, err := c.getSpanForItems(operationTypeQuery)
 			if err != nil {
 				return QueryItemsResponse{}, err
 			}
-			ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+			ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
@@ -561,11 +561,11 @@ func (c *ContainerClient) PatchItem(
 	ops PatchOperations,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	spanName, err := getSpanNameForItems(operationTypePatch, c.id)
+	spanName, err := getSpanNameForItems(c.database.client.getAccountEndpoint(), operationTypePatch, c.database.id, c.id)
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -613,11 +613,11 @@ func (c *ContainerClient) NewTransactionalBatch(partitionKey PartitionKey) Trans
 // Once executed, verify the Success property of the response to determine if the batch was committed
 func (c *ContainerClient) ExecuteTransactionalBatch(ctx context.Context, b TransactionalBatch, o *TransactionalBatchOptions) (TransactionalBatchResponse, error) {
 	var err error
-	spanName, err := getSpanNameForContainers(operationTypeBatch, resourceTypeCollection, c.id)
+	spanName, err := c.getSpanForContainer(operationTypeBatch, resourceTypeCollection, c.id)
 	if err != nil {
 		return TransactionalBatchResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if len(b.operations) == 0 {
 		return TransactionalBatchResponse{}, errors.New("no operations in batch")
@@ -678,4 +678,12 @@ func (c *ContainerClient) getRID(ctx context.Context) (string, error) {
 	}
 
 	return containerResponse.ContainerProperties.ResourceID, nil
+}
+
+func (c *ContainerClient) getSpanForContainer(operationType operationType, resourceType resourceType, id string) (span, error) {
+	return getSpanNameForContainers(c.database.client.getAccountEndpoint(), operationType, resourceType, c.database.id, id)
+}
+
+func (c *ContainerClient) getSpanForItems(operationType operationType) (span, error) {
+	return getSpanNameForItems(c.database.client.getAccountEndpoint(), operationType, c.database.id, c.id)
 }

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -41,6 +41,9 @@ func (c *ContainerClient) ID() string {
 func (c *ContainerClient) Read(
 	ctx context.Context,
 	o *ReadContainerOptions) (ContainerResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.Read", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadContainerOptions{}
 	}
@@ -65,7 +68,8 @@ func (c *ContainerClient) Read(
 		return ContainerResponse{}, err
 	}
 
-	return newContainerResponse(azResponse)
+	response, err := newContainerResponse(azResponse)
+	return response, err
 }
 
 // Replace a Cosmos container.
@@ -75,6 +79,9 @@ func (c *ContainerClient) Replace(
 	ctx context.Context,
 	containerProperties ContainerProperties,
 	o *ReplaceContainerOptions) (ContainerResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.Replace", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReplaceContainerOptions{}
 	}
@@ -101,7 +108,8 @@ func (c *ContainerClient) Replace(
 		return ContainerResponse{}, err
 	}
 
-	return newContainerResponse(azResponse)
+	response, err := newContainerResponse(azResponse)
+	return response, err
 }
 
 // Delete a Cosmos container.
@@ -110,6 +118,9 @@ func (c *ContainerClient) Replace(
 func (c *ContainerClient) Delete(
 	ctx context.Context,
 	o *DeleteContainerOptions) (ContainerResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.Delete", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteContainerOptions{}
 	}
@@ -135,7 +146,8 @@ func (c *ContainerClient) Delete(
 		return ContainerResponse{}, err
 	}
 
-	return newContainerResponse(azResponse)
+	response, err := newContainerResponse(azResponse)
+	return response, err
 }
 
 // ReadThroughput obtains the provisioned throughput information for the container.
@@ -144,6 +156,9 @@ func (c *ContainerClient) Delete(
 func (c *ContainerClient) ReadThroughput(
 	ctx context.Context,
 	o *ThroughputOptions) (ThroughputResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ReadThroughput", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
 	}
@@ -154,7 +169,8 @@ func (c *ContainerClient) ReadThroughput(
 	}
 
 	offers := &cosmosOffers{client: c.database.client}
-	return offers.ReadThroughputIfExists(ctx, rid, o)
+	response, err := offers.ReadThroughputIfExists(ctx, rid, o)
+	return response, err
 }
 
 // ReplaceThroughput updates the provisioned throughput for the container.
@@ -165,6 +181,9 @@ func (c *ContainerClient) ReplaceThroughput(
 	ctx context.Context,
 	throughputProperties ThroughputProperties,
 	o *ThroughputOptions) (ThroughputResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ReplaceThroughput", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
 	}
@@ -175,7 +194,8 @@ func (c *ContainerClient) ReplaceThroughput(
 	}
 
 	offers := &cosmosOffers{client: c.database.client}
-	return offers.ReplaceThroughputIfExists(ctx, throughputProperties, rid, o)
+	response, err := offers.ReplaceThroughputIfExists(ctx, throughputProperties, rid, o)
+	return response, err
 }
 
 // CreateItem creates an item in a Cosmos container.
@@ -188,6 +208,9 @@ func (c *ContainerClient) CreateItem(
 	partitionKey PartitionKey,
 	item []byte,
 	o *ItemOptions) (ItemResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.CreateItem", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
 	}
@@ -220,7 +243,8 @@ func (c *ContainerClient) CreateItem(
 		return ItemResponse{}, err
 	}
 
-	return newItemResponse(azResponse)
+	response, err := newItemResponse(azResponse)
+	return response, err
 }
 
 // UpsertItem creates or replaces an item in a Cosmos container.
@@ -233,6 +257,9 @@ func (c *ContainerClient) UpsertItem(
 	partitionKey PartitionKey,
 	item []byte,
 	o *ItemOptions) (ItemResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.UpsertItem", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
 	}
@@ -269,7 +296,8 @@ func (c *ContainerClient) UpsertItem(
 		return ItemResponse{}, err
 	}
 
-	return newItemResponse(azResponse)
+	response, err := newItemResponse(azResponse)
+	return response, err
 }
 
 // ReplaceItem replaces an item in a Cosmos container.
@@ -284,6 +312,9 @@ func (c *ContainerClient) ReplaceItem(
 	itemId string,
 	item []byte,
 	o *ItemOptions) (ItemResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ReplaceItem", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
 	}
@@ -316,7 +347,8 @@ func (c *ContainerClient) ReplaceItem(
 		return ItemResponse{}, err
 	}
 
-	return newItemResponse(azResponse)
+	response, err := newItemResponse(azResponse)
+	return response, err
 }
 
 // ReadItem reads an item in a Cosmos container.
@@ -329,6 +361,9 @@ func (c *ContainerClient) ReadItem(
 	partitionKey PartitionKey,
 	itemId string,
 	o *ItemOptions) (ItemResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ReadItem", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
 	}
@@ -357,7 +392,8 @@ func (c *ContainerClient) ReadItem(
 		return ItemResponse{}, err
 	}
 
-	return newItemResponse(azResponse)
+	response, err := newItemResponse(azResponse)
+	return response, err
 }
 
 // DeleteItem deletes an item in a Cosmos container.
@@ -370,6 +406,9 @@ func (c *ContainerClient) DeleteItem(
 	partitionKey PartitionKey,
 	itemId string,
 	o *ItemOptions) (ItemResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.DeleteItem", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
 	}
@@ -401,7 +440,8 @@ func (c *ContainerClient) DeleteItem(
 		return ItemResponse{}, err
 	}
 
-	return newItemResponse(azResponse)
+	response, err := newItemResponse(azResponse)
+	return response, err
 }
 
 // NewQueryItemsPager executes a single partition query in a Cosmos container.
@@ -471,6 +511,9 @@ func (c *ContainerClient) PatchItem(
 	itemId string,
 	ops PatchOperations,
 	o *ItemOptions) (ItemResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.PatchItem", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
 	}
@@ -503,7 +546,8 @@ func (c *ContainerClient) PatchItem(
 		return ItemResponse{}, err
 	}
 
-	return newItemResponse(azResponse)
+	response, err := newItemResponse(azResponse)
+	return response, err
 }
 
 // NewTransactionalBatch creates a batch of operations to be committed as a single unit.
@@ -515,6 +559,9 @@ func (c *ContainerClient) NewTransactionalBatch(partitionKey PartitionKey) Trans
 // ExecuteTransactionalBatch executes a transactional batch.
 // Once executed, verify the Success property of the response to determine if the batch was committed
 func (c *ContainerClient) ExecuteTransactionalBatch(ctx context.Context, b TransactionalBatch, o *TransactionalBatchOptions) (TransactionalBatchResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ExecuteTransactionalBatch", c.database.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if len(b.operations) == 0 {
 		return TransactionalBatchResponse{}, errors.New("no operations in batch")
 	}
@@ -563,7 +610,8 @@ func (c *ContainerClient) ExecuteTransactionalBatch(ctx context.Context, b Trans
 		return TransactionalBatchResponse{}, err
 	}
 
-	return newTransactionalBatchResponse(azResponse)
+	response, err := newTransactionalBatchResponse(azResponse)
+	return response, err
 }
 
 func (c *ContainerClient) getRID(ctx context.Context) (string, error) {

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -561,7 +561,7 @@ func (c *ContainerClient) PatchItem(
 	ops PatchOperations,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	spanName, err := getSpanNameForItems(c.database.client.getAccountEndpoint(), operationTypePatch, c.database.id, c.id)
+	spanName, err := c.getSpanForItems(operationTypePatch)
 	if err != nil {
 		return ItemResponse{}, err
 	}
@@ -681,9 +681,9 @@ func (c *ContainerClient) getRID(ctx context.Context) (string, error) {
 }
 
 func (c *ContainerClient) getSpanForContainer(operationType operationType, resourceType resourceType, id string) (span, error) {
-	return getSpanNameForContainers(c.database.client.getAccountEndpoint(), operationType, resourceType, c.database.id, id)
+	return getSpanNameForContainers(c.database.client.accountEndpointUrl(), operationType, resourceType, c.database.id, id)
 }
 
 func (c *ContainerClient) getSpanForItems(operationType operationType) (span, error) {
-	return getSpanNameForItems(c.database.client.getAccountEndpoint(), operationType, c.database.id, c.id)
+	return getSpanNameForItems(c.database.client.accountEndpointUrl(), operationType, c.database.id, c.id)
 }

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -515,6 +515,7 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 		},
 		Fetcher: func(ctx context.Context, page *QueryItemsResponse) (QueryItemsResponse, error) {
 			var err error
+			// Move the span to the pager once https://github.com/Azure/azure-sdk-for-go/issues/23294 is fixed
 			spanName, err := getSpanNameForItems(operationTypeQuery, c.id)
 			if err != nil {
 				return QueryItemsResponse{}, err

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -42,7 +42,11 @@ func (c *ContainerClient) Read(
 	ctx context.Context,
 	o *ReadContainerOptions) (ContainerResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.Read", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForContainers(operationTypeRead, resourceTypeCollection, c.id)
+	if err != nil {
+		return ContainerResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadContainerOptions{}
@@ -80,7 +84,11 @@ func (c *ContainerClient) Replace(
 	containerProperties ContainerProperties,
 	o *ReplaceContainerOptions) (ContainerResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.Replace", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForContainers(operationTypeReplace, resourceTypeCollection, c.id)
+	if err != nil {
+		return ContainerResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReplaceContainerOptions{}
@@ -119,7 +127,11 @@ func (c *ContainerClient) Delete(
 	ctx context.Context,
 	o *DeleteContainerOptions) (ContainerResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.Delete", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForContainers(operationTypeDelete, resourceTypeCollection, c.id)
+	if err != nil {
+		return ContainerResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteContainerOptions{}
@@ -157,7 +169,11 @@ func (c *ContainerClient) ReadThroughput(
 	ctx context.Context,
 	o *ThroughputOptions) (ThroughputResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ReadThroughput", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForContainers(operationTypeRead, resourceTypeOffer, c.id)
+	if err != nil {
+		return ThroughputResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -182,7 +198,11 @@ func (c *ContainerClient) ReplaceThroughput(
 	throughputProperties ThroughputProperties,
 	o *ThroughputOptions) (ThroughputResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ReplaceThroughput", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForContainers(operationTypeReplace, resourceTypeOffer, c.id)
+	if err != nil {
+		return ThroughputResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -209,7 +229,11 @@ func (c *ContainerClient) CreateItem(
 	item []byte,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.CreateItem", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForItems(operationTypeCreate, c.id)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -258,7 +282,11 @@ func (c *ContainerClient) UpsertItem(
 	item []byte,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.UpsertItem", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForItems(operationTypeUpsert, c.id)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -313,7 +341,11 @@ func (c *ContainerClient) ReplaceItem(
 	item []byte,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ReplaceItem", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForItems(operationTypeReplace, c.id)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -362,7 +394,11 @@ func (c *ContainerClient) ReadItem(
 	itemId string,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ReadItem", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForItems(operationTypeRead, c.id)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -407,7 +443,11 @@ func (c *ContainerClient) DeleteItem(
 	itemId string,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.DeleteItem", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForItems(operationTypeDelete, c.id)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -496,6 +536,7 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 
 			return newQueryResponse(azResponse)
 		},
+		Tracer: c.database.client.internal.Tracer(),
 	})
 }
 
@@ -512,7 +553,11 @@ func (c *ContainerClient) PatchItem(
 	ops PatchOperations,
 	o *ItemOptions) (ItemResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.PatchItem", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForItems(operationTypePatch, c.id)
+	if err != nil {
+		return ItemResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -560,7 +605,11 @@ func (c *ContainerClient) NewTransactionalBatch(partitionKey PartitionKey) Trans
 // Once executed, verify the Success property of the response to determine if the batch was committed
 func (c *ContainerClient) ExecuteTransactionalBatch(ctx context.Context, b TransactionalBatch, o *TransactionalBatchOptions) (TransactionalBatchResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "ContainerClient.ExecuteTransactionalBatch", c.database.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForContainers(operationTypeBatch, resourceTypeCollection, c.id)
+	if err != nil {
+		return TransactionalBatchResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, c.database.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if len(b.operations) == 0 {
 		return TransactionalBatchResponse{}, errors.New("no operations in batch")

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -46,7 +46,7 @@ func (c *ContainerClient) Read(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadContainerOptions{}
@@ -88,7 +88,7 @@ func (c *ContainerClient) Replace(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReplaceContainerOptions{}
@@ -131,7 +131,7 @@ func (c *ContainerClient) Delete(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteContainerOptions{}
@@ -173,7 +173,7 @@ func (c *ContainerClient) ReadThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -202,7 +202,7 @@ func (c *ContainerClient) ReplaceThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -233,7 +233,7 @@ func (c *ContainerClient) CreateItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -286,7 +286,7 @@ func (c *ContainerClient) UpsertItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -345,7 +345,7 @@ func (c *ContainerClient) ReplaceItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -398,7 +398,7 @@ func (c *ContainerClient) ReadItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -447,7 +447,7 @@ func (c *ContainerClient) DeleteItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -520,7 +520,7 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 			if err != nil {
 				return QueryItemsResponse{}, err
 			}
-			ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+			ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
@@ -565,7 +565,7 @@ func (c *ContainerClient) PatchItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -617,7 +617,7 @@ func (c *ContainerClient) ExecuteTransactionalBatch(ctx context.Context, b Trans
 	if err != nil {
 		return TransactionalBatchResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if len(b.operations) == 0 {
 		return TransactionalBatchResponse{}, errors.New("no operations in batch")

--- a/sdk/data/azcosmos/cosmos_container_test.go
+++ b/sdk/data/azcosmos/cosmos_container_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -39,6 +40,7 @@ func TestContainerRead(t *testing.T) {
 	}
 
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.SetResponse(
 		mock.WithBody(jsonString),
@@ -49,7 +51,7 @@ func TestContainerRead(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -114,6 +116,7 @@ func TestContainerRead(t *testing.T) {
 
 func TestContainerDeleteItem(t *testing.T) {
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.SetResponse(
 		mock.WithHeader(cosmosHeaderEtag, "someEtag"),
@@ -125,7 +128,7 @@ func TestContainerDeleteItem(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -167,6 +170,7 @@ func TestContainerDeleteItem(t *testing.T) {
 func TestContainerReadItem(t *testing.T) {
 	jsonString := []byte(`{"id":"doc1","foo":"bar"}`)
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.SetResponse(
 		mock.WithBody(jsonString),
@@ -179,7 +183,7 @@ func TestContainerReadItem(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -225,6 +229,7 @@ func TestContainerReadItem(t *testing.T) {
 func TestContainerReplaceItem(t *testing.T) {
 	jsonString := []byte(`{"id":"doc1","foo":"bar"}`)
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.SetResponse(
 		mock.WithBody(jsonString),
@@ -237,7 +242,7 @@ func TestContainerReplaceItem(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -287,6 +292,7 @@ func TestContainerReplaceItem(t *testing.T) {
 func TestContainerUpsertItem(t *testing.T) {
 	jsonString := []byte(`{"id":"doc1","foo":"bar"}`)
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.SetResponse(
 		mock.WithBody(jsonString),
@@ -299,7 +305,7 @@ func TestContainerUpsertItem(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -353,6 +359,7 @@ func TestContainerUpsertItem(t *testing.T) {
 func TestContainerCreateItem(t *testing.T) {
 	jsonString := []byte(`{"id":"doc1","foo":"bar"}`)
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.SetResponse(
 		mock.WithBody(jsonString),
@@ -365,7 +372,7 @@ func TestContainerCreateItem(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -421,6 +428,7 @@ func TestContainerQueryItems(t *testing.T) {
 	jsonStringpage2 := []byte(`{"Documents":[{"id":"doc3","foo":"bar"},{"id":"doc4","foo":"bar"},{"id":"doc5","foo":"bar"}]}`)
 
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.AppendResponse(
 		mock.WithBody(jsonStringpage1),
@@ -444,7 +452,7 @@ func TestContainerQueryItems(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -540,6 +548,7 @@ func TestContainerExecuteBatch(t *testing.T) {
 	}
 
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.SetResponse(
 		mock.WithBody(jsonString),
@@ -552,7 +561,7 @@ func TestContainerExecuteBatch(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -604,6 +613,7 @@ func TestContainerPatchItem(t *testing.T) {
 	patchOpt.AppendSet("/hello", "world")
 
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.SetResponse(
 		mock.WithBody(jsonString),
@@ -616,7 +626,7 @@ func TestContainerPatchItem(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)

--- a/sdk/data/azcosmos/cosmos_container_test.go
+++ b/sdk/data/azcosmos/cosmos_container_test.go
@@ -47,9 +47,9 @@ func TestContainerRead(t *testing.T) {
 		mock.WithHeader(cosmosHeaderRequestCharge, "13.42"),
 		mock.WithStatusCode(200))
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -123,9 +123,9 @@ func TestContainerDeleteItem(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -177,9 +177,9 @@ func TestContainerReadItem(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -235,9 +235,9 @@ func TestContainerReplaceItem(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -297,9 +297,9 @@ func TestContainerUpsertItem(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -363,9 +363,9 @@ func TestContainerCreateItem(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -442,9 +442,9 @@ func TestContainerQueryItems(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -550,9 +550,9 @@ func TestContainerExecuteBatch(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
@@ -614,9 +614,9 @@ func TestContainerPatchItem(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -55,7 +55,7 @@ func (db *DatabaseClient) CreateContainer(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &CreateContainerOptions{}
@@ -120,7 +120,7 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 			if err != nil {
 				return QueryContainersResponse{}, err
 			}
-			ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.client.internal.Tracer(), nil)
+			ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.client.internal.Tracer(), &spanName.options)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
@@ -159,7 +159,7 @@ func (db *DatabaseClient) Read(
 	if err != nil {
 		return DatabaseResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadDatabaseOptions{}
@@ -200,7 +200,7 @@ func (db *DatabaseClient) ReadThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -229,7 +229,7 @@ func (db *DatabaseClient) ReplaceThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -256,7 +256,7 @@ func (db *DatabaseClient) Delete(
 	if err != nil {
 		return DatabaseResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteDatabaseOptions{}

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -115,6 +115,7 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 		},
 		Fetcher: func(ctx context.Context, page *QueryContainersResponse) (QueryContainersResponse, error) {
 			var err error
+			// Move the span to the pager once https://github.com/Azure/azure-sdk-for-go/issues/23294 is fixed
 			spanName, err := getSpanNameForContainers(operationTypeQuery, resourceTypeCollection, c.id)
 			if err != nil {
 				return QueryContainersResponse{}, err

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -297,9 +297,9 @@ func (db *DatabaseClient) getRID(ctx context.Context) (string, error) {
 }
 
 func (db *DatabaseClient) getSpanForDatabases(operationType operationType, resourceType resourceType) (span, error) {
-	return getSpanNameForDatabases(db.client.getAccountEndpoint(), operationType, resourceType, db.id)
+	return getSpanNameForDatabases(db.client.accountEndpointUrl(), operationType, resourceType, db.id)
 }
 
 func (db *DatabaseClient) getSpanForContainers(operationType operationType, resourceType resourceType, id string) (span, error) {
-	return getSpanNameForContainers(db.client.getAccountEndpoint(), operationType, resourceType, db.id, id)
+	return getSpanNameForContainers(db.client.accountEndpointUrl(), operationType, resourceType, db.id, id)
 }

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -51,7 +51,11 @@ func (db *DatabaseClient) CreateContainer(
 	containerProperties ContainerProperties,
 	o *CreateContainerOptions) (ContainerResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.CreateContainer", db.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForContainers(operationTypeCreate, resourceTypeCollection, containerProperties.ID)
+	if err != nil {
+		return ContainerResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, db.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &CreateContainerOptions{}
@@ -132,6 +136,7 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 
 			return newContainersQueryResponse(azResponse)
 		},
+		Tracer: c.client.internal.Tracer(),
 	})
 }
 
@@ -142,7 +147,11 @@ func (db *DatabaseClient) Read(
 	ctx context.Context,
 	o *ReadDatabaseOptions) (DatabaseResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.Read", db.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForDatabases(operationTypeRead, resourceTypeDatabase, db.id)
+	if err != nil {
+		return DatabaseResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, db.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadDatabaseOptions{}
@@ -179,7 +188,11 @@ func (db *DatabaseClient) ReadThroughput(
 	ctx context.Context,
 	o *ThroughputOptions) (ThroughputResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.ReadThroughput", db.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForDatabases(operationTypeRead, resourceTypeOffer, db.id)
+	if err != nil {
+		return ThroughputResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, db.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -204,7 +217,11 @@ func (db *DatabaseClient) ReplaceThroughput(
 	throughputProperties ThroughputProperties,
 	o *ThroughputOptions) (ThroughputResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.ReplaceThroughput", db.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForDatabases(operationTypeReplace, resourceTypeOffer, db.id)
+	if err != nil {
+		return ThroughputResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, db.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -227,7 +244,11 @@ func (db *DatabaseClient) Delete(
 	ctx context.Context,
 	o *DeleteDatabaseOptions) (DatabaseResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.Delete", db.client.internal.Tracer(), nil)
+	spanName, err := getSpanNameForDatabases(operationTypeDelete, resourceTypeDatabase, db.id)
+	if err != nil {
+		return DatabaseResponse{}, err
+	}
+	ctx, endSpan := runtime.StartSpan(ctx, spanName, db.client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteDatabaseOptions{}

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -114,6 +114,13 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 			return page.ContinuationToken != nil
 		},
 		Fetcher: func(ctx context.Context, page *QueryContainersResponse) (QueryContainersResponse, error) {
+			var err error
+			spanName, err := getSpanNameForContainers(operationTypeQuery, resourceTypeCollection, c.id)
+			if err != nil {
+				return QueryContainersResponse{}, err
+			}
+			ctx, endSpan := runtime.StartSpan(ctx, spanName, c.client.internal.Tracer(), nil)
+			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
 					// Use the previous page continuation if available

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -50,6 +50,9 @@ func (db *DatabaseClient) CreateContainer(
 	ctx context.Context,
 	containerProperties ContainerProperties,
 	o *CreateContainerOptions) (ContainerResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.CreateContainer", db.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &CreateContainerOptions{}
 	}
@@ -81,7 +84,8 @@ func (db *DatabaseClient) CreateContainer(
 		return ContainerResponse{}, err
 	}
 
-	return newContainerResponse(azResponse)
+	response, err := newContainerResponse(azResponse)
+	return response, err
 }
 
 // NewQueryContainersPager executes query for containers within a database.
@@ -137,6 +141,9 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 func (db *DatabaseClient) Read(
 	ctx context.Context,
 	o *ReadDatabaseOptions) (DatabaseResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.Read", db.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadDatabaseOptions{}
 	}
@@ -161,7 +168,8 @@ func (db *DatabaseClient) Read(
 		return DatabaseResponse{}, err
 	}
 
-	return newDatabaseResponse(azResponse)
+	response, err := newDatabaseResponse(azResponse)
+	return response, err
 }
 
 // ReadThroughput obtains the provisioned throughput information for the database.
@@ -170,6 +178,9 @@ func (db *DatabaseClient) Read(
 func (db *DatabaseClient) ReadThroughput(
 	ctx context.Context,
 	o *ThroughputOptions) (ThroughputResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.ReadThroughput", db.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
 	}
@@ -180,7 +191,8 @@ func (db *DatabaseClient) ReadThroughput(
 	}
 
 	offers := &cosmosOffers{client: db.client}
-	return offers.ReadThroughputIfExists(ctx, rid, o)
+	response, err := offers.ReadThroughputIfExists(ctx, rid, o)
+	return response, err
 }
 
 // ReplaceThroughput updates the provisioned throughput for the database.
@@ -191,6 +203,9 @@ func (db *DatabaseClient) ReplaceThroughput(
 	ctx context.Context,
 	throughputProperties ThroughputProperties,
 	o *ThroughputOptions) (ThroughputResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.ReplaceThroughput", db.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
 	}
@@ -201,7 +216,8 @@ func (db *DatabaseClient) ReplaceThroughput(
 	}
 
 	offers := &cosmosOffers{client: db.client}
-	return offers.ReplaceThroughputIfExists(ctx, throughputProperties, rid, o)
+	response, err := offers.ReplaceThroughputIfExists(ctx, throughputProperties, rid, o)
+	return response, err
 }
 
 // Delete a Cosmos database.
@@ -210,6 +226,9 @@ func (db *DatabaseClient) ReplaceThroughput(
 func (db *DatabaseClient) Delete(
 	ctx context.Context,
 	o *DeleteDatabaseOptions) (DatabaseResponse, error) {
+	var err error
+	ctx, endSpan := runtime.StartSpan(ctx, "DatabaseClient.Delete", db.client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteDatabaseOptions{}
 	}
@@ -235,7 +254,8 @@ func (db *DatabaseClient) Delete(
 		return DatabaseResponse{}, err
 	}
 
-	return newDatabaseResponse(azResponse)
+	response, err := newDatabaseResponse(azResponse)
+	return response, err
 }
 
 func (db *DatabaseClient) getRID(ctx context.Context) (string, error) {

--- a/sdk/data/azcosmos/cosmos_database_test.go
+++ b/sdk/data/azcosmos/cosmos_database_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
@@ -36,9 +37,9 @@ func TestDatabaseQueryContainers(t *testing.T) {
 
 	verifier := pipelineVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 

--- a/sdk/data/azcosmos/cosmos_database_test.go
+++ b/sdk/data/azcosmos/cosmos_database_test.go
@@ -6,6 +6,7 @@ package azcosmos
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strconv"
 	"testing"
 
@@ -20,6 +21,7 @@ func TestDatabaseQueryContainers(t *testing.T) {
 	jsonStringpage2 := []byte(`{"DocumentCollections":[{"id":"doc3"},{"id":"doc4"},{"id":"doc5"}]}`)
 
 	srv, close := mock.NewTLSServer()
+	defaultEndpoint, _ := url.Parse(srv.URL())
 	defer close()
 	srv.AppendResponse(
 		mock.WithBody(jsonStringpage1),
@@ -39,7 +41,7 @@ func TestDatabaseQueryContainers(t *testing.T) {
 
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerCall: []policy.Policy{&verifier}}, &policy.ClientOptions{Transport: srv})
 	gem := &globalEndpointManager{preferredLocations: []string{}}
-	client := &Client{endpoint: srv.URL(), internal: internalClient, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 
 	database, _ := newDatabase("databaseId", client)
 

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
@@ -176,9 +177,9 @@ func TestGlobalEndpointManagerCanUseMultipleWriteLocations(t *testing.T) {
 	defer close()
 	srv.SetResponse(mock.WithStatusCode(http.StatusOK))
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl}
+	client := &Client{endpoint: srv.URL(), internal: internalClient}
 
 	preferredRegions := []string{"West US", "Central US"}
 

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -196,7 +196,7 @@ func TestGlobalEndpointManagerCanUseMultipleWriteLocations(t *testing.T) {
 		refreshTimeInterval: 5 * time.Minute,
 	}
 
-	gem, err := newGlobalEndpointManager(srv.URL(), pl, []string{}, 5*time.Minute, true)
+	gem, err := newGlobalEndpointManager(srv.URL(), internalClient.Pipeline(), []string{}, 5*time.Minute, true)
 	assert.NoError(t, err)
 
 	// Multiple locations should be false for default GEM

--- a/sdk/data/azcosmos/emulator_cosmos_aad_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_aad_test.go
@@ -30,7 +30,7 @@ func TestAAD(t *testing.T) {
 	}
 
 	aadClient := emulatorTests.getAadClient(t, newSpanValidator(t, spanMatcher{
-		ExpectedSpans: []string{"ContainerClient.CreateItem", "ContainerClient.ReadItem", "ContainerClient.ReplaceItem", "ContainerClient.UpsertItem", "ContainerClient.DeleteItem"},
+		ExpectedSpans: []string{"create_item aContainer", "read_item aContainer", "replace_item aContainer", "upsert_item aContainer", "delete_item aContainer"},
 	}))
 
 	item := map[string]string{

--- a/sdk/data/azcosmos/emulator_cosmos_aad_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_aad_test.go
@@ -11,7 +11,9 @@ import (
 
 func TestAAD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "aadTest")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -27,7 +29,9 @@ func TestAAD(t *testing.T) {
 		t.Fatalf("Failed to create container: %v", err)
 	}
 
-	aadClient := emulatorTests.getAadClient(t)
+	aadClient := emulatorTests.getAadClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{"ContainerClient.CreateItem", "ContainerClient.ReadItem", "ContainerClient.ReplaceItem", "ContainerClient.UpsertItem", "ContainerClient.DeleteItem"},
+	}))
 
 	item := map[string]string{
 		"id":    "1",

--- a/sdk/data/azcosmos/emulator_cosmos_batch_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_batch_test.go
@@ -11,7 +11,9 @@ import (
 
 func TestItemTransactionalBatch(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{"ContainerClient.ExecuteTransactionalBatch"},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -169,7 +171,9 @@ func TestItemTransactionalBatch(t *testing.T) {
 
 func TestItemTransactionalBatchError(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{"ContainerClient.ExecuteTransactionalBatch"},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)

--- a/sdk/data/azcosmos/emulator_cosmos_batch_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_batch_test.go
@@ -12,7 +12,7 @@ import (
 func TestItemTransactionalBatch(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
-		ExpectedSpans: []string{"ContainerClient.ExecuteTransactionalBatch"},
+		ExpectedSpans: []string{"execute_batch aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")
@@ -172,7 +172,7 @@ func TestItemTransactionalBatch(t *testing.T) {
 func TestItemTransactionalBatchError(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
-		ExpectedSpans: []string{"ContainerClient.ExecuteTransactionalBatch"},
+		ExpectedSpans: []string{"execute_batch aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")

--- a/sdk/data/azcosmos/emulator_cosmos_container_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_container_test.go
@@ -10,7 +10,9 @@ import (
 
 func TestContainerCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{"DatabaseClient.CreateContainer", "ContainerClient.Read", "ContainerClient.Replace", "ContainerClient.ReadThroughput", "ContainerClient.ReplaceThroughput", "ContainerClient.Delete"},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "containerCRUD")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -129,7 +131,9 @@ func TestContainerCRUD(t *testing.T) {
 
 func TestContainerAutoscaleCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{"DatabaseClient.CreateContainer", "ContainerClient.Read", "ContainerClient.ReadThroughput", "ContainerClient.ReplaceThroughput", "ContainerClient.Delete"},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "containerCRUD")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)

--- a/sdk/data/azcosmos/emulator_cosmos_container_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_container_test.go
@@ -11,7 +11,7 @@ import (
 func TestContainerCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
-		ExpectedSpans: []string{"DatabaseClient.CreateContainer", "ContainerClient.Read", "ContainerClient.Replace", "ContainerClient.ReadThroughput", "ContainerClient.ReplaceThroughput", "ContainerClient.Delete"},
+		ExpectedSpans: []string{"create_container aContainer", "read_container aContainer", "replace_container aContainer", "read_container_throughput aContainer", "replace_container_throughput aContainer", "delete_container aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "containerCRUD")
@@ -132,7 +132,7 @@ func TestContainerCRUD(t *testing.T) {
 func TestContainerAutoscaleCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
-		ExpectedSpans: []string{"DatabaseClient.CreateContainer", "ContainerClient.Read", "ContainerClient.ReadThroughput", "ContainerClient.ReplaceThroughput", "ContainerClient.Delete"},
+		ExpectedSpans: []string{"create_container aContainer", "read_container aContainer", "read_container_throughput aContainer", "replace_container_throughput aContainer", "delete_container aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "containerCRUD")

--- a/sdk/data/azcosmos/emulator_cosmos_database_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_database_test.go
@@ -11,7 +11,7 @@ import (
 func TestDatabaseCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
-		ExpectedSpans: []string{"Client.CreateDatabase", "DatabaseClient.Read", "DatabaseClient.Delete", "DatabaseClient.ReadThroughput"},
+		ExpectedSpans: []string{"create_database baseDbTest", "read_database baseDbTest", "delete_database baseDbTest", "read_database_throughput baseDbTest"},
 	}))
 
 	database := DatabaseProperties{ID: "baseDbTest"}
@@ -71,7 +71,7 @@ func TestDatabaseCRUD(t *testing.T) {
 func TestDatabaseWithOfferCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
-		ExpectedSpans: []string{"Client.CreateDatabase", "DatabaseClient.Read", "DatabaseClient.Delete", "DatabaseClient.ReadThroughput", "DatabaseClient.ReplaceThroughput"},
+		ExpectedSpans: []string{"create_database baseDbTest", "read_database baseDbTest", "delete_database baseDbTest", "read_database_throughput baseDbTest", "replace_database_throughput baseDbTest"},
 	}))
 
 	database := DatabaseProperties{ID: "baseDbTest"}

--- a/sdk/data/azcosmos/emulator_cosmos_database_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_database_test.go
@@ -10,7 +10,9 @@ import (
 
 func TestDatabaseCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{"Client.CreateDatabase", "DatabaseClient.Read", "DatabaseClient.Delete", "DatabaseClient.ReadThroughput"},
+	}))
 
 	database := DatabaseProperties{ID: "baseDbTest"}
 
@@ -68,7 +70,9 @@ func TestDatabaseCRUD(t *testing.T) {
 
 func TestDatabaseWithOfferCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{"Client.CreateDatabase", "DatabaseClient.Read", "DatabaseClient.Delete", "DatabaseClient.ReadThroughput", "DatabaseClient.ReplaceThroughput"},
+	}))
 
 	database := DatabaseProperties{ID: "baseDbTest"}
 	tp := NewManualThroughputProperties(400)

--- a/sdk/data/azcosmos/emulator_cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_global_endpoint_manager_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestGlobalEndpointManagerEmulator(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 	emulatorRegionName := "South Central US"
 	preferredRegions := []string{}
 	emulatorRegion := accountRegion{Name: emulatorRegionName, Endpoint: "https://127.0.0.1:8081/"}
@@ -77,7 +79,9 @@ func TestGlobalEndpointManagerEmulator(t *testing.T) {
 
 func TestGlobalEndpointManagerPolicyEmulator(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 	emulatorRegionName := "South Central US"
 
 	// Assert location cache is not populated until update() is called within the policy

--- a/sdk/data/azcosmos/emulator_cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_global_endpoint_manager_test.go
@@ -19,7 +19,7 @@ func TestGlobalEndpointManagerEmulator(t *testing.T) {
 	preferredRegions := []string{}
 	emulatorRegion := accountRegion{Name: emulatorRegionName, Endpoint: "https://127.0.0.1:8081/"}
 
-	gem, err := newGlobalEndpointManager(client.endpoint, client.pipeline, preferredRegions, 5*time.Minute, true)
+	gem, err := newGlobalEndpointManager(client.endpoint, client.internal.Pipeline(), preferredRegions, 5*time.Minute, true)
 	assert.NoError(t, err)
 
 	accountProps, err := gem.GetAccountProperties(context.Background())

--- a/sdk/data/azcosmos/emulator_cosmos_item_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_item_test.go
@@ -17,7 +17,9 @@ import (
 
 func TestItemCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{"ContainerClient.CreateItem", "ContainerClient.ReadItem", "ContainerClient.ReplaceItem", "ContainerClient.UpsertItem", "ContainerClient.DeleteItem", "ContainerClient.PatchItem"},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -191,7 +193,9 @@ func TestItemCRUD(t *testing.T) {
 
 func TestItemCRUDforNullPartitionKey(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{"ContainerClient.CreateItem", "ContainerClient.ReadItem", "ContainerClient.ReplaceItem", "ContainerClient.UpsertItem", "ContainerClient.DeleteItem", "ContainerClient.PatchItem"},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -366,7 +370,9 @@ func TestItemCRUDforNullPartitionKey(t *testing.T) {
 
 func TestItemConcurrent(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -417,7 +423,9 @@ func TestItemConcurrent(t *testing.T) {
 
 func TestItemIdEncodingRoutingGW(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -456,7 +464,9 @@ func TestItemIdEncodingRoutingGW(t *testing.T) {
 
 func TestItemIdEncodingComputeGW(t *testing.T) {
 	emulatorTests := newEmulatorTestsWithComputeGateway(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)

--- a/sdk/data/azcosmos/emulator_cosmos_item_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_item_test.go
@@ -18,7 +18,7 @@ import (
 func TestItemCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
-		ExpectedSpans: []string{"ContainerClient.CreateItem", "ContainerClient.ReadItem", "ContainerClient.ReplaceItem", "ContainerClient.UpsertItem", "ContainerClient.DeleteItem", "ContainerClient.PatchItem"},
+		ExpectedSpans: []string{"create_item aContainer", "read_item aContainer", "replace_item aContainer", "upsert_item aContainer", "delete_item aContainer", "patch_item aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")
@@ -194,7 +194,7 @@ func TestItemCRUD(t *testing.T) {
 func TestItemCRUDforNullPartitionKey(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
-		ExpectedSpans: []string{"ContainerClient.CreateItem", "ContainerClient.ReadItem", "ContainerClient.ReplaceItem", "ContainerClient.UpsertItem", "ContainerClient.DeleteItem", "ContainerClient.PatchItem"},
+		ExpectedSpans: []string{"create_item aContainer", "read_item aContainer", "replace_item aContainer", "upsert_item aContainer", "delete_item aContainer", "patch_item aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "itemCRUD")

--- a/sdk/data/azcosmos/emulator_cosmos_query_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_query_test.go
@@ -12,7 +12,9 @@ import (
 
 func TestSinglePartitionQueryWithIndexMetrics(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -85,7 +87,9 @@ func TestSinglePartitionQueryWithIndexMetrics(t *testing.T) {
 
 func TestSinglePartitionQuery(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -171,7 +175,9 @@ func TestSinglePartitionQuery(t *testing.T) {
 
 func TestSinglePartitionQueryWithParameters(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
@@ -221,7 +227,9 @@ func TestSinglePartitionQueryWithParameters(t *testing.T) {
 
 func TestSinglePartitionQueryWithProjection(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+		ExpectedSpans: []string{},
+	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
 	defer emulatorTests.deleteDatabase(t, context.TODO(), database)

--- a/sdk/data/azcosmos/emulator_tests.go
+++ b/sdk/data/azcosmos/emulator_tests.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 )
 
 type emulatorTests struct {
@@ -41,9 +42,12 @@ func newEmulatorTestsWithEndpoint(t *testing.T, e string) *emulatorTests {
 	}
 }
 
-func (e *emulatorTests) getClient(t *testing.T) *Client {
+func (e *emulatorTests) getClient(t *testing.T, tp tracing.Provider) *Client {
 	cred, _ := NewKeyCredential(e.key)
-	client, err := NewClientWithKey(e.host, cred, nil)
+	options := &ClientOptions{ClientOptions: azcore.ClientOptions{
+		TracingProvider: tp,
+	}}
+	client, err := NewClientWithKey(e.host, cred, options)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -51,9 +55,12 @@ func (e *emulatorTests) getClient(t *testing.T) *Client {
 	return client
 }
 
-func (e *emulatorTests) getAadClient(t *testing.T) *Client {
+func (e *emulatorTests) getAadClient(t *testing.T, tp tracing.Provider) *Client {
 	cred := &emulatorTokenCredential{}
-	client, err := NewClient(e.host, cred, nil)
+	options := &ClientOptions{ClientOptions: azcore.ClientOptions{
+		TracingProvider: tp,
+	}}
+	client, err := NewClient(e.host, cred, options)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/sdk/data/azcosmos/go.mod
+++ b/sdk/data/azcosmos/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.13.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0
 	github.com/stretchr/testify v1.9.0

--- a/sdk/data/azcosmos/go.sum
+++ b/sdk/data/azcosmos/go.sum
@@ -1,7 +1,7 @@
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.13.0 h1:GJHeeA2N7xrG3q30L2UXDyuWRzDM900/65j70wcM4Ww=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.13.0/go.mod h1:l38EPgmsp71HHLq9j7De57JcKOWPyhrsW1Awm1JS6K0=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0 h1:nyQWyZvwGTvunIMxi1Y9uXkcyr+I7TeNrr/foo4Kpk8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0/go.mod h1:l38EPgmsp71HHLq9j7De57JcKOWPyhrsW1Awm1JS6K0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH5sE0o6eCJuNDTmH09nDpbc=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0/go.mod h1:9kIvujWAA58nmPmWB1m23fyWic1kYZMxD9CxaWn4Qpg=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=

--- a/sdk/data/azcosmos/operation_type.go
+++ b/sdk/data/azcosmos/operation_type.go
@@ -13,4 +13,6 @@ const (
 	operationTypeReplace operationType = 5
 	operationTypeDelete  operationType = 4
 	operationTypeUpsert  operationType = 20
+	operationTypeQuery   operationType = 15
+	operationTypeBatch   operationType = 40
 )

--- a/sdk/data/azcosmos/otel_constants.go
+++ b/sdk/data/azcosmos/otel_constants.go
@@ -143,34 +143,49 @@ func getSpanNameForItems(endpoint *url.URL, operationType operationType, databas
 }
 
 func getSpanPropertiesForClient(endpoint *url.URL, operationName string) runtime.StartSpanOptions {
-	return runtime.StartSpanOptions{Attributes: []tracing.Attribute{
+	options := runtime.StartSpanOptions{Attributes: []tracing.Attribute{
 		{Key: "db.system", Value: "cosmosdb"},
 		{Key: "db.cosmosdb.connection_mode", Value: "gateway"},
 		{Key: "db.operation.name", Value: operationName},
 		{Key: "server.address", Value: endpoint.Hostname()},
-		{Key: "server.port", Value: endpoint.Port()},
 	}}
+
+	if endpoint.Port() != "443" {
+		options.Attributes = append(options.Attributes, tracing.Attribute{Key: "server.port", Value: endpoint.Port()})
+	}
+
+	return options
 }
 
 func getSpanPropertiesForDatabase(endpoint *url.URL, operationName string, id string) runtime.StartSpanOptions {
-	return runtime.StartSpanOptions{Attributes: []tracing.Attribute{
+	options := runtime.StartSpanOptions{Attributes: []tracing.Attribute{
 		{Key: "db.system", Value: "cosmosdb"},
 		{Key: "db.cosmosdb.connection_mode", Value: "gateway"},
 		{Key: "db.namespace", Value: id},
 		{Key: "db.operation.name", Value: operationName},
 		{Key: "server.address", Value: endpoint.Hostname()},
-		{Key: "server.port", Value: endpoint.Port()},
 	}}
+
+	if endpoint.Port() != "443" {
+		options.Attributes = append(options.Attributes, tracing.Attribute{Key: "server.port", Value: endpoint.Port()})
+	}
+
+	return options
 }
 
 func getSpanPropertiesForContainer(endpoint *url.URL, operationName string, database string, id string) runtime.StartSpanOptions {
-	return runtime.StartSpanOptions{Attributes: []tracing.Attribute{
+	options := runtime.StartSpanOptions{Attributes: []tracing.Attribute{
 		{Key: "db.system", Value: "cosmosdb"},
 		{Key: "db.cosmosdb.connection_mode", Value: "gateway"},
 		{Key: "db.namespace", Value: database},
 		{Key: "db.collection.name", Value: id},
 		{Key: "db.operation.name", Value: operationName},
 		{Key: "server.address", Value: endpoint.Hostname()},
-		{Key: "server.port", Value: endpoint.Port()},
 	}}
+
+	if endpoint.Port() != "443" {
+		options.Attributes = append(options.Attributes, tracing.Attribute{Key: "server.port", Value: endpoint.Port()})
+	}
+
+	return options
 }

--- a/sdk/data/azcosmos/otel_constants.go
+++ b/sdk/data/azcosmos/otel_constants.go
@@ -9,14 +9,14 @@ const (
 	otelSpanNameCreateDatabase              = "create_database %s"
 	otelSpanNameReadDatabase                = "read_database %s"
 	otelSpanNameDeleteDatabase              = "delete_database %s"
-	otelSpanNameQueryDatabases              = "query_databases"
+	otelSpanNameQueryDatabases              = "query_databases %s"
 	otelSpanNameReadThroughputDatabase      = "read_database_throughput %s"
 	otelSpanNameReplaceThroughputDatabase   = "replace_database_throughput %s"
 	otelSpanNameCreateContainer             = "create_container %s"
 	otelSpanNameReadContainer               = "read_container %s"
 	otelSpanNameDeleteContainer             = "delete_container %s"
 	otelSpanNameReplaceContainer            = "replace_container %s"
-	otelSpanNameQueryContainers             = "query_containers"
+	otelSpanNameQueryContainers             = "query_containers %s"
 	otelSpanNameReadThroughputContainer     = "read_container_throughput %s"
 	otelSpanNameReaplaceThroughputContainer = "replace_container_throughput %s"
 	otelSpanNameExecuteBatch                = "execute_batch %s"
@@ -40,7 +40,7 @@ func getSpanNameForDatabases(operationType operationType, resourceType resourceT
 		case operationTypeDelete:
 			return fmt.Sprintf(otelSpanNameDeleteDatabase, id), nil
 		case operationTypeQuery:
-			return otelSpanNameQueryDatabases, nil
+			return fmt.Sprintf(otelSpanNameQueryDatabases, id), nil
 		}
 	case resourceTypeOffer:
 		switch operationType {
@@ -66,7 +66,7 @@ func getSpanNameForContainers(operationType operationType, resourceType resource
 		case operationTypeReplace:
 			return fmt.Sprintf(otelSpanNameReplaceContainer, id), nil
 		case operationTypeQuery:
-			return otelSpanNameQueryContainers, nil
+			return fmt.Sprintf(otelSpanNameQueryContainers, id), nil
 		case operationTypeBatch:
 			return fmt.Sprintf(otelSpanNameExecuteBatch, id), nil
 		}

--- a/sdk/data/azcosmos/otel_constants.go
+++ b/sdk/data/azcosmos/otel_constants.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 )
 
@@ -35,8 +36,8 @@ const (
 )
 
 type span struct {
-	name       string
-	attributes []tracing.Attribute
+	name    string
+	options runtime.StartSpanOptions
 }
 
 func getSpanNameForClient(endpoint *url.URL, operationType operationType, resourceType resourceType, id string) (span, error) {
@@ -53,7 +54,7 @@ func getSpanNameForClient(endpoint *url.URL, operationType operationType, resour
 		return span{}, fmt.Errorf("undefined telemetry span for operationType %v and resourceType %v", operationType, resourceType)
 	}
 
-	return span{name: fmt.Sprintf("%s %s", spanName, id), attributes: getSpanPropertiesForClient(endpoint, spanName)}, nil
+	return span{name: fmt.Sprintf("%s %s", spanName, id), options: getSpanPropertiesForClient(endpoint, spanName)}, nil
 }
 
 func getSpanNameForDatabases(endpoint *url.URL, operationType operationType, resourceType resourceType, id string) (span, error) {
@@ -86,7 +87,7 @@ func getSpanNameForDatabases(endpoint *url.URL, operationType operationType, res
 		return span{}, fmt.Errorf("undefined telemetry span for operationType %v and resourceType %v", operationType, resourceType)
 	}
 
-	return span{name: fmt.Sprintf("%s %s", spanName, id), attributes: getSpanPropertiesForDatabase(endpoint, spanName, id)}, nil
+	return span{name: fmt.Sprintf("%s %s", spanName, id), options: getSpanPropertiesForDatabase(endpoint, spanName, id)}, nil
 }
 
 func getSpanNameForContainers(endpoint *url.URL, operationType operationType, resourceType resourceType, database string, id string) (span, error) {
@@ -118,7 +119,7 @@ func getSpanNameForContainers(endpoint *url.URL, operationType operationType, re
 		return span{}, fmt.Errorf("undefined telemetry span for operationType %v and resourceType %v", operationType, resourceType)
 	}
 
-	return span{name: fmt.Sprintf("%s %s", spanName, id), attributes: getSpanPropertiesForContainer(endpoint, spanName, database, id)}, nil
+	return span{name: fmt.Sprintf("%s %s", spanName, id), options: getSpanPropertiesForContainer(endpoint, spanName, database, id)}, nil
 }
 
 func getSpanNameForItems(endpoint *url.URL, operationType operationType, database string, id string) (span, error) {
@@ -144,32 +145,32 @@ func getSpanNameForItems(endpoint *url.URL, operationType operationType, databas
 		return span{}, fmt.Errorf("undefined telemetry span for operationType %v and resourceType %v", operationType, resourceTypeDocument)
 	}
 
-	return span{name: fmt.Sprintf("%s %s", spanName, id), attributes: getSpanPropertiesForContainer(endpoint, spanName, database, id)}, nil
+	return span{name: fmt.Sprintf("%s %s", spanName, id), options: getSpanPropertiesForContainer(endpoint, spanName, database, id)}, nil
 }
 
-func getSpanPropertiesForClient(endpoint *url.URL, operationName string) []tracing.Attribute {
-	return []tracing.Attribute{
+func getSpanPropertiesForClient(endpoint *url.URL, operationName string) runtime.StartSpanOptions {
+	return runtime.StartSpanOptions{Attributes: []tracing.Attribute{
 		{Key: "db.system", Value: "cosmosdb"},
 		{Key: "db.cosmosdb.connection_mode", Value: "gateway"},
 		{Key: "db.operation.name", Value: operationName},
 		{Key: "server.address", Value: endpoint.Hostname()},
 		{Key: "server.port", Value: endpoint.Port()},
-	}
+	}}
 }
 
-func getSpanPropertiesForDatabase(endpoint *url.URL, operationName string, id string) []tracing.Attribute {
-	return []tracing.Attribute{
+func getSpanPropertiesForDatabase(endpoint *url.URL, operationName string, id string) runtime.StartSpanOptions {
+	return runtime.StartSpanOptions{Attributes: []tracing.Attribute{
 		{Key: "db.system", Value: "cosmosdb"},
 		{Key: "db.cosmosdb.connection_mode", Value: "gateway"},
 		{Key: "db.namespace", Value: id},
 		{Key: "db.operation.name", Value: operationName},
 		{Key: "server.address", Value: endpoint.Hostname()},
 		{Key: "server.port", Value: endpoint.Port()},
-	}
+	}}
 }
 
-func getSpanPropertiesForContainer(endpoint *url.URL, operationName string, database string, id string) []tracing.Attribute {
-	return []tracing.Attribute{
+func getSpanPropertiesForContainer(endpoint *url.URL, operationName string, database string, id string) runtime.StartSpanOptions {
+	return runtime.StartSpanOptions{Attributes: []tracing.Attribute{
 		{Key: "db.system", Value: "cosmosdb"},
 		{Key: "db.cosmosdb.connection_mode", Value: "gateway"},
 		{Key: "db.namespace", Value: database},
@@ -177,5 +178,5 @@ func getSpanPropertiesForContainer(endpoint *url.URL, operationName string, data
 		{Key: "db.operation.name", Value: operationName},
 		{Key: "server.address", Value: endpoint.Hostname()},
 		{Key: "server.port", Value: endpoint.Port()},
-	}
+	}}
 }

--- a/sdk/data/azcosmos/otel_constants.go
+++ b/sdk/data/azcosmos/otel_constants.go
@@ -42,14 +42,9 @@ type span struct {
 
 func getSpanNameForClient(endpoint *url.URL, operationType operationType, resourceType resourceType, id string) (span, error) {
 	var spanName string
-	switch resourceType {
-	case resourceTypeDatabase:
-		switch operationType {
-		case operationTypeQuery:
-			spanName = otelSpanNameQueryDatabases
-		}
+	if resourceType == resourceTypeDatabase && operationType == operationTypeQuery {
+		spanName = otelSpanNameQueryDatabases
 	}
-
 	if spanName == "" {
 		return span{}, fmt.Errorf("undefined telemetry span for operationType %v and resourceType %v", operationType, resourceType)
 	}
@@ -70,8 +65,7 @@ func getSpanNameForDatabases(endpoint *url.URL, operationType operationType, res
 			spanName = otelSpanNameDeleteDatabase
 		}
 	case resourceTypeCollection:
-		switch operationType {
-		case operationTypeQuery:
+		if operationType == operationTypeQuery {
 			spanName = otelSpanNameQueryContainers
 		}
 	case resourceTypeOffer:
@@ -174,7 +168,7 @@ func getSpanPropertiesForContainer(endpoint *url.URL, operationName string, data
 		{Key: "db.system", Value: "cosmosdb"},
 		{Key: "db.cosmosdb.connection_mode", Value: "gateway"},
 		{Key: "db.namespace", Value: database},
-		{Key: "db.collection.name", Value: database},
+		{Key: "db.collection.name", Value: id},
 		{Key: "db.operation.name", Value: operationName},
 		{Key: "server.address", Value: endpoint.Hostname()},
 		{Key: "server.port", Value: endpoint.Port()},

--- a/sdk/data/azcosmos/otel_constants.go
+++ b/sdk/data/azcosmos/otel_constants.go
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import "fmt"
+
+const (
+	otelSpanNameCreateDatabase              = "create_database %s"
+	otelSpanNameReadDatabase                = "read_database %s"
+	otelSpanNameDeleteDatabase              = "delete_database %s"
+	otelSpanNameQueryDatabases              = "query_databases"
+	otelSpanNameReadThroughputDatabase      = "read_database_throughput %s"
+	otelSpanNameReplaceThroughputDatabase   = "replace_database_throughput %s"
+	otelSpanNameCreateContainer             = "create_container %s"
+	otelSpanNameReadContainer               = "read_container %s"
+	otelSpanNameDeleteContainer             = "delete_container %s"
+	otelSpanNameReplaceContainer            = "replace_container %s"
+	otelSpanNameQueryContainers             = "query_containers"
+	otelSpanNameReadThroughputContainer     = "read_container_throughput %s"
+	otelSpanNameReaplaceThroughputContainer = "replace_container_throughput %s"
+	otelSpanNameExecuteBatch                = "execute_batch %s"
+	otelSpanNameCreateItem                  = "create_item %s"
+	otelSpanNameReadItem                    = "read_item %s"
+	otelSpanNameDeleteItem                  = "delete_item %s"
+	otelSpanNameReplaceItem                 = "replace_item %s"
+	otelSpanNameUpsertItem                  = "upsert_item %s"
+	otelSpanNamePatchItem                   = "patch_item %s"
+	otelSpanNameQueryItems                  = "query_items %s"
+)
+
+func getSpanNameForDatabases(operationType operationType, resourceType resourceType, id string) (string, error) {
+	switch resourceType {
+	case resourceTypeDatabase:
+		switch operationType {
+		case operationTypeCreate:
+			return fmt.Sprintf(otelSpanNameCreateDatabase, id), nil
+		case operationTypeRead:
+			return fmt.Sprintf(otelSpanNameReadDatabase, id), nil
+		case operationTypeDelete:
+			return fmt.Sprintf(otelSpanNameDeleteDatabase, id), nil
+		case operationTypeQuery:
+			return otelSpanNameQueryDatabases, nil
+		}
+	case resourceTypeOffer:
+		switch operationType {
+		case operationTypeRead:
+			return fmt.Sprintf(otelSpanNameReadThroughputDatabase, id), nil
+		case operationTypeReplace:
+			return fmt.Sprintf(otelSpanNameReplaceThroughputDatabase, id), nil
+		}
+	}
+	return "", fmt.Errorf("undefined telemetry span for operationType %v and resourceType %v", operationType, resourceType)
+}
+
+func getSpanNameForContainers(operationType operationType, resourceType resourceType, id string) (string, error) {
+	switch resourceType {
+	case resourceTypeCollection:
+		switch operationType {
+		case operationTypeCreate:
+			return fmt.Sprintf(otelSpanNameCreateContainer, id), nil
+		case operationTypeRead:
+			return fmt.Sprintf(otelSpanNameReadContainer, id), nil
+		case operationTypeDelete:
+			return fmt.Sprintf(otelSpanNameDeleteContainer, id), nil
+		case operationTypeReplace:
+			return fmt.Sprintf(otelSpanNameReplaceContainer, id), nil
+		case operationTypeQuery:
+			return otelSpanNameQueryContainers, nil
+		case operationTypeBatch:
+			return fmt.Sprintf(otelSpanNameExecuteBatch, id), nil
+		}
+	case resourceTypeOffer:
+		switch operationType {
+		case operationTypeRead:
+			return fmt.Sprintf(otelSpanNameReadThroughputContainer, id), nil
+		case operationTypeReplace:
+			return fmt.Sprintf(otelSpanNameReaplaceThroughputContainer, id), nil
+		}
+	}
+	return "", fmt.Errorf("undefined telemetry span for operationType %v and resourceType %v", operationType, resourceType)
+}
+
+func getSpanNameForItems(operationType operationType, id string) (string, error) {
+	switch operationType {
+	case operationTypeCreate:
+		return fmt.Sprintf(otelSpanNameCreateItem, id), nil
+	case operationTypeRead:
+		return fmt.Sprintf(otelSpanNameReadItem, id), nil
+	case operationTypeDelete:
+		return fmt.Sprintf(otelSpanNameDeleteItem, id), nil
+	case operationTypeReplace:
+		return fmt.Sprintf(otelSpanNameReplaceItem, id), nil
+	case operationTypeUpsert:
+		return fmt.Sprintf(otelSpanNameUpsertItem, id), nil
+	case operationTypePatch:
+		return fmt.Sprintf(otelSpanNamePatchItem, id), nil
+	case operationTypeQuery:
+		return fmt.Sprintf(otelSpanNameQueryItems, id), nil
+	}
+	return "", fmt.Errorf("undefined telemetry span for operationType %v and resourceType %v", operationType, resourceTypeDocument)
+}

--- a/sdk/data/azcosmos/otel_constants_test.go
+++ b/sdk/data/azcosmos/otel_constants_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestSpanForClient(t *testing.T) {
+	endpoint, _ := url.Parse("https://localhost:8081/")
+	aSpan, err := getSpanNameForClient(endpoint, operationTypeQuery, resourceTypeDatabase, "test")
+	if err != nil {
+		t.Fatalf("Failed to get span name: %v", err)
+	}
+	if aSpan.name != "query_databases test" {
+		t.Fatalf("Expected span name to be 'query_databases test', but got %s", aSpan.name)
+	}
+	if len(aSpan.options.Attributes) == 0 {
+		t.Fatalf("Expected span options to have attributes, but got none")
+	}
+}

--- a/sdk/data/azcosmos/otel_constants_test.go
+++ b/sdk/data/azcosmos/otel_constants_test.go
@@ -5,7 +5,10 @@ package azcosmos
 
 import (
 	"net/url"
+	"slices"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 )
 
 func TestSpanForClient(t *testing.T) {
@@ -19,5 +22,138 @@ func TestSpanForClient(t *testing.T) {
 	}
 	if len(aSpan.options.Attributes) == 0 {
 		t.Fatalf("Expected span options to have attributes, but got none")
+	}
+
+	idx := slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.system" && a.Value == "cosmosdb" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.system' with value 'cosmosdb', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.cosmosdb.connection_mode" && a.Value == "gateway" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.cosmosdb.connection_mode' with value 'gateway', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "server.address" && a.Value == "localhost" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'server.address' with value 'localhost', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "server.port" && a.Value == "8081" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'server.port' with value '8081', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.operation.name" && a.Value == "query_databases" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.operation.name' with value 'query_databases', but got none")
+	}
+
+	aSpan, err = getSpanNameForClient(endpoint, operationTypeCreate, resourceTypeDatabase, "test")
+	if err == nil {
+		t.Fatalf("Expected error, but got none")
+	}
+}
+
+func TestSpanForDatabases(t *testing.T) {
+	endpoint, _ := url.Parse("https://localhost:8081/")
+	aSpan, err := getSpanNameForDatabases(endpoint, operationTypeCreate, resourceTypeDatabase, "test")
+	if err != nil {
+		t.Fatalf("Failed to get span name: %v", err)
+	}
+	if aSpan.name != "create_database test" {
+		t.Fatalf("Expected span name to be 'create_database test', but got %s", aSpan.name)
+	}
+	if len(aSpan.options.Attributes) == 0 {
+		t.Fatalf("Expected span options to have attributes, but got none")
+	}
+
+	idx := slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.system" && a.Value == "cosmosdb" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.system' with value 'cosmosdb', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.cosmosdb.connection_mode" && a.Value == "gateway" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.cosmosdb.connection_mode' with value 'gateway', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "server.address" && a.Value == "localhost" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'server.address' with value 'localhost', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "server.port" && a.Value == "8081" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'server.port' with value '8081', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.operation.name" && a.Value == "create_database" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.operation.name' with value 'create_database', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.namespace" && a.Value == "test" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.namespace' with value 'test', but got none")
+	}
+
+	aSpan, err = getSpanNameForDatabases(endpoint, operationTypeCreate, resourceTypeCollection, "test")
+	if err == nil {
+		t.Fatalf("Expected error, but got none")
+	}
+}
+
+func TestSpanForContainers(t *testing.T) {
+	endpoint, _ := url.Parse("https://localhost:8081/")
+	aSpan, err := getSpanNameForContainers(endpoint, operationTypeCreate, resourceTypeCollection, "db", "test")
+	if err != nil {
+		t.Fatalf("Failed to get span name: %v", err)
+	}
+	if aSpan.name != "create_container test" {
+		t.Fatalf("Expected span name to be 'create_container test', but got %s", aSpan.name)
+	}
+	if len(aSpan.options.Attributes) == 0 {
+		t.Fatalf("Expected span options to have attributes, but got none")
+	}
+
+	idx := slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.system" && a.Value == "cosmosdb" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.system' with value 'cosmosdb', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.cosmosdb.connection_mode" && a.Value == "gateway" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.cosmosdb.connection_mode' with value 'gateway', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "server.address" && a.Value == "localhost" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'server.address' with value 'localhost', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "server.port" && a.Value == "8081" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'server.port' with value '8081', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.operation.name" && a.Value == "create_container" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.operation.name' with value 'create_container', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.namespace" && a.Value == "db" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.namespace' with value 'db', but got none")
+	}
+
+	idx = slices.IndexFunc(aSpan.options.Attributes, func(a tracing.Attribute) bool { return a.Key == "db.collection.name" && a.Value == "test" })
+	if idx == -1 {
+		t.Fatalf("Expected attribute 'db.collection.name' with value 'test', but got none")
+	}
+
+	aSpan, err = getSpanNameForContainers(endpoint, operationTypeCreate, resourceTypeDatabase, "db", "test")
+	if err == nil {
+		t.Fatalf("Expected error, but got none")
 	}
 }

--- a/sdk/data/azcosmos/tracing_test.go
+++ b/sdk/data/azcosmos/tracing_test.go
@@ -26,8 +26,8 @@ func newSpanValidator(t *testing.T, matcher spanMatcher) tracing.Provider {
 					if match.name == expectedSpan {
 						found = true
 						require.True(t, match.ended, "span %s wasn't ended", match.name)
-						break;
-					}	
+						break
+					}
 				}
 				require.True(t, found, "span %s wasn't found", expectedSpan)
 			}

--- a/sdk/data/azcosmos/tracing_test.go
+++ b/sdk/data/azcosmos/tracing_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
+	"github.com/stretchr/testify/require"
+)
+
+// NewSpanValidator creates a tracing.Provider that verifies a span was created that matches the specified SpanMatcher.
+func NewSpanValidator(t *testing.T, matcher SpanMatcher) tracing.Provider {
+	return tracing.NewProvider(func(name, version string) tracing.Tracer {
+		tt := matchingTracer{
+			matcher: matcher,
+		}
+
+		t.Cleanup(func() {
+			require.NotNil(t, tt.match, "didn't find a span with name %s", tt.matcher.Name)
+			require.True(t, tt.match.ended, "span wasn't ended")
+			require.EqualValues(t, matcher.Status, tt.match.status, "span status values don't match")
+		})
+
+		return tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {
+			kind := tracing.SpanKindInternal
+			if options != nil {
+				kind = options.Kind
+			}
+			return tt.Start(ctx, spanName, kind)
+		}, nil)
+	}, nil)
+}
+
+// SpanMatcher contains the values to match when a span is created.
+type SpanMatcher struct {
+	Name   string
+	Status tracing.SpanStatus
+}
+
+type matchingTracer struct {
+	matcher SpanMatcher
+	match   *span
+}
+
+func (mt *matchingTracer) Start(ctx context.Context, spanName string, kind tracing.SpanKind) (context.Context, tracing.Span) {
+	if spanName != mt.matcher.Name {
+		return ctx, tracing.Span{}
+	}
+	// span name matches our matcher, track it
+	mt.match = &span{
+		name: spanName,
+	}
+	return ctx, tracing.NewSpan(tracing.SpanImpl{
+		End:       mt.match.End,
+		SetStatus: mt.match.SetStatus,
+	})
+}
+
+type span struct {
+	name   string
+	status tracing.SpanStatus
+	desc   string
+	ended  bool
+}
+
+func (s *span) End() {
+	s.ended = true
+}
+
+func (s *span) SetStatus(code tracing.SpanStatus, desc string) {
+	s.status = code
+	s.desc = desc
+	s.ended = true
+}

--- a/sdk/data/azcosmos/tracing_test.go
+++ b/sdk/data/azcosmos/tracing_test.go
@@ -26,6 +26,7 @@ func newSpanValidator(t *testing.T, matcher spanMatcher) tracing.Provider {
 					if match.name == expectedSpan {
 						found = true
 						require.True(t, match.ended, "span %s wasn't ended", match.name)
+						break;
 					}	
 				}
 				require.True(t, found, "span %s wasn't found", expectedSpan)

--- a/sdk/data/azcosmos/tracing_test.go
+++ b/sdk/data/azcosmos/tracing_test.go
@@ -6,6 +6,7 @@ package azcosmos
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
@@ -55,7 +56,7 @@ type matchingTracer struct {
 
 func (mt *matchingTracer) Start(ctx context.Context, spanName string, kind tracing.SpanKind) (context.Context, tracing.Span) {
 
-	if slices.IndexFunc(mt.matcher.ExpectedSpans, func(i string) bool { return i == spanName }) < 0 {
+	if slices.IndexFunc(mt.matcher.ExpectedSpans, func(i string) bool { return i == spanName }) < 0 && !strings.Contains(spanName, "NextPage") {
 		return ctx, tracing.Span{}
 	}
 	// span name matches our matcher, track it

--- a/sdk/data/azcosmos/tracing_test.go
+++ b/sdk/data/azcosmos/tracing_test.go
@@ -51,7 +51,7 @@ type spanMatcher struct {
 
 type matchingTracer struct {
 	matcher spanMatcher
-	matches []*span
+	matches []*matchingSpan
 }
 
 func (mt *matchingTracer) Start(ctx context.Context, spanName string, kind tracing.SpanKind) (context.Context, tracing.Span) {
@@ -60,7 +60,7 @@ func (mt *matchingTracer) Start(ctx context.Context, spanName string, kind traci
 		return ctx, tracing.Span{}
 	}
 	// span name matches our matcher, track it
-	newSpan := &span{
+	newSpan := &matchingSpan{
 		name: spanName,
 	}
 	mt.matches = append(mt.matches, newSpan)
@@ -70,18 +70,18 @@ func (mt *matchingTracer) Start(ctx context.Context, spanName string, kind traci
 	})
 }
 
-type span struct {
+type matchingSpan struct {
 	name   string
 	status tracing.SpanStatus
 	desc   string
 	ended  bool
 }
 
-func (s *span) End() {
+func (s *matchingSpan) End() {
 	s.ended = true
 }
 
-func (s *span) SetStatus(code tracing.SpanStatus, desc string) {
+func (s *matchingSpan) SetStatus(code tracing.SpanStatus, desc string) {
 	s.status = code
 	s.desc = desc
 	s.ended = true

--- a/sdk/data/azcosmos/version.go
+++ b/sdk/data/azcosmos/version.go
@@ -3,5 +3,9 @@
 
 package azcosmos
 
-// serviceLibVersion is the semantic version (see http://semver.org) of this module.
-const serviceLibVersion = "v1.0.4"
+const (
+	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	// serviceLibVersion is the semantic version (see http://semver.org) of this module.
+	serviceLibVersion = "v1.0.4"
+)


### PR DESCRIPTION
This PR modifies `Client` to have the internal `azcore.Client` embedded to leverage the Pipeline and Trace.

All the methods (except Pagers because they internally already do it) that execute an async operation will now start a Span respectively.

Added a helper SpanValidator to be used in tests to validate that the expected Spans are generated.

## Properties

Reference: https://github.com/open-telemetry/semantic-conventions/blob/v1.27.0/docs/database/cosmosdb.md

* The code defines the `TracingOptions` to set `az.namespace` to `Microsoft.DocumentDB`
* `db.system` = `cosmosdb`
* `db.cosmosdb.connection_mode` = `gateway`
* `db.namespace` (when applicable) = datbase id
* `db.collection.name` (when applicable) = container id
* `db.operation.name` = span name (for example `create_container`)
* `server.address` and `server.port` = based on the endpoint (for example `myaccount.documents.azure.com`, `server.port` is added only if it's different than 443)

## Span names

Covers the list in 

https://github.com/Azure/azure-sdk-for-go/blob/29ab5117d5e5a878f37d89ff27eb5b808a137dbc/sdk/data/azcosmos/otel_constants.go#L15-L35

Closes #23185