### PR TITLE
Specify resources and OS for ACI managed identity test

### DIFF
--- a/sdk/azidentity/test-resources-post.ps1
+++ b/sdk/azidentity/test-resources-post.ps1
@@ -71,6 +71,9 @@ $aciName = "azidentity-test"
 az container create -g $rg -n $aciName --image $image `
   --acr-identity $($DeploymentOutputs['AZIDENTITY_USER_ASSIGNED_IDENTITY']) `
   --assign-identity [system] $($DeploymentOutputs['AZIDENTITY_USER_ASSIGNED_IDENTITY']) `
+  --cpu 1 `
+  --memory 1.0 `
+  --os-type Linux `
   --role "Storage Blob Data Reader" `
   --scope $($DeploymentOutputs['AZIDENTITY_STORAGE_ID']) `
   -e AZIDENTITY_STORAGE_NAME=$($DeploymentOutputs['AZIDENTITY_STORAGE_NAME']) `


### PR DESCRIPTION
These are apparently required by the service version specified by the Azure CLI version used in CI