### PR TITLE
[azcore] Add text [un]marshalling support to ResourceID

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 * Added field `OperationLocationResultPath` to `runtime.NewPollerOptions[T]` for LROs that use the `Operation-Location` pattern.
+* Support `encoding.TextMarshaler` and `encoding.TextUnmarshaler` interfaces in `arm.ResourceID`.
 
 ### Breaking Changes
 

--- a/sdk/azcore/arm/internal/resource/resource_identifier.go
+++ b/sdk/azcore/arm/internal/resource/resource_identifier.go
@@ -110,6 +110,21 @@ func (id *ResourceID) String() string {
 	return id.stringValue
 }
 
+// MarshalText returns a textual representation of the ResourceID
+func (id *ResourceID) MarshalText() ([]byte, error) {
+	return []byte(id.String()), nil
+}
+
+// UnmarshalText decodes the textual representation of a ResourceID
+func (id *ResourceID) UnmarshalText(text []byte) error {
+	newId, err := ParseResourceID(string(text))
+	if err != nil {
+		return err
+	}
+	*id = *newId
+	return nil
+}
+
 func newResourceID(parent *ResourceID, resourceTypeName string, resourceName string) *ResourceID {
 	id := &ResourceID{}
 	id.init(parent, chooseResourceType(resourceTypeName, parent), resourceName, true)

--- a/sdk/azcore/arm/internal/resource/resource_identifier_test.go
+++ b/sdk/azcore/arm/internal/resource/resource_identifier_test.go
@@ -6,7 +6,10 @@
 
 package resource
 
-import "testing"
+import (
+	"encoding"
+	"testing"
+)
 
 func TestParseResourceIdentifier(t *testing.T) {
 	testData := map[string]*ResourceID{
@@ -217,6 +220,26 @@ func TestParseResourceIdentifier(t *testing.T) {
 		if !equals(id, expected) {
 			t.Fatalf("resource id not identical, get %v, expected %v", *id, *expected)
 		}
+	}
+}
+
+// Ensure ResourceID implements these interfaces
+var _ encoding.TextMarshaler = (*ResourceID)(nil)
+var _ encoding.TextUnmarshaler = (*ResourceID)(nil)
+
+func TestMarshalResourceIdentifier(t *testing.T) {
+	resourceID := &ResourceID{}
+	input := []byte("/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/resourceGroups/myRg/providers/Microsoft.ApiManagement/service/myServiceName/subscriptions/mySubs")
+	err := resourceID.UnmarshalText(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	output, err := resourceID.MarshalText()
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if string(output) != string(input) {
+		t.Fatalf("resource id changed, got %v, expected %v", string(output), string(input))
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

It would be handy for [ResourceID](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/internal/resource#ResourceID) to support the [encoding.TextMarshaler](https://pkg.go.dev/encoding@go1.23.0#TextMarshaler) and [encoding.TextUnmarshaler](https://pkg.go.dev/encoding@go1.23.0#TextUnmarshaler) interfaces so that, for example, JSON data that includes a resource ID string can be unmarshaled directly to a [ResourceID](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/internal/resource#ResourceID) struct (and vice versa for marshaling).

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
