### PR TITLE
remove pkg.go.dev link in readme

### DIFF
--- a/sdk/resourcemanager/aad/armaad/README.md
+++ b/sdk/resourcemanager/aad/armaad/README.md
@@ -1,7 +1,5 @@
 # Azure Active Directory Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/aad/armaad)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/aad/armaad)
-
 The `armaad` module provides operations for working with Azure Active Directory.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/aad/armaad)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/aad/armaad
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Active Directory.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Active Directory. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armaad.NewClientFactory(<subscription ID>, cred, &options)
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPrivateLinkResourcesClient()

--- a/sdk/resourcemanager/addons/armaddons/README.md
+++ b/sdk/resourcemanager/addons/armaddons/README.md
@@ -1,7 +1,5 @@
 # Azure Addons Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/addons/armaddons)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/addons/armaddons)
-
 The `armaddons` module provides operations for working with Azure Addons.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/addons/armaddons)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/addons/armaddons
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Addons.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Addons. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armaddons.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSupportPlanTypesClient()

--- a/sdk/resourcemanager/advisor/armadvisor/README.md
+++ b/sdk/resourcemanager/advisor/armadvisor/README.md
@@ -1,7 +1,5 @@
 # Azure Advisor Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor)
-
 The `armadvisor` module provides operations for working with Azure Advisor.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/advisor/armadvisor)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Advisor.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Advisor. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armadvisor.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSuppressionsClient()

--- a/sdk/resourcemanager/agrifood/armagrifood/README.md
+++ b/sdk/resourcemanager/agrifood/armagrifood/README.md
@@ -1,7 +1,5 @@
 # Azure AgriFood Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/agrifood/armagrifood)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/agrifood/armagrifood)
-
 The `armagrifood` module provides operations for working with Azure AgriFood.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/agrifood/armagrifood)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/agrifood/armagrifoo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure AgriFood.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure AgriFood. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armagrifood.NewClientFactory(<subscription ID>, cred, &opt
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewExtensionsClient()

--- a/sdk/resourcemanager/alertsmanagement/armalertsmanagement/README.md
+++ b/sdk/resourcemanager/alertsmanagement/armalertsmanagement/README.md
@@ -1,7 +1,5 @@
 # Azure Alerts Management Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/armalertsmanagement)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/armalertsmanagement)
-
 The `armalertsmanagement` module provides operations for working with Azure Alerts Management.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/alertsmanagement/armalertsmanagement)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Alerts Management.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Alerts Management. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armalertsmanagement.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAlertProcessingRulesClient()

--- a/sdk/resourcemanager/analysisservices/armanalysisservices/README.md
+++ b/sdk/resourcemanager/analysisservices/armanalysisservices/README.md
@@ -1,7 +1,5 @@
 # Azure Analysis Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/analysisservices/armanalysisservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/analysisservices/armanalysisservices)
-
 The `armanalysisservices` module provides operations for working with Azure Analysis Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/analysisservices/armanalysisservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/analysisservices/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Analysis Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Analysis Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armanalysisservices.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServersClient()

--- a/sdk/resourcemanager/apicenter/armapicenter/README.md
+++ b/sdk/resourcemanager/apicenter/armapicenter/README.md
@@ -1,7 +1,5 @@
 # Azure Apicenter Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apicenter/armapicenter)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apicenter/armapicenter)
-
 The `armapicenter` module provides operations for working with Azure Apicenter.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/apicenter/armapicenter)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apicenter/armapicen
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Apicenter.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Apicenter. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ client, err := armapicenter.NewClientFactory(<subscription ID>, cred, &options)
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAPIDefinitionsClient()

--- a/sdk/resourcemanager/apimanagement/armapimanagement/README.md
+++ b/sdk/resourcemanager/apimanagement/armapimanagement/README.md
@@ -1,7 +1,5 @@
 # Azure API Management Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement/v2)
-
 The `armapimanagement` module provides operations for working with Azure API Management.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/apimanagement/armapimanagement)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armap
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure API Management.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure API Management. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armapimanagement.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServiceClient()

--- a/sdk/resourcemanager/appcomplianceautomation/armappcomplianceautomation/README.md
+++ b/sdk/resourcemanager/appcomplianceautomation/armappcomplianceautomation/README.md
@@ -1,7 +1,5 @@
 # Azure Appcomplianceautomation Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcomplianceautomation/armappcomplianceautomation)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcomplianceautomation/armappcomplianceautomation)
-
 The `armappcomplianceautomation` module provides operations for working with Azure Appcomplianceautomation.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/appcomplianceautomation/armappcomplianceautomation)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcomplianceautoma
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Appcomplianceautomation.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Appcomplianceautomation. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armappcomplianceautomation.NewClientFactory(<subscription 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSnapshotClient()

--- a/sdk/resourcemanager/appconfiguration/armappconfiguration/README.md
+++ b/sdk/resourcemanager/appconfiguration/armappconfiguration/README.md
@@ -1,7 +1,5 @@
 # Azure App Configuration Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration/v2)
-
 The `armappconfiguration` module provides operations for working with Azure App Configuration.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/appconfiguration/armappconfiguration)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure App Configuration.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure App Configuration. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armappconfiguration.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewConfigurationStoresClient()

--- a/sdk/resourcemanager/appcontainers/armappcontainers/README.md
+++ b/sdk/resourcemanager/appcontainers/armappcontainers/README.md
@@ -1,7 +1,5 @@
 # Azure Container Apps Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3)
-
 The `armappcontainers` module provides operations for working with Azure Container Apps.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/appcontainers/armappcontainers)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armap
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Container Apps.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Container Apps. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armappcontainers.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAppResiliencyClient()

--- a/sdk/resourcemanager/applicationinsights/armapplicationinsights/README.md
+++ b/sdk/resourcemanager/applicationinsights/armapplicationinsights/README.md
@@ -1,7 +1,5 @@
 # Azure Application Insight Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/applicationinsights/armapplicationinsights)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/applicationinsights/armapplicationinsights)
-
 The `armapplicationinsights` module provides operations for working with Azure Application Insight.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/applicationinsights/armapplicationinsights)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/applicationinsights
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Application Insight.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Application Insight. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armapplicationinsights.NewClientFactory(<subscription ID>,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAPIKeysClient()

--- a/sdk/resourcemanager/appplatform/armappplatform/README.md
+++ b/sdk/resourcemanager/appplatform/armappplatform/README.md
@@ -1,7 +1,5 @@
 # Azure App Platform Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform/v2)
-
 The `armappplatform` module provides operations for working with Azure App Platform.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/appplatform/armappplatform)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappp
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure App Platform.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure App Platform. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armappplatform.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAPIPortalCustomDomainsClient()

--- a/sdk/resourcemanager/appservice/armappservice/README.md
+++ b/sdk/resourcemanager/appservice/armappservice/README.md
@@ -1,7 +1,5 @@
 # Azure App Service Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v4)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v4)
-
 The `armappservice` module provides operations for working with Azure App Service.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/appservice/armappservice)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappse
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure App Service.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure App Service. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armappservice.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCertificateOrdersClient()

--- a/sdk/resourcemanager/astro/armastro/CHANGELOG.md
+++ b/sdk/resourcemanager/astro/armastro/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.1.0 (2024-02-23)
+### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/astro/armastro` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 

--- a/sdk/resourcemanager/astro/armastro/README.md
+++ b/sdk/resourcemanager/astro/armastro/README.md
@@ -1,7 +1,5 @@
 # Azure Astro Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/astro/armastro)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/astro/armastro)
-
 The `armastro` module provides operations for working with Azure Astro.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/astro/armastro)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/astro/armastro
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Astro.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Astro. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armastro.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewOrganizationsClient()

--- a/sdk/resourcemanager/attestation/armattestation/README.md
+++ b/sdk/resourcemanager/attestation/armattestation/README.md
@@ -1,7 +1,5 @@
 # Azure Attestation Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/attestation/armattestation)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/attestation/armattestation)
-
 The `armattestation` module provides operations for working with Azure Attestation.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/attestation/armattestation)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/attestation/armatte
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Attestation.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Attestation. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armattestation.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewProvidersClient()

--- a/sdk/resourcemanager/authorization/armauthorization/README.md
+++ b/sdk/resourcemanager/authorization/armauthorization/README.md
@@ -1,7 +1,5 @@
 # Azure Authorization Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3)
-
 The `armauthorization` module provides operations for working with Azure Authorization.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/authorization/armauthorization)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armau
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Authorization.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Authorization. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -73,12 +71,11 @@ clientFactory, err := armX.NewClientFactory(<subscription ID>, cred, &options)
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
-```go
+````go
 client := clientFactory.NewXClient()
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3)
 
 The `armauthorization` module provides operations for working with Azure Authorization.
 
@@ -99,7 +96,7 @@ Install the Azure Authorization module:
 
 ```sh
 go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3
-```
+````
 
 ## Fakes
 
@@ -110,7 +107,7 @@ Please see https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Authorization.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Authorization. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -139,7 +136,7 @@ clientFactory, err := armauthorization.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPermissionsClient()

--- a/sdk/resourcemanager/automanage/armautomanage/README.md
+++ b/sdk/resourcemanager/automanage/armautomanage/README.md
@@ -1,7 +1,5 @@
 # Azure Automanage Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automanage/armautomanage)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automanage/armautomanage)
-
 The `armautomanage` module provides operations for working with Azure Automanage.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/automanage/armautomanage)
@@ -35,7 +33,7 @@ import (
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Automanage.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Automanage. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -64,7 +62,7 @@ clientFactory, err := armautomanage.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 reportsClient := clientFactory.NewReportsClient()
@@ -103,7 +101,7 @@ properties := armautomanage.ConfigurationProfileProperties{
 location := "eastus"
 environment := "dev"
 
-// tags may be omitted 
+// tags may be omitted
 tags := make(map[string]*string)
 tags["environment"] = &environment
 
@@ -116,7 +114,6 @@ profile := armautomanage.ConfigurationProfile{
 newProfile, err := configProfilesClient.CreateOrUpdate(context.Background(), configurationProfileName, "resourceGroupName", profile, nil)
 ```
 
-
 ## Get an Automanage Configuration Profile
 
 ```go
@@ -126,13 +123,11 @@ data, err := json.MarshalIndent(profile, "", "   ")
 fmt.Println(string(data))
 ```
 
-
 ## Delete an Automanage Configuration Profile
 
 ```go
 _, err := configProfilesClient.Delete(context.Background(), "resourceGroupName", "configurationProfileName", nil)
 ```
-
 
 ## Get an Automanage Profile Assignment
 
@@ -141,7 +136,6 @@ assignment, err := assignmentClient.Get(context.Background(), "resourceGroupName
 data, err := json.MarshalIndent(assignment, "", "   ")
 fmt.Println(string(data))
 ```
-
 
 ## Create an Assignment between a VM and an Automanage Best Practices Production Configuration Profile
 
@@ -160,7 +154,6 @@ assignment := armautomanage.ConfigurationProfileAssignment{
 newAssignment, err = assignmentClient.CreateOrUpdate(context.Background(), "default", "resourceGroupName", "vmName", assignment, nil)
 ```
 
-
 ## Create an Assignment between a VM and a Custom Automanage Configuration Profile
 
 ```go
@@ -177,7 +170,6 @@ assignment := armautomanage.ConfigurationProfileAssignment{
 // assignment name must be 'default'
 newAssignment, err = assignmentClient.CreateOrUpdate(context.Background(), "default", "resourceGroupName", "vmName", assignment, nil)
 ```
-
 
 ## Provide Feedback
 

--- a/sdk/resourcemanager/automation/armautomation/README.md
+++ b/sdk/resourcemanager/automation/armautomation/README.md
@@ -1,7 +1,5 @@
 # Azure Automation Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automation/armautomation)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automation/armautomation)
-
 The `armautomation` module provides operations for working with Azure Automation.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/automation/armautomation)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automation/armautom
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Automation.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Automation. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armautomation.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewHybridRunbookWorkerGroupClient()
@@ -66,7 +64,6 @@ The fake package contains types used for constructing in-memory fake servers use
 This allows writing tests to cover various success/error conditions without the need for connecting to a live service.
 
 Please see https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes for details and examples on how to use fakes.
-
 
 ## Provide Feedback
 

--- a/sdk/resourcemanager/avs/armavs/README.md
+++ b/sdk/resourcemanager/avs/armavs/README.md
@@ -1,7 +1,5 @@
 # Azure VMware Solution Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/avs/armavs/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/avs/armavs/v2)
-
 The `armavs` module provides operations for working with Azure VMware Solution.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/avs/armavs)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/avs/armavs/v2
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure VMware Solution.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure VMware Solution. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armavs.NewClientFactory(<subscription ID>, cred, &options)
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAddonsClient()

--- a/sdk/resourcemanager/azurearcdata/armazurearcdata/README.md
+++ b/sdk/resourcemanager/azurearcdata/armazurearcdata/README.md
@@ -1,7 +1,5 @@
 # Azure Hybrid Data Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/azurearcdata/armazurearcdata)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/azurearcdata/armazurearcdata)
-
 The `armazurearcdata` module provides operations for working with Azure Hybrid Data.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/azurearcdata/armazurearcdata)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/azurearcdata/armazu
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Hybrid Data.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Hybrid Data. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armazurearcdata.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSQLServerInstancesClient()

--- a/sdk/resourcemanager/azuredata/armazuredata/README.md
+++ b/sdk/resourcemanager/azuredata/armazuredata/README.md
@@ -1,7 +1,5 @@
 # Azure Hybrid Data Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/azuredata/armazuredata)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/azuredata/armazuredata)
-
 The `armazuredata` module provides operations for working with Azure Hybrid Data.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/azuredata/armazuredata)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/azuredata/armazured
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Hybrid Data.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Hybrid Data. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armazuredata.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSQLServersClient()

--- a/sdk/resourcemanager/azurestackhci/armazurestackhci/README.md
+++ b/sdk/resourcemanager/azurestackhci/armazurestackhci/README.md
@@ -1,7 +1,5 @@
 # Azure Stack HCI Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/azurestackhci/armazurestackhci/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/azurestackhci/armazurestackhci/v2)
-
 The `armazurestackhci` module provides operations for working with Azure Stack HCI.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/azurestackhci/armazurestackhci)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/azurestackhci/armaz
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Stack HCI.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Stack HCI. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armazurestackhci.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewArcSettingsClient()

--- a/sdk/resourcemanager/baremetalinfrastructure/armbaremetalinfrastructure/README.md
+++ b/sdk/resourcemanager/baremetalinfrastructure/armbaremetalinfrastructure/README.md
@@ -1,7 +1,5 @@
 # Azure Bare Metal Infrastructure Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/baremetalinfrastructure/armbaremetalinfrastructure/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/baremetalinfrastructure/armbaremetalinfrastructure/v2)
-
 The `armbaremetalinfrastructure` module provides operations for working with Azure Bare Metal Infrastructure.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/baremetalinfrastructure/armbaremetalinfrastructure)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/baremetalinfrastruc
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Bare Metal Infrastructure.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Bare Metal Infrastructure. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armbaremetalinfrastructure.NewClientFactory(<subscription 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAzureBareMetalInstancesClient()

--- a/sdk/resourcemanager/batch/armbatch/README.md
+++ b/sdk/resourcemanager/batch/armbatch/README.md
@@ -1,7 +1,5 @@
 # Azure Batch Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/batch/armbatch/v3)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/batch/armbatch/v3)
-
 The `armbatch` module provides operations for working with Azure Batch.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/batch/armbatch)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/batch/armbatch/v3
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Batch.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Batch. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armbatch.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountClient()

--- a/sdk/resourcemanager/billing/armbilling/README.md
+++ b/sdk/resourcemanager/billing/armbilling/README.md
@@ -1,7 +1,5 @@
 # Azure Billing Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billing/armbilling)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billing/armbilling)
-
 The `armbilling` module provides operations for working with Azure Billing.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/billing/armbilling)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billing/armbilling
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Billing.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Billing. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armbilling.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewInvoicesClient()

--- a/sdk/resourcemanager/billingbenefits/armbillingbenefits/README.md
+++ b/sdk/resourcemanager/billingbenefits/armbillingbenefits/README.md
@@ -1,7 +1,5 @@
 # Azure Billingbenefits Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits/v2)
-
 The `armbillingbenefits` module provides operations for working with Azure Billingbenefits.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/billingbenefits/armbillingbenefits)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Billingbenefits.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Billingbenefits. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armbillingbenefits.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewRPClient()

--- a/sdk/resourcemanager/blockchain/armblockchain/README.md
+++ b/sdk/resourcemanager/blockchain/armblockchain/README.md
@@ -1,7 +1,5 @@
 # Azure Blockchain Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/blockchain/armblockchain)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/blockchain/armblockchain)
-
 The `armblockchain` module provides operations for working with Azure Blockchain.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/blockchain/armblockchain)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/blockchain/armblock
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Blockchain.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Blockchain. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armblockchain.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewMembersClient()

--- a/sdk/resourcemanager/blueprint/armblueprint/README.md
+++ b/sdk/resourcemanager/blueprint/armblueprint/README.md
@@ -1,7 +1,5 @@
 # Azure Blueprint Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/blueprint/armblueprint)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/blueprint/armblueprint)
-
 The `armblueprint` module provides operations for working with Azure Blueprint.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/blueprint/armblueprint)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/blueprint/armbluepr
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Blueprint.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Blueprint. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armblueprint.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewBlueprintsClient()

--- a/sdk/resourcemanager/botservice/armbotservice/README.md
+++ b/sdk/resourcemanager/botservice/armbotservice/README.md
@@ -1,7 +1,5 @@
 # Azure Bot Service Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/botservice/armbotservice)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/botservice/armbotservice)
-
 The `armbotservice` module provides operations for working with Azure Bot Service.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/botservice/armbotservice)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/botservice/armbotse
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Bot Service.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Bot Service. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armbotservice.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewBotsClient()

--- a/sdk/resourcemanager/cdn/armcdn/README.md
+++ b/sdk/resourcemanager/cdn/armcdn/README.md
@@ -1,7 +1,5 @@
 # Azure Content Delivery Network Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn/v2)
-
 The `armcdn` module provides operations for working with Azure Content Delivery Network.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/cdn/armcdn)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn/v2
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Content Delivery Network.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Content Delivery Network. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcdn.NewClientFactory(<subscription ID>, cred, &options)
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAFDCustomDomainsClient()

--- a/sdk/resourcemanager/changeanalysis/armchangeanalysis/README.md
+++ b/sdk/resourcemanager/changeanalysis/armchangeanalysis/README.md
@@ -1,7 +1,5 @@
 # Azure Change Analysis Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/changeanalysis/armchangeanalysis)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/changeanalysis/armchangeanalysis)
-
 The `armchangeanalysis` module provides operations for working with Azure Change Analysis.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/changeanalysis/armchangeanalysis)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/changeanalysis/armc
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Change Analysis.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Change Analysis. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armchangeanalysis.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewChangesClient()

--- a/sdk/resourcemanager/chaos/armchaos/README.md
+++ b/sdk/resourcemanager/chaos/armchaos/README.md
@@ -1,7 +1,5 @@
 # Azure Chaos Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/chaos/armchaos)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/chaos/armchaos)
-
 The `armchaos` module provides operations for working with Azure Chaos.
 This package is currently in Beta and is not yet fully supported.
 
@@ -26,7 +24,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/chaos/armchaos
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Chaos.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Chaos. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -55,7 +53,7 @@ clientFactory, err := armchaos.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCapabilitiesClient()

--- a/sdk/resourcemanager/cognitiveservices/armcognitiveservices/README.md
+++ b/sdk/resourcemanager/cognitiveservices/armcognitiveservices/README.md
@@ -1,7 +1,5 @@
 # Azure Cognitive Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices)
-
 The `armcognitiveservices` module provides operations for working with Azure Cognitive Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/cognitiveservices/armcognitiveservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Cognitive Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Cognitive Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcognitiveservices.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()

--- a/sdk/resourcemanager/commerce/armcommerce/README.md
+++ b/sdk/resourcemanager/commerce/armcommerce/README.md
@@ -1,7 +1,5 @@
 # Azure Commerce Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/commerce/armcommerce)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/commerce/armcommerce)
-
 The `armcommerce` module provides operations for working with Azure Commerce.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/commerce/armcommerce)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/commerce/armcommerc
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Commerce.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Commerce. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcommerce.NewClientFactory(<subscription ID>, cred, &opt
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewRateCardClient()

--- a/sdk/resourcemanager/communication/armcommunication/README.md
+++ b/sdk/resourcemanager/communication/armcommunication/README.md
@@ -1,7 +1,5 @@
 # Azure Communication Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/communication/armcommunication/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/communication/armcommunication/v2)
-
 The `armcommunication` module provides operations for working with Azure Communication Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/communication/armcommunication)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/communication/armco
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Communication Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Communication Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcommunication.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDomainsClient()

--- a/sdk/resourcemanager/compute/armcompute/README.md
+++ b/sdk/resourcemanager/compute/armcompute/README.md
@@ -1,7 +1,5 @@
 # Azure Compute Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6)
-
 The `armcompute` module provides operations for working with Azure Compute.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/compute/armcompute)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Compute.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Compute. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcompute.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAvailabilitySetsClient()

--- a/sdk/resourcemanager/computefleet/armcomputefleet/README.md
+++ b/sdk/resourcemanager/computefleet/armcomputefleet/README.md
@@ -1,7 +1,5 @@
 # Azure Compute Fleet Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/computefleet/armcomputefleet)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/computefleet/armcomputefleet)
-
 The `armcomputefleet` module provides operations for working with Azure Compute Fleet.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/computefleet/armcomputefleet)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/computefleet/armcom
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Compute Fleet.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Compute Fleet. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcomputefleet.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewFleetsClient()

--- a/sdk/resourcemanager/computeschedule/armcomputeschedule/README.md
+++ b/sdk/resourcemanager/computeschedule/armcomputeschedule/README.md
@@ -1,8 +1,7 @@
 # Azure Compute Schedule Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/computeschedule/armcomputeschedule)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/computeschedule/armcomputeschedule)
-
 Microsoft Azure Compute Schedule allows customers to schedule one off operations on their virtual machines. These operations include:
+
 - Start
 - Deallocate
 - Hibernate
@@ -35,7 +34,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/computeschedule/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Compute Schedule.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Compute Schedule. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -64,7 +63,7 @@ clientFactory, err := armcomputeschedule.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewScheduledActionsClient()

--- a/sdk/resourcemanager/confidentialledger/armconfidentialledger/README.md
+++ b/sdk/resourcemanager/confidentialledger/armconfidentialledger/README.md
@@ -1,7 +1,5 @@
 # Azure Confidential Ledger Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/confidentialledger/armconfidentialledger)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/confidentialledger/armconfidentialledger)
-
 The `armconfidentialledger` module provides operations for working with Azure Confidential Ledger.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/confidentialledger/armconfidentialledger)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/confidentialledger/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Confidential Ledger.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Confidential Ledger. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armconfidentialledger.NewClientFactory(<subscription ID>, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/confluent/armconfluent/README.md
+++ b/sdk/resourcemanager/confluent/armconfluent/README.md
@@ -1,7 +1,5 @@
 # Azure Confluent Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/confluent/armconfluent)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/confluent/armconfluent)
-
 The `armconfluent` module provides operations for working with Azure Confluent.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/confluent/armconfluent)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/confluent/armconflu
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Confluent.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Confluent. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armconfluent.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccessClient()

--- a/sdk/resourcemanager/connectedvmware/armconnectedvmware/CHANGELOG.md
+++ b/sdk/resourcemanager/connectedvmware/armconnectedvmware/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.1.1 (2023-12-22)
-### Others Change
+### Others Changes
 
 - Fixed README.md
 

--- a/sdk/resourcemanager/connectedvmware/armconnectedvmware/CHANGELOG.md
+++ b/sdk/resourcemanager/connectedvmware/armconnectedvmware/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.1.1 (2023-12-22)
-### Others Changes
+### Other Changes
 
 - Fixed README.md
 

--- a/sdk/resourcemanager/connectedvmware/armconnectedvmware/README.md
+++ b/sdk/resourcemanager/connectedvmware/armconnectedvmware/README.md
@@ -1,7 +1,5 @@
 # Azure Arc VMware Management Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/connectedvmware/armconnectedvmware)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/connectedvmware/armconnectedvmware)
-
 The `armconnectedvmware` module provides operations for working with Azure Arc VMware Management.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/connectedvmware/armconnectedvmware)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/connectedvmware/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Arc VMware Management.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Arc VMware Management. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armconnectedvmware.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewVCentersClient()

--- a/sdk/resourcemanager/consumption/armconsumption/README.md
+++ b/sdk/resourcemanager/consumption/armconsumption/README.md
@@ -1,7 +1,5 @@
 # Azure Consumption Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption)
-
 The `armconsumption` module provides operations for working with Azure Consumption.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/consumption/armconsumption)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armcons
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Consumption.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Consumption. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armconsumption.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPriceSheetClient()

--- a/sdk/resourcemanager/containerinstance/armcontainerinstance/README.md
+++ b/sdk/resourcemanager/containerinstance/armcontainerinstance/README.md
@@ -1,7 +1,5 @@
 # Azure Container Instance Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2)
-
 The `armcontainerinstance` module provides operations for working with Azure Container Instance.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/containerinstance/armcontainerinstance)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Container Instance.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Container Instance. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcontainerinstance.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewContainerGroupProfileClient()

--- a/sdk/resourcemanager/containerorchestratorruntime/armcontainerorchestratorruntime/README.md
+++ b/sdk/resourcemanager/containerorchestratorruntime/armcontainerorchestratorruntime/README.md
@@ -1,7 +1,5 @@
 # Azure Container Orchestrator Runtime Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerorchestratorruntime/armcontainerorchestratorruntime)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerorchestratorruntime/armcontainerorchestratorruntime)
-
 The `armcontainerorchestratorruntime` module provides operations for working with Azure Container Orchestrator Runtime.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/containerorchestratorruntime/armcontainerorchestratorruntime)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerorchestrat
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Container Orchestrator Runtime.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Container Orchestrator Runtime. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcontainerorchestratorruntime.NewClientFactory(<subscrip
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.{{NewClientName}}()

--- a/sdk/resourcemanager/containerregistry/armcontainerregistry/README.md
+++ b/sdk/resourcemanager/containerregistry/armcontainerregistry/README.md
@@ -1,7 +1,5 @@
 # Azure Container Registry Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry)
-
 The `armcontainerregistry` module provides operations for working with Azure Container Registry.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/containerregistry/armcontainerregistry)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Container Registry.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Container Registry. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcontainerregistry.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewImportPipelinesClient()

--- a/sdk/resourcemanager/containerservice/armcontainerservice/README.md
+++ b/sdk/resourcemanager/containerservice/armcontainerservice/README.md
@@ -1,7 +1,5 @@
 # Azure Container Service Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6)
-
 The `armcontainerservice` module provides operations for working with Azure Container Service.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/containerservice/armcontainerservice)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Container Service.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Container Service. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcontainerservice.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAgentPoolsClient()

--- a/sdk/resourcemanager/containerservicefleet/armcontainerservicefleet/README.md
+++ b/sdk/resourcemanager/containerservicefleet/armcontainerservicefleet/README.md
@@ -1,7 +1,5 @@
 # Azure Kubernetes Fleet Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservicefleet/armcontainerservicefleet)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservicefleet/armcontainerservicefleet)
-
 The `armcontainerservicefleet` module provides operations for working with Azure Kubernetes Fleet.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/containerservicefleet/armcontainerservicefleet)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservicefle
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Kubernetes Fleet.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Kubernetes Fleet. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcontainerservicefleet.NewClientFactory(<subscription ID
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAutoUpgradeProfilesClient()

--- a/sdk/resourcemanager/cosmos/armcosmos/README.md
+++ b/sdk/resourcemanager/cosmos/armcosmos/README.md
@@ -1,7 +1,5 @@
 # Azure Cosmos DB Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v4)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v4)
-
 The `armcosmos` module provides operations for working with Azure Cosmos DB.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/cosmos/armcosmos)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v4
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Cosmos DB.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Cosmos DB. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcosmos.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCassandraClustersClient()
@@ -66,7 +64,6 @@ The fake package contains types used for constructing in-memory fake servers use
 This allows writing tests to cover various success/error conditions without the need for connecting to a live service.
 
 Please see https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes for details and examples on how to use fakes.
-
 
 ## More sample code
 

--- a/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql/README.md
+++ b/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql/README.md
@@ -1,7 +1,5 @@
 # Azure Cosmosforpostgresql Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql)
-
 The `armcosmosforpostgresql` module provides operations for working with Azure Cosmosforpostgresql.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Cosmosforpostgresql.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Cosmosforpostgresql. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ client, err := armcosmosforpostgresql.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClustersClient()

--- a/sdk/resourcemanager/costmanagement/armcostmanagement/README.md
+++ b/sdk/resourcemanager/costmanagement/armcostmanagement/README.md
@@ -1,7 +1,5 @@
 # Azure Costmanagement Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement/v2)
-
 The `armcostmanagement` module provides operations for working with Azure Costmanagement.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/costmanagement/armcostmanagement)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armc
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Costmanagement.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Costmanagement. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcostmanagement.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAlertsClient()

--- a/sdk/resourcemanager/customerinsights/armcustomerinsights/README.md
+++ b/sdk/resourcemanager/customerinsights/armcustomerinsights/README.md
@@ -1,7 +1,5 @@
 # Azure Customer Insights Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/customerinsights/armcustomerinsights)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/customerinsights/armcustomerinsights)
-
 The `armcustomerinsights` module provides operations for working with Azure Customer Insights.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/customerinsights/armcustomerinsights)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/customerinsights/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Customer Insights.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Customer Insights. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcustomerinsights.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewHubsClient()

--- a/sdk/resourcemanager/customerlockbox/armcustomerlockbox/README.md
+++ b/sdk/resourcemanager/customerlockbox/armcustomerlockbox/README.md
@@ -1,7 +1,5 @@
 # Azure Customer Lockbox Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/customerlockbox/armcustomerlockbox)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/customerlockbox/armcustomerlockbox)
-
 The `armcustomerlockbox` module provides operations for working with Azure Customer Lockbox.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/customerlockbox/armcustomerlockbox)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/customerlockbox/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Customer Lockbox.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Customer Lockbox. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcustomerlockbox.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewGetClient()

--- a/sdk/resourcemanager/customproviders/armcustomproviders/README.md
+++ b/sdk/resourcemanager/customproviders/armcustomproviders/README.md
@@ -1,7 +1,5 @@
 # Azure Custom Providers Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/customproviders/armcustomproviders)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/customproviders/armcustomproviders)
-
 The `armcustomproviders` module provides operations for working with Azure Custom Providers.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/customproviders/armcustomproviders)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/customproviders/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Custom Providers.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Custom Providers. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armcustomproviders.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCustomResourceProviderClient()

--- a/sdk/resourcemanager/dashboard/armdashboard/README.md
+++ b/sdk/resourcemanager/dashboard/armdashboard/README.md
@@ -1,7 +1,5 @@
 # Azure Dashboard Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashboard)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashboard)
-
 The `armdashboard` module provides operations for working with Azure Dashboard.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/dashboard/armdashboard)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashbo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Dashboard.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Dashboard. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdashboard.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewGrafanaClient()

--- a/sdk/resourcemanager/databoundaries/armdataboundaries/README.md
+++ b/sdk/resourcemanager/databoundaries/armdataboundaries/README.md
@@ -1,7 +1,5 @@
 # Azure Data Boundary Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databoundaries/armdataboundaries)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databoundaries/armdataboundaries)
-
 The `armdataboundaries` module provides operations for working with Azure Data Boundary.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/databoundaries/armdataboundaries)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databoundaries/armd
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Boundary.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Boundary. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdataboundaries.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.()

--- a/sdk/resourcemanager/databox/armdatabox/README.md
+++ b/sdk/resourcemanager/databox/armdatabox/README.md
@@ -1,7 +1,5 @@
 # Azure Data Box Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databox/armdatabox/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databox/armdatabox/v2)
-
 The `armdatabox` module provides operations for working with Azure Data Box.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/databox/armdatabox)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databox/armdatabox/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Box.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Box. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdatabox.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServiceClient()

--- a/sdk/resourcemanager/databoxedge/armdataboxedge/README.md
+++ b/sdk/resourcemanager/databoxedge/armdataboxedge/README.md
@@ -1,7 +1,5 @@
 # Azure Data Box Edge Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databoxedge/armdataboxedge)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databoxedge/armdataboxedge)
-
 The `armdataboxedge` module provides operations for working with Azure Data Box Edge.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/databoxedge/armdataboxedge)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databoxedge/armdata
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Box Edge.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Box Edge. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdataboxedge.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewUsersClient()

--- a/sdk/resourcemanager/databricks/armdatabricks/README.md
+++ b/sdk/resourcemanager/databricks/armdatabricks/README.md
@@ -1,7 +1,5 @@
 # Azure Databricks Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks)
-
 The `armdatabricks` module provides operations for working with Azure Databricks.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/databricks/armdatabricks)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatab
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Databricks.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Databricks. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdatabricks.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewWorkspacesClient()

--- a/sdk/resourcemanager/datacatalog/armdatacatalog/README.md
+++ b/sdk/resourcemanager/datacatalog/armdatacatalog/README.md
@@ -1,7 +1,5 @@
 # Azure Data Catalog Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datacatalog/armdatacatalog)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datacatalog/armdatacatalog)
-
 The `armdatacatalog` module provides operations for working with Azure Data Catalog.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/datacatalog/armdatacatalog)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datacatalog/armdata
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Catalog.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Catalog. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdatacatalog.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewADCCatalogsClient()

--- a/sdk/resourcemanager/datadog/armdatadog/README.md
+++ b/sdk/resourcemanager/datadog/armdatadog/README.md
@@ -1,7 +1,5 @@
 # Azure Datadog Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datadog/armdatadog)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datadog/armdatadog)
-
 The `armdatadog` module provides operations for working with Azure Datadog.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/datadog/armdatadog)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datadog/armdatadog
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Datadog.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Datadog. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdatadog.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewMarketplaceAgreementsClient()

--- a/sdk/resourcemanager/datafactory/armdatafactory/README.md
+++ b/sdk/resourcemanager/datafactory/armdatafactory/README.md
@@ -1,7 +1,5 @@
 # Azure Data Factory Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v9)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v9)
-
 The `armdatafactory` module provides operations for working with Azure Data Factory.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/datafactory/armdatafactory)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdata
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Factory.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Factory. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdatafactory.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewActivityRunsClient()
@@ -66,7 +64,6 @@ The fake package contains types used for constructing in-memory fake servers use
 This allows writing tests to cover various success/error conditions without the need for connecting to a live service.
 
 Please see https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes for details and examples on how to use fakes.
-
 
 ## Provide Feedback
 

--- a/sdk/resourcemanager/datalake-analytics/armdatalakeanalytics/README.md
+++ b/sdk/resourcemanager/datalake-analytics/armdatalakeanalytics/README.md
@@ -1,7 +1,5 @@
 # Azure Data Lake Analytics Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-analytics/armdatalakeanalytics)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-analytics/armdatalakeanalytics)
-
 The `armdatalakeanalytics` module provides operations for working with Azure Data Lake Analytics.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/datalake-analytics/armdatalakeanalytics)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-analytics/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Lake Analytics.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Lake Analytics. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdatalakeanalytics.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDataLakeStoreAccountsClient()

--- a/sdk/resourcemanager/datalake-store/armdatalakestore/README.md
+++ b/sdk/resourcemanager/datalake-store/armdatalakestore/README.md
@@ -1,7 +1,5 @@
 # Azure Data Lake Storage Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-store/armdatalakestore)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-store/armdatalakestore)
-
 The `armdatalakestore` module provides operations for working with Azure Data Lake Storage.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/datalake-store/armdatalakestore)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datalake-store/armd
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Lake Storage.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Lake Storage. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdatalakestore.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()

--- a/sdk/resourcemanager/datamigration/armdatamigration/README.md
+++ b/sdk/resourcemanager/datamigration/armdatamigration/README.md
@@ -1,7 +1,5 @@
 # Azure Data Migration Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datamigration/armdatamigration)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datamigration/armdatamigration)
-
 The `armdatamigration` module provides operations for working with Azure Data Migration.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/datamigration/armdatamigration)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datamigration/armda
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Migration.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Migration. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdatamigration.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServicesClient()

--- a/sdk/resourcemanager/dataprotection/armdataprotection/README.md
+++ b/sdk/resourcemanager/dataprotection/armdataprotection/README.md
@@ -1,7 +1,5 @@
 # Azure Backup Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dataprotection/armdataprotection/v3)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dataprotection/armdataprotection/v3)
-
 The `armdataprotection` module provides operations for working with Azure Backup.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/dataprotection/armdataprotection)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dataprotection/armd
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Backup.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Backup. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdataprotection.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewBackupInstancesClient()

--- a/sdk/resourcemanager/datashare/armdatashare/README.md
+++ b/sdk/resourcemanager/datashare/armdatashare/README.md
@@ -1,7 +1,5 @@
 # Azure Data Shara Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datashare/armdatashare)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datashare/armdatashare)
-
 The `armdatashare` module provides operations for working with Azure Data Shara.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/datashare/armdatashare)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datashare/armdatash
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Shara.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Shara. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdatashare.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()

--- a/sdk/resourcemanager/delegatednetwork/armdelegatednetwork/README.md
+++ b/sdk/resourcemanager/delegatednetwork/armdelegatednetwork/README.md
@@ -1,7 +1,5 @@
 # Azure Delegated Network Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/delegatednetwork/armdelegatednetwork)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/delegatednetwork/armdelegatednetwork)
-
 The `armdelegatednetwork` module provides operations for working with Azure Delegated Network.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/delegatednetwork/armdelegatednetwork)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/delegatednetwork/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Delegated Network.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Delegated Network. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdelegatednetwork.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/deploymentmanager/armdeploymentmanager/README.md
+++ b/sdk/resourcemanager/deploymentmanager/armdeploymentmanager/README.md
@@ -1,7 +1,5 @@
 # Azure Deployment manager Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deploymentmanager/armdeploymentmanager)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deploymentmanager/armdeploymentmanager)
-
 The `armdeploymentmanager` module provides operations for working with Azure Deployment manager.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/deploymentmanager/armdeploymentmanager)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deploymentmanager/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Deployment manager.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Deployment manager. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdeploymentmanager.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServicesClient()

--- a/sdk/resourcemanager/desktopvirtualization/armdesktopvirtualization/README.md
+++ b/sdk/resourcemanager/desktopvirtualization/armdesktopvirtualization/README.md
@@ -1,7 +1,5 @@
 # Azure Virtual Desktop Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/desktopvirtualization/armdesktopvirtualization/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/desktopvirtualization/armdesktopvirtualization/v2)
-
 The `armdesktopvirtualization` module provides operations for working with Azure Virtual Desktop.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/desktopvirtualization/armdesktopvirtualization)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/desktopvirtualizati
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Virtual Desktop.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Virtual Desktop. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdesktopvirtualization.NewClientFactory(<subscription ID
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAppAttachPackageClient()

--- a/sdk/resourcemanager/devcenter/armdevcenter/README.md
+++ b/sdk/resourcemanager/devcenter/armdevcenter/README.md
@@ -1,7 +1,5 @@
 # Azure Dev Center Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devcenter/armdevcenter/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devcenter/armdevcenter/v2)
-
 The `armdevcenter` module provides operations for working with Azure Dev Center.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/devcenter/armdevcenter)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devcenter/armdevcen
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Dev Center.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Dev Center. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdevcenter.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAttachedNetworksClient()

--- a/sdk/resourcemanager/devhub/armdevhub/README.md
+++ b/sdk/resourcemanager/devhub/armdevhub/README.md
@@ -1,7 +1,5 @@
 # Azure Devhub Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devhub/armdevhub)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devhub/armdevhub)
-
 The `armdevhub` module provides operations for working with Azure Devhub.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/devhub/armdevhub)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devhub/armdevhub
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Devhub.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Devhub. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdevhub.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDeveloperHubServiceClient()

--- a/sdk/resourcemanager/deviceprovisioningservices/armdeviceprovisioningservices/README.md
+++ b/sdk/resourcemanager/deviceprovisioningservices/armdeviceprovisioningservices/README.md
@@ -1,7 +1,5 @@
 # Azure Device Provisioning Service Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceprovisioningservices/armdeviceprovisioningservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceprovisioningservices/armdeviceprovisioningservices)
-
 The `armdeviceprovisioningservices` module provides operations for working with Azure Device Provisioning Service.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/deviceprovisioningservices/armdeviceprovisioningservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceprovisionings
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Device Provisioning Service.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Device Provisioning Service. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdeviceprovisioningservices.NewClientFactory(<subscripti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewIotDpsResourceClient()

--- a/sdk/resourcemanager/deviceregistry/armdeviceregistry/CHANGELOG.md
+++ b/sdk/resourcemanager/deviceregistry/armdeviceregistry/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.1.0 (2024-04-26)
+### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceregistry/armdeviceregistry` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 

--- a/sdk/resourcemanager/deviceregistry/armdeviceregistry/README.md
+++ b/sdk/resourcemanager/deviceregistry/armdeviceregistry/README.md
@@ -1,7 +1,5 @@
 # Azure Deviceregistry Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceregistry/armdeviceregistry)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceregistry/armdeviceregistry)
-
 The `armdeviceregistry` module provides operations for working with Azure Deviceregistry.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/deviceregistry/armdeviceregistry)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceregistry/armd
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Deviceregistry.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Deviceregistry. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdeviceregistry.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAssetEndpointProfilesClient()

--- a/sdk/resourcemanager/deviceupdate/armdeviceupdate/README.md
+++ b/sdk/resourcemanager/deviceupdate/armdeviceupdate/README.md
@@ -1,7 +1,5 @@
 # Azure Device Update Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceupdate/armdeviceupdate)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceupdate/armdeviceupdate)
-
 The `armdeviceupdate` module provides operations for working with Azure Device Update.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/deviceupdate/armdeviceupdate)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/deviceupdate/armdev
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Device Update.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Device Update. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdeviceupdate.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()

--- a/sdk/resourcemanager/devops/armdevops/README.md
+++ b/sdk/resourcemanager/devops/armdevops/README.md
@@ -1,7 +1,5 @@
 # Azure DevOps Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devops/armdevops)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devops/armdevops)
-
 The `armdevops` module provides operations for working with Azure DevOps.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/devops/armdevops)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devops/armdevops
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure DevOps.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure DevOps. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdevops.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPipelinesClient()

--- a/sdk/resourcemanager/devopsinfrastructure/armdevopsinfrastructure/CHANGELOG.md
+++ b/sdk/resourcemanager/devopsinfrastructure/armdevopsinfrastructure/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.1.0 (2024-05-24)
+### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devopsinfrastructure/armdevopsinfrastructure` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 

--- a/sdk/resourcemanager/devopsinfrastructure/armdevopsinfrastructure/README.md
+++ b/sdk/resourcemanager/devopsinfrastructure/armdevopsinfrastructure/README.md
@@ -1,7 +1,5 @@
 # Azure DevOps Infrastructure Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devopsinfrastructure/armdevopsinfrastructure)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devopsinfrastructure/armdevopsinfrastructure)
-
 The `armdevopsinfrastructure` module provides operations for working with Azure DevOps Infrastructure.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/devopsinfrastructure/armdevopsinfrastructure)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devopsinfrastructur
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure DevOps Infrastructure.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure DevOps Infrastructure. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdevopsinfrastructure.NewClientFactory(<subscription ID>
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewImageVersionsClient()

--- a/sdk/resourcemanager/devtestlabs/armdevtestlabs/README.md
+++ b/sdk/resourcemanager/devtestlabs/armdevtestlabs/README.md
@@ -1,7 +1,5 @@
 # Azure Lab Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devtestlabs/armdevtestlabs)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devtestlabs/armdevtestlabs)
-
 The `armdevtestlabs` module provides operations for working with Azure Lab Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/devtestlabs/armdevtestlabs)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/devtestlabs/armdevt
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Lab Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Lab Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdevtestlabs.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPolicySetsClient()

--- a/sdk/resourcemanager/digitaltwins/armdigitaltwins/README.md
+++ b/sdk/resourcemanager/digitaltwins/armdigitaltwins/README.md
@@ -1,7 +1,5 @@
 # Azure Digital Twins Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/digitaltwins/armdigitaltwins)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/digitaltwins/armdigitaltwins)
-
 The `armdigitaltwins` module provides operations for working with Azure Digital Twins.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/digitaltwins/armdigitaltwins)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/digitaltwins/armdig
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Digital Twins.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Digital Twins. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdigitaltwins.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()
@@ -66,7 +64,6 @@ The fake package contains types used for constructing in-memory fake servers use
 This allows writing tests to cover various success/error conditions without the need for connecting to a live service.
 
 Please see https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes for details and examples on how to use fakes.
-
 
 ## Provide Feedback
 

--- a/sdk/resourcemanager/dns/armdns/README.md
+++ b/sdk/resourcemanager/dns/armdns/README.md
@@ -1,7 +1,5 @@
 # Azure DNS Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns)
-
 The `armdns` module provides operations for working with Azure DNS.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/dns/armdns)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure DNS.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure DNS. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdns.NewClientFactory(<subscription ID>, cred, &options)
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDnssecConfigsClient()

--- a/sdk/resourcemanager/dnsresolver/armdnsresolver/README.md
+++ b/sdk/resourcemanager/dnsresolver/armdnsresolver/README.md
@@ -1,7 +1,5 @@
 # Azure DNS Private Resolver Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dnsresolver/armdnsresolver)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dnsresolver/armdnsresolver)
-
 The `armdnsresolver` module provides operations for working with Azure DNS Private Resolver.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/dnsresolver/armdnsresolver)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dnsresolver/armdnsr
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure DNS Private Resolver.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure DNS Private Resolver. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdnsresolver.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDNSForwardingRulesetsClient()

--- a/sdk/resourcemanager/domainservices/armdomainservices/README.md
+++ b/sdk/resourcemanager/domainservices/armdomainservices/README.md
@@ -1,7 +1,5 @@
 # Azure Domain Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/domainservices/armdomainservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/domainservices/armdomainservices)
-
 The `armdomainservices` module provides operations for working with Azure Domain Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/domainservices/armdomainservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/domainservices/armd
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Domain Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Domain Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdomainservices.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDomainServiceOperationsClient()

--- a/sdk/resourcemanager/dynatrace/armdynatrace/README.md
+++ b/sdk/resourcemanager/dynatrace/armdynatrace/README.md
@@ -1,7 +1,5 @@
 # Azure Dynatrace Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dynatrace/armdynatrace/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dynatrace/armdynatrace/v2)
-
 The `armdynatrace` module provides operations for working with Azure Dynatrace.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/dynatrace/armdynatrace)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dynatrace/armdynatr
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Dynatrace.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Dynatrace. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdynatrace.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewMonitorsClient()

--- a/sdk/resourcemanager/edgeorder/armedgeorder/README.md
+++ b/sdk/resourcemanager/edgeorder/armedgeorder/README.md
@@ -1,7 +1,5 @@
 # Azure Edge Order Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgeorder/armedgeorder)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgeorder/armedgeorder)
-
 The `armedgeorder` module provides operations for working with Azure Edge Order.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/edgeorder/armedgeorder)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgeorder/armedgeor
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Edge Order.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Edge Order. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armedgeorder.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewManagementClient()

--- a/sdk/resourcemanager/edgeorderpartner/armedgeorderpartner/README.md
+++ b/sdk/resourcemanager/edgeorderpartner/armedgeorderpartner/README.md
@@ -1,7 +1,5 @@
 # Azure Edge Order Partner Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgeorderpartner/armedgeorderpartner)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgeorderpartner/armedgeorderpartner)
-
 The `armedgeorderpartner` module provides operations for working with Azure Edge Order Partner.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/edgeorderpartner/armedgeorderpartner)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgeorderpartner/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Edge Order Partner.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Edge Order Partner. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armedgeorderpartner.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAPISClient()

--- a/sdk/resourcemanager/edgezones/armedgezones/README.md
+++ b/sdk/resourcemanager/edgezones/armedgezones/README.md
@@ -1,7 +1,5 @@
 # Azure Edgezones Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgezones/armedgezones)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgezones/armedgezones)
-
 The `armedgezones` module provides operations for working with Azure Edgezones.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/edgezones/armedgezones)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgezones/armedgezo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Edgezones.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Edgezones. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armedgezones.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewExtendedZonesClient()

--- a/sdk/resourcemanager/education/armeducation/README.md
+++ b/sdk/resourcemanager/education/armeducation/README.md
@@ -1,7 +1,5 @@
 # Azure Education Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/education/armeducation)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/education/armeducation)
-
 The `armeducation` module provides operations for working with Azure Education.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/education/armeducation)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/education/armeducat
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Education.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Education. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armeducation.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewStudentsClient()

--- a/sdk/resourcemanager/elastic/armelastic/README.md
+++ b/sdk/resourcemanager/elastic/armelastic/README.md
@@ -1,7 +1,5 @@
 # Azure Elastic Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/elastic/armelastic)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/elastic/armelastic)
-
 The `armelastic` module provides operations for working with Azure Elastic.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/elastic/armelastic)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/elastic/armelastic
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Elastic.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Elastic. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armelastic.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAllTrafficFiltersClient()

--- a/sdk/resourcemanager/elasticsan/armelasticsan/README.md
+++ b/sdk/resourcemanager/elasticsan/armelasticsan/README.md
@@ -1,7 +1,5 @@
 # Azure Elasticsan Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/elasticsan/armelasticsan)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/elasticsan/armelasticsan)
-
 The `armelasticsan` module provides operations for working with Azure Elasticsan.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/elasticsan/armelasticsan)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/elasticsan/armelast
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Elasticsan.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Elasticsan. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armelasticsan.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewElasticSansClient()

--- a/sdk/resourcemanager/engagementfabric/armengagementfabric/README.md
+++ b/sdk/resourcemanager/engagementfabric/armengagementfabric/README.md
@@ -1,7 +1,5 @@
 # Azure Engagement Fabric Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/engagementfabric/armengagementfabric)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/engagementfabric/armengagementfabric)
-
 The `armengagementfabric` module provides operations for working with Azure Engagement Fabric.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/engagementfabric/armengagementfabric)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/engagementfabric/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Engagement Fabric.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Engagement Fabric. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armengagementfabric.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()

--- a/sdk/resourcemanager/eventgrid/armeventgrid/README.md
+++ b/sdk/resourcemanager/eventgrid/armeventgrid/README.md
@@ -1,7 +1,5 @@
 # Azure Event Grid Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2)
-
 The `armeventgrid` module provides operations for working with Azure Event Grid.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/eventgrid/armeventgrid)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventg
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Event Grid.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Event Grid. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armeventgrid.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCaCertificatesClient()

--- a/sdk/resourcemanager/eventhub/armeventhub/README.md
+++ b/sdk/resourcemanager/eventhub/armeventhub/README.md
@@ -1,7 +1,5 @@
 # Azure Event Hubs Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub)
-
 The `armeventhub` module provides operations for working with Azure Event Hubs.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/eventhub/armeventhub)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhu
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Event Hubs.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Event Hubs. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armeventhub.NewClientFactory(<subscription ID>, cred, &opt
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewApplicationGroupClient()

--- a/sdk/resourcemanager/extendedlocation/armextendedlocation/README.md
+++ b/sdk/resourcemanager/extendedlocation/armextendedlocation/README.md
@@ -1,7 +1,5 @@
 # Azure Extended Location Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/extendedlocation/armextendedlocation)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/extendedlocation/armextendedlocation)
-
 The `armextendedlocation` module provides operations for working with Azure Extended Location.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/extendedlocation/armextendedlocation)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/extendedlocation/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Extended Location.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Extended Location. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armextendedlocation.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCustomLocationsClient()

--- a/sdk/resourcemanager/fabric/armfabric/README.md
+++ b/sdk/resourcemanager/fabric/armfabric/README.md
@@ -1,7 +1,5 @@
 # Azure Fabric Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fabric/armfabric)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fabric/armfabric)
-
 The `armfabric` module provides operations for working with Azure Fabric.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/fabric/armfabric)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fabric/armfabric
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Fabric.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Fabric. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armfabric.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCapacitiesClient()

--- a/sdk/resourcemanager/fluidrelay/armfluidrelay/README.md
+++ b/sdk/resourcemanager/fluidrelay/armfluidrelay/README.md
@@ -1,7 +1,5 @@
 # Azure Fluidrelay Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fluidrelay/armfluidrelay)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fluidrelay/armfluidrelay)
-
 The `armfluidrelay` module provides operations for working with Azure Fluidrelay.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/fluidrelay/armfluidrelay)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fluidrelay/armfluid
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Fluidrelay.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Fluidrelay. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armfluidrelay.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServersClient()

--- a/sdk/resourcemanager/frontdoor/armfrontdoor/README.md
+++ b/sdk/resourcemanager/frontdoor/armfrontdoor/README.md
@@ -1,7 +1,5 @@
 # Azure Front Door Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor)
-
 The `armfrontdoor` module provides operations for working with Azure Front Door.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/frontdoor/armfrontdoor)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontd
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Front Door.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Front Door. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armfrontdoor.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewEndpointsClient()

--- a/sdk/resourcemanager/graphservices/armgraphservices/README.md
+++ b/sdk/resourcemanager/graphservices/armgraphservices/README.md
@@ -1,7 +1,5 @@
 # Azure Graphservices Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/graphservices/armgraphservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/graphservices/armgraphservices)
-
 The `armgraphservices` module provides operations for working with Azure Graphservices.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/graphservices/armgraphservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/graphservices/armgr
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Graphservices.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Graphservices. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armgraphservices.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountClient()

--- a/sdk/resourcemanager/guestconfiguration/armguestconfiguration/README.md
+++ b/sdk/resourcemanager/guestconfiguration/armguestconfiguration/README.md
@@ -1,7 +1,5 @@
 # Azure Guest Configuration Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/guestconfiguration/armguestconfiguration)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/guestconfiguration/armguestconfiguration)
-
 The `armguestconfiguration` module provides operations for working with Azure Guest Configuration.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/guestconfiguration/armguestconfiguration)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/guestconfiguration/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Guest Configuration.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Guest Configuration. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armguestconfiguration.NewClientFactory(<subscription ID>, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAssignmentsClient()

--- a/sdk/resourcemanager/hanaonazure/armhanaonazure/README.md
+++ b/sdk/resourcemanager/hanaonazure/armhanaonazure/README.md
@@ -1,7 +1,5 @@
 # Azure SAP HANA Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hanaonazure/armhanaonazure)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hanaonazure/armhanaonazure)
-
 The `armhanaonazure` module provides operations for working with Azure SAP HANA.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hanaonazure/armhanaonazure)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hanaonazure/armhana
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure SAP HANA.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure SAP HANA. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhanaonazure.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSapMonitorsClient()

--- a/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules/README.md
+++ b/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules/README.md
@@ -1,7 +1,5 @@
 # Azure Dedicated HSM Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules/v2)
-
 The `armhardwaresecuritymodules` module provides operations for working with Azure Dedicated HSM.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hardwaresecuritymod
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Dedicated HSM.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Dedicated HSM. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhardwaresecuritymodules.NewClientFactory(<subscription 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCloudHsmClusterPrivateEndpointConnectionsClient()

--- a/sdk/resourcemanager/hdinsight/armhdinsight/README.md
+++ b/sdk/resourcemanager/hdinsight/armhdinsight/README.md
@@ -1,7 +1,5 @@
 # Azure HDInsight Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hdinsight/armhdinsight)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hdinsight/armhdinsight)
-
 The `armhdinsight` module provides operations for working with Azure HDInsight.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hdinsight/armhdinsight)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hdinsight/armhdinsi
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure HDInsight.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure HDInsight. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhdinsight.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewApplicationsClient()

--- a/sdk/resourcemanager/hdinsightcontainers/armhdinsightcontainers/README.md
+++ b/sdk/resourcemanager/hdinsightcontainers/armhdinsightcontainers/README.md
@@ -1,7 +1,5 @@
 # Azure Hdinsight Containers Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hdinsightcontainers/armhdinsightcontainers)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hdinsightcontainers/armhdinsightcontainers)
-
 The `armhdinsightcontainers` module provides operations for working with Azure Hdinsight Containers.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hdinsightcontainers/armhdinsightcontainers)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hdinsightcontainers
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Hdinsight Containers.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Hdinsight Containers. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhdinsightcontainers.NewClientFactory(<subscription ID>,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAvailableClusterPoolVersionsClient()

--- a/sdk/resourcemanager/healthbot/armhealthbot/README.md
+++ b/sdk/resourcemanager/healthbot/armhealthbot/README.md
@@ -1,7 +1,5 @@
 # Azure Health Bot Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthbot/armhealthbot)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthbot/armhealthbot)
-
 The `armhealthbot` module provides operations for working with Azure Health Bot.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/healthbot/armhealthbot)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthbot/armhealth
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Health Bot.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Health Bot. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhealthbot.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewBotsClient()

--- a/sdk/resourcemanager/healthcareapis/armhealthcareapis/README.md
+++ b/sdk/resourcemanager/healthcareapis/armhealthcareapis/README.md
@@ -1,7 +1,5 @@
 # Azure Healthcare APIs Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthcareapis/armhealthcareapis/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthcareapis/armhealthcareapis/v2)
-
 The `armhealthcareapis` module provides operations for working with Azure Healthcare APIs.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/healthcareapis/armhealthcareapis)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthcareapis/armh
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Healthcare APIs.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Healthcare APIs. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhealthcareapis.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDicomServicesClient()

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/README.md
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/README.md
@@ -1,7 +1,5 @@
 # Azure HealthDataAIServices Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices)
-
 The `armhealthdataaiservices` module provides operations for working with Azure HealthDataAIServices.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthdataaiservice
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure HealthDataAIServices.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure HealthDataAIServices. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhealthdataaiservices.NewClientFactory(<subscription ID>
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDeidServicesClient()

--- a/sdk/resourcemanager/hybridcompute/armhybridcompute/README.md
+++ b/sdk/resourcemanager/hybridcompute/armhybridcompute/README.md
@@ -1,7 +1,5 @@
 # Azure Hybrid Compute Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2)
-
 The `armhybridcompute` module provides operations for working with Azure Hybrid Compute.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hybridcompute/armhybridcompute)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhy
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Hybrid Compute.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Hybrid Compute. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhybridcompute.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewExtensionMetadataClient()

--- a/sdk/resourcemanager/hybridconnectivity/armhybridconnectivity/README.md
+++ b/sdk/resourcemanager/hybridconnectivity/armhybridconnectivity/README.md
@@ -1,7 +1,5 @@
 # Azure Arc Connectivity Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridconnectivity/armhybridconnectivity)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridconnectivity/armhybridconnectivity)
-
 The `armhybridconnectivity` module provides operations for working with Azure Arc Connectivity.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hybridconnectivity/armhybridconnectivity)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridconnectivity/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Arc Connectivity.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Arc Connectivity. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhybridconnectivity.NewClientFactory(<subscription ID>, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewEndpointsClient()

--- a/sdk/resourcemanager/hybridcontainerservice/armhybridcontainerservice/README.md
+++ b/sdk/resourcemanager/hybridcontainerservice/armhybridcontainerservice/README.md
@@ -1,7 +1,5 @@
 # Azure Hybrid Container Service Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcontainerservice/armhybridcontainerservice)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcontainerservice/armhybridcontainerservice)
-
 The `armhybridcontainerservice` module provides operations for working with Azure Hybrid Container Service.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hybridcontainerservice/armhybridcontainerservice)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcontainerserv
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Hybrid Container Service.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Hybrid Container Service. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhybridcontainerservice.NewClientFactory(<subscription I
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewVirtualNetworksClient()
@@ -66,7 +64,6 @@ The fake package contains types used for constructing in-memory fake servers use
 This allows writing tests to cover various success/error conditions without the need for connecting to a live service.
 
 Please see https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes for details and examples on how to use fakes.
-
 
 ## Provide Feedback
 

--- a/sdk/resourcemanager/hybriddatamanager/armhybriddatamanager/README.md
+++ b/sdk/resourcemanager/hybriddatamanager/armhybriddatamanager/README.md
@@ -1,7 +1,5 @@
 # Azure Data Manager Service Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybriddatamanager/armhybriddatamanager)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybriddatamanager/armhybriddatamanager)
-
 The `armhybriddatamanager` module provides operations for working with Azure Data Manager Service.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hybriddatamanager/armhybriddatamanager)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybriddatamanager/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Data Manager Service.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Data Manager Service. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhybriddatamanager.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDataManagersClient()

--- a/sdk/resourcemanager/hybridkubernetes/armhybridkubernetes/README.md
+++ b/sdk/resourcemanager/hybridkubernetes/armhybridkubernetes/README.md
@@ -1,7 +1,5 @@
 # Azure Kubernetes Connect Service Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridkubernetes/armhybridkubernetes)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridkubernetes/armhybridkubernetes)
-
 The `armhybridkubernetes` module provides operations for working with Azure Kubernetes Connect Service.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hybridkubernetes/armhybridkubernetes)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridkubernetes/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Kubernetes Connect Service.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Kubernetes Connect Service. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhybridkubernetes.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewConnectedClusterClient()

--- a/sdk/resourcemanager/hybridnetwork/armhybridnetwork/README.md
+++ b/sdk/resourcemanager/hybridnetwork/armhybridnetwork/README.md
@@ -1,7 +1,5 @@
 # Azure Private Edge Zone Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridnetwork/armhybridnetwork/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridnetwork/armhybridnetwork/v2)
-
 The `armhybridnetwork` module provides operations for working with Azure Private Edge Zone.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/hybridnetwork/armhybridnetwork)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridnetwork/armhy
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Private Edge Zone.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Private Edge Zone. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armhybridnetwork.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDevicesClient()

--- a/sdk/resourcemanager/informaticadatamgmt/arminformaticadatamgmt/README.md
+++ b/sdk/resourcemanager/informaticadatamgmt/arminformaticadatamgmt/README.md
@@ -1,7 +1,5 @@
 # Azure Informatica DataManagement Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/informaticadatamgmt/arminformaticadatamgmt)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/informaticadatamgmt/arminformaticadatamgmt)
-
 The `arminformaticadatamgmt` module provides operations for working with Azure Informatica DataManagement.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/informaticadatamgmt/arminformaticadatamgmt)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/informaticadatamgmt
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Informatica DataManagement.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Informatica DataManagement. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := arminformaticadatamgmt.NewClientFactory(<subscription ID>,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewOrganizationsClient()

--- a/sdk/resourcemanager/integrationspaces/armintegrationspaces/CHANGELOG.md
+++ b/sdk/resourcemanager/integrationspaces/armintegrationspaces/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.1.0 (2023-11-24)
+### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/integrationspaces/armintegrationspaces` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 

--- a/sdk/resourcemanager/integrationspaces/armintegrationspaces/README.md
+++ b/sdk/resourcemanager/integrationspaces/armintegrationspaces/README.md
@@ -1,7 +1,5 @@
 # Azure Integrationspaces Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/integrationspaces/armintegrationspaces)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/integrationspaces/armintegrationspaces)
-
 The `armintegrationspaces` module provides operations for working with Azure Integrationspaces.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/integrationspaces/armintegrationspaces)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/integrationspaces/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Integrationspaces.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Integrationspaces. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armintegrationspaces.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewInfrastructureResourcesClient()

--- a/sdk/resourcemanager/iotcentral/armiotcentral/README.md
+++ b/sdk/resourcemanager/iotcentral/armiotcentral/README.md
@@ -1,7 +1,5 @@
 # Azure IoT Central Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotcentral/armiotcentral)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotcentral/armiotcentral)
-
 The `armiotcentral` module provides operations for working with Azure IoT Central.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/iotcentral/armiotcentral)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotcentral/armiotce
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure IoT Central.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure IoT Central. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armiotcentral.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAppsClient()

--- a/sdk/resourcemanager/iotfirmwaredefense/armiotfirmwaredefense/README.md
+++ b/sdk/resourcemanager/iotfirmwaredefense/armiotfirmwaredefense/README.md
@@ -1,7 +1,5 @@
 # Azure Iotfirmwaredefense Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotfirmwaredefense/armiotfirmwaredefense)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotfirmwaredefense/armiotfirmwaredefense)
-
 The `armiotfirmwaredefense` module provides operations for working with Azure Iotfirmwaredefense.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/iotfirmwaredefense/armiotfirmwaredefense)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotfirmwaredefense/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Iotfirmwaredefense.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Iotfirmwaredefense. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ client, err := armiotfirmwaredefense.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewBinaryHardeningClient()

--- a/sdk/resourcemanager/iothub/armiothub/README.md
+++ b/sdk/resourcemanager/iothub/armiothub/README.md
@@ -1,7 +1,5 @@
 # Azure IoT Hub Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub)
-
 The `armiothub` module provides operations for working with Azure IoT Hub.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/iothub/armiothub)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure IoT Hub.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure IoT Hub. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armiothub.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewResourceClient()

--- a/sdk/resourcemanager/iotoperations/armiotoperations/README.md
+++ b/sdk/resourcemanager/iotoperations/armiotoperations/README.md
@@ -1,7 +1,5 @@
 # Azure IoTOperations Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotoperations/armiotoperations)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotoperations/armiotoperations)
-
 The `armiotoperations` module provides operations for working with Azure IoTOperations.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/iotoperations/armiotoperations)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotoperations/armio
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure IoTOperations.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure IoTOperations. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armiotoperations.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewBrokerAuthenticationClient()

--- a/sdk/resourcemanager/iotsecurity/armiotsecurity/README.md
+++ b/sdk/resourcemanager/iotsecurity/armiotsecurity/README.md
@@ -1,7 +1,5 @@
 # Azure IoT Security Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotsecurity/armiotsecurity)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotsecurity/armiotsecurity)
-
 The `armiotsecurity` module provides operations for working with Azure IoT Security.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/iotsecurity/armiotsecurity)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iotsecurity/armiots
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure IoT Security.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure IoT Security. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armiotsecurity.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDevicesClient()

--- a/sdk/resourcemanager/keyvault/armkeyvault/README.md
+++ b/sdk/resourcemanager/keyvault/armkeyvault/README.md
@@ -1,7 +1,5 @@
 # Azure Key Vault Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault)
-
 The `armkeyvault` module provides operations for working with Azure Key Vault.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/keyvault/armkeyvault)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvaul
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Key Vault.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Key Vault. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armkeyvault.NewClientFactory(<subscription ID>, cred, &opt
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewVaultsClient()

--- a/sdk/resourcemanager/kubernetesconfiguration/armkubernetesconfiguration/README.md
+++ b/sdk/resourcemanager/kubernetesconfiguration/armkubernetesconfiguration/README.md
@@ -1,7 +1,5 @@
 # Azure Kubernetes Configuration Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kubernetesconfiguration/armkubernetesconfiguration/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kubernetesconfiguration/armkubernetesconfiguration/v2)
-
 The `armkubernetesconfiguration` module provides operations for working with Azure Kubernetes Configuration.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/kubernetesconfiguration/armkubernetesconfiguration)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kubernetesconfigura
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Kubernetes Configuration.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Kubernetes Configuration. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armkubernetesconfiguration.NewClientFactory(<subscription 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSourceControlConfigurationsClient()

--- a/sdk/resourcemanager/kusto/armkusto/README.md
+++ b/sdk/resourcemanager/kusto/armkusto/README.md
@@ -1,7 +1,5 @@
 # Azure Kusto Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2)
-
 The `armkusto` module provides operations for working with Azure Kusto.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/kusto/armkusto)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Kusto.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Kusto. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armkusto.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDatabasesClient()

--- a/sdk/resourcemanager/labservices/armlabservices/README.md
+++ b/sdk/resourcemanager/labservices/armlabservices/README.md
@@ -1,7 +1,5 @@
 # Azure Lab Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/labservices/armlabservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/labservices/armlabservices)
-
 The `armlabservices` module provides operations for working with Azure Lab Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/labservices/armlabservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/labservices/armlabs
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Lab Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Lab Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armlabservices.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewLabPlansClient()

--- a/sdk/resourcemanager/largeinstance/armlargeinstance/CHANGELOG.md
+++ b/sdk/resourcemanager/largeinstance/armlargeinstance/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.1.0 (2024-02-23)
+### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/largeinstance/armlargeinstance` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 

--- a/sdk/resourcemanager/largeinstance/armlargeinstance/README.md
+++ b/sdk/resourcemanager/largeinstance/armlargeinstance/README.md
@@ -1,7 +1,5 @@
 # Azure Largeinstance Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/largeinstance/armlargeinstance)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/largeinstance/armlargeinstance)
-
 The `armlargeinstance` module provides operations for working with Azure Largeinstance.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/largeinstance/armlargeinstance)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/largeinstance/armla
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Largeinstance.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Largeinstance. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armlargeinstance.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAzureLargeInstanceClient()

--- a/sdk/resourcemanager/liftrqumulo/armqumulo/README.md
+++ b/sdk/resourcemanager/liftrqumulo/armqumulo/README.md
@@ -1,7 +1,5 @@
 # Azure Liftr Qumulo Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/liftrqumulo/armqumulo/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/liftrqumulo/armqumulo/v2)
-
 The `armqumulo` module provides operations for working with Azure Liftr Qumulo.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/liftrqumulo/armqumulo)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/liftrqumulo/armqumu
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Liftr Qumulo.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Liftr Qumulo. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armqumulo.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewFileSystemsClient()

--- a/sdk/resourcemanager/loadtesting/armloadtesting/README.md
+++ b/sdk/resourcemanager/loadtesting/armloadtesting/README.md
@@ -1,7 +1,5 @@
 # Azure Load Testing Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/loadtesting/armloadtesting)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/loadtesting/armloadtesting)
-
 The `armloadtesting` module provides operations for working with Azure Load Testing.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/loadtesting/armloadtesting)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/loadtesting/armload
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Load Testing.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Load Testing. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armloadtesting.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewLoadTestsClient()

--- a/sdk/resourcemanager/logic/armlogic/README.md
+++ b/sdk/resourcemanager/logic/armlogic/README.md
@@ -1,7 +1,5 @@
 # Azure Logic Apps Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic)
-
 The `armlogic` module provides operations for working with Azure Logic Apps.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/logic/armlogic)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Logic Apps.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Logic Apps. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armlogic.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewWorkflowsClient()

--- a/sdk/resourcemanager/logz/armlogz/README.md
+++ b/sdk/resourcemanager/logz/armlogz/README.md
@@ -1,7 +1,5 @@
 # Azure Logz Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logz/armlogz)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logz/armlogz)
-
 The `armlogz` module provides operations for working with Azure Logz.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/logz/armlogz)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logz/armlogz
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Logz.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Logz. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armlogz.NewClientFactory(<subscription ID>, cred, &options
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSingleSignOnClient()

--- a/sdk/resourcemanager/m365securityandcompliance/armm365securityandcompliance/README.md
+++ b/sdk/resourcemanager/m365securityandcompliance/armm365securityandcompliance/README.md
@@ -1,7 +1,5 @@
 # Azure Directory and Database Infrastructure Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/m365securityandcompliance/armm365securityandcompliance)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/m365securityandcompliance/armm365securityandcompliance)
-
 The `armm365securityandcompliance` module provides operations for working with Azure Directory and Database Infrastructure.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/m365securityandcompliance/armm365securityandcompliance)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/m365securityandcomp
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Directory and Database Infrastructure.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Directory and Database Infrastructure. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armm365securityandcompliance.NewClientFactory(<subscriptio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPrivateEndpointConnectionsForMIPPolicySyncClient()

--- a/sdk/resourcemanager/machinelearning/armmachinelearning/README.md
+++ b/sdk/resourcemanager/machinelearning/armmachinelearning/README.md
@@ -1,7 +1,5 @@
 # Azure Machine Learning Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4)
-
 The `armmachinelearning` module provides operations for working with Azure Machine Learning.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/machinelearning/armmachinelearning)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Machine Learning.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Machine Learning. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmachinelearning.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewBatchDeploymentsClient()

--- a/sdk/resourcemanager/machinelearningservices/armmachinelearningservices/CHANGELOG.md
+++ b/sdk/resourcemanager/machinelearningservices/armmachinelearningservices/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 1.0.1 (2022-05-30)
+### Other Changes
 
 - Deprecated: use github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning instead.
 

--- a/sdk/resourcemanager/machinelearningservices/armmachinelearningservices/README.md
+++ b/sdk/resourcemanager/machinelearningservices/armmachinelearningservices/README.md
@@ -1,7 +1,5 @@
 # Azure Machine Learning Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearningservices/armmachinelearningservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearningservices/armmachinelearningservices)
-
 The `armmachinelearningservices` module provides operations for working with Azure Machine Learning Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/machinelearningservices/armmachinelearningservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearningserv
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Machine Learning Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Machine Learning Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -35,7 +33,7 @@ For more information on authentication, please see the documentation for `aziden
 
 ## Clients
 
-Azure Machine Learning Services modules consist of one or more clients.  A client groups a set of related APIs, providing access to its functionality within the specified subscription.  Create one or more clients to access the APIs you require using your credential.
+Azure Machine Learning Services modules consist of one or more clients. A client groups a set of related APIs, providing access to its functionality within the specified subscription. Create one or more clients to access the APIs you require using your credential.
 
 ```go
 client, err := armmachinelearningservices.NewQuotasClient(<subscription ID>, cred, nil)

--- a/sdk/resourcemanager/maintenance/armmaintenance/README.md
+++ b/sdk/resourcemanager/maintenance/armmaintenance/README.md
@@ -1,7 +1,5 @@
 # Azure Maintenance Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/maintenance/armmaintenance)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/maintenance/armmaintenance)
-
 The `armmaintenance` module provides operations for working with Azure Maintenance.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/maintenance/armmaintenance)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/maintenance/armmain
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Maintenance.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Maintenance. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmaintenance.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewApplyUpdateForResourceGroupClient()

--- a/sdk/resourcemanager/managednetwork/armmanagednetwork/README.md
+++ b/sdk/resourcemanager/managednetwork/armmanagednetwork/README.md
@@ -1,7 +1,5 @@
 # Azure Managed Network Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managednetwork/armmanagednetwork)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managednetwork/armmanagednetwork)
-
 The `armmanagednetwork` module provides operations for working with Azure Managed Network.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/managednetwork/armmanagednetwork)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managednetwork/armm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Managed Network.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Managed Network. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmanagednetwork.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewManagedNetworksClient()

--- a/sdk/resourcemanager/managednetworkfabric/armmanagednetworkfabric/README.md
+++ b/sdk/resourcemanager/managednetworkfabric/armmanagednetworkfabric/README.md
@@ -1,7 +1,5 @@
 # Azure Managednetworkfabric Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managednetworkfabric/armmanagednetworkfabric)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managednetworkfabric/armmanagednetworkfabric)
-
 The `armmanagednetworkfabric` module provides operations for working with Azure Managednetworkfabric.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/managednetworkfabric/armmanagednetworkfabric)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managednetworkfabri
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Managednetworkfabric.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Managednetworkfabric. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ client, err := armmanagednetworkfabric.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewExternalNetworksClient()

--- a/sdk/resourcemanager/managedservices/armmanagedservices/README.md
+++ b/sdk/resourcemanager/managedservices/armmanagedservices/README.md
@@ -1,7 +1,5 @@
 # Azure Managed Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices)
-
 The `armmanagedservices` module provides operations for working with Azure Managed Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/managedservices/armmanagedservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Managed Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Managed Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmanagedservices.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewRegistrationDefinitionsClient()

--- a/sdk/resourcemanager/managementgroups/armmanagementgroups/README.md
+++ b/sdk/resourcemanager/managementgroups/armmanagementgroups/README.md
@@ -1,7 +1,5 @@
 # Azure Management Groups Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups)
-
 The `armmanagementgroups` module provides operations for working with Azure Management Groups.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/managementgroups/armmanagementgroups)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Management Groups.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Management Groups. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmanagementgroups.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/managementpartner/armmanagementpartner/README.md
+++ b/sdk/resourcemanager/managementpartner/armmanagementpartner/README.md
@@ -1,7 +1,5 @@
 # Azure Management Partner Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementpartner/armmanagementpartner)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementpartner/armmanagementpartner)
-
 The `armmanagementpartner` module provides operations for working with Azure Management Partner.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/managementpartner/armmanagementpartner)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementpartner/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Management Partner.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Management Partner. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmanagementpartner.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPartnerClient()

--- a/sdk/resourcemanager/maps/armmaps/README.md
+++ b/sdk/resourcemanager/maps/armmaps/README.md
@@ -1,7 +1,5 @@
 # Azure Maps Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/maps/armmaps)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/maps/armmaps)
-
 The `armmaps` module provides operations for working with Azure Maps.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/maps/armmaps)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/maps/armmaps
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Maps.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Maps. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmaps.NewClientFactory(<subscription ID>, cred, &options
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/mariadb/armmariadb/README.md
+++ b/sdk/resourcemanager/mariadb/armmariadb/README.md
@@ -1,7 +1,5 @@
 # Azure OSS Databases Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mariadb/armmariadb)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mariadb/armmariadb)
-
 The `armmariadb` module provides operations for working with Azure OSS Databases.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/mariadb/armmariadb)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mariadb/armmariadb
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure OSS Databases.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure OSS Databases. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmariadb.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDatabasesClient()

--- a/sdk/resourcemanager/marketplace/armmarketplace/README.md
+++ b/sdk/resourcemanager/marketplace/armmarketplace/README.md
@@ -1,7 +1,5 @@
 # Azure Marketplace Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/marketplace/armmarketplace)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/marketplace/armmarketplace)
-
 The `armmarketplace` module provides operations for working with Azure Marketplace.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/marketplace/armmarketplace)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/marketplace/armmark
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Marketplace.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Marketplace. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmarketplace.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPrivateStoreClient()

--- a/sdk/resourcemanager/marketplaceordering/armmarketplaceordering/README.md
+++ b/sdk/resourcemanager/marketplaceordering/armmarketplaceordering/README.md
@@ -1,7 +1,5 @@
 # Azure Marketplace Ordering Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/marketplaceordering/armmarketplaceordering)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/marketplaceordering/armmarketplaceordering)
-
 The `armmarketplaceordering` module provides operations for working with Azure Marketplace Ordering.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/marketplaceordering/armmarketplaceordering)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/marketplaceordering
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Marketplace Ordering.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Marketplace Ordering. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmarketplaceordering.NewClientFactory(<subscription ID>,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewMarketplaceAgreementsClient()

--- a/sdk/resourcemanager/mediaservices/armmediaservices/README.md
+++ b/sdk/resourcemanager/mediaservices/armmediaservices/README.md
@@ -1,7 +1,5 @@
 # Azure Media Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mediaservices/armmediaservices/v3)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mediaservices/armmediaservices/v3)
-
 The `armmediaservices` module provides operations for working with Azure Media Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/mediaservices/armmediaservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mediaservices/armme
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Media Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Media Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmediaservices.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/migrate/armmigrate/README.md
+++ b/sdk/resourcemanager/migrate/armmigrate/README.md
@@ -1,7 +1,5 @@
 # Azure Migrate Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/migrate/armmigrate)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/migrate/armmigrate)
-
 The `armmigrate` module provides operations for working with Azure Migrate.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/migrate/armmigrate)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/migrate/armmigrate
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Migrate.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Migrate. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmigrate.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewGroupsClient()

--- a/sdk/resourcemanager/migrationdiscovery/armmigrationdiscoverysap/CHANGELOG.md
+++ b/sdk/resourcemanager/migrationdiscovery/armmigrationdiscoverysap/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.1.0 (2024-03-22)
+### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/migrationdiscovery/armmigrationdiscoverysap` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 

--- a/sdk/resourcemanager/migrationdiscovery/armmigrationdiscoverysap/README.md
+++ b/sdk/resourcemanager/migrationdiscovery/armmigrationdiscoverysap/README.md
@@ -1,7 +1,5 @@
 # Azure Migrationdiscovery Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/migrationdiscovery/armmigrationdiscoverysap)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/migrationdiscovery/armmigrationdiscoverysap)
-
 The `armmigrationdiscoverysap` module provides operations for working with Azure Migrationdiscovery.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/migrationdiscovery/armmigrationdiscoverysap)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/migrationdiscovery/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Migrationdiscovery.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Migrationdiscovery. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmigrationdiscoverysap.NewClientFactory(<subscription ID
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSapDiscoverySitesClient()

--- a/sdk/resourcemanager/mixedreality/armmixedreality/README.md
+++ b/sdk/resourcemanager/mixedreality/armmixedreality/README.md
@@ -1,7 +1,5 @@
 # Azure Mixed Readlity Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mixedreality/armmixedreality)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mixedreality/armmixedreality)
-
 The `armmixedreality` module provides operations for working with Azure Mixed Readlity.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/mixedreality/armmixedreality)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mixedreality/armmix
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Mixed Readlity.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Mixed Readlity. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmixedreality.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewObjectAnchorsAccountsClient()

--- a/sdk/resourcemanager/mobilenetwork/armmobilenetwork/README.md
+++ b/sdk/resourcemanager/mobilenetwork/armmobilenetwork/README.md
@@ -1,7 +1,5 @@
 # Azure Private 5G Core Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mobilenetwork/armmobilenetwork/v4)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mobilenetwork/armmobilenetwork/v4)
-
 The `armmobilenetwork` module provides operations for working with Azure Private 5G Core.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/mobilenetwork/armmobilenetwork)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mobilenetwork/armmo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Private 5G Core.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Private 5G Core. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmobilenetwork.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAttachedDataNetworksClient()

--- a/sdk/resourcemanager/mongocluster/armmongocluster/README.md
+++ b/sdk/resourcemanager/mongocluster/armmongocluster/README.md
@@ -1,7 +1,5 @@
 # Azure Mongocluster Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster)
-
 The `armmongocluster` module provides operations for working with Azure Mongocluster.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/mongocluster/armmongocluster)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmon
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Mongocluster.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Mongocluster. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmongocluster.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewFirewallRulesClient()

--- a/sdk/resourcemanager/monitor/armmonitor/README.md
+++ b/sdk/resourcemanager/monitor/armmonitor/README.md
@@ -1,7 +1,5 @@
 # Azure Monitor Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor)
-
 The `armmonitor` module provides operations for working with Azure Monitor.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/monitor/armmonitor)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Monitor.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Monitor. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -35,7 +33,7 @@ For more information on authentication, please see the documentation for `aziden
 
 ## Client Factory
 
-Azure Monitor module consists of one or more clients.  We provide a client factory which could be used to create any client in this module.
+Azure Monitor module consists of one or more clients. We provide a client factory which could be used to create any client in this module.
 
 ```go
 clientFactory, err := armmonitor.NewClientFactory(<subscription ID>, cred, nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmonitor.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAlertRuleIncidentsClient()

--- a/sdk/resourcemanager/msi/armmsi/README.md
+++ b/sdk/resourcemanager/msi/armmsi/README.md
@@ -1,7 +1,5 @@
 # Azure Managed Service Identity Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi)
-
 The `armmsi` module provides operations for working with Azure Managed Service Identity.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/msi/armmsi)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Managed Service Identity.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Managed Service Identity. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmsi.NewClientFactory(<subscription ID>, cred, &options)
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSystemAssignedIdentitiesClient()

--- a/sdk/resourcemanager/mysql/armmysql/README.md
+++ b/sdk/resourcemanager/mysql/armmysql/README.md
@@ -1,7 +1,5 @@
 # Azure Database for MySQL Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql)
-
 The `armmysql` module provides operations for working with Azure Database for MySQL.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/mysql/armmysql)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Database for MySQL.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Database for MySQL. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmysql.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDatabasesClient()

--- a/sdk/resourcemanager/mysql/armmysqlflexibleservers/README.md
+++ b/sdk/resourcemanager/mysql/armmysqlflexibleservers/README.md
@@ -1,7 +1,5 @@
 # Azure Database for MySQL Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers/v2)
-
 The `armmysqlflexibleservers` module provides operations for working with Azure Database for MySQL.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/mysql/armmysqlflexibleservers)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexi
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Database for MySQL.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Database for MySQL. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmysqlflexibleservers.NewClientFactory(<subscription ID>
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAdvancedThreatProtectionSettingsClient()

--- a/sdk/resourcemanager/netapp/armnetapp/README.md
+++ b/sdk/resourcemanager/netapp/armnetapp/README.md
@@ -1,7 +1,5 @@
 # Azure NetApp Files Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/netapp/armnetapp/v7)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/netapp/armnetapp/v7)
-
 The `armnetapp` module provides operations for working with Azure NetApp Files.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/netapp/armnetapp)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/netapp/armnetapp/v7
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure NetApp Files.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure NetApp Files. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armnetapp.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()
@@ -66,7 +64,6 @@ The fake package contains types used for constructing in-memory fake servers use
 This allows writing tests to cover various success/error conditions without the need for connecting to a live service.
 
 Please see https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes for details and examples on how to use fakes.
-
 
 ## Major Version Upgrade
 

--- a/sdk/resourcemanager/network/armnetwork/README.md
+++ b/sdk/resourcemanager/network/armnetwork/README.md
@@ -1,7 +1,5 @@
 # Azure Network Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6)
-
 The `armnetwork` module provides operations for working with Azure Network.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/network/armnetwork)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Network.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Network. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -35,7 +33,7 @@ For more information on authentication, please see the documentation for `aziden
 
 ## Client Factory
 
-Azure Network module consists of one or more clients.  We provide a client factory which could be used to create any client in this module.
+Azure Network module consists of one or more clients. We provide a client factory which could be used to create any client in this module.
 
 ```go
 clientFactory, err := armnetwork.NewClientFactory(<subscription ID>, cred, nil)
@@ -54,7 +52,7 @@ clientFactory, err := armnetwork.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAdminRuleCollectionsClient()

--- a/sdk/resourcemanager/networkanalytics/armnetworkanalytics/README.md
+++ b/sdk/resourcemanager/networkanalytics/armnetworkanalytics/README.md
@@ -1,7 +1,5 @@
 # Azure Networkanalytics Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkanalytics/armnetworkanalytics)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkanalytics/armnetworkanalytics)
-
 The `armnetworkanalytics` module provides operations for working with Azure Networkanalytics.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/networkanalytics/armnetworkanalytics)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkanalytics/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Networkanalytics.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Networkanalytics. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armnetworkanalytics.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDataProductsCatalogsClient()

--- a/sdk/resourcemanager/networkcloud/armnetworkcloud/README.md
+++ b/sdk/resourcemanager/networkcloud/armnetworkcloud/README.md
@@ -1,7 +1,5 @@
 # Azure Networkcloud Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkcloud/armnetworkcloud)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkcloud/armnetworkcloud)
-
 The `armnetworkcloud` module provides operations for working with Azure Networkcloud.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/networkcloud/armnetworkcloud)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkcloud/armnet
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Networkcloud.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Networkcloud. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ client, err := armnetworkcloud.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewTrunkedNetworksClient()

--- a/sdk/resourcemanager/networkfunction/armnetworkfunction/README.md
+++ b/sdk/resourcemanager/networkfunction/armnetworkfunction/README.md
@@ -1,7 +1,5 @@
 # Azure Network Function Manager Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkfunction/armnetworkfunction/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkfunction/armnetworkfunction/v2)
-
 The `armnetworkfunction` module provides operations for working with Azure Network Function Manager.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/networkfunction/armnetworkfunction)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkfunction/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Network Function Manager.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Network Function Manager. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armnetworkfunction.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/newrelic/armnewrelicobservability/README.md
+++ b/sdk/resourcemanager/newrelic/armnewrelicobservability/README.md
@@ -1,7 +1,5 @@
 # Azure Newrelic Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/newrelic/armnewrelicobservability)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/newrelic/armnewrelicobservability)
-
 The `armnewrelicobservability` module provides operations for working with Azure Newrelic.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/newrelic/armnewrelicobservability)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/newrelic/armnewreli
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Newrelic.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Newrelic. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armnewrelicobservability.NewClientFactory(<subscription ID
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()

--- a/sdk/resourcemanager/nginx/armnginx/README.md
+++ b/sdk/resourcemanager/nginx/armnginx/README.md
@@ -1,7 +1,5 @@
 # Azure Nginx Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/nginx/armnginx/v3)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/nginx/armnginx/v3)
-
 The `armnginx` module provides operations for working with Azure Nginx.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/nginx/armnginx)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/nginx/armnginx/v3
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Nginx.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Nginx. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armnginx.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCertificatesClient()

--- a/sdk/resourcemanager/notificationhubs/armnotificationhubs/README.md
+++ b/sdk/resourcemanager/notificationhubs/armnotificationhubs/README.md
@@ -1,7 +1,5 @@
 # Azure Notification Hubs Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs/v2)
-
 The `armnotificationhubs` module provides operations for working with Azure Notification Hubs.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/notificationhubs/armnotificationhubs)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Notification Hubs.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Notification Hubs. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armnotificationhubs.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/oep/armoep/README.md
+++ b/sdk/resourcemanager/oep/armoep/README.md
@@ -1,7 +1,5 @@
 # Azure Open Energy Platform Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/oep/armoep)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/oep/armoep)
-
 The `armoep` module provides operations for working with Azure Open Energy Platform.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/oep/armoep)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/oep/armoep
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Open Energy Platform.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Open Energy Platform. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armoep.NewClientFactory(<subscription ID>, cred, &options)
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.LocationsClient()

--- a/sdk/resourcemanager/operationalinsights/armoperationalinsights/README.md
+++ b/sdk/resourcemanager/operationalinsights/armoperationalinsights/README.md
@@ -1,7 +1,5 @@
 # Azure Operational Insights Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v2)
-
 The `armoperationalinsights` module provides operations for working with Azure Operational Insights.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/operationalinsights/armoperationalinsights)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Operational Insights.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Operational Insights. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armoperationalinsights.NewClientFactory(<subscription ID>,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAvailableServiceTiersClient()

--- a/sdk/resourcemanager/operationsmanagement/armoperationsmanagement/README.md
+++ b/sdk/resourcemanager/operationsmanagement/armoperationsmanagement/README.md
@@ -1,7 +1,5 @@
 # Azure Operations Management Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationsmanagement/armoperationsmanagement)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationsmanagement/armoperationsmanagement)
-
 The `armoperationsmanagement` module provides operations for working with Azure Operations Management.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/operationsmanagement/armoperationsmanagement)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationsmanagemen
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Operations Management.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Operations Management. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armoperationsmanagement.NewClientFactory(<subscription ID>
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewManagementConfigurationsClient()

--- a/sdk/resourcemanager/oracledatabase/armoracledatabase/README.md
+++ b/sdk/resourcemanager/oracledatabase/armoracledatabase/README.md
@@ -1,7 +1,5 @@
 # Azure Oracle Database Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/oracledatabase/armoracledatabase)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/oracledatabase/armoracledatabase)
-
 The `armoracledatabase` module provides operations for working with Azure Oracle Database.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/oracledatabase/armoracledatabase)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/oracledatabase/armo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Oracle Database.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Oracle Database. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armoracledatabase.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAutonomousDatabaseBackupsClient()

--- a/sdk/resourcemanager/orbital/armorbital/README.md
+++ b/sdk/resourcemanager/orbital/armorbital/README.md
@@ -1,7 +1,5 @@
 # Azure Orbital Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/orbital/armorbital/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/orbital/armorbital/v2)
-
 The `armorbital` module provides operations for working with Azure Orbital.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/orbital/armorbital)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/orbital/armorbital/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Orbital.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Orbital. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armorbital.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewContactsClient()

--- a/sdk/resourcemanager/paloaltonetworksngfw/armpanngfw/README.md
+++ b/sdk/resourcemanager/paloaltonetworksngfw/armpanngfw/README.md
@@ -1,7 +1,5 @@
 # Azure PaloAltoNetworks Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/paloaltonetworksngfw/armpanngfw)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/paloaltonetworksngfw/armpanngfw)
-
 The `armpanngfw` module provides operations for working with Azure PaloAltoNetworks.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/paloaltonetworksngfw/armpanngfw)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/paloaltonetworksngf
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure PaloAltoNetworks.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure PaloAltoNetworks. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpanngfw.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewLocalRulesClient()

--- a/sdk/resourcemanager/peering/armpeering/README.md
+++ b/sdk/resourcemanager/peering/armpeering/README.md
@@ -1,7 +1,5 @@
 # Azure Peering Service Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/peering/armpeering)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/peering/armpeering)
-
 The `armpeering` module provides operations for working with Azure Peering Service.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/peering/armpeering)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/peering/armpeering
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Peering Service.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Peering Service. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpeering.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPeeringsClient()

--- a/sdk/resourcemanager/playwrighttesting/armplaywrighttesting/README.md
+++ b/sdk/resourcemanager/playwrighttesting/armplaywrighttesting/README.md
@@ -1,7 +1,5 @@
 # Azure Playwrighttesting Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/playwrighttesting/armplaywrighttesting)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/playwrighttesting/armplaywrighttesting)
-
 The `armplaywrighttesting` module provides operations for working with Azure Playwrighttesting.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/playwrighttesting/armplaywrighttesting)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/playwrighttesting/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Playwrighttesting.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Playwrighttesting. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armplaywrighttesting.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewQuotasClient()

--- a/sdk/resourcemanager/policyinsights/armpolicyinsights/README.md
+++ b/sdk/resourcemanager/policyinsights/armpolicyinsights/README.md
@@ -1,7 +1,5 @@
 # Azure Policy Insight Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/policyinsights/armpolicyinsights)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/policyinsights/armpolicyinsights)
-
 The `armpolicyinsights` module provides operations for working with Azure Policy Insight.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/policyinsights/armpolicyinsights)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/policyinsights/armp
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Policy Insight.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Policy Insight. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpolicyinsights.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPolicyEventsClient()

--- a/sdk/resourcemanager/portal/armportal/README.md
+++ b/sdk/resourcemanager/portal/armportal/README.md
@@ -1,7 +1,5 @@
 # Azure Portal Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/portal/armportal)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/portal/armportal)
-
 The `armportal` module provides operations for working with Azure Portal.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/portal/armportal)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/portal/armportal
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Portal.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Portal. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armportal.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDashboardsClient()

--- a/sdk/resourcemanager/postgresql/armpostgresql/README.md
+++ b/sdk/resourcemanager/postgresql/armpostgresql/README.md
@@ -1,7 +1,5 @@
 # Azure Database for PostgreSQL Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql)
-
 The `armpostgresql` module provides operations for working with Azure Database for PostgreSQL.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/postgresql/armpostgresql)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostg
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Database for PostgreSQL.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Database for PostgreSQL. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpostgresql.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServersClient()

--- a/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/README.md
+++ b/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/README.md
@@ -1,7 +1,5 @@
 # Azure Database for PostgreSQL Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v4)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v4)
-
 The `armpostgresqlflexibleservers` module provides operations for working with Azure Database for PostgreSQL.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostg
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Database for PostgreSQL.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Database for PostgreSQL. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpostgresqlflexibleservers.NewClientFactory(<subscriptio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAdministratorsClient()

--- a/sdk/resourcemanager/postgresqlhsc/armpostgresqlhsc/CHANGELOG.md
+++ b/sdk/resourcemanager/postgresqlhsc/armpostgresqlhsc/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.6.1 (2023-06-23)
+### Other Changes
 
 - Deprecated: use github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql instead.
 

--- a/sdk/resourcemanager/postgresqlhsc/armpostgresqlhsc/README.md
+++ b/sdk/resourcemanager/postgresqlhsc/armpostgresqlhsc/README.md
@@ -1,7 +1,5 @@
 # Azure Database for PostgreSQL HSC Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresqlhsc/armpostgresqlhsc)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresqlhsc/armpostgresqlhsc)
-
 The `armpostgresqlhsc` module provides operations for working with Azure Database for PostgreSQL HSC.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/postgresqlhsc/armpostgresqlhsc)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresqlhsc/armpo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Database for PostgreSQL HSC.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Database for PostgreSQL HSC. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpostgresqlhsc.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServersClient()

--- a/sdk/resourcemanager/powerbidedicated/armpowerbidedicated/README.md
+++ b/sdk/resourcemanager/powerbidedicated/armpowerbidedicated/README.md
@@ -1,7 +1,5 @@
 # Azure Power BI Dedicated Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbidedicated/armpowerbidedicated)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbidedicated/armpowerbidedicated)
-
 The `armpowerbidedicated` module provides operations for working with Azure Power BI Dedicated.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/powerbidedicated/armpowerbidedicated)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbidedicated/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Power BI Dedicated.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Power BI Dedicated. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpowerbidedicated.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAutoScaleVCoresClient()

--- a/sdk/resourcemanager/powerbiembedded/armpowerbiembedded/README.md
+++ b/sdk/resourcemanager/powerbiembedded/armpowerbiembedded/README.md
@@ -1,7 +1,5 @@
 # Azure Power BI Embedded Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbiembedded/armpowerbiembedded)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbiembedded/armpowerbiembedded)
-
 The `armpowerbiembedded` module provides operations for working with Azure Power BI Embedded.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/powerbiembedded/armpowerbiembedded)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbiembedded/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Power BI Embedded.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Power BI Embedded. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpowerbiembedded.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewWorkspacesClient()

--- a/sdk/resourcemanager/powerbiprivatelinks/armpowerbiprivatelinks/README.md
+++ b/sdk/resourcemanager/powerbiprivatelinks/armpowerbiprivatelinks/README.md
@@ -1,7 +1,5 @@
 # Azure Power BI Private Links Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbiprivatelinks/armpowerbiprivatelinks/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbiprivatelinks/armpowerbiprivatelinks/v2)
-
 The `armpowerbiprivatelinks` module provides operations for working with Azure Power BI Private Links.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/powerbiprivatelinks/armpowerbiprivatelinks)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbiprivatelinks
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Power BI Private Links.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Power BI Private Links. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpowerbiprivatelinks.NewClientFactory(<subscription ID>,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPowerBIResourcesClient()

--- a/sdk/resourcemanager/powerplatform/armpowerplatform/README.md
+++ b/sdk/resourcemanager/powerplatform/armpowerplatform/README.md
@@ -1,7 +1,5 @@
 # Azure Power Platform Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerplatform/armpowerplatform)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerplatform/armpowerplatform)
-
 The `armpowerplatform` module provides operations for working with Azure Power Platform.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/powerplatform/armpowerplatform)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerplatform/armpo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Power Platform.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Power Platform. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpowerplatform.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()

--- a/sdk/resourcemanager/privatedns/armprivatedns/README.md
+++ b/sdk/resourcemanager/privatedns/armprivatedns/README.md
@@ -1,7 +1,5 @@
 # Azure Private DNS Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns)
-
 The `armprivatedns` module provides operations for working with Azure Private DNS.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/privatedns/armprivatedns)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armpriva
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Private DNS.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Private DNS. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armprivatedns.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewPrivateZonesClient()

--- a/sdk/resourcemanager/providerhub/armproviderhub/README.md
+++ b/sdk/resourcemanager/providerhub/armproviderhub/README.md
@@ -1,7 +1,5 @@
 # Azure Provider HUB Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/providerhub/armproviderhub)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/providerhub/armproviderhub)
-
 The `armproviderhub` module provides operations for working with Azure Provider HUB.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/providerhub/armproviderhub)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/providerhub/armprov
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Provider HUB.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Provider HUB. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armproviderhub.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/purview/armpurview/README.md
+++ b/sdk/resourcemanager/purview/armpurview/README.md
@@ -1,7 +1,5 @@
 # Azure Purview Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/purview/armpurview)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/purview/armpurview)
-
 The `armpurview` module provides operations for working with Azure Purview.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/purview/armpurview)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/purview/armpurview
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Purview.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Purview. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpurview.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()

--- a/sdk/resourcemanager/quantum/armquantum/README.md
+++ b/sdk/resourcemanager/quantum/armquantum/README.md
@@ -1,7 +1,5 @@
 # Azure Quantum Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/quantum/armquantum)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/quantum/armquantum)
-
 The `armquantum` module provides operations for working with Azure Quantum.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/quantum/armquantum)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/quantum/armquantum
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Quantum.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Quantum. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armquantum.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewOfferingsClient()

--- a/sdk/resourcemanager/quota/armquota/README.md
+++ b/sdk/resourcemanager/quota/armquota/README.md
@@ -1,7 +1,5 @@
 # Azure Quota Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/quota/armquota)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/quota/armquota)
-
 The `armquota` module provides operations for working with Azure Quota.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/quota/armquota)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/quota/armquota
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Quota.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Quota. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armquota.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewGroupQuotaSubscriptionAllocationClient()

--- a/sdk/resourcemanager/recoveryservices/armrecoveryservices/README.md
+++ b/sdk/resourcemanager/recoveryservices/armrecoveryservices/README.md
@@ -1,7 +1,5 @@
 # Azure Recovery Services Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v2)
-
 The `armrecoveryservices` module provides operations for working with Azure Recovery Services.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/recoveryservices/armrecoveryservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Recovery Services.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Recovery Services. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armrecoveryservices.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/README.md
+++ b/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/README.md
@@ -1,7 +1,5 @@
 # Azure Recovery Services Backup Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4)
-
 The `armrecoveryservicesbackup` module provides operations for working with Azure Recovery Services Backup.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Recovery Services Backup.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Recovery Services Backup. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armrecoveryservicesbackup.NewClientFactory(<subscription I
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewBMSPrepareDataMoveOperationResultClient()

--- a/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery/README.md
+++ b/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery/README.md
@@ -1,7 +1,5 @@
 # Azure Recovery Services Site Recovery Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery/v2)
-
 The `armrecoveryservicessiterecovery` module provides operations for working with Azure Recovery Services Site Recovery.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Recovery Services Site Recovery.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Recovery Services Site Recovery. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armrecoveryservicessiterecovery.NewClientFactory(<subscrip
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewMigrationRecoveryPointsClient()

--- a/sdk/resourcemanager/recoveryservicesdatareplication/armrecoveryservicesdatareplication/README.md
+++ b/sdk/resourcemanager/recoveryservicesdatareplication/armrecoveryservicesdatareplication/README.md
@@ -1,7 +1,5 @@
 # Azure Recoveryservicesdatareplication Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservicesdatareplication/armrecoveryservicesdatareplication)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservicesdatareplication/armrecoveryservicesdatareplication)
-
 The `armrecoveryservicesdatareplication` module provides operations for working with Azure Recoveryservicesdatareplication.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/recoveryservicesdatareplication/armrecoveryservicesdatareplication)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservicesdat
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Recoveryservicesdatareplication.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Recoveryservicesdatareplication. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armrecoveryservicesdatareplication.NewClientFactory(<subsc
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDraClient()

--- a/sdk/resourcemanager/redhatopenshift/armredhatopenshift/README.md
+++ b/sdk/resourcemanager/redhatopenshift/armredhatopenshift/README.md
@@ -1,7 +1,5 @@
 # Azure RedHat Open Shift Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redhatopenshift/armredhatopenshift)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redhatopenshift/armredhatopenshift)
-
 The `armredhatopenshift` module provides operations for working with Azure RedHat Open Shift.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/redhatopenshift/armredhatopenshift)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redhatopenshift/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure RedHat Open Shift.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure RedHat Open Shift. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armredhatopenshift.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewMachinePoolsClient()

--- a/sdk/resourcemanager/redis/armredis/README.md
+++ b/sdk/resourcemanager/redis/armredis/README.md
@@ -1,7 +1,5 @@
 # Azure Cache for Redis Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3)
-
 The `armredis` module provides operations for working with Azure Cache for Redis.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/redis/armredis)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Cache for Redis.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Cache for Redis. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armredis.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccessPolicyAssignmentClient()

--- a/sdk/resourcemanager/redisenterprise/armredisenterprise/README.md
+++ b/sdk/resourcemanager/redisenterprise/armredisenterprise/README.md
@@ -1,7 +1,5 @@
 # Azure Redis Enterprise Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v2)
-
 The `armredisenterprise` module provides operations for working with Azure Redis Enterprise.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/redisenterprise/armredisenterprise)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Redis Enterprise.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Redis Enterprise. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armredisenterprise.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccessPolicyAssignmentClient()

--- a/sdk/resourcemanager/relay/armrelay/README.md
+++ b/sdk/resourcemanager/relay/armrelay/README.md
@@ -1,7 +1,5 @@
 # Azure Relay Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay)
-
 The `armrelay` module provides operations for working with Azure Relay.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/relay/armrelay)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Relay.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Relay. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armrelay.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewNamespacesClient()

--- a/sdk/resourcemanager/reservations/armreservations/README.md
+++ b/sdk/resourcemanager/reservations/armreservations/README.md
@@ -1,7 +1,5 @@
 # Azure Servations Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations/v3)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations/v3)
-
 The `armreservations` module provides operations for working with Azure Servations.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/reservations/armreservations)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armres
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Servations.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Servations. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armreservations.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewReservationClient()
@@ -66,7 +64,6 @@ The fake package contains types used for constructing in-memory fake servers use
 This allows writing tests to cover various success/error conditions without the need for connecting to a live service.
 
 Please see https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes for details and examples on how to use fakes.
-
 
 ## Provide Feedback
 

--- a/sdk/resourcemanager/resourceconnector/armresourceconnector/README.md
+++ b/sdk/resourcemanager/resourceconnector/armresourceconnector/README.md
@@ -1,7 +1,5 @@
 # Azure Resource Connector Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourceconnector/armresourceconnector)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourceconnector/armresourceconnector)
-
 The `armresourceconnector` module provides operations for working with Azure Resource Connector.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resourceconnector/armresourceconnector)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourceconnector/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Resource Connector.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Resource Connector. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armresourceconnector.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAppliancesClient()

--- a/sdk/resourcemanager/resourcegraph/armresourcegraph/README.md
+++ b/sdk/resourcemanager/resourcegraph/armresourcegraph/README.md
@@ -1,7 +1,5 @@
 # Azure Resource Graph Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph)
-
 The `armresourcegraph` module provides operations for working with Azure Resource Graph.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resourcegraph/armresourcegraph)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armre
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Resource Graph.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Resource Graph. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armresourcegraph.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/README.md
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/README.md
@@ -1,7 +1,5 @@
 # Azure Resource Health Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth)
-
 The `armresourcehealth` module provides operations for working with Azure Resource Health.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resourcehealth/armresourcehealth)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armr
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Resource Health.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Resource Health. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armresourcehealth.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAvailabilityStatusesClient()

--- a/sdk/resourcemanager/resourcemover/armresourcemover/README.md
+++ b/sdk/resourcemanager/resourcemover/armresourcemover/README.md
@@ -1,7 +1,5 @@
 # Azure Resource Mover Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcemover/armresourcemover)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcemover/armresourcemover)
-
 The `armresourcemover` module provides operations for working with Azure Resource Mover.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resourcemover/armresourcemover)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcemover/armre
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Resource Mover.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Resource Mover. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armresourcemover.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewMoveCollectionsClient()

--- a/sdk/resourcemanager/resources/armchanges/README.md
+++ b/sdk/resourcemanager/resources/armchanges/README.md
@@ -1,7 +1,5 @@
 # Azure resources Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armchanges)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armchanges)
-
 The `armchanges` module provides operations for working with Azure resources.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armchanges)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armchange
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure resources.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure resources. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armchanges.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/resources/armdeploymentscripts/README.md
+++ b/sdk/resourcemanager/resources/armdeploymentscripts/README.md
@@ -1,7 +1,5 @@
 # Azure Deployment Scripts Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentscripts/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentscripts/v2)
-
 The `armdeploymentscripts` module provides operations for working with Azure Deployment Scripts.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armdeploymentscripts)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploy
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Deployment Scripts.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Deployment Scripts. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdeploymentscripts.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/resources/armdeploymentstacks/README.md
+++ b/sdk/resourcemanager/resources/armdeploymentstacks/README.md
@@ -1,7 +1,5 @@
 # Azure Resources Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentstacks)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentstacks)
-
 The `armdeploymentstacks` module provides operations for working with Azure Resources.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armdeploymentstacks)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploy
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Resources.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Resources. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armdeploymentstacks.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/resources/armfeatures/README.md
+++ b/sdk/resourcemanager/resources/armfeatures/README.md
@@ -1,7 +1,5 @@
 # Azure Features Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armfeatures)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armfeatures)
-
 The `armfeatures` module provides operations for working with Azure Features.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armfeatures)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armfeatur
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Features.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Features. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armfeatures.NewClientFactory(<subscription ID>, cred, &opt
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/resources/armlinks/README.md
+++ b/sdk/resourcemanager/resources/armlinks/README.md
@@ -1,7 +1,5 @@
 # Azure Resource Links Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlinks)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlinks)
-
 The `armlinks` module provides operations for working with Azure Resource Links.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armlinks)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlinks
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Resource Links.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Resource Links. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armlinks.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewResourceLinksClient()

--- a/sdk/resourcemanager/resources/armlocks/README.md
+++ b/sdk/resourcemanager/resources/armlocks/README.md
@@ -1,7 +1,5 @@
 # Azure Resource Lock Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks)
-
 The `armlocks` module provides operations for working with Azure Resource Lock.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armlocks)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Resource Lock.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Resource Lock. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armlocks.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewManagementLocksClient()

--- a/sdk/resourcemanager/resources/armmanagedapplications/README.md
+++ b/sdk/resourcemanager/resources/armmanagedapplications/README.md
@@ -1,7 +1,5 @@
 # Azure Managed Applications Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armmanagedapplications)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armmanagedapplications)
-
 The `armmanagedapplications` module provides operations for working with Azure Managed Applications.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armmanagedapplications)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armmanage
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Managed Applications.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Managed Applications. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmanagedapplications.NewClientFactory(<subscription ID>,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewApplicationClient()

--- a/sdk/resourcemanager/resources/armpolicy/README.md
+++ b/sdk/resourcemanager/resources/armpolicy/README.md
@@ -1,7 +1,5 @@
 # Azure Resource Policy Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy)
-
 The `armpolicy` module provides operations for working with Azure Resource Policy.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armpolicy)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Resource Policy.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Resource Policy. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armpolicy.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDefinitionsClient()

--- a/sdk/resourcemanager/resources/armresources/README.md
+++ b/sdk/resourcemanager/resources/armresources/README.md
@@ -1,7 +1,5 @@
 # Azure Resources Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources)
-
 The `armresources` module provides operations for working with Azure Resources.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armresources)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresour
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Resources.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Resources. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armresources.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/resources/armsubscriptions/README.md
+++ b/sdk/resourcemanager/resources/armsubscriptions/README.md
@@ -1,7 +1,5 @@
 # Azure Subscriptions Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions)
-
 The `armsubscriptions` module provides operations for working with Azure Subscriptions.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armsubscriptions)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscr
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Subscriptions.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Subscriptions. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsubscriptions.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/resources/armtemplatespecs/README.md
+++ b/sdk/resourcemanager/resources/armtemplatespecs/README.md
@@ -1,7 +1,5 @@
 # Azure Template Specs Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armtemplatespecs)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armtemplatespecs)
-
 The `armtemplatespecs` module provides operations for working with Azure Template Specs.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/resources/armtemplatespecs)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armtempla
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Template Specs.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Template Specs. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armtemplatespecs.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/saas/armsaas/README.md
+++ b/sdk/resourcemanager/saas/armsaas/README.md
@@ -1,7 +1,5 @@
 # Azure SaaS Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/saas/armsaas)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/saas/armsaas)
-
 The `armsaas` module provides operations for working with Azure SaaS.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/saas/armsaas)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/saas/armsaas
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure SaaS.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure SaaS. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsaas.NewClientFactory(<subscription ID>, cred, &options
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/scheduler/armscheduler/README.md
+++ b/sdk/resourcemanager/scheduler/armscheduler/README.md
@@ -1,7 +1,5 @@
 # Azure Scheduler Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/scheduler/armscheduler)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/scheduler/armscheduler)
-
 The `armscheduler` module provides operations for working with Azure Scheduler.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/scheduler/armscheduler)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/scheduler/armschedu
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Scheduler.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Scheduler. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armscheduler.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewJobsClient()

--- a/sdk/resourcemanager/scvmm/armscvmm/README.md
+++ b/sdk/resourcemanager/scvmm/armscvmm/README.md
@@ -1,7 +1,5 @@
 # Azure Scvmm Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/scvmm/armscvmm)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/scvmm/armscvmm)
-
 The `armscvmm` module provides operations for working with Azure Scvmm.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/scvmm/armscvmm)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/scvmm/armscvmm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Scvmm.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Scvmm. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armscvmm.NewClientFactory(<subscription ID>, cred, &option
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAvailabilitySetsClient()

--- a/sdk/resourcemanager/search/armsearch/README.md
+++ b/sdk/resourcemanager/search/armsearch/README.md
@@ -1,7 +1,5 @@
 # Azure Search Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch)
-
 The `armsearch` module provides operations for working with Azure Search.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/search/armsearch)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Search.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Search. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsearch.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAdminKeysClient()

--- a/sdk/resourcemanager/security/armsecurity/README.md
+++ b/sdk/resourcemanager/security/armsecurity/README.md
@@ -1,7 +1,5 @@
 # Azure Security Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity)
-
 The `armsecurity` module provides operations for working with Azure Security.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/security/armsecurity)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurit
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Security.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Security. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsecurity.NewClientFactory(<subscription ID>, cred, &opt
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAPICollectionsClient()

--- a/sdk/resourcemanager/securitydevops/armsecuritydevops/README.md
+++ b/sdk/resourcemanager/securitydevops/armsecuritydevops/README.md
@@ -1,7 +1,5 @@
 # Azure Securitydevops Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/securitydevops/armsecuritydevops)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/securitydevops/armsecuritydevops)
-
 The `armsecuritydevops` module provides operations for working with Azure Securitydevops.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/securitydevops/armsecuritydevops)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/securitydevops/arms
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Securitydevops.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Securitydevops. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsecuritydevops.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAzureDevOpsConnectorStatsClient()

--- a/sdk/resourcemanager/securityinsights/armsecurityinsights/README.md
+++ b/sdk/resourcemanager/securityinsights/armsecurityinsights/README.md
@@ -1,7 +1,5 @@
 # Azure Security Insight Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/securityinsights/armsecurityinsights/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/securityinsights/armsecurityinsights/v2)
-
 The `armsecurityinsights` module provides operations for working with Azure Security Insight.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/securityinsights/armsecurityinsights)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/securityinsights/ar
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Security Insight.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Security Insight. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsecurityinsights.NewClientFactory(<subscription ID>, cr
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewActionsClient()

--- a/sdk/resourcemanager/selfhelp/armselfhelp/README.md
+++ b/sdk/resourcemanager/selfhelp/armselfhelp/README.md
@@ -1,7 +1,5 @@
 # Azure Selfhelp Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/selfhelp/armselfhelp/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/selfhelp/armselfhelp/v2)
-
 The `armselfhelp` module provides operations for working with Azure Selfhelp.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/selfhelp/armselfhelp)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/selfhelp/armselfhel
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Selfhelp.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Selfhelp. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armselfhelp.NewClientFactory(<subscription ID>, cred, &opt
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDiscoverySolutionNLPSubscriptionScopeClient()

--- a/sdk/resourcemanager/serialconsole/armserialconsole/README.md
+++ b/sdk/resourcemanager/serialconsole/armserialconsole/README.md
@@ -1,7 +1,5 @@
 # Azure Serial Console Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/serialconsole/armserialconsole)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/serialconsole/armserialconsole)
-
 The `armserialconsole` module provides operations for working with Azure Serial Console.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/serialconsole/armserialconsole)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/serialconsole/armse
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Serial Console.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Serial Console. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armserialconsole.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSerialPortsClient()

--- a/sdk/resourcemanager/servicebus/armservicebus/README.md
+++ b/sdk/resourcemanager/servicebus/armservicebus/README.md
@@ -1,7 +1,5 @@
 # Azure Service Bus Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus)
-
 The `armservicebus` module provides operations for working with Azure Service Bus.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/servicebus/armservicebus)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservi
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Service Bus.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Service Bus. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armservicebus.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewNamespacesClient()

--- a/sdk/resourcemanager/servicefabric/armservicefabric/README.md
+++ b/sdk/resourcemanager/servicefabric/armservicefabric/README.md
@@ -1,7 +1,5 @@
 # Azure Service Fabric Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabric/armservicefabric)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabric/armservicefabric)
-
 The `armservicefabric` module provides operations for working with Azure Service Fabric.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/servicefabric/armservicefabric)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabric/armse
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Service Fabric.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Service Fabric. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armservicefabric.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServicesClient()

--- a/sdk/resourcemanager/servicefabricmanagedclusters/armservicefabricmanagedclusters/README.md
+++ b/sdk/resourcemanager/servicefabricmanagedclusters/armservicefabricmanagedclusters/README.md
@@ -1,7 +1,5 @@
 # Azure Servicefabricmanagedclusters Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabricmanagedclusters/armservicefabricmanagedclusters)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabricmanagedclusters/armservicefabricmanagedclusters)
-
 The `armservicefabricmanagedclusters` module provides operations for working with Azure Servicefabricmanagedclusters.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/servicefabricmanagedclusters/armservicefabricmanagedclusters)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabricmanage
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Servicefabricmanagedclusters.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Servicefabricmanagedclusters. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armservicefabricmanagedclusters.NewClientFactory(<subscrip
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewApplicationTypeVersionsClient()

--- a/sdk/resourcemanager/servicefabricmesh/armservicefabricmesh/CHANGELOG.md
+++ b/sdk/resourcemanager/servicefabricmesh/armservicefabricmesh/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.6.2 (2023-09-22)
+### Other Changes
 
 Please note, this package has been deprecated. The service backing this library is retired on April 28th, 2021. For more details on the Azure Service Fabric Mesh retirement, please visit: https://azure.microsoft.com/updates/azure-service-fabric-mesh-preview-retirement/.
 

--- a/sdk/resourcemanager/servicefabricmesh/armservicefabricmesh/README.md
+++ b/sdk/resourcemanager/servicefabricmesh/armservicefabricmesh/README.md
@@ -2,8 +2,6 @@
 
 Please note, this package has been deprecated. The service backing this library is retired on April 28th, 2021. For more details on the Azure Service Fabric Mesh retirement, please visit: https://azure.microsoft.com/updates/azure-service-fabric-mesh-preview-retirement/.
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabricmesh/armservicefabricmesh)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabricmesh/armservicefabricmesh)
-
 The `armservicefabricmesh` module provides operations for working with Azure Service Fabric Mesh.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/servicefabricmesh/armservicefabricmesh)
@@ -27,7 +25,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicefabricmesh/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Service Fabric Mesh.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Service Fabric Mesh. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -56,7 +54,7 @@ clientFactory, err := armservicefabricmesh.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServiceClient()

--- a/sdk/resourcemanager/servicelinker/armservicelinker/README.md
+++ b/sdk/resourcemanager/servicelinker/armservicelinker/README.md
@@ -1,7 +1,5 @@
 # Azure Service Linker Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicelinker/armservicelinker/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicelinker/armservicelinker/v2)
-
 The `armservicelinker` module provides operations for working with Azure Service Linker.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/servicelinker/armservicelinker)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicelinker/armse
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Service Linker.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Service Linker. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armservicelinker.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewLinkerClient()

--- a/sdk/resourcemanager/servicenetworking/armservicenetworking/README.md
+++ b/sdk/resourcemanager/servicenetworking/armservicenetworking/README.md
@@ -1,7 +1,5 @@
 # Azure Servicenetworking Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicenetworking/armservicenetworking)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicenetworking/armservicenetworking)
-
 The `armservicenetworking` module provides operations for working with Azure Servicenetworking.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/servicenetworking/armservicenetworking)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicenetworking/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Servicenetworking.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Servicenetworking. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armservicenetworking.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAssociationsInterfaceClient()

--- a/sdk/resourcemanager/signalr/armsignalr/README.md
+++ b/sdk/resourcemanager/signalr/armsignalr/README.md
@@ -1,7 +1,5 @@
 # Azure Signalr Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/signalr/armsignalr)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/signalr/armsignalr)
-
 The `armsignalr` module provides operations for working with Azure Signalr.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/signalr/armsignalr)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/signalr/armsignalr
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Signalr.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Signalr. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsignalr.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/solutions/armmanagedapplications/README.md
+++ b/sdk/resourcemanager/solutions/armmanagedapplications/README.md
@@ -1,7 +1,5 @@
 # Azure Managed Application Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/solutions/armmanagedapplications/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/solutions/armmanagedapplications/v2)
-
 The `armmanagedapplications` module provides operations for working with Azure Managed Application.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/solutions/armmanagedapplications)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/solutions/armmanage
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Managed Application.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Managed Application. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armmanagedapplications.NewClientFactory(<subscription ID>,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewApplicationsClient()

--- a/sdk/resourcemanager/sphere/armsphere/README.md
+++ b/sdk/resourcemanager/sphere/armsphere/README.md
@@ -1,7 +1,5 @@
 # Azure Sphere Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sphere/armsphere)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sphere/armsphere)
-
 The `armsphere` module provides operations for working with Azure Sphere.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/sphere/armsphere)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sphere/armsphere
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Sphere.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Sphere. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsphere.NewClientFactory(<subscription ID>, cred, &optio
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCatalogsClient()

--- a/sdk/resourcemanager/springappdiscovery/armspringappdiscovery/CHANGELOG.md
+++ b/sdk/resourcemanager/springappdiscovery/armspringappdiscovery/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.1.0 (2024-02-01)
+### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/springappdiscovery/armspringappdiscovery` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 

--- a/sdk/resourcemanager/springappdiscovery/armspringappdiscovery/README.md
+++ b/sdk/resourcemanager/springappdiscovery/armspringappdiscovery/README.md
@@ -1,7 +1,5 @@
 # Azure Springappdiscovery Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/springappdiscovery/armspringappdiscovery)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/springappdiscovery/armspringappdiscovery)
-
 The `armspringappdiscovery` module provides operations for working with Azure Springappdiscovery.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/springappdiscovery/armspringappdiscovery)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/springappdiscovery/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Springappdiscovery.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Springappdiscovery. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armspringappdiscovery.NewClientFactory(<subscription ID>, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewErrorSummariesClient()

--- a/sdk/resourcemanager/sql/armsql/README.md
+++ b/sdk/resourcemanager/sql/armsql/README.md
@@ -1,7 +1,5 @@
 # Azure SQL Database Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql/v2)
-
 The `armsql` module provides operations for working with Azure SQL Database.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/sql/armsql)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql/v2
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure SQL Database.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure SQL Database. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsql.NewClientFactory(<subscription ID>, cred, &options)
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAgentClient()

--- a/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine/README.md
+++ b/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine/README.md
@@ -1,7 +1,5 @@
 # Azure SQL Server on Azure Virtual Machines Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine)
-
 The `armsqlvirtualmachine` module provides operations for working with Azure SQL Server on Azure Virtual Machines.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sqlvirtualmachine/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure SQL Server on Azure Virtual Machines.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure SQL Server on Azure Virtual Machines. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsqlvirtualmachine.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSQLVirtualMachinesClient()

--- a/sdk/resourcemanager/standbypool/armstandbypool/README.md
+++ b/sdk/resourcemanager/standbypool/armstandbypool/README.md
@@ -1,7 +1,5 @@
 # Azure Standbypool Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/standbypool/armstandbypool)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/standbypool/armstandbypool)
-
 The `armstandbypool` module provides operations for working with Azure Standbypool.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/standbypool/armstandbypool)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/standbypool/armstan
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Standbypool.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Standbypool. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstandbypool.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewStandbyContainerGroupPoolRuntimeViewsClient()

--- a/sdk/resourcemanager/storage/armstorage/README.md
+++ b/sdk/resourcemanager/storage/armstorage/README.md
@@ -1,7 +1,5 @@
 # Azure Storage Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage)
-
 The `armstorage` module provides operations for working with Azure Storage.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/storage/armstorage)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Storage.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Storage. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstorage.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAccountsClient()

--- a/sdk/resourcemanager/storageactions/armstorageactions/CHANGELOG.md
+++ b/sdk/resourcemanager/storageactions/armstorageactions/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.1.0 (2024-03-08)
+### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storageactions/armstorageactions` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 

--- a/sdk/resourcemanager/storageactions/armstorageactions/README.md
+++ b/sdk/resourcemanager/storageactions/armstorageactions/README.md
@@ -1,7 +1,5 @@
 # Azure Storageactions Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storageactions/armstorageactions)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storageactions/armstorageactions)
-
 The `armstorageactions` module provides operations for working with Azure Storageactions.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/storageactions/armstorageactions)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storageactions/arms
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Storageactions.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Storageactions. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstorageactions.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewStorageTaskAssignmentClient()

--- a/sdk/resourcemanager/storagecache/armstoragecache/README.md
+++ b/sdk/resourcemanager/storagecache/armstoragecache/README.md
@@ -1,7 +1,5 @@
 # Azure Storage Caches Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagecache/armstoragecache/v4)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagecache/armstoragecache/v4)
-
 The `armstoragecache` module provides operations for working with Azure Storage Caches.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/storagecache/armstoragecache)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagecache/armsto
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Storage Caches.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Storage Caches. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstoragecache.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAmlFilesystemsClient()

--- a/sdk/resourcemanager/storageimportexport/armstorageimportexport/README.md
+++ b/sdk/resourcemanager/storageimportexport/armstorageimportexport/README.md
@@ -1,7 +1,5 @@
 # Azure Storage Import/Export Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storageimportexport/armstorageimportexport)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storageimportexport/armstorageimportexport)
-
 The `armstorageimportexport` module provides operations for working with Azure Storage Import/Export.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/storageimportexport/armstorageimportexport)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storageimportexport
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Storage Import/Export.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Storage Import/Export. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstorageimportexport.NewClientFactory(<subscription ID>,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewJobsClient()

--- a/sdk/resourcemanager/storagemover/armstoragemover/README.md
+++ b/sdk/resourcemanager/storagemover/armstoragemover/README.md
@@ -1,7 +1,5 @@
 # Azure Storage Mover Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagemover/armstoragemover/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagemover/armstoragemover/v2)
-
 The `armstoragemover` module provides operations for working with Azure Storage Mover.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/storagemover/armstoragemover)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagemover/armsto
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Storage Mover.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Storage Mover. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstoragemover.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewAgentsClient()

--- a/sdk/resourcemanager/storagepool/armstoragepool/README.md
+++ b/sdk/resourcemanager/storagepool/armstoragepool/README.md
@@ -1,7 +1,5 @@
 # Azure Storage Pool Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagepool/armstoragepool)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagepool/armstoragepool)
-
 The `armstoragepool` module provides operations for working with Azure Storage Pool.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/storagepool/armstoragepool)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagepool/armstor
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Storage Pool.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Storage Pool. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstoragepool.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewDiskPoolsClient()

--- a/sdk/resourcemanager/storagesync/armstoragesync/README.md
+++ b/sdk/resourcemanager/storagesync/armstoragesync/README.md
@@ -1,7 +1,5 @@
 # Azure Storage Sync Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagesync/armstoragesync)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagesync/armstoragesync)
-
 The `armstoragesync` module provides operations for working with Azure Storage Sync.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/storagesync/armstoragesync)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagesync/armstor
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Storage Sync.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Storage Sync. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstoragesync.NewClientFactory(<subscription ID>, cred, &
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServicesClient()

--- a/sdk/resourcemanager/storsimple1200series/armstorsimple1200series/README.md
+++ b/sdk/resourcemanager/storsimple1200series/armstorsimple1200series/README.md
@@ -1,7 +1,5 @@
 # Azure Storsimple1200series Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storsimple1200series/armstorsimple1200series)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storsimple1200series/armstorsimple1200series)
-
 The `armstorsimple1200series` module provides operations for working with Azure Storsimple1200series.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/storsimple1200series/armstorsimple1200series)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storsimple1200serie
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Storsimple1200series.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Storsimple1200series. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstorsimple1200series.NewClientFactory(<subscription ID>
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewIscsiDisksClient()

--- a/sdk/resourcemanager/storsimple8000series/armstorsimple8000series/README.md
+++ b/sdk/resourcemanager/storsimple8000series/armstorsimple8000series/README.md
@@ -1,7 +1,5 @@
 # Azure Storsimple8000series Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storsimple8000series/armstorsimple8000series)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storsimple8000series/armstorsimple8000series)
-
 The `armstorsimple8000series` module provides operations for working with Azure Storsimple8000series.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/storsimple8000series/armstorsimple8000series)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storsimple8000serie
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Storsimple8000series.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Storsimple8000series. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstorsimple8000series.NewClientFactory(<subscription ID>
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewBackupsClient()

--- a/sdk/resourcemanager/streamanalytics/armstreamanalytics/README.md
+++ b/sdk/resourcemanager/streamanalytics/armstreamanalytics/README.md
@@ -1,7 +1,5 @@
 # Azure Stream Analytics Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/streamanalytics/armstreamanalytics/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/streamanalytics/armstreamanalytics/v2)
-
 The `armstreamanalytics` module provides operations for working with Azure Stream Analytics.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/streamanalytics/armstreamanalytics)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/streamanalytics/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Stream Analytics.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Stream Analytics. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armstreamanalytics.NewClientFactory(<subscription ID>, cre
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClustersClient()

--- a/sdk/resourcemanager/subscription/armsubscription/README.md
+++ b/sdk/resourcemanager/subscription/armsubscription/README.md
@@ -1,7 +1,5 @@
 # Azure Subscription Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription)
-
 The `armsubscription` module provides operations for working with Azure Subscription.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/subscription/armsubscription)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsub
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Subscription.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Subscription. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsubscription.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/support/armsupport/README.md
+++ b/sdk/resourcemanager/support/armsupport/README.md
@@ -1,7 +1,5 @@
 # Azure Support Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/support/armsupport)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/support/armsupport)
-
 The `armsupport` module provides operations for working with Azure Support.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/support/armsupport)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/support/armsupport
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Support.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Support. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsupport.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewChatTranscriptsClient()

--- a/sdk/resourcemanager/synapse/armsynapse/README.md
+++ b/sdk/resourcemanager/synapse/armsynapse/README.md
@@ -1,7 +1,5 @@
 # Azure Synapse Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse)
-
 The `armsynapse` module provides operations for working with Azure Synapse.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/synapse/armsynapse)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Synapse.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Synapse. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armsynapse.NewClientFactory(<subscription ID>, cred, &opti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewKustoPoolDataConnectionsClient()

--- a/sdk/resourcemanager/testbase/armtestbase/README.md
+++ b/sdk/resourcemanager/testbase/armtestbase/README.md
@@ -1,7 +1,5 @@
 # Azure Test Base for M365 Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/testbase/armtestbase)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/testbase/armtestbase)
-
 The `armtestbase` module provides operations for working with Azure Test Base for M365.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/testbase/armtestbase)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/testbase/armtestbas
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Test Base for M365.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Test Base for M365. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armtestbase.NewClientFactory(<subscription ID>, cred, &opt
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewEmailEventsClient()

--- a/sdk/resourcemanager/timeseriesinsights/armtimeseriesinsights/README.md
+++ b/sdk/resourcemanager/timeseriesinsights/armtimeseriesinsights/README.md
@@ -1,7 +1,5 @@
 # Azure Time Series Insights Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/timeseriesinsights/armtimeseriesinsights)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/timeseriesinsights/armtimeseriesinsights)
-
 The `armtimeseriesinsights` module provides operations for working with Azure Time Series Insights.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/timeseriesinsights/armtimeseriesinsights)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/timeseriesinsights/
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Time Series Insights.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Time Series Insights. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armtimeseriesinsights.NewClientFactory(<subscription ID>, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewEventSourcesClient()

--- a/sdk/resourcemanager/trafficmanager/armtrafficmanager/README.md
+++ b/sdk/resourcemanager/trafficmanager/armtrafficmanager/README.md
@@ -1,7 +1,5 @@
 # Azure Traffic Manager Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager)
-
 The `armtrafficmanager` module provides operations for working with Azure Traffic Manager.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/trafficmanager/armtrafficmanager)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armt
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Traffic Manager.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Traffic Manager. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armtrafficmanager.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewHeatMapClient()

--- a/sdk/resourcemanager/trustedsigning/armtrustedsigning/README.md
+++ b/sdk/resourcemanager/trustedsigning/armtrustedsigning/README.md
@@ -1,7 +1,5 @@
 # Azure Trustedsigning Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trustedsigning/armtrustedsigning)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trustedsigning/armtrustedsigning)
-
 The `armtrustedsigning` module provides operations for working with Azure Trustedsigning.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/trustedsigning/armtrustedsigning)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trustedsigning/armt
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Trustedsigning.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Trustedsigning. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armtrustedsigning.NewClientFactory(<subscription ID>, cred
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewCertificateProfilesClient()

--- a/sdk/resourcemanager/videoanalyzer/armvideoanalyzer/CHANGELOG.md
+++ b/sdk/resourcemanager/videoanalyzer/armvideoanalyzer/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
 ## 0.4.2 (2022-05-16)
-### Deprecated
+### Other Changes
+
 - We’re retiring the Azure Video Analyzer preview service; you're advised to transition your applications off of Video Analyzer by 01 December 2022. This SDK is no longer maintained and won’t work after the service is retired. To learn how to transition off, please refer to: https://github.com/MicrosoftDocs/azure-docs/blob/4ba87bedc7b17a32903c99afb3ca4163be0dcc90/articles/azure-video-analyzer/video-analyzer-docs/transition-from-video-analyzer.md.
+
 ## 0.4.0 (2022-04-18)
 ### Breaking Changes
 

--- a/sdk/resourcemanager/videoanalyzer/armvideoanalyzer/README.md
+++ b/sdk/resourcemanager/videoanalyzer/armvideoanalyzer/README.md
@@ -1,7 +1,5 @@
 # Azure Video Analyzer Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/videoanalyzer/armvideoanalyzer)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/videoanalyzer/armvideoanalyzer)
-
 The `armvideoanalyzer` module provides operations for working with Azure Video Analyzer.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/videoanalyzer/armvideoanalyzer)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/videoanalyzer/armvi
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Video Analyzer.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Video Analyzer. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -35,7 +33,7 @@ For more information on authentication, please see the documentation for `aziden
 
 ## Clients
 
-Azure Video Analyzer modules consist of one or more clients.  A client groups a set of related APIs, providing access to its functionality within the specified subscription.  Create one or more clients to access the APIs you require using your credential.
+Azure Video Analyzer modules consist of one or more clients. A client groups a set of related APIs, providing access to its functionality within the specified subscription. Create one or more clients to access the APIs you require using your credential.
 
 ```go
 client, err := armvideoanalyzer.NewVideoAnalyzersClient(<subscription ID>, cred, nil)

--- a/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder/README.md
+++ b/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder/README.md
@@ -1,7 +1,5 @@
 # Azure Virtual Machine Image Builder Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder/v2)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder/v2)
-
 The `armvirtualmachineimagebuilder` module provides operations for working with Azure Virtual Machine Image Builder.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/virtualmachineimagebuilder/armvirtualmachineimagebuilder)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/virtualmachineimage
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Virtual Machine Image Builder.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Virtual Machine Image Builder. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armvirtualmachineimagebuilder.NewClientFactory(<subscripti
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewTriggersClient()

--- a/sdk/resourcemanager/visualstudio/armvisualstudio/README.md
+++ b/sdk/resourcemanager/visualstudio/armvisualstudio/README.md
@@ -1,7 +1,5 @@
 # Azure Visual Studio Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/visualstudio/armvisualstudio)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/visualstudio/armvisualstudio)
-
 The `armvisualstudio` module provides operations for working with Azure Visual Studio.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/visualstudio/armvisualstudio)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/visualstudio/armvis
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Visual Studio.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Visual Studio. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armvisualstudio.NewClientFactory(<subscription ID>, cred, 
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewProjectsClient()

--- a/sdk/resourcemanager/vmwarecloudsimple/armvmwarecloudsimple/README.md
+++ b/sdk/resourcemanager/vmwarecloudsimple/armvmwarecloudsimple/README.md
@@ -1,7 +1,5 @@
 # Azure VMware Cloud Simple Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/vmwarecloudsimple/armvmwarecloudsimple)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/vmwarecloudsimple/armvmwarecloudsimple)
-
 The `armvmwarecloudsimple` module provides operations for working with Azure VMware Cloud Simple.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/vmwarecloudsimple/armvmwarecloudsimple)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/vmwarecloudsimple/a
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure VMware Cloud Simple.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure VMware Cloud Simple. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armvmwarecloudsimple.NewClientFactory(<subscription ID>, c
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewVirtualMachinesClient()

--- a/sdk/resourcemanager/voiceservices/armvoiceservices/README.md
+++ b/sdk/resourcemanager/voiceservices/armvoiceservices/README.md
@@ -1,7 +1,5 @@
 # Azure VoiceServices Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/voiceservices/armvoiceservices)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/voiceservices/armvoiceservices)
-
 The `armvoiceservices` module provides operations for working with Azure VoiceServices.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/voiceservices/armvoiceservices)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/voiceservices/armvo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure VoiceServices.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure VoiceServices. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -35,7 +33,7 @@ For more information on authentication, please see the documentation for `aziden
 
 ## Client Factory
 
-Azure VoiceServices module consists of one or more clients.  We provide a client factory which could be used to create any client in this module.
+Azure VoiceServices module consists of one or more clients. We provide a client factory which could be used to create any client in this module.
 
 ```go
 clientFactory, err := armvoiceservices.NewClientFactory(<subscription ID>, cred, nil)
@@ -54,7 +52,7 @@ clientFactory, err := armvoiceservices.NewClientFactory(<subscription ID>, cred,
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewTestLinesClient()

--- a/sdk/resourcemanager/webpubsub/armwebpubsub/README.md
+++ b/sdk/resourcemanager/webpubsub/armwebpubsub/README.md
@@ -1,7 +1,5 @@
 # Azure Web PubSub Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/webpubsub/armwebpubsub)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/webpubsub/armwebpubsub)
-
 The `armwebpubsub` module provides operations for working with Azure Web PubSub.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/webpubsub/armwebpubsub)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/webpubsub/armwebpub
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Web PubSub.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Web PubSub. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armwebpubsub.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewClient()

--- a/sdk/resourcemanager/windowsesu/armwindowsesu/README.md
+++ b/sdk/resourcemanager/windowsesu/armwindowsesu/README.md
@@ -1,7 +1,5 @@
 # Azure Windows ESU Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/windowsesu/armwindowsesu)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/windowsesu/armwindowsesu)
-
 The `armwindowsesu` module provides operations for working with Azure Windows ESU.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/windowsesu/armwindowsesu)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/windowsesu/armwindo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Windows ESU.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Windows ESU. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armwindowsesu.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewMultipleActivationKeysClient()

--- a/sdk/resourcemanager/windowsiot/armwindowsiot/README.md
+++ b/sdk/resourcemanager/windowsiot/armwindowsiot/README.md
@@ -1,7 +1,5 @@
 # Azure Windows IoT Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/windowsiot/armwindowsiot)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/windowsiot/armwindowsiot)
-
 The `armwindowsiot` module provides operations for working with Azure Windows IoT.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/windowsiot/armwindowsiot)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/windowsiot/armwindo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Windows IoT.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Windows IoT. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armwindowsiot.NewClientFactory(<subscription ID>, cred, &o
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewServicesClient()

--- a/sdk/resourcemanager/workloadmonitor/armworkloadmonitor/CHANGELOG.md
+++ b/sdk/resourcemanager/workloadmonitor/armworkloadmonitor/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.5.1 (2022-11-23)
+### Other Changes
 
 Deprecated: The service backing this library is retired on November 30th, 2022. At that point, this library will no longer work. Please migrate to Azure Monitor Log Alerts API in module github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor.
 For more details on the Azure VM Insights Guest Health retirement, please visit: https://azure.microsoft.com/updates/transition-to-azure-monitor-log-alerts-for-vm-guest-health-by-30-november-2022

--- a/sdk/resourcemanager/workloadmonitor/armworkloadmonitor/README.md
+++ b/sdk/resourcemanager/workloadmonitor/armworkloadmonitor/README.md
@@ -3,8 +3,6 @@
 Deprecated: The service backing this library is retired on November 30th, 2022. At that point, this library will no longer work. Please migrate to Azure Monitor Log Alerts API in module github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor.
 For more details on the Azure VM Insights Guest Health retirement, please visit: https://azure.microsoft.com/updates/transition-to-azure-monitor-log-alerts-for-vm-guest-health-by-30-november-2022
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloadmonitor/armworkloadmonitor)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloadmonitor/armworkloadmonitor)
-
 The `armworkloadmonitor` module provides operations for working with Azure Workload Monitor.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/workloadmonitor/armworkloadmonitor)
@@ -28,7 +26,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloadmonitor/arm
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Workload Monitor.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Workload Monitor. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -38,7 +36,7 @@ For more information on authentication, please see the documentation for `aziden
 
 ## Clients
 
-Azure Workload Monitor modules consist of one or more clients.  A client groups a set of related APIs, providing access to its functionality within the specified subscription.  Create one or more clients to access the APIs you require using your credential.
+Azure Workload Monitor modules consist of one or more clients. A client groups a set of related APIs, providing access to its functionality within the specified subscription. Create one or more clients to access the APIs you require using your credential.
 
 ```go
 client, err := armworkloadmonitor.NewHealthMonitorsClient(<subscription ID>, cred, nil)

--- a/sdk/resourcemanager/workloads/armworkloads/README.md
+++ b/sdk/resourcemanager/workloads/armworkloads/README.md
@@ -1,7 +1,5 @@
 # Azure Workloads Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloads/armworkloads)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloads/armworkloads)
-
 The `armworkloads` module provides operations for working with Azure Workloads.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/workloads/armworkloads)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloads/armworklo
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Workloads.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Workloads. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armworkloads.NewClientFactory(<subscription ID>, cred, &op
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewProviderInstancesClient()
@@ -66,7 +64,6 @@ The fake package contains types used for constructing in-memory fake servers use
 This allows writing tests to cover various success/error conditions without the need for connecting to a live service.
 
 Please see https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes for details and examples on how to use fakes.
-
 
 ## Provide Feedback
 

--- a/sdk/resourcemanager/workloadssapvirtualinstance/armworkloadssapvirtualinstance/CHANGELOG.md
+++ b/sdk/resourcemanager/workloadssapvirtualinstance/armworkloadssapvirtualinstance/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.1.0 (2024-02-23)
+### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloadssapvirtualinstance/armworkloadssapvirtualinstance` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 

--- a/sdk/resourcemanager/workloadssapvirtualinstance/armworkloadssapvirtualinstance/README.md
+++ b/sdk/resourcemanager/workloadssapvirtualinstance/armworkloadssapvirtualinstance/README.md
@@ -1,7 +1,5 @@
 # Azure Workloadssapvirtualinstance Module for Go
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloadssapvirtualinstance/armworkloadssapvirtualinstance)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloadssapvirtualinstance/armworkloadssapvirtualinstance)
-
 The `armworkloadssapvirtualinstance` module provides operations for working with Azure Workloadssapvirtualinstance.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/workloadssapvirtualinstance/armworkloadssapvirtualinstance)
@@ -25,7 +23,7 @@ go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloadssapvirtual
 
 ## Authorization
 
-When creating a client, you will need to provide a credential for authenticating with Azure Workloadssapvirtualinstance.  The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
+When creating a client, you will need to provide a credential for authenticating with Azure Workloadssapvirtualinstance. The `azidentity` module provides facilities for various ways of authenticating with Azure including client/secret, certificate, managed identity, and more.
 
 ```go
 cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -54,7 +52,7 @@ clientFactory, err := armworkloadssapvirtualinstance.NewClientFactory(<subscript
 
 ## Clients
 
-A client groups a set of related APIs, providing access to its functionality.  Create one or more clients to access the APIs you require using client factory.
+A client groups a set of related APIs, providing access to its functionality. Create one or more clients to access the APIs you require using client factory.
 
 ```go
 client := clientFactory.NewSAPApplicationServerInstancesClient()


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go

Problem facing:
We have a package link in all our Go SDK packages’ readme.md file. This link is designed to let customers easy to visit the package page in pkg.go.dev from the source code repo.
Also, we have a ci verification that will check if each link in the doc file is valid. Then the problem came. When we release the first beta or any first major version (v2+), the link page is not available before the release tag has been added.
So, in PR or even release pipeline, the ci job will fail.

Decision:
After discussion, we decided to remove the link based on the fact that the link provides minimal value.

Other changes in this PR are from auto-format of md file.
