### PR TITLE
[azopenaiassistants] Removing a bit that was making an assistants test less reliable

### DIFF
--- a/sdk/ai/azopenaiassistants/client_vectorstores_test.go
+++ b/sdk/ai/azopenaiassistants/client_vectorstores_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/ai/azopenaiassistants"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -118,7 +117,7 @@ func TestVectorStores(t *testing.T) {
 			Azure: azure,
 		})
 
-		seed := time.Now().UnixNano()
+		seed := getRandomName(t, "test-vector-stores")
 
 		// create a couple of vector stores in the (unlikely) case, that we don't have enough to test with...
 		resp1, err := client.CreateVectorStore(context.Background(), azopenaiassistants.VectorStoreBody{
@@ -181,7 +180,7 @@ func TestVectorStoresWithBatch(t *testing.T) {
 			Azure: azure,
 		})
 
-		seed := time.Now().UnixNano()
+		seed := getRandomName(t, "test-vector-stores-with-batch")
 
 		createVectorResp, err := client.CreateVectorStore(context.Background(), azopenaiassistants.VectorStoreBody{
 			Name: to.Ptr(fmt.Sprintf("go-vsb-%X", seed)),

--- a/sdk/ai/azopenaiassistants/client_vectorstores_test.go
+++ b/sdk/ai/azopenaiassistants/client_vectorstores_test.go
@@ -204,18 +204,20 @@ func TestVectorStoresWithBatch(t *testing.T) {
 			fileIDs = append(fileIDs, *uploadFileResp.ID)
 		}
 
+		t.Logf("File IDs: %#v", fileIDs)
+
 		createBatchResp, err := client.CreateVectorStoreFileBatch(context.Background(), *createVectorResp.ID, azopenaiassistants.CreateVectorStoreFileBatchBody{
 			FileIDs: fileIDs,
 		}, nil)
 		require.NoError(t, err)
 
+		t.Logf("Vector store batch: %#v", *createBatchResp.ID)
+
 		getResp, err := client.GetVectorStoreFileBatch(context.Background(), *createVectorResp.ID, *createBatchResp.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, *createBatchResp.ID, *getResp.ID)
 
-		pager := client.NewListVectorStoreFileBatchFilesPager(*createVectorResp.ID, *createBatchResp.ID, &azopenaiassistants.ListVectorStoreFileBatchFilesOptions{
-			Limit: to.Ptr[int32](2), // split all of our files across two pages
-		})
+		pager := client.NewListVectorStoreFileBatchFilesPager(*createVectorResp.ID, *createBatchResp.ID, nil)
 
 		found := 0
 
@@ -228,8 +230,6 @@ func TestVectorStoresWithBatch(t *testing.T) {
 				delete(fileIDMap, *v.ID)
 				found++
 			}
-
-			require.LessOrEqual(t, len(resp.Data), 2)
 		}
 
 		require.Equal(t, numUploaded, found)

--- a/sdk/ai/azopenaiassistants/shared_test.go
+++ b/sdk/ai/azopenaiassistants/shared_test.go
@@ -346,3 +346,10 @@ func getValue[T any](v *T, def T) T {
 
 	return *v
 }
+
+func getRandomName(t *testing.T, prefix string) string {
+	seed, err := recording.GenerateAlphaNumericID(t, prefix, 6+len(prefix), true)
+	require.NoError(t, err)
+
+	return seed
+}


### PR DESCRIPTION
As files are updated on the backend, the iteration order changes. The paging aspect of this isn't critical, so I'm just removing it, making the test reliable again.
