### PR TITLE
Don't use empty variables in command line

### DIFF
--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -9,15 +9,16 @@ Param(
 
 $ErrorActionPreference = 'Stop'
 
-$raceDetector = ''
+# empty string produces incorrect command, so we include the -v here so it's never empty
+$raceDetector = '-v'
 if ($enableRaceDetector) {
-    $raceDetector = '-race'
+    $raceDetector = '-race -v'
 }
 
 Push-Location sdk/$serviceDirectory
 Write-Host "##[command] Executing 'go test -timeout $testTimeout $raceDetector -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
 
-go test -timeout $testTimeout $raceDetector -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
+go test -timeout $testTimeout $raceDetector -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
 # go test will return a non-zero exit code on test failures so don't skip generating the report in this case
 $GOTESTEXITCODE = $LASTEXITCODE
 


### PR DESCRIPTION
It causes the command to behave incorrectly.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
