### PR TITLE
[keyvault] add fakes support to internal

### DIFF
--- a/sdk/security/keyvault/internal/CHANGELOG.md
+++ b/sdk/security/keyvault/internal/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.2-beta.1 (Unreleased)
 
 ### Features Added
+* Added fakes support
 
 ### Breaking Changes
 

--- a/sdk/security/keyvault/internal/challenge_policy.go
+++ b/sdk/security/keyvault/internal/challenge_policy.go
@@ -1,6 +1,3 @@
-//go:build go1.18
-// +build go1.18
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/security/keyvault/internal/challenge_policy_test.go
+++ b/sdk/security/keyvault/internal/challenge_policy_test.go
@@ -1,6 +1,3 @@
-//go:build go1.18
-// +build go1.18
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/security/keyvault/internal/doc.go
+++ b/sdk/security/keyvault/internal/doc.go
@@ -1,6 +1,3 @@
-//go:build go1.18
-// +build go1.18
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/security/keyvault/internal/fake_challenge.go
+++ b/sdk/security/keyvault/internal/fake_challenge.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+
 package internal
 
 import (
@@ -23,7 +24,6 @@ func (m *FakeChallenge) Do(req *http.Request) (*http.Response, error, bool) {
 		Body:       http.NoBody,
 		Header:     http.Header{},
 	}
-	//resp.Header.Set("WWW-Authenticate", "Bearer authorization=\"https://fake.login.microsoftonline.com/00000000-0000-0000-0000-000000000000\" resource=\"https://vault.azure.net\"")
-	resp.Header.Set("WWW-Authenticate", "Bearer authorization=\"https://fake.com/0\" resource=\"test\"")
+	resp.Header.Set("WWW-Authenticate", `Bearer authorization="https://fake.local/tenant" resource="https://vault.azure.net"`)
 	return resp, nil, true
 }

--- a/sdk/security/keyvault/internal/fake_challenge.go
+++ b/sdk/security/keyvault/internal/fake_challenge.go
@@ -6,6 +6,7 @@ package internal
 import (
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // FakeChallenge is used by fake servers to fake the authentication challenge.
@@ -18,7 +19,7 @@ func (m *FakeChallenge) Do(req *http.Request) (*http.Response, error, bool) {
 		// presence of an authorization header means we don't need to elicit a challenge
 		return nil, nil, false
 	}
-	resource := req.Host
+
 	resp := &http.Response{
 		Request:    req,
 		Status:     "fake unauthorized",
@@ -26,6 +27,10 @@ func (m *FakeChallenge) Do(req *http.Request) (*http.Response, error, bool) {
 		Body:       http.NoBody,
 		Header:     http.Header{},
 	}
+
+	s := strings.Split(req.URL.Host, ".")
+	resource := fmt.Sprintf("%s://%s", req.URL.Scheme, strings.Join(s[len(s)-3:], "."))
 	resp.Header.Set("WWW-Authenticate", fmt.Sprintf(`Bearer authorization="https://fake.local/tenant" resource="%s"`, resource))
+
 	return resp, nil, true
 }

--- a/sdk/security/keyvault/internal/fake_challenge.go
+++ b/sdk/security/keyvault/internal/fake_challenge.go
@@ -4,6 +4,7 @@
 package internal
 
 import (
+	"fmt"
 	"net/http"
 )
 
@@ -17,6 +18,7 @@ func (m *FakeChallenge) Do(req *http.Request) (*http.Response, error, bool) {
 		// presence of an authorization header means we don't need to elicit a challenge
 		return nil, nil, false
 	}
+	resource := req.Host
 	resp := &http.Response{
 		Request:    req,
 		Status:     "fake unauthorized",
@@ -24,6 +26,6 @@ func (m *FakeChallenge) Do(req *http.Request) (*http.Response, error, bool) {
 		Body:       http.NoBody,
 		Header:     http.Header{},
 	}
-	resp.Header.Set("WWW-Authenticate", `Bearer authorization="https://fake.local/tenant" resource="https://vault.azure.net"`)
+	resp.Header.Set("WWW-Authenticate", fmt.Sprintf(`Bearer authorization="https://fake.local/tenant" resource="%s"`, resource))
 	return resp, nil, true
 }

--- a/sdk/security/keyvault/internal/fake_challenge.go
+++ b/sdk/security/keyvault/internal/fake_challenge.go
@@ -23,6 +23,7 @@ func (m *FakeChallenge) Do(req *http.Request) (*http.Response, error, bool) {
 		Body:       http.NoBody,
 		Header:     http.Header{},
 	}
-	resp.Header.Set("WWW-Authenticate", "Bearer authorization=\"https://fake.login.microsoftonline.com/00000000-0000-0000-0000-000000000000\" resource=\"https://vault.azure.net\"")
+	//resp.Header.Set("WWW-Authenticate", "Bearer authorization=\"https://fake.login.microsoftonline.com/00000000-0000-0000-0000-000000000000\" resource=\"https://vault.azure.net\"")
+	resp.Header.Set("WWW-Authenticate", "Bearer authorization=\"https://fake.com/0\" resource=\"test\"")
 	return resp, nil, true
 }

--- a/sdk/security/keyvault/internal/fake_challenge.go
+++ b/sdk/security/keyvault/internal/fake_challenge.go
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+package internal
+
+import (
+	"net/http"
+)
+
+// FakeChallenge is used by fake servers to fake the authentication challenge.
+type FakeChallenge struct{}
+
+// Do initiates an authentication challenge IFF req doesn't contain an Authorization header.
+// When the last return value is true, the fake server will use the returned response/error.
+func (m *FakeChallenge) Do(req *http.Request) (*http.Response, error, bool) {
+	if req.Header.Get("Authorization") != "" {
+		// presence of an authorization header means we don't need to elicit a challenge
+		return nil, nil, false
+	}
+	resp := &http.Response{
+		Request:    req,
+		Status:     "fake unauthorized",
+		StatusCode: http.StatusUnauthorized,
+		Body:       http.NoBody,
+		Header:     http.Header{},
+	}
+	resp.Header.Set("WWW-Authenticate", "Bearer authorization=\"https://fake.login.microsoftonline.com/00000000-0000-0000-0000-000000000000\" resource=\"https://vault.azure.net\"")
+	return resp, nil, true
+}

--- a/sdk/security/keyvault/internal/fake_challenge_test.go
+++ b/sdk/security/keyvault/internal/fake_challenge_test.go
@@ -21,8 +21,9 @@ func TestFakeChallenge(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	headers := resp.Header
-	_, ok := headers["Www-Authenticate"]
+	header, ok := headers["Www-Authenticate"]
 	require.True(t, ok)
+	require.Equal(t, `Bearer authorization="https://fake.local/tenant" resource="https://vault.azure.net"`, header[0])
 
 	req.Header.Set("Authorization", "fakeauthorization")
 	resp, err, intercepted = interceptor.Do(resp.Request)

--- a/sdk/security/keyvault/internal/fake_challenge_test.go
+++ b/sdk/security/keyvault/internal/fake_challenge_test.go
@@ -3,6 +3,10 @@
 
 package internal
 
-const (
-	version = "v1.1.2-beta.1" //nolint
+import (
+	"testing"
 )
+
+func TestFakeChallenge(t *testing.T) {
+
+}

--- a/sdk/security/keyvault/internal/fake_challenge_test.go
+++ b/sdk/security/keyvault/internal/fake_challenge_test.go
@@ -4,9 +4,29 @@
 package internal
 
 import (
+	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestFakeChallenge(t *testing.T) {
+	interceptor := &FakeChallenge{}
+	req, err := http.NewRequest(http.MethodGet, "https://42.vault.azure.net", nil)
+	require.NoError(t, err)
 
+	resp, err, intercepted := interceptor.Do(req)
+	require.NoError(t, err)
+	require.True(t, intercepted)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	headers := resp.Header
+	_, ok := headers["Www-Authenticate"]
+	require.True(t, ok)
+
+	req.Header.Set("Authorization", "fakeauthorization")
+	resp, err, intercepted = interceptor.Do(resp.Request)
+	require.NoError(t, err)
+	require.False(t, intercepted)
+	require.Nil(t, resp)
 }

--- a/sdk/security/keyvault/internal/parse.go
+++ b/sdk/security/keyvault/internal/parse.go
@@ -1,6 +1,3 @@
-//go:build go1.18
-// +build go1.18
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 package internal

--- a/sdk/security/keyvault/internal/parse.go
+++ b/sdk/security/keyvault/internal/parse.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+
 package internal
 
 import (

--- a/sdk/security/keyvault/internal/parse_test.go
+++ b/sdk/security/keyvault/internal/parse_test.go
@@ -1,6 +1,3 @@
-//go:build go1.18
-// +build go1.18
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 package internal

--- a/sdk/security/keyvault/internal/parse_test.go
+++ b/sdk/security/keyvault/internal/parse_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+
 package internal
 
 import (


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-go/issues/23355

Adding FakeChallenge to Key Vault to allow fakes support
