### PR TITLE
Allow the span kind to be set via StartSpanOptions

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added field `Kind` to `runtime.StartSpanOptions` to allow a kind to be set when starting a span.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/azcore/runtime/policy_http_trace.go
+++ b/sdk/azcore/runtime/policy_http_trace.go
@@ -96,6 +96,8 @@ func (h *httpTracePolicy) Do(req *policy.Request) (resp *http.Response, err erro
 
 // StartSpanOptions contains the optional values for StartSpan.
 type StartSpanOptions struct {
+	// Kind indicates the kind of Span.
+	Kind tracing.SpanKind
 	// Attributes contains key-value pairs of attributes for the span.
 	Attributes []tracing.Attribute
 }
@@ -115,7 +117,6 @@ func StartSpan(ctx context.Context, name string, tracer tracing.Tracer, options 
 	// we MUST propagate the active tracer before returning so that the trace policy can access it
 	ctx = context.WithValue(ctx, shared.CtxWithTracingTracer{}, tracer)
 
-	const newSpanKind = tracing.SpanKindInternal
 	if activeSpan := ctx.Value(ctxActiveSpan{}); activeSpan != nil {
 		// per the design guidelines, if a SDK method Foo() calls SDK method Bar(),
 		// then the span for Bar() must be suppressed. however, if Bar() makes a REST
@@ -131,12 +132,15 @@ func StartSpan(ctx context.Context, name string, tracer tracing.Tracer, options 
 	if options == nil {
 		options = &StartSpanOptions{}
 	}
+	if options.Kind == 0 {
+		options.Kind = tracing.SpanKindInternal
+	}
 
 	ctx, span := tracer.Start(ctx, name, &tracing.SpanOptions{
-		Kind:       newSpanKind,
+		Kind:       options.Kind,
 		Attributes: options.Attributes,
 	})
-	ctx = context.WithValue(ctx, ctxActiveSpan{}, newSpanKind)
+	ctx = context.WithValue(ctx, ctxActiveSpan{}, options.Kind)
 	return ctx, func(err error) {
 		if err != nil {
 			errType := strings.Replace(fmt.Sprintf("%T", err), "*exported.", "*azcore.", 1)


### PR DESCRIPTION
This PR adds a `Kind` field to azcore's StartSpanOptions so that consumers of `azcore.StartSpan` can customize the span kind.

I plan to follow up with a PR against azcosmos where it can classify its spans as Client spans so that consumers of azcosmos have its spans show up like db client spans.

- [X] The purpose of this PR is explained in this or a referenced issue.
- [X] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [X] Tests are included and/or updated for code changes.
- [X] Updates to module CHANGELOG.md are included.
- [X] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
