### PR TITLE
Add crc header in put blob response

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed a bug to ensure crc64 response header is returned in Put Blob request. Fixes [#23372](https://github.com/Azure/azure-sdk-for-go/issues/23372).
 
 ### Other Changes
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## 1.4.1-beta.2 (Unreleased)
 
 ### Features Added
+* Added crc64 response header to Put Blob.
 
 ### Breaking Changes
 
 ### Bugs Fixed
-* Fixed a bug to ensure crc64 response header is returned in Put Blob request. Fixes [#23372](https://github.com/Azure/azure-sdk-for-go/issues/23372).
 
 ### Other Changes
 

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -357,6 +357,36 @@ func (s *BlockBlobUnrecordedTestsSuite) TestBlockBlobClientConnectionString() {
 //		_require.EqualValues(destData, content)
 //	}
 
+func (s *BlockBlobRecordedTestsSuite) TestPutBlob() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	accountName, accountKey := testcommon.GetGenericAccountInfo(testcommon.TestAccountDefault)
+	blobName := testName
+	blobURL := fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s", accountName, containerName, blobName)
+
+	cred, err := blob.NewSharedKeyCredential(accountName, accountKey)
+	_require.NoError(err)
+
+	bbClient, err := blockblob.NewClientWithSharedKeyCredential(blobURL, cred, nil)
+	_require.NoError(err)
+
+	contentSize := 4 * 1024 // 4 KB
+	r, _ := testcommon.GetDataAndReader(testName, contentSize)
+	rsc := streaming.NopCloser(r)
+
+	resp, err := bbClient.Upload(context.Background(), rsc, nil)
+	_require.NoError(err)
+	_require.NotNil(resp)
+	_require.NotNil(resp.ContentCRC64)
+}
+
 func (s *BlockBlobUnrecordedTestsSuite) TestStageBlockFromURLWithMD5() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -378,13 +378,17 @@ func (s *BlockBlobRecordedTestsSuite) TestPutBlobCrcResponseHeader() {
 	_require.NoError(err)
 
 	contentSize := 4 * 1024 // 4 KB
-	r, _ := testcommon.GetDataAndReader(testName, contentSize)
+	r, sourceData := testcommon.GetDataAndReader(testName, contentSize)
 	rsc := streaming.NopCloser(r)
+	crc64Value := crc64.Checksum(sourceData, shared.CRC64Table)
+	crc := make([]byte, 8)
+	binary.LittleEndian.PutUint64(crc, crc64Value)
 
 	resp, err := bbClient.Upload(context.Background(), rsc, nil)
 	_require.NoError(err)
 	_require.NotNil(resp)
 	_require.NotNil(resp.ContentCRC64)
+	_require.Equal(resp.ContentCRC64, crc)
 }
 
 func (s *BlockBlobUnrecordedTestsSuite) TestStageBlockFromURLWithMD5() {

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -357,7 +357,7 @@ func (s *BlockBlobUnrecordedTestsSuite) TestBlockBlobClientConnectionString() {
 //		_require.EqualValues(destData, content)
 //	}
 
-func (s *BlockBlobRecordedTestsSuite) TestPutBlob() {
+func (s *BlockBlobRecordedTestsSuite) TestPutBlobCrcResponseHeader() {
 	_require := require.New(s.T())
 	testName := s.T().Name()
 	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)

--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -46,7 +46,8 @@ directive:
   transform: >
       $["x-ms-content-crc64"] = {
         "x-ms-client-name": "ContentCRC64",
-        "type": "array",
+        "type": "string",
+        "format": "byte",
         "description": "Returned for a block blob so that the client can check the integrity of message content."
       };
 ```

--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -38,6 +38,19 @@ directive:
       replaceAll(`[]string{"2021-12-02"}`, `[]string{ServiceVersion}`);
 ```
 
+### Fix CRC Response Header in PutBlob response
+``` yaml
+directive:
+- from: swagger-document
+  where: $["x-ms-paths"]["/{containerName}/{blob}?BlockBlob"].put.responses["201"].headers
+  transform: >
+      $["x-ms-content-crc64"] = {
+        "x-ms-client-name": "ContentCRC64",
+        "type": "array",
+        "description": "Returned for a block blob so that the client can check the integrity of message content."
+      };
+```
+
 ### Undo breaking change with BlobName 
 ``` yaml
 directive:

--- a/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
@@ -940,6 +940,9 @@ func (client *BlockBlobClient) uploadHandleResponse(resp *http.Response) (BlockB
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
+	if val := resp.Header.Get("x-ms-content-crc64"); val != "" {
+		result.ContentCRC64 = &val
+	}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {

--- a/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
@@ -941,7 +941,11 @@ func (client *BlockBlobClient) uploadHandleResponse(resp *http.Response) (BlockB
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("x-ms-content-crc64"); val != "" {
-		result.ContentCRC64 = &val
+		contentCRC64, err := base64.StdEncoding.DecodeString(val)
+		if err != nil {
+			return BlockBlobClientUploadResponse{}, err
+		}
+		result.ContentCRC64 = contentCRC64
 	}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)

--- a/sdk/storage/azblob/internal/generated/zz_responses.go
+++ b/sdk/storage/azblob/internal/generated/zz_responses.go
@@ -1179,6 +1179,9 @@ type BlockBlobClientUploadResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
+	// ContentCRC64 contains the information returned from the x-ms-content-crc64 header response.
+	ContentCRC64 *string
+
 	// ContentMD5 contains the information returned from the Content-MD5 header response.
 	ContentMD5 []byte
 

--- a/sdk/storage/azblob/internal/generated/zz_responses.go
+++ b/sdk/storage/azblob/internal/generated/zz_responses.go
@@ -1180,7 +1180,7 @@ type BlockBlobClientUploadResponse struct {
 	ClientRequestID *string
 
 	// ContentCRC64 contains the information returned from the x-ms-content-crc64 header response.
-	ContentCRC64 *string
+	ContentCRC64 []byte
 
 	// ContentMD5 contains the information returned from the Content-MD5 header response.
 	ContentMD5 []byte


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
