### PR TITLE
fix(pollers/util.go): Handle missing JSON path gracefully by using entire payload

### DIFF
--- a/sdk/azcore/internal/pollers/util.go
+++ b/sdk/azcore/internal/pollers/util.go
@@ -177,15 +177,17 @@ func ResultHelper[T any](resp *http.Response, failed bool, jsonPath string, out 
 		return err
 	}
 
+	// try to extract the payload from the response if JSON path is provided
 	if jsonPath != "" && len(payload) > 0 {
-		// extract the payload from the specified JSON path.
-		// do this before the zero-length check in case there
-		// is no payload.
 		jsonBody := map[string]json.RawMessage{}
 		if err = json.Unmarshal(payload, &jsonBody); err != nil {
 			return err
 		}
-		payload = jsonBody[jsonPath]
+		// if the JSON path is found, use that as the payload
+		// otherwise, use the entire payload
+		if v, ok := jsonBody[jsonPath]; ok {
+			payload = v
+		}
 	}
 
 	if len(payload) == 0 {


### PR DESCRIPTION
## What

`ResultHelper` attempts to extract the value at the specified JSON path.
If the specified JSON path is not found in the response, the entire payload is used as the result.

## Why

In #22980, JSON path extraction was introduced.
However, in Azure Document Intelligence that adopted Operation-Location header strategy, it is not included under the key payloadPath: "result". As a result, the correct output cannot be retrieved (always nil).

This fix updates the logic to use the entire response if the specified JSON path key does not exist.

## Ref
- [Azure Document Intelligence quickstart guide](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/quickstarts/get-started-sdks-rest-api?view=doc-intel-3.0.0&preserve-view=true&pivots=programming-language-rest-api#examine-the-response).

---

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
