### PR TITLE
Revert "added new tests with recordings"

### DIFF
--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_6ddd63221c"
+  "Tag": "go/storage/azfile_d78a137605"
 }

--- a/sdk/storage/azfile/directory/client_test.go
+++ b/sdk/storage/azfile/directory/client_test.go
@@ -421,43 +421,6 @@ func (d *DirectoryRecordedTestsSuite) TestDirSetPropertiesNonDefault() {
 	_require.EqualValues(fileAttributes2, fileAttributes)
 }
 
-func (d *DirectoryRecordedTestsSuite) TestDirSetPropertiesFilePermissionFormat() {
-	_require := require.New(d.T())
-	testName := d.T().Name()
-	svcClient, err := testcommon.GetServiceClient(d.T(), testcommon.TestAccountDefault, nil)
-	_require.NoError(err)
-
-	shareName := testcommon.GenerateShareName(testName)
-	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
-	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
-
-	dirName := testcommon.GenerateDirectoryName(testName)
-	dirClient := testcommon.GetDirectoryClient(dirName, shareClient)
-
-	cResp, err := dirClient.Create(context.Background(), &directory.CreateOptions{
-		FilePermissionFormat: (*file.PermissionFormat)(to.Ptr(testcommon.FilePermissionBinary)),
-		FilePermissions: &file.Permissions{
-			Permission: &testcommon.SampleBinary,
-		},
-	})
-	_require.NoError(err)
-	_require.NotNil(cResp.FilePermissionKey)
-	_require.NoError(err)
-
-	// Set the custom permissions
-	sResp, err := dirClient.SetProperties(context.Background(), &directory.SetPropertiesOptions{
-		FilePermissionFormat: (*directory.FilePermissionFormat)(to.Ptr(testcommon.FilePermissionFormatSddl)),
-		FilePermissions: &file.Permissions{
-			Permission: &testcommon.SampleSDDL,
-		},
-	})
-	_require.NoError(err)
-	_require.NotNil(sResp.FileCreationTime)
-	_require.NotNil(sResp.FileLastWriteTime)
-	_require.NotNil(sResp.FilePermissionKey)
-	_require.NotEqual(*sResp.FilePermissionKey, *cResp.FilePermissionKey)
-}
-
 func (d *DirectoryUnrecordedTestsSuite) TestDirCreateDeleteNonDefault() {
 	_require := require.New(d.T())
 	testName := d.T().Name()

--- a/sdk/storage/azfile/directory/constants.go
+++ b/sdk/storage/azfile/directory/constants.go
@@ -8,9 +8,6 @@ package directory
 
 import "github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/generated"
 
-// FilePermissionFormat contains the format of the file permissions, Can be sddl (Default) or Binary.
-type FilePermissionFormat = generated.FilePermissionFormat
-
 // ListFilesIncludeType defines values for ListFilesIncludeType
 type ListFilesIncludeType = generated.ListFilesIncludeType
 

--- a/sdk/storage/azfile/directory/models.go
+++ b/sdk/storage/azfile/directory/models.go
@@ -29,6 +29,9 @@ type DestinationLeaseAccessConditions = generated.DestinationLeaseAccessConditio
 
 // ---------------------------------------------------------------------------------------------------------------------
 
+// PermissionFormat contains the format of the file permissions, Can be sddl (Default) or Binary.
+type PermissionFormat = generated.FilePermissionFormat
+
 // CreateOptions contains the optional parameters for the Client.Create method.
 type CreateOptions struct {
 	// The default value is 'Directory' for Attributes and 'now' for CreationTime and LastWriteTime fields in file.SMBProperties.
@@ -42,7 +45,7 @@ type CreateOptions struct {
 	// explicitly set to SDDL, the permission is returned in SDDL format. If x-ms-file-permission-format is explicitly set to
 	// binary, the permission is returned as a base64 string representing the binary
 	// encoding of the permission
-	FilePermissionFormat *FilePermissionFormat
+	FilePermissionFormat *PermissionFormat
 }
 
 func (o *CreateOptions) format() *generated.DirectoryClientCreateOptions {
@@ -52,7 +55,7 @@ func (o *CreateOptions) format() *generated.DirectoryClientCreateOptions {
 			FileCreationTime:     to.Ptr(shared.DefaultCurrentTimeString),
 			FileLastWriteTime:    to.Ptr(shared.DefaultCurrentTimeString),
 			FilePermission:       to.Ptr(shared.DefaultFilePermissionString),
-			FilePermissionFormat: to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat)),
+			FilePermissionFormat: to.Ptr(PermissionFormat(shared.DefaultFilePermissionFormat)),
 		}
 	}
 
@@ -67,7 +70,7 @@ func (o *CreateOptions) format() *generated.DirectoryClientCreateOptions {
 		FileLastWriteTime:    fileLastWriteTime,
 		FilePermission:       permission,
 		FilePermissionKey:    permissionKey,
-		FilePermissionFormat: to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat)),
+		FilePermissionFormat: to.Ptr(PermissionFormat(shared.DefaultFilePermissionFormat)),
 		Metadata:             o.Metadata,
 	}
 
@@ -98,7 +101,7 @@ type RenameOptions struct {
 	// FilePermissions contains the optional parameters for the permissions on the file.
 	FilePermissions *file.Permissions
 	// FilePermissionFormat contains the file permission format, sddl(Default) or Binary.
-	FilePermissionFormat *FilePermissionFormat
+	FilePermissionFormat *PermissionFormat
 	// IgnoreReadOnly specifies whether the ReadOnly attribute on a pre-existing destination file should be respected.
 	// If true, rename will succeed, otherwise, a previous file at the destination with the ReadOnly attribute set will cause rename to fail.
 	IgnoreReadOnly *bool
@@ -116,7 +119,7 @@ type RenameOptions struct {
 func (o *RenameOptions) format() (*generated.DirectoryClientRenameOptions, *generated.DestinationLeaseAccessConditions, *generated.CopyFileSMBInfo) {
 	if o == nil {
 		return &generated.DirectoryClientRenameOptions{
-			FilePermissionFormat: to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat)),
+			FilePermissionFormat: to.Ptr(PermissionFormat(shared.DefaultFilePermissionFormat)),
 		}, nil, nil
 	}
 
@@ -127,7 +130,7 @@ func (o *RenameOptions) format() (*generated.DirectoryClientRenameOptions, *gene
 	renameOpts := &generated.DirectoryClientRenameOptions{
 		FilePermission:       permission,
 		FilePermissionKey:    permissionKey,
-		FilePermissionFormat: to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat)),
+		FilePermissionFormat: to.Ptr(PermissionFormat(shared.DefaultFilePermissionFormat)),
 		IgnoreReadOnly:       o.IgnoreReadOnly,
 		Metadata:             o.Metadata,
 		ReplaceIfExists:      o.ReplaceIfExists,
@@ -174,7 +177,7 @@ type SetPropertiesOptions struct {
 	// The default value is 'preserve' for Permission field in file.Permissions.
 	FilePermissions *file.Permissions
 	// FilePermissionFormat contains the format of the file permissions, Can be sddl (Default) or Binary.
-	FilePermissionFormat *FilePermissionFormat
+	FilePermissionFormat *PermissionFormat
 }
 
 func (o *SetPropertiesOptions) format() *generated.DirectoryClientSetPropertiesOptions {
@@ -184,7 +187,7 @@ func (o *SetPropertiesOptions) format() *generated.DirectoryClientSetPropertiesO
 			FileCreationTime:     to.Ptr(shared.DefaultPreserveString),
 			FileLastWriteTime:    to.Ptr(shared.DefaultPreserveString),
 			FilePermission:       to.Ptr(shared.DefaultPreserveString),
-			FilePermissionFormat: to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat)),
+			FilePermissionFormat: to.Ptr(PermissionFormat(shared.DefaultFilePermissionFormat)),
 		}
 	}
 
@@ -199,7 +202,7 @@ func (o *SetPropertiesOptions) format() *generated.DirectoryClientSetPropertiesO
 		FileLastWriteTime:    fileLastWriteTime,
 		FilePermission:       permission,
 		FilePermissionKey:    permissionKey,
-		FilePermissionFormat: to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat)),
+		FilePermissionFormat: to.Ptr(PermissionFormat(shared.DefaultFilePermissionFormat)),
 	}
 
 	if o.FilePermissionFormat != nil {

--- a/sdk/storage/azfile/file/constants.go
+++ b/sdk/storage/azfile/file/constants.go
@@ -67,9 +67,6 @@ const (
 	RangeWriteTypeClear  RangeWriteType = generated.FileRangeWriteTypeClear
 )
 
-// PermissionFormat contains the format of the file permissions, Can be sddl (Default) or Binary.
-type PermissionFormat = generated.FilePermissionFormat
-
 // PossibleRangeWriteTypeValues returns the possible values for the RangeWriteType const type.
 func PossibleRangeWriteTypeValues() []RangeWriteType {
 	return generated.PossibleFileRangeWriteTypeValues()

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -43,6 +43,9 @@ func ParseNTFSFileAttributes(attributes *string) (*NTFSFileAttributes, error) {
 // Permissions contains the optional parameters for the permissions on the file.
 type Permissions = exported.Permissions
 
+// PermissionFormat contains the format of the file permissions, Can be sddl (Default) or Binary.
+type PermissionFormat = generated.FilePermissionFormat
+
 // HTTPHeaders contains optional parameters for the Client.Create method.
 type HTTPHeaders = generated.ShareFileHTTPHeaders
 

--- a/sdk/storage/azfile/share/constants.go
+++ b/sdk/storage/azfile/share/constants.go
@@ -17,8 +17,6 @@ const (
 	AccessTierTransactionOptimized AccessTier = generated.ShareAccessTierTransactionOptimized
 )
 
-type PermissionFormat = generated.FilePermissionFormat
-
 // PossibleAccessTierValues returns the possible values for the AccessTier const type.
 func PossibleAccessTierValues() []AccessTier {
 	return generated.PossibleShareAccessTierValues()

--- a/sdk/storage/azfile/share/models.go
+++ b/sdk/storage/azfile/share/models.go
@@ -274,6 +274,8 @@ func (o *CreatePermissionOptions) format(sharePermission string) (Permission, *g
 // Permission - A permission (a security descriptor) at the share level.
 type Permission = generated.SharePermission
 
+type PermissionFormat = generated.FilePermissionFormat
+
 // ---------------------------------------------------------------------------------------------------------------------
 
 // GetPermissionOptions contains the optional parameters for the Client.GetPermission method.


### PR DESCRIPTION
This reverts commit ff52c44237a6bcdbd6ef1bbc2435f984c0581274.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
