### PR TITLE
Pass race detector value in only when it is set

### DIFF
--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -12,7 +12,7 @@ Push-Location sdk/$serviceDirectory
 
 if ($enableRaceDetector) {
     Write-Host "##[command] Executing 'go test -timeout $testTimeout -race -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
-    go test -timeout $testTimeout -v -coverprofile -race coverage.txt ./... | Tee-Object -FilePath outfile.txt
+    go test -timeout $testTimeout -race -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
 } else {
     Write-Host "##[command] Executing 'go test -timeout $testTimeout -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
     go test -timeout $testTimeout -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -8,16 +8,16 @@ Param(
 )
 
 $ErrorActionPreference = 'Stop'
+Push-Location sdk/$serviceDirectory
 
-$raceDetector = ''
 if ($enableRaceDetector) {
-    $raceDetector = '-race'
+    Write-Host "##[command] Executing 'go test -timeout $testTimeout -race -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
+    go test -timeout $testTimeout -v -coverprofile -race coverage.txt ./... | Tee-Object -FilePath outfile.txt
+} else {
+    Write-Host "##[command] Executing 'go test -timeout $testTimeout -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
+    go test -timeout $testTimeout -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
 }
 
-Push-Location sdk/$serviceDirectory
-Write-Host "##[command] Executing 'go test -timeout $testTimeout $raceDetector -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
-
-go test -timeout $testTimeout $raceDetector -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt
 # go test will return a non-zero exit code on test failures so don't skip generating the report in this case
 $GOTESTEXITCODE = $LASTEXITCODE
 


### PR DESCRIPTION
Powershell passes the empty string default value for race detector as a positional argument, which is causing the go command line to treat it as the test selector argument, instead of `./...`. This has been causing all pipelines to not run any tests in sub-directories since June 2024.

Hat tip to @gracewilcox for discovering this issue.