### PR TITLE
fix: integer overflow on calcDelay

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 * Omit the `ResponseError.RawResponse` field from JSON marshaling so instances can be marshaled.
+* Fixed an integer overflow in the retry policy.
 
 ### Other Changes
 

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -65,7 +65,7 @@ func calcDelay(o policy.RetryOptions, try int32) time.Duration { // try is >=1; 
 		factor = time.Duration(int64(1)<<try - 1)
 	}
 
-	delay := time.Duration(factor) * o.RetryDelay
+	delay := factor * o.RetryDelay
 	if delay < factor {
 		// overflow has happend so set to max value
 		delay = time.Duration(math.MaxInt64)

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -62,7 +62,7 @@ func calcDelay(o policy.RetryOptions, try int32) time.Duration { // try is >=1; 
 	// avoid overflow when shifting left
 	factor := time.Duration(math.MaxInt64)
 	if try < 63 {
-		factor = time.Duration(int64(1)<<try - 1)
+		factor = time.Duration(int64(1<<try) - 1)
 	}
 
 	delay := factor * o.RetryDelay

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -79,7 +79,7 @@ func calcDelay(o policy.RetryOptions, try int32) time.Duration { // try is >=1; 
 	jitterMultiplier := rand.Float64()/2 + 0.8 // NOTE: We want math/rand; not crypto/rand
 
 	delayFloat := float64(delay) * jitterMultiplier
-	if delayFloat > float64(maxDelay) {
+	if delayFloat >= float64(maxDelay) { // NOTE: if the jitter pushes us over the maxDelay, just return the maxDelay
 		delay = maxDelay
 	} else {
 		delay = time.Duration(delayFloat)

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -59,28 +59,25 @@ func setDefaults(o *policy.RetryOptions) {
 }
 
 func calcDelay(o policy.RetryOptions, try int32) time.Duration { // try is >=1; never 0
-	const maxDelay = math.MaxInt64
-
-	var factor int64
-	if try >= 63 {
-		factor = maxDelay
-	} else {
-		factor = int64(1)<<try - 1
+	// avoid overflow when shifting left
+	factor := time.Duration(math.MaxInt64)
+	if try < 63 {
+		factor = time.Duration(int64(1)<<try - 1)
 	}
 
-	var delay time.Duration
-	if factor > maxDelay/int64(o.RetryDelay) {
-		delay = maxDelay
-	} else {
-		delay = time.Duration(factor) * o.RetryDelay
+	delay := time.Duration(factor) * o.RetryDelay
+	if delay < factor {
+		// overflow has happend so set to max value
+		delay = time.Duration(math.MaxInt64)
 	}
 
 	// Introduce jitter:  [0.0, 1.0) / 2 = [0.0, 0.5) + 0.8 = [0.8, 1.3)
 	jitterMultiplier := rand.Float64()/2 + 0.8 // NOTE: We want math/rand; not crypto/rand
 
 	delayFloat := float64(delay) * jitterMultiplier
-	if delayFloat >= float64(maxDelay) { // NOTE: if the jitter pushes us over the maxDelay, just return the maxDelay
-		delay = maxDelay
+	if delayFloat > float64(math.MaxInt64) {
+		// the jitter pushed us over MaxInt64, so just use MaxInt64
+		delay = time.Duration(math.MaxInt64)
 	} else {
 		delay = time.Duration(delayFloat)
 	}

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -82,7 +82,7 @@ func calcDelay(o policy.RetryOptions, try int32) time.Duration { // try is >=1; 
 		delay = time.Duration(delayFloat)
 	}
 
-	if delay > o.MaxRetryDelay {
+	if delay > o.MaxRetryDelay { // MaxRetryDelay is backfilled with non-negative value
 		delay = o.MaxRetryDelay
 	}
 

--- a/sdk/azcore/runtime/policy_retry.go
+++ b/sdk/azcore/runtime/policy_retry.go
@@ -67,7 +67,7 @@ func calcDelay(o policy.RetryOptions, try int32) time.Duration { // try is >=1; 
 
 	delay := factor * o.RetryDelay
 	if delay < factor {
-		// overflow has happend so set to max value
+		// overflow has happened so set to max value
 		delay = time.Duration(math.MaxInt64)
 	}
 

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -955,7 +955,7 @@ func TestCalcDelay(t *testing.T) {
 		}
 		setDefaults(&retryOptions)
 
-		for i := int32(63); i < 1000; i++ {
+		for i := int32(63); i < 100000; i++ {
 			requireWithinJitter(
 				t, math.MaxInt64, calcDelay(retryOptions, i),
 			)

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -894,3 +894,24 @@ func (n *nilRespInjector) Do(req *http.Request) (*http.Response, error) {
 	}
 	return n.t.Do(req)
 }
+
+func BenchmarkCalcDelay_defaultSettings(b *testing.B) {
+	retryOptions := policy.RetryOptions{}
+	setDefaults(&retryOptions)
+
+	for i := 0; i < b.N; i++ {
+		calcDelay(retryOptions, 32)
+	}
+}
+
+func BenchmarkCalcDelay_overflow(b *testing.B) {
+	retryOptions := policy.RetryOptions{
+		RetryDelay:    1,
+		MaxRetryDelay: math.MaxInt64,
+	}
+	setDefaults(&retryOptions)
+
+	for i := 0; i < b.N; i++ {
+		calcDelay(retryOptions, 100)
+	}
+}

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -915,3 +915,50 @@ func BenchmarkCalcDelay_overflow(b *testing.B) {
 		calcDelay(retryOptions, 100)
 	}
 }
+
+func TestCalcDelay(t *testing.T) {
+	requireWithinJitter := func(t testing.TB, expected, actual time.Duration) {
+		lower, upper := float64(expected)*0.8, float64(expected)*1.3
+		require.Truef(
+			t, float64(actual) >= lower && float64(actual) <= upper,
+			"%.2f not within jitter of %.2f", actual.Seconds(), expected.Seconds(),
+		)
+	}
+
+	t.Run("basic cases", func(t *testing.T) {
+		retryOptions := policy.RetryOptions{
+			RetryDelay:    1 * time.Second,
+			MaxRetryDelay: 30 * time.Second,
+		}
+		setDefaults(&retryOptions)
+
+		for i := int32(1); i <= 5; i++ {
+			delay := float64(calcDelay(retryOptions, i))
+			expected := float64((1<<i - 1) * int64(retryOptions.RetryDelay))
+			requireWithinJitter(
+				t, time.Duration(expected), time.Duration(delay),
+			)
+		}
+		for i := int32(6); i < 100; i++ {
+			require.Equal(
+				t,
+				calcDelay(retryOptions, i),
+				retryOptions.MaxRetryDelay,
+			)
+		}
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		retryOptions := policy.RetryOptions{
+			RetryDelay:    1,
+			MaxRetryDelay: math.MaxInt64,
+		}
+		setDefaults(&retryOptions)
+
+		for i := int32(63); i < 1000; i++ {
+			requireWithinJitter(
+				t, math.MaxInt64, calcDelay(retryOptions, i),
+			)
+		}
+	})
+}


### PR DESCRIPTION
The current `calcDelay` overflows when `try` >= 36 when using default retry options settings (800ms). Example: https://go.dev/play/p/-w0DcQsN1cD . This pull request fixed by adding bound checks on the values.

The new implementation does not increase the overhead of the function per the benchmark results:

```
# on commit: babb98a69995529ea3d2fd45995ef48a3a410849
$ go test -v -bench=. -run=BenchmarkCalcDelay -benchtime=20s
goos: linux
goarch: amd64
pkg: github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime
cpu: AMD EPYC 7763 64-Core Processor                
BenchmarkCalcDelay_defaultSettings
BenchmarkCalcDelay_defaultSettings-2    1000000000              17.03 ns/op
BenchmarkCalcDelay_overflow
BenchmarkCalcDelay_overflow-2           1000000000              16.64 ns/op
PASS
ok      github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime    37.016s

# on commit: d7effab1ad0c72aae14df58922f48d0a360bce02
$ go test -v -bench=. -run=BenchmarkCalcDelay -benchtime=20s
goos: linux
goarch: amd64
pkg: github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime
cpu: AMD EPYC 7763 64-Core Processor                
BenchmarkCalcDelay_defaultSettings
BenchmarkCalcDelay_defaultSettings-2    1000000000              15.53 ns/op
BenchmarkCalcDelay_overflow
BenchmarkCalcDelay_overflow-2           1000000000              15.91 ns/op
PASS
ok      github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime    34.586s
```

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
