### PR TITLE
azcontainerregistry: delegate token caching

### DIFF
--- a/sdk/containers/azcontainerregistry/authentication_policy.go
+++ b/sdk/containers/azcontainerregistry/authentication_policy.go
@@ -7,18 +7,13 @@
 package azcontainerregistry
 
 import (
-	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 )
 
 const (
@@ -106,39 +101,6 @@ func (p *authenticationPolicy) Do(req *policy.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-func (c *authenticationTokenCache) AcquireAccessToken(ctx context.Context, service, scope string) (string, error) {
-	// anonymous access
-	if c.cred == nil {
-		resp, err := c.authClient.ExchangeACRRefreshTokenForACRAccessToken(ctx, service, scope, "", &authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions{GrantType: to.Ptr(tokenGrantTypePassword)})
-		if err != nil {
-			return "", err
-		}
-		c.accessTokenCache.Store(*resp.acrAccessToken.AccessToken)
-		return *resp.acrAccessToken.AccessToken, nil
-	}
-
-	// access with token
-	// get refresh token from cache/request
-	refreshToken, err := c.refreshTokenCache.Get(acquiringResourceState{
-		ctx:           ctx,
-		aadCredential: c.cred,
-		aadScopes:     c.aadScopes,
-		authClient:    c.authClient,
-		service:       service,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	// get access token from request
-	resp, err := c.authClient.ExchangeACRRefreshTokenForACRAccessToken(ctx, service, scope, refreshToken.Token, &authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions{GrantType: to.Ptr(tokenGrantTypeRefreshToken)})
-	if err != nil {
-		return "", err
-	}
-	c.accessTokenCache.Store(*resp.acrAccessToken.AccessToken)
-	return *resp.acrAccessToken.AccessToken, nil
-}
-
 func findServiceAndScope(resp *http.Response) (string, string, error) {
 	authHeader := resp.Header.Get("WWW-Authenticate")
 	if authHeader == "" {
@@ -174,79 +136,4 @@ func getChallengeRequest(oriReq policy.Request) (*policy.Request, error) {
 	}
 	copied.Raw().Header.Del("Content-Type")
 	return copied, nil
-}
-
-type acquiringResourceState struct {
-	ctx context.Context
-
-	aadCredential azcore.TokenCredential
-	aadScopes     []string
-
-	authClient *authenticationClient
-	service    string
-}
-
-// acquireRefreshToken acquires or updates the refresh token of ACR service; only one thread/goroutine at a time ever calls this function
-func acquireRefreshToken(state acquiringResourceState) (newResource azcore.AccessToken, newExpiration time.Time, err error) {
-	// get AAD token from credential
-	aadToken, err := state.aadCredential.GetToken(
-		state.ctx,
-		policy.TokenRequestOptions{
-			Scopes: state.aadScopes,
-		},
-	)
-	if err != nil {
-		return azcore.AccessToken{}, time.Time{}, err
-	}
-
-	// exchange refresh token with AAD token
-	refreshResp, err := state.authClient.ExchangeAADAccessTokenForACRRefreshToken(state.ctx, postContentSchemaGrantTypeAccessToken, state.service, &authenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions{
-		AccessToken: &aadToken.Token,
-	})
-	if err != nil {
-		return azcore.AccessToken{}, time.Time{}, err
-	}
-
-	refreshToken := azcore.AccessToken{
-		Token: *refreshResp.acrRefreshToken.RefreshToken,
-	}
-
-	// get refresh token expire time
-	refreshToken.ExpiresOn, err = getJWTExpireTime(*refreshResp.acrRefreshToken.RefreshToken)
-	if err != nil {
-		return azcore.AccessToken{}, time.Time{}, err
-	}
-
-	// return refresh token
-	return refreshToken, refreshToken.ExpiresOn, nil
-}
-
-func getJWTExpireTime(token string) (time.Time, error) {
-	values := strings.Split(token, ".")
-	if len(values) > 2 {
-		value := values[1]
-		padding := len(value) % 4
-		if padding > 0 {
-			for i := 0; i < 4-padding; i++ {
-				value += "="
-			}
-		}
-		parsedValue, err := base64.StdEncoding.DecodeString(value)
-		if err != nil {
-			return time.Time{}, err
-		}
-
-		var jsonValue *jwtOnlyWithExp
-		err = json.Unmarshal(parsedValue, &jsonValue)
-		if err != nil {
-			return time.Time{}, err
-		}
-		return time.Unix(jsonValue.Exp, 0), nil
-	}
-
-	return time.Time{}, errors.New("could not parse refresh token expire time")
-}
-
-type jwtOnlyWithExp struct {
-	Exp int64 `json:"exp"`
 }

--- a/sdk/containers/azcontainerregistry/authentication_policy_test.go
+++ b/sdk/containers/azcontainerregistry/authentication_policy_test.go
@@ -144,7 +144,7 @@ func Test_authenticationPolicy_getAccessToken_live(t *testing.T) {
 	}
 	request, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://test.com")
 	require.NoError(t, err)
-	token, err := p.getAccessToken(request, strings.TrimPrefix(endpoint, "https://"), "registry:catalog:*")
+	token, err := p.getAccessToken(request.Raw().Context(), strings.TrimPrefix(endpoint, "https://"), "registry:catalog:*")
 	require.NoError(t, err)
 	require.NotEmpty(t, token)
 }
@@ -169,14 +169,14 @@ func Test_authenticationPolicy_getAccessToken_error(t *testing.T) {
 	}
 	request, err := runtime.NewRequest(context.Background(), http.MethodGet, srv.URL())
 	require.NoError(t, err)
-	_, err = p.getAccessToken(request, "service", "scope")
+	_, err = p.getAccessToken(request.Raw().Context(), "service", "scope")
 	require.Error(t, err)
-	_, err = p.getAccessToken(request, "service", "scope")
+	_, err = p.getAccessToken(request.Raw().Context(), "service", "scope")
 	require.Error(t, err)
-	_, err = p.getAccessToken(request, "service", "scope")
+	_, err = p.getAccessToken(request.Raw().Context(), "service", "scope")
 	require.Error(t, err)
 	p.cred = nil
-	_, err = p.getAccessToken(request, "service", "scope")
+	_, err = p.getAccessToken(request.Raw().Context(), "service", "scope")
 	require.Error(t, err)
 }
 
@@ -191,7 +191,7 @@ func Test_authenticationPolicy_getAccessToken_live_anonymous(t *testing.T) {
 	}
 	request, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://test.com")
 	require.NoError(t, err)
-	token, err := p.getAccessToken(request, strings.TrimPrefix(endpoint, "https://"), "registry:catalog:*")
+	token, err := p.getAccessToken(request.Raw().Context(), strings.TrimPrefix(endpoint, "https://"), "registry:catalog:*")
 	require.NoError(t, err)
 	require.NotEmpty(t, token)
 }

--- a/sdk/containers/azcontainerregistry/authentication_token_cache.go
+++ b/sdk/containers/azcontainerregistry/authentication_token_cache.go
@@ -1,0 +1,41 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azcontainerregistry
+
+import (
+	"sync/atomic"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/temporal"
+)
+
+type authenticationTokenCacheOptions struct{}
+
+type authenticationTokenCache struct {
+	refreshTokenCache *temporal.Resource[azcore.AccessToken, acquiringResourceState]
+	accessTokenCache  atomic.Value
+	cred              azcore.TokenCredential
+	aadScopes         []string
+	authClient        *authenticationClient
+}
+
+func newAuthenticationTokenCache(cred azcore.TokenCredential, scopes []string, authClient *authenticationClient, opts *authenticationTokenCacheOptions) *authenticationTokenCache {
+	return &authenticationTokenCache{
+		cred:              cred,
+		aadScopes:         scopes,
+		authClient:        authClient,
+		refreshTokenCache: temporal.NewResource(acquireRefreshToken),
+	}
+}
+
+func (c *authenticationTokenCache) Load() string {
+	value, ok := c.accessTokenCache.Load().(string)
+	if !ok {
+		return ""
+	}
+	return value
+}

--- a/sdk/containers/azcontainerregistry/authentication_token_cache.go
+++ b/sdk/containers/azcontainerregistry/authentication_token_cache.go
@@ -7,9 +7,17 @@
 package azcontainerregistry
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/temporal"
 )
 
@@ -38,4 +46,112 @@ func (c *authenticationTokenCache) Load() string {
 		return ""
 	}
 	return value
+}
+
+func (c *authenticationTokenCache) AcquireAccessToken(ctx context.Context, service, scope string) (string, error) {
+	// anonymous access
+	if c.cred == nil {
+		resp, err := c.authClient.ExchangeACRRefreshTokenForACRAccessToken(ctx, service, scope, "", &authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions{GrantType: to.Ptr(tokenGrantTypePassword)})
+		if err != nil {
+			return "", err
+		}
+		c.accessTokenCache.Store(*resp.acrAccessToken.AccessToken)
+		return *resp.acrAccessToken.AccessToken, nil
+	}
+
+	// access with token
+	// get refresh token from cache/request
+	refreshToken, err := c.refreshTokenCache.Get(acquiringResourceState{
+		ctx:           ctx,
+		aadCredential: c.cred,
+		aadScopes:     c.aadScopes,
+		authClient:    c.authClient,
+		service:       service,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// get access token from request
+	resp, err := c.authClient.ExchangeACRRefreshTokenForACRAccessToken(ctx, service, scope, refreshToken.Token, &authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions{GrantType: to.Ptr(tokenGrantTypeRefreshToken)})
+	if err != nil {
+		return "", err
+	}
+	c.accessTokenCache.Store(*resp.acrAccessToken.AccessToken)
+	return *resp.acrAccessToken.AccessToken, nil
+}
+
+type acquiringResourceState struct {
+	ctx context.Context
+
+	aadCredential azcore.TokenCredential
+	aadScopes     []string
+
+	authClient *authenticationClient
+	service    string
+}
+
+// acquireRefreshToken acquires or updates the refresh token of ACR service; only one thread/goroutine at a time ever calls this function
+func acquireRefreshToken(state acquiringResourceState) (newResource azcore.AccessToken, newExpiration time.Time, err error) {
+	// get AAD token from credential
+	aadToken, err := state.aadCredential.GetToken(
+		state.ctx,
+		policy.TokenRequestOptions{
+			Scopes: state.aadScopes,
+		},
+	)
+	if err != nil {
+		return azcore.AccessToken{}, time.Time{}, err
+	}
+
+	// exchange refresh token with AAD token
+	refreshResp, err := state.authClient.ExchangeAADAccessTokenForACRRefreshToken(state.ctx, postContentSchemaGrantTypeAccessToken, state.service, &authenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions{
+		AccessToken: &aadToken.Token,
+	})
+	if err != nil {
+		return azcore.AccessToken{}, time.Time{}, err
+	}
+
+	refreshToken := azcore.AccessToken{
+		Token: *refreshResp.acrRefreshToken.RefreshToken,
+	}
+
+	// get refresh token expire time
+	refreshToken.ExpiresOn, err = getJWTExpireTime(*refreshResp.acrRefreshToken.RefreshToken)
+	if err != nil {
+		return azcore.AccessToken{}, time.Time{}, err
+	}
+
+	// return refresh token
+	return refreshToken, refreshToken.ExpiresOn, nil
+}
+
+func getJWTExpireTime(token string) (time.Time, error) {
+	values := strings.Split(token, ".")
+	if len(values) > 2 {
+		value := values[1]
+		padding := len(value) % 4
+		if padding > 0 {
+			for i := 0; i < 4-padding; i++ {
+				value += "="
+			}
+		}
+		parsedValue, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return time.Time{}, err
+		}
+
+		var jsonValue *jwtOnlyWithExp
+		err = json.Unmarshal(parsedValue, &jsonValue)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return time.Unix(jsonValue.Exp, 0), nil
+	}
+
+	return time.Time{}, errors.New("could not parse refresh token expire time")
+}
+
+type jwtOnlyWithExp struct {
+	Exp int64 `json:"exp"`
 }


### PR DESCRIPTION
azcontainerregistry: decouple token exchange from request specifics

I would like to propose a generally-useful token cache in a future
commit. Managing the refresh tokens and exchanging them for access
tokens does not need to rely specifically on the authentication policy
or the specific client request being made, so this commit decouples the
two concerns, thereby enabling the future refactor to be simpler.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

azcontainerregistry: delegate token caching

Mechanically refactor token caching, retrieval and exchange behavior
from the authentication policy into a dedicated object, allowing us to
separate token management concerns from Azure client policy concerns.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

azcontainerregistry: move code

This commit simply moves code from one location to another, broken out
from other commits for ease of review.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Builds on top of #23270 

Proving out a separation of concerns that could solve https://github.com/Azure/azure-sdk-for-go/issues/20571
