### PR TITLE
Adding Operator Nexus - Network Cloud to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -463,6 +463,10 @@
 # ServiceLabel: %Notification Hub
 #/<NotInRepo>/          @tjsomasundaram
 
+# ServiceLabel: %Operator Nexus - Network Cloud
+#/<NotInRepo>/           @Azure/azure-sdk-write-networkcloud
+
+
 # ServiceLabel: %Policy
 #/<NotInRepo>/          @aperezcloud @kenieva
 


### PR DESCRIPTION
Add Operator Nexus - Network Cloud to CODEOWNERS file to receive bot notifications 
