### PR TITLE
Authorize azidentity test app deployment with WIF

### DIFF
--- a/sdk/azidentity/ci.yml
+++ b/sdk/azidentity/ci.yml
@@ -37,6 +37,15 @@ extends:
       UsePipelineProxy: false
 
       ${{ if endsWith(variables['Build.DefinitionName'], 'weekly') }}:
+        PreSteps:
+        - task: AzureCLI@2
+          displayName: Set OIDC token
+          inputs:
+            azureSubscription: azure-sdk-tests
+            scriptType: pscore
+            scriptLocation: inlineScript
+            addSpnToEnvironment: true
+            inlineScript: Write-Host "##vso[task.setvariable variable=OIDC_TOKEN;]$($env:idToken)"
         MatrixConfigs:
           - Name: managed_identity_matrix
             GenerateVMJobs: true

--- a/sdk/azidentity/ci.yml
+++ b/sdk/azidentity/ci.yml
@@ -41,11 +41,11 @@ extends:
         - task: AzureCLI@2
           displayName: Set OIDC token
           inputs:
-            azureSubscription: azure-sdk-tests
-            scriptType: pscore
-            scriptLocation: inlineScript
             addSpnToEnvironment: true
+            azureSubscription: azure-sdk-tests
             inlineScript: Write-Host "##vso[task.setvariable variable=OIDC_TOKEN;]$($env:idToken)"
+            scriptLocation: inlineScript
+            scriptType: pscore
         MatrixConfigs:
           - Name: managed_identity_matrix
             GenerateVMJobs: true

--- a/sdk/azidentity/test-resources-post.ps1
+++ b/sdk/azidentity/test-resources-post.ps1
@@ -28,7 +28,7 @@ if ($CI) {
     Write-Host "Skipping post-provisioning script because resources weren't deployed"
     return
   }
-  az login --allow-no-subscriptions --federated-token $env:OIDC_TOKEN --service-principal -t $TenantId -u $TestApplicationId
+  az login --federated-token $env:OIDC_TOKEN --service-principal -t $TenantId -u $TestApplicationId
   az account set --subscription $DeploymentOutputs['AZIDENTITY_SUBSCRIPTION_ID']
 }
 

--- a/sdk/azidentity/test-resources-post.ps1
+++ b/sdk/azidentity/test-resources-post.ps1
@@ -5,7 +5,19 @@
 
 param (
   [hashtable] $AdditionalParameters = @{},
-  [hashtable] $DeploymentOutputs
+  [hashtable] $DeploymentOutputs,
+
+  [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string] $TenantId,
+
+  [Parameter()]
+  [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+  [string] $TestApplicationId,
+
+  # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
+  [Parameter(ValueFromRemainingArguments = $true)]
+  $RemainingArguments
 )
 
 $ErrorActionPreference = 'Stop'
@@ -16,14 +28,14 @@ if ($CI) {
     Write-Host "Skipping post-provisioning script because resources weren't deployed"
     return
   }
-  az login --service-principal -u $DeploymentOutputs['AZIDENTITY_CLIENT_ID'] -p $DeploymentOutputs['AZIDENTITY_CLIENT_SECRET'] --tenant $DeploymentOutputs['AZIDENTITY_TENANT_ID']
+  az login --allow-no-subscriptions --federated-token $env:OIDC_TOKEN --service-principal -t $TenantId -u $TestApplicationId
   az account set --subscription $DeploymentOutputs['AZIDENTITY_SUBSCRIPTION_ID']
 }
 
 Write-Host "Building container"
 $image = "$($DeploymentOutputs['AZIDENTITY_ACR_LOGIN_SERVER'])/azidentity-managed-id-test"
 Set-Content -Path "$PSScriptRoot/Dockerfile" -Value @"
-FROM mcr.microsoft.com/oss/go/microsoft/golang:latest as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:latest AS builder
 ENV GOARCH=amd64 GOWORK=off
 COPY . /azidentity
 WORKDIR /azidentity/testdata/managed-id-test
@@ -53,9 +65,9 @@ az container create -g $rg -n $aciName --image $image `
   --role "Storage Blob Data Reader" `
   --scope $($DeploymentOutputs['AZIDENTITY_STORAGE_ID']) `
   -e AZIDENTITY_STORAGE_NAME=$($DeploymentOutputs['AZIDENTITY_STORAGE_NAME']) `
-     AZIDENTITY_STORAGE_NAME_USER_ASSIGNED=$($DeploymentOutputs['AZIDENTITY_STORAGE_NAME_USER_ASSIGNED']) `
-     AZIDENTITY_USER_ASSIGNED_IDENTITY=$($DeploymentOutputs['AZIDENTITY_USER_ASSIGNED_IDENTITY']) `
-     FUNCTIONS_CUSTOMHANDLER_PORT=80
+  AZIDENTITY_STORAGE_NAME_USER_ASSIGNED=$($DeploymentOutputs['AZIDENTITY_STORAGE_NAME_USER_ASSIGNED']) `
+  AZIDENTITY_USER_ASSIGNED_IDENTITY=$($DeploymentOutputs['AZIDENTITY_USER_ASSIGNED_IDENTITY']) `
+  FUNCTIONS_CUSTOMHANDLER_PORT=80
 Write-Host "##vso[task.setvariable variable=AZIDENTITY_ACI_NAME;]$aciName"
 
 # Azure Functions deployment: copy the Windows binary from the Docker image, deploy it in a zip


### PR DESCRIPTION
The post script uses the Azure CLI to deploy test applications. Switching the pipeline to federated auth broke its login because the test resource deployment script no longer provides a service principal secret. With this PR the script instead logs in a federated identity using a token acquired in a pre step (this token isn't available in the Azure PowerShell task that runs the script).