### PR TITLE
disable sovereign cloud

### DIFF
--- a/sdk/monitor/azquery/ci.yml
+++ b/sdk/monitor/azquery/ci.yml
@@ -28,7 +28,6 @@ extends:
     ServiceDirectory: 'monitor/azquery'
     RunLiveTests: true
     UsePipelineProxy: false
-    SupportedClouds: 'Public,UsGov,China'
     EnvVars:
       AZURE_CLIENT_ID: $(AZQUERY_CLIENT_ID)
       AZURE_TENANT_ID: $(AZQUERY_TENANT_ID)

--- a/sdk/monitor/ingestion/azlogs/ci.ingestion.yml
+++ b/sdk/monitor/ingestion/azlogs/ci.ingestion.yml
@@ -28,4 +28,3 @@ extends:
     ServiceDirectory: 'monitor/ingestion/azlogs'
     RunLiveTests: true
     UsePipelineProxy: false
-    SupportedClouds: 'Public,UsGov,China'

--- a/sdk/monitor/query/azlogs/ci.yml
+++ b/sdk/monitor/query/azlogs/ci.yml
@@ -28,7 +28,6 @@ extends:
     ServiceDirectory: 'monitor/query/azlogs'
     RunLiveTests: true
     UsePipelineProxy: false
-    SupportedClouds: 'Public,UsGov,China'
     EnvVars:
       AZURE_CLIENT_ID: $(AZLOGS_CLIENT_ID)
       AZURE_TENANT_ID: $(AZLOGS_TENANT_ID)

--- a/sdk/monitor/query/azmetrics/ci.yml
+++ b/sdk/monitor/query/azmetrics/ci.yml
@@ -28,4 +28,3 @@ extends:
     ServiceDirectory: 'monitor/query/azmetrics'
     RunLiveTests: true
     UsePipelineProxy: false
-    SupportedClouds: 'Public,UsGov,China'

--- a/sdk/security/keyvault/azcertificates/ci.yml
+++ b/sdk/security/keyvault/azcertificates/ci.yml
@@ -28,5 +28,4 @@ extends:
     ServiceDirectory: 'security/keyvault/azcertificates'
     RunLiveTests: true
     UsePipelineProxy: false
-    SupportedClouds: 'Public,UsGov,China'
     TestRunTime: '900s'

--- a/sdk/security/keyvault/azkeys/ci.yml
+++ b/sdk/security/keyvault/azkeys/ci.yml
@@ -28,7 +28,6 @@ extends:
     ServiceDirectory: 'security/keyvault/azkeys'
     RunLiveTests: true
     UsePipelineProxy: false
-    SupportedClouds: 'Public,UsGov,China'
     CloudConfig:
       Public:
       UsGov:

--- a/sdk/security/keyvault/azsecrets/ci.yml
+++ b/sdk/security/keyvault/azsecrets/ci.yml
@@ -28,4 +28,3 @@ extends:
     ServiceDirectory: 'security/keyvault/azsecrets'
     RunLiveTests: true
     UsePipelineProxy: false
-    SupportedClouds: 'Public,UsGov,China'


### PR DESCRIPTION
Eng sys team currently has the USGov testing tenant shutdown.

Disabling all sovereign cloud tests in the weekly pipelines until they come to a decision on sovereign cloud testing.