### PR TITLE
Allow data plane module paths

### DIFF
--- a/eng/tools/generator/typespec/typespec-go.go
+++ b/eng/tools/generator/typespec/typespec-go.go
@@ -42,11 +42,16 @@ func NewGoEmitterOptions(emitOption any) (*GoEmitterOptions, error) {
 	return &option, err
 }
 
-const moduleRegex = `^github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/(\w+)/arm(\w+)$`
+const moduleRegex = `^github.com/Azure/azure-sdk-for-go/sdk/` +
+	`(` +
+	`resourcemanager/\w+/arm\w+` + // either an ARM package (ie: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus)
+	`|` +
+	`.+?/az[^/]+` + // or a data plane package (ie, github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces)
+	`)$`
 
 var (
 	ErrModuleEmpty  = errors.New("typesepec-go option `module` is required")
-	ErrModuleFormat = errors.New("module must be in the format of github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/xxx/armxxx")
+	ErrModuleFormat = errors.New("module must be in the format of github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/xxx/armxxx or github.com/Azure/azure-sdk-for-go/sdk/xxx/azxxx")
 )
 
 func (o *GoEmitterOptions) Validate() error {

--- a/eng/tools/generator/typespec/typespec-go_test.go
+++ b/eng/tools/generator/typespec/typespec-go_test.go
@@ -7,6 +7,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGoEmitterOptionsAreValid(t *testing.T) {
+	modules := []string{
+		"github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces",
+		"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus",
+	}
+
+	for _, module := range modules {
+		t.Run("Check "+module, func(t *testing.T) {
+			// module format is correct
+			goOption := map[string]any{
+				"module": module,
+			}
+			goEmitOptions, err := typespec.NewGoEmitterOptions(goOption)
+			assert.NoError(t, err)
+			err = goEmitOptions.Validate()
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestGoEmitterOptionsValidate(t *testing.T) {
 	goOption := map[string]any{
 		"module": "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/xxx/armxxx",


### PR DESCRIPTION
(NOTE: I'm not sure if this is the true home for this code, or just a copy - please advise!)

Data plane module paths don't include `resourcemanager` and `arm`, so they were failing the previous regex. I modified it to allow both types, and, if it's data plane, to allow 'az' as the prefix.

This was causing a build failure for me here: https://github.com/Azure/azure-rest-api-specs/pull/31719/checks?check_run_id=33822699487
