### PR TITLE
Zero ProxyPort means "use same port as StartTestProxy"

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+* Zero `RecordingOptions.ProxyPort` is interpreted as indicating the default port used
+  by `StartTestProxy`
 
 ## 1.10.0 (2024-07-16)
 

--- a/sdk/internal/recording/recording.go
+++ b/sdk/internal/recording/recording.go
@@ -174,8 +174,9 @@ func init() {
 }
 
 var (
-	recordMode string
-	rootCAs    *x509.CertPool
+	defaultPort = os.Getpid()%10000 + 20000
+	recordMode  string
+	rootCAs     *x509.CertPool
 )
 
 const (
@@ -230,7 +231,8 @@ var client = http.Client{
 }
 
 type RecordingOptions struct {
-	UseHTTPS        bool
+	UseHTTPS bool
+	// ProxyPort is the port the test proxy is listening on. Defaults to the port used by [StartTestProxy].
 	ProxyPort       int
 	GroupForReplace string
 	Variables       map[string]interface{}
@@ -244,7 +246,7 @@ type RecordingOptions struct {
 func defaultOptions() *RecordingOptions {
 	return &RecordingOptions{
 		UseHTTPS:  true,
-		ProxyPort: os.Getpid()%10000 + 20000,
+		ProxyPort: defaultPort,
 	}
 }
 
@@ -271,14 +273,11 @@ func (r RecordingOptions) ReplaceAuthority(t *testing.T, rawReq *http.Request) *
 }
 
 func (r RecordingOptions) host() string {
-	if r.ProxyPort != 0 {
-		return fmt.Sprintf("localhost:%d", r.ProxyPort)
+	port := r.ProxyPort
+	if port == 0 {
+		port = defaultPort
 	}
-
-	if r.UseHTTPS {
-		return "localhost:5001"
-	}
-	return "localhost:5000"
+	return fmt.Sprintf("localhost:%d", port)
 }
 
 func (r RecordingOptions) scheme() string {

--- a/sdk/internal/recording/recording_test.go
+++ b/sdk/internal/recording/recording_test.go
@@ -65,18 +65,21 @@ func (s *recordingTests) TestGetEnvVariable() {
 
 func (s *recordingTests) TestRecordingOptions() {
 	require := require.New(s.T())
+	port := 42
 	r := RecordingOptions{
-		UseHTTPS: true,
+		ProxyPort: port,
+		UseHTTPS:  true,
 	}
-	require.Equal(r.baseURL(), "https://localhost:5001")
+	require.Equal(r.baseURL(), fmt.Sprintf("https://localhost:%d", port))
 
 	r.UseHTTPS = false
-	require.Equal(r.baseURL(), "http://localhost:5000")
+	require.Equal(r.baseURL(), fmt.Sprintf("http://localhost:%d", port))
 
 	r = *defaultOptions()
-	require.Equal(r.baseURL(), fmt.Sprintf("https://localhost:%d", r.ProxyPort))
-	// ProxyPort should be generated deterministically
-	require.Equal(r.ProxyPort, defaultOptions().ProxyPort)
+	require.Equal(r.baseURL(), fmt.Sprintf("https://localhost:%d", defaultPort))
+	require.Equal(defaultPort, defaultOptions().ProxyPort)
+
+	require.Equal(RecordingOptions{}.baseURL(), fmt.Sprintf("http://localhost:%d", defaultPort))
 }
 
 func (s *recordingTests) TestStartStop() {


### PR DESCRIPTION
This fixes a bug affecting any test that sets RecordingOptions (main has no such test today), for example because it needs sanitizers that shouldn't apply to other tests. When RecordingOptions is nonzero, the `recording` API requires callers to set `RecordingOptions.ProxyPort`, otherwise functions default to port 5000/5001. These defaults are a legacy from the days of SDK developers and CI managing their own proxies. However, today `recording` manages the proxy and configures it to listen on a different, arbitrary port that it doesn't expose. The upshot is that callers have no reasonable way to set ProxyPort correctly for a managed proxy and setting RecordingOptions breaks tests.

The fix here is to interpret a zero ProxyPort as indicating "use the same port as StartTestProxy". I like this better than exposing the arbitrary port because it makes a zero ProxyPort useful and simplifies the default path. This change would inconvenience anyone using a self-managed proxy listening on port 5000/5001 though--they would have to set ProxyPort--but none of our tests do that.