### PR TITLE
[azservicebus] Fixing error checking to take error wrapping into account

### DIFF
--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0
-	github.com/Azure/go-amqp v1.0.5
+	github.com/Azure/go-amqp v1.1.0
 )
 
 require (

--- a/sdk/messaging/azservicebus/go.sum
+++ b/sdk/messaging/azservicebus/go.sum
@@ -7,8 +7,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0/go.mod h1:9kIvujWAA58nmPmWB1m23fyWic1kYZMxD9CxaWn4Qpg=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
-github.com/Azure/go-amqp v1.0.5 h1:po5+ljlcNSU8xtapHTe8gIc8yHxCzC03E8afH2g1ftU=
-github.com/Azure/go-amqp v1.0.5/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
+github.com/Azure/go-amqp v1.1.0 h1:XUhx5f4lZFVf6LQc5kBUFECW0iJW9VLxKCYrBeGwl0U=
+github.com/Azure/go-amqp v1.1.0/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -53,9 +53,7 @@ func TransformError(err error) error {
 		return nil
 	}
 
-	_, ok := err.(*exported.Error)
-
-	if ok {
+	if ourErr := (*exported.Error)(nil); errors.As(err, &ourErr) {
 		// it's already been wrapped.
 		return err
 	}
@@ -222,6 +220,16 @@ func GetRecoveryKind(err error) RecoveryKind {
 		return RecoveryKindFatal
 	}
 
+	// check the AMQP condition first since it's usually more specific than just knowing it came
+	// from a link, or a connection.
+	if amqpError := (*amqp.Error)(nil); errors.As(err, &amqpError) {
+		recoveryKind, ok := amqpConditionsToRecoveryKind[amqpError.Condition]
+
+		if ok {
+			return recoveryKind
+		}
+	}
+
 	// check the "special" AMQP errors that aren't condition-based.
 	if IsLinkError(err) {
 		return RecoveryKindLink
@@ -240,18 +248,6 @@ func GetRecoveryKind(err error) RecoveryKind {
 		// temporary, operation should just be retryable since drain will
 		// eventually complete.
 		return RecoveryKindNone
-	}
-
-	// then it's _probably_ an actual *amqp.Error, in which case we bucket it by
-	// the 'condition'.
-	var amqpError *amqp.Error
-
-	if errors.As(err, &amqpError) {
-		recoveryKind, ok := amqpConditionsToRecoveryKind[amqpError.Condition]
-
-		if ok {
-			return recoveryKind
-		}
 	}
 
 	var rpcErr RPCError
@@ -308,14 +304,6 @@ type (
 	// ErrNoMessages is returned when an operation returned no messages. It is not indicative that there will not be
 	// more messages in the future.
 	ErrNoMessages struct{}
-
-	// ErrNotFound is returned when an entity is not found (404)
-	ErrNotFound struct {
-		EntityPath string
-	}
-
-	// ErrConnectionClosed indicates that the connection has been closed.
-	ErrConnectionClosed string
 )
 
 func (e ErrMissingField) Error() string {
@@ -350,20 +338,6 @@ func (e ErrAMQP) Error() string {
 
 func (e ErrNoMessages) Error() string {
 	return "no messages available"
-}
-
-func (e ErrNotFound) Error() string {
-	return fmt.Sprintf("entity at %s not found", e.EntityPath)
-}
-
-// IsErrNotFound returns true if the error argument is an ErrNotFound type
-func IsErrNotFound(err error) bool {
-	_, ok := err.(ErrNotFound)
-	return ok
-}
-
-func (e ErrConnectionClosed) Error() string {
-	return fmt.Sprintf("the connection has been closed: %s", string(e))
 }
 
 func isLockLostError(err error) bool {

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -230,8 +230,9 @@ func GetRecoveryKind(err error) RecoveryKind {
 		}
 	}
 
-	// check the "special" AMQP errors that aren't condition-based.
-	if IsLinkError(err) {
+	// fall back to just checking where the error was delivered (ie, LinkError, ConnError, SessionError) - in most cases that should give
+	// us an idea of how localized the failure was.
+	if linkErr := (*amqp.LinkError)(nil); errors.As(err, &linkErr) {
 		return RecoveryKindLink
 	}
 

--- a/sdk/messaging/azservicebus/internal/stress/Chart.lock
+++ b/sdk/messaging/azservicebus/internal/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.3.2
-digest: sha256:6eee71a7e8a4c0dc06d5fbbce39ef63237a0db0b7fc2da66e98e96b68985b764
-generated: "2024-05-30T01:39:24.209525275Z"
+  version: 0.3.3
+digest: sha256:1cffb5ed8ea74953ab7611f9e2de2163af2c3f0918afb9928f71210da9c19a4a
+generated: "2024-08-20T18:36:50.631058604-07:00"

--- a/sdk/messaging/azservicebus/internal/stress/stress-test-resources.bicep
+++ b/sdk/messaging/azservicebus/internal/stress/stress-test-resources.bicep
@@ -14,6 +14,7 @@ module sb '../../test-resources.bicep' = {
     location: resourceGroup().location
     testApplicationOid: testApplicationOid
     enablePremium: false // we don't use/need Premium for our stress tests
+    disableAddingRBACRole: true // in stress we just inherit these permissions, we don't set the RBAC roles explicitly
   }
 }
 

--- a/sdk/messaging/azservicebus/test-resources.bicep
+++ b/sdk/messaging/azservicebus/test-resources.bicep
@@ -13,6 +13,9 @@ param location string = resourceGroup().location
 @description('Enable deploying a premium service bus')
 param enablePremium bool = true
 
+@description('Disable applying any RBAC rules')
+param disableAddingRBACRole bool = false
+
 var apiVersion = '2017-04-01'
 var serviceBusDataOwnerRoleId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/090c5cfd-751d-490a-894a-3ce6f1109419'
 
@@ -86,7 +89,7 @@ resource authorizationRuleNameListenOnly 'Microsoft.ServiceBus/namespaces/Author
   }
 }
 
-resource dataOwnerRoleId 'Microsoft.Authorization/roleAssignments@2018-01-01-preview' = {
+resource dataOwnerRoleId 'Microsoft.Authorization/roleAssignments@2018-01-01-preview' = if (!disableAddingRBACRole) {
   name: guid('dataOwnerRoleId${baseName}')
   properties: {
     roleDefinitionId: serviceBusDataOwnerRoleId


### PR DESCRIPTION
Found a few bugs that came in as we crossed between go-amqp versions. We weren't properly unwrapping errors, which meant that our AMQP condition based recovery code wasn't running. This still works most of the time, but it's best to correct it now.

- Upgrading to latest go-amqp, which lets us errors.As() for the AMQP error.
- GetRecoveryKind() should check the AMQP errors's condition first as it has more specific information about what's broken
- Updated all the tests to account for this new possiblity (wrapped error being ignored in favor of the AMQP condition in the inner AMQP error)
- Deleted two unused error types (ErrConnectionClosed, ErrNotFound)
- Did a small amount of cleanup to eliminate some lint warnings, and to delete unused error types that were left over from our original port of this file.