### PR TITLE
DefaultAzureCredential continues after an unexpected IMDS response

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Bugs Fixed
 
 ### Other Changes
+* If `DefaultAzureCredential` receives a non-JSON response when probing IMDS before
+  attempting to authenticate a managed identity, it continues to the next credential
+  in the chain instead of immediately returning an error.
 
 ## 1.8.0-beta.1 (2024-07-17)
 


### PR DESCRIPTION
This should create a better experience for some apps using DefaultAzureCredential on networks hosting something other than IMDS on `169.254.169.254`. ManagedIdentityCredential behavior when used directly is unchanged.

Closes #23250