### PR TITLE
Name anonymous struct types in azidentity tests

### DIFF
--- a/sdk/azidentity/client_assertion_credential_test.go
+++ b/sdk/azidentity/client_assertion_credential_test.go
@@ -18,10 +18,10 @@ import (
 )
 
 func TestClientAssertionCredential(t *testing.T) {
-	key := struct{}{}
+	type key struct{}
 	calls := 0
 	getAssertion := func(c context.Context) (string, error) {
-		if v := c.Value(key); v == nil || !v.(bool) {
+		if v := c.Value(key{}); v == nil || !v.(bool) {
 			t.Fatal("unexpected context in getAssertion")
 		}
 		calls++
@@ -33,7 +33,7 @@ func TestClientAssertionCredential(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.WithValue(context.Background(), key, true)
+	ctx := context.WithValue(context.Background(), key{}, true)
 	_, err = cred.GetToken(ctx, testTRO)
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/azidentity/device_code_credential_test.go
+++ b/sdk/azidentity/device_code_credential_test.go
@@ -29,7 +29,8 @@ func TestDeviceCodeCredential_GetTokenInvalidCredentials(t *testing.T) {
 }
 
 func TestDeviceCodeCredential_UserPromptError(t *testing.T) {
-	expectedCtx := context.WithValue(context.Background(), struct{}{}, "")
+	type key struct{}
+	expectedCtx := context.WithValue(context.Background(), key{}, "")
 	expected := DeviceCodeMessage{UserCode: "user code", VerificationURL: "http://localhost", Message: "message"}
 	success := "it worked"
 	options := DeviceCodeCredentialOptions{

--- a/sdk/azidentity/on_behalf_of_credential_test.go
+++ b/sdk/azidentity/on_behalf_of_credential_test.go
@@ -74,12 +74,12 @@ func TestOnBehalfOfCredential(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			key := struct{}{}
-			ctx := context.WithValue(context.Background(), key, true)
+			type key struct{}
+			ctx := context.WithValue(context.Background(), key{}, true)
 			srv := mockSTS{tokenRequestCallback: func(r *http.Request) *http.Response {
 				if c := r.Context(); c == nil {
 					t.Fatal("AcquireTokenOnBehalfOf received no Context")
-				} else if v := c.Value(key); v == nil || !v.(bool) {
+				} else if v := c.Value(key{}); v == nil || !v.(bool) {
 					t.Fatal("AcquireTokenOnBehalfOf received unexpected Context")
 				}
 				if err := r.ParseForm(); err != nil {


### PR DESCRIPTION
The latest golangci-lint adds `SA1029: should not use empty anonymous struct as key for value; define your own type to avoid collisions`