### PR TITLE
[azopenaiextensions] Remove the "next page" paging which breaks when assistants are (legit…

### DIFF
--- a/sdk/ai/azopenaiextensions/client_assistants_test.go
+++ b/sdk/ai/azopenaiextensions/client_assistants_test.go
@@ -67,15 +67,6 @@ func TestAssistants(t *testing.T) {
 
 			var pages []openai.Assistant = pager.Data
 			require.NotEmpty(t, pages)
-
-			page, err := pager.GetNextPage()
-			require.NoError(t, err)
-
-			if page != nil { // a nil page indicates we've read all pages.
-				pages = append(pages, page.Data...)
-			}
-
-			require.NotEmpty(t, pages)
 		}
 	}
 

--- a/sdk/ai/azopenaiextensions/client_assistants_test.go
+++ b/sdk/ai/azopenaiextensions/client_assistants_test.go
@@ -37,6 +37,18 @@ func TestAssistants(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		junkAssistant, err := assistantClient.New(context.Background(), openai.BetaAssistantNewParams{
+			Model:        openai.F(azureOpenAI.Assistants.Model),
+			Instructions: openai.String("Answer questions in any manner possible"),
+		})
+		require.NoError(t, err)
+
+		// ensure there's at least one assistant "after" what we request
+		t.Cleanup(func() {
+			_, err := assistantClient.Delete(context.Background(), junkAssistant.ID)
+			require.NoError(t, err)
+		})
+
 		const desc = "This is a newly updated description"
 
 		// update the assistant's description

--- a/sdk/ai/azopenaiextensions/client_shared_test.go
+++ b/sdk/ai/azopenaiextensions/client_shared_test.go
@@ -201,15 +201,15 @@ func newStainlessTestClientWithOptions(t *testing.T, ep endpoint, options *stain
 		return nil
 	}
 
-	tokenCredential, err := credential.New(nil)
-	require.NoError(t, err)
-
 	if options != nil && options.UseAPIKey {
 		return openai.NewClient(
 			azure.WithEndpoint(ep.URL, apiVersion),
 			azure.WithAPIKey(ep.APIKey),
 		)
 	}
+
+	tokenCredential, err := credential.New(nil)
+	require.NoError(t, err)
 
 	return openai.NewClient(
 		azure.WithEndpoint(ep.URL, apiVersion),


### PR DESCRIPTION
This is not a problem in our code, that I can see - it's just a hazard of having a paging API sees state from other tests that are running, so it can be removed at any time as those tests tear down.