### PR TITLE
Azcosmos no tracer to pager

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -3,12 +3,13 @@
 ## 1.1.1 (Unreleased)
 
 ### Features Added
-* Set all Telemetry spans to have the Kind of SpanKindClient
-* Set request_charge and status_code on all trace spans
+* Set all Telemetry spans to have the Kind of SpanKindClient. See [PR 23618](https://github.com/Azure/azure-sdk-for-go/pull/23618)
+* Set request_charge and status_code on all trace spans. See [PR 23652](https://github.com/Azure/azure-sdk-for-go/pull/23652)
 
 ### Breaking Changes
 
 ### Bugs Fixed
+* Pager Telemetry spans are now more consistent with the rest of the spans. See [PR 23658](https://github.com/Azure/azure-sdk-for-go/pull/23658)
 
 ### Other Changes
 

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -278,7 +278,6 @@ func (c *Client) NewQueryDatabasesPager(query string, o *QueryDatabasesOptions) 
 		},
 		Fetcher: func(ctx context.Context, page *QueryDatabasesResponse) (QueryDatabasesResponse, error) {
 			var err error
-			// Move the span to the pager once https://github.com/Azure/azure-sdk-for-go/issues/23294 is fixed
 			spanName, err := getSpanNameForClient(c.accountEndpointUrl(), operationTypeQuery, resourceTypeDatabase, c.accountEndpointUrl().Hostname())
 			if err != nil {
 				return QueryDatabasesResponse{}, err
@@ -307,7 +306,6 @@ func (c *Client) NewQueryDatabasesPager(query string, o *QueryDatabasesOptions) 
 
 			return newDatabasesQueryResponse(azResponse)
 		},
-		Tracer: c.internal.Tracer(),
 	})
 }
 

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -515,7 +515,6 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 		},
 		Fetcher: func(ctx context.Context, page *QueryItemsResponse) (QueryItemsResponse, error) {
 			var err error
-			// Move the span to the pager once https://github.com/Azure/azure-sdk-for-go/issues/23294 is fixed
 			spanName, err := c.getSpanForItems(operationTypeQuery)
 			if err != nil {
 				return QueryItemsResponse{}, err
@@ -544,7 +543,6 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 
 			return newQueryResponse(azResponse)
 		},
-		Tracer: c.database.client.internal.Tracer(),
 	})
 }
 

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -115,7 +115,6 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 		},
 		Fetcher: func(ctx context.Context, page *QueryContainersResponse) (QueryContainersResponse, error) {
 			var err error
-			// Move the span to the pager once https://github.com/Azure/azure-sdk-for-go/issues/23294 is fixed
 			spanName, err := c.getSpanForDatabases(operationTypeQuery, resourceTypeCollection)
 			if err != nil {
 				return QueryContainersResponse{}, err
@@ -144,7 +143,6 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 
 			return newContainersQueryResponse(azResponse)
 		},
-		Tracer: c.client.internal.Tracer(),
 	})
 }
 

--- a/sdk/data/azcosmos/emulator_cosmos_container_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_container_test.go
@@ -11,7 +11,7 @@ import (
 func TestContainerCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
-		ExpectedSpans: []string{"create_container aContainer", "read_container aContainer", "replace_container aContainer", "read_container_throughput aContainer", "replace_container_throughput aContainer", "delete_container aContainer"},
+		ExpectedSpans: []string{"create_container aContainer", "read_container aContainer", "query_containers containerCRUD", "replace_container aContainer", "read_container_throughput aContainer", "replace_container_throughput aContainer", "delete_container aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "containerCRUD")

--- a/sdk/data/azcosmos/emulator_cosmos_database_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_database_test.go
@@ -11,7 +11,7 @@ import (
 func TestDatabaseCRUD(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
-		ExpectedSpans: []string{"create_database baseDbTest", "read_database baseDbTest", "delete_database baseDbTest", "read_database_throughput baseDbTest"},
+		ExpectedSpans: []string{"create_database baseDbTest", "read_database baseDbTest", "query_databases localhost", "delete_database baseDbTest", "read_database_throughput baseDbTest"},
 	}))
 
 	database := DatabaseProperties{ID: "baseDbTest"}

--- a/sdk/data/azcosmos/emulator_cosmos_query_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_query_test.go
@@ -13,7 +13,7 @@ import (
 func TestSinglePartitionQueryWithIndexMetrics(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
-		ExpectedSpans: []string{},
+		ExpectedSpans: []string{"query_items aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
@@ -88,7 +88,7 @@ func TestSinglePartitionQueryWithIndexMetrics(t *testing.T) {
 func TestSinglePartitionQuery(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
-		ExpectedSpans: []string{},
+		ExpectedSpans: []string{"query_items aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
@@ -176,7 +176,7 @@ func TestSinglePartitionQuery(t *testing.T) {
 func TestSinglePartitionQueryWithParameters(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
-		ExpectedSpans: []string{},
+		ExpectedSpans: []string{"query_items aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
@@ -228,7 +228,7 @@ func TestSinglePartitionQueryWithParameters(t *testing.T) {
 func TestSinglePartitionQueryWithProjection(t *testing.T) {
 	emulatorTests := newEmulatorTests(t)
 	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
-		ExpectedSpans: []string{},
+		ExpectedSpans: []string{"query_items aContainer"},
 	}))
 
 	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")


### PR DESCRIPTION
- Refs https://github.com/Azure/azure-sdk-for-go/issues/23294

Originally the thought was that the azcore Pager should provide a way to better customize the spans it creates, and that the azcosmos Pager based spans could take advantage of that.

As I was digging it to try to make that work I did realize a few things.

1. The spans being set within the azcosmos Fetcher functions are currently being surpressed due to the StartSpan code policy to not allow nested spans most of the time.
2. Adding a way to customize the span creation in the azcore Pager would add complexity for what is currently just a simple wrapper around the Fetcher function
3. If a Tracer is not set on the PagingHandler a null Tracer is used which results in StartSpan not adding an active span to the context.

Considering all the above. I think the simplest way to allow azcosmos to customize the tracer used for Pager spans is to not set a tracer in PagingHandler, and allow the custom one within the Fetcher function to take precedence.


For testing, I've pushed a commit with just the tests to show that before this change the tests fail to have the `query_` spans. Then I've pushed the commit that removes setting the Tracer and you can see the tests all pass now.

[Example of a failing test](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4265647&view=logs&j=07a8bf49-95b8-5c7c-de1a-77230f20b6cf&t=79c67422-3cb3-50fc-4ea3-00a141e27961):
![Messages: span query_items aContainer wasn't found](https://github.com/user-attachments/assets/9a5d82a1-010d-4847-b128-a80d1d76952b)


- [X] The purpose of this PR is explained in this or a referenced issue.
- [X] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [X] Updates to module CHANGELOG.md are included.
- [X] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
