### PR TITLE
Removing impression tracking pixels from READMEs ***NO_CI***

### DIFF
--- a/sdk/azidentity/MIGRATION.md
+++ b/sdk/azidentity/MIGRATION.md
@@ -304,4 +304,4 @@ client := subscriptions.NewClient()
 client.Authorizer = azidext.NewTokenCredentialAdapter(cred, []string{"https://management.azure.com//.default"})
 ```
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fazidentity%2FMIGRATION.png)
+

--- a/sdk/azidentity/README.md
+++ b/sdk/azidentity/README.md
@@ -254,4 +254,4 @@ additional questions or comments.
 [ctc_overview]: https://aka.ms/azsdk/go/identity/credential-chains#chainedtokencredential-overview
 [dac_overview]: https://aka.ms/azsdk/go/identity/credential-chains#defaultazurecredential-overview
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fazidentity%2FREADME.png)
+

--- a/sdk/azidentity/cache/README.md
+++ b/sdk/azidentity/cache/README.md
@@ -26,4 +26,4 @@ For more information, see the
 or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
 additional questions or comments.
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fazidentity%2Fcache%2FREADME.png)
+

--- a/sdk/data/azappconfig/README.md
+++ b/sdk/data/azappconfig/README.md
@@ -70,4 +70,4 @@ contact opencode@microsoft.com with any additional questions or comments.
 [azappconfig_setting]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig#Setting
 [azappconfig_src]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/data/azappconfig
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fdata%2Fazappconfig%2FREADME.png)
+

--- a/sdk/data/azcosmos/README.md
+++ b/sdk/data/azcosmos/README.md
@@ -214,4 +214,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go/sdk/data/azcosmos/README.png)
+

--- a/sdk/data/aztables/README.md
+++ b/sdk/data/aztables/README.md
@@ -632,4 +632,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct][msft_oss_co
 
 [tables_rest]: https://learn.microsoft.com/rest/api/storageservices/table-service-rest-api
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go/sdk/data/aztables/README.png)
+

--- a/sdk/messaging/azeventhubs/README.md
+++ b/sdk/messaging/azeventhubs/README.md
@@ -130,4 +130,4 @@ Azure SDK for Go is licensed under the [MIT](https://github.com/Azure/azure-sdk-
 [godoc]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs
 [godoc_examples]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs#pkg-examples
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fmessaging%2Fazeventhubs%2FREADME.png)
+

--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -310,7 +310,7 @@ See the [examples][godoc_examples] for using this library to send and receive me
 
 If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-go/blob/main/CONTRIBUTING.md) to learn more about how to build and test the code.
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fmessaging%2Fazservicebus%2FREADME.png)
+
 
 [new_issue]: https://github.com/Azure/azure-sdk-for-go/issues/new
 [azure_identity_pkg]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity

--- a/sdk/security/keyvault/azcertificates/README.md
+++ b/sdk/security/keyvault/azcertificates/README.md
@@ -143,4 +143,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [certificates_samples]: https://aka.ms/azsdk/go/keyvault-certificates/docs#pkg-examples
 [managed_identity]: https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fsecurity%2Fkeyvault%2Fazcertificates%2FREADME.png)
+

--- a/sdk/security/keyvault/azkeys/README.md
+++ b/sdk/security/keyvault/azkeys/README.md
@@ -144,4 +144,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [keys_samples]: https://aka.ms/azsdk/go/keyvault-keys/docs#pkg-examples
 [managed_identity]: https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fsecurity%2Fkeyvault%2Fazkeys%2FREADME.png)
+

--- a/sdk/security/keyvault/azsecrets/README.md
+++ b/sdk/security/keyvault/azsecrets/README.md
@@ -141,4 +141,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [module_source]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/security/keyvault/azsecrets
 [secrets_samples]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets#pkg-examples
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fsecurity%2Fkeyvault%2Fazsecrets%2FREADME.png)
+

--- a/sdk/storage/azblob/README.md
+++ b/sdk/storage/azblob/README.md
@@ -249,7 +249,7 @@ For more information see the [Code of Conduct FAQ][coc_faq]
 or contact [opencode@microsoft.com][coc_contact] with any
 additional questions or comments.
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fstorage%2Fazblob%2FREADME.png)
+
 
 <!-- LINKS -->
 [source]: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/storage/azblob


### PR DESCRIPTION
Pixels like these were used to track impressions on READMEs, deleteing them in accordance to latest policy

```markdown
![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-go%2Fsdk%2Fdata%2Fazappconfig%2FREADME.png)
```
