### PR TITLE
Azcore separate tracer

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Features Added
 
+* `Client` has a new method called `WithCoreTracerName` that can be used by consumers that wish to have the azcore http tracer's module name and version set to azcore's values instead of the consumer modules values
+
 ### Breaking Changes
+
+* `tracing.NewProvider`'s `newTracerFn` and `Provider.NewTracer` now take a schemaURL for their 3rd argument.
 
 ### Bugs Fixed
 

--- a/sdk/azcore/arm/client.go
+++ b/sdk/azcore/arm/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 )
 
 // ClientOptions contains configuration settings for a client's pipeline.
@@ -52,7 +53,7 @@ func NewClient(moduleName, moduleVersion string, cred azcore.TokenCredential, op
 		return nil, err
 	}
 
-	tr := options.TracingProvider.NewTracer(moduleName, moduleVersion)
+	tr := options.TracingProvider.NewTracer(moduleName, moduleVersion, semconv.SchemaURL)
 	return &Client{ep: ep, pl: pl, tr: tr}, nil
 }
 

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 )
 
 // AccessToken represents an Azure service bearer access token with expiry information.
@@ -137,7 +138,7 @@ func NewClient(moduleName, moduleVersion string, plOpts runtime.PipelineOptions,
 
 	pl := runtime.NewPipeline(moduleName, moduleVersion, plOpts, options)
 
-	tr := options.TracingProvider.NewTracer(moduleName, moduleVersion)
+	tr := options.TracingProvider.NewTracer(moduleName, moduleVersion, semconv.SchemaURL)
 	if tr.Enabled() && plOpts.Tracing.Namespace != "" {
 		tr.SetAttributes(tracing.Attribute{Key: shared.TracingNamespaceAttrName, Value: plOpts.Tracing.Namespace})
 	}
@@ -165,7 +166,7 @@ func (c *Client) Tracer() tracing.Tracer {
 // Note that the values for module name and version will be preserved from the source Client.
 //   - clientName - the fully qualified name of the client ("package.Client"); this is used by the tracing provider when creating spans
 func (c *Client) WithClientName(clientName string) *Client {
-	tr := c.tp.NewTracer(clientName, c.modVer)
+	tr := c.tp.NewTracer(clientName, c.modVer, semconv.SchemaURL)
 	if tr.Enabled() && c.namespace != "" {
 		tr.SetAttributes(tracing.Attribute{Key: shared.TracingNamespaceAttrName, Value: c.namespace})
 	}
@@ -178,7 +179,7 @@ func (c *Client) WithClientName(clientName string) *Client {
 // Note that the values for module name and version will be preserved from the source Client for use in the
 // HTTP UserAgent Header set by TelemetryPolicy
 func (c *Client) WithCoreTracerName() *Client {
-	tr := c.tp.NewTracer(shared.Module, shared.Version)
+	tr := c.tp.NewTracer(shared.Module, shared.Version, semconv.SchemaURL)
 	if tr.Enabled() && c.namespace != "" {
 		tr.SetAttributes(tracing.Attribute{Key: shared.TracingNamespaceAttrName, Value: c.namespace})
 	}

--- a/sdk/azcore/core.go
+++ b/sdk/azcore/core.go
@@ -171,3 +171,16 @@ func (c *Client) WithClientName(clientName string) *Client {
 	}
 	return &Client{pl: c.pl, tr: tr, tp: c.tp, modVer: c.modVer, namespace: c.namespace}
 }
+
+// WithCoreName returns a shallow copy of the Client with its tracing client name changed to use azcore's module name and version.
+// This is intended for library consumers that want to have their own named tracer for client activities that are
+// Seperate from the Core HTTP tracing.
+// Note that the values for module name and version will be preserved from the source Client for use in the
+// HTTP UserAgent Header set by TelemetryPolicy
+func (c *Client) WithCoreTracerName() *Client {
+	tr := c.tp.NewTracer(shared.Module, shared.Version)
+	if tr.Enabled() && c.namespace != "" {
+		tr.SetAttributes(tracing.Attribute{Key: shared.TracingNamespaceAttrName, Value: c.namespace})
+	}
+	return &Client{pl: c.pl, tr: tr, tp: c.tp, modVer: c.modVer, namespace: c.namespace}
+}

--- a/sdk/azcore/core_test.go
+++ b/sdk/azcore/core_test.go
@@ -220,6 +220,59 @@ func TestClientWithClientName(t *testing.T) {
 	require.EqualValues(t, "az.namespace:Widget.Factory", attrString)
 }
 
+func TestClientWithCoreName(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+
+	var clientName string
+	var modVersion string
+	var attrString string
+	client, err := NewClient("module", "v1.0.0", runtime.PipelineOptions{
+		Tracing: runtime.TracingOptions{
+			Namespace: "Widget.Factory",
+		},
+	}, &policy.ClientOptions{
+		TracingProvider: tracing.NewProvider(func(name, version string) tracing.Tracer {
+			clientName = name
+			modVersion = version
+			return tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {
+				require.NotNil(t, options)
+				for _, attr := range options.Attributes {
+					if attr.Key == shared.TracingNamespaceAttrName {
+						v, ok := attr.Value.(string)
+						require.True(t, ok)
+						attrString = attr.Key + ":" + v
+					}
+				}
+				return ctx, tracing.Span{}
+			}, nil)
+		}, nil),
+		Transport: srv,
+	})
+	newClient := client.WithCoreTracerName()
+	require.NoError(t, err)
+	require.NotNil(t, newClient)
+	require.NotZero(t, newClient.Pipeline())
+	require.NotZero(t, newClient.Tracer())
+	require.EqualValues(t, client.Pipeline(), newClient.Pipeline())
+
+	// Tracer's name and version are set to azcore's module and version
+	require.EqualValues(t, shared.Module, clientName)
+	require.EqualValues(t, shared.Version, modVersion)
+
+	const requestEndpoint = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fakeResourceGroupo/providers/Microsoft.Storage/storageAccounts/fakeAccountName"
+	req, err := exported.NewRequest(context.WithValue(context.Background(), shared.CtxWithTracingTracer{}, client.Tracer()), http.MethodGet, srv.URL()+requestEndpoint)
+	require.NoError(t, err)
+	srv.SetResponse()
+	_, err = newClient.Pipeline().Do(req)
+	require.NoError(t, err)
+	require.EqualValues(t, "az.namespace:Widget.Factory", attrString)
+
+	// HTTP User agent is still set to calling module's name and version
+	ua := req.Raw().Header.Get(shared.HeaderUserAgent)
+	require.Contains(t, ua, "azsdk-go-module/v1.0.0")
+}
+
 func TestNewKeyCredential(t *testing.T) {
 	require.NotNil(t, NewKeyCredential("foo"))
 }

--- a/sdk/azcore/core_test.go
+++ b/sdk/azcore/core_test.go
@@ -138,7 +138,7 @@ func TestNewClientTracingEnabled(t *testing.T) {
 			Namespace: "Widget.Factory",
 		},
 	}, &policy.ClientOptions{
-		TracingProvider: tracing.NewProvider(func(name, version string) tracing.Tracer {
+		TracingProvider: tracing.NewProvider(func(name, version, schemaURL string) tracing.Tracer {
 			return tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {
 				require.NotNil(t, options)
 				for _, attr := range options.Attributes {
@@ -179,7 +179,7 @@ func TestClientWithClientName(t *testing.T) {
 			Namespace: "Widget.Factory",
 		},
 	}, &policy.ClientOptions{
-		TracingProvider: tracing.NewProvider(func(name, version string) tracing.Tracer {
+		TracingProvider: tracing.NewProvider(func(name, version, schemaURL string) tracing.Tracer {
 			clientName = name
 			modVersion = version
 			return tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {
@@ -232,7 +232,7 @@ func TestClientWithCoreName(t *testing.T) {
 			Namespace: "Widget.Factory",
 		},
 	}, &policy.ClientOptions{
-		TracingProvider: tracing.NewProvider(func(name, version string) tracing.Tracer {
+		TracingProvider: tracing.NewProvider(func(name, version, schemaURL string) tracing.Tracer {
 			clientName = name
 			modVersion = version
 			return tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0
 	github.com/stretchr/testify v1.9.0
+	go.opentelemetry.io/otel v1.14.0
 	golang.org/x/net v0.29.0
 )
 

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -3,6 +3,7 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -11,6 +12,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.opentelemetry.io/otel v1.14.0 h1:/79Huy8wbf5DnIPhemGB+zEPVwnN6fuQybr/SRXa6hM=
+go.opentelemetry.io/otel v1.14.0/go.mod h1:o4buv+dJzx8rohcUeRmWUZhqupFvzWis188WlggnNeU=
 golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
 golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=

--- a/sdk/azcore/tracing/tracing.go
+++ b/sdk/azcore/tracing/tracing.go
@@ -19,7 +19,7 @@ type ProviderOptions struct {
 // NewProvider creates a new Provider with the specified values.
 //   - newTracerFn is the underlying implementation for creating Tracer instances
 //   - options contains optional values; pass nil to accept the default value
-func NewProvider(newTracerFn func(name, version string) Tracer, options *ProviderOptions) Provider {
+func NewProvider(newTracerFn func(name, version, schemaURL string) Tracer, options *ProviderOptions) Provider {
 	return Provider{
 		newTracerFn: newTracerFn,
 	}
@@ -28,15 +28,16 @@ func NewProvider(newTracerFn func(name, version string) Tracer, options *Provide
 // Provider is the factory that creates Tracer instances.
 // It defaults to a no-op provider.
 type Provider struct {
-	newTracerFn func(name, version string) Tracer
+	newTracerFn func(name, version, schemaURL string) Tracer
 }
 
 // NewTracer creates a new Tracer for the specified module name and version.
 //   - module - the fully qualified name of the module
 //   - version - the version of the module
-func (p Provider) NewTracer(module, version string) (tracer Tracer) {
+//   - schemaURL - the url for the schema used for the tracing span names
+func (p Provider) NewTracer(module, version, schemaURL string) (tracer Tracer) {
 	if p.newTracerFn != nil {
-		tracer = p.newTracerFn(module, version)
+		tracer = p.newTracerFn(module, version, schemaURL)
 	}
 	return
 }

--- a/sdk/azcore/tracing/tracing_test.go
+++ b/sdk/azcore/tracing/tracing_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestProviderZeroValues(t *testing.T) {
 	pr := Provider{}
-	tr := pr.NewTracer("name", "version")
+	tr := pr.NewTracer("name", "version", "")
 	require.Zero(t, tr)
 	require.False(t, tr.Enabled())
 	tr.SetAttributes()
@@ -37,7 +37,7 @@ func TestProvider(t *testing.T) {
 	var setStatusCalled bool
 	var spanFromContextCalled bool
 
-	pr := NewProvider(func(name, version string) Tracer {
+	pr := NewProvider(func(name, version, schemaURL string) Tracer {
 		return NewTracer(func(context.Context, string, *SpanOptions) (context.Context, Span) {
 			return nil, NewSpan(SpanImpl{
 				AddEvent:      func(string, ...Attribute) { addEventCalled = true },
@@ -52,7 +52,7 @@ func TestProvider(t *testing.T) {
 			},
 		})
 	}, nil)
-	tr := pr.NewTracer("name", "version")
+	tr := pr.NewTracer("name", "version", "")
 	require.NotZero(t, tr)
 	require.True(t, tr.Enabled())
 	sp := tr.SpanFromContext(context.Background())


### PR DESCRIPTION
- Fixes https://github.com/Azure/azure-sdk-for-go/issues/23307

- This PR allows a schemaURL to be passed to the NewTracer function so that consumers can create tracers that use a different schemaURL than azcore.
- It updates azcore to use the otel semconv package that sets a schemaURL and then uses the semconv Constances for the span keys that have defined semconv keys.

This PR also adds a `WithCoreTracerName` function to the azcore client so the consumers that do want to do custom tracing can make azcore using azcore's module name and version for the HTTP tracing, and their own module name and version for their portion of the tracing. Using `WithCoreTracerName` only changes the values used for tracing to azcore values, it still leaves the passed in module name and version for use with the HTTP User Agent header.

I chose this approach because it looks like many of the consumers of this client 

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
