### PR TITLE
Add OperationLocationResultPath to NewPollerOptions[T]

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added field `OperationLocationResultPath` to `runtime.NewPollerOptions[T]` for LROs that use the `Operation-Location` pattern.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -50,7 +50,13 @@ const (
 // NewPollerOptions contains the optional parameters for NewPoller.
 type NewPollerOptions[T any] struct {
 	// FinalStateVia contains the final-state-via value for the LRO.
+	// NOTE: used only for Azure-AsyncOperation and Operation-Location LROs.
 	FinalStateVia FinalStateVia
+
+	// OperationLocationResultPath contains the JSON path to the result's
+	// payload when it's included with the terminal success response.
+	// NOTE: only used for Operation-Location LROs.
+	OperationLocationResultPath string
 
 	// Response contains a preconstructed response type.
 	// The final payload will be unmarshaled into it and returned.
@@ -98,7 +104,7 @@ func NewPoller[T any](resp *http.Response, pl exported.Pipeline, options *NewPol
 		opr, err = async.New[T](pl, resp, options.FinalStateVia)
 	} else if op.Applicable(resp) {
 		// op poller must be checked before loc as it can also have a location header
-		opr, err = op.New[T](pl, resp, options.FinalStateVia)
+		opr, err = op.New[T](pl, resp, options.FinalStateVia, options.OperationLocationResultPath)
 	} else if loc.Applicable(resp) {
 		opr, err = loc.New[T](pl, resp)
 	} else if body.Applicable(resp) {
@@ -172,7 +178,7 @@ func NewPollerFromResumeToken[T any](token string, pl exported.Pipeline, options
 	} else if loc.CanResume(asJSON) {
 		opr, _ = loc.New[T](pl, nil)
 	} else if op.CanResume(asJSON) {
-		opr, _ = op.New[T](pl, nil, "")
+		opr, _ = op.New[T](pl, nil, "", "")
 	} else {
 		return nil, fmt.Errorf("unhandled poller token %s", string(raw))
 	}

--- a/sdk/azcore/runtime/poller_test.go
+++ b/sdk/azcore/runtime/poller_test.go
@@ -514,7 +514,9 @@ func TestOpPollerWithWidgetPOST(t *testing.T) {
 		},
 	}
 	pl := newTestPipeline(&policy.ClientOptions{Transport: srv})
-	lro, err := NewPoller[widget](firstResp, pl, nil)
+	lro, err := NewPoller(firstResp, pl, &NewPollerOptions[widget]{
+		OperationLocationResultPath: "result",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The result path must be configurable instead of hard-coded to result.
