### PR TITLE
[azcosmos] Add LIMITED cross-partition query support

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.2.1 (Unreleased)
 
 ### Features Added
-* Added limited support for cross-partition queries that can be served by the gateway. See [PR 23926](https://github.com/Azure/azure-sdk-for-go/pull/23926) and <https://learn.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway> for more details.
+* Added limited support for cross-partition queries that can be served by the gateway. See [PR 23926](https://github.com/Azure/azure-sdk-for-go/pull/23926) and <https://learn.microsoft.com/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway> for more details.
 
 ### Breaking Changes
 

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## 1.2.1 (Unreleased)
 
 ### Features Added
+* Added limited support for cross-partition queries that can be served by the gateway. See [PR 23926](https://github.com/Azure/azure-sdk-for-go/pull/23926) and <https://learn.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway> for more details.
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+* All queries now set the `x-ms-documentdb-query-enablecrosspartition` header. This should not impact single-partition queries, but in the event that it does cause problems for you, this behavior can be disabled by setting the `EnableCrossPartitionQuery` value on `azcosmos.QueryOptions` to `false`.
 
 ## 1.2.0 (2024-11-12)
 

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -498,7 +498,7 @@ func (c *ContainerClient) DeleteItem(
 // If the query does not filter down to a single partition (i.e. it does not filter on partition key at all, or filters on only some of the partition keys a container defines), the query will be executed as a cross partition query.
 // The Azure Cosmos DB Gateway API, used by the Go SDK, can only perform a LIMITED set of cross-partition queries.
 // Specifically, the gateway can only perform simple projections and filtering on cross partition queries.
-// See https://learn.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway for more details.
+// See https://learn.microsoft.com/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway for more details.
 //
 // When performing a cross-partition query, the Gateway may return pages of inconsistent size, or even empty pages (while still having a non-nil continuation token).
 // Ensure you fully iterate the pager, even if you receive empty pages, to ensure you get all results.

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -490,7 +490,7 @@ func (c *ContainerClient) DeleteItem(
 // o - Options for the operation.
 //
 // Limited cross partition queries ARE possible with the Go SDK.
-// You can specify an empty list of partition keys by passing `NewPartitionKey()` to the `partitionKey` parameter, to indicate that the query WHERE clauses will indicate the partitions to query.
+// You can specify an empty list of partition keys by passing `NewPartitionKey()` to the `partitionKey` parameter, to indicate that the query WHERE clauses will specify which partitions to query.
 // If you specify partition keys in the `partitionKey` parameter, you must specify ALL partition keys that the container has (in the case of hierarchical partitioning).
 //
 // If the query itself contains WHERE clauses that filter down to a single partition, the query will be executed on that partition.

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -489,8 +489,9 @@ func (c *ContainerClient) DeleteItem(
 // partitionKey - The partition key to scope the query on. See below for more information on cross partition queries.
 // o - Options for the operation.
 //
-// Limited cross partition queries ARE possible with the Go SDK.
 // You can specify an empty list of partition keys by passing `NewPartitionKey()` to the `partitionKey` parameter, to indicate that the query WHERE clauses will specify which partitions to query.
+//
+// Limited cross partition queries ARE possible with the Go SDK.
 // If you specify partition keys in the `partitionKey` parameter, you must specify ALL partition keys that the container has (in the case of hierarchical partitioning).
 //
 // If the query itself contains WHERE clauses that filter down to a single partition, the query will be executed on that partition.
@@ -498,6 +499,9 @@ func (c *ContainerClient) DeleteItem(
 // The Azure Cosmos DB Gateway API, used by the Go SDK, can only perform a LIMITED set of cross-partition queries.
 // Specifically, the gateway can only perform simple projections and filtering on cross partition queries.
 // See https://learn.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway for more details.
+//
+// When performing a cross-partition query, the Gateway may return pages of inconsistent size, or even empty pages (while still having a non-nil continuation token).
+// Ensure you fully iterate the pager, even if you receive empty pages, to ensure you get all results.
 //
 // If you provide a query that the gateway cannot execute, it will return a BadRequest error.
 func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey PartitionKey, o *QueryOptions) *runtime.Pager[QueryItemsResponse] {

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -486,8 +486,20 @@ func (c *ContainerClient) DeleteItem(
 
 // NewQueryItemsPager executes a single partition query in a Cosmos container.
 // query - The SQL query to execute.
-// partitionKey - The partition key to scope the query on.
+// partitionKey - The partition key to scope the query on. See below for more information on cross partition queries.
 // o - Options for the operation.
+//
+// Limited cross partition queries ARE possible with the Go SDK.
+// You can specify an empty list of partition keys by passing `NewPartitionKey()` to the `partitionKey` parameter, to indicate that the query WHERE clauses will indicate the partitions to query.
+// If you specify partition keys in the `partitionKey` parameter, you must specify ALL partition keys that the container has (in the case of hierarchical partitioning).
+//
+// If the query itself contains WHERE clauses that filter down to a single partition, the query will be executed on that partition.
+// If the query does not filter down to a single partition (i.e. it does not filter on partition key at all, or filters on only some of the partition keys a container defines), the query will be executed as a cross partition query.
+// The Azure Cosmos DB Gateway API, used by the Go SDK, can only perform a LIMITED set of cross-partition queries.
+// Specifically, the gateway can only perform simple projections and filtering on cross partition queries.
+// See https://learn.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway for more details.
+//
+// If you provide a query that the gateway cannot execute, it will return a BadRequest error.
 func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey PartitionKey, o *QueryOptions) *runtime.Pager[QueryItemsResponse] {
 	correlatedActivityId, _ := uuid.New()
 	h := headerOptionsOverride{

--- a/sdk/data/azcosmos/cosmos_headers_policy.go
+++ b/sdk/data/azcosmos/cosmos_headers_policy.go
@@ -30,7 +30,7 @@ func (p *headerPolicies) Do(req *policy.Request) (*http.Response, error) {
 				enableContentResponseOnWrite = *o.headerOptionsOverride.enableContentResponseOnWrite
 			}
 
-			if o.headerOptionsOverride.partitionKey != nil {
+			if o.headerOptionsOverride.partitionKey != nil && len(o.headerOptionsOverride.partitionKey.values) > 0 {
 				pkAsString, err := o.headerOptionsOverride.partitionKey.toJsonString()
 				if err != nil {
 					return nil, err

--- a/sdk/data/azcosmos/cosmos_http_constants.go
+++ b/sdk/data/azcosmos/cosmos_http_constants.go
@@ -36,6 +36,7 @@ const (
 	cosmosHeaderIsBatchAtomic                      string = "x-ms-cosmos-batch-atomic"
 	cosmosHeaderIsBatchOrdered                     string = "x-ms-cosmos-batch-ordered"
 	cosmosHeaderSDKSupportedCapabilities           string = "x-ms-cosmos-sdk-supportedcapabilities"
+	cosmosHeaderEnableCrossPartitionQuery          string = "x-ms-documentdb-query-enablecrosspartition"
 	headerXmsDate                                  string = "x-ms-date"
 	headerAuthorization                            string = "Authorization"
 	headerContentType                              string = "Content-Type"

--- a/sdk/data/azcosmos/cosmos_query_request_options.go
+++ b/sdk/data/azcosmos/cosmos_query_request_options.go
@@ -39,6 +39,11 @@ type QueryOptions struct {
 	QueryParameters []QueryParameter
 	// Options for operations in the dedicated gateway.
 	DedicatedGatewayRequestOptions *DedicatedGatewayRequestOptions
+	// EnableCrossPartitionQuery configures the behavior of the query engine when executing queries.
+	// If set to true, the query engine will set the 'x-ms-documentdb-query-enablecrosspartition' header to true for cross-partition queries.
+	// If set to false, cross-partition queries will be rejected.
+	// The default value, if this is not set, is TRUE.
+	EnableCrossPartitionQuery *bool
 }
 
 func (options *QueryOptions) toHeaders() *map[string]string {
@@ -82,7 +87,10 @@ func (options *QueryOptions) toHeaders() *map[string]string {
 	}
 
 	headers[cosmosHeaderPopulateQueryMetrics] = "true"
-	headers[cosmosHeaderEnableCrossPartitionQuery] = "true"
+
+	if options.EnableCrossPartitionQuery == nil || *options.EnableCrossPartitionQuery {
+		headers[cosmosHeaderEnableCrossPartitionQuery] = "true"
+	}
 
 	return &headers
 }

--- a/sdk/data/azcosmos/cosmos_query_request_options.go
+++ b/sdk/data/azcosmos/cosmos_query_request_options.go
@@ -82,6 +82,7 @@ func (options *QueryOptions) toHeaders() *map[string]string {
 	}
 
 	headers[cosmosHeaderPopulateQueryMetrics] = "true"
+	headers[cosmosHeaderEnableCrossPartitionQuery] = "true"
 
 	return &headers
 }

--- a/sdk/data/azcosmos/cosmos_query_request_options.go
+++ b/sdk/data/azcosmos/cosmos_query_request_options.go
@@ -42,7 +42,7 @@ type QueryOptions struct {
 	// EnableCrossPartitionQuery configures the behavior of the query engine when executing queries.
 	// If set to true, the query engine will set the 'x-ms-documentdb-query-enablecrosspartition' header to true for cross-partition queries.
 	// If set to false, cross-partition queries will be rejected.
-	// The default value, if this is not set, is TRUE.
+	// The default value, if this is not set, is true.
 	EnableCrossPartitionQuery *bool
 }
 

--- a/sdk/data/azcosmos/emulator_cosmos_query_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_query_test.go
@@ -6,8 +6,13 @@ package azcosmos
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSinglePartitionQueryWithIndexMetrics(t *testing.T) {
@@ -26,63 +31,18 @@ func TestSinglePartitionQueryWithIndexMetrics(t *testing.T) {
 	}
 
 	_, err := database.CreateContainer(context.TODO(), properties, nil)
-	if err != nil {
-		t.Fatalf("Failed to create container: %v", err)
-	}
+	assert.NoError(t, err)
 
 	container, _ := database.NewContainer("aContainer")
-	documentsPerPk := 1
-	createSampleItems(t, container, documentsPerPk)
+	assert.NoError(t, createSampleItems(container, 2, 10))
 
-	receivedIds := []string{}
-	queryPager := container.NewQueryItemsPager("select * from docs c where c.someProp = '2'", NewPartitionKeyString("1"), &QueryOptions{PopulateIndexMetrics: true})
-	for queryPager.More() {
-		queryResponse, err := queryPager.NextPage(context.TODO())
-		if err != nil {
-			t.Fatalf("Failed to query items: %v", err)
-		}
-
-		for _, item := range queryResponse.Items {
-			var itemResponseBody map[string]interface{}
-			err = json.Unmarshal(item, &itemResponseBody)
-			if err != nil {
-				t.Fatalf("Failed to unmarshal: %v", err)
-			}
-			receivedIds = append(receivedIds, itemResponseBody["id"].(string))
-		}
-
-		if queryPager.More() && queryResponse.ContinuationToken == nil {
-			t.Fatal("Query has more pages but no continuation was provided")
-		}
-
-		if queryResponse.QueryMetrics == nil {
-			t.Fatal("Query metrics were not returned")
-		}
-
-		if queryResponse.IndexMetrics == nil {
-			t.Fatal("Index metrics were not returned")
-		}
-
-		if queryResponse.ActivityID == "" {
-			t.Fatal("Activity id was not returned")
-		}
-
-		if queryResponse.RequestCharge == 0 {
-			t.Fatal("Request charge was not returned")
-		}
-
-		if len(queryResponse.Items) != 1 && len(queryResponse.Items) != 0 {
-			t.Fatalf("Expected 1 items, got %d", len(queryResponse.Items))
-		}
-	}
-
-	if len(receivedIds) != 1 {
-		t.Fatalf("Expected 1 documents, got %d", len(receivedIds))
-	}
-
-	if receivedIds[0] != "0" {
-		t.Fatalf("Expected id 0, got %s", receivedIds[0])
-	}
+	opt := QueryOptions{PopulateIndexMetrics: true}
+	queryPager := container.NewQueryItemsPager("select * from docs c where c.someProp = 'some_4'", NewPartitionKeyString("1"), &opt)
+	receivedIds, err := collectResultIds(t, 1, queryPager, &opt, parseIdProperty)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		[]string{"4"},
+		receivedIds)
 }
 
 func TestSinglePartitionQuery(t *testing.T) {
@@ -101,76 +61,52 @@ func TestSinglePartitionQuery(t *testing.T) {
 	}
 
 	_, err := database.CreateContainer(context.TODO(), properties, nil)
-	if err != nil {
-		t.Fatalf("Failed to create container: %v", err)
-	}
+	assert.NoError(t, err)
 
 	container, _ := database.NewContainer("aContainer")
-	documentsPerPk := 10
-	createSampleItems(t, container, documentsPerPk)
+	assert.NoError(t, createSampleItems(container, 2, 10))
 
-	numberOfPages := 0
-	receivedIds := []string{}
 	opt := QueryOptions{PageSizeHint: 5}
-	queryPager := container.NewQueryItemsPager("select * from c", NewPartitionKeyString("1"), &opt)
-	for queryPager.More() {
-		queryResponse, err := queryPager.NextPage(context.TODO())
-		if err != nil {
-			t.Fatalf("Failed to query items: %v", err)
-		}
+	// We include an ORDER BY to ensure that ORDER BY statements are still allowed even when we're setting the cross-partition flag, as long as the query itself is still single-partition.
+	queryPager := container.NewQueryItemsPager("select * from c order by c.id", NewPartitionKeyString("1"), &opt)
+	receivedIds, err := collectResultIds(t, 2, queryPager, &opt, parseIdProperty)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		// Single partition result
+		[]string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
+		receivedIds)
+}
 
-		numberOfPages++
-		for _, item := range queryResponse.Items {
-			var itemResponseBody map[string]interface{}
-			err = json.Unmarshal(item, &itemResponseBody)
-			if err != nil {
-				t.Fatalf("Failed to unmarshal: %v", err)
-			}
-			receivedIds = append(receivedIds, itemResponseBody["id"].(string))
-		}
+func TestSinglePartitionQueryInline(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
+		ExpectedSpans: []string{"query_items aContainer"},
+	}))
 
-		if queryPager.More() && queryResponse.ContinuationToken == nil {
-			t.Fatal("Query has more pages but no continuation was provided")
-		}
-
-		if queryResponse.QueryMetrics == nil {
-			t.Fatal("Query metrics were not returned")
-		}
-
-		if queryResponse.IndexMetrics != nil {
-			t.Fatal("Index metrics were returned")
-		}
-
-		if queryResponse.ActivityID == "" {
-			t.Fatal("Activity id was not returned")
-		}
-
-		if queryResponse.RequestCharge == 0 {
-			t.Fatal("Request charge was not returned")
-		}
-
-		if len(queryResponse.Items) != 5 && len(queryResponse.Items) != 0 {
-			t.Fatalf("Expected 5 items, got %d", len(queryResponse.Items))
-		}
-
-		if numberOfPages == 2 && opt.ContinuationToken != nil {
-			t.Fatalf("Original options should not be modified, initial continuation was empty, now it has %v", opt.ContinuationToken)
-		}
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	properties := ContainerProperties{
+		ID: "aContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths: []string{"/pk"},
+		},
 	}
 
-	if numberOfPages != 2 {
-		t.Fatalf("Expected 2 pages, got %d", numberOfPages)
-	}
+	_, err := database.CreateContainer(context.TODO(), properties, nil)
+	assert.NoError(t, err)
 
-	if len(receivedIds) != documentsPerPk {
-		t.Fatalf("Expected %d documents, got %d", documentsPerPk, len(receivedIds))
-	}
+	container, _ := database.NewContainer("aContainer")
+	assert.NoError(t, createSampleItems(container, 2, 10))
 
-	for i := 0; i < documentsPerPk; i++ {
-		if receivedIds[i] != strconv.Itoa(i) {
-			t.Fatalf("Expected id %d, got %s", i, receivedIds[i])
-		}
-	}
+	opt := QueryOptions{PageSizeHint: 5}
+	// We can specify the partition key inline in the query itself.
+	queryPager := container.NewQueryItemsPager("select * from c where c.pk = '1' order by c.id", NewPartitionKey(), &opt)
+	receivedIds, err := collectResultIds(t, 2, queryPager, &opt, parseIdProperty)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		// Single partition result
+		[]string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
+		receivedIds)
 }
 
 func TestSinglePartitionQueryWithParameters(t *testing.T) {
@@ -189,40 +125,23 @@ func TestSinglePartitionQueryWithParameters(t *testing.T) {
 	}
 
 	_, err := database.CreateContainer(context.TODO(), properties, nil)
-	if err != nil {
-		t.Fatalf("Failed to create container: %v", err)
-	}
+	assert.NoError(t, err)
 
 	container, _ := database.NewContainer("aContainer")
-	documentsPerPk := 1
-	createSampleItems(t, container, documentsPerPk)
+	assert.NoError(t, createSampleItems(container, 2, 10))
 
-	receivedIds := []string{}
 	opt := QueryOptions{
 		QueryParameters: []QueryParameter{
-			{"@prop", "2"},
+			{"@prop", "some_4"},
 		},
 	}
-	queryPager := container.NewQueryItemsPager("select * from c where c.someProp = @prop", NewPartitionKeyString("1"), &opt)
-	for queryPager.More() {
-		queryResponse, err := queryPager.NextPage(context.TODO())
-		if err != nil {
-			t.Fatalf("Failed to query items: %v", err)
-		}
-
-		for _, item := range queryResponse.Items {
-			var itemResponseBody map[string]interface{}
-			err = json.Unmarshal(item, &itemResponseBody)
-			if err != nil {
-				t.Fatalf("Failed to unmarshal: %v", err)
-			}
-			receivedIds = append(receivedIds, itemResponseBody["id"].(string))
-		}
-	}
-
-	if len(receivedIds) != 1 {
-		t.Fatalf("Expected 1 document, got %d", len(receivedIds))
-	}
+	// We include an ORDER BY to ensure that ORDER BY statements are still allowed even when we're setting the cross-partition flag, as long as the query itself is still single-partition.
+	queryPager := container.NewQueryItemsPager("select * from c where c.someProp = @prop order by c.id", NewPartitionKeyString("1"), &opt)
+	receivedIds, err := collectResultIds(t, 1, queryPager, &opt, parseIdProperty)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		[]string{"4"},
+		receivedIds)
 }
 
 func TestSinglePartitionQueryWithProjection(t *testing.T) {
@@ -241,110 +160,329 @@ func TestSinglePartitionQueryWithProjection(t *testing.T) {
 	}
 
 	_, err := database.CreateContainer(context.TODO(), properties, nil)
-	if err != nil {
-		t.Fatalf("Failed to create container: %v", err)
-	}
+	assert.NoError(t, err)
 
 	container, _ := database.NewContainer("aContainer")
-	documentsPerPk := 10
-	createSampleItems(t, container, documentsPerPk)
+	assert.NoError(t, createSampleItems(container, 2, 10))
 
-	numberOfPages := 0
-	receivedIds := []string{}
 	opt := QueryOptions{PageSizeHint: 5}
-	queryPager := container.NewQueryItemsPager("select value c.id from c", NewPartitionKeyString("1"), &opt)
+
+	// We include an ORDER BY to ensure that ORDER BY statements are still allowed even when we're setting the cross-partition flag, as long as the query itself is still single-partition.
+	queryPager := container.NewQueryItemsPager("select value c.id from c order by c.id", NewPartitionKeyString("1"), &opt)
+	receivedIds, err := collectResultIds(t, 2, queryPager, &opt, parseValueAsId)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		// Single partition result
+		[]string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
+		receivedIds)
+}
+
+func TestCrossPartitionQuery(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
+		ExpectedSpans: []string{"query_items aContainer"},
+	}))
+
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	properties := ContainerProperties{
+		ID: "aContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths: []string{"/pk"},
+		},
+	}
+
+	_, err := database.CreateContainer(context.TODO(), properties, nil)
+	assert.NoError(t, err)
+
+	container, _ := database.NewContainer("aContainer")
+	assert.NoError(t, createSampleItems(container, 2, 10))
+
+	opt := QueryOptions{PageSizeHint: 5}
+	queryPager := container.NewQueryItemsPager("select * from c", NewPartitionKey(), &opt)
+	receivedIds, err := collectResultIds(t, 5, queryPager, &opt, parseIdProperty)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		// Partitions should be interleaved and not re-ordered by ID.
+		[]string{"0", "10", "1", "11", "2", "12", "3", "13", "4", "14", "5", "15", "6", "16", "7", "17", "8", "18", "9", "19"},
+		receivedIds)
+}
+
+func TestCrossPartitionQueryFailsIfGatewayCannotSatisfyRequest(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
+		ExpectedSpans: []string{"query_items aContainer"},
+	}))
+
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	properties := ContainerProperties{
+		ID: "aContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths: []string{"/pk"},
+		},
+	}
+
+	_, err := database.CreateContainer(context.TODO(), properties, nil)
+	assert.NoError(t, err)
+
+	container, _ := database.NewContainer("aContainer")
+	assert.NoError(t, createSampleItems(container, 2, 10))
+
+	opt := QueryOptions{PageSizeHint: 5}
+	queryPager := container.NewQueryItemsPager("select * from c order by c.id", NewPartitionKey(), &opt)
+	receivedIds, err := collectResultIds(t, 5, queryPager, &opt, parseIdProperty)
+	assert.Nil(t, receivedIds)
+
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "Failed to query items: "))
+	assert.True(t, strings.Contains(err.Error(), "BadRequest"))
+	assert.True(t, strings.Contains(err.Error(), "cross partition query can not be directly served by the gateway"))
+}
+
+func TestHierarchicalPartitionQuerySinglePartition(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
+		ExpectedSpans: []string{"query_items aContainer"},
+	}))
+
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	properties := ContainerProperties{
+		ID: "aContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths:   []string{"/parent", "/child"},
+			Version: 2,
+		},
+	}
+
+	_, err := database.CreateContainer(context.TODO(), properties, nil)
+	assert.NoError(t, err)
+
+	container, _ := database.NewContainer("aContainer")
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "1",
+		"parent": "parent1",
+		"child":  "child1",
+	}, NewPartitionKeyString("parent1").AppendString("child1")))
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "2",
+		"parent": "parent1",
+		"child":  "child2",
+	}, NewPartitionKeyString("parent1").AppendString("child2")))
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "3",
+		"parent": "parent2",
+		"child":  "child1",
+	}, NewPartitionKeyString("parent2").AppendString("child1")))
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "4",
+		"parent": "parent2",
+		"child":  "child2",
+	}, NewPartitionKeyString("parent2").AppendString("child2")))
+
+	opt := QueryOptions{PageSizeHint: 5}
+	queryPager := container.NewQueryItemsPager("select * from c order by c.id", NewPartitionKeyString("parent1").AppendString("child2"), &opt)
+	receivedIds, err := collectResultIds(t, 1, queryPager, &opt, parseIdProperty)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"2"}, receivedIds)
+}
+
+func TestHierarchicalPartitionQueryParentPartition(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
+		ExpectedSpans: []string{"query_items aContainer"},
+	}))
+
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	properties := ContainerProperties{
+		ID: "aContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths:   []string{"/parent", "/child"},
+			Version: 2,
+		},
+	}
+
+	_, err := database.CreateContainer(context.TODO(), properties, nil)
+	assert.NoError(t, err)
+
+	container, _ := database.NewContainer("aContainer")
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "1",
+		"parent": "parent1",
+		"child":  "child1",
+	}, NewPartitionKeyString("parent1").AppendString("child1")))
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "2",
+		"parent": "parent1",
+		"child":  "child2",
+	}, NewPartitionKeyString("parent1").AppendString("child2")))
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "3",
+		"parent": "parent2",
+		"child":  "child1",
+	}, NewPartitionKeyString("parent2").AppendString("child1")))
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "4",
+		"parent": "parent2",
+		"child":  "child2",
+	}, NewPartitionKeyString("parent2").AppendString("child2")))
+
+	opt := QueryOptions{PageSizeHint: 5}
+	queryPager := container.NewQueryItemsPager("select * from c where c.parent = 'parent1'", NewPartitionKey(), &opt)
+	receivedIds, err := collectResultIds(t, 1, queryPager, &opt, parseIdProperty)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"1", "2"}, receivedIds)
+}
+
+func TestHierarchicalPartitionQueryNoPartition(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
+		ExpectedSpans: []string{"query_items aContainer"},
+	}))
+
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "queryTests")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	properties := ContainerProperties{
+		ID: "aContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths:   []string{"/parent", "/child"},
+			Version: 2,
+		},
+	}
+
+	_, err := database.CreateContainer(context.TODO(), properties, nil)
+	assert.NoError(t, err)
+
+	container, _ := database.NewContainer("aContainer")
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "1",
+		"parent": "parent1",
+		"child":  "child1",
+	}, NewPartitionKeyString("parent1").AppendString("child1")))
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "2",
+		"parent": "parent1",
+		"child":  "child2",
+	}, NewPartitionKeyString("parent1").AppendString("child2")))
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "3",
+		"parent": "parent2",
+		"child":  "child1",
+	}, NewPartitionKeyString("parent2").AppendString("child1")))
+	assert.NoError(t, createSampleItem(container, map[string]interface{}{
+		"id":     "4",
+		"parent": "parent2",
+		"child":  "child2",
+	}, NewPartitionKeyString("parent2").AppendString("child2")))
+
+	opt := QueryOptions{PageSizeHint: 5}
+	queryPager := container.NewQueryItemsPager("select * from c", NewPartitionKey(), &opt)
+	receivedIds, err := collectResultIds(t, 1, queryPager, &opt, parseIdProperty)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"1", "2", "3", "4"}, receivedIds)
+}
+
+func createSampleItems(container *ContainerClient, partitions int, documentsPerPartition int) error {
+	for i := 0; i < documentsPerPartition; i++ {
+		// We insert documents alternating between partitions.
+		// This simulates a kind of "worst-case" illustration of how cross-partition queries can interleave results since the "default" ordering is by insertion order.
+		for pk := 0; pk < partitions; pk++ {
+			id := strconv.Itoa(i + (pk * documentsPerPartition))
+			pkStr := strconv.Itoa(pk + 1)
+			err := createSampleItem(container, map[string]interface{}{
+				"id":       id,
+				"pk":       pkStr,
+				"someProp": fmt.Sprintf("some_%s", id),
+			}, NewPartitionKeyString(pkStr))
+			if err != nil {
+				return fmt.Errorf("Failed to create sample item: %v", err)
+			}
+		}
+	}
+	return nil
+}
+
+func createSampleItem(container *ContainerClient, item map[string]interface{}, pk PartitionKey) error {
+	marshalled, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+
+	_, err = container.CreateItem(context.TODO(), pk, marshalled, nil)
+	if err != nil {
+		return fmt.Errorf("Failed to create item: %v", err)
+	}
+	return nil
+}
+
+func parseValueAsId(item []byte) (string, error) {
+	var itemResponseBody string
+	err := json.Unmarshal(item, &itemResponseBody)
+	if err != nil {
+		return "", err
+	}
+	return itemResponseBody, nil
+}
+
+func parseIdProperty(item []byte) (string, error) {
+	var itemResponseBody map[string]interface{}
+	err := json.Unmarshal(item, &itemResponseBody)
+	if err != nil {
+		return "", err
+	}
+	return itemResponseBody["id"].(string), nil
+}
+
+func collectResultIds(t *testing.T, expectedPageCount int, queryPager *runtime.Pager[QueryItemsResponse], originalOptions *QueryOptions, idParser func([]byte) (string, error)) ([]string, error) {
+	ids := []string{}
+	pageCount := 0
 	for queryPager.More() {
 		queryResponse, err := queryPager.NextPage(context.TODO())
 		if err != nil {
-			t.Fatalf("Failed to query items: %v", err)
+			return nil, fmt.Errorf("Failed to query items: %v", err)
 		}
 
-		numberOfPages++
+		pageCount++
 		for _, item := range queryResponse.Items {
-			var itemResponseBody string
-			err = json.Unmarshal(item, &itemResponseBody)
+			id, err := idParser(item)
 			if err != nil {
-				t.Fatalf("Failed to unmarshal: %v", err)
+				return nil, fmt.Errorf("Failed to unmarshal: %v", err)
 			}
-			receivedIds = append(receivedIds, itemResponseBody)
+			ids = append(ids, id)
 		}
 
 		if queryPager.More() && queryResponse.ContinuationToken == nil {
-			t.Fatal("Query has more pages but no continuation was provided")
+			return nil, fmt.Errorf("Query has more pages but no continuation was provided")
 		}
 
 		if queryResponse.QueryMetrics == nil {
-			t.Fatal("Query metrics were not returned")
+			return nil, fmt.Errorf("Query metrics were not returned")
 		}
 
-		if queryResponse.IndexMetrics != nil {
-			t.Fatal("Index metrics were returned")
+		if !originalOptions.PopulateIndexMetrics && queryResponse.IndexMetrics != nil {
+			return nil, fmt.Errorf("Index metrics were returned but not requested")
+		} else if originalOptions.PopulateIndexMetrics && queryResponse.IndexMetrics == nil {
+			return nil, fmt.Errorf("Index metrics were requested but not returned")
 		}
 
 		if queryResponse.ActivityID == "" {
-			t.Fatal("Activity id was not returned")
+			return nil, fmt.Errorf("Activity id was not returned")
 		}
 
 		if queryResponse.RequestCharge == 0 {
-			t.Fatal("Request charge was not returned")
+			return nil, fmt.Errorf("Request charge was not returned")
 		}
 
-		if len(queryResponse.Items) != 5 && len(queryResponse.Items) != 0 {
-			t.Fatalf("Expected 5 items, got %d", len(queryResponse.Items))
+		if originalOptions.PageSizeHint > 0 && len(queryResponse.Items) > int(originalOptions.PageSizeHint) {
+			return nil, fmt.Errorf("Expected 1-%d items, got %d", int(originalOptions.PageSizeHint), len(queryResponse.Items))
 		}
 
-		if numberOfPages == 2 && opt.ContinuationToken != nil {
-			t.Fatalf("Original options should not be modified, initial continuation was empty, now it has %v", opt.ContinuationToken)
-		}
-	}
-
-	if numberOfPages != 2 {
-		t.Fatalf("Expected 2 pages, got %d", numberOfPages)
-	}
-
-	if len(receivedIds) != documentsPerPk {
-		t.Fatalf("Expected %d documents, got %d", documentsPerPk, len(receivedIds))
-	}
-
-	for i := 0; i < documentsPerPk; i++ {
-		if receivedIds[i] != strconv.Itoa(i) {
-			t.Fatalf("Expected id %d, got %s", i, receivedIds[i])
+		if pageCount == expectedPageCount && originalOptions.ContinuationToken != nil {
+			return nil, fmt.Errorf("Original options should not be modified, initial continuation was empty, now it has %v", originalOptions.ContinuationToken)
 		}
 	}
-}
-
-func createSampleItems(t *testing.T, container *ContainerClient, documentsPerPk int) {
-	for i := 0; i < documentsPerPk; i++ {
-		item := map[string]string{
-			"id":       strconv.Itoa(i),
-			"pk":       "1",
-			"someProp": "2",
-		}
-
-		marshalled, err := json.Marshal(item)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = container.CreateItem(context.TODO(), NewPartitionKeyString("1"), marshalled, nil)
-		if err != nil {
-			t.Fatalf("Failed to create item: %v", err)
-		}
-
-		item2 := map[string]string{
-			"id":       strconv.Itoa(i),
-			"pk":       "2",
-			"someProp": "2",
-		}
-
-		marshalled, err = json.Marshal(item2)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = container.CreateItem(context.TODO(), NewPartitionKeyString("2"), marshalled, nil)
-		if err != nil {
-			t.Fatalf("Failed to create item: %v", err)
-		}
-	}
+	assert.Equal(t, expectedPageCount, pageCount)
+	return ids, nil
 }

--- a/sdk/data/azcosmos/shared_key_credential.go
+++ b/sdk/data/azcosmos/shared_key_credential.go
@@ -85,7 +85,7 @@ func (c *KeyCredential) buildCanonicalizedAuthHeader(isDatabaseAccount bool, met
 
 	resourceAddress, _ = url.PathUnescape(resourceAddress)
 
-	// https://docs.microsoft.com/en-us/rest/api/cosmos-db/access-control-on-cosmosdb-resources#constructkeytoken
+	// https://docs.microsoft.com/rest/api/cosmos-db/access-control-on-cosmosdb-resources#constructkeytoken
 	stringToSign := join(strings.ToLower(method), "\n", strings.ToLower(resourceTypePath), "\n", resourceAddress, "\n", strings.ToLower(xmsDate), "\n", "", "\n")
 	signature := c.computeHMACSHA256(stringToSign)
 


### PR DESCRIPTION
This PR adds very limited support for cross-partition queries to the Cosmos Go SDK.

It works by _always_ adding the `enablecrosspartitionquery` header to the query request. We didn't want to make a separate option because in the future we're hoping to have richer support for cross partition queries that can be lit up automatically.

> [!IMPORTANT]
> The cross-partition query functionality added here is **limited** to cross-partition queries that can be successfully executed against the Gateway API. See https://learn.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway for more details. The doc comments describe this limitation.

I'm hoping the doc comments largely explain things, so I don't want to get too deep here, if you have questions, please ask them and I can clarify the doc comments! Essentially, the `partitionKey` parameter in `NewQueryItemsPager` is now optional and can be omitted by passing `azcosmos.NewPartitionKey()`, which creates an "empty" partition key (the interior array of values is non-nil, but empty). This was the easiest way to allow users to omit this parameter. We couldn't just accept `nil` here, because the `partitionKey` parameter is not a pointer, it's a concrete type.

I also reworked the `emulator_cosmos_query_test` tests to be a little more readable (IMO) by using `stretchr/testify`, which we were already using in some other test files. It provides the `assert` package which has more readable test assertions (again, IMO). I added some cross-partition tests there to validate behavior against the emulator.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
