### PR TITLE
Return an error for nonlocal paths in test proxy archives

### DIFF
--- a/sdk/internal/recording/server.go
+++ b/sdk/internal/recording/server.go
@@ -144,8 +144,10 @@ func extractTestProxyArchive(archivePath string, outputDir string) error {
 		if err != nil {
 			return err
 		}
-
 		targetPath := filepath.Join(outputDir, header.Name)
+		if !strings.HasPrefix(targetPath, filepath.Clean(outputDir)) {
+			return fmt.Errorf("illegal file path: %q", header.Name)
+		}
 
 		log.Println("Extracting", targetPath)
 

--- a/sdk/internal/recording/server.go
+++ b/sdk/internal/recording/server.go
@@ -144,6 +144,7 @@ func extractTestProxyArchive(archivePath string, outputDir string) error {
 		if err != nil {
 			return err
 		}
+
 		targetPath := filepath.Join(outputDir, header.Name)
 		if !strings.HasPrefix(targetPath, filepath.Clean(outputDir)) {
 			return fmt.Errorf("illegal file path: %q", header.Name)


### PR DESCRIPTION
This prevents overwriting arbitrary files outside the target directory. We already return an error for such paths in zips but not in tarballs. I added a test for both cases.