### PR TITLE
[Storage] Swagger update for stg95

### DIFF
--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -22,7 +22,7 @@ export-clients: true
 use: "@autorest/go@4.0.0-preview.65"
 ```
 
-### Updating service version to 2024-08-04
+### Updating service version to 2024-11-04
 ```yaml
 directive:
 - from: 
@@ -35,7 +35,7 @@ directive:
   where: $
   transform: >-
     return $.
-      replaceAll(`[]string{"2021-12-02"}`, `[]string{ServiceVersion}`);
+      replaceAll(`[]string{"2024-08-04"}`, `[]string{ServiceVersion}`);
 ```
 
 ### Fix CRC Response Header in PutBlob response

--- a/sdk/storage/azblob/internal/generated/constants.go
+++ b/sdk/storage/azblob/internal/generated/constants.go
@@ -6,4 +6,4 @@
 
 package generated
 
-const ServiceVersion = "2024-08-04"
+const ServiceVersion = "2024-11-04"

--- a/sdk/storage/azblob/internal/generated/zz_appendblob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_appendblob_client.go
@@ -116,7 +116,7 @@ func (client *AppendBlobClient) appendBlockCreateRequest(ctx context.Context, co
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := req.SetBody(body, "application/octet-stream"); err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (client *AppendBlobClient) appendBlockFromURLCreateRequest(ctx context.Cont
 	if options != nil && options.SourceRange != nil {
 		req.Raw().Header["x-ms-source-range"] = []string{*options.SourceRange}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -494,7 +494,7 @@ func (client *AppendBlobClient) createCreateRequest(ctx context.Context, content
 	if options != nil && options.BlobTagsString != nil {
 		req.Raw().Header["x-ms-tags"] = []string{*options.BlobTagsString}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -615,7 +615,7 @@ func (client *AppendBlobClient) sealCreateRequest(ctx context.Context, options *
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 

--- a/sdk/storage/azblob/internal/generated/zz_blob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blob_client.go
@@ -72,7 +72,7 @@ func (client *BlobClient) abortCopyFromURLCreateRequest(ctx context.Context, cop
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -161,7 +161,7 @@ func (client *BlobClient) acquireLeaseCreateRequest(ctx context.Context, duratio
 	if options != nil && options.ProposedLeaseID != nil {
 		req.Raw().Header["x-ms-proposed-lease-id"] = []string{*options.ProposedLeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -259,7 +259,7 @@ func (client *BlobClient) breakLeaseCreateRequest(ctx context.Context, options *
 	if options != nil && options.BreakPeriod != nil {
 		req.Raw().Header["x-ms-lease-break-period"] = []string{strconv.FormatInt(int64(*options.BreakPeriod), 10)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -365,7 +365,7 @@ func (client *BlobClient) changeLeaseCreateRequest(ctx context.Context, leaseID 
 	req.Raw().Header["x-ms-lease-action"] = []string{"change"}
 	req.Raw().Header["x-ms-lease-id"] = []string{leaseID}
 	req.Raw().Header["x-ms-proposed-lease-id"] = []string{proposedLeaseID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -517,7 +517,7 @@ func (client *BlobClient) copyFromURLCreateRequest(ctx context.Context, copySour
 	if options != nil && options.BlobTagsString != nil {
 		req.Raw().Header["x-ms-tags"] = []string{*options.BlobTagsString}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -659,7 +659,7 @@ func (client *BlobClient) createSnapshotCreateRequest(ctx context.Context, optio
 			}
 		}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -788,7 +788,7 @@ func (client *BlobClient) deleteCreateRequest(ctx context.Context, options *Blob
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -854,7 +854,7 @@ func (client *BlobClient) deleteImmutabilityPolicyCreateRequest(ctx context.Cont
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -965,7 +965,7 @@ func (client *BlobClient) downloadCreateRequest(ctx context.Context, options *Bl
 	if options != nil && options.RangeGetContentMD5 != nil {
 		req.Raw().Header["x-ms-range-get-content-md5"] = []string{strconv.FormatBool(*options.RangeGetContentMD5)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1229,7 +1229,7 @@ func (client *BlobClient) getAccountInfoCreateRequest(ctx context.Context, optio
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1343,7 +1343,7 @@ func (client *BlobClient) getPropertiesCreateRequest(ctx context.Context, option
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1640,7 +1640,7 @@ func (client *BlobClient) getTagsCreateRequest(ctx context.Context, options *Blo
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1742,7 +1742,7 @@ func (client *BlobClient) queryCreateRequest(ctx context.Context, options *BlobC
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if options != nil && options.QueryRequest != nil {
 		if err := runtime.MarshalAsXML(req, *options.QueryRequest); err != nil {
 			return nil, err
@@ -1961,7 +1961,7 @@ func (client *BlobClient) releaseLeaseCreateRequest(ctx context.Context, leaseID
 	}
 	req.Raw().Header["x-ms-lease-action"] = []string{"release"}
 	req.Raw().Header["x-ms-lease-id"] = []string{leaseID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -2055,7 +2055,7 @@ func (client *BlobClient) renewLeaseCreateRequest(ctx context.Context, leaseID s
 	}
 	req.Raw().Header["x-ms-lease-action"] = []string{"renew"}
 	req.Raw().Header["x-ms-lease-id"] = []string{leaseID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -2138,7 +2138,7 @@ func (client *BlobClient) setExpiryCreateRequest(ctx context.Context, expiryOpti
 	if options != nil && options.ExpiresOn != nil {
 		req.Raw().Header["x-ms-expiry-time"] = []string{*options.ExpiresOn}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -2252,7 +2252,7 @@ func (client *BlobClient) setHTTPHeadersCreateRequest(ctx context.Context, optio
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -2345,7 +2345,7 @@ func (client *BlobClient) setImmutabilityPolicyCreateRequest(ctx context.Context
 	if options != nil && options.ImmutabilityPolicyExpiry != nil {
 		req.Raw().Header["x-ms-immutability-policy-until-date"] = []string{(*options.ImmutabilityPolicyExpiry).In(gmt).Format(time.RFC1123)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -2422,7 +2422,7 @@ func (client *BlobClient) setLegalHoldCreateRequest(ctx context.Context, legalHo
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
 	req.Raw().Header["x-ms-legal-hold"] = []string{strconv.FormatBool(legalHold)}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -2536,7 +2536,7 @@ func (client *BlobClient) setMetadataCreateRequest(ctx context.Context, options 
 			}
 		}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -2645,7 +2645,7 @@ func (client *BlobClient) setTagsCreateRequest(ctx context.Context, tags BlobTag
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := runtime.MarshalAsXML(req, tags); err != nil {
 		return nil, err
 	}
@@ -2735,7 +2735,7 @@ func (client *BlobClient) setTierCreateRequest(ctx context.Context, tier AccessT
 	if options != nil && options.RehydratePriority != nil {
 		req.Raw().Header["x-ms-rehydrate-priority"] = []string{string(*options.RehydratePriority)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -2861,7 +2861,7 @@ func (client *BlobClient) startCopyFromURLCreateRequest(ctx context.Context, cop
 	if options != nil && options.BlobTagsString != nil {
 		req.Raw().Header["x-ms-tags"] = []string{*options.BlobTagsString}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -2945,7 +2945,7 @@ func (client *BlobClient) undeleteCreateRequest(ctx context.Context, options *Bl
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 

--- a/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
@@ -152,7 +152,7 @@ func (client *BlockBlobClient) commitBlockListCreateRequest(ctx context.Context,
 	if options != nil && options.BlobTagsString != nil {
 		req.Raw().Header["x-ms-tags"] = []string{*options.BlobTagsString}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := runtime.MarshalAsXML(req, blocks); err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (client *BlockBlobClient) getBlockListCreateRequest(ctx context.Context, li
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -470,7 +470,7 @@ func (client *BlockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, 
 	if options != nil && options.BlobTagsString != nil {
 		req.Raw().Header["x-ms-tags"] = []string{*options.BlobTagsString}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -599,7 +599,7 @@ func (client *BlockBlobClient) stageBlockCreateRequest(ctx context.Context, bloc
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := req.SetBody(body, "application/octet-stream"); err != nil {
 		return nil, err
 	}
@@ -748,7 +748,7 @@ func (client *BlockBlobClient) stageBlockFromURLCreateRequest(ctx context.Contex
 	if options != nil && options.SourceRange != nil {
 		req.Raw().Header["x-ms-source-range"] = []string{*options.SourceRange}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -927,7 +927,7 @@ func (client *BlockBlobClient) uploadCreateRequest(ctx context.Context, contentL
 	if options != nil && options.BlobTagsString != nil {
 		req.Raw().Header["x-ms-tags"] = []string{*options.BlobTagsString}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := req.SetBody(body, "application/octet-stream"); err != nil {
 		return nil, err
 	}

--- a/sdk/storage/azblob/internal/generated/zz_container_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_container_client.go
@@ -83,7 +83,7 @@ func (client *ContainerClient) acquireLeaseCreateRequest(ctx context.Context, du
 	if options != nil && options.ProposedLeaseID != nil {
 		req.Raw().Header["x-ms-proposed-lease-id"] = []string{*options.ProposedLeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -174,7 +174,7 @@ func (client *ContainerClient) breakLeaseCreateRequest(ctx context.Context, opti
 	if options != nil && options.BreakPeriod != nil {
 		req.Raw().Header["x-ms-lease-break-period"] = []string{strconv.FormatInt(int64(*options.BreakPeriod), 10)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -273,7 +273,7 @@ func (client *ContainerClient) changeLeaseCreateRequest(ctx context.Context, lea
 	req.Raw().Header["x-ms-lease-action"] = []string{"change"}
 	req.Raw().Header["x-ms-lease-id"] = []string{leaseID}
 	req.Raw().Header["x-ms-proposed-lease-id"] = []string{proposedLeaseID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -369,7 +369,7 @@ func (client *ContainerClient) createCreateRequest(ctx context.Context, options 
 			}
 		}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -456,7 +456,7 @@ func (client *ContainerClient) deleteCreateRequest(ctx context.Context, options 
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -534,7 +534,7 @@ func (client *ContainerClient) filterBlobsCreateRequest(ctx context.Context, whe
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -609,7 +609,7 @@ func (client *ContainerClient) getAccessPolicyCreateRequest(ctx context.Context,
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -692,7 +692,7 @@ func (client *ContainerClient) getAccountInfoCreateRequest(ctx context.Context, 
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -775,7 +775,7 @@ func (client *ContainerClient) getPropertiesCreateRequest(ctx context.Context, o
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -897,7 +897,7 @@ func (client *ContainerClient) ListBlobFlatSegmentCreateRequest(ctx context.Cont
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -988,7 +988,7 @@ func (client *ContainerClient) ListBlobHierarchySegmentCreateRequest(ctx context
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1071,7 +1071,7 @@ func (client *ContainerClient) releaseLeaseCreateRequest(ctx context.Context, le
 	}
 	req.Raw().Header["x-ms-lease-action"] = []string{"release"}
 	req.Raw().Header["x-ms-lease-id"] = []string{leaseID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1152,7 +1152,7 @@ func (client *ContainerClient) renameCreateRequest(ctx context.Context, sourceCo
 	if options != nil && options.SourceLeaseID != nil {
 		req.Raw().Header["x-ms-source-lease-id"] = []string{*options.SourceLeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1229,7 +1229,7 @@ func (client *ContainerClient) renewLeaseCreateRequest(ctx context.Context, leas
 	}
 	req.Raw().Header["x-ms-lease-action"] = []string{"renew"}
 	req.Raw().Header["x-ms-lease-id"] = []string{leaseID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1314,7 +1314,7 @@ func (client *ContainerClient) restoreCreateRequest(ctx context.Context, options
 	if options != nil && options.DeletedContainerVersion != nil {
 		req.Raw().Header["x-ms-deleted-container-version"] = []string{*options.DeletedContainerVersion}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1397,7 +1397,7 @@ func (client *ContainerClient) setAccessPolicyCreateRequest(ctx context.Context,
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	type wrapper struct {
 		XMLName      xml.Name             `xml:"SignedIdentifiers"`
 		ContainerACL *[]*SignedIdentifier `xml:"SignedIdentifier"`
@@ -1495,7 +1495,7 @@ func (client *ContainerClient) setMetadataCreateRequest(ctx context.Context, opt
 			}
 		}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1578,7 +1578,7 @@ func (client *ContainerClient) submitBatchCreateRequest(ctx context.Context, con
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := req.SetBody(body, multipartContentType); err != nil {
 		return nil, err
 	}

--- a/sdk/storage/azblob/internal/generated/zz_pageblob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_pageblob_client.go
@@ -114,7 +114,7 @@ func (client *PageBlobClient) clearPagesCreateRequest(ctx context.Context, conte
 	if options != nil && options.Range != nil {
 		req.Raw().Header["x-ms-range"] = []string{*options.Range}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -235,7 +235,7 @@ func (client *PageBlobClient) copyIncrementalCreateRequest(ctx context.Context, 
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfTags != nil {
 		req.Raw().Header["x-ms-if-tags"] = []string{*modifiedAccessConditions.IfTags}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -399,7 +399,7 @@ func (client *PageBlobClient) createCreateRequest(ctx context.Context, contentLe
 	if options != nil && options.BlobTagsString != nil {
 		req.Raw().Header["x-ms-tags"] = []string{*options.BlobTagsString}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -533,7 +533,7 @@ func (client *PageBlobClient) GetPageRangesCreateRequest(ctx context.Context, op
 	if options != nil && options.Range != nil {
 		req.Raw().Header["x-ms-range"] = []string{*options.Range}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -660,7 +660,7 @@ func (client *PageBlobClient) GetPageRangesDiffCreateRequest(ctx context.Context
 	if options != nil && options.Range != nil {
 		req.Raw().Header["x-ms-range"] = []string{*options.Range}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -782,7 +782,7 @@ func (client *PageBlobClient) resizeCreateRequest(ctx context.Context, blobConte
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -891,7 +891,7 @@ func (client *PageBlobClient) updateSequenceNumberCreateRequest(ctx context.Cont
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
 	req.Raw().Header["x-ms-sequence-number-action"] = []string{string(sequenceNumberAction)}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -1031,7 +1031,7 @@ func (client *PageBlobClient) uploadPagesCreateRequest(ctx context.Context, cont
 	if options != nil && options.Range != nil {
 		req.Raw().Header["x-ms-range"] = []string{*options.Range}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := req.SetBody(body, "application/octet-stream"); err != nil {
 		return nil, err
 	}
@@ -1224,7 +1224,7 @@ func (client *PageBlobClient) uploadPagesFromURLCreateRequest(ctx context.Contex
 		req.Raw().Header["x-ms-source-if-unmodified-since"] = []string{(*sourceModifiedAccessConditions.SourceIfUnmodifiedSince).In(gmt).Format(time.RFC1123)}
 	}
 	req.Raw().Header["x-ms-source-range"] = []string{sourceRange}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 

--- a/sdk/storage/azblob/internal/generated/zz_service_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_service_client.go
@@ -77,7 +77,7 @@ func (client *ServiceClient) filterBlobsCreateRequest(ctx context.Context, where
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -146,7 +146,7 @@ func (client *ServiceClient) getAccountInfoCreateRequest(ctx context.Context, op
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -226,7 +226,7 @@ func (client *ServiceClient) getPropertiesCreateRequest(ctx context.Context, opt
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -289,7 +289,7 @@ func (client *ServiceClient) getStatisticsCreateRequest(ctx context.Context, opt
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -361,7 +361,7 @@ func (client *ServiceClient) getUserDelegationKeyCreateRequest(ctx context.Conte
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := runtime.MarshalAsXML(req, keyInfo); err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func (client *ServiceClient) ListContainersSegmentCreateRequest(ctx context.Cont
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	return req, nil
 }
 
@@ -492,7 +492,7 @@ func (client *ServiceClient) setPropertiesCreateRequest(ctx context.Context, sto
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := runtime.MarshalAsXML(req, storageServiceProperties); err != nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func (client *ServiceClient) submitBatchCreateRequest(ctx context.Context, conte
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{ServiceVersion}
 	if err := req.SetBody(body, multipartContentType); err != nil {
 		return nil, err
 	}

--- a/sdk/storage/azfile/internal/generated/autorest.md
+++ b/sdk/storage/azfile/internal/generated/autorest.md
@@ -22,7 +22,7 @@ export-clients: true
 use: "@autorest/go@4.0.0-preview.61"
 ```
 
-### Updating service version to 2024-05-04
+### Updating service version to 2024-11-04
 
 ```yaml
 directive:
@@ -34,8 +34,7 @@ directive:
   where: $
   transform: >-
     return $.
-      replaceAll(`[]string{"2023-08-03"}`, `[]string{ServiceVersion}`).
-      replaceAll(`2023-08-03`, `2024-08-04`);
+      replaceAll(`[]string{"2021-12-02"}`, `[]string{ServiceVersion}`);
 ```
 
 ### Don't include share name, directory, or file name in path - we have direct URIs

--- a/sdk/storage/azfile/internal/generated/autorest.md
+++ b/sdk/storage/azfile/internal/generated/autorest.md
@@ -7,7 +7,7 @@ go: true
 clear-output-folder: false
 version: "^3.0.0"
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f6f50c6388fd5836fa142384641b8353a99874ef/specification/storage/data-plane/Microsoft.FileStorage/stable/2024-08-04/file.json"
+input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/storage/data-plane/Microsoft.FileStorage/stable/2024-11-04/file.json"
 credential-scope: "https://storage.azure.com/.default"
 output-folder: ../generated
 file-prefix: "zz_"

--- a/sdk/storage/azfile/internal/generated/autorest.md
+++ b/sdk/storage/azfile/internal/generated/autorest.md
@@ -7,7 +7,7 @@ go: true
 clear-output-folder: false
 version: "^3.0.0"
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/storage/data-plane/Microsoft.FileStorage/stable/2024-11-04/file.json"
+input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/bb1b07077b624d1aa982430f9e19a90d553357c4/specification/storage/data-plane/Microsoft.FileStorage/stable/2024-11-04/file.json"
 credential-scope: "https://storage.azure.com/.default"
 output-folder: ../generated
 file-prefix: "zz_"

--- a/sdk/storage/azfile/internal/generated/constants.go
+++ b/sdk/storage/azfile/internal/generated/constants.go
@@ -6,4 +6,4 @@
 
 package generated
 
-const ServiceVersion = "2024-08-04"
+const ServiceVersion = "2024-11-04"

--- a/sdk/storage/azfile/internal/generated/zz_constants.go
+++ b/sdk/storage/azfile/internal/generated/zz_constants.go
@@ -75,6 +75,21 @@ func PossibleFileLastWrittenModeValues() []FileLastWrittenMode {
 	}
 }
 
+type FilePermissionFormat string
+
+const (
+	FilePermissionFormatBinary FilePermissionFormat = "Binary"
+	FilePermissionFormatSddl   FilePermissionFormat = "Sddl"
+)
+
+// PossibleFilePermissionFormatValues returns the possible values for the FilePermissionFormat const type.
+func PossibleFilePermissionFormatValues() []FilePermissionFormat {
+	return []FilePermissionFormat{
+		FilePermissionFormatBinary,
+		FilePermissionFormatSddl,
+	}
+}
+
 type FileRangeWriteType string
 
 const (

--- a/sdk/storage/azfile/internal/generated/zz_directory_client.go
+++ b/sdk/storage/azfile/internal/generated/zz_directory_client.go
@@ -34,7 +34,7 @@ type DirectoryClient struct {
 // Create - Creates a new directory under the specified share or parent directory.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - DirectoryClientCreateOptions contains the optional parameters for the DirectoryClient.Create method.
 func (client *DirectoryClient) Create(ctx context.Context, options *DirectoryClientCreateOptions) (DirectoryClientCreateResponse, error) {
 	var err error
@@ -76,9 +76,12 @@ func (client *DirectoryClient) createCreateRequest(ctx context.Context, options 
 			}
 		}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.FilePermission != nil {
 		req.Raw().Header["x-ms-file-permission"] = []string{*options.FilePermission}
+	}
+	if options != nil && options.FilePermissionFormat != nil {
+		req.Raw().Header["x-ms-file-permission-format"] = []string{string(*options.FilePermissionFormat)}
 	}
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}
@@ -174,7 +177,7 @@ func (client *DirectoryClient) createHandleResponse(resp *http.Response) (Direct
 // Delete - Removes the specified empty directory. Note that the directory must be empty before it can be deleted.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - DirectoryClientDeleteOptions contains the optional parameters for the DirectoryClient.Delete method.
 func (client *DirectoryClient) Delete(ctx context.Context, options *DirectoryClientDeleteOptions) (DirectoryClientDeleteResponse, error) {
 	var err error
@@ -209,7 +212,7 @@ func (client *DirectoryClient) deleteCreateRequest(ctx context.Context, options 
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if client.fileRequestIntent != nil {
 		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
@@ -239,7 +242,7 @@ func (client *DirectoryClient) deleteHandleResponse(resp *http.Response) (Direct
 // ForceCloseHandles - Closes all handles open for given directory.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - handleID - Specifies handle ID opened on the file or directory to be closed. Asterisk (‘*’) is a wildcard that specifies
 //     all handles.
 //   - options - DirectoryClientForceCloseHandlesOptions contains the optional parameters for the DirectoryClient.ForceCloseHandles
@@ -284,7 +287,7 @@ func (client *DirectoryClient) forceCloseHandlesCreateRequest(ctx context.Contex
 	if options != nil && options.Recursive != nil {
 		req.Raw().Header["x-ms-recursive"] = []string{strconv.FormatBool(*options.Recursive)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
@@ -338,7 +341,7 @@ func (client *DirectoryClient) forceCloseHandlesHandleResponse(resp *http.Respon
 // subdirectories.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - DirectoryClientGetPropertiesOptions contains the optional parameters for the DirectoryClient.GetProperties method.
 func (client *DirectoryClient) GetProperties(ctx context.Context, options *DirectoryClientGetPropertiesOptions) (DirectoryClientGetPropertiesResponse, error) {
 	var err error
@@ -376,7 +379,7 @@ func (client *DirectoryClient) getPropertiesCreateRequest(ctx context.Context, o
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if client.fileRequestIntent != nil {
 		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
@@ -464,7 +467,7 @@ func (client *DirectoryClient) getPropertiesHandleResponse(resp *http.Response) 
 // NewListFilesAndDirectoriesSegmentPager - Returns a list of files or directories under the specified share or directory.
 // It lists the contents only for a single level of the directory hierarchy.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - DirectoryClientListFilesAndDirectoriesSegmentOptions contains the optional parameters for the DirectoryClient.NewListFilesAndDirectoriesSegmentPager
 //     method.
 //
@@ -496,7 +499,7 @@ func (client *DirectoryClient) ListFilesAndDirectoriesSegmentCreateRequest(ctx c
 		reqQP.Set("include", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Include), "[]")), ","))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.IncludeExtendedInfo != nil {
 		req.Raw().Header["x-ms-file-extended-info"] = []string{strconv.FormatBool(*options.IncludeExtendedInfo)}
 	}
@@ -538,7 +541,7 @@ func (client *DirectoryClient) ListFilesAndDirectoriesSegmentHandleResponse(resp
 // ListHandles - Lists handles for directory.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - DirectoryClientListHandlesOptions contains the optional parameters for the DirectoryClient.ListHandles method.
 func (client *DirectoryClient) ListHandles(ctx context.Context, options *DirectoryClientListHandlesOptions) (DirectoryClientListHandlesResponse, error) {
 	var err error
@@ -582,7 +585,7 @@ func (client *DirectoryClient) listHandlesCreateRequest(ctx context.Context, opt
 	if options != nil && options.Recursive != nil {
 		req.Raw().Header["x-ms-recursive"] = []string{strconv.FormatBool(*options.Recursive)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
@@ -621,7 +624,7 @@ func (client *DirectoryClient) listHandlesHandleResponse(resp *http.Response) (D
 // Rename - Renames a directory
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - renameSource - Required. Specifies the URI-style path of the source file, up to 2 KB in length.
 //   - options - DirectoryClientRenameOptions contains the optional parameters for the DirectoryClient.Rename method.
 //   - SourceLeaseAccessConditions - SourceLeaseAccessConditions contains a group of parameters for the DirectoryClient.Rename
@@ -660,7 +663,7 @@ func (client *DirectoryClient) renameCreateRequest(ctx context.Context, renameSo
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	req.Raw().Header["x-ms-file-rename-source"] = []string{renameSource}
 	if options != nil && options.ReplaceIfExists != nil {
 		req.Raw().Header["x-ms-file-rename-replace-if-exists"] = []string{strconv.FormatBool(*options.ReplaceIfExists)}
@@ -688,6 +691,9 @@ func (client *DirectoryClient) renameCreateRequest(ctx context.Context, renameSo
 	}
 	if options != nil && options.FilePermission != nil {
 		req.Raw().Header["x-ms-file-permission"] = []string{*options.FilePermission}
+	}
+	if options != nil && options.FilePermissionFormat != nil {
+		req.Raw().Header["x-ms-file-permission-format"] = []string{string(*options.FilePermissionFormat)}
 	}
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}
@@ -784,7 +790,7 @@ func (client *DirectoryClient) renameHandleResponse(resp *http.Response) (Direct
 // SetMetadata - Updates user defined metadata for the specified directory.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - DirectoryClientSetMetadataOptions contains the optional parameters for the DirectoryClient.SetMetadata method.
 func (client *DirectoryClient) SetMetadata(ctx context.Context, options *DirectoryClientSetMetadataOptions) (DirectoryClientSetMetadataResponse, error) {
 	var err error
@@ -824,7 +830,7 @@ func (client *DirectoryClient) setMetadataCreateRequest(ctx context.Context, opt
 			}
 		}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
@@ -867,7 +873,7 @@ func (client *DirectoryClient) setMetadataHandleResponse(resp *http.Response) (D
 // SetProperties - Sets properties on the directory.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - DirectoryClientSetPropertiesOptions contains the optional parameters for the DirectoryClient.SetProperties method.
 func (client *DirectoryClient) SetProperties(ctx context.Context, options *DirectoryClientSetPropertiesOptions) (DirectoryClientSetPropertiesResponse, error) {
 	var err error
@@ -900,9 +906,12 @@ func (client *DirectoryClient) setPropertiesCreateRequest(ctx context.Context, o
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.FilePermission != nil {
 		req.Raw().Header["x-ms-file-permission"] = []string{*options.FilePermission}
+	}
+	if options != nil && options.FilePermissionFormat != nil {
+		req.Raw().Header["x-ms-file-permission-format"] = []string{string(*options.FilePermissionFormat)}
 	}
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}

--- a/sdk/storage/azfile/internal/generated/zz_file_client.go
+++ b/sdk/storage/azfile/internal/generated/zz_file_client.go
@@ -35,7 +35,7 @@ type FileClient struct {
 // AbortCopy - Aborts a pending Copy File operation, and leaves a destination file with zero length and full metadata.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - copyID - The copy identifier provided in the x-ms-copy-id header of the original Copy File operation.
 //   - options - FileClientAbortCopyOptions contains the optional parameters for the FileClient.AbortCopy method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
@@ -71,7 +71,7 @@ func (client *FileClient) abortCopyCreateRequest(ctx context.Context, copyID str
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["x-ms-copy-action"] = []string{"abort"}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
@@ -107,7 +107,7 @@ func (client *FileClient) abortCopyHandleResponse(resp *http.Response) (FileClie
 // AcquireLease - [Update] The Lease File operation establishes and manages a lock on a file for write and delete operations
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - duration - Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite
 //     lease can be between 15 and 60 seconds. A lease duration cannot be changed using
 //     renew or change.
@@ -147,7 +147,7 @@ func (client *FileClient) acquireLeaseCreateRequest(ctx context.Context, duratio
 	if options != nil && options.ProposedLeaseID != nil {
 		req.Raw().Header["x-ms-proposed-lease-id"] = []string{*options.ProposedLeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
@@ -199,7 +199,7 @@ func (client *FileClient) acquireLeaseHandleResponse(resp *http.Response) (FileC
 // BreakLease - [Update] The Lease File operation establishes and manages a lock on a file for write and delete operations
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - FileClientBreakLeaseOptions contains the optional parameters for the FileClient.BreakLease method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *FileClient) BreakLease(ctx context.Context, options *FileClientBreakLeaseOptions, leaseAccessConditions *LeaseAccessConditions) (FileClientBreakLeaseResponse, error) {
@@ -236,7 +236,7 @@ func (client *FileClient) breakLeaseCreateRequest(ctx context.Context, options *
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
@@ -288,7 +288,7 @@ func (client *FileClient) breakLeaseHandleResponse(resp *http.Response) (FileCli
 // ChangeLease - [Update] The Lease File operation establishes and manages a lock on a file for write and delete operations
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - leaseID - Specifies the current lease ID on the resource.
 //   - options - FileClientChangeLeaseOptions contains the optional parameters for the FileClient.ChangeLease method.
 func (client *FileClient) ChangeLease(ctx context.Context, leaseID string, options *FileClientChangeLeaseOptions) (FileClientChangeLeaseResponse, error) {
@@ -326,7 +326,7 @@ func (client *FileClient) changeLeaseCreateRequest(ctx context.Context, leaseID 
 	if options != nil && options.ProposedLeaseID != nil {
 		req.Raw().Header["x-ms-proposed-lease-id"] = []string{*options.ProposedLeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
@@ -378,7 +378,7 @@ func (client *FileClient) changeLeaseHandleResponse(resp *http.Response) (FileCl
 // Create - Creates a new file or replaces a file. Note it only initializes the file with no content.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - fileContentLength - Specifies the maximum size for the file, up to 4 TB.
 //   - options - FileClientCreateOptions contains the optional parameters for the FileClient.Create method.
 //   - ShareFileHTTPHeaders - ShareFileHTTPHeaders contains a group of parameters for the FileClient.Create method.
@@ -415,7 +415,7 @@ func (client *FileClient) createCreateRequest(ctx context.Context, fileContentLe
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	req.Raw().Header["x-ms-content-length"] = []string{strconv.FormatInt(fileContentLength, 10)}
 	req.Raw().Header["x-ms-type"] = []string{"file"}
 	if shareFileHTTPHeaders != nil && shareFileHTTPHeaders.ContentType != nil {
@@ -445,6 +445,9 @@ func (client *FileClient) createCreateRequest(ctx context.Context, fileContentLe
 	}
 	if options != nil && options.FilePermission != nil {
 		req.Raw().Header["x-ms-file-permission"] = []string{*options.FilePermission}
+	}
+	if options != nil && options.FilePermissionFormat != nil {
+		req.Raw().Header["x-ms-file-permission-format"] = []string{string(*options.FilePermissionFormat)}
 	}
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}
@@ -543,7 +546,7 @@ func (client *FileClient) createHandleResponse(resp *http.Response) (FileClientC
 // Delete - removes the file from the storage account.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - FileClientDeleteOptions contains the optional parameters for the FileClient.Delete method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *FileClient) Delete(ctx context.Context, options *FileClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions) (FileClientDeleteResponse, error) {
@@ -578,7 +581,7 @@ func (client *FileClient) deleteCreateRequest(ctx context.Context, options *File
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
@@ -611,7 +614,7 @@ func (client *FileClient) deleteHandleResponse(resp *http.Response) (FileClientD
 // Download - Reads or downloads a file from the system, including its metadata and properties.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - FileClientDownloadOptions contains the optional parameters for the FileClient.Download method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *FileClient) Download(ctx context.Context, options *FileClientDownloadOptions, leaseAccessConditions *LeaseAccessConditions) (FileClientDownloadResponse, error) {
@@ -647,7 +650,7 @@ func (client *FileClient) downloadCreateRequest(ctx context.Context, options *Fi
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.Range != nil {
 		req.Raw().Header["x-ms-range"] = []string{*options.Range}
 	}
@@ -817,7 +820,7 @@ func (client *FileClient) downloadHandleResponse(resp *http.Response) (FileClien
 // ForceCloseHandles - Closes all handles open for given file
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - handleID - Specifies handle ID opened on the file or directory to be closed. Asterisk (‘*’) is a wildcard that specifies
 //     all handles.
 //   - options - FileClientForceCloseHandlesOptions contains the optional parameters for the FileClient.ForceCloseHandles method.
@@ -858,7 +861,7 @@ func (client *FileClient) forceCloseHandlesCreateRequest(ctx context.Context, ha
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["x-ms-handle-id"] = []string{handleID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
@@ -911,7 +914,7 @@ func (client *FileClient) forceCloseHandlesHandleResponse(resp *http.Response) (
 // not return the content of the file.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - FileClientGetPropertiesOptions contains the optional parameters for the FileClient.GetProperties method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *FileClient) GetProperties(ctx context.Context, options *FileClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (FileClientGetPropertiesResponse, error) {
@@ -949,7 +952,7 @@ func (client *FileClient) getPropertiesCreateRequest(ctx context.Context, option
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
@@ -1103,7 +1106,7 @@ func (client *FileClient) getPropertiesHandleResponse(resp *http.Response) (File
 // GetRangeList - Returns the list of valid ranges for a file.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - FileClientGetRangeListOptions contains the optional parameters for the FileClient.GetRangeList method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *FileClient) GetRangeList(ctx context.Context, options *FileClientGetRangeListOptions, leaseAccessConditions *LeaseAccessConditions) (FileClientGetRangeListResponse, error) {
@@ -1142,7 +1145,7 @@ func (client *FileClient) getRangeListCreateRequest(ctx context.Context, options
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.Range != nil {
 		req.Raw().Header["x-ms-range"] = []string{*options.Range}
 	}
@@ -1204,7 +1207,7 @@ func (client *FileClient) getRangeListHandleResponse(resp *http.Response) (FileC
 // ListHandles - Lists handles for file
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - FileClientListHandlesOptions contains the optional parameters for the FileClient.ListHandles method.
 func (client *FileClient) ListHandles(ctx context.Context, options *FileClientListHandlesOptions) (FileClientListHandlesResponse, error) {
 	var err error
@@ -1245,7 +1248,7 @@ func (client *FileClient) listHandlesCreateRequest(ctx context.Context, options 
 		reqQP.Set("sharesnapshot", *options.Sharesnapshot)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if client.allowTrailingDot != nil {
 		req.Raw().Header["x-ms-allow-trailing-dot"] = []string{strconv.FormatBool(*client.allowTrailingDot)}
 	}
@@ -1284,7 +1287,7 @@ func (client *FileClient) listHandlesHandleResponse(resp *http.Response) (FileCl
 // ReleaseLease - [Update] The Lease File operation establishes and manages a lock on a file for write and delete operations
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - leaseID - Specifies the current lease ID on the resource.
 //   - options - FileClientReleaseLeaseOptions contains the optional parameters for the FileClient.ReleaseLease method.
 func (client *FileClient) ReleaseLease(ctx context.Context, leaseID string, options *FileClientReleaseLeaseOptions) (FileClientReleaseLeaseResponse, error) {
@@ -1319,7 +1322,7 @@ func (client *FileClient) releaseLeaseCreateRequest(ctx context.Context, leaseID
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["x-ms-lease-action"] = []string{"release"}
 	req.Raw().Header["x-ms-lease-id"] = []string{leaseID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
@@ -1368,7 +1371,7 @@ func (client *FileClient) releaseLeaseHandleResponse(resp *http.Response) (FileC
 // Rename - Renames a file
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - renameSource - Required. Specifies the URI-style path of the source file, up to 2 KB in length.
 //   - options - FileClientRenameOptions contains the optional parameters for the FileClient.Rename method.
 //   - SourceLeaseAccessConditions - SourceLeaseAccessConditions contains a group of parameters for the DirectoryClient.Rename
@@ -1407,7 +1410,7 @@ func (client *FileClient) renameCreateRequest(ctx context.Context, renameSource 
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	req.Raw().Header["x-ms-file-rename-source"] = []string{renameSource}
 	if options != nil && options.ReplaceIfExists != nil {
 		req.Raw().Header["x-ms-file-rename-replace-if-exists"] = []string{strconv.FormatBool(*options.ReplaceIfExists)}
@@ -1435,6 +1438,9 @@ func (client *FileClient) renameCreateRequest(ctx context.Context, renameSource 
 	}
 	if options != nil && options.FilePermission != nil {
 		req.Raw().Header["x-ms-file-permission"] = []string{*options.FilePermission}
+	}
+	if options != nil && options.FilePermissionFormat != nil {
+		req.Raw().Header["x-ms-file-permission-format"] = []string{string(*options.FilePermissionFormat)}
 	}
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}
@@ -1534,7 +1540,7 @@ func (client *FileClient) renameHandleResponse(resp *http.Response) (FileClientR
 // SetHTTPHeaders - Sets HTTP headers on the file.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - FileClientSetHTTPHeadersOptions contains the optional parameters for the FileClient.SetHTTPHeaders method.
 //   - ShareFileHTTPHeaders - ShareFileHTTPHeaders contains a group of parameters for the FileClient.Create method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
@@ -1568,7 +1574,7 @@ func (client *FileClient) setHTTPHeadersCreateRequest(ctx context.Context, optio
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.FileContentLength != nil {
 		req.Raw().Header["x-ms-content-length"] = []string{strconv.FormatInt(*options.FileContentLength, 10)}
 	}
@@ -1592,6 +1598,9 @@ func (client *FileClient) setHTTPHeadersCreateRequest(ctx context.Context, optio
 	}
 	if options != nil && options.FilePermission != nil {
 		req.Raw().Header["x-ms-file-permission"] = []string{*options.FilePermission}
+	}
+	if options != nil && options.FilePermissionFormat != nil {
+		req.Raw().Header["x-ms-file-permission-format"] = []string{string(*options.FilePermissionFormat)}
 	}
 	if options != nil && options.FilePermissionKey != nil {
 		req.Raw().Header["x-ms-file-permission-key"] = []string{*options.FilePermissionKey}
@@ -1693,7 +1702,7 @@ func (client *FileClient) setHTTPHeadersHandleResponse(resp *http.Response) (Fil
 // SetMetadata - Updates user-defined metadata for the specified file.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - FileClientSetMetadataOptions contains the optional parameters for the FileClient.SetMetadata method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *FileClient) SetMetadata(ctx context.Context, options *FileClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions) (FileClientSetMetadataResponse, error) {
@@ -1733,7 +1742,7 @@ func (client *FileClient) setMetadataCreateRequest(ctx context.Context, options 
 			}
 		}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
@@ -1786,7 +1795,7 @@ func (client *FileClient) setMetadataHandleResponse(resp *http.Response) (FileCl
 // StartCopy - Copies a blob or file to a destination file within the storage account.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - copySource - Specifies the URL of the source file or blob, up to 2 KB in length. To copy a file to another file within
 //     the same storage account, you may use Shared Key to authenticate the source file. If you are
 //     copying a file from another storage account, or if you are copying a blob from the same storage account or another storage
@@ -1825,7 +1834,7 @@ func (client *FileClient) startCopyCreateRequest(ctx context.Context, copySource
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.Metadata != nil {
 		for k, v := range options.Metadata {
 			if v != nil {
@@ -1915,7 +1924,7 @@ func (client *FileClient) startCopyHandleResponse(resp *http.Response) (FileClie
 // UploadRange - Upload a range of bytes to a file.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - rangeParam - Specifies the range of bytes to be written. Both the start and end of the range must be specified. For an
 //     update operation, the range can be up to 4 MB in size. For a clear operation, the range can be
 //     up to the value of the file's full size. The File service accepts only a single byte range for the Range and 'x-ms-range'
@@ -1967,7 +1976,7 @@ func (client *FileClient) uploadRangeCreateRequest(ctx context.Context, rangePar
 	if options != nil && options.ContentMD5 != nil {
 		req.Raw().Header["Content-MD5"] = []string{base64.StdEncoding.EncodeToString(options.ContentMD5)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
@@ -2040,7 +2049,7 @@ func (client *FileClient) uploadRangeHandleResponse(resp *http.Response) (FileCl
 // UploadRangeFromURL - Upload a range of bytes to a file where the contents are read from a URL.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - rangeParam - Writes data to the specified byte range in the file.
 //   - copySource - Specifies the URL of the source file or blob, up to 2 KB in length. To copy a file to another file within
 //     the same storage account, you may use Shared Key to authenticate the source file. If you are
@@ -2100,7 +2109,7 @@ func (client *FileClient) uploadRangeFromURLCreateRequest(ctx context.Context, r
 	if sourceModifiedAccessConditions != nil && sourceModifiedAccessConditions.SourceIfNoneMatchCRC64 != nil {
 		req.Raw().Header["x-ms-source-if-none-match-crc64"] = []string{base64.StdEncoding.EncodeToString(sourceModifiedAccessConditions.SourceIfNoneMatchCRC64)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}

--- a/sdk/storage/azfile/internal/generated/zz_models.go
+++ b/sdk/storage/azfile/internal/generated/zz_models.go
@@ -254,6 +254,7 @@ type ShareFileRangeList struct {
 type SharePermission struct {
 	// REQUIRED; The permission in the Security Descriptor Definition Language (SDDL).
 	Permission *string
+	Format     *FilePermissionFormat
 }
 
 // ShareProperties - Properties of a share.
@@ -282,6 +283,9 @@ type ShareProperties struct {
 	// The current lease status of the share.
 	LeaseStatus                   *LeaseStatusType `xml:"LeaseStatus"`
 	NextAllowedQuotaDowngradeTime *time.Time       `xml:"NextAllowedQuotaDowngradeTime"`
+	PaidBurstingEnabled           *bool            `xml:"PaidBurstingEnabled"`
+	PaidBurstingMaxBandwidthMibps *int64           `xml:"PaidBurstingMaxBandwidthMibps"`
+	PaidBurstingMaxIops           *int64           `xml:"PaidBurstingMaxIops"`
 	ProvisionedBandwidthMiBps     *int32           `xml:"ProvisionedBandwidthMiBps"`
 	ProvisionedEgressMBps         *int32           `xml:"ProvisionedEgressMBps"`
 	ProvisionedIngressMBps        *int32           `xml:"ProvisionedIngressMBps"`

--- a/sdk/storage/azfile/internal/generated/zz_models_serde.go
+++ b/sdk/storage/azfile/internal/generated/zz_models_serde.go
@@ -182,6 +182,7 @@ func (s ShareFileRangeList) MarshalXML(enc *xml.Encoder, start xml.StartElement)
 // MarshalJSON implements the json.Marshaller interface for type SharePermission.
 func (s SharePermission) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "format", s.Format)
 	populate(objectMap, "permission", s.Permission)
 	return json.Marshal(objectMap)
 }
@@ -195,6 +196,9 @@ func (s *SharePermission) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "format":
+			err = unpopulate(val, "Format", &s.Format)
+			delete(rawMsg, key)
 		case "permission":
 			err = unpopulate(val, "Permission", &s.Permission)
 			delete(rawMsg, key)

--- a/sdk/storage/azfile/internal/generated/zz_options.go
+++ b/sdk/storage/azfile/internal/generated/zz_options.go
@@ -69,6 +69,13 @@ type DirectoryClientCreateOptions struct {
 	// or x-ms-file-permission-key should be specified.
 	FilePermission *string
 
+	// Optional. Available for version 2023-06-01 and later. Specifies the format in which the permission is returned. Acceptable
+	// values are SDDL or binary. If x-ms-file-permission-format is unspecified or
+	// explicitly set to SDDL, the permission is returned in SDDL format. If x-ms-file-permission-format is explicitly set to
+	// binary, the permission is returned as a base64 string representing the binary
+	// encoding of the permission
+	FilePermissionFormat *FilePermissionFormat
+
 	// Key of the permission to be set for the directory/file. Note: Only one of the x-ms-file-permission or x-ms-file-permission-key
 	// should be specified.
 	FilePermissionKey *string
@@ -178,6 +185,13 @@ type DirectoryClientRenameOptions struct {
 	// or x-ms-file-permission-key should be specified.
 	FilePermission *string
 
+	// Optional. Available for version 2023-06-01 and later. Specifies the format in which the permission is returned. Acceptable
+	// values are SDDL or binary. If x-ms-file-permission-format is unspecified or
+	// explicitly set to SDDL, the permission is returned in SDDL format. If x-ms-file-permission-format is explicitly set to
+	// binary, the permission is returned as a base64 string representing the binary
+	// encoding of the permission
+	FilePermissionFormat *FilePermissionFormat
+
 	// Key of the permission to be set for the directory/file. Note: Only one of the x-ms-file-permission or x-ms-file-permission-key
 	// should be specified.
 	FilePermissionKey *string
@@ -232,6 +246,13 @@ type DirectoryClientSetPropertiesOptions struct {
 	// value: Inherit. If SDDL is specified as input, it must have owner, group and dacl. Note: Only one of the x-ms-file-permission
 	// or x-ms-file-permission-key should be specified.
 	FilePermission *string
+
+	// Optional. Available for version 2023-06-01 and later. Specifies the format in which the permission is returned. Acceptable
+	// values are SDDL or binary. If x-ms-file-permission-format is unspecified or
+	// explicitly set to SDDL, the permission is returned in SDDL format. If x-ms-file-permission-format is explicitly set to
+	// binary, the permission is returned as a base64 string representing the binary
+	// encoding of the permission
+	FilePermissionFormat *FilePermissionFormat
 
 	// Key of the permission to be set for the directory/file. Note: Only one of the x-ms-file-permission or x-ms-file-permission-key
 	// should be specified.
@@ -312,6 +333,13 @@ type FileClientCreateOptions struct {
 	// value: Inherit. If SDDL is specified as input, it must have owner, group and dacl. Note: Only one of the x-ms-file-permission
 	// or x-ms-file-permission-key should be specified.
 	FilePermission *string
+
+	// Optional. Available for version 2023-06-01 and later. Specifies the format in which the permission is returned. Acceptable
+	// values are SDDL or binary. If x-ms-file-permission-format is unspecified or
+	// explicitly set to SDDL, the permission is returned in SDDL format. If x-ms-file-permission-format is explicitly set to
+	// binary, the permission is returned as a base64 string representing the binary
+	// encoding of the permission
+	FilePermissionFormat *FilePermissionFormat
 
 	// Key of the permission to be set for the directory/file. Note: Only one of the x-ms-file-permission or x-ms-file-permission-key
 	// should be specified.
@@ -434,6 +462,13 @@ type FileClientRenameOptions struct {
 	// or x-ms-file-permission-key should be specified.
 	FilePermission *string
 
+	// Optional. Available for version 2023-06-01 and later. Specifies the format in which the permission is returned. Acceptable
+	// values are SDDL or binary. If x-ms-file-permission-format is unspecified or
+	// explicitly set to SDDL, the permission is returned in SDDL format. If x-ms-file-permission-format is explicitly set to
+	// binary, the permission is returned as a base64 string representing the binary
+	// encoding of the permission
+	FilePermissionFormat *FilePermissionFormat
+
 	// Key of the permission to be set for the directory/file. Note: Only one of the x-ms-file-permission or x-ms-file-permission-key
 	// should be specified.
 	FilePermissionKey *string
@@ -482,6 +517,13 @@ type FileClientSetHTTPHeadersOptions struct {
 	// value: Inherit. If SDDL is specified as input, it must have owner, group and dacl. Note: Only one of the x-ms-file-permission
 	// or x-ms-file-permission-key should be specified.
 	FilePermission *string
+
+	// Optional. Available for version 2023-06-01 and later. Specifies the format in which the permission is returned. Acceptable
+	// values are SDDL or binary. If x-ms-file-permission-format is unspecified or
+	// explicitly set to SDDL, the permission is returned in SDDL format. If x-ms-file-permission-format is explicitly set to
+	// binary, the permission is returned as a base64 string representing the binary
+	// encoding of the permission
+	FilePermissionFormat *FilePermissionFormat
 
 	// Key of the permission to be set for the directory/file. Note: Only one of the x-ms-file-permission or x-ms-file-permission-key
 	// should be specified.
@@ -673,6 +715,17 @@ type ShareClientCreateOptions struct {
 	// A name-value pair to associate with a file storage object.
 	Metadata map[string]*string
 
+	// Optional. Boolean. Default if not specified is false. This property enables paid bursting.
+	PaidBurstingEnabled *bool
+
+	// Optional. Integer. Default if not specified is the maximum throughput the file share can support. Current maximum for a
+	// file share is 10,340 MiB/sec.
+	PaidBurstingMaxBandwidthMibps *int64
+
+	// Optional. Integer. Default if not specified is the maximum IOPS the file share can support. Current maximum for a file
+	// share is 102,400 IOPS.
+	PaidBurstingMaxIops *int64
+
 	// Specifies the maximum size of the share, in gigabytes.
 	Quota *int32
 
@@ -723,6 +776,13 @@ type ShareClientGetAccessPolicyOptions struct {
 
 // ShareClientGetPermissionOptions contains the optional parameters for the ShareClient.GetPermission method.
 type ShareClientGetPermissionOptions struct {
+	// Optional. Available for version 2023-06-01 and later. Specifies the format in which the permission is returned. Acceptable
+	// values are SDDL or binary. If x-ms-file-permission-format is unspecified or
+	// explicitly set to SDDL, the permission is returned in SDDL format. If x-ms-file-permission-format is explicitly set to
+	// binary, the permission is returned as a base64 string representing the binary
+	// encoding of the permission
+	FilePermissionFormat *FilePermissionFormat
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for File Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN]
 	Timeout *int32
@@ -812,6 +872,17 @@ type ShareClientSetPropertiesOptions struct {
 	// Specifies the access tier of the share.
 	AccessTier                           *ShareAccessTier
 	EnableSnapshotVirtualDirectoryAccess *bool
+
+	// Optional. Boolean. Default if not specified is false. This property enables paid bursting.
+	PaidBurstingEnabled *bool
+
+	// Optional. Integer. Default if not specified is the maximum throughput the file share can support. Current maximum for a
+	// file share is 10,340 MiB/sec.
+	PaidBurstingMaxBandwidthMibps *int64
+
+	// Optional. Integer. Default if not specified is the maximum IOPS the file share can support. Current maximum for a file
+	// share is 102,400 IOPS.
+	PaidBurstingMaxIops *int64
 
 	// Specifies the maximum size of the share, in gigabytes.
 	Quota *int32

--- a/sdk/storage/azfile/internal/generated/zz_response_types.go
+++ b/sdk/storage/azfile/internal/generated/zz_response_types.go
@@ -1134,6 +1134,16 @@ type ShareClientGetPropertiesResponse struct {
 	// response.
 	NextAllowedQuotaDowngradeTime *time.Time
 
+	// PaidBurstingEnabled contains the information returned from the x-ms-share-paid-bursting-enabled header response.
+	PaidBurstingEnabled *bool
+
+	// PaidBurstingMaxBandwidthMibps contains the information returned from the x-ms-share-paid-bursting-max-bandwidth-mibps header
+	// response.
+	PaidBurstingMaxBandwidthMibps *int64
+
+	// PaidBurstingMaxIops contains the information returned from the x-ms-share-paid-bursting-max-iops header response.
+	PaidBurstingMaxIops *int64
+
 	// ProvisionedBandwidthMiBps contains the information returned from the x-ms-share-provisioned-bandwidth-mibps header response.
 	ProvisionedBandwidthMiBps *int32
 

--- a/sdk/storage/azfile/internal/generated/zz_service_client.go
+++ b/sdk/storage/azfile/internal/generated/zz_service_client.go
@@ -22,15 +22,16 @@ import (
 // ServiceClient contains the methods for the Service group.
 // Don't use this type directly, use a constructor function instead.
 type ServiceClient struct {
-	internal *azcore.Client
-	endpoint string
+	internal          *azcore.Client
+	endpoint          string
+	fileRequestIntent *ShareTokenIntent
 }
 
 // GetProperties - Gets the properties of a storage account's File service, including properties for Storage Analytics metrics
 // and CORS (Cross-Origin Resource Sharing) rules.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ServiceClientGetPropertiesOptions contains the optional parameters for the ServiceClient.GetProperties method.
 func (client *ServiceClient) GetProperties(ctx context.Context, options *ServiceClientGetPropertiesOptions) (ServiceClientGetPropertiesResponse, error) {
 	var err error
@@ -63,7 +64,10 @@ func (client *ServiceClient) getPropertiesCreateRequest(ctx context.Context, opt
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
+	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
 }
@@ -86,7 +90,7 @@ func (client *ServiceClient) getPropertiesHandleResponse(resp *http.Response) (S
 // NewListSharesSegmentPager - The List Shares Segment operation returns a list of the shares and share snapshots under the
 // specified account.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ServiceClientListSharesSegmentOptions contains the optional parameters for the ServiceClient.NewListSharesSegmentPager
 //     method.
 //
@@ -114,7 +118,10 @@ func (client *ServiceClient) ListSharesSegmentCreateRequest(ctx context.Context,
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
+	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
 }
@@ -138,7 +145,7 @@ func (client *ServiceClient) ListSharesSegmentHandleResponse(resp *http.Response
 // metrics and CORS (Cross-Origin Resource Sharing) rules.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - storageServiceProperties - The StorageService properties.
 //   - options - ServiceClientSetPropertiesOptions contains the optional parameters for the ServiceClient.SetProperties method.
 func (client *ServiceClient) SetProperties(ctx context.Context, storageServiceProperties StorageServiceProperties, options *ServiceClientSetPropertiesOptions) (ServiceClientSetPropertiesResponse, error) {
@@ -172,7 +179,10 @@ func (client *ServiceClient) setPropertiesCreateRequest(ctx context.Context, sto
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
+	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	if err := runtime.MarshalAsXML(req, storageServiceProperties); err != nil {
 		return nil, err

--- a/sdk/storage/azfile/internal/generated/zz_share_client.go
+++ b/sdk/storage/azfile/internal/generated/zz_share_client.go
@@ -33,7 +33,7 @@ type ShareClient struct {
 // delete share operations.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - duration - Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite
 //     lease can be between 15 and 60 seconds. A lease duration cannot be changed using
 //     renew or change.
@@ -77,9 +77,12 @@ func (client *ShareClient) acquireLeaseCreateRequest(ctx context.Context, durati
 	if options != nil && options.ProposedLeaseID != nil {
 		req.Raw().Header["x-ms-proposed-lease-id"] = []string{*options.ProposedLeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -124,7 +127,7 @@ func (client *ShareClient) acquireLeaseHandleResponse(resp *http.Response) (Shar
 // delete share operations.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientBreakLeaseOptions contains the optional parameters for the ShareClient.BreakLease method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *ShareClient) BreakLease(ctx context.Context, options *ShareClientBreakLeaseOptions, leaseAccessConditions *LeaseAccessConditions) (ShareClientBreakLeaseResponse, error) {
@@ -168,9 +171,12 @@ func (client *ShareClient) breakLeaseCreateRequest(ctx context.Context, options 
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -223,7 +229,7 @@ func (client *ShareClient) breakLeaseHandleResponse(resp *http.Response) (ShareC
 // delete share operations.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - leaseID - Specifies the current lease ID on the resource.
 //   - options - ShareClientChangeLeaseOptions contains the optional parameters for the ShareClient.ChangeLease method.
 func (client *ShareClient) ChangeLease(ctx context.Context, leaseID string, options *ShareClientChangeLeaseOptions) (ShareClientChangeLeaseResponse, error) {
@@ -265,9 +271,12 @@ func (client *ShareClient) changeLeaseCreateRequest(ctx context.Context, leaseID
 	if options != nil && options.ProposedLeaseID != nil {
 		req.Raw().Header["x-ms-proposed-lease-id"] = []string{*options.ProposedLeaseID}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -312,7 +321,7 @@ func (client *ShareClient) changeLeaseHandleResponse(resp *http.Response) (Share
 // fails.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientCreateOptions contains the optional parameters for the ShareClient.Create method.
 func (client *ShareClient) Create(ctx context.Context, options *ShareClientCreateOptions) (ShareClientCreateResponse, error) {
 	var err error
@@ -357,7 +366,7 @@ func (client *ShareClient) createCreateRequest(ctx context.Context, options *Sha
 	if options != nil && options.AccessTier != nil {
 		req.Raw().Header["x-ms-access-tier"] = []string{string(*options.AccessTier)}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.EnabledProtocols != nil {
 		req.Raw().Header["x-ms-enabled-protocols"] = []string{*options.EnabledProtocols}
 	}
@@ -366,6 +375,18 @@ func (client *ShareClient) createCreateRequest(ctx context.Context, options *Sha
 	}
 	if options != nil && options.EnableSnapshotVirtualDirectoryAccess != nil {
 		req.Raw().Header["x-ms-enable-snapshot-virtual-directory-access"] = []string{strconv.FormatBool(*options.EnableSnapshotVirtualDirectoryAccess)}
+	}
+	if options != nil && options.PaidBurstingEnabled != nil {
+		req.Raw().Header["x-ms-share-paid-bursting-enabled"] = []string{strconv.FormatBool(*options.PaidBurstingEnabled)}
+	}
+	if options != nil && options.PaidBurstingMaxBandwidthMibps != nil {
+		req.Raw().Header["x-ms-share-paid-bursting-max-bandwidth-mibps"] = []string{strconv.FormatInt(*options.PaidBurstingMaxBandwidthMibps, 10)}
+	}
+	if options != nil && options.PaidBurstingMaxIops != nil {
+		req.Raw().Header["x-ms-share-paid-bursting-max-iops"] = []string{strconv.FormatInt(*options.PaidBurstingMaxIops, 10)}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -403,7 +424,7 @@ func (client *ShareClient) createHandleResponse(resp *http.Response) (ShareClien
 // CreatePermission - Create a permission (a security descriptor).
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - sharePermission - A permission (a security descriptor) at the share level.
 //   - options - ShareClientCreatePermissionOptions contains the optional parameters for the ShareClient.CreatePermission method.
 func (client *ShareClient) CreatePermission(ctx context.Context, sharePermission SharePermission, options *ShareClientCreatePermissionOptions) (ShareClientCreatePermissionResponse, error) {
@@ -437,7 +458,7 @@ func (client *ShareClient) createPermissionCreateRequest(ctx context.Context, sh
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if client.fileRequestIntent != nil {
 		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
@@ -473,7 +494,7 @@ func (client *ShareClient) createPermissionHandleResponse(resp *http.Response) (
 // CreateSnapshot - Creates a read-only snapshot of a share.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientCreateSnapshotOptions contains the optional parameters for the ShareClient.CreateSnapshot method.
 func (client *ShareClient) CreateSnapshot(ctx context.Context, options *ShareClientCreateSnapshotOptions) (ShareClientCreateSnapshotResponse, error) {
 	var err error
@@ -513,7 +534,10 @@ func (client *ShareClient) createSnapshotCreateRequest(ctx context.Context, opti
 			}
 		}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
+	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
 }
@@ -554,7 +578,7 @@ func (client *ShareClient) createSnapshotHandleResponse(resp *http.Response) (Sh
 // contained within it are later deleted during garbage collection.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientDeleteOptions contains the optional parameters for the ShareClient.Delete method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *ShareClient) Delete(ctx context.Context, options *ShareClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions) (ShareClientDeleteResponse, error) {
@@ -590,12 +614,15 @@ func (client *ShareClient) deleteCreateRequest(ctx context.Context, options *Sha
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.DeleteSnapshots != nil {
 		req.Raw().Header["x-ms-delete-snapshots"] = []string{string(*options.DeleteSnapshots)}
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -623,7 +650,7 @@ func (client *ShareClient) deleteHandleResponse(resp *http.Response) (ShareClien
 // GetAccessPolicy - Returns information about stored access policies specified on the share.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientGetAccessPolicyOptions contains the optional parameters for the ShareClient.GetAccessPolicy method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *ShareClient) GetAccessPolicy(ctx context.Context, options *ShareClientGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (ShareClientGetAccessPolicyResponse, error) {
@@ -657,9 +684,12 @@ func (client *ShareClient) getAccessPolicyCreateRequest(ctx context.Context, opt
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -700,7 +730,7 @@ func (client *ShareClient) getAccessPolicyHandleResponse(resp *http.Response) (S
 // GetPermission - Returns the permission (security descriptor) for a given key
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - filePermissionKey - Key of the permission to be set for the directory/file.
 //   - options - ShareClientGetPermissionOptions contains the optional parameters for the ShareClient.GetPermission method.
 func (client *ShareClient) GetPermission(ctx context.Context, filePermissionKey string, options *ShareClientGetPermissionOptions) (ShareClientGetPermissionResponse, error) {
@@ -735,7 +765,10 @@ func (client *ShareClient) getPermissionCreateRequest(ctx context.Context, fileP
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["x-ms-file-permission-key"] = []string{filePermissionKey}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	if options != nil && options.FilePermissionFormat != nil {
+		req.Raw().Header["x-ms-file-permission-format"] = []string{string(*options.FilePermissionFormat)}
+	}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if client.fileRequestIntent != nil {
 		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
@@ -769,7 +802,7 @@ func (client *ShareClient) getPermissionHandleResponse(resp *http.Response) (Sha
 // data returned does not include the share's list of files.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientGetPropertiesOptions contains the optional parameters for the ShareClient.GetProperties method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *ShareClient) GetProperties(ctx context.Context, options *ShareClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (ShareClientGetPropertiesResponse, error) {
@@ -805,9 +838,12 @@ func (client *ShareClient) getPropertiesCreateRequest(ctx context.Context, optio
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -880,6 +916,27 @@ func (client *ShareClient) getPropertiesHandleResponse(resp *http.Response) (Sha
 		}
 		result.NextAllowedQuotaDowngradeTime = &nextAllowedQuotaDowngradeTime
 	}
+	if val := resp.Header.Get("x-ms-share-paid-bursting-enabled"); val != "" {
+		paidBurstingEnabled, err := strconv.ParseBool(val)
+		if err != nil {
+			return ShareClientGetPropertiesResponse{}, err
+		}
+		result.PaidBurstingEnabled = &paidBurstingEnabled
+	}
+	if val := resp.Header.Get("x-ms-share-paid-bursting-max-bandwidth-mibps"); val != "" {
+		paidBurstingMaxBandwidthMibps, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return ShareClientGetPropertiesResponse{}, err
+		}
+		result.PaidBurstingMaxBandwidthMibps = &paidBurstingMaxBandwidthMibps
+	}
+	if val := resp.Header.Get("x-ms-share-paid-bursting-max-iops"); val != "" {
+		paidBurstingMaxIops, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return ShareClientGetPropertiesResponse{}, err
+		}
+		result.PaidBurstingMaxIops = &paidBurstingMaxIops
+	}
 	if val := resp.Header.Get("x-ms-share-provisioned-bandwidth-mibps"); val != "" {
 		provisionedBandwidthMiBps32, err := strconv.ParseInt(val, 10, 32)
 		provisionedBandwidthMiBps := int32(provisionedBandwidthMiBps32)
@@ -935,7 +992,7 @@ func (client *ShareClient) getPropertiesHandleResponse(resp *http.Response) (Sha
 // GetStatistics - Retrieves statistics related to the share.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientGetStatisticsOptions contains the optional parameters for the ShareClient.GetStatistics method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *ShareClient) GetStatistics(ctx context.Context, options *ShareClientGetStatisticsOptions, leaseAccessConditions *LeaseAccessConditions) (ShareClientGetStatisticsResponse, error) {
@@ -969,9 +1026,12 @@ func (client *ShareClient) getStatisticsCreateRequest(ctx context.Context, optio
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -1013,7 +1073,7 @@ func (client *ShareClient) getStatisticsHandleResponse(resp *http.Response) (Sha
 // delete share operations.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - leaseID - Specifies the current lease ID on the resource.
 //   - options - ShareClientReleaseLeaseOptions contains the optional parameters for the ShareClient.ReleaseLease method.
 func (client *ShareClient) ReleaseLease(ctx context.Context, leaseID string, options *ShareClientReleaseLeaseOptions) (ShareClientReleaseLeaseResponse, error) {
@@ -1052,9 +1112,12 @@ func (client *ShareClient) releaseLeaseCreateRequest(ctx context.Context, leaseI
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["x-ms-lease-action"] = []string{"release"}
 	req.Raw().Header["x-ms-lease-id"] = []string{leaseID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -1096,7 +1159,7 @@ func (client *ShareClient) releaseLeaseHandleResponse(resp *http.Response) (Shar
 // delete share operations.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - leaseID - Specifies the current lease ID on the resource.
 //   - options - ShareClientRenewLeaseOptions contains the optional parameters for the ShareClient.RenewLease method.
 func (client *ShareClient) RenewLease(ctx context.Context, leaseID string, options *ShareClientRenewLeaseOptions) (ShareClientRenewLeaseResponse, error) {
@@ -1135,9 +1198,12 @@ func (client *ShareClient) renewLeaseCreateRequest(ctx context.Context, leaseID 
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["x-ms-lease-action"] = []string{"renew"}
 	req.Raw().Header["x-ms-lease-id"] = []string{leaseID}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -1181,7 +1247,7 @@ func (client *ShareClient) renewLeaseHandleResponse(resp *http.Response) (ShareC
 // Restore - Restores a previously deleted Share.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientRestoreOptions contains the optional parameters for the ShareClient.Restore method.
 func (client *ShareClient) Restore(ctx context.Context, options *ShareClientRestoreOptions) (ShareClientRestoreResponse, error) {
 	var err error
@@ -1214,7 +1280,7 @@ func (client *ShareClient) restoreCreateRequest(ctx context.Context, options *Sh
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}
@@ -1223,6 +1289,9 @@ func (client *ShareClient) restoreCreateRequest(ctx context.Context, options *Sh
 	}
 	if options != nil && options.DeletedShareVersion != nil {
 		req.Raw().Header["x-ms-deleted-share-version"] = []string{*options.DeletedShareVersion}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -1263,7 +1332,7 @@ func (client *ShareClient) restoreHandleResponse(resp *http.Response) (ShareClie
 // SetAccessPolicy - Sets a stored access policy for use with shared access signatures.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - shareACL - The ACL for the share.
 //   - options - ShareClientSetAccessPolicyOptions contains the optional parameters for the ShareClient.SetAccessPolicy method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
@@ -1298,9 +1367,12 @@ func (client *ShareClient) setAccessPolicyCreateRequest(ctx context.Context, sha
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	type wrapper struct {
@@ -1345,7 +1417,7 @@ func (client *ShareClient) setAccessPolicyHandleResponse(resp *http.Response) (S
 // SetMetadata - Sets one or more user-defined name-value pairs for the specified share.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientSetMetadataOptions contains the optional parameters for the ShareClient.SetMetadata method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *ShareClient) SetMetadata(ctx context.Context, options *ShareClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions) (ShareClientSetMetadataResponse, error) {
@@ -1386,9 +1458,12 @@ func (client *ShareClient) setMetadataCreateRequest(ctx context.Context, options
 			}
 		}
 	}
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil
@@ -1426,7 +1501,7 @@ func (client *ShareClient) setMetadataHandleResponse(resp *http.Response) (Share
 // SetProperties - Sets properties for the specified share.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 2024-08-04
+// Generated from API version 2024-11-04
 //   - options - ShareClientSetPropertiesOptions contains the optional parameters for the ShareClient.SetProperties method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ShareClient.GetProperties method.
 func (client *ShareClient) SetProperties(ctx context.Context, options *ShareClientSetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (ShareClientSetPropertiesResponse, error) {
@@ -1460,7 +1535,7 @@ func (client *ShareClient) setPropertiesCreateRequest(ctx context.Context, optio
 		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["x-ms-version"] = []string{"2024-08-04"}
+	req.Raw().Header["x-ms-version"] = []string{"2024-11-04"}
 	if options != nil && options.Quota != nil {
 		req.Raw().Header["x-ms-share-quota"] = []string{strconv.FormatInt(int64(*options.Quota), 10)}
 	}
@@ -1475,6 +1550,18 @@ func (client *ShareClient) setPropertiesCreateRequest(ctx context.Context, optio
 	}
 	if options != nil && options.EnableSnapshotVirtualDirectoryAccess != nil {
 		req.Raw().Header["x-ms-enable-snapshot-virtual-directory-access"] = []string{strconv.FormatBool(*options.EnableSnapshotVirtualDirectoryAccess)}
+	}
+	if options != nil && options.PaidBurstingEnabled != nil {
+		req.Raw().Header["x-ms-share-paid-bursting-enabled"] = []string{strconv.FormatBool(*options.PaidBurstingEnabled)}
+	}
+	if options != nil && options.PaidBurstingMaxBandwidthMibps != nil {
+		req.Raw().Header["x-ms-share-paid-bursting-max-bandwidth-mibps"] = []string{strconv.FormatInt(*options.PaidBurstingMaxBandwidthMibps, 10)}
+	}
+	if options != nil && options.PaidBurstingMaxIops != nil {
+		req.Raw().Header["x-ms-share-paid-bursting-max-iops"] = []string{strconv.FormatInt(*options.PaidBurstingMaxIops, 10)}
+	}
+	if client.fileRequestIntent != nil {
+		req.Raw().Header["x-ms-file-request-intent"] = []string{string(*client.fileRequestIntent)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	return req, nil


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go


Only swagger change is in files, others use the previous swagger and only updates in the service version 