### PR TITLE
[azopenai] Fixed a spelling error in the deserialization of the messa…

### DIFF
--- a/sdk/ai/azopenai/client_extra.go
+++ b/sdk/ai/azopenai/client_extra.go
@@ -53,7 +53,7 @@ func newContentFilterResponseError(resp *http.Response) error {
 		Error struct {
 			InnerError struct {
 				ContentFilterResults *ContentFilterResults `json:"content_filter_result"`
-			} `json:"innererror"`
+			} `json:"inner_error"`
 		}
 	}
 

--- a/sdk/ai/azopenai/testdata/content_filter_response_error.json
+++ b/sdk/ai/azopenai/testdata/content_filter_response_error.json
@@ -1,13 +1,16 @@
 {
     "error": {
-        "message": "The response was filtered due to the prompt triggering Azure OpenAI’s content management policy. Please modify your prompt and retry. To learn more about our content filtering policies please read our documentation: https://go.microsoft.com/fwlink/?linkid=2198766",
-        "type": null,
-        "param": "prompt",
-        "code": "content_filter",
-        "status": 400,
-        "innererror": {
+        "inner_error": {
             "code": "ResponsibleAIPolicyViolation",
-            "content_filter_result": {
+            "content_filter_results": {
+                "sexual": {
+                    "filtered": true,
+                    "severity": "medium"
+                },
+                "violence": {
+                    "filtered": false,
+                    "severity": "safe"
+                },
                 "hate": {
                     "filtered": false,
                     "severity": "safe"
@@ -15,16 +18,12 @@
                 "self_harm": {
                     "filtered": false,
                     "severity": "safe"
-                },
-                "sexual": {
-                    "filtered": false,
-                    "severity": "safe"
-                },
-                "violence": {
-                    "filtered": true,
-                    "severity": "medium"
                 }
             }
-        }
+        },
+        "code": "content_filter",
+        "message": "The response was filtered due to the prompt triggering Azure OpenAI's content management policy. Please modify your prompt and retry. To learn more about our content filtering policies please read our documentation: \r\nhttps://go.microsoft.com/fwlink/?linkid=2198766.",
+        "param": "prompt",
+        "type": null
     }
 }

--- a/sdk/ai/azopenaiextensions/custom_errors.go
+++ b/sdk/ai/azopenaiextensions/custom_errors.go
@@ -79,7 +79,7 @@ func ExtractContentFilterError(err error, contentFilterErr **ContentFilterError)
 			InnerError struct {
 				Code                 string                              `json:"code"`
 				ContentFilterResults ContentFilterResultDetailsForPrompt `json:"content_filter_result"`
-			} `json:"innererror"`
+			} `json:"inner_error"`
 		} `json:"error"`
 	}
 

--- a/sdk/ai/azopenaiextensions/testdata/content_filter_response_error.json
+++ b/sdk/ai/azopenaiextensions/testdata/content_filter_response_error.json
@@ -5,7 +5,7 @@
         "param": "prompt",
         "code": "content_filter",
         "status": 400,
-        "innererror": {
+        "inner_error": {
             "code": "ResponsibleAIPolicyViolation",
             "content_filter_result": {
                 "hate": {


### PR DESCRIPTION
Fixed a spelling error in the deserialization of the message returned when the completions API triggers the content filter. "innererror" has been corrected to "inner_error".

[Microsoft's documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/content-filter?tabs=warning%2Cuser-prompt%2Cpython-new#example-scenario-an-input-prompt-containing-content-that-is-classified-at-a-filtered-category-and-severity-level-is-sent-to-the-completions-api) also has a spelling error for "innererror". When I actually called the API, it returned "inner_error". I don't know where the problem is, but to ensure my program can run correctly, please merge this pull request. Thank you.
Here are the actual return data when calling the API:
``` json
{
    "error": {
        "inner_error": {
            "code": "ResponsibleAIPolicyViolation",
            "content_filter_results": {
                "sexual": {
                    "filtered": true,
                    "severity": "medium"
                },
                "violence": {
                    "filtered": false,
                    "severity": "safe"
                },
                "hate": {
                    "filtered": false,
                    "severity": "safe"
                },
                "self_harm": {
                    "filtered": false,
                    "severity": "safe"
                }
            }
        },
        "code": "content_filter",
        "message": "The response was filtered due to the prompt triggering Azure OpenAI's content management policy. Please modify your prompt and retry. To learn more about our content filtering policies please read our documentation: \r\nhttps://go.microsoft.com/fwlink/?linkid=2198766.",
        "param": "prompt",
        "type": null
    }
}
```
@microsoft-github-policy-service agree