### PR TITLE
BearerTokenPolicy rewinds bodies before retrying

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Release History
 
-## 1.15.1 (Unreleased)
+## 1.16.0 (2024-10-17)
 
 ### Features Added
 
 * Added field `Kind` to `runtime.StartSpanOptions` to allow a kind to be set when starting a span.
 
-### Breaking Changes
-
 ### Bugs Fixed
 
-### Other Changes
+* `BearerTokenPolicy` now rewinds request bodies before retrying
 
 ## 1.15.0 (2024-10-14)
 

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -40,5 +40,5 @@ const (
 	Module = "azcore"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.15.1"
+	Version = "v1.16.0"
 )


### PR DESCRIPTION
`http.Client` is not kind: it reads every request body and never rewinds. `BearerTokenPolicy` must therefore rewind bodies before retrying requests, to ensure the transport includes content when sending a retry.