### PR TITLE
Improve presentation of test proxy recording mismatch errors

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Other Changes
 * Zero `RecordingOptions.ProxyPort` is interpreted as indicating the default port used
   by `StartTestProxy`
+* Improved presentation of test proxy recording mismatch errors
 
 ## 1.10.0 (2024-07-16)
 

--- a/sdk/internal/recording/recording.go
+++ b/sdk/internal/recording/recording.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -662,7 +663,14 @@ func (c RecordingHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	// poll for status and/or fetch the final result.
 	resp.Request.URL.Scheme = origScheme
 	resp.Request.URL.Host = origHost
-	return resp, nil
+	// if the response is a recording mismatch error from the proxy, return
+	// its message as a simple error that prints legibly in test output
+	if er := resp.Header.Get("x-request-mismatch-error"); er != "" {
+		if msg, e := base64.StdEncoding.DecodeString(er); e == nil {
+			err = errors.New(string(msg))
+		}
+	}
+	return resp, err
 }
 
 // NewRecordingHTTPClient returns a type that implements `azcore.Transporter`. This will automatically route tests on the `Do` call.


### PR DESCRIPTION
## Before

`RecordingHTTPClient.Do` returns the proxy's 404, from which the (service) client produces a ResponseError containing the proxy's error message as raw JSON:
```
--- FAIL: TestPool (8.17s)
    client_test.go:381: 
      Error: Received unexpected error:
             POST https://batch.local/pools/nope
             --------------------------------------------------------------------------------
             RESPONSE 404: 404 Not Found
             ERROR CODE UNAVAILABLE
             --------------------------------------------------------------------------------
             {
               "Message": "Unable to find a record for the request POST https://batch.local/pools/nope?api-version
=2024-07-01.20.0\nUri doesn\u0027t match:\n    request \u003Chttps://batch.local/pools/nope?api-version=2024-07-01
.20.0\u003E\n    record  \u003Chttps://batch.local/pools?api-version=2024-07-01.20.0\u003E\nHeader differences:\nB
ody differences:\nRemaining Entries:\n0: https://batch.local/pools?api-version=2024-07-01.20.0\n1: https://batch.l
ocal/pools/TestPoolpKCkPT0Gu6JN5Dkj?api-version=2024-07-01.20.0\n2: https://batch.local/nodecounts?api-version=202
4-07-01.20.0\n3: https://batch.local/pools?api-version=2024-07-01.20.0\n4: https://batch.local/pools/TestPoolpKCkP
T0Gu6JN5Dkj?api-version=2024-07-01.20.0\n5: https://batch.local/pools/TestPoolpKCkPT0Gu6JN5Dkj?%24select=allocatio
nState\u0026api-version=2024-07-01.20.0\n6: https://batch.local/pools/TestPoolpKCkPT0Gu6JN5Dkj/enableautoscale?api
-version=2024-07-01.20.0\n7: https://batch.local/pools/TestPoolpKCkPT0Gu6JN5Dkj/evaluateautoscale?api-version=2024
-07-01.20.0\n8: https://batch.local/pools/TestPoolpKCkPT0Gu6JN5Dkj/disableautoscale?api-version=2024-07-01.20.0\n9
: https://batch.local/pools/TestPoolpKCkPT0Gu6JN5Dkj/resize?api-version=2024-07-01.20.0\n10: https://batch.local/p
ools/TestPoolpKCkPT0Gu6JN5Dkj/stopresize?api-version=2024-07-01.20.0\n11: https://batch.local/pools/TestPoolpKCkPT
0Gu6JN5Dkj?api-version=2024-07-01.20.0\n",
               "Status": "NotFound"
             }
             --------------------------------------------------------------------------------
```
## After
`RecordingHTTPClient.Do` returns an error containing the proxy's formatted error message:
```
--- FAIL: TestPool (9.23s)
    client_test.go:381: 
      Error: Received unexpected error:
             Unable to find a record for the request POST https://batch.local/pools/nope?api-version=2024-07-01.20.0
             Uri doesn't match:
                 request <https://batch.local/pools/nope?api-version=2024-07-01.20.0>
                 record  <https://batch.local/pools?api-version=2024-07-01.20.0>
             Header differences:
             Body differences:
```