### PR TITLE
[azservicebus] Fixing a bug where our management link would hang in certain circumstances

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.2.3 (Unreleased)
+
+### Bugs Fixed
+
+- Fixed a bug where cancelling RenewMessageLock() calls could cause hangs in future RenewMessageLock calls. (PR#TBD)
+
 ## 1.2.2 (2024-08-15)
 
 ### Bugs Fixed

--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Fixed a bug where cancelling RenewMessageLock() calls could cause hangs in future RenewMessageLock calls. (PR#TBD)
+- Fixed a bug where cancelling RenewMessageLock() calls could cause hangs in future RenewMessageLock calls. (PR#23400)
 
 ## 1.2.2 (2024-08-15)
 

--- a/sdk/messaging/azeventhubs/internal/constants.go
+++ b/sdk/messaging/azeventhubs/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.2.2"
+const Version = "v1.2.3"

--- a/sdk/messaging/azeventhubs/internal/rpc.go
+++ b/sdk/messaging/azeventhubs/internal/rpc.go
@@ -125,6 +125,10 @@ func NewRPCLink(ctx context.Context, args RPCLinkArgs) (amqpwrap.RPCLink, error)
 	receiverOpts := &amqp.ReceiverOptions{
 		TargetAddress: link.clientAddress,
 		Credit:        defaultReceiverCredits,
+
+		// set our receiver link into the "receive and delete" mode - messages arrive pre-settled.
+		SettlementMode:            amqp.ReceiverSettleModeFirst.Ptr(),
+		RequestedSenderSettleMode: amqp.SenderSettleModeSettled.Ptr(),
 	}
 
 	if link.sessionID != nil {
@@ -304,10 +308,6 @@ func (l *rpcLink) internalRPC(ctx context.Context, msg *amqp.Message) (*amqpwrap
 		Code:        int(statusCode),
 		Description: description,
 		Message:     res,
-	}
-
-	if err := l.receiver.AcceptMessage(ctx, res); err != nil {
-		return response, fmt.Errorf("failed accepting message on rpc link: %w", err)
 	}
 
 	var rpcErr RPCError

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed a bug where cancelling RenewMessageLock() calls could cause hangs in future RenewMessageLock calls. (PR#TBD)
+- Fixed a bug where cancelling RenewMessageLock() calls could cause hangs in future RenewMessageLock calls. (PR#23400)
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where cancelling RenewMessageLock() calls could cause hangs in future RenewMessageLock calls. (PR#TBD)
+
 ### Other Changes
 
 ## 1.7.1 (2024-05-20)


### PR DESCRIPTION
Fixing a bug where we could end up getting our management link stuck.
    
The problem was basically a combination of errors:
1. We were missing the sender settlement mode, which made it so we were only 1/2 in the "receive and delete" mode that we intended to be.
2. Ignoring that, our AcceptMessage() call was actually load bearing and critical and _wasn't_ getting called in some cases, like if you cancelled the call.