### PR TITLE
Changelog updates for Cosmos release 1.3.0

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Release History
 
-## 1.2.1 (Unreleased)
+## 1.3.0 (2025-02-12)
 
 ### Features Added
 * Added limited support for cross-partition queries that can be served by the gateway. See [PR 23926](https://github.com/Azure/azure-sdk-for-go/pull/23926) and <https://learn.microsoft.com/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway> for more details.
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 * All queries now set the `x-ms-documentdb-query-enablecrosspartition` header. This should not impact single-partition queries, but in the event that it does cause problems for you, this behavior can be disabled by setting the `EnableCrossPartitionQuery` value on `azcosmos.QueryOptions` to `false`.

--- a/sdk/data/azcosmos/version.go
+++ b/sdk/data/azcosmos/version.go
@@ -7,5 +7,5 @@ const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
 	// serviceLibVersion is the semantic version (see http://semver.org) of this module.
-	serviceLibVersion = "v1.2.1"
+	serviceLibVersion = "v1.3.0"
 )


### PR DESCRIPTION
Updates changelog and version number for 1.3.0 release.

Details, including a link to the included PR, can be found in the Changelog. The only thing in this release is the limited support for cross-partition queries that can be served from the gateway.