### PR TITLE
[keyvault/azsecrets] make azsecrets.Client thread-safe

### DIFF
--- a/sdk/security/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/security/keyvault/azsecrets/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed data race when using Client from multiple goroutines concurrently.
 
 ### Other Changes
 


### PR DESCRIPTION
azsecrets.Client uses NewKeyVaultChallengePolicy. This policy is not goroutine-safe, violating the documented requirement that policies are goroutine-safe [1]. This leads to data races which are reported by Go's race detector.

Fix NewKeyVaultChallengePolicy to be goroutine-safe using a mutex. This can lead to redundant preflight requests, but at least Go's race detector no longer complains.

Test plan:

    $ cd sdk/security/keyvault/internal/
    $ go test -race

Fixes #24031.

[1] https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-core-concepts

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
