### PR TITLE
Trigger live ACI test via HTTP

### DIFF
--- a/sdk/azidentity/test-resources-post.ps1
+++ b/sdk/azidentity/test-resources-post.ps1
@@ -72,6 +72,7 @@ az container create -g $rg -n $aciName --image $image `
   --acr-identity $($DeploymentOutputs['AZIDENTITY_USER_ASSIGNED_IDENTITY']) `
   --assign-identity [system] $($DeploymentOutputs['AZIDENTITY_USER_ASSIGNED_IDENTITY']) `
   --cpu 1 `
+  --ip-address Public `
   --memory 1.0 `
   --os-type Linux `
   --role "Storage Blob Data Reader" `
@@ -82,7 +83,8 @@ az container create -g $rg -n $aciName --image $image `
   AZIDENTITY_USER_ASSIGNED_IDENTITY_CLIENT_ID=$($DeploymentOutputs['AZIDENTITY_USER_ASSIGNED_IDENTITY_CLIENT_ID']) `
   AZIDENTITY_USER_ASSIGNED_IDENTITY_OBJECT_ID=$($DeploymentOutputs['AZIDENTITY_USER_ASSIGNED_IDENTITY_OBJECT_ID']) `
   FUNCTIONS_CUSTOMHANDLER_PORT=80
-Write-Host "##vso[task.setvariable variable=AZIDENTITY_ACI_NAME;]$aciName"
+$aciIP = az container show -g $rg -n $aciName --query ipAddress.ip --output tsv
+Write-Host "##vso[task.setvariable variable=AZIDENTITY_ACI_IP;]$aciIP"
 
 # Azure Functions deployment: copy the Windows binary from the Docker image, deploy it in a zip
 Write-Host "Deploying to Azure Functions"


### PR DESCRIPTION
Something recently changed in either the Azure CLI or DevOps such that `script` as used in our live ACI test no longer exits in a reasonable amount of time. Happily, we don't need this workaround anymore because the new test subscription allows opening a port to the internet.