### PR TITLE
Perf: Use WalkDir for optimized directory traversal

### DIFF
--- a/eng/tools/doccheck/main.go
+++ b/eng/tools/doccheck/main.go
@@ -21,7 +21,7 @@ func filter(f fs.FileInfo) bool {
 func findAllSubDirectories(root string) []string {
 	var ret []string
 
-	filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+	filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			panic(err)
 		}
@@ -31,9 +31,9 @@ func findAllSubDirectories(root string) []string {
 		if strings.Contains(path, "eng/tools") {
 			return filepath.SkipDir
 		}
-		if info.IsDir() && strings.HasSuffix(path, "internal") {
+		if d.IsDir() && strings.HasSuffix(path, "internal") {
 			return filepath.SkipDir
-		} else if info.IsDir() {
+		} else if d.IsDir() {
 			ret = append(ret, path)
 		}
 		return nil

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -139,16 +139,16 @@ func ReadV2ModuleNameToGetNamespace(path string) (map[string][]PackageInfo, erro
 // remove all sdk generated files in given path
 func CleanSDKGeneratedFiles(path string) error {
 	log.Printf("Removing all sdk generated files in '%s'...", path)
-	return filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+	return filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
-		if strings.HasSuffix(info.Name(), ".go") {
+		if strings.HasSuffix(d.Name(), ".go") {
 			b, err := os.ReadFile(path)
 			if err != nil {
 				return err
@@ -553,16 +553,16 @@ func replaceModuleImport(path, rpName, namespaceName, previousVersion, currentVe
 		return nil
 	}
 
-	return filepath.Walk(filepath.Join(path, subPath), func(path string, info fs.FileInfo, err error) error {
+	return filepath.WalkDir(filepath.Join(path, subPath), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 		suffix := false
 		for i := 0; i < len(suffixes) && !suffix; i++ {
-			suffix = strings.HasSuffix(info.Name(), suffixes[i])
+			suffix = strings.HasSuffix(d.Name(), suffixes[i])
 		}
 
 		if suffix {
@@ -705,16 +705,16 @@ func ReplaceConstModuleVersion(packagePath string, newVersion string) error {
 }
 
 func ReplaceModule(newVersion *semver.Version, packagePath, baseModule string, suffixs ...string) error {
-	return filepath.Walk(packagePath, func(path string, info fs.FileInfo, err error) error {
+	return filepath.WalkDir(packagePath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
-		hasSuffix := slices.ContainsFunc(suffixs, func(s string) bool { return strings.HasSuffix(info.Name(), s) })
+		hasSuffix := slices.ContainsFunc(suffixs, func(s string) bool { return strings.HasSuffix(d.Name(), s) })
 		if len(suffixs) == 0 || hasSuffix {
 			if err = ReplaceImport(path, baseModule, newVersion.Major()); err != nil {
 				return err

--- a/eng/tools/indexer/util/util.go
+++ b/eng/tools/indexer/util/util.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -47,11 +47,11 @@ func GetIndexedPackages(content io.Reader) (PackageSet, error) {
 // Each directory entry is converted to a complete package path, e.g. "github.com/Azure/azure-sdk-for-go/services/foo/...".
 func GetPackagesForIndexing(dir string) (PackageSet, error) {
 	leafDirs := []string{}
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			// check if leaf dir
 			fi, err := ioutil.ReadDir(path)
 			if err != nil {

--- a/eng/tools/internal/coverage/coverage.go
+++ b/eng/tools/internal/coverage/coverage.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -36,7 +37,7 @@ func check(e error) {
 func findCoverageFiles(root string) []string {
 	var coverageFiles []string
 
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/eng/tools/internal/report/packages.go
+++ b/eng/tools/internal/report/packages.go
@@ -5,6 +5,7 @@ package report
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -16,11 +17,11 @@ const apiDirSuffix = "api"
 // GetPackages returns all the go sdk packages under the given root directory
 func GetPackages(dir string) ([]string, error) {
 	var pkgDirs []string
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			// check if leaf dir
 			fi, err := os.ReadDir(path)
 			if err != nil {

--- a/eng/tools/profileBuilder/model/latest.go
+++ b/eng/tools/profileBuilder/model/latest.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -7,6 +8,7 @@ package model
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"log"
 	"os"
@@ -111,9 +113,9 @@ func GetLatestPackages(rootDir string, includePreview bool, verboseLog *log.Logg
 
 	tracker := latestTracker{}
 
-	filepath.Walk(rootDir, func(currentPath string, info os.FileInfo, openErr error) error {
+	filepath.WalkDir(rootDir, func(currentPath string, d fs.DirEntry, openErr error) error {
 		pi, err := DeconstructPath(currentPath)
-		if err != nil || !info.IsDir() {
+		if err != nil || !d.IsDir() {
 			return nil
 		} else if !predicate(currentPath) {
 			verboseLog.Printf("%q rejected by Predicate", currentPath)

--- a/eng/tools/profileBuilder/model/transforms.go
+++ b/eng/tools/profileBuilder/model/transforms.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -17,6 +18,7 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -56,8 +58,8 @@ func BuildProfile(packageList ListDefinition, name, outputLocation string, outpu
 			pkgDir = abs
 		}
 		go func(pd string) {
-			filepath.Walk(pd, func(path string, info os.FileInfo, err error) error {
-				if !info.IsDir() {
+			filepath.WalkDir(pd, func(path string, d fs.DirEntry, err error) error {
+				if !d.IsDir() {
 					return nil
 				}
 				fs := token.NewFileSet()

--- a/eng/tools/smoketests/cmd/root.go
+++ b/eng/tools/smoketests/cmd/root.go
@@ -82,9 +82,9 @@ func inIgnoredDirectories(path string) bool {
 func findModuleDirectories(root string) []string {
 	var ret []string
 
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		handle(err)
-		if strings.Contains(info.Name(), "go.mod") && !inIgnoredDirectories(path) {
+		if strings.Contains(d.Name(), "go.mod") && !inIgnoredDirectories(path) {
 			path = strings.ReplaceAll(path, "\\", "/")
 			path = strings.ReplaceAll(path, "/go.mod", "")
 			parts := strings.Split(path, "/sdk/")
@@ -232,9 +232,9 @@ func BuildModFile(modules []Module, serviceDirectory string) error {
 func FindExampleFiles(root, serviceDirectory string) ([]string, error) {
 	var ret []string
 
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		handle(err)
-		if strings.HasPrefix(info.Name(), "example_") && !inIgnoredDirectories(path) && strings.HasSuffix(info.Name(), ".go") {
+		if strings.HasPrefix(d.Name(), "example_") && !inIgnoredDirectories(path) && strings.HasSuffix(d.Name(), ".go") {
 			path = strings.ReplaceAll(path, "\\", "/")
 			if serviceDirectory == "" || strings.Contains(path, serviceDirectory) {
 				ret = append(ret, path)
@@ -307,8 +307,8 @@ func CopyExampleFiles(exFiles []string, dest string) {
 // ReplacePackageStatement replaces all "package ***" with a common "package main" statement
 func ReplacePackageStatement(root string) error {
 	packageName := "package main"
-	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if strings.HasSuffix(info.Name(), ".go") {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if strings.HasSuffix(d.Name(), ".go") {
 			handle(err)
 			data, err := ioutil.ReadFile(path)
 			handle(err)
@@ -367,7 +367,7 @@ func BuildMainFile(root string, c ConfigFile) error {
 func FindEnvVars(root string) error {
 	fmt.Println("Find all environment variables using `os.Getenv` or `os.LookupEnv`")
 
-	err := filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if strings.HasSuffix(path, ".go") {
 			// Find Env Vars
 			searchFile(path)


### PR DESCRIPTION
filepath.Walk calls os.Lstat for every file or directory to retrieve os.FileInfo, which can be slower. filepath.WalkDir avoids unnecessary system calls since it provides a fs.DirEntry, which includes file type information without requiring a stat call.

