### PR TITLE
fix: make it os compatible. 

### DIFF
--- a/eng/tools/generator/cmd/issue/link/common.go
+++ b/eng/tools/generator/cmd/issue/link/common.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -45,7 +44,7 @@ func GetReadmePathFromChangedFiles(ctx context.Context, client *query.Client, fi
 	// find readme files one by one
 	readmeFiles := make(map[Readme]bool)
 	for _, file := range files {
-		readme, err := GetReadmeFromPath(ctx, client, path.Dir(file))
+		readme, err := GetReadmeFromPath(ctx, client, filepath.Dir(file))
 		if err != nil {
 			log.Printf("Changed file '%s' does not belong to any RP, ignoring", file)
 			continue
@@ -145,7 +144,7 @@ func GetTspConfigPathFromChangedFiles(ctx context.Context, client *query.Client,
 	// find readme files one by one
 	tspConfigFiles := make(map[Readme]bool)
 	for _, file := range files {
-		tspConfig, err := GetTspConfigFromPath(ctx, client, path.Dir(file))
+		tspConfig, err := GetTspConfigFromPath(ctx, client, filepath.Dir(file))
 		if err != nil {
 			log.Printf("Changed file '%s' does not belong to any RP, ignoring", file)
 			continue

--- a/eng/tools/generator/cmd/v2/common/changelogProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/changelogProcessor.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -87,7 +87,7 @@ func ContainsPreviewAPIVersion(packagePath string) (bool, error) {
 
 	for _, file := range files {
 		if strings.HasSuffix(file.Name(), ".go") {
-			b, err := os.ReadFile(path.Join(packagePath, file.Name()))
+			b, err := os.ReadFile(filepath.Join(packagePath, file.Name()))
 			if err != nil {
 				return false, err
 			}

--- a/eng/tools/generator/cmd/v2/common/changelogProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/changelogProcessor.go
@@ -86,7 +86,7 @@ func ContainsPreviewAPIVersion(packagePath string) (bool, error) {
 	}
 
 	for _, file := range files {
-		if strings.HasSuffix(file.Name(), ".go") {
+		if filepath.Ext(file.Name()) == ".go" {
 			b, err := os.ReadFile(filepath.Join(packagePath, file.Name()))
 			if err != nil {
 				return false, err

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -15,7 +15,6 @@ import (
 	"io/fs"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -232,7 +231,7 @@ func RemoveTagSet(path string) error {
 
 // get swagger rp folder name from autorest.md file
 func GetSpecRpName(packageRootPath string) (string, error) {
-	b, err := os.ReadFile(path.Join(packageRootPath, "autorest.md"))
+	b, err := os.ReadFile(filepath.Join(packageRootPath, "autorest.md"))
 	if err != nil {
 		return "", err
 	}

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -147,7 +147,7 @@ func CleanSDKGeneratedFiles(path string) error {
 			return nil
 		}
 
-		if strings.HasSuffix(d.Name(), ".go") {
+		if filepath.Ext(d.Name()) == ".go" {
 			b, err := os.ReadFile(path)
 			if err != nil {
 				return err

--- a/eng/tools/generator/cmd/v2/refresh/refreshCmd.go
+++ b/eng/tools/generator/cmd/v2/refresh/refreshCmd.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -117,7 +117,7 @@ func (c *commandContext) execute(sdkRepoParam, specRepoParam string) error {
 
 	var rpNames []string
 	if c.flags.RPs == "" {
-		rps, err := os.ReadDir(path.Join(generateCtx.SDKPath, "sdk", "resourcemanager"))
+		rps, err := os.ReadDir(filepath.Join(generateCtx.SDKPath, "sdk", "resourcemanager"))
 		if err != nil {
 			return fmt.Errorf("failed to get all rps: %+v", err)
 		}
@@ -129,14 +129,14 @@ func (c *commandContext) execute(sdkRepoParam, specRepoParam string) error {
 	}
 
 	for _, rpName := range rpNames {
-		namespaces, err := os.ReadDir(path.Join(generateCtx.SDKPath, "sdk", "resourcemanager", rpName))
+		namespaces, err := os.ReadDir(filepath.Join(generateCtx.SDKPath, "sdk", "resourcemanager", rpName))
 		if err != nil {
 			continue
 		}
 
 		for _, namespace := range namespaces {
 			log.Printf("Release generation for rp: %s, namespace: %s", rpName, namespace.Name())
-			specRpName, err := common.GetSpecRpName(path.Join(generateCtx.SDKPath, "sdk", "resourcemanager", rpName, namespace.Name()))
+			specRpName, err := common.GetSpecRpName(filepath.Join(generateCtx.SDKPath, "sdk", "resourcemanager", rpName, namespace.Name()))
 			if err != nil {
 				continue
 			}

--- a/eng/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/eng/tools/generator/cmd/v2/release/releaseCmd.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -148,7 +148,7 @@ func (c *commandContext) execute(sdkRepoParam, specRepoParam string) error {
 		return err
 	}
 
-	if path.Ext(c.rpName) == ".json" {
+	if filepath.Ext(c.rpName) == ".json" {
 		return c.generateFromRequest(sdkRepo, specRepoParam, specCommitHash)
 	} else {
 		return c.generate(sdkRepo, specCommitHash)

--- a/eng/tools/internal/coverage/coverage.go
+++ b/eng/tools/internal/coverage/coverage.go
@@ -41,7 +41,7 @@ func findCoverageFiles(root string) []string {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(path, coverageXmlFile) {
+		if !d.IsDir() && d.Name() == coverageXmlFile {
 			coverageFiles = append(coverageFiles, path)
 		}
 

--- a/eng/tools/mgmtreport/main.go
+++ b/eng/tools/mgmtreport/main.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -209,19 +208,19 @@ func execute(sdkPath, personalAccessToken, storageAccountKey string) error {
 	}
 
 	log.Println("generate a report in Markdown format...")
-	err = generateMDReport(mgmtReport, path.Join(sdkPath, "mgmtReport.md"))
+	err = generateMDReport(mgmtReport, filepath.Join(sdkPath, "mgmtReport.md"))
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	log.Println("generate a report in HTML format...")
-	err = generateHTMLReport(mgmtReport, path.Join(sdkPath, "mgmtReport.html"))
+	err = generateHTMLReport(mgmtReport, filepath.Join(sdkPath, "mgmtReport.html"))
 	if err != nil {
 		return err
 	}
 
 	log.Println("upload mgmt report to cloud...")
-	err = uploadHTMLReport(path.Join(sdkPath, "mgmtReport.html"), storageAccountName, storageAccountKey, storageContainerName, containerBlobName)
+	err = uploadHTMLReport(filepath.Join(sdkPath, "mgmtReport.html"), storageAccountName, storageAccountKey, storageContainerName, containerBlobName)
 	if err != nil {
 		return err
 	}

--- a/eng/tools/profileBuilder/model/latest.go
+++ b/eng/tools/profileBuilder/model/latest.go
@@ -11,15 +11,12 @@ import (
 	"io/fs"
 	"io/ioutil"
 	"log"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 )
-
-const previewSubdir = string(os.PathSeparator) + "preview" + string(os.PathSeparator)
 
 var previewVer = regexp.MustCompile(`(?:v?\d{4}-\d{2}-\d{2}|v?\d+[\.\d+\.\d\-]*)(?:-preview|-beta)`)
 
@@ -31,9 +28,14 @@ func acceptAllPredicate(name string) bool {
 }
 
 func includePreviewPredicate(name string) bool {
-	// check if the path contains a /preview/ subdirectory
-	if strings.Contains(name, previewSubdir) {
-		return false
+	// Split the path into components
+	components := strings.Split(filepath.ToSlash(name), "/")
+
+	// Check if any component is "preview"
+	for _, component := range components {
+		if component == "preview" {
+			return false
+		}
 	}
 	return !previewVer.MatchString(name)
 }

--- a/eng/tools/profileBuilder/model/transforms.go
+++ b/eng/tools/profileBuilder/model/transforms.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -191,7 +190,7 @@ func updateAliasPackageUserAgent(ap *AliasPackage, profileName string) {
 func writeAliasPackage(ap *AliasPackage, outputPath string, outputLog, errLog *log.Logger) {
 	files := token.NewFileSet()
 
-	err := os.MkdirAll(path.Dir(outputPath), 0755|os.ModeDir)
+	err := os.MkdirAll(filepath.Dir(outputPath), 0755|os.ModeDir)
 	if err != nil {
 		errLog.Fatalf("error creating directory: %v", err)
 	}

--- a/eng/tools/smoketests/cmd/root.go
+++ b/eng/tools/smoketests/cmd/root.go
@@ -84,7 +84,7 @@ func findModuleDirectories(root string) []string {
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		handle(err)
-		if strings.Contains(d.Name(), "go.mod") && !inIgnoredDirectories(path) {
+		if d.Name() == "go.mod" && !inIgnoredDirectories(path) {
 			path = strings.ReplaceAll(path, "\\", "/")
 			path = strings.ReplaceAll(path, "/go.mod", "")
 			parts := strings.Split(path, "/sdk/")

--- a/eng/tools/smoketests/cmd/root.go
+++ b/eng/tools/smoketests/cmd/root.go
@@ -234,7 +234,7 @@ func FindExampleFiles(root, serviceDirectory string) ([]string, error) {
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		handle(err)
-		if strings.HasPrefix(d.Name(), "example_") && !inIgnoredDirectories(path) && strings.HasSuffix(d.Name(), ".go") {
+		if strings.HasPrefix(d.Name(), "example_") && !inIgnoredDirectories(path) && filepath.Ext(d.Name()) == ".go" {
 			path = strings.ReplaceAll(path, "\\", "/")
 			if serviceDirectory == "" || strings.Contains(path, serviceDirectory) {
 				ret = append(ret, path)
@@ -308,7 +308,7 @@ func CopyExampleFiles(exFiles []string, dest string) {
 func ReplacePackageStatement(root string) error {
 	packageName := "package main"
 	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if strings.HasSuffix(d.Name(), ".go") {
+		if filepath.Ext(d.Name()) == ".go" {
 			handle(err)
 			data, err := ioutil.ReadFile(path)
 			handle(err)
@@ -368,7 +368,7 @@ func FindEnvVars(root string) error {
 	fmt.Println("Find all environment variables using `os.Getenv` or `os.LookupEnv`")
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if strings.HasSuffix(path, ".go") {
+		if filepath.Ext(path) == ".go" {
 			// Find Env Vars
 			searchFile(path)
 		}

--- a/sdk/internal/recording/server.go
+++ b/sdk/internal/recording/server.go
@@ -177,7 +177,7 @@ func extractTestProxyArchive(archivePath string, outputDir string) error {
 
 func installTestProxy(archivePath string, outputDir string, proxyPath string) error {
 	var err error
-	if strings.HasSuffix(archivePath, ".zip") {
+	if filepath.Ext(archivePath) == ".zip" {
 		err = extractTestProxyZip(archivePath, outputDir)
 	} else {
 		err = extractTestProxyArchive(archivePath, outputDir)


### PR DESCRIPTION
Remove strings.Contains to: 
- Update findCoverageFile to match exact file names.
- Enhance includePreviewPredicate for exact names.
- Direct file checking of go.mod.
- Remove hardcoded previewSubdir const

Remove path packge methods: 
- Use path/filepath methods to make it cross platform.
- Use filepath.Ext for file extension. 


