### PR TITLE
[azservicebus/azeventhubs] Enable custom endpoints, which allows our library to be used with TCP proxies

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.2.4 (Unreleased)
+## 1.3.0 (Unreleased)
 
 ### Features Added
+
+- ProducerClient and ConsumerClient allow the endpoint to be overridden with CustomEndpoint, allowing the use of TCP proxies with AMQP.
 
 ### Breaking Changes
 

--- a/sdk/messaging/azeventhubs/consumer_client.go
+++ b/sdk/messaging/azeventhubs/consumer_client.go
@@ -20,6 +20,9 @@ type ConsumerClientOptions struct {
 	// ApplicationID is used as the identifier when setting the User-Agent property.
 	ApplicationID string
 
+	// A custom endpoint address that can be used when establishing the connection to the service.
+	CustomEndpoint string
+
 	// InstanceID is a unique name used to identify the consumer. This can help with
 	// diagnostics as this name will be returned in error messages. By default,
 	// an identifier will be automatically generated.
@@ -230,6 +233,10 @@ func newConsumerClient(args consumerClientArgs, options *ConsumerClientOptions) 
 
 	if options.ApplicationID != "" {
 		nsOptions = append(nsOptions, internal.NamespaceWithUserAgent(options.ApplicationID))
+	}
+
+	if options.CustomEndpoint != "" {
+		nsOptions = append(nsOptions, internal.NamespaceWithCustomEndpoint(options.CustomEndpoint))
 	}
 
 	nsOptions = append(nsOptions, internal.NamespaceWithRetryOptions(options.RetryOptions))

--- a/sdk/messaging/azeventhubs/example_consumerclient_test.go
+++ b/sdk/messaging/azeventhubs/example_consumerclient_test.go
@@ -151,3 +151,22 @@ func ExampleConsumerClient_NewPartitionClient_configuringPrefetch() {
 		fmt.Printf("Body: %s\n", string(evt.Body))
 	}
 }
+
+func ExampleNewConsumerClient_usingCustomEndpoint() {
+	// `DefaultAzureCredential` tries several common credential types. For more credential types
+	// see this link: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-credential-types.
+	defaultAzureCred, err := azidentity.NewDefaultAzureCredential(nil)
+
+	if err != nil {
+		panic(err)
+	}
+
+	consumerClient, err = azeventhubs.NewConsumerClient("<ex: myeventhubnamespace.servicebus.windows.net>", "eventhub-name", azeventhubs.DefaultConsumerGroup, defaultAzureCred, &azeventhubs.ConsumerClientOptions{
+		// A custom endpoint can be used when you need to connect to a TCP proxy.
+		CustomEndpoint: "<address/hostname of TCP proxy>",
+	})
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/sdk/messaging/azeventhubs/example_producerclient_test.go
+++ b/sdk/messaging/azeventhubs/example_producerclient_test.go
@@ -180,3 +180,22 @@ func ExampleProducerClient_GetPartitionProperties() {
 	fmt.Printf("First sequence number for partition ID %s: %d\n", partitionProps.PartitionID, partitionProps.BeginningSequenceNumber)
 	fmt.Printf("Last sequence number for partition ID %s: %d\n", partitionProps.PartitionID, partitionProps.LastEnqueuedSequenceNumber)
 }
+
+func ExampleNewProducerClient_usingCustomEndpoint() {
+	// `DefaultAzureCredential` tries several common credential types. For more credential types
+	// see this link: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-credential-types.
+	defaultAzureCred, err := azidentity.NewDefaultAzureCredential(nil)
+
+	if err != nil {
+		panic(err)
+	}
+
+	producerClient, err = azeventhubs.NewProducerClient("<ex: myeventhubnamespace.servicebus.windows.net>", "eventhub-name", defaultAzureCred, &azeventhubs.ProducerClientOptions{
+		// A custom endpoint can be used when you need to connect to a TCP proxy.
+		CustomEndpoint: "<address/hostname of TCP proxy>",
+	})
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/sdk/messaging/azeventhubs/internal/constants.go
+++ b/sdk/messaging/azeventhubs/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.2.4"
+const Version = "v1.3.0"

--- a/sdk/messaging/azeventhubs/producer_client.go
+++ b/sdk/messaging/azeventhubs/producer_client.go
@@ -31,6 +31,9 @@ type ProducerClientOptions struct {
 	// Application ID that will be passed to the namespace.
 	ApplicationID string
 
+	// A custom endpoint address that can be used when establishing the connection to the service.
+	CustomEndpoint string
+
 	// NewWebSocketConn is a function that can create a net.Conn for use with websockets.
 	// For an example, see ExampleNewClient_usingWebsockets() function in example_client_test.go.
 	NewWebSocketConn func(ctx context.Context, params WebSocketConnParams) (net.Conn, error)
@@ -259,6 +262,10 @@ func newProducerClientImpl(creds producerClientCreds, options *ProducerClientOpt
 
 		if options.ApplicationID != "" {
 			nsOptions = append(nsOptions, internal.NamespaceWithUserAgent(options.ApplicationID))
+		}
+
+		if options.CustomEndpoint != "" {
+			nsOptions = append(nsOptions, internal.NamespaceWithCustomEndpoint(options.CustomEndpoint))
 		}
 
 		nsOptions = append(nsOptions, internal.NamespaceWithRetryOptions(options.RetryOptions))

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.7.4 (Unreleased)
+## 1.8.0 (Unreleased)
 
 ### Features Added
+
+- Client allows the endpoint to be overridden with CustomEndpoint, allowing the use of TCP proxies with AMQP.
 
 ### Breaking Changes
 

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -49,6 +49,9 @@ type ClientOptions struct {
 	// Application ID that will be passed to the namespace.
 	ApplicationID string
 
+	// A custom endpoint address that can be used when establishing the connection to the service.
+	CustomEndpoint string
+
 	// NewWebSocketConn is a function that can create a net.Conn for use with websockets.
 	// For an example, see ExampleNewClient_usingWebsockets() function in example_client_test.go.
 	NewWebSocketConn func(ctx context.Context, args NewWebSocketConnArgs) (net.Conn, error)
@@ -158,6 +161,10 @@ func newClientImpl(creds clientCreds, args clientImplArgs) (*Client, error) {
 
 		if args.ClientOptions.ApplicationID != "" {
 			nsOptions = append(nsOptions, internal.NamespaceWithUserAgent(args.ClientOptions.ApplicationID))
+		}
+
+		if args.ClientOptions.CustomEndpoint != "" {
+			nsOptions = append(nsOptions, internal.NamespaceWithCustomEndpoint(args.ClientOptions.CustomEndpoint))
 		}
 
 		nsOptions = append(nsOptions, internal.NamespaceWithRetryOptions(args.ClientOptions.RetryOptions))

--- a/sdk/messaging/azservicebus/example_client_test.go
+++ b/sdk/messaging/azservicebus/example_client_test.go
@@ -90,6 +90,28 @@ func Example_enablingLogging() {
 	)
 }
 
+func ExampleNewClient_usingCustomEndpoint() {
+	// NOTE: If you'd like to authenticate using a Service Bus connection string
+	// look at `NewClientFromConnectionString` instead.
+
+	// `DefaultAzureCredential` tries several common credential types. For more credential types
+	// see this link: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-credential-types.
+	credential, err := azidentity.NewDefaultAzureCredential(nil)
+
+	if err != nil {
+		panic(err)
+	}
+
+	client, err = azservicebus.NewClient("<ex: myservicebus.servicebus.windows.net>", credential, &azservicebus.ClientOptions{
+		// A custom endpoint can be used when you need to connect to a TCP proxy.
+		CustomEndpoint: "<address/hostname of TCP proxy>",
+	})
+
+	if err != nil {
+		panic(err)
+	}
+}
+
 // fakes for examples
 var endpoint string
 var tokenCredential azcore.TokenCredential

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.7.4"
+const Version = "v1.8.0"


### PR DESCRIPTION
This is a feature that .NET has, and it's handy for when you need to route your TCP traffic through a proxy. It also enables some testing scenarios.

APIViews:
- azservicebus: https://apiview.dev/Assemblies/Review/0579bbe5a2324f17a48f1a2bca2ff383?revisionId=e548a02147214107802f26ba47e2a9bf&diffOnly=True&doc=False&diffRevisionId=868bd2a67e9641a3bad83fb66cde2dc4
- azeventhubs: https://apiview.dev/Assemblies/Review/e1445c654ad0416c821be30b02dc445c/3c935256189a453ead108bc9fd3ec9f2?diffRevisionId=51318a1ab3b44f2486db3d3f860834f1&doc=False&diffOnly=True