### PR TITLE
azcontainerregistry tests build images instead of importing them

### DIFF
--- a/sdk/containers/azcontainerregistry/assets.json
+++ b/sdk/containers/azcontainerregistry/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/containers/azcontainerregistry",
-  "Tag": "go/containers/azcontainerregistry_734baeebc4"
+  "Tag": "go/containers/azcontainerregistry_7310e70bf5"
 }

--- a/sdk/containers/azcontainerregistry/authentication_policy_test.go
+++ b/sdk/containers/azcontainerregistry/authentication_policy_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/temporal"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/test/credential"
@@ -201,20 +200,11 @@ func Test_authenticationPolicy_anonymousAccess(t *testing.T) {
 	endpoint, _, options := getEndpointCredAndClientOptions(t)
 	client, err := NewClient(endpoint, nil, &ClientOptions{ClientOptions: options})
 	require.NoError(t, err)
-	ctx := context.Background()
 	pager := client.NewListRepositoriesPager(nil)
-	repositoryName := ""
 	for pager.More() {
-		page, err := pager.NextPage(ctx)
+		_, err = pager.NextPage(ctx)
 		require.NoError(t, err)
-		require.NotEmpty(t, page.Repositories.Names)
-		if repositoryName == "" {
-			repositoryName = *page.Repositories.Names[0]
-		}
 	}
-	require.NotEmpty(t, repositoryName)
-	_, err = client.UpdateRepositoryProperties(ctx, repositoryName, &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{CanDelete: to.Ptr(true)}})
-	require.Error(t, err)
 }
 
 func Test_getChallengeRequest(t *testing.T) {

--- a/sdk/containers/azcontainerregistry/blob_client_test.go
+++ b/sdk/containers/azcontainerregistry/blob_client_test.go
@@ -125,12 +125,13 @@ func TestBlobClient(t *testing.T) {
 		res, err := client.GetBlob(ctx, repository, blobDigest, nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, *res.ContentLength)
-		if recording.GetRecordMode() != recording.PlaybackMode {
-			reader, err := NewDigestValidationReader(blobDigest, res.BlobData)
-			require.NoError(t, err)
-			_, err = io.ReadAll(reader)
-			require.NoError(t, err)
+		reader, err := NewDigestValidationReader(blobDigest, res.BlobData)
+		require.NoError(t, err)
+		if recording.GetRecordMode() == recording.PlaybackMode {
+			reader.digestValidator = &sha256Validator{&fakeHash{}}
 		}
+		_, err = io.ReadAll(reader)
+		require.NoError(t, err)
 	})
 
 	t.Run("GetBlob_fail", func(t *testing.T) {
@@ -164,12 +165,13 @@ func TestBlobClient(t *testing.T) {
 			}
 			current += chunkSize
 		}
-		if recording.GetRecordMode() != recording.PlaybackMode {
-			reader, err := NewDigestValidationReader(blobDigest, blob)
-			require.NoError(t, err)
-			_, err = io.ReadAll(reader)
-			require.NoError(t, err)
+		reader, err := NewDigestValidationReader(blobDigest, blob)
+		require.NoError(t, err)
+		if recording.GetRecordMode() == recording.PlaybackMode {
+			reader.digestValidator = &sha256Validator{&fakeHash{}}
 		}
+		_, err = io.ReadAll(reader)
+		require.NoError(t, err)
 	})
 
 	t.Run("GetChunk_fail", func(t *testing.T) {

--- a/sdk/containers/azcontainerregistry/blob_custom_client_test.go
+++ b/sdk/containers/azcontainerregistry/blob_custom_client_test.go
@@ -8,96 +8,142 @@ package azcontainerregistry
 
 import (
 	"bytes"
-	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/stretchr/testify/require"
-	"io"
-	"net/http"
-	"testing"
 )
 
-func TestBlobClient_CompleteUpload(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewBlobClient(endpoint, cred, &BlobClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	getRes, err := client.GetBlob(ctx, "alpine", alpineBlobDigest, nil)
-	require.NoError(t, err)
-	blob, err := io.ReadAll(getRes.BlobData)
-	require.NoError(t, err)
-	startRes, err := client.StartUpload(ctx, "hello-world", nil)
-	require.NoError(t, err)
-	calculator := NewBlobDigestCalculator()
-	uploadResp, err := client.UploadChunk(ctx, *startRes.Location, bytes.NewReader(blob), calculator, nil)
-	require.NoError(t, err)
-	completeResp, err := client.CompleteUpload(ctx, *uploadResp.Location, calculator, nil)
-	require.NoError(t, err)
-	require.NotEmpty(t, *completeResp.DockerContentDigest)
-}
+func TestBlobCustomClient(t *testing.T) {
+	repository, digest := buildImage(t)
+	blobDigest := blobDigest(t, repository, digest)
 
-func TestBlobClient_UploadChunk(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewBlobClient(endpoint, cred, &BlobClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	getRes, err := client.GetBlob(ctx, "alpine", alpineBlobDigest, nil)
-	require.NoError(t, err)
-	blob, err := io.ReadAll(getRes.BlobData)
-	require.NoError(t, err)
-	startRes, err := client.StartUpload(ctx, "hello-world", nil)
-	require.NoError(t, err)
-	calculator := NewBlobDigestCalculator()
-	uploadResp, err := client.UploadChunk(ctx, *startRes.Location, bytes.NewReader(blob), calculator, nil)
-	require.NoError(t, err)
-	require.NotEmpty(t, *uploadResp.Location)
-	_, err = client.CancelUpload(ctx, *uploadResp.Location, nil)
-	require.NoError(t, err)
-}
-
-func TestBlobClient_CompleteUpload_uploadByChunk(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewBlobClient(endpoint, cred, &BlobClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	getRes, err := client.GetBlob(ctx, "alpine", alpineBlobDigest, nil)
-	require.NoError(t, err)
-	blob, err := io.ReadAll(getRes.BlobData)
-	require.NoError(t, err)
-	startRes, err := client.StartUpload(ctx, "hello-world", nil)
-	require.NoError(t, err)
-	calculator := NewBlobDigestCalculator()
-	oriReader := bytes.NewReader(blob)
-	size := int64(len(blob))
-	chunkSize := int64(736)
-	current := int64(0)
-	location := *startRes.Location
-	for {
-		end := current + chunkSize
-		if end > size {
-			end = size
+	t.Run("CompleteUpload", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewBlobClient(endpoint, cred, &BlobClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		getRes, err := client.GetBlob(ctx, repository, blobDigest, nil)
+		require.NoError(t, err)
+		blob, err := io.ReadAll(getRes.BlobData)
+		require.NoError(t, err)
+		startRes, err := client.StartUpload(ctx, "hello-world", nil)
+		require.NoError(t, err)
+		calculator := NewBlobDigestCalculator()
+		if recording.GetRecordMode() == recording.PlaybackMode {
+			calculator.h = &fakeHash{}
 		}
-		chunkReader := io.NewSectionReader(oriReader, current, end-current)
-		uploadResp, err := client.UploadChunk(ctx, location, chunkReader, calculator, &BlobClientUploadChunkOptions{RangeStart: to.Ptr(int32(current)), RangeEnd: to.Ptr(int32(end - 1))})
+		uploadResp, err := client.UploadChunk(ctx, *startRes.Location, bytes.NewReader(blob), calculator, nil)
+		require.NoError(t, err)
+		completeResp, err := client.CompleteUpload(ctx, *uploadResp.Location, calculator, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, *completeResp.DockerContentDigest)
+	})
+
+	t.Run("CompleteUpload_uploadByChunk", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewBlobClient(endpoint, cred, &BlobClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		getRes, err := client.GetBlob(ctx, repository, blobDigest, nil)
+		require.NoError(t, err)
+		blob, err := io.ReadAll(getRes.BlobData)
+		require.NoError(t, err)
+		startRes, err := client.StartUpload(ctx, "hello-world", nil)
+		require.NoError(t, err)
+		calculator := NewBlobDigestCalculator()
+		if recording.GetRecordMode() == recording.PlaybackMode {
+			calculator.h = &fakeHash{}
+		}
+		oriReader := bytes.NewReader(blob)
+		size := int64(len(blob))
+		chunkSize := int64(736)
+		current := int64(0)
+		location := *startRes.Location
+		for {
+			end := current + chunkSize
+			if end > size {
+				end = size
+			}
+			chunkReader := io.NewSectionReader(oriReader, current, end-current)
+			uploadResp, err := client.UploadChunk(ctx, location, chunkReader, calculator, &BlobClientUploadChunkOptions{RangeStart: to.Ptr(int32(current)), RangeEnd: to.Ptr(int32(end - 1))})
+			require.NoError(t, err)
+			require.NotEmpty(t, *uploadResp.Location)
+			location = *uploadResp.Location
+			current = end
+			if current >= size {
+				break
+			}
+		}
+		completeResp, err := client.CompleteUpload(ctx, location, calculator, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, *completeResp.DockerContentDigest)
+	})
+
+	t.Run("CompleteUpload_uploadByChunkFailOver", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewBlobClient(endpoint, cred, &BlobClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		getRes, err := client.GetBlob(ctx, repository, blobDigest, nil)
+		require.NoError(t, err)
+		blob, err := io.ReadAll(getRes.BlobData)
+		require.NoError(t, err)
+		startRes, err := client.StartUpload(ctx, "hello-world", nil)
+		require.NoError(t, err)
+		calculator := NewBlobDigestCalculator()
+		if recording.GetRecordMode() == recording.PlaybackMode {
+			calculator.h = &fakeHash{}
+		}
+		oriReader := bytes.NewReader(blob)
+		firstPart := io.NewSectionReader(oriReader, int64(0), int64(len(blob)/2))
+		secondPart := io.NewSectionReader(oriReader, int64(len(blob)/2), int64(len(blob)-len(blob)/2))
+		uploadResp, err := client.UploadChunk(ctx, *startRes.Location, firstPart, calculator, &BlobClientUploadChunkOptions{RangeStart: to.Ptr(int32(0)), RangeEnd: to.Ptr(int32(len(blob)/2 - 1))})
 		require.NoError(t, err)
 		require.NotEmpty(t, *uploadResp.Location)
-		location = *uploadResp.Location
-		current = end
-		if current >= size {
-			break
+		sum := calculator.h.Sum(nil)
+		// upload with a wrong range to test fail over
+		_, err = client.UploadChunk(ctx, *uploadResp.Location, secondPart, calculator, &BlobClientUploadChunkOptions{RangeStart: to.Ptr(int32(-1)), RangeEnd: to.Ptr(int32(-1))})
+		require.Error(t, err)
+		require.Equal(t, sum, calculator.h.Sum(nil))
+		uploadResp, err = client.UploadChunk(ctx, *uploadResp.Location, secondPart, calculator, &BlobClientUploadChunkOptions{RangeStart: to.Ptr(int32(len(blob) / 2)), RangeEnd: to.Ptr(int32(len(blob) - 1))})
+		require.NoError(t, err)
+		require.NotEmpty(t, *uploadResp.Location)
+		completeResp, err := client.CompleteUpload(ctx, *uploadResp.Location, calculator, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, *completeResp.DockerContentDigest)
+	})
+
+	t.Run("UploadChunk", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewBlobClient(endpoint, cred, &BlobClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		getRes, err := client.GetBlob(ctx, repository, blobDigest, nil)
+		require.NoError(t, err)
+		blob, err := io.ReadAll(getRes.BlobData)
+		require.NoError(t, err)
+		startRes, err := client.StartUpload(ctx, "hello-world", nil)
+		require.NoError(t, err)
+		calculator := NewBlobDigestCalculator()
+		if recording.GetRecordMode() == recording.PlaybackMode {
+			calculator.h = &fakeHash{}
 		}
-	}
-	completeResp, err := client.CompleteUpload(ctx, location, calculator, nil)
-	require.NoError(t, err)
-	require.NotEmpty(t, *completeResp.DockerContentDigest)
+		uploadResp, err := client.UploadChunk(ctx, *startRes.Location, bytes.NewReader(blob), calculator, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, *uploadResp.Location)
+		_, err = client.CancelUpload(ctx, *uploadResp.Location, nil)
+		require.NoError(t, err)
+	})
 }
 
 func TestNewBlobClient(t *testing.T) {
@@ -111,39 +157,7 @@ func TestNewBlobClient(t *testing.T) {
 	require.Errorf(t, err, "provided Cloud field is missing Azure Container Registry configuration")
 }
 
-func TestBlobClient_CompleteUpload_uploadByChunkFailOver(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewBlobClient(endpoint, cred, &BlobClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	getRes, err := client.GetBlob(ctx, "alpine", alpineBlobDigest, nil)
-	require.NoError(t, err)
-	blob, err := io.ReadAll(getRes.BlobData)
-	require.NoError(t, err)
-	startRes, err := client.StartUpload(ctx, "hello-world", nil)
-	require.NoError(t, err)
-	calculator := NewBlobDigestCalculator()
-	oriReader := bytes.NewReader(blob)
-	firstPart := io.NewSectionReader(oriReader, int64(0), int64(len(blob)/2))
-	secondPart := io.NewSectionReader(oriReader, int64(len(blob)/2), int64(len(blob)-len(blob)/2))
-	uploadResp, err := client.UploadChunk(ctx, *startRes.Location, firstPart, calculator, &BlobClientUploadChunkOptions{RangeStart: to.Ptr(int32(0)), RangeEnd: to.Ptr(int32(len(blob)/2 - 1))})
-	require.NoError(t, err)
-	require.NotEmpty(t, *uploadResp.Location)
-	sum := calculator.h.Sum(nil)
-	// upload with a wrong range to test fail over
-	_, err = client.UploadChunk(ctx, *uploadResp.Location, secondPart, calculator, &BlobClientUploadChunkOptions{RangeStart: to.Ptr(int32(-1)), RangeEnd: to.Ptr(int32(-1))})
-	require.Error(t, err)
-	require.Equal(t, sum, calculator.h.Sum(nil))
-	uploadResp, err = client.UploadChunk(ctx, *uploadResp.Location, secondPart, calculator, &BlobClientUploadChunkOptions{RangeStart: to.Ptr(int32(len(blob) / 2)), RangeEnd: to.Ptr(int32(len(blob) - 1))})
-	require.NoError(t, err)
-	require.NotEmpty(t, *uploadResp.Location)
-	completeResp, err := client.CompleteUpload(ctx, *uploadResp.Location, calculator, nil)
-	require.NoError(t, err)
-	require.NotEmpty(t, *completeResp.DockerContentDigest)
-}
-
-func TestBlobClient_UploadChunk_retry(t *testing.T) {
+func TestBlobCustomClient_UploadChunk_retry(t *testing.T) {
 	srv, closeServer := mock.NewServer()
 	defer closeServer()
 	srv.AppendResponse(mock.WithStatusCode(http.StatusGatewayTimeout))
@@ -156,10 +170,24 @@ func TestBlobClient_UploadChunk_retry(t *testing.T) {
 		azcoreClient,
 		srv.URL(),
 	}
-	ctx := context.Background()
 	chunkData := bytes.NewReader([]byte("test"))
 	calculator := NewBlobDigestCalculator()
 	_, err = client.UploadChunk(ctx, "location", chunkData, calculator, nil)
 	require.NoError(t, err)
 	require.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", fmt.Sprintf("%x", calculator.h.Sum(nil)))
 }
+
+// fakeHash is a fake hash.Hash for playback mode
+type fakeHash struct{}
+
+func (f *fakeHash) Write(p []byte) (int, error) { return 0, nil }
+
+func (f *fakeHash) Sum(b []byte) []byte { return []byte{0} }
+
+func (f *fakeHash) Reset() {}
+
+func (f *fakeHash) Size() int { return 0 }
+
+func (f *fakeHash) BlockSize() int { return 1 }
+
+func (f *fakeHash) MarshalBinary() ([]byte, error) { return nil, nil }

--- a/sdk/containers/azcontainerregistry/ci.yml
+++ b/sdk/containers/azcontainerregistry/ci.yml
@@ -24,13 +24,18 @@ pr:
 extends:
   template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
+    PreSteps:
+    - task: AzureCLI@2
+      displayName: Set OIDC token
+      inputs:
+        addSpnToEnvironment: true
+        azureSubscription: azure-sdk-tests
+        inlineScript: Write-Host "##vso[task.setvariable variable=OIDC_TOKEN;]$($env:idToken)"
+        scriptType: pscore
+        scriptLocation: inlineScript
     ServiceDirectory: 'containers/azcontainerregistry'
     RunLiveTests: true
+    UseFederatedAuth: true
     UsePipelineProxy: false
     TestRunTime: '30m'
     SupportedClouds: 'Public,UsGov'
-    EnvVars:
-      AZURE_CLIENT_ID: $(AZCONTAINERREGISTRY_CLIENT_ID)
-      AZURE_TENANT_ID: $(AZCONTAINERREGISTRY_TENANT_ID)
-      AZURE_CLIENT_SECRET: $(AZCONTAINERREGISTRY_CLIENT_SECRET)
-      AZURE_SUBSCRIPTION_ID: $(AZCONTAINERREGISTRY_SUBSCRIPTION_ID)

--- a/sdk/containers/azcontainerregistry/client_test.go
+++ b/sdk/containers/azcontainerregistry/client_test.go
@@ -8,8 +8,6 @@ package azcontainerregistry
 
 import (
 	"bytes"
-	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -20,61 +18,36 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/stretchr/testify/require"
 )
 
-const alpineManifestDigest = "sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a"
-
 func TestClient_DeleteManifest(t *testing.T) {
+	repository, _ := buildImage(t)
 	startRecording(t)
 	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	resp, err := client.GetTagProperties(ctx, "busybox", "1.36.1-uclibc", nil)
-	require.NoError(t, err)
-	_, err = client.DeleteManifest(ctx, "busybox", *resp.Tag.Digest, nil)
-	require.NoError(t, err)
-	_, err = client.DeleteManifest(ctx, "hello-world", "sha256:sha256:aa0cc8055b82dc2509bed2e19b275c8f463506616377219d9642221ab53cf9fe", nil)
-	require.NoError(t, err)
-}
-
-func TestClient_DeleteManifest_wrongDigest(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.DeleteManifest(ctx, "alpine", "error-digest", nil)
-	require.Error(t, err)
-}
-
-func TestClient_DeleteManifest_empty(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient("endpoint", nil, nil)
 	require.NoError(t, err)
 	_, err = client.DeleteManifest(ctx, "", "digest", nil)
 	require.Error(t, err)
 	_, err = client.DeleteManifest(ctx, "name", "", nil)
 	require.Error(t, err)
+	resp, err := client.GetTagProperties(ctx, repository, "latest", nil)
+	require.NoError(t, err)
+	_, err = client.DeleteManifest(ctx, repository, *resp.Tag.Digest, nil)
+	require.NoError(t, err)
 }
 
 func TestClient_DeleteRepository(t *testing.T) {
+	repository, _ := buildImage(t)
 	startRecording(t)
 	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.DeleteRepository(ctx, "eclipse-mosquitto", nil)
-	require.NoError(t, err)
-}
-
-func TestClient_DeleteRepository_empty(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient("endpoint", nil, nil)
 	require.NoError(t, err)
 	_, err = client.DeleteRepository(ctx, "", nil)
 	require.Error(t, err)
+	_, err = client.DeleteRepository(ctx, repository, nil)
+	require.NoError(t, err)
 }
 
 func TestClient_DeleteRepository_error(t *testing.T) {
@@ -88,29 +61,22 @@ func TestClient_DeleteRepository_error(t *testing.T) {
 		azcoreClient,
 		srv.URL(),
 	}
-	ctx := context.Background()
 	_, err = client.DeleteRepository(ctx, "test", nil)
 	require.Error(t, err)
 }
 
 func TestClient_DeleteTag(t *testing.T) {
+	repository, _ := buildImage(t)
 	startRecording(t)
 	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.DeleteTag(ctx, "alpine", "3.14.8", nil)
-	require.NoError(t, err)
-}
-
-func TestClient_DeleteTag_empty(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient("endpoint", nil, nil)
 	require.NoError(t, err)
 	_, err = client.DeleteTag(ctx, "", "tag", nil)
 	require.Error(t, err)
 	_, err = client.DeleteTag(ctx, "name", "", nil)
 	require.Error(t, err)
+	_, err = client.DeleteTag(ctx, repository, "latest", nil)
+	require.NoError(t, err)
 }
 
 func TestClient_DeleteTag_error(t *testing.T) {
@@ -124,25 +90,27 @@ func TestClient_DeleteTag_error(t *testing.T) {
 		azcoreClient,
 		srv.URL(),
 	}
-	ctx := context.Background()
 	_, err = client.DeleteTag(ctx, "name", "tag", nil)
 	require.Error(t, err)
 }
 
 func TestClient_GetManifest(t *testing.T) {
+	repository, _ := buildImage(t)
 	startRecording(t)
 	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
 	require.NoError(t, err)
-	res, err := client.GetManifest(ctx, "alpine", "3.17.1", &ClientGetManifestOptions{Accept: to.Ptr("application/vnd.docker.distribution.manifest.v2+json")})
+	_, err = client.GetManifest(ctx, repository, "wrong-tag", &ClientGetManifestOptions{Accept: to.Ptr("application/vnd.docker.distribution.manifest.v2+json")})
+	require.Error(t, err)
+	res, err := client.GetManifest(ctx, repository, "latest", &ClientGetManifestOptions{Accept: to.Ptr("application/vnd.docker.distribution.manifest.v2+json")})
 	require.NoError(t, err)
-	reader, err := NewDigestValidationReader(*res.DockerContentDigest, res.ManifestData)
-	require.NoError(t, err)
-	manifest, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	require.NotEmpty(t, manifest)
-	fmt.Printf("manifest content: %s\n", manifest)
+	if recording.GetRecordMode() != recording.PlaybackMode {
+		reader, err := NewDigestValidationReader(*res.DockerContentDigest, res.ManifestData)
+		require.NoError(t, err)
+		manifest, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.NotEmpty(t, manifest)
+	}
 }
 
 func TestClient_GetManifest_wrongServerDigest(t *testing.T) {
@@ -156,7 +124,6 @@ func TestClient_GetManifest_wrongServerDigest(t *testing.T) {
 		azcoreClient,
 		srv.URL(),
 	}
-	ctx := context.Background()
 	resp, err := client.GetManifest(ctx, "name", "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", nil)
 	require.NoError(t, err)
 	reader, err := NewDigestValidationReader(*resp.DockerContentDigest, resp.ManifestData)
@@ -166,7 +133,6 @@ func TestClient_GetManifest_wrongServerDigest(t *testing.T) {
 }
 
 func TestClient_GetManifest_empty(t *testing.T) {
-	ctx := context.Background()
 	client, err := NewClient("endpoint", nil, nil)
 	require.NoError(t, err)
 	_, err = client.GetManifest(ctx, "", "tag", nil)
@@ -175,171 +141,150 @@ func TestClient_GetManifest_empty(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestClient_GetManifest_wrongTag(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.GetManifest(ctx, "alpine", "wrong-tag", &ClientGetManifestOptions{Accept: to.Ptr("application/vnd.docker.distribution.manifest.v2+json")})
-	require.Error(t, err)
-}
+func TestClient(t *testing.T) {
+	repository, digest := buildImage(t)
 
-func TestClient_GetManifestProperties(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	digestRes, err := client.GetManifestProperties(ctx, "alpine", alpineManifestDigest, nil)
-	require.NoError(t, err)
-	require.Equal(t, *digestRes.Manifest.Digest, alpineManifestDigest)
-	resp, err := client.GetTagProperties(ctx, "alpine", "3.17.1", nil)
-	require.NoError(t, err)
-	tagRes, err := client.GetManifestProperties(ctx, "alpine", *resp.Tag.Digest, nil)
-	require.NoError(t, err)
-	require.Equal(t, alpineManifestDigest, *tagRes.Manifest.Digest)
-}
-
-func TestClient_GetManifestProperties_empty(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient("endpoint", nil, nil)
-	require.NoError(t, err)
-	_, err = client.GetManifestProperties(ctx, "", "digest", nil)
-	require.Error(t, err)
-	_, err = client.GetManifestProperties(ctx, "name", "", nil)
-	require.Error(t, err)
-}
-
-func TestClient_GetManifestProperties_wrongDigest(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.GetManifestProperties(ctx, "alpine", "wrong-digest", nil)
-	require.Error(t, err)
-}
-
-func TestClient_GetRepositoryProperties(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	res, err := client.GetRepositoryProperties(ctx, "alpine", nil)
-	require.NoError(t, err)
-	require.NotEmpty(t, *res.Name)
-	fmt.Printf("repository name: %s\n", *res.Name)
-	require.NotEmpty(t, *res.RegistryLoginServer)
-	fmt.Printf("registry login server of the repository: %s\n", *res.RegistryLoginServer)
-	require.NotEmpty(t, *res.ManifestCount)
-	fmt.Printf("repository manifest count: %d\n", *res.ManifestCount)
-}
-
-func TestClient_GetRepositoryProperties_empty(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient("endpoint", nil, nil)
-	require.NoError(t, err)
-	_, err = client.GetRepositoryProperties(ctx, "", nil)
-	require.Error(t, err)
-}
-
-func TestClient_GetRepositoryProperties_wrongName(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.GetRepositoryProperties(ctx, "wrong-name", nil)
-	require.Error(t, err)
-}
-
-func TestClient_GetTagProperties(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	res, err := client.GetTagProperties(ctx, "alpine", "3.17.1", nil)
-	require.NoError(t, err)
-	require.NotEmpty(t, *res.Tag.Name)
-	fmt.Printf("tag name: %s\n", *res.Tag.Name)
-	require.NotEmpty(t, *res.Tag.Digest)
-	fmt.Printf("tag digest: %s\n", *res.Tag.Digest)
-}
-
-func TestClient_GetTagProperties_empty(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient("endpoint", nil, nil)
-	require.NoError(t, err)
-	_, err = client.GetTagProperties(ctx, "", "", nil)
-	require.Error(t, err)
-	_, err = client.GetTagProperties(ctx, "name", "", nil)
-	require.Error(t, err)
-}
-
-func TestClient_GetTagProperties_wrongTag(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.GetTagProperties(ctx, "alpine", "wrong-tag", nil)
-	require.Error(t, err)
-}
-
-func TestClient_NewListManifestsPager(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	pager := client.NewListManifestsPager("alpine", &ClientListManifestsOptions{
-		MaxNum: to.Ptr[int32](1),
-	})
-	items := 0
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
+	t.Run("GetManifestProperties", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
 		require.NoError(t, err)
-		require.NotEmpty(t, page.Manifests.Attributes)
-		items += len(page.Manifests.Attributes)
-	}
-	require.NotZero(t, items)
-
-	pager = client.NewListManifestsPager("alpine", &ClientListManifestsOptions{
-		OrderBy: to.Ptr(ArtifactManifestOrderByLastUpdatedOnDescending),
-	})
-	var descendingItems []*ManifestAttributes
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
+		_, err = client.GetManifestProperties(ctx, "", "digest", nil)
+		require.Error(t, err)
+		_, err = client.GetManifestProperties(ctx, "name", "", nil)
+		require.Error(t, err)
+		_, err = client.GetManifestProperties(ctx, repository, "wrong-digest", nil)
+		require.Error(t, err)
+		digestRes, err := client.GetManifestProperties(ctx, repository, digest, nil)
 		require.NoError(t, err)
-		require.NotEmpty(t, page.Manifests.Attributes)
-		for i, v := range page.Manifests.Attributes {
-			fmt.Printf("manifest order by last updated on descending %d: %s\n", i+1, *v.Digest)
-			descendingItems = append(descendingItems, v)
+		require.Equal(t, *digestRes.Manifest.Digest, digest)
+		resp, err := client.GetTagProperties(ctx, repository, "latest", nil)
+		require.NoError(t, err)
+		tagRes, err := client.GetManifestProperties(ctx, repository, *resp.Tag.Digest, nil)
+		require.NoError(t, err)
+		require.Equal(t, digest, *tagRes.Manifest.Digest)
+	})
+
+	t.Run("GetRepositoryProperties", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		_, err = client.GetRepositoryProperties(ctx, "", nil)
+		require.Error(t, err)
+		_, err = client.GetRepositoryProperties(ctx, "wrong-name", nil)
+		require.Error(t, err)
+		res, err := client.GetRepositoryProperties(ctx, repository, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, *res.Name)
+		require.NotEmpty(t, *res.RegistryLoginServer)
+		require.NotEmpty(t, *res.ManifestCount)
+	})
+
+	t.Run("GetTagProperties", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		_, err = client.GetTagProperties(ctx, "", "", nil)
+		require.Error(t, err)
+		_, err = client.GetTagProperties(ctx, "name", "", nil)
+		require.Error(t, err)
+		_, err = client.GetTagProperties(ctx, repository, "wrong-tag", nil)
+		require.Error(t, err)
+		res, err := client.GetTagProperties(ctx, repository, "latest", nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, *res.Tag.Name)
+		require.NotEmpty(t, *res.Tag.Digest)
+	})
+
+	t.Run("NewListManifestsPager", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		pager := client.NewListManifestsPager(repository, &ClientListManifestsOptions{
+			MaxNum: to.Ptr[int32](1),
+		})
+		items := 0
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, page.Manifests.Attributes)
+			items += len(page.Manifests.Attributes)
 		}
-	}
-	pager = client.NewListManifestsPager("alpine", &ClientListManifestsOptions{
-		OrderBy: to.Ptr(ArtifactManifestOrderByLastUpdatedOnAscending),
-	})
-	var ascendingItems []*ManifestAttributes
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		require.NoError(t, err)
-		require.NotEmpty(t, page.Manifests.Attributes)
-		for i, v := range page.Manifests.Attributes {
-			fmt.Printf("manifest order by last updated on descending %d: %s\n", i+1, *v.Digest)
-			ascendingItems = append(ascendingItems, v)
+		require.NotZero(t, items)
+
+		pager = client.NewListManifestsPager(repository, &ClientListManifestsOptions{
+			OrderBy: to.Ptr(ArtifactManifestOrderByLastUpdatedOnDescending),
+		})
+		var descendingItems []*ManifestAttributes
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, page.Manifests.Attributes)
+			descendingItems = append(descendingItems, page.Manifests.Attributes...)
 		}
-	}
-	for i := range descendingItems {
-		require.Equal(t, descendingItems[i].Digest, ascendingItems[len(ascendingItems)-1-i].Digest)
-	}
+		pager = client.NewListManifestsPager(repository, &ClientListManifestsOptions{
+			OrderBy: to.Ptr(ArtifactManifestOrderByLastUpdatedOnAscending),
+		})
+		var ascendingItems []*ManifestAttributes
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, page.Manifests.Attributes)
+			ascendingItems = append(ascendingItems, page.Manifests.Attributes...)
+		}
+		for i := range descendingItems {
+			require.Equal(t, descendingItems[i].Digest, ascendingItems[len(ascendingItems)-1-i].Digest)
+		}
+	})
+
+	t.Run("NewListTagsPager", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		pager := client.NewListTagsPager(repository, &ClientListTagsOptions{
+			MaxNum: to.Ptr[int32](1),
+		})
+		items := 0
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, page.Tags)
+			require.Equal(t, 1, len(page.Tags))
+			items += len(page.Tags)
+		}
+		require.NotZero(t, items)
+
+		pager = client.NewListTagsPager(repository, &ClientListTagsOptions{
+			OrderBy: to.Ptr(ArtifactTagOrderByLastUpdatedOnDescending),
+		})
+		var descendingItems []*TagAttributes
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, page.Tags)
+			descendingItems = append(descendingItems, page.Tags...)
+		}
+		pager = client.NewListTagsPager(repository, &ClientListTagsOptions{
+			OrderBy: to.Ptr(ArtifactTagOrderByLastUpdatedOnAscending),
+		})
+		var ascendingItems []*TagAttributes
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, page.Tags)
+			ascendingItems = append(ascendingItems, page.Tags...)
+		}
+		for i := range descendingItems {
+			require.Equal(t, descendingItems[i].Name, ascendingItems[len(ascendingItems)-1-i].Name)
+		}
+	})
 }
 
 func TestClient_NewListManifestsPager_empty(t *testing.T) {
-	ctx := context.Background()
 	client, err := NewClient("endpoint", nil, nil)
 	require.NoError(t, err)
 	pager := client.NewListManifestsPager("", nil)
@@ -353,7 +298,6 @@ func TestClient_NewListManifestsPager_empty(t *testing.T) {
 func TestClient_NewListManifestsPager_wrongRepositoryName(t *testing.T) {
 	startRecording(t)
 	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
 	require.NoError(t, err)
 	pager := client.NewListManifestsPager("wrong-name", nil)
@@ -365,9 +309,10 @@ func TestClient_NewListManifestsPager_wrongRepositoryName(t *testing.T) {
 }
 
 func TestClient_NewListRepositoriesPager(t *testing.T) {
+	// ensure the registry contains at least one repository
+	_, _ = buildImage(t)
 	startRecording(t)
 	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
 	require.NoError(t, err)
 	pager := client.NewListRepositoriesPager(&ClientListRepositoriesOptions{
@@ -380,13 +325,10 @@ func TestClient_NewListRepositoriesPager(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, page.Repositories.Names)
 		pages++
-		for i, v := range page.Repositories.Names {
-			fmt.Printf("page %d repository %d: %s\n", pages, i+1, *v)
-			items++
-		}
+		items += len(page.Repositories.Names)
 	}
-	require.Equal(t, 3, pages)
-	require.Equal(t, 3, items)
+	require.NotZero(t, pages)
+	require.NotZero(t, items)
 }
 
 func TestClient_NewListRepositoriesPager_error(t *testing.T) {
@@ -400,7 +342,6 @@ func TestClient_NewListRepositoriesPager_error(t *testing.T) {
 		azcoreClient,
 		srv.URL(),
 	}
-	ctx := context.Background()
 	pager := client.NewListRepositoriesPager(nil)
 	for pager.More() {
 		_, err := pager.NextPage(ctx)
@@ -409,58 +350,7 @@ func TestClient_NewListRepositoriesPager_error(t *testing.T) {
 	}
 }
 
-func TestClient_NewListTagsPager(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	pager := client.NewListTagsPager("alpine", &ClientListTagsOptions{
-		MaxNum: to.Ptr[int32](1),
-	})
-	items := 0
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		require.NoError(t, err)
-		require.NotEmpty(t, page.Tags)
-		require.Equal(t, 1, len(page.Tags))
-		items += len(page.Tags)
-	}
-	require.NotZero(t, items)
-
-	pager = client.NewListTagsPager("alpine", &ClientListTagsOptions{
-		OrderBy: to.Ptr(ArtifactTagOrderByLastUpdatedOnDescending),
-	})
-	var descendingItems []*TagAttributes
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		require.NoError(t, err)
-		require.NotEmpty(t, page.Tags)
-		for i, v := range page.Tags {
-			fmt.Printf("tag order by last updated on descending %d: %s\n", i+1, *v.Name)
-			descendingItems = append(descendingItems, v)
-		}
-	}
-	pager = client.NewListTagsPager("alpine", &ClientListTagsOptions{
-		OrderBy: to.Ptr(ArtifactTagOrderByLastUpdatedOnAscending),
-	})
-	var ascendingItems []*TagAttributes
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		require.NoError(t, err)
-		require.NotEmpty(t, page.Tags)
-		for i, v := range page.Tags {
-			fmt.Printf("tag order by last updated on descending %d: %s\n", i+1, *v.Name)
-			ascendingItems = append(ascendingItems, v)
-		}
-	}
-	for i := range descendingItems {
-		require.Equal(t, descendingItems[i].Name, ascendingItems[len(ascendingItems)-1-i].Name)
-	}
-}
-
 func TestClient_NewListTagsPager_empty(t *testing.T) {
-	ctx := context.Background()
 	client, err := NewClient("endpoint", nil, nil)
 	require.NoError(t, err)
 	pager := client.NewListTagsPager("", nil)
@@ -474,7 +364,6 @@ func TestClient_NewListTagsPager_empty(t *testing.T) {
 func TestClient_NewListTagsPager_wrongRepositoryName(t *testing.T) {
 	startRecording(t)
 	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
 	require.NoError(t, err)
 	pager := client.NewListTagsPager("wrong-name", nil)
@@ -485,157 +374,124 @@ func TestClient_NewListTagsPager_wrongRepositoryName(t *testing.T) {
 	}
 }
 
-func TestClient_UpdateManifestProperties(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	resp, err := client.GetTagProperties(ctx, "alpine", "3.17.1", nil)
-	require.NoError(t, err)
-	res, err := client.UpdateManifestProperties(ctx, "alpine", *resp.Tag.Digest, &ClientUpdateManifestPropertiesOptions{Value: &ManifestWriteableProperties{
-		CanWrite: to.Ptr(false),
-	},
-	})
-	require.NoError(t, err)
-	require.False(t, *res.Manifest.ChangeableAttributes.CanWrite)
-	res, err = client.UpdateManifestProperties(ctx, "alpine", alpineManifestDigest, &ClientUpdateManifestPropertiesOptions{Value: &ManifestWriteableProperties{
-		CanWrite: to.Ptr(true),
-	},
-	})
-	require.NoError(t, err)
-	require.True(t, *res.Manifest.ChangeableAttributes.CanWrite)
-}
+func TestClient_Update(t *testing.T) {
+	repository, _ := buildImage(t)
 
-func TestClient_UpdateManifestProperties_empty(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient("endpoint", nil, nil)
-	require.NoError(t, err)
-	_, err = client.UpdateManifestProperties(ctx, "", "digest", nil)
-	require.Error(t, err)
-	_, err = client.UpdateManifestProperties(ctx, "name", "", nil)
-	require.Error(t, err)
-}
-
-func TestClient_UpdateManifestProperties_wrongDigest(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.GetTagProperties(ctx, "alpine", "wrong-digest", nil)
-	require.Error(t, err)
-}
-
-func TestClient_UpdateRepositoryProperties(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	res, err := client.UpdateRepositoryProperties(ctx, "busybox", &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{
-		CanWrite: to.Ptr(false),
-	},
+	t.Run("UpdateManifestProperties", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		_, err = client.UpdateManifestProperties(ctx, "", "digest", nil)
+		require.Error(t, err)
+		_, err = client.UpdateManifestProperties(ctx, "name", "", nil)
+		require.Error(t, err)
+		_, err = client.GetTagProperties(ctx, repository, "wrong-tag", nil)
+		require.Error(t, err)
+		resp, err := client.GetTagProperties(ctx, repository, "latest", nil)
+		require.NoError(t, err)
+		res, err := client.UpdateManifestProperties(ctx, repository, *resp.Tag.Digest, &ClientUpdateManifestPropertiesOptions{
+			Value: &ManifestWriteableProperties{
+				CanWrite: to.Ptr(false),
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, *res.Manifest.ChangeableAttributes.CanWrite)
+		res, err = client.UpdateManifestProperties(ctx, repository, *resp.Tag.Digest, &ClientUpdateManifestPropertiesOptions{
+			Value: &ManifestWriteableProperties{
+				CanWrite: to.Ptr(true),
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, *res.Manifest.ChangeableAttributes.CanWrite)
 	})
-	require.NoError(t, err)
-	require.False(t, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
-	res, err = client.UpdateRepositoryProperties(ctx, "busybox", &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{
-		CanWrite: to.Ptr(true),
-	},
-	})
-	require.NoError(t, err)
-	require.True(t, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
-}
 
-func TestClient_UpdateRepositoryProperties_empty(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient("endpoint", nil, nil)
-	require.NoError(t, err)
-	_, err = client.UpdateRepositoryProperties(ctx, "", nil)
-	require.Error(t, err)
-}
-
-func TestClient_UpdateRepositoryProperties_wrongRepository(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.UpdateRepositoryProperties(ctx, "wrong-repository", &ClientUpdateRepositoryPropertiesOptions{Value: &RepositoryWriteableProperties{
-		CanWrite: to.Ptr(false),
-	},
+	t.Run("UpdateRepositoryProperties", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		_, err = client.UpdateRepositoryProperties(ctx, "", nil)
+		require.Error(t, err)
+		_, err = client.UpdateRepositoryProperties(ctx, "wrong-repository", &ClientUpdateRepositoryPropertiesOptions{
+			Value: &RepositoryWriteableProperties{
+				CanWrite: to.Ptr(false),
+			},
+		})
+		require.Error(t, err)
+		res, err := client.UpdateRepositoryProperties(ctx, repository, &ClientUpdateRepositoryPropertiesOptions{
+			Value: &RepositoryWriteableProperties{
+				CanWrite: to.Ptr(false),
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
+		res, err = client.UpdateRepositoryProperties(ctx, repository, &ClientUpdateRepositoryPropertiesOptions{
+			Value: &RepositoryWriteableProperties{
+				CanWrite: to.Ptr(true),
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, *res.ContainerRepositoryProperties.ChangeableAttributes.CanWrite)
 	})
-	require.Error(t, err)
-}
 
-func TestClient_UpdateTagProperties(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	res, err := client.UpdateTagProperties(ctx, "alpine", "3.17.1", &ClientUpdateTagPropertiesOptions{Value: &TagWriteableProperties{
-		CanWrite: to.Ptr(false),
-	},
+	t.Run("UpdateTagProperties", func(t *testing.T) {
+		startRecording(t)
+		endpoint, cred, options := getEndpointCredAndClientOptions(t)
+		client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
+		require.NoError(t, err)
+		_, err = client.UpdateTagProperties(ctx, "name", "", nil)
+		require.Error(t, err)
+		_, err = client.UpdateTagProperties(ctx, "", "tag", nil)
+		require.Error(t, err)
+		_, err = client.UpdateTagProperties(ctx, repository, "wrong-tag", &ClientUpdateTagPropertiesOptions{
+			Value: &TagWriteableProperties{
+				CanWrite: to.Ptr(false),
+			},
+		})
+		require.Error(t, err)
+		res, err := client.UpdateTagProperties(ctx, repository, "latest", &ClientUpdateTagPropertiesOptions{
+			Value: &TagWriteableProperties{
+				CanWrite: to.Ptr(false),
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, *res.Tag.ChangeableAttributes.CanWrite)
+		res, err = client.UpdateTagProperties(ctx, repository, "latest", &ClientUpdateTagPropertiesOptions{
+			Value: &TagWriteableProperties{
+				CanWrite: to.Ptr(true),
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, *res.Tag.ChangeableAttributes.CanWrite)
 	})
-	require.NoError(t, err)
-	require.False(t, *res.Tag.ChangeableAttributes.CanWrite)
-	res, err = client.UpdateTagProperties(ctx, "alpine", "3.17.1", &ClientUpdateTagPropertiesOptions{Value: &TagWriteableProperties{
-		CanWrite: to.Ptr(true),
-	},
-	})
-	require.NoError(t, err)
-	require.True(t, *res.Tag.ChangeableAttributes.CanWrite)
-}
-
-func TestClient_UpdateTagProperties_empty(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient("endpoint", nil, nil)
-	require.NoError(t, err)
-	_, err = client.UpdateTagProperties(ctx, "name", "", nil)
-	require.Error(t, err)
-	_, err = client.UpdateTagProperties(ctx, "", "tag", nil)
-	require.Error(t, err)
-}
-
-func TestClient_UpdateTagProperties_wrongTag(t *testing.T) {
-	startRecording(t)
-	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
-	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
-	require.NoError(t, err)
-	_, err = client.UpdateTagProperties(ctx, "alpine", "wrong-tag", &ClientUpdateTagPropertiesOptions{Value: &TagWriteableProperties{
-		CanWrite: to.Ptr(false),
-	},
-	})
-	require.Error(t, err)
 }
 
 func TestClient_UploadManifest(t *testing.T) {
+	repository, _ := buildImage(t)
 	startRecording(t)
 	endpoint, cred, options := getEndpointCredAndClientOptions(t)
-	ctx := context.Background()
 	client, err := NewClient(endpoint, cred, &ClientOptions{ClientOptions: options})
 	require.NoError(t, err)
-	getRes, err := client.GetManifest(ctx, "hello-world", "latest", &ClientGetManifestOptions{Accept: to.Ptr("application/vnd.oci.image.index.v1+json")})
+	getRes, err := client.GetManifest(ctx, repository, "latest", &ClientGetManifestOptions{Accept: to.Ptr("application/vnd.oci.image.index.v1+json")})
 	require.NoError(t, err)
 	manifest, err := io.ReadAll(getRes.ManifestData)
 	require.NoError(t, err)
 	reader := bytes.NewReader(manifest)
-	uploadRes, err := client.UploadManifest(ctx, "hello-world", "test", "application/vnd.oci.image.index.v1+json", streaming.NopCloser(reader), nil)
+	uploadRes, err := client.UploadManifest(ctx, repository, "test", "application/vnd.oci.image.index.v1+json", streaming.NopCloser(reader), nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, *uploadRes.DockerContentDigest)
-	fmt.Printf("uploaded manifest digest: %s\n", *uploadRes.DockerContentDigest)
 	_, err = reader.Seek(0, io.SeekStart)
 	require.NoError(t, err)
-	validateReader, err := NewDigestValidationReader(*uploadRes.DockerContentDigest, reader)
-	require.NoError(t, err)
-	_, err = io.ReadAll(validateReader)
-	require.NoError(t, err)
+	if recording.GetRecordMode() != recording.PlaybackMode {
+		validateReader, err := NewDigestValidationReader(*uploadRes.DockerContentDigest, reader)
+		require.NoError(t, err)
+		_, err = io.ReadAll(validateReader)
+		require.NoError(t, err)
+	}
 }
 
 func TestClient_UploadManifest_empty(t *testing.T) {
-	ctx := context.Background()
 	client, err := NewClient("endpoint", nil, nil)
 	require.NoError(t, err)
 	_, err = client.UploadManifest(ctx, "", "reference", "contentType", nil, nil)
@@ -655,7 +511,6 @@ func TestClient_UploadManifest_error(t *testing.T) {
 		azcoreClient,
 		srv.URL(),
 	}
-	ctx := context.Background()
 	_, err = client.UploadManifest(ctx, "name", "reference", "contentType", nil, nil)
 	require.Error(t, err)
 }
@@ -667,7 +522,6 @@ func TestClient_wrongEndpoint(t *testing.T) {
 		azcoreClient,
 		"wrong-endpoint",
 	}
-	ctx := context.Background()
 	_, err = client.DeleteManifest(ctx, "name", "digest", nil)
 	require.Error(t, err)
 	_, err = client.DeleteRepository(ctx, "name", nil)

--- a/sdk/containers/azcontainerregistry/go.mod
+++ b/sdk/containers/azcontainerregistry/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/sdk/containers/azcontainerregistry/go.sum
+++ b/sdk/containers/azcontainerregistry/go.sum
@@ -4,10 +4,6 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0/go.mod h1:9kIvujWAA58nmPmWB1m23fyWic1kYZMxD9CxaWn4Qpg=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0 h1:DWlwvVV5r/Wy1561nZ3wrpI1/vDIBRY/Wd1HWaRBZWA=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0/go.mod h1:E7ltexgRDmeJ0fJWv0D/HLwY2xbDdN+uv+X2uZtOx3w=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/sdk/containers/azcontainerregistry/test-resources-post.ps1
+++ b/sdk/containers/azcontainerregistry/test-resources-post.ps1
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# IMPORTANT: Do not invoke this file directly. Please instead run eng/common/TestResources/New-TestResources.ps1 from the repository root.
+
+param (
+    [hashtable] $DeploymentOutputs,
+
+    [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $TenantId,
+
+    [Parameter()]
+    [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+    [string] $TestApplicationId,
+
+    # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $RemainingArguments
+)
+
+if ($CI) {
+    az login --federated-token $env:OIDC_TOKEN --service-principal -t $TenantId -u $TestApplicationId
+    az account set --subscription $DeploymentOutputs['AZCONTAINERREGISTRY_SUBSCRIPTION_ID']
+}

--- a/sdk/containers/azcontainerregistry/test-resources.bicep
+++ b/sdk/containers/azcontainerregistry/test-resources.bicep
@@ -5,7 +5,7 @@ param baseName string
 param location string = resourceGroup().location
 
 resource registry 'Microsoft.ContainerRegistry/registries@2022-02-01-preview' = {
-  name: '${baseName}'
+  name: baseName
   location: location
   sku: {
     name: 'Standard'

--- a/sdk/containers/azcontainerregistry/testdata/Dockerfile
+++ b/sdk/containers/azcontainerregistry/testdata/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+ARG ID
+COPY Dockerfile $ID


### PR DESCRIPTION
Live tests are flaky and usually fail today because they import images from Docker Hub to the test registry, and Docker Hub throttles anonymous pulls. Furthermore, the test suite is hard to maintain because relationships and dependencies between imported images and test cases aren't clear. Some tests refer to images by name, some refer to images or their layers by hard-coded digest, tests can break each other by performing destructive operations on a shared image, etc. This PR addresses these problems by building images on demand via ACR scheduled tasks and organizing tests around the images they operate on so tests own images and don't need to hard-code any details.

Closes #22988