### PR TITLE
Cosmos DB: Fixes metadata routing on multi-master

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bugs Fixed
 * Fixed sending `Prefer` header with `return=minimal` value on metadata operations. See [PR 23335](https://github.com/Azure/azure-sdk-for-go/pull/23335)
+* Fixed routing metadata requests to satellite regions when using ClientOptions.PreferredRegions and multiple write region accounts. See [PR 23339](https://github.com/Azure/azure-sdk-for-go/pull/23339)
 
 ### Other Changes
 

--- a/sdk/data/azcosmos/cosmos_client_retry_policy.go
+++ b/sdk/data/azcosmos/cosmos_client_retry_policy.go
@@ -40,7 +40,7 @@ func (p *clientRetryPolicy) Do(req *policy.Request) (*http.Response, error) {
 	for {
 		// Update the retry context with the latest retry values
 		req.SetOperationValue(retryContext)
-		resolvedEndpoint := p.gem.ResolveServiceEndpoint(retryContext.retryCount, o.isWriteOperation, retryContext.useWriteEndpoint)
+		resolvedEndpoint := p.gem.ResolveServiceEndpoint(retryContext.retryCount, o.resourceType, o.isWriteOperation, retryContext.useWriteEndpoint)
 		req.Raw().Host = resolvedEndpoint.Host
 		req.Raw().URL.Host = resolvedEndpoint.Host
 		response, err := req.Next() // err can happen in weird scenarios (connectivity, etc)

--- a/sdk/data/azcosmos/cosmos_client_retry_policy.go
+++ b/sdk/data/azcosmos/cosmos_client_retry_policy.go
@@ -74,11 +74,11 @@ func (p *clientRetryPolicy) Do(req *policy.Request) (*http.Response, error) {
 					return nil, errorinfo.NonRetriableError(azruntime.NewResponseErrorWithErrorCode(response, response.Status))
 				}
 			} else if response.StatusCode == http.StatusNotFound {
-				if !p.attemptRetryOnSessionUnavailable(req, o.isWriteOperation, &retryContext) {
+				if !p.attemptRetryOnSessionUnavailable(o.isWriteOperation, &retryContext) {
 					return nil, errorinfo.NonRetriableError(azruntime.NewResponseErrorWithErrorCode(response, response.Status))
 				}
 			} else if response.StatusCode == http.StatusServiceUnavailable {
-				if !p.attemptRetryOnServiceUnavailable(req, o.isWriteOperation, &retryContext) {
+				if !p.attemptRetryOnServiceUnavailable(o.isWriteOperation, &retryContext) {
 					return nil, errorinfo.NonRetriableError(azruntime.NewResponseErrorWithErrorCode(response, response.Status))
 				}
 			}
@@ -151,7 +151,7 @@ func (p *clientRetryPolicy) attemptRetryOnEndpointFailure(req *policy.Request, i
 	return true, nil
 }
 
-func (p *clientRetryPolicy) attemptRetryOnSessionUnavailable(req *policy.Request, isWriteOperation bool, retryContext *retryContext) bool {
+func (p *clientRetryPolicy) attemptRetryOnSessionUnavailable(isWriteOperation bool, retryContext *retryContext) bool {
 	if p.gem.CanUseMultipleWriteLocations() {
 		endpoints := p.gem.locationCache.locationInfo.availReadLocations
 		if isWriteOperation {
@@ -170,7 +170,7 @@ func (p *clientRetryPolicy) attemptRetryOnSessionUnavailable(req *policy.Request
 	return true
 }
 
-func (p *clientRetryPolicy) attemptRetryOnServiceUnavailable(req *policy.Request, isWriteOperation bool, retryContext *retryContext) bool {
+func (p *clientRetryPolicy) attemptRetryOnServiceUnavailable(isWriteOperation bool, retryContext *retryContext) bool {
 	if !p.gem.locationCache.enableCrossRegionRetries || retryContext.preferredLocationIndex >= len(p.gem.preferredLocations) {
 		return false
 	}

--- a/sdk/data/azcosmos/cosmos_client_retry_policy_test.go
+++ b/sdk/data/azcosmos/cosmos_client_retry_policy_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
@@ -43,7 +44,7 @@ func TestSessionNotAvailableSingleMaster(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
 	// Setting up responses for consistent failures
 	srv.AppendResponse(
@@ -53,7 +54,7 @@ func TestSessionNotAvailableSingleMaster(t *testing.T) {
 		mock.WithHeader("x-ms-substatus", "1002"),
 		mock.WithStatusCode(404))
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 	_, err = container.ReadItem(context.TODO(), NewPartitionKeyString("1"), "doc1", nil)
@@ -130,7 +131,7 @@ func TestSessionNotAvailableMultiMaster(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
 	// Setting up responses for using all retries and failing
 	srv.AppendResponse(
@@ -146,7 +147,7 @@ func TestSessionNotAvailableMultiMaster(t *testing.T) {
 		mock.WithHeader("x-ms-substatus", "1002"),
 		mock.WithStatusCode(404))
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 	_, err = container.ReadItem(context.TODO(), NewPartitionKeyString("1"), "doc1", nil)
@@ -238,7 +239,7 @@ func TestReadEndpointFailure(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
 	// Setting up responses for retrying twice
 	srv.AppendResponse(
@@ -250,7 +251,7 @@ func TestReadEndpointFailure(t *testing.T) {
 	srv.AppendResponse(
 		mock.WithStatusCode(200))
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 	_, err = container.ReadItem(context.TODO(), NewPartitionKeyString("1"), "doc1", nil)
@@ -291,9 +292,9 @@ func TestWriteEndpointFailure(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 
@@ -354,9 +355,9 @@ func TestReadServiceUnavailable(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 
@@ -427,9 +428,9 @@ func TestWriteServiceUnavailable(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 
@@ -506,9 +507,9 @@ func TestDnsErrorRetry(t *testing.T) {
 	retryPolicy := &clientRetryPolicy{gem: gem}
 	verifier := clientRetryPolicyVerifier{}
 
-	pl := azruntime.NewPipeline("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{PerRetry: []policy.Policy{&verifier, retryPolicy}}, &policy.ClientOptions{Transport: srv})
 
-	client := &Client{endpoint: srv.URL(), pipeline: pl, gem: gem}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
 	db, _ := client.NewDatabase("database_id")
 	container, _ := db.NewContainer("container_id")
 

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager.go
@@ -92,8 +92,8 @@ func (gem *globalEndpointManager) shouldRefresh() bool {
 	return time.Since(gem.lastUpdateTime) > gem.refreshTimeInterval
 }
 
-func (gem *globalEndpointManager) ResolveServiceEndpoint(locationIndex int, isWriteOperation, useWriteEndpoint bool) url.URL {
-	return gem.locationCache.resolveServiceEndpoint(locationIndex, isWriteOperation, useWriteEndpoint)
+func (gem *globalEndpointManager) ResolveServiceEndpoint(locationIndex int, resourceType resourceType, isWriteOperation, useWriteEndpoint bool) url.URL {
+	return gem.locationCache.resolveServiceEndpoint(locationIndex, resourceType, isWriteOperation, useWriteEndpoint)
 }
 
 func (gem *globalEndpointManager) Update(ctx context.Context, forceRefresh bool) error {

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -413,7 +413,7 @@ func createLocationCacheForGem(defaultEndpoint url.URL, isMultiMaster bool) *loc
 	}
 
 	// Order by preference
-	cache.update(nil, nil, nil, nil)
+	_ := cache.update(nil, nil, nil, nil)
 
 	return &cache
 }

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -413,7 +413,7 @@ func createLocationCacheForGem(defaultEndpoint url.URL, isMultiMaster bool) *loc
 	}
 
 	// Order by preference
-	_ := cache.update(nil, nil, nil, nil)
+	_ = cache.update(nil, nil, nil, nil)
 
 	return &cache
 }

--- a/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/cosmos_global_endpoint_manager_test.go
@@ -274,7 +274,7 @@ func TestGlobalEndpointManagerResolveEndpointSingleMasterDocumentOperation(t *te
 	serverEndpoint, _ := url.Parse("https://myaccount.documents.azure.com:443/")
 
 	mockLc := createLocationCacheForGem(*serverEndpoint, false)
-	
+
 	mockGem := globalEndpointManager{
 		clientEndpoint:      "https://localhost",
 		preferredLocations:  []string{"Central US"},
@@ -299,7 +299,7 @@ func TestGlobalEndpointManagerResolveEndpointMultiMasterDocumentOperation(t *tes
 	serverEndpoint, _ := url.Parse("https://myaccount.documents.azure.com:443/")
 
 	mockLc := createLocationCacheForGem(*serverEndpoint, true)
-	
+
 	mockGem := globalEndpointManager{
 		clientEndpoint:      "https://localhost",
 		preferredLocations:  []string{"Central US"},
@@ -324,7 +324,7 @@ func TestGlobalEndpointManagerResolveEndpointSingleMasterMetadataOperation(t *te
 	serverEndpoint, _ := url.Parse("https://myaccount.documents.azure.com:443/")
 
 	mockLc := createLocationCacheForGem(*serverEndpoint, false)
-	
+
 	mockGem := globalEndpointManager{
 		clientEndpoint:      "https://localhost",
 		preferredLocations:  []string{"Central US"},
@@ -349,7 +349,7 @@ func TestGlobalEndpointManagerResolveEndpointMultiMasterMetadataOperation(t *tes
 	serverEndpoint, _ := url.Parse("https://myaccount.documents.azure.com:443/")
 
 	mockLc := createLocationCacheForGem(*serverEndpoint, true)
-	
+
 	mockGem := globalEndpointManager{
 		clientEndpoint:      "https://localhost",
 		preferredLocations:  []string{"Central US"},

--- a/sdk/data/azcosmos/cosmos_location_cache.go
+++ b/sdk/data/azcosmos/cosmos_location_cache.go
@@ -113,8 +113,8 @@ func (lc *locationCache) update(writeLocations []accountRegion, readLocations []
 	return nil
 }
 
-func (lc *locationCache) resolveServiceEndpoint(locationIndex int, isWriteOperation, useWriteEndpoint bool) url.URL {
-	if (isWriteOperation || useWriteEndpoint) && !lc.canUseMultipleWriteLocs() {
+func (lc *locationCache) resolveServiceEndpoint(locationIndex int, resourceType resourceType, isWriteOperation, useWriteEndpoint bool) url.URL {
+	if (isWriteOperation || useWriteEndpoint) && !lc.canUseMultipleWriteLocsToRoute(resourceType) {
 		if lc.enableCrossRegionRetries && len(lc.locationInfo.availWriteLocations) > 0 {
 			locationIndex = min(locationIndex%2, len(lc.locationInfo.availWriteLocations)-1)
 			writeLocation := lc.locationInfo.availWriteLocations[locationIndex]
@@ -128,6 +128,10 @@ func (lc *locationCache) resolveServiceEndpoint(locationIndex int, isWriteOperat
 		endpoints = lc.locationInfo.writeEndpoints
 	}
 	return endpoints[locationIndex%len(endpoints)]
+}
+
+func (lc *locationCache) canUseMultipleWriteLocsToRoute(resourceType resourceType) bool {
+	return lc.canUseMultipleWriteLocs() && resourceType == resourceTypeDocument
 }
 
 func (lc *locationCache) readEndpoints() ([]url.URL, error) {


### PR DESCRIPTION
## Scenario

Metadata read requests (not item operations) can be routed to any available regions. Metadata write requests, should always be routed to the primary / hub region.

In cases where the account is Single Write Region, this rule applies correctly.

The SDK allows users to define a list of Preferred Regions to route requests preferably. This preference applies in the following way:

* Single Write Region: Affects read operations
* Multi Write Region: Affects read and write operations

## Problem

The problem is that the above rules should apply for Item operations. Metadata operations, even on a Multi Write Region account, cannot be routed to secondary regions.

Currently when routing requests, the Global Endpoint Manager is treating all requests the same way and for Metadata write operations and Multi Write Region accounts, it will apply the user preference.

## Solution

Take into consideration the Resource Type when deciding if it's possible to route write operations to preferred regions and only do it for Item operations.

Similar code path in .NET

https://github.com/Azure/azure-cosmos-dotnet-v3/blob/2fbc27835fde0837d4b3efea0f722c5f5c64119e/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs#L530-L535