### PR TITLE
[azcore/runtime] add error.type attribute and span links to runtime.StartSpan

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Added type `Link` to the `tracing` package to support Span Links.
 * Added method `LinkFromContext()` to `tracing.Tracer` to support Span Links.
 * Added method `AddLink()` to `tracing.Span` to support Span Links.
-* Added field `StartSpanOptions` to `runtime.StartSpanOptions` to support Span Links.
+* Added field `Links` to `runtime.StartSpanOptions` to support Span Links.
 * Added type `Propagator` to the `tracing` package to support context propagation.
 * Added type `Carrier` to the `tracing` package to support context propagation.
 * Added method `NewPropagator()` to type `tracing.Provider` to support context propagation.

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added type `Link` to the `tracing` package to support Span Links.
 * Added method `LinkFromContext()` to `tracing.Tracer` to support Span Links.
 * Added method `AddLink()` to `tracing.Span` to support Span Links.
+* Added field `StartSpanOptions` to `runtime.StartSpanOptions` to support Span Links.
 * Added type `Propagator` to the `tracing` package to support context propagation.
 * Added type `Carrier` to the `tracing` package to support context propagation.
 * Added method `NewPropagator()` to type `tracing.Provider` to support context propagation.

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -21,6 +21,9 @@
 
 ### Other Changes
 
+* Added `tracing.SpanOptions.Link` when starting a span with `runtime.StartSpan` to support Span Links.
+* Added Span Attribute `error.type` to report an error when ending a span with `runtime.StartSpan`.
+
 ## 1.17.0 (2025-01-07)
 
 ### Features Added

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Other Changes
 
-* Added `tracing.SpanOptions.Link` when starting a span with `runtime.StartSpan` to support Span Links.
+* Added `tracing.SpanOptions.Links` when starting a span with `runtime.StartSpan` to support Span Links.
 * Added Span Attribute `error.type` to report an error when ending a span with `runtime.StartSpan`.
 
 ## 1.17.0 (2025-01-07)

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -22,7 +22,6 @@
 
 ### Other Changes
 
-* Added `tracing.SpanOptions.Links` when starting a span with `runtime.StartSpan` to support Span Links.
 * Added Span Attribute `error.type` to report an error when ending a span with `runtime.StartSpan`.
 
 ## 1.17.0 (2025-01-07)

--- a/sdk/azcore/runtime/policy_http_trace_test.go
+++ b/sdk/azcore/runtime/policy_http_trace_test.go
@@ -181,7 +181,7 @@ func TestStartSpan(t *testing.T) {
 	require.EqualValues(t, tracing.SpanStatusError, spanStatus)
 	require.Contains(t, errStr, "*azcore.ResponseError")
 	require.Contains(t, errStr, "ERROR CODE: ErrorItFailed")
-	require.Contains(t, spanAttrs, tracing.Attribute{Key: attrErrType, Value: "azcore.ResponseError"})
+	require.Contains(t, spanAttrs, tracing.Attribute{Key: attrErrType, Value: "*azcore.ResponseError"})
 }
 
 func TestStartSpansDontNest(t *testing.T) {

--- a/sdk/azcore/runtime/policy_http_trace_test.go
+++ b/sdk/azcore/runtime/policy_http_trace_test.go
@@ -150,10 +150,14 @@ func TestStartSpan(t *testing.T) {
 
 	// with error
 	var spanStatus tracing.SpanStatus
+	var spanAttrs []tracing.Attribute
 	var errStr string
 	tr = tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {
 		spanImpl := tracing.SpanImpl{
 			End: func() { endCalled = true },
+			SetAttributes: func(attribute ...tracing.Attribute) {
+				spanAttrs = append(spanAttrs, attribute...)
+			},
 			SetStatus: func(ss tracing.SpanStatus, s string) {
 				spanStatus = ss
 				errStr = s
@@ -177,6 +181,7 @@ func TestStartSpan(t *testing.T) {
 	require.EqualValues(t, tracing.SpanStatusError, spanStatus)
 	require.Contains(t, errStr, "*azcore.ResponseError")
 	require.Contains(t, errStr, "ERROR CODE: ErrorItFailed")
+	require.Contains(t, spanAttrs, tracing.Attribute{Key: attrErrType, Value: "azcore.ResponseError"})
 }
 
 func TestStartSpansDontNest(t *testing.T) {
@@ -258,6 +263,51 @@ func TestStartSpanWithAttributes(t *testing.T) {
 	}, nil)
 	ctx, end := StartSpan(context.Background(), "TestStartSpan", tr, &StartSpanOptions{
 		Attributes: spanAttrs,
+	})
+	end(nil)
+	ctxTr := ctx.Value(shared.CtxWithTracingTracer{})
+	require.NotNil(t, ctxTr)
+	_, ok := ctxTr.(tracing.Tracer)
+	require.True(t, ok)
+	require.True(t, startCalled)
+	require.True(t, endCalled)
+}
+
+func TestStartSpanWithLinks(t *testing.T) {
+	spanLinks := []tracing.Link{
+		{
+			SpanContext: tracing.NewSpanContext(tracing.SpanContextConfig{
+				Remote: true,
+			}),
+			Attributes: []tracing.Attribute{
+				{
+					Key:   "int_attr",
+					Value: int64(12345),
+				},
+				{
+					Key:   "string_attr",
+					Value: "foo",
+				},
+			},
+		},
+	}
+
+	var startCalled bool
+	var endCalled bool
+	tr := tracing.NewTracer(func(ctx context.Context, spanName string, options *tracing.SpanOptions) (context.Context, tracing.Span) {
+		startCalled = true
+		require.EqualValues(t, "TestStartSpan", spanName)
+		require.NotNil(t, options)
+		require.EqualValues(t, tracing.SpanKindInternal, options.Kind)
+		require.EqualValues(t, spanLinks, options.Links)
+		require.Zero(t, options.Attributes)
+		spanImpl := tracing.SpanImpl{
+			End: func() { endCalled = true },
+		}
+		return ctx, tracing.NewSpan(spanImpl)
+	}, nil)
+	ctx, end := StartSpan(context.Background(), "TestStartSpan", tr, &StartSpanOptions{
+		Links: spanLinks,
 	})
 	end(nil)
 	ctxTr := ctx.Value(shared.CtxWithTracingTracer{})


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

* Added `tracing.SpanOptions.Link` when starting a span with `runtime.StartSpan` to support Span Links.
* Added Span Attribute `error.type` to report an error when ending a span with `runtime.StartSpan`. This follows the guideline from https://opentelemetry.io/docs/specs/semconv/attributes-registry/error/ and was recommended in [this PR comment](https://github.com/Azure/azure-sdk-for-go/pull/23860#discussion_r1927981899).

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
