### PR TITLE
refine sdk automation tool

### DIFF
--- a/eng/tools/generator/cmd/v2/common/changelogProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/changelogProcessor.go
@@ -30,8 +30,8 @@ const (
 	sdk_remote_url    = "https://github.com/Azure/azure-sdk-for-go.git"
 )
 
-func GetAllVersionTags(packageModuleRelativePath string) ([]string, error) {
-	arr := strings.Split(packageModuleRelativePath, "/")
+func GetAllVersionTags(moduleRelativePath string) ([]string, error) {
+	arr := strings.Split(moduleRelativePath, "/")
 	log.Printf("Fetching all release tags from GitHub for RP: '%s' Package: '%s' ...", arr[len(arr)-2], arr[len(arr)-1])
 	client := http.Client{}
 	res, err := client.Get(sdk_tag_fetch_url)
@@ -52,7 +52,7 @@ func GetAllVersionTags(packageModuleRelativePath string) ([]string, error) {
 	versionTag := make(map[string]string)
 	for _, tag := range result {
 		tagName := tag["ref"].(string)
-		if strings.Contains(tagName, packageModuleRelativePath+"/v") {
+		if strings.Contains(tagName, moduleRelativePath+"/v") {
 			m := regexp.MustCompile(semver.SemVerRegex).FindString(tagName)
 			versions = append(versions, m)
 			versionTag[m] = tagName

--- a/eng/tools/generator/cmd/v2/common/changelogProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/changelogProcessor.go
@@ -168,7 +168,8 @@ func GetExportsFromTag(sdkRepo repo.SDKRepository, packagePath, tag string) (*ex
 
 	// get exports
 	result, err := exports.Get(packagePath)
-	if err != nil {
+	// bypass the error if the package doesn't contain any exports, return nil
+	if err != nil && !strings.Contains(err.Error(), "doesn't contain any exports") {
 		return nil, err
 	}
 

--- a/eng/tools/generator/cmd/v2/common/constants.go
+++ b/eng/tools/generator/cmd/v2/common/constants.go
@@ -5,4 +5,6 @@ package common
 
 const (
 	ChangelogFileName = "CHANGELOG.md"
+	GoModFileName     = "go.mod"
+	SdkRootPath       = "sdk"
 )

--- a/eng/tools/generator/cmd/v2/common/constants.go
+++ b/eng/tools/generator/cmd/v2/common/constants.go
@@ -6,5 +6,5 @@ package common
 const (
 	ChangelogFileName = "CHANGELOG.md"
 	GoModFileName     = "go.mod"
-	SdkRootPath       = "sdk"
+	SdkRootPath       = "/sdk"
 )

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -138,6 +138,9 @@ func ReadV2ModuleNameToGetNamespace(path string) (map[string][]PackageInfo, erro
 
 // remove all sdk generated files in given path
 func CleanSDKGeneratedFiles(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
 	log.Printf("Removing all sdk generated files in '%s'...", path)
 	return filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -802,4 +805,33 @@ func importPath(s *ast.ImportSpec) string {
 		return ""
 	}
 	return t
+}
+
+// Walks the sdk directory to find module based on a go.mod file
+func FindModuleDirByGoMod(root string) (string, error) {
+	path := root
+	curLevel := 0
+	maxLevel := 5
+	for !strings.HasSuffix(path, SdkRootPath) && curLevel < maxLevel {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			path = filepath.Dir(path)
+			curLevel++
+			continue
+		}
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return "", err
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			if entry.Name() == GoModFileName {
+				return path, nil
+			}
+		}
+		path = filepath.Dir(path)
+		curLevel++
+	}
+	return "", fmt.Errorf("not found module, package path:%s", root)
 }

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -818,17 +818,9 @@ func FindModuleDirByGoMod(root string) (string, error) {
 			curLevel++
 			continue
 		}
-		entries, err := os.ReadDir(path)
-		if err != nil {
-			return "", err
-		}
-		for _, entry := range entries {
-			if entry.IsDir() {
-				continue
-			}
-			if entry.Name() == GoModFileName {
-				return path, nil
-			}
+		goModFilePath := filepath.Join(path, GoModFileName)
+		if _, err := os.Stat(goModFilePath); err == nil {
+			return path, nil
 		}
 		path = filepath.Dir(path)
 		curLevel++

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -397,7 +397,6 @@ func AddChangelogToFile(changelog *Changelog, version *semver.Version, packageRo
 
 // replace `{{NewClientName}}` placeholder in README.md by first func name according to `^New.+Method$` pattern
 func ReplaceNewClientNamePlaceholder(packageRootPath string, exports exports.Content) error {
-	path := filepath.Join(packageRootPath, "README.md")
 	var clientName string
 	for _, k := range SortFuncItem(exports.Funcs) {
 		v := exports.Funcs[k]
@@ -405,6 +404,12 @@ func ReplaceNewClientNamePlaceholder(packageRootPath string, exports exports.Con
 			clientName = k
 			break
 		}
+	}
+
+	path := filepath.Join(packageRootPath, "README.md")
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
 	}
 
 	b, err := os.ReadFile(path)
@@ -420,9 +425,13 @@ func UpdateModuleDefinition(packageRootPath, packageModuleRelativePath string, v
 	if version.Major() > 1 {
 		path := filepath.Join(packageRootPath, "go.mod")
 
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return nil
+		}
+
 		b, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("cannot parse version from changelog")
+			return fmt.Errorf("cannot read go.mod")
 		}
 
 		lines := strings.Split(string(b), "\n")
@@ -691,6 +700,11 @@ func ReplaceReadmeNewClientName(packageRootPath string, exports exports.Content)
 
 func ReplaceConstModuleVersion(packagePath string, newVersion string) error {
 	path := filepath.Join(packagePath, "constants.go")
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err

--- a/eng/tools/generator/cmd/v2/common/fileProcessor_test.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor_test.go
@@ -4,11 +4,16 @@
 package common
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/eng/tools/generator/repo"
 	"github.com/Azure/azure-sdk-for-go/eng/tools/internal/delta"
 	"github.com/Azure/azure-sdk-for-go/eng/tools/internal/exports"
 	"github.com/Azure/azure-sdk-for-go/eng/tools/internal/report"
+	"github.com/Azure/azure-sdk-for-go/eng/tools/internal/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,4 +126,17 @@ func TestCalculateNewVersion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, newVersion.String(), "1.2.0-beta.2")
 	assert.Equal(t, BetaLabel, prl)
+}
+
+func TestFindModule(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	sdkRoot := utils.NormalizePath(cwd)
+	sdkRepo, err := repo.OpenSDKRepository(sdkRoot)
+	assert.NoError(t, err)
+	module, err := FindModuleDirByGoMod(fmt.Sprintf("%s/%s", filepath.ToSlash(sdkRepo.Root()), "sdk/security/keyvault/azadmin/settings"))
+	assert.NoError(t, err)
+	moduleRelativePath, err := filepath.Rel(sdkRepo.Root(), module)
+	assert.NoError(t, err)
+	assert.Equal(t, "sdk/security/keyvault/azadmin", filepath.ToSlash(moduleRelativePath))
 }

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -32,13 +32,14 @@ type GenerateContext struct {
 }
 
 type GenerateResult struct {
-	Version           string
-	RPName            string
-	PackageName       string
-	PackageAbsPath    string
-	Changelog         Changelog
-	ChangelogMD       string
-	PullRequestLabels string
+	Version             string
+	RPName              string
+	PackageName         string
+	PackageAbsPath      string
+	Changelog           Changelog
+	ChangelogMD         string
+	PullRequestLabels   string
+	PackageRelativePath string
 }
 
 type GenerateParam struct {
@@ -375,7 +376,47 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 	}
 }
 
-func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam, packageRelativePath string, moduleRelativePath string) (*GenerateResult, error) {
+func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam) (*GenerateResult, error) {
+	isModule := true
+
+	packageRelativePath := ctx.TypeSpecConfig.GetPackageRelativePath()
+	if packageRelativePath == "" {
+		return nil, fmt.Errorf("package module relative path not found in %s", ctx.TypeSpecConfig.Path)
+	}
+
+	moduleRelativePath := ctx.TypeSpecConfig.GetModuleRelativePath()
+	// if module relative path is not provided, find it from the sdk path by go.mod
+	if moduleRelativePath == "" {
+		isModule = false
+		val, err := FindModuleDirByGoMod(filepath.Join(ctx.SDKPath, packageRelativePath))
+		if err != nil {
+			return nil, err
+		}
+		moduleRelativePath, err = filepath.Rel(ctx.SDKPath, val)
+		if err != nil {
+			return nil, err
+		}
+		moduleRelativePath = filepath.ToSlash(moduleRelativePath)
+	}
+
+	if !strings.HasPrefix(packageRelativePath, moduleRelativePath) {
+		return nil, fmt.Errorf("module relative path '%s' is not a prefix of package relative path '%s', please check your tspconfig.yaml file", moduleRelativePath, packageRelativePath)
+	}
+
+	if packageRelativePath != moduleRelativePath {
+		isModule = false
+	}
+
+	// if rp name and namespace name are not provided, extract them from the module path
+	if len(generateParam.RPName) == 0 && len(generateParam.NamespaceName) == 0 {
+		rpAndNamespaceName, err := ctx.TypeSpecConfig.GetRpAndPackageNameByModule(moduleRelativePath)
+		if err != nil {
+			return nil, err
+		}
+		generateParam.RPName = rpAndNamespaceName[0]
+		generateParam.NamespaceName = rpAndNamespaceName[1]
+	}
+
 	packagePath := filepath.Join(ctx.SDKPath, packageRelativePath)
 	modulePath := filepath.Join(ctx.SDKPath, moduleRelativePath)
 	changelogPath := filepath.Join(modulePath, ChangelogFileName)
@@ -426,7 +467,7 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam, pa
 	log.Printf("Start to run `tsp-client init` to generate the code...")
 	defaultModuleVersion := version.String()
 	emitOption := ""
-	if generateParam.IsModule {
+	if isModule {
 		emitOption = fmt.Sprintf("module-version=%s", defaultModuleVersion)
 	}
 	if generateParam.TypeSpecEmitOption != "" {
@@ -523,7 +564,7 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam, pa
 			return nil, err
 		}
 
-		if !generateParam.IsModule {
+		if isModule {
 			// remove go.mod for sub package
 			goModPath := filepath.Join(packagePath, "go.mod")
 			if _, err := os.Stat(goModPath); !os.IsNotExist(err) {
@@ -539,13 +580,14 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam, pa
 		}
 
 		return &GenerateResult{
-			Version:           version.String(),
-			RPName:            generateParam.RPName,
-			PackageName:       generateParam.NamespaceName,
-			PackageAbsPath:    packagePath,
-			Changelog:         *changelog,
-			ChangelogMD:       changelog.ToCompactMarkdown() + "\n" + changelog.GetChangeSummary(),
-			PullRequestLabels: string(prl),
+			Version:             version.String(),
+			RPName:              generateParam.RPName,
+			PackageName:         generateParam.NamespaceName,
+			PackageAbsPath:      packagePath,
+			Changelog:           *changelog,
+			ChangelogMD:         changelog.ToCompactMarkdown() + "\n" + changelog.GetChangeSummary(),
+			PullRequestLabels:   string(prl),
+			PackageRelativePath: packageRelativePath,
 		}, nil
 	} else {
 		log.Printf("Calculate new version...")
@@ -637,13 +679,14 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam, pa
 		}
 
 		return &GenerateResult{
-			Version:           version.String(),
-			RPName:            generateParam.RPName,
-			PackageName:       generateParam.NamespaceName,
-			PackageAbsPath:    packagePath,
-			Changelog:         *changelog,
-			ChangelogMD:       changelogMd + "\n" + changelog.GetChangeSummary(),
-			PullRequestLabels: string(prl),
+			Version:             version.String(),
+			RPName:              generateParam.RPName,
+			PackageName:         generateParam.NamespaceName,
+			PackageAbsPath:      packagePath,
+			Changelog:           *changelog,
+			ChangelogMD:         changelogMd + "\n" + changelog.GetChangeSummary(),
+			PullRequestLabels:   string(prl),
+			PackageRelativePath: packageRelativePath,
 		}, nil
 	}
 }

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -56,7 +56,6 @@ type GenerateParam struct {
 	ForceStableVersion   bool
 	TypeSpecEmitOption   string
 	TspClientOptions     []string
-	IsModule             bool
 }
 
 func (ctx *GenerateContext) GenerateForAutomation(readme, repo, goVersion string) ([]GenerateResult, []error) {

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -55,6 +55,7 @@ type GenerateParam struct {
 	ForceStableVersion   bool
 	TypeSpecEmitOption   string
 	TspClientOptions     []string
+	IsModule             bool
 }
 
 func (ctx *GenerateContext) GenerateForAutomation(readme, repo, goVersion string) ([]GenerateResult, []error) {
@@ -424,7 +425,10 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam, pa
 
 	log.Printf("Start to run `tsp-client init` to generate the code...")
 	defaultModuleVersion := version.String()
-	emitOption := fmt.Sprintf("module-version=%s", defaultModuleVersion)
+	emitOption := ""
+	if generateParam.IsModule {
+		emitOption = fmt.Sprintf("module-version=%s", defaultModuleVersion)
+	}
 	if generateParam.TypeSpecEmitOption != "" {
 		emitOption = fmt.Sprintf("%s;%s", emitOption, generateParam.TypeSpecEmitOption)
 	}
@@ -519,7 +523,7 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam, pa
 			return nil, err
 		}
 
-		if packageRelativePath != moduleRelativePath {
+		if !generateParam.IsModule {
 			// remove go.mod for sub package
 			goModPath := filepath.Join(packagePath, "go.mod")
 			if _, err := os.Stat(goModPath); !os.IsNotExist(err) {

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -377,7 +377,7 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 }
 
 func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam) (*GenerateResult, error) {
-	isModule := true
+	isSubPackage := false
 
 	packageRelativePath := ctx.TypeSpecConfig.GetPackageRelativePath()
 	if packageRelativePath == "" {
@@ -387,7 +387,7 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam) (*
 	moduleRelativePath := ctx.TypeSpecConfig.GetModuleRelativePath()
 	// if module relative path is not provided, find it from the sdk path by go.mod
 	if moduleRelativePath == "" {
-		isModule = false
+		isSubPackage = true
 		val, err := FindModuleDirByGoMod(filepath.Join(ctx.SDKPath, packageRelativePath))
 		if err != nil {
 			return nil, err
@@ -404,7 +404,7 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam) (*
 	}
 
 	if packageRelativePath != moduleRelativePath {
-		isModule = false
+		isSubPackage = true
 	}
 
 	// if rp name and namespace name are not provided, extract them from the module path
@@ -467,7 +467,7 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam) (*
 	log.Printf("Start to run `tsp-client init` to generate the code...")
 	defaultModuleVersion := version.String()
 	emitOption := ""
-	if isModule {
+	if !isSubPackage {
 		emitOption = fmt.Sprintf("module-version=%s", defaultModuleVersion)
 	}
 	if generateParam.TypeSpecEmitOption != "" {
@@ -564,7 +564,7 @@ func (ctx *GenerateContext) GenerateForTypeSpec(generateParam *GenerateParam) (*
 			return nil, err
 		}
 
-		if isModule {
+		if isSubPackage {
 			// remove go.mod for sub package
 			goModPath := filepath.Join(packagePath, "go.mod")
 			if _, err := os.Stat(goModPath); !os.IsNotExist(err) {

--- a/eng/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/eng/tools/generator/cmd/v2/release/releaseCmd.go
@@ -183,21 +183,6 @@ func (c *commandContext) generate(sdkRepo repo.SDKRepository, specCommitHash str
 
 	if existTypeSpec {
 		log.Printf("Generate SDK through TypeSpec...")
-
-		packageRelativePath := generateCtx.TypeSpecConfig.GetPackageRelativePath()
-		if packageRelativePath == "" {
-			return fmt.Errorf("package module relative path not found")
-		}
-
-		moduleRelativePath := generateCtx.TypeSpecConfig.GetModuleRelativePath()
-		if moduleRelativePath == "" {
-			return fmt.Errorf("module relative path not found in %s", generateCtx.TypeSpecConfig.Path)
-		}
-
-		if !strings.HasPrefix(packageRelativePath, moduleRelativePath) {
-			return fmt.Errorf("module relative path '%s' is not a prefix of package relative path '%s', please check your tspconfig.yaml file", moduleRelativePath, packageRelativePath)
-		}
-
 		result, err = generateCtx.GenerateForTypeSpec(&common.GenerateParam{
 			RPName:               c.rpName,
 			NamespaceName:        c.namespaceName,
@@ -209,7 +194,7 @@ func (c *commandContext) generate(sdkRepo repo.SDKRepository, specCommitHash str
 			GoVersion:            c.flags.GoVersion,
 			TypeSpecEmitOption:   c.flags.TypeSpecGoOption,
 			TspClientOptions:     c.flags.TspClientOption,
-		}, packageRelativePath, moduleRelativePath)
+		})
 	} else {
 		log.Printf("Generate SDK through AutoRest...")
 		result, err = generateCtx.GenerateForSingleRPNamespace(&common.GenerateParam{

--- a/eng/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/eng/tools/generator/cmd/v2/release/releaseCmd.go
@@ -183,10 +183,21 @@ func (c *commandContext) generate(sdkRepo repo.SDKRepository, specCommitHash str
 
 	if existTypeSpec {
 		log.Printf("Generate SDK through TypeSpec...")
-		packageModuleRelativePath := generateCtx.TypeSpecConfig.GetPackageModuleRelativePath()
-		if packageModuleRelativePath == "" {
+
+		packageRelativePath := generateCtx.TypeSpecConfig.GetPackageRelativePath()
+		if packageRelativePath == "" {
 			return fmt.Errorf("package module relative path not found")
 		}
+
+		moduleRelativePath := generateCtx.TypeSpecConfig.GetModuleRelativePath()
+		if moduleRelativePath == "" {
+			return fmt.Errorf("module relative path not found in %s", generateCtx.TypeSpecConfig.Path)
+		}
+
+		if !strings.HasPrefix(packageRelativePath, moduleRelativePath) {
+			return fmt.Errorf("module relative path '%s' is not a prefix of package relative path '%s', please check your tspconfig.yaml file", moduleRelativePath, packageRelativePath)
+		}
+
 		result, err = generateCtx.GenerateForTypeSpec(&common.GenerateParam{
 			RPName:               c.rpName,
 			NamespaceName:        c.namespaceName,
@@ -198,7 +209,7 @@ func (c *commandContext) generate(sdkRepo repo.SDKRepository, specCommitHash str
 			GoVersion:            c.flags.GoVersion,
 			TypeSpecEmitOption:   c.flags.TypeSpecGoOption,
 			TspClientOptions:     c.flags.TspClientOption,
-		}, packageModuleRelativePath)
+		}, packageRelativePath, moduleRelativePath)
 	} else {
 		log.Printf("Generate SDK through AutoRest...")
 		result, err = generateCtx.GenerateForSingleRPNamespace(&common.GenerateParam{

--- a/eng/tools/generator/config/typespecRequests.go
+++ b/eng/tools/generator/config/typespecRequests.go
@@ -48,7 +48,7 @@ func GetTypeSpecProjectsFromConfig(config *Config, specRoot string) (tspProjects
 			if err != nil {
 				return nil, err
 			}
-			module, err := tspConfig.GetModuleName()
+			module, err := tspConfig.GetRpAndPackageName()
 			if err != nil {
 				return nil, err
 			}

--- a/eng/tools/generator/config/validate/localValidator.go
+++ b/eng/tools/generator/config/validate/localValidator.go
@@ -82,7 +82,7 @@ func getReadmeGoFromReadme(readme string) string {
 	return strings.ReplaceAll(readme, readmeFilename, goReadmeFilename)
 }
 
-func GetModuleName(content []byte) (string, string) {
+func GetRpAndPackageName(content []byte) (string, string) {
 	moduleExist := regexp.MustCompile(goReadmeModuleName).Match(content)
 	if moduleExist {
 		moduleName := regexp.MustCompile(goReadmeModuleName).FindString(string(content))

--- a/eng/tools/generator/template/typespec/CHANGELOG.md.tpl
+++ b/eng/tools/generator/template/typespec/CHANGELOG.md.tpl
@@ -3,6 +3,6 @@
 ## {{.packageVersion}} ({{.releaseDate}})
 ### Other Changes
 
-The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/{{.rpName}}/{{.packageName}}` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
+The package of `github.com/Azure/azure-sdk-for-go/sdk/{{.moduleRelativePath}}` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 
 To learn more, please refer to our documentation [Quick Start](https://aka.ms/azsdk/go/mgmt).

--- a/eng/tools/generator/template/typespec/README.md.tpl
+++ b/eng/tools/generator/template/typespec/README.md.tpl
@@ -2,7 +2,7 @@
 
 The `{{.packageName}}` module provides operations for working with Azure {{.packageTitle}}.
 
-[Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/{{.rpName}}/{{.packageName}})
+[Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/{{.moduleRelativePath}})
 
 # Getting started
 
@@ -18,7 +18,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure {{.packageTitle}} module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/{{.rpName}}/{{.packageName}}
+go get github.com/Azure/azure-sdk-for-go/{{.moduleRelativePath}}
 ```
 
 ## Authorization

--- a/eng/tools/generator/template/typespec/ci.yml.tpl
+++ b/eng/tools/generator/template/typespec/ci.yml.tpl
@@ -8,7 +8,7 @@ trigger:
       - release/*
   paths:
     include:
-    - sdk/resourcemanager/{{.rpName}}/{{.packageName}}/
+    - {{.moduleRelativePath}}/
 
 pr:
   branches:
@@ -19,10 +19,10 @@ pr:
       - release/*
   paths:
     include:
-    - sdk/resourcemanager/{{.rpName}}/{{.packageName}}/
+    - {{.moduleRelativePath}}/
 
 extends:
   template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
     IncludeRelease: true
-    ServiceDirectory: 'resourcemanager/{{.rpName}}/{{.packageName}}'
+    ServiceDirectory: '{{.serviceDir}}'

--- a/eng/tools/generator/template/typespec/go.mod.tpl
+++ b/eng/tools/generator/template/typespec/go.mod.tpl
@@ -1,4 +1,4 @@
-module github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/{{.rpName}}/{{.packageName}}
+module github.com/Azure/azure-sdk-for-go/{{.moduleRelativePath}}
 
 go {{.goVersion}}
 

--- a/eng/tools/generator/typespec/tspconfig.go
+++ b/eng/tools/generator/typespec/tspconfig.go
@@ -117,7 +117,19 @@ func ParseTypeSpecConfig(tspconfigPath string) (*TypeSpecConfig, error) {
 	return &tspConfig, err
 }
 
-func (tc *TypeSpecConfig) GetPackageModuleRelativePath() string {
+func (tc *TypeSpecConfig) GetPackageRelativePath() string {
+	goConfig := tc.Options["@azure-tools/typespec-go"].(map[string]interface{})
+	if goConfig["package-dir"] == nil {
+		return tc.GetModuleRelativePath()
+	} else {
+		if goConfig["service-dir"] == nil {
+			goConfig["service-dir"] = tc.Parameters["service-dir"].(map[string]interface {})["default"]
+		}
+		return goConfig["service-dir"].(string) + "/" + goConfig["package-dir"].(string)
+	}
+}
+
+func (tc *TypeSpecConfig) GetModuleRelativePath() string {
 	goConfig := tc.Options["@azure-tools/typespec-go"].(map[string]interface{})
 	if goConfig["module"] == nil {
 		return ""
@@ -180,9 +192,9 @@ func (tc TypeSpecConfig) ExistEmitOption(emit string) bool {
 	return err == nil
 }
 
-// GetModuleName return [rpName, packageName]
-// module: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/{rpName}/{packageName}
-func (tc TypeSpecConfig) GetModuleName() ([2]string, error) {
+// GetRpAndPackageName return [rpName, packageName]
+// module: github.com/Azure/azure-sdk-for-go/sdk/.../{rpName}/{packageName}
+func (tc TypeSpecConfig) GetRpAndPackageName() ([2]string, error) {
 	option, err := tc.EmitOption(string(TypeSpec_GO))
 	if err != nil {
 		return [2]string{}, err
@@ -191,9 +203,6 @@ func (tc TypeSpecConfig) GetModuleName() ([2]string, error) {
 	module := (option.(map[string]any))["module"].(string)
 	s := strings.Split(module, "/")
 	l := len(s)
-	if l != 7 {
-		return [2]string{}, fmt.Errorf("module is invalid and must be in the format of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/{rpName}/{packageName}`")
-	}
 	if !strings.Contains(s[l-1], "arm") && !strings.Contains(s[l-1], "az") {
 		return [2]string{}, fmt.Errorf("packageName is invalid and must start with `arm` or `az`")
 	}

--- a/eng/tools/generator/typespec/tspconfig_test.go
+++ b/eng/tools/generator/typespec/tspconfig_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTypeSpecConfig_GetPackageModuleRelativePath(t *testing.T) {
+func TestTypeSpecConfig_GetPackageRelativePath(t *testing.T) {
 	tests := []struct {
 		name     string
 		config   typespec.TypeSpecConfig
 		expected string
 	}{
 		{
-			name: "Valid module path",
+			name: "Package path from module",
 			config: typespec.TypeSpecConfig{
 				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
 					Options: map[string]any{
@@ -27,7 +27,75 @@ func TestTypeSpecConfig_GetPackageModuleRelativePath(t *testing.T) {
 			expected: "sdk/messaging/eventgrid/azsystemevents",
 		},
 		{
-			name: "Module path with placeholders",
+			name: "Package path from module with placeholder",
+			config: typespec.TypeSpecConfig{
+				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
+					Options: map[string]any{
+						"@azure-tools/typespec-go": map[string]any{
+							"module":      "github.com/Azure/azure-sdk-for-go/{service-dir}/armcompute",
+							"service-dir": "sdk/resourcemanager/compute",
+						},
+					},
+				},
+			},
+			expected: "sdk/resourcemanager/compute/armcompute",
+		},
+		{
+			name: "Empty package path",
+			config: typespec.TypeSpecConfig{
+				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
+					Options: map[string]any{
+						"@azure-tools/typespec-go": map[string]any{},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "Package path from service and package dir",
+			config: typespec.TypeSpecConfig{
+				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
+					Options: map[string]any{
+						"@azure-tools/typespec-go": map[string]any{
+							"module":      "github.com/Azure/azure-sdk-for-go/{service-dir}/azadmin",
+							"service-dir": "sdk/security/keyvault",
+							"package-dir": "azadmin/backup",
+						},
+					},
+				},
+			},
+			expected: "sdk/security/keyvault/azadmin/backup",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.config.GetPackageRelativePath())
+		})
+	}
+}
+
+func TestTypeSpecConfig_GetModuleRelativePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   typespec.TypeSpecConfig
+		expected string
+	}{
+		{
+			name: "Normal",
+			config: typespec.TypeSpecConfig{
+				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
+					Options: map[string]any{
+						"@azure-tools/typespec-go": map[string]any{
+							"module": "github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azsystemevents",
+						},
+					},
+				},
+			},
+			expected: "sdk/messaging/eventgrid/azsystemevents",
+		},
+		{
+			name: "Module with placeholder",
 			config: typespec.TypeSpecConfig{
 				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
 					Options: map[string]any{
@@ -42,7 +110,7 @@ func TestTypeSpecConfig_GetPackageModuleRelativePath(t *testing.T) {
 			expected: "sdk/resourcemanager/compute/armcompute",
 		},
 		{
-			name: "Module path without module key",
+			name: "Empty module",
 			config: typespec.TypeSpecConfig{
 				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
 					Options: map[string]any{
@@ -52,11 +120,26 @@ func TestTypeSpecConfig_GetPackageModuleRelativePath(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			name: "Module different from package path",
+			config: typespec.TypeSpecConfig{
+				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
+					Options: map[string]any{
+						"@azure-tools/typespec-go": map[string]any{
+							"module":      "github.com/Azure/azure-sdk-for-go/{service-dir}/azadmin",
+							"service-dir": "sdk/security/keyvault",
+							"package-dir": "azadmin/backup",
+						},
+					},
+				},
+			},
+			expected: "sdk/security/keyvault/azadmin",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.config.GetPackageModuleRelativePath())
+			assert.Equal(t, tt.expected, tt.config.GetModuleRelativePath())
 		})
 	}
 }

--- a/eng/tools/generator/typespec/typespec-go.go
+++ b/eng/tools/generator/typespec/typespec-go.go
@@ -2,6 +2,7 @@ package typespec
 
 import (
 	"errors"
+	"log"
 	"regexp"
 
 	"github.com/goccy/go-yaml"
@@ -56,7 +57,8 @@ var (
 
 func (o *GoEmitterOptions) Validate() error {
 	if o.Module == "" {
-		return ErrModuleEmpty
+		log.Printf("typesepec-go option `module` is empty")
+		return nil
 	}
 
 	matched := regexp.MustCompile(moduleRegex).MatchString(o.Module)


### PR DESCRIPTION
1. do not throw error is no exports found
2. support sub package generation

follow up tasks:
1. migrate current mpg generation from call tsp-client directly to use go generate to do so
2. decide how code generator support sub package generation