### PR TITLE
fix typespec changelog template

### DIFF
--- a/eng/tools/generator/template/typespec/CHANGELOG.md.tpl
+++ b/eng/tools/generator/template/typespec/CHANGELOG.md.tpl
@@ -3,6 +3,6 @@
 ## {{.packageVersion}} ({{.releaseDate}})
 ### Other Changes
 
-The package of `github.com/Azure/azure-sdk-for-go/sdk/{{.moduleRelativePath}}` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
+The package of `github.com/Azure/azure-sdk-for-go/{{.moduleRelativePath}}` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).
 
 To learn more, please refer to our documentation [Quick Start](https://aka.ms/azsdk/go/mgmt).


### PR DESCRIPTION
Fixed wrong package path of typespec changelog template. related pr: https://github.com/Azure/azure-sdk-for-go/pull/24141

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
