### PR TITLE
azcontainerregistry: expose authentication client, options

### DIFF
--- a/sdk/containers/azcontainerregistry/.gitignore
+++ b/sdk/containers/azcontainerregistry/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+package.json
+node_modules

--- a/sdk/containers/azcontainerregistry/.gitignore
+++ b/sdk/containers/azcontainerregistry/.gitignore
@@ -1,3 +1,0 @@
-package-lock.json
-package.json
-node_modules

--- a/sdk/containers/azcontainerregistry/authentication_client.go
+++ b/sdk/containers/azcontainerregistry/authentication_client.go
@@ -19,9 +19,9 @@ import (
 	"strings"
 )
 
-// authenticationClient contains the methods for the Authentication group.
+// AuthenticationClient contains the methods for the Authentication group.
 // Don't use this type directly, use a constructor function instead.
-type authenticationClient struct {
+type AuthenticationClient struct {
 	internal *azcore.Client
 	endpoint string
 }
@@ -32,30 +32,30 @@ type authenticationClient struct {
 // Generated from API version 2021-07-01
 //   - grantType - Can take a value of accesstokenrefreshtoken, or accesstoken, or refresh_token
 //   - service - Indicates the name of your Azure container registry.
-//   - options - authenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions contains the optional parameters for the
-//     authenticationClient.ExchangeAADAccessTokenForACRRefreshToken method.
-func (client *authenticationClient) ExchangeAADAccessTokenForACRRefreshToken(ctx context.Context, grantType postContentSchemaGrantType, service string, options *authenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions) (authenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse, error) {
+//   - options - AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions contains the optional parameters for the
+//     AuthenticationClient.ExchangeAADAccessTokenForACRRefreshToken method.
+func (client *AuthenticationClient) ExchangeAADAccessTokenForACRRefreshToken(ctx context.Context, grantType PostContentSchemaGrantType, service string, options *AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions) (AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse, error) {
 	var err error
 	ctx, endSpan := runtime.StartSpan(ctx, "AuthenticationClient.ExchangeAADAccessTokenForACRRefreshToken", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.exchangeAADAccessTokenForACRRefreshTokenCreateRequest(ctx, grantType, service, options)
 	if err != nil {
-		return authenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}, err
+		return AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return authenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}, err
+		return AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return authenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}, err
+		return AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}, err
 	}
 	resp, err := client.exchangeAADAccessTokenForACRRefreshTokenHandleResponse(httpResp)
 	return resp, err
 }
 
 // exchangeAADAccessTokenForACRRefreshTokenCreateRequest creates the ExchangeAADAccessTokenForACRRefreshToken request.
-func (client *authenticationClient) exchangeAADAccessTokenForACRRefreshTokenCreateRequest(ctx context.Context, grantType postContentSchemaGrantType, service string, options *authenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions) (*policy.Request, error) {
+func (client *AuthenticationClient) exchangeAADAccessTokenForACRRefreshTokenCreateRequest(ctx context.Context, grantType PostContentSchemaGrantType, service string, options *AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions) (*policy.Request, error) {
 	urlPath := "/oauth2/exchange"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -85,10 +85,10 @@ func (client *authenticationClient) exchangeAADAccessTokenForACRRefreshTokenCrea
 }
 
 // exchangeAADAccessTokenForACRRefreshTokenHandleResponse handles the ExchangeAADAccessTokenForACRRefreshToken response.
-func (client *authenticationClient) exchangeAADAccessTokenForACRRefreshTokenHandleResponse(resp *http.Response) (authenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse, error) {
-	result := authenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.acrRefreshToken); err != nil {
-		return authenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}, err
+func (client *AuthenticationClient) exchangeAADAccessTokenForACRRefreshTokenHandleResponse(resp *http.Response) (AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse, error) {
+	result := AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.ACRRefreshToken); err != nil {
+		return AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse{}, err
 	}
 	return result, nil
 }
@@ -101,30 +101,30 @@ func (client *authenticationClient) exchangeAADAccessTokenForACRRefreshTokenHand
 //   - scope - Which is expected to be a valid scope, and can be specified more than once for multiple scope requests. You obtained
 //     this from the Www-Authenticate response header from the challenge.
 //   - refreshToken - Must be a valid ACR refresh token
-//   - options - authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions contains the optional parameters for the
-//     authenticationClient.ExchangeACRRefreshTokenForACRAccessToken method.
-func (client *authenticationClient) ExchangeACRRefreshTokenForACRAccessToken(ctx context.Context, service string, scope string, refreshToken string, options *authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions) (authenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse, error) {
+//   - options - AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions contains the optional parameters for the
+//     AuthenticationClient.ExchangeACRRefreshTokenForACRAccessToken method.
+func (client *AuthenticationClient) ExchangeACRRefreshTokenForACRAccessToken(ctx context.Context, service string, scope string, refreshToken string, options *AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions) (AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse, error) {
 	var err error
 	ctx, endSpan := runtime.StartSpan(ctx, "AuthenticationClient.ExchangeACRRefreshTokenForACRAccessToken", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.exchangeACRRefreshTokenForACRAccessTokenCreateRequest(ctx, service, scope, refreshToken, options)
 	if err != nil {
-		return authenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}, err
+		return AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return authenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}, err
+		return AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return authenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}, err
+		return AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}, err
 	}
 	resp, err := client.exchangeACRRefreshTokenForACRAccessTokenHandleResponse(httpResp)
 	return resp, err
 }
 
 // exchangeACRRefreshTokenForACRAccessTokenCreateRequest creates the ExchangeACRRefreshTokenForACRAccessToken request.
-func (client *authenticationClient) exchangeACRRefreshTokenForACRAccessTokenCreateRequest(ctx context.Context, service string, scope string, refreshToken string, options *authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions) (*policy.Request, error) {
+func (client *AuthenticationClient) exchangeACRRefreshTokenForACRAccessTokenCreateRequest(ctx context.Context, service string, scope string, refreshToken string, options *AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions) (*policy.Request, error) {
 	urlPath := "/oauth2/token"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -149,10 +149,10 @@ func (client *authenticationClient) exchangeACRRefreshTokenForACRAccessTokenCrea
 }
 
 // exchangeACRRefreshTokenForACRAccessTokenHandleResponse handles the ExchangeACRRefreshTokenForACRAccessToken response.
-func (client *authenticationClient) exchangeACRRefreshTokenForACRAccessTokenHandleResponse(resp *http.Response) (authenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse, error) {
-	result := authenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.acrAccessToken); err != nil {
-		return authenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}, err
+func (client *AuthenticationClient) exchangeACRRefreshTokenForACRAccessTokenHandleResponse(resp *http.Response) (AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse, error) {
+	result := AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.ACRAccessToken); err != nil {
+		return AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse{}, err
 	}
 	return result, nil
 }

--- a/sdk/containers/azcontainerregistry/authentication_custom_client.go
+++ b/sdk/containers/azcontainerregistry/authentication_custom_client.go
@@ -11,17 +11,17 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-// authenticationClientOptions contains the optional parameters for the newAuthenticationClient method.
-type authenticationClientOptions struct {
+// AuthenticationClientOptions contains the optional parameters for the NewAuthenticationClient method.
+type AuthenticationClientOptions struct {
 	azcore.ClientOptions
 }
 
-// newAuthenticationClient creates a new instance of AuthenticationClient with the specified values.
+// NewAuthenticationClient creates a new instance of AuthenticationClient with the specified values.
 //   - endpoint - Registry login URL
 //   - options - Client options, pass nil to accept the default values.
-func newAuthenticationClient(endpoint string, options *authenticationClientOptions) (*authenticationClient, error) {
+func NewAuthenticationClient(endpoint string, options *AuthenticationClientOptions) (*AuthenticationClient, error) {
 	if options == nil {
-		options = &authenticationClientOptions{}
+		options = &AuthenticationClientOptions{}
 	}
 
 	azcoreClient, err := azcore.NewClient(moduleName, moduleVersion, runtime.PipelineOptions{}, &options.ClientOptions)
@@ -29,7 +29,7 @@ func newAuthenticationClient(endpoint string, options *authenticationClientOptio
 		return nil, err
 	}
 
-	client := &authenticationClient{
+	client := &AuthenticationClient{
 		internal: azcoreClient,
 		endpoint: endpoint,
 	}

--- a/sdk/containers/azcontainerregistry/authentication_custom_client_test.go
+++ b/sdk/containers/azcontainerregistry/authentication_custom_client_test.go
@@ -7,12 +7,13 @@
 package azcontainerregistry
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_newAuthenticationClient(t *testing.T) {
-	client, err := newAuthenticationClient("test", nil)
+	client, err := NewAuthenticationClient("test", nil)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 }

--- a/sdk/containers/azcontainerregistry/authentication_policy.go
+++ b/sdk/containers/azcontainerregistry/authentication_policy.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/temporal"
 )
 
@@ -49,10 +49,10 @@ type authenticationPolicy struct {
 	accessTokenCache  atomic.Value
 	cred              azcore.TokenCredential
 	aadScopes         []string
-	authClient        *authenticationClient
+	authClient        *AuthenticationClient
 }
 
-func newAuthenticationPolicy(cred azcore.TokenCredential, scopes []string, authClient *authenticationClient, opts *authenticationPolicyOptions) *authenticationPolicy {
+func newAuthenticationPolicy(cred azcore.TokenCredential, scopes []string, authClient *AuthenticationClient, opts *authenticationPolicyOptions) *authenticationPolicy {
 	return &authenticationPolicy{
 		cred:              cred,
 		aadScopes:         scopes,
@@ -114,11 +114,11 @@ func (p *authenticationPolicy) Do(req *policy.Request) (*http.Response, error) {
 func (p *authenticationPolicy) getAccessToken(req *policy.Request, service, scope string) (string, error) {
 	// anonymous access
 	if p.cred == nil {
-		resp, err := p.authClient.ExchangeACRRefreshTokenForACRAccessToken(req.Raw().Context(), service, scope, "", &authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions{GrantType: to.Ptr(tokenGrantTypePassword)})
+		resp, err := p.authClient.ExchangeACRRefreshTokenForACRAccessToken(req.Raw().Context(), service, scope, "", &AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions{GrantType: to.Ptr(TokenGrantTypePassword)})
 		if err != nil {
 			return "", err
 		}
-		return *resp.acrAccessToken.AccessToken, nil
+		return *resp.ACRAccessToken.AccessToken, nil
 	}
 
 	// access with token
@@ -133,11 +133,11 @@ func (p *authenticationPolicy) getAccessToken(req *policy.Request, service, scop
 	}
 
 	// get access token from request
-	resp, err := p.authClient.ExchangeACRRefreshTokenForACRAccessToken(req.Raw().Context(), service, scope, refreshToken.Token, &authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions{GrantType: to.Ptr(tokenGrantTypeRefreshToken)})
+	resp, err := p.authClient.ExchangeACRRefreshTokenForACRAccessToken(req.Raw().Context(), service, scope, refreshToken.Token, &AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions{GrantType: to.Ptr(TokenGrantTypeRefreshToken)})
 	if err != nil {
 		return "", err
 	}
-	return *resp.acrAccessToken.AccessToken, nil
+	return *resp.ACRAccessToken.AccessToken, nil
 }
 
 func findServiceAndScope(resp *http.Response) (string, string, error) {
@@ -197,7 +197,7 @@ func acquireRefreshToken(state acquiringResourceState) (newResource azcore.Acces
 	}
 
 	// exchange refresh token with AAD token
-	refreshResp, err := state.policy.authClient.ExchangeAADAccessTokenForACRRefreshToken(state.req.Raw().Context(), postContentSchemaGrantTypeAccessToken, state.service, &authenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions{
+	refreshResp, err := state.policy.authClient.ExchangeAADAccessTokenForACRRefreshToken(state.req.Raw().Context(), PostContentSchemaGrantTypeAccessToken, state.service, &AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions{
 		AccessToken: &aadToken.Token,
 	})
 	if err != nil {
@@ -205,11 +205,11 @@ func acquireRefreshToken(state acquiringResourceState) (newResource azcore.Acces
 	}
 
 	refreshToken := azcore.AccessToken{
-		Token: *refreshResp.acrRefreshToken.RefreshToken,
+		Token: *refreshResp.ACRRefreshToken.RefreshToken,
 	}
 
 	// get refresh token expire time
-	refreshToken.ExpiresOn, err = getJWTExpireTime(*refreshResp.acrRefreshToken.RefreshToken)
+	refreshToken.ExpiresOn, err = getJWTExpireTime(*refreshResp.ACRRefreshToken.RefreshToken)
 	if err != nil {
 		return azcore.AccessToken{}, time.Time{}, err
 	}

--- a/sdk/containers/azcontainerregistry/authentication_policy_test.go
+++ b/sdk/containers/azcontainerregistry/authentication_policy_test.go
@@ -133,7 +133,7 @@ func Test_authenticationPolicy_getAccessToken_live(t *testing.T) {
 	if reflect.ValueOf(options.Cloud).IsZero() {
 		options.Cloud = cloud.AzurePublic
 	}
-	authClient, err := newAuthenticationClient(endpoint, &authenticationClientOptions{options})
+	authClient, err := NewAuthenticationClient(endpoint, &AuthenticationClientOptions{options})
 	require.NoError(t, err)
 	p := &authenticationPolicy{
 		temporal.NewResource(acquireRefreshToken),
@@ -157,7 +157,7 @@ func Test_authenticationPolicy_getAccessToken_error(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte("{\"refresh_token\": \".eyJqdGkiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJzdWIiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJuYmYiOjQ2NzA0MTEyMTIsImV4cCI6NDY3MDQyMjkxMiwiaWF0Ijo0NjcwNDExMjEyLCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJhdWQiOiJhemFjcmxpdmV0ZXN0LmF6dXJlY3IuaW8iLCJ2ZXJzaW9uIjoiMS4wIiwicmlkIjoiMDAwMCIsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiYXBwaWQiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJwZXJtaXNzaW9ucyI6eyJBY3Rpb25zIjpbInJlYWQiLCJ3cml0ZSIsImRlbGV0ZSIsImRlbGV0ZWQvcmVhZCIsImRlbGV0ZWQvcmVzdG9yZS9hY3Rpb24iXSwiTm90QWN0aW9ucyI6bnVsbH0sInJvbGVzIjpbXX0.\"}")))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte("wrong response")))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte("wrong response")))
-	authClient, err := newAuthenticationClient(srv.URL(), &authenticationClientOptions{ClientOptions: azcore.ClientOptions{Transport: srv}})
+	authClient, err := NewAuthenticationClient(srv.URL(), &AuthenticationClientOptions{ClientOptions: azcore.ClientOptions{Transport: srv}})
 	require.NoError(t, err)
 
 	p := &authenticationPolicy{
@@ -183,7 +183,7 @@ func Test_authenticationPolicy_getAccessToken_error(t *testing.T) {
 func Test_authenticationPolicy_getAccessToken_live_anonymous(t *testing.T) {
 	startRecording(t)
 	endpoint, _, options := getEndpointCredAndClientOptions(t)
-	authClient, err := newAuthenticationClient(endpoint, &authenticationClientOptions{options})
+	authClient, err := NewAuthenticationClient(endpoint, &AuthenticationClientOptions{options})
 	require.NoError(t, err)
 	p := &authenticationPolicy{
 		refreshTokenCache: temporal.NewResource(acquireRefreshToken),
@@ -242,7 +242,7 @@ func Test_authenticationPolicy(t *testing.T) {
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte("{\"access_token\": \"test\"}")))
 	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
 
-	authClient, err := newAuthenticationClient(srv.URL(), &authenticationClientOptions{ClientOptions: azcore.ClientOptions{Transport: srv}})
+	authClient, err := NewAuthenticationClient(srv.URL(), &AuthenticationClientOptions{ClientOptions: azcore.ClientOptions{Transport: srv}})
 	require.NoError(t, err)
 	authPolicy := &authenticationPolicy{
 		temporal.NewResource(acquireRefreshToken),

--- a/sdk/containers/azcontainerregistry/autorest.md
+++ b/sdk/containers/azcontainerregistry/autorest.md
@@ -420,6 +420,20 @@ directive:
         $.ArtifactOperatingSystem.description = "The artifact platform's operating system.";
 ```
 
+### Add description for RefreshToken and AccessToken
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions
+    transform: >
+        $.RefreshToken.description = "The ACR refresh token response.";
+  - from: swagger-document
+    where: $.definitions
+    transform: >
+      $.AccessToken.description = "The ACR access token response.";
+```
+
 ### Remove useless Marshal method
 
 ```yaml

--- a/sdk/containers/azcontainerregistry/autorest.md
+++ b/sdk/containers/azcontainerregistry/autorest.md
@@ -309,49 +309,6 @@ directive:
     transform: return $.replaceAll(/result\.Link = &val/g, "val = runtime.JoinPaths(client.endpoint, extractNextLink(val))\n\t\tresult.Link = &val");
 ```
 
-### Do not export Authentication client and related models
-
-```yaml
-directive:
-  - from:
-      - authentication_client.go
-    where: $
-    transform: return $.replaceAll(/ AuthenticationClient/g, " authenticationClient").replaceAll(/\*AuthenticationClient/g, "*authenticationClient").replace(/NewAuthenticationClient/, "newAuthenticationClient").replaceAll(/\(AuthenticationClient/g, "(authenticationClient");
-  - from:
-      - authentication_client.go
-    where: $
-    transform: return $.replace(/PostContentSchemaGrantType/, "postContentSchemaGrantType").replace(/PostContentSchemaGrantType/, "postContentSchemaGrantType");
-  - from:
-      - authentication_client.go
-    where: $
-    transform: return $.replace(/result\.AcrAccessToken/, "result.acrAccessToken").replace(/result\.AcrRefreshToken/, "result.acrRefreshToken");
-  - from:
-      - response_types.go
-    where: $
-    transform: return $.replaceAll(/AuthenticationClient/g, "authenticationClient").replace(/AcrRefreshToken\n/, "acrRefreshToken\n").replace(/AcrAccessToken\n/, "acrAccessToken\n");
-  - from:
-      - models.go
-      - options.go
-    where: $
-    transform: return $.replaceAll(/AuthenticationClient/g, "authenticationClient").replace(/AcrRefreshToken struct/, "acrRefreshToken struct").replace(/AcrAccessToken struct/, "acrAccessToken struct");
-  - from:
-      - options.go
-    where: $
-    transform: return $.replace(/TokenGrantType/, "tokenGrantType");
-  - from:
-      - constants.go
-    where: $
-    transform: return $.replaceAll(/ TokenGrantType/g, " tokenGrantType").replaceAll(/\tTokenGrantType/g, "\ttokenGrantType").replaceAll(/\]TokenGrantType/g, "]tokenGrantType").replaceAll(/PossibleTokenGrantType/g, "possibleTokenGrantType");
-  - from:
-      - constants.go
-    where: $
-    transform: return $.replaceAll(/ PostContentSchemaGrantType/g, " postContentSchemaGrantType").replaceAll(/\tPostContentSchemaGrantType/g, "\tpostContentSchemaGrantType").replaceAll(/\]PostContentSchemaGrantType/g, "]postContentSchemaGrantType").replaceAll(/PossiblePostContentSchemaGrantType/g, "possiblePostContentSchemaGrantType");
-  - from:
-      - models_serde.go
-    where: $
-    transform: return $.replaceAll(/ AcrAccessToken/g, " acrAccessToken").replace(/\*AcrAccessToken/g, "*acrAccessToken").replaceAll(/ AcrRefreshToken/g, " acrRefreshToken").replace(/\*AcrRefreshToken/g, "*acrRefreshToken");
-```
-
 ### Rename all Acr to ACR
 
 ```yaml

--- a/sdk/containers/azcontainerregistry/blob_custom_client.go
+++ b/sdk/containers/azcontainerregistry/blob_custom_client.go
@@ -10,13 +10,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"reflect"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"io"
-	"reflect"
 )
 
 // BlobClientOptions contains the optional parameters for the NewBlobClient method.
@@ -41,7 +42,7 @@ func NewBlobClient(endpoint string, credential azcore.TokenCredential, options *
 		return nil, errors.New("provided Cloud field is missing Azure Container Registry configuration")
 	}
 
-	authClient, err := newAuthenticationClient(endpoint, &authenticationClientOptions{
+	authClient, err := NewAuthenticationClient(endpoint, &AuthenticationClientOptions{
 		options.ClientOptions,
 	})
 	if err != nil {

--- a/sdk/containers/azcontainerregistry/constants.go
+++ b/sdk/containers/azcontainerregistry/constants.go
@@ -163,36 +163,36 @@ func PossibleContentTypeValues() []ContentType {
 	}
 }
 
-// postContentSchemaGrantType - Can take a value of accesstokenrefreshtoken, or accesstoken, or refresh_token
-type postContentSchemaGrantType string
+// PostContentSchemaGrantType - Can take a value of accesstokenrefreshtoken, or accesstoken, or refresh_token
+type PostContentSchemaGrantType string
 
 const (
-	postContentSchemaGrantTypeAccessToken             postContentSchemaGrantType = "access_token"
-	postContentSchemaGrantTypeAccessTokenRefreshToken postContentSchemaGrantType = "access_token_refresh_token"
-	postContentSchemaGrantTypeRefreshToken            postContentSchemaGrantType = "refresh_token"
+	PostContentSchemaGrantTypeAccessToken             PostContentSchemaGrantType = "access_token"
+	PostContentSchemaGrantTypeAccessTokenRefreshToken PostContentSchemaGrantType = "access_token_refresh_token"
+	PostContentSchemaGrantTypeRefreshToken            PostContentSchemaGrantType = "refresh_token"
 )
 
-// possiblePostContentSchemaGrantTypeValues returns the possible values for the postContentSchemaGrantType const type.
-func possiblePostContentSchemaGrantTypeValues() []postContentSchemaGrantType {
-	return []postContentSchemaGrantType{
-		postContentSchemaGrantTypeAccessToken,
-		postContentSchemaGrantTypeAccessTokenRefreshToken,
-		postContentSchemaGrantTypeRefreshToken,
+// PossiblePostContentSchemaGrantTypeValues returns the possible values for the PostContentSchemaGrantType const type.
+func PossiblePostContentSchemaGrantTypeValues() []PostContentSchemaGrantType {
+	return []PostContentSchemaGrantType{
+		PostContentSchemaGrantTypeAccessToken,
+		PostContentSchemaGrantTypeAccessTokenRefreshToken,
+		PostContentSchemaGrantTypeRefreshToken,
 	}
 }
 
-// tokenGrantType - Grant type is expected to be refresh_token
-type tokenGrantType string
+// TokenGrantType - Grant type is expected to be refresh_token
+type TokenGrantType string
 
 const (
-	tokenGrantTypePassword     tokenGrantType = "password"
-	tokenGrantTypeRefreshToken tokenGrantType = "refresh_token"
+	TokenGrantTypePassword     TokenGrantType = "password"
+	TokenGrantTypeRefreshToken TokenGrantType = "refresh_token"
 )
 
-// possibleTokenGrantTypeValues returns the possible values for the tokenGrantType const type.
-func possibleTokenGrantTypeValues() []tokenGrantType {
-	return []tokenGrantType{
-		tokenGrantTypePassword,
-		tokenGrantTypeRefreshToken,
+// PossibleTokenGrantTypeValues returns the possible values for the TokenGrantType const type.
+func PossibleTokenGrantTypeValues() []TokenGrantType {
+	return []TokenGrantType{
+		TokenGrantTypePassword,
+		TokenGrantTypeRefreshToken,
 	}
 }

--- a/sdk/containers/azcontainerregistry/constants_test.go
+++ b/sdk/containers/azcontainerregistry/constants_test.go
@@ -7,8 +7,9 @@
 package azcontainerregistry
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPossibleArtifactArchitectureValues(t *testing.T) {
@@ -32,9 +33,9 @@ func TestPossibleContentTypeValues(t *testing.T) {
 }
 
 func Test_possiblePostContentSchemaGrantTypeValues(t *testing.T) {
-	require.Equal(t, 3, len(possiblePostContentSchemaGrantTypeValues()))
+	require.Equal(t, 3, len(PossiblePostContentSchemaGrantTypeValues()))
 }
 
 func Test_possibleTokenGrantTypeValues(t *testing.T) {
-	require.Equal(t, 2, len(possibleTokenGrantTypeValues()))
+	require.Equal(t, 2, len(PossibleTokenGrantTypeValues()))
 }

--- a/sdk/containers/azcontainerregistry/custom_client.go
+++ b/sdk/containers/azcontainerregistry/custom_client.go
@@ -8,11 +8,12 @@ package azcontainerregistry
 
 import (
 	"errors"
+	"reflect"
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"reflect"
-	"strings"
 )
 
 // ClientOptions contains the optional parameters for the NewClient method.
@@ -37,7 +38,7 @@ func NewClient(endpoint string, credential azcore.TokenCredential, options *Clie
 		return nil, errors.New("provided Cloud field is missing Azure Container Registry configuration")
 	}
 
-	authClient, err := newAuthenticationClient(endpoint, &authenticationClientOptions{
+	authClient, err := NewAuthenticationClient(endpoint, &AuthenticationClientOptions{
 		options.ClientOptions,
 	})
 	if err != nil {

--- a/sdk/containers/azcontainerregistry/models.go
+++ b/sdk/containers/azcontainerregistry/models.go
@@ -10,11 +10,13 @@ package azcontainerregistry
 
 import "time"
 
+// ACRAccessToken - The ACR access token response.
 type ACRAccessToken struct {
 	// The access token for performing authenticated requests
 	AccessToken *string
 }
 
+// ACRRefreshToken - The ACR refresh token response.
 type ACRRefreshToken struct {
 	// The refresh token to be used for generating access tokens
 	RefreshToken *string

--- a/sdk/containers/azcontainerregistry/models.go
+++ b/sdk/containers/azcontainerregistry/models.go
@@ -10,12 +10,12 @@ package azcontainerregistry
 
 import "time"
 
-type acrAccessToken struct {
+type ACRAccessToken struct {
 	// The access token for performing authenticated requests
 	AccessToken *string
 }
 
-type acrRefreshToken struct {
+type ACRRefreshToken struct {
 	// The refresh token to be used for generating access tokens
 	RefreshToken *string
 }

--- a/sdk/containers/azcontainerregistry/models_serde.go
+++ b/sdk/containers/azcontainerregistry/models_serde.go
@@ -15,8 +15,15 @@ import (
 	"reflect"
 )
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type acrAccessToken.
-func (a *acrAccessToken) UnmarshalJSON(data []byte) error {
+// MarshalJSON implements the json.Marshaller interface for type ACRAccessToken.
+func (a ACRAccessToken) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "access_token", a.AccessToken)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ACRAccessToken.
+func (a *ACRAccessToken) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", a, err)
@@ -35,8 +42,15 @@ func (a *acrAccessToken) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type acrRefreshToken.
-func (a *acrRefreshToken) UnmarshalJSON(data []byte) error {
+// MarshalJSON implements the json.Marshaller interface for type ACRRefreshToken.
+func (a ACRRefreshToken) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "refresh_token", a.RefreshToken)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ACRRefreshToken.
+func (a *ACRRefreshToken) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", a, err)

--- a/sdk/containers/azcontainerregistry/options.go
+++ b/sdk/containers/azcontainerregistry/options.go
@@ -8,9 +8,9 @@
 
 package azcontainerregistry
 
-// authenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions contains the optional parameters for the authenticationClient.ExchangeAADAccessTokenForACRRefreshToken
+// AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions contains the optional parameters for the AuthenticationClient.ExchangeAADAccessTokenForACRRefreshToken
 // method.
-type authenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions struct {
+type AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions struct {
 	// AAD access token, mandatory when granttype is accesstokenrefreshtoken or access_token.
 	AccessToken *string
 
@@ -21,11 +21,11 @@ type authenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions struct 
 	Tenant *string
 }
 
-// authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions contains the optional parameters for the authenticationClient.ExchangeACRRefreshTokenForACRAccessToken
+// AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions contains the optional parameters for the AuthenticationClient.ExchangeACRRefreshTokenForACRAccessToken
 // method.
-type authenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions struct {
+type AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenOptions struct {
 	// Grant type is expected to be refresh_token
-	GrantType *tokenGrantType
+	GrantType *TokenGrantType
 }
 
 // BlobClientCancelUploadOptions contains the optional parameters for the BlobClient.CancelUpload method.

--- a/sdk/containers/azcontainerregistry/response_types.go
+++ b/sdk/containers/azcontainerregistry/response_types.go
@@ -10,14 +10,14 @@ package azcontainerregistry
 
 import "io"
 
-// authenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse contains the response from method authenticationClient.ExchangeAADAccessTokenForACRRefreshToken.
-type authenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse struct {
-	acrRefreshToken
+// AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse contains the response from method AuthenticationClient.ExchangeAADAccessTokenForACRRefreshToken.
+type AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse struct {
+	ACRRefreshToken
 }
 
-// authenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse contains the response from method authenticationClient.ExchangeACRRefreshTokenForACRAccessToken.
-type authenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse struct {
-	acrAccessToken
+// AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse contains the response from method AuthenticationClient.ExchangeACRRefreshTokenForACRAccessToken.
+type AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse struct {
+	ACRAccessToken
 }
 
 // BlobClientCancelUploadResponse contains the response from method BlobClient.CancelUpload.

--- a/sdk/containers/azcontainerregistry/response_types.go
+++ b/sdk/containers/azcontainerregistry/response_types.go
@@ -12,11 +12,13 @@ import "io"
 
 // AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse contains the response from method AuthenticationClient.ExchangeAADAccessTokenForACRRefreshToken.
 type AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenResponse struct {
+	// The ACR refresh token response.
 	ACRRefreshToken
 }
 
 // AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse contains the response from method AuthenticationClient.ExchangeACRRefreshTokenForACRAccessToken.
 type AuthenticationClientExchangeACRRefreshTokenForACRAccessTokenResponse struct {
+	// The ACR access token response.
 	ACRAccessToken
 }
 


### PR DESCRIPTION
The ACR authentication API is a public-facing API. Consumers would like to use the well-tested code in the SDK to interface with this API instead of having to roll their own. This commit simply exposes all of the structs, functions and constants that are necessary to consume this API.

Part of https://github.com/Azure/azure-sdk-for-go/issues/20571