### PR TITLE
Investigate behavior of AzurePipelinesCredential with invalid system access token

### DIFF
--- a/sdk/azidentity/azure_pipelines_credential_test.go
+++ b/sdk/azidentity/azure_pipelines_credential_test.go
@@ -56,7 +56,7 @@ func TestAzurePipelinesCredential(t *testing.T) {
 		}
 		clientID := os.Getenv("AZURESUBSCRIPTION_CLIENT_ID")
 		connectionID := os.Getenv("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID")
-		systemAccessToken := os.Getenv("SYSTEM_ACCESSTOKEN")
+		systemAccessToken := "invalidSystemAccessToken"
 		tenantID := os.Getenv("AZURESUBSCRIPTION_TENANT_ID")
 		unset := []string{}
 		if clientID == "" {
@@ -75,7 +75,6 @@ func TestAzurePipelinesCredential(t *testing.T) {
 			t.Skip("no value for ", strings.Join(unset, ", "))
 		}
 		cred, err := NewAzurePipelinesCredential(tenantID, clientID, connectionID, systemAccessToken, nil)
-		require.NoError(t, err)
-		testGetTokenSuccess(t, cred)
+		require.ErrorContains(t, err, "302 (Found)")
 	})
 }


### PR DESCRIPTION
Modifying the existing live test similar to https://github.com/Azure/azure-sdk-for-cpp/pull/5875 to see the GoLang behavior