### PR TITLE
azcontainerregistry: move method to function

### DIFF
--- a/sdk/containers/azcontainerregistry/authentication_policy.go
+++ b/sdk/containers/azcontainerregistry/authentication_policy.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/temporal"
 )
 
@@ -77,7 +77,7 @@ func (p *authenticationPolicy) Do(req *policy.Request) (*http.Response, error) {
 	} else {
 		// do challenge process for the initial request
 		var challengeReq *policy.Request
-		challengeReq, err = p.getChallengeRequest(*req)
+		challengeReq, err = getChallengeRequest(*req)
 		if err != nil {
 			return nil, err
 		}
@@ -167,7 +167,7 @@ func findServiceAndScope(resp *http.Response) (string, string, error) {
 	return valuesMap["service"], valuesMap["scope"], nil
 }
 
-func (p authenticationPolicy) getChallengeRequest(oriReq policy.Request) (*policy.Request, error) {
+func getChallengeRequest(oriReq policy.Request) (*policy.Request, error) {
 	copied := oriReq.Clone(oriReq.Raw().Context())
 	err := copied.SetBody(nil, "")
 	if err != nil {

--- a/sdk/containers/azcontainerregistry/authentication_policy_test.go
+++ b/sdk/containers/azcontainerregistry/authentication_policy_test.go
@@ -217,14 +217,13 @@ func Test_authenticationPolicy_anonymousAccess(t *testing.T) {
 	require.Error(t, err)
 }
 
-func Test_authenticationPolicy_getChallengeRequest(t *testing.T) {
+func Test_getChallengeRequest(t *testing.T) {
 	oriReq, err := runtime.NewRequest(context.Background(), http.MethodPost, "https://test.com")
 	require.NoError(t, err)
 	testBody := []byte("test")
 	err = oriReq.SetBody(streaming.NopCloser(bytes.NewReader(testBody)), "text/plain")
 	require.NoError(t, err)
-	p := &authenticationPolicy{}
-	challengeReq, err := p.getChallengeRequest(*oriReq)
+	challengeReq, err := getChallengeRequest(*oriReq)
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%d", len(testBody)), oriReq.Raw().Header.Get("Content-Length"))
 	require.Equal(t, "", challengeReq.Raw().Header.Get("Content-Length"))


### PR DESCRIPTION
The Go documentation strongly discourages structs from having methods with both pointer recievers and non-pointer recievers. For the auth policy, `getChallengeRequest` presumably did not have a pointer reciever since it did not make use of the struct at all. We can simply move this to a function.

