### PR TITLE
Add zos support to storage/azblob

### DIFF
--- a/sdk/storage/azblob/internal/shared/mmf_unix.go
+++ b/sdk/storage/azblob/internal/shared/mmf_unix.go
@@ -1,6 +1,6 @@
-//go:build go1.18 && (linux || darwin || dragonfly || freebsd || openbsd || netbsd || solaris || aix)
+//go:build go1.18 && (linux || darwin || dragonfly || freebsd || openbsd || netbsd || solaris || aix || zos)
 // +build go1.18
-// +build linux darwin dragonfly freebsd openbsd netbsd solaris aix
+// +build linux darwin dragonfly freebsd openbsd netbsd solaris aix zos
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

Add support for zos to storage/azblob. This is mainly to enable building modules that depend on the azure-sdk module in some capacity.

Due to hardware requirements tests are not updated.


- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
