### PR TITLE
[azmetrics] add api version support

### DIFF
--- a/sdk/monitor/query/azmetrics/CHANGELOG.md
+++ b/sdk/monitor/query/azmetrics/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
-## 1.1.1 (Unreleased)
+## 1.2.0 (Unreleased)
 
 ### Features Added
+* Added API Version support. Users can now change the default API Version by setting ClientOptions.APIVersion
 
 ### Breaking Changes
 

--- a/sdk/monitor/query/azmetrics/custom_client.go
+++ b/sdk/monitor/query/azmetrics/custom_client.go
@@ -42,7 +42,13 @@ func NewClient(endpoint string, credential azcore.TokenCredential, options *Clie
 	}
 
 	authPolicy := runtime.NewBearerTokenPolicy(credential, []string{c.Audience + "/.default"}, nil)
-	azcoreClient, err := azcore.NewClient(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, &options.ClientOptions)
+	azcoreClient, err := azcore.NewClient(moduleName, version, runtime.PipelineOptions{
+		APIVersion: runtime.APIVersionOptions{
+			Location: runtime.APIVersionLocationQueryParam,
+			Name:     "api-version",
+		},
+		PerRetry: []policy.Policy{authPolicy},
+	}, &options.ClientOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/monitor/query/azmetrics/version.go
+++ b/sdk/monitor/query/azmetrics/version.go
@@ -8,5 +8,5 @@ package azmetrics
 
 const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics"
-	version    = "v1.1.1"
+	version    = "v1.2.0"
 )


### PR DESCRIPTION
Closes #23819

Adds API version support. Instead of only being able to use the default version, users can now set the API version themselves.