### PR TITLE
Omit RawResponse from JSON payload

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Omit the `ResponseError.RawResponse` field from JSON marshaling so instances can be marshaled.
+
 ### Other Changes
 
 ## 1.14.0 (2024-08-07)

--- a/sdk/azcore/errors.go
+++ b/sdk/azcore/errors.go
@@ -11,4 +11,7 @@ import "github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 // ResponseError is returned when a request is made to a service and
 // the service returns a non-success HTTP status code.
 // Use errors.As() to access this type in the error chain.
+//
+// When marshaling instances, the RawResponse field will be omitted.
+// However, the contents returned by Error() will be preserved.
 type ResponseError = exported.ResponseError

--- a/sdk/azcore/internal/exported/response_error.go
+++ b/sdk/azcore/internal/exported/response_error.go
@@ -181,15 +181,10 @@ type responseError struct {
 }
 
 func (e ResponseError) MarshalJSON() ([]byte, error) {
-	// populate errMsg as needed
-	if e.errMsg == "" {
-		_ = e.Error()
-	}
-
 	return json.Marshal(responseError{
 		ErrorCode:    e.ErrorCode,
 		StatusCode:   e.StatusCode,
-		ErrorMessage: e.errMsg,
+		ErrorMessage: e.Error(),
 	})
 }
 

--- a/sdk/azcore/internal/exported/response_error.go
+++ b/sdk/azcore/internal/exported/response_error.go
@@ -117,7 +117,7 @@ type ResponseError struct {
 	StatusCode int
 
 	// RawResponse is the underlying HTTP response.
-	RawResponse *http.Response
+	RawResponse *http.Response `json:"-"`
 }
 
 // Error implements the error interface for type ResponseError.

--- a/sdk/azcore/internal/exported/response_error_test.go
+++ b/sdk/azcore/internal/exported/response_error_test.go
@@ -7,6 +7,7 @@
 package exported
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -547,4 +548,18 @@ ERROR CODE: ErrorTooManyCheats
 	require.True(t, ok)
 	require.Len(t, msg, 1)
 	require.EqualValues(t, want, msg[0])
+}
+
+func TestResponseErrorMarshal(t *testing.T) {
+	respErr := &ResponseError{
+		ErrorCode:  "TheErrorCode",
+		StatusCode: http.StatusBadRequest,
+		RawResponse: &http.Response{
+			Request: &http.Request{},
+		},
+	}
+
+	b, err := json.Marshal(respErr)
+	require.NoError(t, err)
+	require.EqualValues(t, `{"ErrorCode":"TheErrorCode","StatusCode":400}`, string(b))
 }


### PR DESCRIPTION
The *http.Request inside the *http.Response contains fields that aren't marshalable (func). Since the RawResponse is used to construct the error message which isn't contractual, just omit it from the payload.

Fixes https://github.com/Azure/azure-sdk-for-go/issues/23454