### PR TITLE
Add Attributes field to StartSpanOptions

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added field `Attributes` to `runtime.StartSpanOptions` to simplify creating spans with attributes.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/azcore/runtime/policy_http_trace.go
+++ b/sdk/azcore/runtime/policy_http_trace.go
@@ -96,7 +96,8 @@ func (h *httpTracePolicy) Do(req *policy.Request) (resp *http.Response, err erro
 
 // StartSpanOptions contains the optional values for StartSpan.
 type StartSpanOptions struct {
-	// for future expansion
+	// Attributes contains key-value pairs of attributes for the span.
+	Attributes []tracing.Attribute
 }
 
 // StartSpan starts a new tracing span.
@@ -126,8 +127,14 @@ func StartSpan(ctx context.Context, name string, tracer tracing.Tracer, options 
 			return ctx, func(err error) {}
 		}
 	}
+
+	if options == nil {
+		options = &StartSpanOptions{}
+	}
+
 	ctx, span := tracer.Start(ctx, name, &tracing.SpanOptions{
-		Kind: newSpanKind,
+		Kind:       newSpanKind,
+		Attributes: options.Attributes,
 	})
 	ctx = context.WithValue(ctx, ctxActiveSpan{}, newSpanKind)
 	return ctx, func(err error) {


### PR DESCRIPTION
This simplifies creating spans with preset span attributes.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
