### PR TITLE
Update to the latest two versions of Go

### DIFF
--- a/eng/pipelines/mgmt-auto-release.yml
+++ b/eng/pipelines/mgmt-auto-release.yml
@@ -31,7 +31,7 @@ extends:
                   
               - task: GoTool@0
                 inputs:
-                  version: '1.22.0'
+                  version: '1.23.2'
 
               - task: ShellScript@2
                 inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client-samples.yml
@@ -24,24 +24,22 @@ stages:
             pool.name: azsdk-pool-mms-win-2022-general
             image.name: MMS2022
             go.version: '1.18.10'
-          Linux_Go121:
-            pool.name: azsdk-pool-mms-ubuntu-2004-general
-            image.name: MMSUbuntu20.04
-            go.version: '1.21.7'
-          Windows_Go121:
-            pool.name: azsdk-pool-mms-win-2022-general
-            image.name: MMS2022
-            go.version: '1.21.7'
           Linux_Go122:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.22.0'
-            GOEXPERIMENT: nocoverageredesign
+            go.version: '1.22.8'
           Windows_Go122:
             pool.name: azsdk-pool-mms-win-2022-general
             image.name: MMS2022
-            go.version: '1.22.0'
-            GOEXPERIMENT: nocoverageredesign
+            go.version: '1.22.8'
+          Linux_Go123:
+            pool.name: azsdk-pool-mms-ubuntu-2004-general
+            image.name: MMSUbuntu20.04
+            go.version: '1.23.2'
+          Windows_Go123:
+            pool.name: azsdk-pool-mms-win-2022-general
+            image.name: MMS2022
+            go.version: '1.23.2'
       pool:
         name: $(pool.name)
         vmImage: $(image.name)
@@ -75,7 +73,7 @@ stages:
       steps:
       - task: GoTool@0
         inputs:
-          version: '1.22.0'
+          version: '1.23.2'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -153,7 +153,7 @@ extends:
 
               - task: GoTool@0
                 inputs:
-                  version: '1.22.0'
+                  version: '1.23.2'
                 displayName: "Select Go Version"
 
               - template: /eng/pipelines/templates/steps/create-go-workspace.yml@self

--- a/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-eng-client.yml
@@ -40,24 +40,22 @@ stages:
               pool.name: azsdk-pool-mms-win-2022-general
               image.name: MMS2022
               go.version: '1.18.10'
-          Linux_Go121:
-            pool.name: azsdk-pool-mms-ubuntu-2004-general
-            image.name: MMSUbuntu20.04
-            go.version: '1.21.7'
-          Windows_Go121:
-            pool.name: azsdk-pool-mms-win-2022-general
-            image.name: MMS2022
-            go.version: '1.21.7'
           Linux_Go122:
             pool.name: azsdk-pool-mms-ubuntu-2004-general
             image.name: MMSUbuntu20.04
-            go.version: '1.22.0'
-            GOEXPERIMENT: nocoverageredesign
+            go.version: '1.22.8'
           Windows_Go122:
             pool.name: azsdk-pool-mms-win-2022-general
             image.name: MMS2022
-            go.version: '1.22.0'
-            GOEXPERIMENT: nocoverageredesign
+            go.version: '1.22.8'
+          Linux_Go123:
+            pool.name: azsdk-pool-mms-ubuntu-2004-general
+            image.name: MMSUbuntu20.04
+            go.version: '1.23.2'
+          Windows_Go123:
+            pool.name: azsdk-pool-mms-win-2022-general
+            image.name: MMS2022
+            go.version: '1.23.2'
             generate.bom: true
       pool:
         name: $(pool.name)
@@ -97,7 +95,7 @@ stages:
 
       - task: GoTool@0
         inputs:
-          version: '1.22.0'
+          version: '1.23.2'
         displayName: "Select Go Version"
 
       - template: ../steps/create-go-workspace.yml

--- a/eng/pipelines/templates/jobs/mgmt-mock-test.yml
+++ b/eng/pipelines/templates/jobs/mgmt-mock-test.yml
@@ -19,7 +19,7 @@ jobs:
       displayName: 'Install autorest'
     - task: GoTool@0
       inputs:
-        version: '1.22.0'
+        version: '1.23.2'
       displayName: "Select Go Version"
 
     - template: /eng/pipelines/templates/steps/create-go-workspace.yml

--- a/eng/pipelines/templates/stages/ci-platform-matrix-complete.json
+++ b/eng/pipelines/templates/stages/ci-platform-matrix-complete.json
@@ -10,30 +10,6 @@
                 "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL"
             }
         },
-        "go.version": ["1.21.7", "1.18.10"]
-    },
-    "include": [
-        {
-            "WindowsNoCoverage": {
-                "windows-22_1220_nocoverage":
-                {
-                    "go.version": "1.22.0",
-                    "GOEXPERIMENT": "nocoverageredesign",
-                    "generate.bom": "true",
-                    "OSVmImage": "env:WINDOWSVMIMAGE",
-                    "Pool":"env:WINDOWSPOOL"
-                }
-            }
-        },
-        {
-            "LinuxNoCoverage": {
-                "ubuntu-2004_nocoverage": {
-                    "go.version": "1.22.0",
-                    "GOEXPERIMENT": "nocoverageredesign",
-                    "OSVmImage": "env:LINUXVMIMAGE",
-                    "Pool": "env:LINUXPOOL"
-                }
-            }
-        }
-    ]
+        "go.version": ["1.23.2", "1.22.8", "1.18.10"]
+    }
 }

--- a/eng/pipelines/templates/stages/ci-platform-matrix.json
+++ b/eng/pipelines/templates/stages/ci-platform-matrix.json
@@ -10,30 +10,6 @@
                 "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL"
             }
         },
-        "go.version": ["1.21.7"]
-    },
-    "include": [
-        {
-            "WindowsNoCoverage": {
-                "windows-22_1220_nocoverage":
-                {
-                    "go.version": "1.22.0",
-                    "GOEXPERIMENT": "nocoverageredesign",
-                    "generate.bom": "true",
-                    "OSVmImage": "env:WINDOWSVMIMAGE",
-                    "Pool":"env:WINDOWSPOOL"
-                }
-            }
-        },
-        {
-            "LinuxNoCoverage": {
-                "ubuntu-2004_nocoverage": {
-                    "go.version": "1.22.0",
-                    "GOEXPERIMENT": "nocoverageredesign",
-                    "OSVmImage": "env:LINUXVMIMAGE",
-                    "Pool": "env:LINUXPOOL"
-                }
-            }
-        }
-    ]
+        "go.version": ["1.23.2", "1.22.8"]
+    }
 }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -12,25 +12,8 @@
     },
     "GoVersion": [
       "1.18.10",
-      "1.21.7"
+      "1.22.8",
+      "1.23.2"
     ]
-  },
-  "include": [
-    {
-      "Agent": {
-        "ubuntu-20.04": {
-          "OSVmImage": "env:LINUXVMIMAGE",
-          "Pool": "env:LINUXPOOL"
-        },
-        "windows-2022": {
-          "OSVmImage": "env:WINDOWSVMIMAGE",
-          "Pool": "env:WINDOWSPOOL"
-        }
-      },
-      "GoVersion": [
-        "1.22.0"
-      ],
-      "GOEXPERIMENT": "nocoverageredesign"
-    }
-  ]
+  }
 }

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
-  GoLintCLIVersion: 'v1.59.0'
+  GoLintCLIVersion: 'v1.61.0'
   Package.EnableSBOMSigning: true
   # Enable go native component governance detection
   # https://docs.opensource.microsoft.com/tools/cg/index.html

--- a/eng/scripts/automation_init.sh
+++ b/eng/scripts/automation_init.sh
@@ -16,10 +16,10 @@ outputFile="$(realpath $outputFile)"
 echo "output json file: $outputFile"
 
 TMPDIR="/tmp"
-if [ ! "$(go version | awk '{print $3}' | cut -c 3-6)" = "1.22" ]
+if [ ! "$(go version | awk '{print $3}' | cut -c 3-6)" = "1.23" ]
 then
-  wget -q https://golang.org/dl/go1.22.0.linux-amd64.tar.gz
-  tar -C $TMPDIR -xzf go1.22.0.linux-amd64.tar.gz
+  wget -q https://golang.org/dl/go1.23.2.linux-amd64.tar.gz
+  tar -C $TMPDIR -xzf go1.23.2.linux-amd64.tar.gz
   export GOROOT=$TMPDIR/go
   export PATH=$GOROOT/bin:$PATH
 fi

--- a/sdk/azcore/messaging/cloud_event_test.go
+++ b/sdk/azcore/messaging/cloud_event_test.go
@@ -5,7 +5,7 @@ package messaging
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -110,7 +110,7 @@ func TestCloudEventUnmarshalFull(t *testing.T) {
 
 func TestCloudEventUnmarshalFull_InteropWithPython(t *testing.T) {
 	// this event is a Python serialized CloudEvent
-	text, err := ioutil.ReadFile("testdata/cloudevent_binary_with_extensions.json")
+	text, err := os.ReadFile("testdata/cloudevent_binary_with_extensions.json")
 	require.NoError(t, err)
 
 	var ce *CloudEvent
@@ -141,7 +141,7 @@ func TestCloudEventUnmarshalFull_InteropWithPython(t *testing.T) {
 }
 
 func TestCloudEventUnmarshalRequiredFieldsOnly(t *testing.T) {
-	text, err := ioutil.ReadFile("testdata/cloudevent_required_only.json")
+	text, err := os.ReadFile("testdata/cloudevent_required_only.json")
 	require.NoError(t, err)
 
 	var ce *CloudEvent

--- a/sdk/internal/log/log.go
+++ b/sdk/internal/log/log.go
@@ -44,7 +44,7 @@ func Should(cls Event) bool {
 	if log.lst == nil {
 		return false
 	}
-	if log.cls == nil || len(log.cls) == 0 {
+	if len(log.cls) == 0 {
 		return true
 	}
 	for _, c := range log.cls {

--- a/sdk/internal/recording/recording.go
+++ b/sdk/internal/recording/recording.go
@@ -144,7 +144,7 @@ func init() {
 		certPool, err = x509.SystemCertPool()
 		if err != nil {
 			log.Println("could not create a system cert pool")
-			log.Panicf(err.Error())
+			log.Panic(err.Error())
 		}
 	}
 	cert, err := os.ReadFile(localFile)

--- a/sdk/internal/recording/server.go
+++ b/sdk/internal/recording/server.go
@@ -12,7 +12,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -303,11 +302,11 @@ func ensureTestProxyInstalled(proxyVersion string, proxyPath string, proxyDir st
 }
 
 func getProxyLog() (*os.File, error) {
-	rand.Seed(time.Now().UnixNano())
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	const letters = "abcdefghijklmnopqrstuvwxyz"
 	suffix := make([]byte, 6)
 	for i := range suffix {
-		suffix[i] = letters[rand.Intn(len(letters))]
+		suffix[i] = letters[rng.Intn(len(letters))]
 	}
 	proxyLogName := fmt.Sprintf("test-proxy.log.%s", suffix)
 	proxyLog, err := os.Create(filepath.Join(os.TempDir(), proxyLogName))
@@ -322,14 +321,14 @@ func getProxyVersion(gitRoot string) (string, error) {
 	overrideProxyVersionConfig := filepath.Join(gitRoot, "eng/target_proxy_version.txt")
 
 	if _, err := os.Stat(overrideProxyVersionConfig); err == nil {
-		version, err := ioutil.ReadFile(overrideProxyVersionConfig)
+		version, err := os.ReadFile(overrideProxyVersionConfig)
 		if err == nil {
 			proxyVersion := strings.TrimSpace(string(version))
 			return proxyVersion, nil
 		}
 	}
 
-	version, err := ioutil.ReadFile(proxyVersionConfig)
+	version, err := os.ReadFile(proxyVersionConfig)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Remove setting nocoverageredesign as the underlying issue has been fixed, so it's no longer required.
Update to latest version of golangci-lint.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
