### PR TITLE
Enable concurrent process to construct persistent caches

### DIFF
--- a/sdk/azidentity/cache/CHANGELOG.md
+++ b/sdk/azidentity/cache/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* `New` no longer returns an error when called simultaneously in two processes
 
 ### Other Changes
 


### PR DESCRIPTION
Closes #23588 by randomizing the name of the cache used to test the storage implementation. This makes it feasible for at least 90 processes on Linux and 1000+ on macOS and Windows to call `cache.New` simultaneously.