### PR TITLE
feat: support configuring azure cloud with env

### DIFF
--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -20,9 +20,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/internal"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/internal"
 )
 
 const (
@@ -37,6 +38,7 @@ const (
 	azureRegionalAuthorityName      = "AZURE_REGIONAL_AUTHORITY_NAME"
 	azureTenantID                   = "AZURE_TENANT_ID"
 	azureUsername                   = "AZURE_USERNAME"
+	azureCloud                      = "AZURE_CLOUD"
 
 	organizationsTenantID   = "organizations"
 	developerSignOnClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"

--- a/sdk/azidentity/environment_credential_test.go
+++ b/sdk/azidentity/environment_credential_test.go
@@ -335,3 +335,18 @@ func TestEnvironmentCredential_InvalidPasswordLive(t *testing.T) {
 		t.Fatal("missing credential type prefix")
 	}
 }
+
+func TestEnvironmentCredential_InvalidCloud(t *testing.T) {
+	vars := map[string]string{
+		azureClientID: developerSignOnClientID,
+		azureTenantID: liveUser.tenantID,
+		azureUsername: liveUser.username,
+		azurePassword: liveUser.password,
+		azureCloud:    "invalid",
+	}
+	setEnvironmentVariables(t, vars)
+	_, err := NewEnvironmentCredential(&EnvironmentCredentialOptions{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+}


### PR DESCRIPTION
- This adds support for `AZURE_CLOUD` env. 
- I followed [terraform `environment`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#argument-reference). 
- I wasn't quite sure how to test it.
- I'm also not sure what to put in CHANGELOG.md


### Checklist
- [x] The purpose of this PR is explained in this or a referenced issue https://github.com/Azure/azure-sdk-for-go/issues/23328
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
