### PR TITLE
[azeventhubs] Fixing a bug where a cancelled recovery could result in a perpetually broken client

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.2.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.2.2 (2024-08-15)
 
 ### Bugs Fixed
 
-- Fixed a bug that where a short context deadline could prevent recovery from ever happening. The end result would be a broken PartitionClient/ConsumerClient that would never recover from the underlying failure. (PR#      )
-
-### Other Changes
+- Fixed a bug that where a short context deadline could prevent recovery from ever happening. The end result would be a broken PartitionClient/ConsumerClient that would never recover from the underlying failure. (PR#23337)
 
 ## 1.2.1 (2024-05-20)
 

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug that where a short context deadline could prevent recovery from ever happening. The end result would be a broken PartitionClient/ConsumerClient that would never recover from the underlying failure. (PR#      )
+
 ### Other Changes
 
 ## 1.2.1 (2024-05-20)

--- a/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.3.2
-digest: sha256:6eee71a7e8a4c0dc06d5fbbce39ef63237a0db0b7fc2da66e98e96b68985b764
-generated: "2024-05-30T01:22:48.620817144Z"
+  version: 0.3.3
+digest: sha256:1cffb5ed8ea74953ab7611f9e2de2163af2c3f0918afb9928f71210da9c19a4a
+generated: "2024-08-14T17:44:22.828343827-07:00"

--- a/sdk/messaging/azeventhubs/internal/eh/stress/templates/stress-test-job.yaml
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/templates/stress-test-job.yaml
@@ -21,6 +21,7 @@ spec:
       args: 
         - >
           set -ex;
+          set -o pipefail;
           mkdir -p "$DEBUG_SHARE";
           {{if eq .Stress.testTarget "multibalance" }}
           /app/stress "{{.Stress.testTarget}}" "-rounds" "{{.Stress.rounds}}" "{{.Stress.verbose}}" 2>&1 | tee -a "${DEBUG_SHARE}/{{ .Stress.Scenario }}-`date +%s`.log";

--- a/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
+++ b/sdk/messaging/azeventhubs/internal/eh/stress/tests/shared.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	azlog "github.com/Azure/azure-sdk-for-go/sdk/internal/log"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/test/credential"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/checkpoints"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/internal/test"
@@ -109,7 +109,9 @@ func newStressTestData(name string, baggage map[string]string) (*stressTestData,
 
 	td.TC = telemetryClient{tc}
 
-	td.Cred, err = credential.New(nil)
+	// NOTE: this isn't run in the live testing pipelines, only within stress testing
+	// so you shouldn't use the test credential.
+	td.Cred, err = azidentity.NewDefaultAzureCredential(nil)
 
 	if err != nil {
 		return nil, err

--- a/sdk/messaging/azeventhubs/internal/links.go
+++ b/sdk/messaging/azeventhubs/internal/links.go
@@ -21,7 +21,10 @@ type AMQPLink interface {
 // LinksForPartitionClient are the functions that the PartitionClient uses within Links[T]
 // (for unit testing only)
 type LinksForPartitionClient[LinkT AMQPLink] interface {
+	// Retry is [Links.Retry]
 	Retry(ctx context.Context, eventName azlog.Event, operation string, partitionID string, retryOptions exported.RetryOptions, fn func(ctx context.Context, lwid LinkWithID[LinkT]) error) error
+
+	// Close is [Links.Close]
 	Close(ctx context.Context) error
 }
 


### PR DESCRIPTION
Fixing a customer issue where they cancel in the middle of our retry loop and prevent our recovery from happening.
    
This simplifies the overall logic and should be just fine - some of the cases it was trying to handle aren't needed anymore because of changes in the recovery code, etc...
    
Also, updated stress tests to include pipefail, which makes sure that, if the underlying test fails, the script _exits_ instead of potentially reporting okay because `tee` happened to work :) Also, the stress tests were incorrectly using the test credential, and we can't/don't use that in stress testing.

Fixes #23282