### PR TITLE
Convert to dfs error while getproperties call

### DIFF
--- a/sdk/storage/azdatalake/directory/client_test.go
+++ b/sdk/storage/azdatalake/directory/client_test.go
@@ -297,6 +297,7 @@ func (s *RecordedTestSuite) TestCreateNewSubdirectoryClient() {
 
 	_, err = dirFileClient.GetProperties(context.Background(), nil)
 	_require.Error(err) // we should get back a 404
+	_require.True(datalakeerror.HasCode(err, datalakeerror.PathNotFound))
 }
 
 func (s *RecordedTestSuite) TestCreateNewSubdirectoryClientWithSpecialName() {

--- a/sdk/storage/azdatalake/file/client.go
+++ b/sdk/storage/azdatalake/file/client.go
@@ -235,6 +235,7 @@ func (f *Client) GetProperties(ctx context.Context, options *GetPropertiesOption
 	ctxWithResp := shared.WithCaptureBlobResponse(ctx, &respFromCtx)
 	resp, err := f.blobClient().GetProperties(ctxWithResp, opts)
 	if err != nil {
+		err = exported.ConvertToDFSError(err)
 		return GetPropertiesResponse{}, err
 	}
 	newResp := path.FormatGetPropertiesResponse(&resp, respFromCtx)

--- a/sdk/storage/azdatalake/file/client.go
+++ b/sdk/storage/azdatalake/file/client.go
@@ -239,7 +239,6 @@ func (f *Client) GetProperties(ctx context.Context, options *GetPropertiesOption
 		return GetPropertiesResponse{}, err
 	}
 	newResp := path.FormatGetPropertiesResponse(&resp, respFromCtx)
-	err = exported.ConvertToDFSError(err)
 	return newResp, err
 }
 

--- a/sdk/storage/azdatalake/file/client_test.go
+++ b/sdk/storage/azdatalake/file/client_test.go
@@ -1011,6 +1011,7 @@ func (s *RecordedTestSuite) TestFileSetExpiry() {
 	time.Sleep(time.Second * 12)
 
 	_, err = fClient.GetProperties(context.Background(), nil)
+	testcommon.ValidateErrorCode(_require, err, datalakeerror.PathNotFound)
 	_require.Error(err)
 }
 

--- a/sdk/storage/azdatalake/file/client_test.go
+++ b/sdk/storage/azdatalake/file/client_test.go
@@ -597,6 +597,7 @@ func (s *RecordedTestSuite) TestCreateFileWithExpiryRelativeToNow() {
 	time.Sleep(time.Second * 10)
 	_, err = fClient.GetProperties(context.Background(), nil)
 	_require.Error(err)
+	testcommon.ValidateErrorCode(_require, err, datalakeerror.PathNotFound)
 }
 
 func (s *RecordedTestSuite) TestCreateFileWithNeverExpire() {


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
