### PR TITLE
Fixing ModuleName to be compliant with the standard

### DIFF
--- a/sdk/messaging/eventgrid/azeventgrid/internal/version.go
+++ b/sdk/messaging/eventgrid/azeventgrid/internal/version.go
@@ -6,7 +6,7 @@ package internal
 // Constants to identify the module
 const (
 	// ModuleName is the module name that shows in telemetry.
-	ModuleName = "azeventgrid"
+	ModuleName = "github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azeventgrid"
 
 	// ModuleVersion is the semantic version (see http://semver.org) of this module.
 	ModuleVersion = "v1.0.1"

--- a/sdk/messaging/eventgrid/aznamespaces/internal/version.go
+++ b/sdk/messaging/eventgrid/aznamespaces/internal/version.go
@@ -11,7 +11,7 @@ package internal
 // Constants to identify the module
 const (
 	// ModuleName is the module name that shows in telemetry.
-	ModuleName = "aznamespaces"
+	ModuleName = "github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces"
 
 	// ModuleVersion is the semantic version (see http://semver.org) of this module.
 	ModuleVersion = "v1.0.1"

--- a/sdk/messaging/eventgrid/azsystemevents/internal/version.go
+++ b/sdk/messaging/eventgrid/azsystemevents/internal/version.go
@@ -6,7 +6,7 @@ package internal
 // Constants to identify the module
 const (
 	// ModuleName is the module name that shows in telemetry.
-	ModuleName = "azsystemevents"
+	ModuleName = "github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azsystemevents"
 
 	// ModuleVersion is the semantic version (see http://semver.org) of this module.
 	ModuleVersion = "v0.6.0"

--- a/sdk/template/aztemplate/version.go
+++ b/sdk/template/aztemplate/version.go
@@ -9,7 +9,7 @@ package aztemplate
 // Constants to identify the module
 const (
 	// moduleName is the module name that shows in telemetry.
-	moduleName = "aztemplate"
+	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate"
 
 	// moduleVersion is the semantic version (see http://semver.org) of this module.
 	moduleVersion = "v0.6.0"


### PR DESCRIPTION
Fixing all the outdated projects - ModuleName is intended to be the full module path, not just the folder name.

Also, updated the template project.