### PR TITLE
Clarify AzureCLICredential invalid Subscription error

### DIFF
--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -70,7 +70,11 @@ func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredent
 	}
 	for _, r := range cp.Subscription {
 		if !(alphanumeric(r) || r == '-' || r == '_' || r == ' ' || r == '.') {
-			return nil, fmt.Errorf("%s: invalid Subscription %q", credNameAzureCLI, cp.Subscription)
+			return nil, fmt.Errorf(
+				"%s: Subscription %q contains invalid characters. If this is the name of a subscription, use its ID instead",
+				credNameAzureCLI,
+				cp.Subscription,
+			)
 		}
 	}
 	if cp.TenantID != "" && !validTenantID(cp.TenantID) {


### PR DESCRIPTION
The set of characters we allow for a subscription name is drawn from general Azure guidelines because subscription name requirements aren't well documented. We disallow some characters that are valid in a subscription name, such as `()`. Rather than allow valid characters that may be unsafe to interpolate into a command line, this PR clarifies the error message and recommends customers work around a validation error by using the subscription's ID (a UUID) instead of its name.