### PR TITLE
[key vault] add api version support

### DIFF
--- a/sdk/security/keyvault/azadmin/CHANGELOG.md
+++ b/sdk/security/keyvault/azadmin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 1.2.1 (Unreleased)
 
 #### Features Added
+* Added API Version support. Users can now change the default API Version by setting ClientOptions.APIVersion
 
 #### Breaking Changes
 

--- a/sdk/security/keyvault/azadmin/backup/custom_client.go
+++ b/sdk/security/keyvault/azadmin/backup/custom_client.go
@@ -44,6 +44,10 @@ func NewClient(vaultURL string, credential azcore.TokenCredential, options *Clie
 		},
 	)
 	azcoreClient, err := azcore.NewClient(ainternal.ModuleName, ainternal.Version, runtime.PipelineOptions{
+		APIVersion: runtime.APIVersionOptions{
+			Location: runtime.APIVersionLocationQueryParam,
+			Name:     "api-version",
+		},
 		PerRetry: []policy.Policy{authPolicy},
 		Tracing: runtime.TracingOptions{
 			Namespace: "Microsoft.KeyVault",

--- a/sdk/security/keyvault/azadmin/rbac/client_test.go
+++ b/sdk/security/keyvault/azadmin/rbac/client_test.go
@@ -259,16 +259,10 @@ func TestAPIVersion(t *testing.T) {
 	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer close()
 	srv.AppendResponse(
-		mock.WithHeader("WWW-Authenticate", `Bearer authorization="https://login.microsoftonline.com/tenant", resource="https://managedhsm.azure.net"`),
-		mock.WithStatusCode(401),
-		mock.WithPredicate(requireVersion(t)),
-	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
-	srv.AppendResponse(
 		mock.WithStatusCode(200),
 		mock.WithPredicate(requireVersion(t)),
 	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
+	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 
 	opts := &rbac.ClientOptions{
 		ClientOptions: azcore.ClientOptions{

--- a/sdk/security/keyvault/azadmin/rbac/custom_client.go
+++ b/sdk/security/keyvault/azadmin/rbac/custom_client.go
@@ -39,6 +39,10 @@ func NewClient(vaultURL string, credential azcore.TokenCredential, options *Clie
 		},
 	)
 	azcoreClient, err := azcore.NewClient(ainternal.ModuleName, ainternal.Version, runtime.PipelineOptions{
+		APIVersion: runtime.APIVersionOptions{
+			Location: runtime.APIVersionLocationQueryParam,
+			Name:     "api-version",
+		},
 		PerRetry: []policy.Policy{authPolicy},
 		Tracing: runtime.TracingOptions{
 			Namespace: "Microsoft.KeyVault",

--- a/sdk/security/keyvault/azadmin/settings/client_test.go
+++ b/sdk/security/keyvault/azadmin/settings/client_test.go
@@ -139,16 +139,10 @@ func TestAPIVersion(t *testing.T) {
 	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer close()
 	srv.AppendResponse(
-		mock.WithHeader("WWW-Authenticate", `Bearer authorization="https://login.microsoftonline.com/tenant", resource="https://managedhsm.azure.net"`),
-		mock.WithStatusCode(401),
-		mock.WithPredicate(requireVersion(t)),
-	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
-	srv.AppendResponse(
 		mock.WithStatusCode(200),
 		mock.WithPredicate(requireVersion(t)),
 	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
+	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 
 	opts := &settings.ClientOptions{
 		ClientOptions: azcore.ClientOptions{

--- a/sdk/security/keyvault/azadmin/settings/client_test.go
+++ b/sdk/security/keyvault/azadmin/settings/client_test.go
@@ -9,12 +9,15 @@ package settings_test
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
+	azcred "github.com/Azure/azure-sdk-for-go/sdk/internal/test/credential"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin/settings"
 	"github.com/stretchr/testify/require"
 )
@@ -122,4 +125,40 @@ func TestUpdateSetting_InvalidSettingName(t *testing.T) {
 	require.Nil(t, res.Value)
 	var httpErr *azcore.ResponseError
 	require.ErrorAs(t, err, &httpErr)
+}
+
+func TestAPIVersion(t *testing.T) {
+	apiVersion := "7.3"
+	var requireVersion = func(t *testing.T) func(req *http.Request) bool {
+		return func(r *http.Request) bool {
+			version := r.URL.Query().Get("api-version")
+			require.Equal(t, version, apiVersion)
+			return true
+		}
+	}
+	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer close()
+	srv.AppendResponse(
+		mock.WithHeader("WWW-Authenticate", `Bearer authorization="https://login.microsoftonline.com/tenant", resource="https://managedhsm.azure.net"`),
+		mock.WithStatusCode(401),
+		mock.WithPredicate(requireVersion(t)),
+	)
+	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
+	srv.AppendResponse(
+		mock.WithStatusCode(200),
+		mock.WithPredicate(requireVersion(t)),
+	)
+	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
+
+	opts := &settings.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport:  srv,
+			APIVersion: apiVersion,
+		},
+	}
+	client, err := settings.NewClient(hsmURL, &azcred.Fake{}, opts)
+	require.NoError(t, err)
+
+	_, err = client.GetSetting(context.Background(), "name", nil)
+	require.NoError(t, err)
 }

--- a/sdk/security/keyvault/azadmin/settings/custom_client.go
+++ b/sdk/security/keyvault/azadmin/settings/custom_client.go
@@ -39,6 +39,10 @@ func NewClient(vaultURL string, credential azcore.TokenCredential, options *Clie
 		},
 	)
 	azcoreClient, err := azcore.NewClient(ainternal.ModuleName, ainternal.Version, runtime.PipelineOptions{
+		APIVersion: runtime.APIVersionOptions{
+			Location: runtime.APIVersionLocationQueryParam,
+			Name:     "api-version",
+		},
 		PerRetry: []policy.Policy{authPolicy},
 		Tracing: runtime.TracingOptions{
 			Namespace: "Microsoft.KeyVault",

--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.1 (Unreleased)
 
 ### Features Added
+* Added API Version support. Users can now change the default API Version by setting ClientOptions.APIVersion
 
 ### Breaking Changes
 

--- a/sdk/security/keyvault/azcertificates/client_test.go
+++ b/sdk/security/keyvault/azcertificates/client_test.go
@@ -672,26 +672,18 @@ func TestUpdateCertificatePolicy(t *testing.T) {
 
 func TestAPIVersion(t *testing.T) {
 	apiVersion := "7.3"
-	var requireVersion = func(t *testing.T) func(req *http.Request) bool {
-		return func(r *http.Request) bool {
-			version := r.URL.Query().Get("api-version")
-			require.Equal(t, version, apiVersion)
-			return true
-		}
+	var requireVersion = func(req *http.Request) bool {
+		version := req.URL.Query().Get("api-version")
+		require.Equal(t, version, apiVersion)
+		return true
 	}
 	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer close()
 	srv.AppendResponse(
-		mock.WithHeader("WWW-Authenticate", `Bearer authorization="https://login.microsoftonline.com/tenant", resource="https://vault.azure.net"`),
-		mock.WithStatusCode(401),
-		mock.WithPredicate(requireVersion(t)),
-	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
-	srv.AppendResponse(
 		mock.WithStatusCode(200),
-		mock.WithPredicate(requireVersion(t)),
+		mock.WithPredicate(requireVersion),
 	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
+	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 
 	opts := &azcertificates.ClientOptions{
 		ClientOptions: azcore.ClientOptions{

--- a/sdk/security/keyvault/azcertificates/custom_client.go
+++ b/sdk/security/keyvault/azcertificates/custom_client.go
@@ -41,6 +41,10 @@ func NewClient(vaultURL string, credential azcore.TokenCredential, options *Clie
 		},
 	)
 	azcoreClient, err := azcore.NewClient(moduleName, version, runtime.PipelineOptions{
+		APIVersion: runtime.APIVersionOptions{
+			Location: runtime.APIVersionLocationQueryParam,
+			Name:     "api-version",
+		},
 		PerRetry: []policy.Policy{authPolicy},
 		Tracing: runtime.TracingOptions{
 			Namespace: "Microsoft.KeyVault",

--- a/sdk/security/keyvault/azkeys/CHANGELOG.md
+++ b/sdk/security/keyvault/azkeys/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.1 (Unreleased)
 
 ### Features Added
+* Added API Version support. Users can now change the default API Version by setting ClientOptions.APIVersion
 
 ### Breaking Changes
 

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -731,3 +731,39 @@ func TestWrapUnwrap(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIVersion(t *testing.T) {
+	apiVersion := "7.3"
+	var requireVersion = func(t *testing.T) func(req *http.Request) bool {
+		return func(r *http.Request) bool {
+			version := r.URL.Query().Get("api-version")
+			require.Equal(t, version, apiVersion)
+			return true
+		}
+	}
+	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer close()
+	srv.AppendResponse(
+		mock.WithHeader("WWW-Authenticate", `Bearer authorization="https://login.microsoftonline.com/tenant", resource="https://vault.azure.net"`),
+		mock.WithStatusCode(401),
+		mock.WithPredicate(requireVersion(t)),
+	)
+	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
+	srv.AppendResponse(
+		mock.WithStatusCode(200),
+		mock.WithPredicate(requireVersion(t)),
+	)
+	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
+
+	opts := &azkeys.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport:  srv,
+			APIVersion: apiVersion,
+		},
+	}
+	client, err := azkeys.NewClient(vaultURL, &azcred.Fake{}, opts)
+	require.NoError(t, err)
+
+	_, err = client.GetKey(context.Background(), "name", "", nil)
+	require.NoError(t, err)
+}

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -734,26 +734,18 @@ func TestWrapUnwrap(t *testing.T) {
 
 func TestAPIVersion(t *testing.T) {
 	apiVersion := "7.3"
-	var requireVersion = func(t *testing.T) func(req *http.Request) bool {
-		return func(r *http.Request) bool {
-			version := r.URL.Query().Get("api-version")
-			require.Equal(t, version, apiVersion)
-			return true
-		}
+	var requireVersion = func(req *http.Request) bool {
+		version := req.URL.Query().Get("api-version")
+		require.Equal(t, version, apiVersion)
+		return true
 	}
 	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer close()
 	srv.AppendResponse(
-		mock.WithHeader("WWW-Authenticate", `Bearer authorization="https://login.microsoftonline.com/tenant", resource="https://vault.azure.net"`),
-		mock.WithStatusCode(401),
-		mock.WithPredicate(requireVersion(t)),
-	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
-	srv.AppendResponse(
 		mock.WithStatusCode(200),
-		mock.WithPredicate(requireVersion(t)),
+		mock.WithPredicate(requireVersion),
 	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
+	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 
 	opts := &azkeys.ClientOptions{
 		ClientOptions: azcore.ClientOptions{

--- a/sdk/security/keyvault/azkeys/custom_client.go
+++ b/sdk/security/keyvault/azkeys/custom_client.go
@@ -38,6 +38,10 @@ func NewClient(vaultURL string, credential azcore.TokenCredential, options *Clie
 		},
 	)
 	azcoreClient, err := azcore.NewClient(moduleName, version, runtime.PipelineOptions{
+		APIVersion: runtime.APIVersionOptions{
+			Location: runtime.APIVersionLocationQueryParam,
+			Name:     "api-version",
+		},
 		PerRetry: []policy.Policy{authPolicy},
 		Tracing: runtime.TracingOptions{
 			Namespace: "Microsoft.KeyVault",

--- a/sdk/security/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/security/keyvault/azsecrets/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.1 (Unreleased)
 
 ### Features Added
+* Added API Version support. Users can now change the default API Version by setting ClientOptions.APIVersion
 
 ### Breaking Changes
 

--- a/sdk/security/keyvault/azsecrets/client_test.go
+++ b/sdk/security/keyvault/azsecrets/client_test.go
@@ -414,10 +414,9 @@ func TestAPIVersion(t *testing.T) {
 			APIVersion: apiVersion,
 		},
 	}
-	client, err := azsecrets.NewClient(vaultURL, credential, opts)
+	client, err := azsecrets.NewClient(vaultURL, &azcred.Fake{}, opts)
 	require.NoError(t, err)
 
-	res, err := client.GetSecret(context.Background(), "name", "", nil)
-	_ = res
+	_, err = client.GetSecret(context.Background(), "name", "", nil)
 	require.NoError(t, err)
 }

--- a/sdk/security/keyvault/azsecrets/client_test.go
+++ b/sdk/security/keyvault/azsecrets/client_test.go
@@ -387,26 +387,18 @@ func TestRecover(t *testing.T) {
 
 func TestAPIVersion(t *testing.T) {
 	apiVersion := "7.3"
-	var requireVersion = func(t *testing.T) func(req *http.Request) bool {
-		return func(r *http.Request) bool {
-			version := r.URL.Query().Get("api-version")
-			require.Equal(t, version, apiVersion)
-			return true
-		}
+	var requireVersion = func(req *http.Request) bool {
+		version := req.URL.Query().Get("api-version")
+		require.Equal(t, version, apiVersion)
+		return true
 	}
 	srv, close := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer close()
 	srv.AppendResponse(
-		mock.WithHeader("WWW-Authenticate", `Bearer authorization="https://login.microsoftonline.com/tenant", resource="https://vault.azure.net"`),
-		mock.WithStatusCode(401),
-		mock.WithPredicate(requireVersion(t)),
-	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
-	srv.AppendResponse(
 		mock.WithStatusCode(200),
-		mock.WithPredicate(requireVersion(t)),
+		mock.WithPredicate(requireVersion),
 	)
-	srv.AppendResponse() // when a response's predicate returns true, srv pops the following one
+	srv.AppendResponse(mock.WithStatusCode(http.StatusInternalServerError))
 
 	opts := &azsecrets.ClientOptions{
 		ClientOptions: azcore.ClientOptions{

--- a/sdk/security/keyvault/azsecrets/custom_client.go
+++ b/sdk/security/keyvault/azsecrets/custom_client.go
@@ -38,6 +38,10 @@ func NewClient(vaultURL string, credential azcore.TokenCredential, options *Clie
 		},
 	)
 	azcoreClient, err := azcore.NewClient(moduleName, version, runtime.PipelineOptions{
+		APIVersion: runtime.APIVersionOptions{
+			Location: runtime.APIVersionLocationQueryParam,
+			Name:     "api-version",
+		},
 		PerRetry: []policy.Policy{authPolicy},
 		Tracing: runtime.TracingOptions{
 			Namespace: "Microsoft.KeyVault",


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-for-go/issues/22396

Adds API version support. Instead of only being able to use the default version, users can now set the API version themselves.