### PR TITLE
Updating Liftr base package version

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -13,7 +13,7 @@
         "@azure-tools/typespec-azure-resource-manager": "0.50.0",
         "@azure-tools/typespec-azure-rulesets": "0.50.0",
         "@azure-tools/typespec-client-generator-core": "0.50.2",
-        "@azure-tools/typespec-liftr-base": "0.6.0",
+        "@azure-tools/typespec-liftr-base": "0.7.0",
         "@typespec/compiler": "0.64.0",
         "@typespec/http": "0.64.0",
         "@typespec/openapi": "0.64.0",
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.6.0.tgz",
-      "integrity": "sha512-MQV7ESlCqWrgclTSgs/dllS/jKrMrjs9C0UNExXsYhpjUtpv/BnmToWaWL4hA/5rg5JgxDp1MSAjZ5PBjGo1ig==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.7.0.tgz",
+      "integrity": "sha512-r4pPk/nOVo6S651McQqLmuSNr7FIRLzt7pj2Pk0+H5EgniKm6X0uwsXk7u2N2GpEmoGnL2yVNxTTMSOtUrkXwQ==",
       "dev": true
     },
     "node_modules/@babel/helper-validator-identifier": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -14,6 +14,6 @@
     "@typespec/openapi": "0.64.0",
     "@typespec/rest": "0.64.0",
     "@typespec/versioning": "0.64.0",
-    "@azure-tools/typespec-liftr-base": "0.6.0"
+    "@azure-tools/typespec-liftr-base": "0.7.0"
   }
 }


### PR DESCRIPTION
Upgrading the liftr base package version to 0.7.0 as per azure spec repo. Facing failure in https://github.com/Azure/azure-rest-api-specs/pull/32582
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [X] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
