### PR TITLE
Add some response values as attributes to the azcosmos traces

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 * Set all Telemetry spans to have the Kind of SpanKindClient
+* Set request_charge and status_code on all trace spans
 
 ### Breaking Changes
 

--- a/sdk/data/azcosmos/emulator_cosmos_aad_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_aad_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAAD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 
@@ -29,7 +29,7 @@ func TestAAD(t *testing.T) {
 		t.Fatalf("Failed to create container: %v", err)
 	}
 
-	aadClient := emulatorTests.getAadClient(t, newSpanValidator(t, spanMatcher{
+	aadClient := emulatorTests.getAadClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{"create_item aContainer", "read_item aContainer", "replace_item aContainer", "upsert_item aContainer", "delete_item aContainer"},
 	}))
 

--- a/sdk/data/azcosmos/emulator_cosmos_batch_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_batch_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestItemTransactionalBatch(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{"execute_batch aContainer"},
 	}))
 
@@ -171,7 +171,7 @@ func TestItemTransactionalBatch(t *testing.T) {
 
 func TestItemTransactionalBatchError(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{"execute_batch aContainer"},
 	}))
 

--- a/sdk/data/azcosmos/emulator_cosmos_container_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_container_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestContainerCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{"create_container aContainer", "read_container aContainer", "replace_container aContainer", "read_container_throughput aContainer", "replace_container_throughput aContainer", "delete_container aContainer"},
 	}))
 
@@ -131,7 +131,7 @@ func TestContainerCRUD(t *testing.T) {
 
 func TestContainerAutoscaleCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{"create_container aContainer", "read_container aContainer", "read_container_throughput aContainer", "replace_container_throughput aContainer", "delete_container aContainer"},
 	}))
 

--- a/sdk/data/azcosmos/emulator_cosmos_database_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_database_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDatabaseCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{"create_database baseDbTest", "read_database baseDbTest", "delete_database baseDbTest", "read_database_throughput baseDbTest"},
 	}))
 
@@ -70,7 +70,7 @@ func TestDatabaseCRUD(t *testing.T) {
 
 func TestDatabaseWithOfferCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{"create_database baseDbTest", "read_database baseDbTest", "delete_database baseDbTest", "read_database_throughput baseDbTest", "replace_database_throughput baseDbTest"},
 	}))
 

--- a/sdk/data/azcosmos/emulator_cosmos_global_endpoint_manager_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_global_endpoint_manager_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestGlobalEndpointManagerEmulator(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 	emulatorRegionName := "South Central US"
@@ -79,7 +79,7 @@ func TestGlobalEndpointManagerEmulator(t *testing.T) {
 
 func TestGlobalEndpointManagerPolicyEmulator(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 	emulatorRegionName := "South Central US"

--- a/sdk/data/azcosmos/emulator_cosmos_item_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_item_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestItemCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{"create_item aContainer", "read_item aContainer", "replace_item aContainer", "upsert_item aContainer", "delete_item aContainer", "patch_item aContainer"},
 	}))
 
@@ -193,7 +193,7 @@ func TestItemCRUD(t *testing.T) {
 
 func TestItemCRUDforNullPartitionKey(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{"create_item aContainer", "read_item aContainer", "replace_item aContainer", "upsert_item aContainer", "delete_item aContainer", "patch_item aContainer"},
 	}))
 
@@ -370,7 +370,7 @@ func TestItemCRUDforNullPartitionKey(t *testing.T) {
 
 func TestItemConcurrent(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 
@@ -423,7 +423,7 @@ func TestItemConcurrent(t *testing.T) {
 
 func TestItemIdEncodingRoutingGW(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 
@@ -464,7 +464,7 @@ func TestItemIdEncodingRoutingGW(t *testing.T) {
 
 func TestItemIdEncodingComputeGW(t *testing.T) {
 	emulatorTests := newEmulatorTestsWithComputeGateway(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 

--- a/sdk/data/azcosmos/emulator_cosmos_query_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_query_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSinglePartitionQueryWithIndexMetrics(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 
@@ -87,7 +87,7 @@ func TestSinglePartitionQueryWithIndexMetrics(t *testing.T) {
 
 func TestSinglePartitionQuery(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 
@@ -175,7 +175,7 @@ func TestSinglePartitionQuery(t *testing.T) {
 
 func TestSinglePartitionQueryWithParameters(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 
@@ -227,7 +227,7 @@ func TestSinglePartitionQueryWithParameters(t *testing.T) {
 
 func TestSinglePartitionQueryWithProjection(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
-	client := emulatorTests.getClient(t, newSpanValidator(t, spanMatcher{
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
 		ExpectedSpans: []string{},
 	}))
 


### PR DESCRIPTION
When https://github.com/Azure/azure-sdk-for-go/pull/23268 was being considered there was [a request](https://github.com/Azure/azure-sdk-for-go/pull/23268#discussion_r1712146494) to add attributes based on the response.

This PR adds `db.cosmosdb.request_charge` and `db.cosmosdb.status_code` to all requests (at least the ones that make use of `executeAndEnsureSuccessResponse` which appear to be all of them right now.

I could not figure out how to get the sub status code out of the HTTP response. I'd be happy to add it here or in a follow up if I can get some help as to where to find it in the response.

Refs: https://github.com/Azure/azure-sdk-for-go/issues/23308

- [X] The purpose of this PR is explained in this or a referenced issue.
- [X] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [X] Tests are included and/or updated for code changes.
- [X] Updates to module CHANGELOG.md are included.
- [X] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
