### PR TITLE
Cosmos DB: Fixes minimal response header being sent on metadata operations

### DIFF
--- a/sdk/data/azcosmos/cosmos_headers_policy.go
+++ b/sdk/data/azcosmos/cosmos_headers_policy.go
@@ -43,7 +43,7 @@ func (p *headerPolicies) Do(req *policy.Request) (*http.Response, error) {
 			}
 		}
 
-		if o.isWriteOperation && !enableContentResponseOnWrite {
+		if o.isWriteOperation && o.resourceType == resourceTypeDocument && !enableContentResponseOnWrite {
 			req.Raw().Header.Add(cosmosHeaderPrefer, cosmosHeaderValuesPreferMinimal)
 		}
 	}


### PR DESCRIPTION
Minimal content header by design should be used on Item operations. On non-Item operations it should ideally be ignored by the service but there's evidence that if sent during a Delete Container operation with Shared Throughput, it causes an HTTP 500 on the service.

This PR makes sure that the header is only sent on Item operations