### PR TITLE
Run live managed identity tests in westus2

### DIFF
--- a/sdk/azidentity/ci.yml
+++ b/sdk/azidentity/ci.yml
@@ -29,6 +29,7 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-identity-test-resources)
       EnableRaceDetector: true
+      Location: westus2
       RunLiveTests: true
       ServiceDirectory: azidentity
       UsePipelineProxy: false


### PR DESCRIPTION
TME subscription (#23570) lacks quota for the necessary resources in the default region (westus)