### PR TITLE
[azcertificates] generate 7.6-preview.2 

### DIFF
--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## 1.3.2-beta.1 (Unreleased)
 
 ### Features Added
+* Added `PreserveCertOrder`
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+* Upgraded to API service version `7.6-preview.2`
 
 ## 1.3.1 (2025-02-13)
 

--- a/sdk/security/keyvault/azcertificates/assets.json
+++ b/sdk/security/keyvault/azcertificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/security/keyvault/azcertificates",
-  "Tag": "go/security/keyvault/azcertificates_75bde7ecf6"
+  "Tag": "go/security/keyvault/azcertificates_833943984f"
 }

--- a/sdk/security/keyvault/azcertificates/build.go
+++ b/sdk/security/keyvault/azcertificates/build.go
@@ -1,4 +1,4 @@
-//go:generate tsp-client update
+//go:generate tsp-client update --local-spec-repo /home/grace/code/azure-rest-api-specs/specification/keyvault/Security.KeyVault.Certificates
 //go:generate go run internal/transforms.go
 //go:generate goimports -w .
 

--- a/sdk/security/keyvault/azcertificates/build.go
+++ b/sdk/security/keyvault/azcertificates/build.go
@@ -1,4 +1,4 @@
-//go:generate tsp-client update --local-spec-repo /home/grace/code/azure-rest-api-specs/specification/keyvault/Security.KeyVault.Certificates
+//go:generate tsp-client update
 //go:generate go run internal/transforms.go
 //go:generate goimports -w .
 

--- a/sdk/security/keyvault/azcertificates/client.go
+++ b/sdk/security/keyvault/azcertificates/client.go
@@ -30,7 +30,7 @@ type Client struct {
 // downloaded. This operation requires the certificates/backup permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate.
 //   - options - BackupCertificateOptions contains the optional parameters for the Client.BackupCertificate method.
 func (client *Client) BackupCertificate(ctx context.Context, name string, options *BackupCertificateOptions) (BackupCertificateResponse, error) {
@@ -67,7 +67,7 @@ func (client *Client) backupCertificateCreateRequest(ctx context.Context, name s
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -87,7 +87,7 @@ func (client *Client) backupCertificateHandleResponse(resp *http.Response) (Back
 // If this is the first version, the certificate resource is created. This operation requires the certificates/create permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate. The value you provide may be copied globally for the purpose of running the service.
 //     The value provided should not include personally identifiable or sensitive information.
 //   - parameters - The parameters to create a certificate.
@@ -126,7 +126,7 @@ func (client *Client) createCertificateCreateRequest(ctx context.Context, name s
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -151,7 +151,7 @@ func (client *Client) createCertificateHandleResponse(resp *http.Response) (Crea
 // individual versions of a certificate object. This operation requires the certificates/delete permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate.
 //   - options - DeleteCertificateOptions contains the optional parameters for the Client.DeleteCertificate method.
 func (client *Client) DeleteCertificate(ctx context.Context, name string, options *DeleteCertificateOptions) (DeleteCertificateResponse, error) {
@@ -188,7 +188,7 @@ func (client *Client) deleteCertificateCreateRequest(ctx context.Context, name s
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -209,7 +209,7 @@ func (client *Client) deleteCertificateHandleResponse(resp *http.Response) (Dele
 // no longer created. This operation requires the certificates/update permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate.
 //   - options - DeleteCertificateOperationOptions contains the optional parameters for the Client.DeleteCertificateOperation
 //     method.
@@ -247,7 +247,7 @@ func (client *Client) deleteCertificateOperationCreateRequest(ctx context.Contex
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -268,7 +268,7 @@ func (client *Client) deleteCertificateOperationHandleResponse(resp *http.Respon
 // permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - options - DeleteContactsOptions contains the optional parameters for the Client.DeleteContacts method.
 func (client *Client) DeleteContacts(ctx context.Context, options *DeleteContactsOptions) (DeleteContactsResponse, error) {
 	var err error
@@ -300,7 +300,7 @@ func (client *Client) deleteContactsCreateRequest(ctx context.Context, _ *Delete
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -321,7 +321,7 @@ func (client *Client) deleteContactsHandleResponse(resp *http.Response) (DeleteC
 // requires the certificates/manageissuers/deleteissuers permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - issuerName - The name of the issuer.
 //   - options - DeleteIssuerOptions contains the optional parameters for the Client.DeleteIssuer method.
 func (client *Client) DeleteIssuer(ctx context.Context, issuerName string, options *DeleteIssuerOptions) (DeleteIssuerResponse, error) {
@@ -358,7 +358,7 @@ func (client *Client) deleteIssuerCreateRequest(ctx context.Context, issuerName 
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -378,7 +378,7 @@ func (client *Client) deleteIssuerHandleResponse(resp *http.Response) (DeleteIss
 // Gets information about a specific certificate. This operation requires the certificates/get permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate in the given vault.
 //   - version - The version of the certificate. This URI fragment is optional. If not specified, the latest version of the certificate
 //     is returned.
@@ -418,7 +418,7 @@ func (client *Client) getCertificateCreateRequest(ctx context.Context, name stri
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -438,7 +438,7 @@ func (client *Client) getCertificateHandleResponse(resp *http.Response) (GetCert
 // Gets the creation operation associated with a specified certificate. This operation requires the certificates/get permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate.
 //   - options - GetCertificateOperationOptions contains the optional parameters for the Client.GetCertificateOperation method.
 func (client *Client) GetCertificateOperation(ctx context.Context, name string, options *GetCertificateOperationOptions) (GetCertificateOperationResponse, error) {
@@ -475,7 +475,7 @@ func (client *Client) getCertificateOperationCreateRequest(ctx context.Context, 
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -496,7 +496,7 @@ func (client *Client) getCertificateOperationHandleResponse(resp *http.Response)
 // operation requires the certificates/get permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate in a given key vault.
 //   - options - GetCertificatePolicyOptions contains the optional parameters for the Client.GetCertificatePolicy method.
 func (client *Client) GetCertificatePolicy(ctx context.Context, name string, options *GetCertificatePolicyOptions) (GetCertificatePolicyResponse, error) {
@@ -533,7 +533,7 @@ func (client *Client) getCertificatePolicyCreateRequest(ctx context.Context, nam
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -554,7 +554,7 @@ func (client *Client) getCertificatePolicyHandleResponse(resp *http.Response) (G
 // operation requires the certificates/managecontacts permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - options - GetContactsOptions contains the optional parameters for the Client.GetContacts method.
 func (client *Client) GetContacts(ctx context.Context, options *GetContactsOptions) (GetContactsResponse, error) {
 	var err error
@@ -586,7 +586,7 @@ func (client *Client) getContactsCreateRequest(ctx context.Context, _ *GetContac
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -608,7 +608,7 @@ func (client *Client) getContactsHandleResponse(resp *http.Response) (GetContact
 // permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate
 //   - options - GetDeletedCertificateOptions contains the optional parameters for the Client.GetDeletedCertificate method.
 func (client *Client) GetDeletedCertificate(ctx context.Context, name string, options *GetDeletedCertificateOptions) (GetDeletedCertificateResponse, error) {
@@ -645,7 +645,7 @@ func (client *Client) getDeletedCertificateCreateRequest(ctx context.Context, na
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -666,7 +666,7 @@ func (client *Client) getDeletedCertificateHandleResponse(resp *http.Response) (
 // operation requires the certificates/manageissuers/getissuers permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - issuerName - The name of the issuer.
 //   - options - GetIssuerOptions contains the optional parameters for the Client.GetIssuer method.
 func (client *Client) GetIssuer(ctx context.Context, issuerName string, options *GetIssuerOptions) (GetIssuerResponse, error) {
@@ -703,7 +703,7 @@ func (client *Client) getIssuerCreateRequest(ctx context.Context, issuerName str
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -725,7 +725,7 @@ func (client *Client) getIssuerHandleResponse(resp *http.Response) (GetIssuerRes
 // PEM file must contain the key as well as x509 certificates. Key Vault will only accept a key in PKCS#8 format.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate. The value you provide may be copied globally for the purpose of running the service.
 //     The value provided should not include personally identifiable or sensitive information.
 //   - parameters - The parameters to import the certificate.
@@ -764,7 +764,7 @@ func (client *Client) importCertificateCreateRequest(ctx context.Context, name s
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -788,7 +788,7 @@ func (client *Client) importCertificateHandleResponse(resp *http.Response) (Impo
 // The GetCertificates operation returns the set of certificates resources in the specified key vault. This operation requires
 // the certificates/list permission.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - options - ListCertificatePropertiesOptions contains the optional parameters for the Client.NewListCertificatePropertiesPager
 //     method.
 func (client *Client) NewListCertificatePropertiesPager(options *ListCertificatePropertiesOptions) *runtime.Pager[ListCertificatePropertiesResponse] {
@@ -823,7 +823,7 @@ func (client *Client) listCertificatePropertiesCreateRequest(ctx context.Context
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	if options != nil && options.IncludePending != nil {
 		reqQP.Set("includePending", strconv.FormatBool(*options.IncludePending))
 	}
@@ -846,7 +846,7 @@ func (client *Client) listCertificatePropertiesHandleResponse(resp *http.Respons
 // The GetCertificateVersions operation returns the versions of a certificate in the specified key vault. This operation requires
 // the certificates/list permission.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate.
 //   - options - ListCertificatePropertiesVersionsOptions contains the optional parameters for the Client.NewListCertificatePropertiesVersionsPager
 //     method.
@@ -886,7 +886,7 @@ func (client *Client) listCertificatePropertiesVersionsCreateRequest(ctx context
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -908,7 +908,7 @@ func (client *Client) listCertificatePropertiesVersionsHandleResponse(resp *http
 // for recovery or purging. This operation includes deletion-specific information. This operation requires the certificates/get/list
 // permission. This operation can only be enabled on soft-delete enabled vaults.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - options - ListDeletedCertificatePropertiesOptions contains the optional parameters for the Client.NewListDeletedCertificatePropertiesPager
 //     method.
 func (client *Client) NewListDeletedCertificatePropertiesPager(options *ListDeletedCertificatePropertiesOptions) *runtime.Pager[ListDeletedCertificatePropertiesResponse] {
@@ -943,7 +943,7 @@ func (client *Client) listDeletedCertificatePropertiesCreateRequest(ctx context.
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	if options != nil && options.IncludePending != nil {
 		reqQP.Set("includePending", strconv.FormatBool(*options.IncludePending))
 	}
@@ -966,7 +966,7 @@ func (client *Client) listDeletedCertificatePropertiesHandleResponse(resp *http.
 // The GetCertificateIssuers operation returns the set of certificate issuer resources in the specified key vault. This operation
 // requires the certificates/manageissuers/getissuers permission.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - options - ListIssuerPropertiesOptions contains the optional parameters for the Client.NewListIssuerPropertiesPager method.
 func (client *Client) NewListIssuerPropertiesPager(options *ListIssuerPropertiesOptions) *runtime.Pager[ListIssuerPropertiesResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ListIssuerPropertiesResponse]{
@@ -1000,7 +1000,7 @@ func (client *Client) listIssuerPropertiesCreateRequest(ctx context.Context, _ *
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -1021,7 +1021,7 @@ func (client *Client) listIssuerPropertiesHandleResponse(resp *http.Response) (L
 // in the service. This operation requires the certificates/create permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate.
 //   - parameters - The parameters to merge certificate.
 //   - options - MergeCertificateOptions contains the optional parameters for the Client.MergeCertificate method.
@@ -1059,7 +1059,7 @@ func (client *Client) mergeCertificateCreateRequest(ctx context.Context, name st
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1085,7 +1085,7 @@ func (client *Client) mergeCertificateHandleResponse(resp *http.Response) (Merge
 // the certificate/purge permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate
 //   - options - PurgeDeletedCertificateOptions contains the optional parameters for the Client.PurgeDeletedCertificate method.
 func (client *Client) PurgeDeletedCertificate(ctx context.Context, name string, options *PurgeDeletedCertificateOptions) (PurgeDeletedCertificateResponse, error) {
@@ -1121,7 +1121,7 @@ func (client *Client) purgeDeletedCertificateCreateRequest(ctx context.Context, 
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -1134,7 +1134,7 @@ func (client *Client) purgeDeletedCertificateCreateRequest(ctx context.Context, 
 // This operation requires the certificates/recover permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the deleted certificate
 //   - options - RecoverDeletedCertificateOptions contains the optional parameters for the Client.RecoverDeletedCertificate method.
 func (client *Client) RecoverDeletedCertificate(ctx context.Context, name string, options *RecoverDeletedCertificateOptions) (RecoverDeletedCertificateResponse, error) {
@@ -1171,7 +1171,7 @@ func (client *Client) recoverDeletedCertificateCreateRequest(ctx context.Context
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -1191,7 +1191,7 @@ func (client *Client) recoverDeletedCertificateHandleResponse(resp *http.Respons
 // Restores a backed up certificate, and all its versions, to a vault. This operation requires the certificates/restore permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - parameters - The parameters to restore the certificate.
 //   - options - RestoreCertificateOptions contains the optional parameters for the Client.RestoreCertificate method.
 func (client *Client) RestoreCertificate(ctx context.Context, parameters RestoreCertificateParameters, options *RestoreCertificateOptions) (RestoreCertificateResponse, error) {
@@ -1224,7 +1224,7 @@ func (client *Client) restoreCertificateCreateRequest(ctx context.Context, param
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1248,7 +1248,7 @@ func (client *Client) restoreCertificateHandleResponse(resp *http.Response) (Res
 // Sets the certificate contacts for the specified key vault. This operation requires the certificates/managecontacts permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - contacts - The contacts for the key vault certificate.
 //   - options - SetContactsOptions contains the optional parameters for the Client.SetContacts method.
 func (client *Client) SetContacts(ctx context.Context, contacts Contacts, options *SetContactsOptions) (SetContactsResponse, error) {
@@ -1281,7 +1281,7 @@ func (client *Client) setContactsCreateRequest(ctx context.Context, contacts Con
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1306,7 +1306,7 @@ func (client *Client) setContactsHandleResponse(resp *http.Response) (SetContact
 // permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - issuerName - The name of the issuer. The value you provide may be copied globally for the purpose of running the service.
 //     The value provided should not include personally identifiable or sensitive information.
 //   - parameter - Certificate issuer set parameter.
@@ -1345,7 +1345,7 @@ func (client *Client) setIssuerCreateRequest(ctx context.Context, issuerName str
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1370,7 +1370,7 @@ func (client *Client) setIssuerHandleResponse(resp *http.Response) (SetIssuerRes
 // certificate's attributes. This operation requires the certificates/update permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate in the given key vault.
 //   - version - The version of the certificate.
 //   - parameters - The parameters for certificate update.
@@ -1410,7 +1410,7 @@ func (client *Client) updateCertificateCreateRequest(ctx context.Context, name s
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1434,7 +1434,7 @@ func (client *Client) updateCertificateHandleResponse(resp *http.Response) (Upda
 // Updates a certificate creation operation that is already in progress. This operation requires the certificates/update permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate.
 //   - certificateOperation - The certificate operation response.
 //   - options - UpdateCertificateOperationOptions contains the optional parameters for the Client.UpdateCertificateOperation
@@ -1473,7 +1473,7 @@ func (client *Client) updateCertificateOperationCreateRequest(ctx context.Contex
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1498,7 +1498,7 @@ func (client *Client) updateCertificateOperationHandleResponse(resp *http.Respon
 // permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - name - The name of the certificate in the given vault.
 //   - certificatePolicy - The policy for the certificate.
 //   - options - UpdateCertificatePolicyOptions contains the optional parameters for the Client.UpdateCertificatePolicy method.
@@ -1536,7 +1536,7 @@ func (client *Client) updateCertificatePolicyCreateRequest(ctx context.Context, 
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1561,7 +1561,7 @@ func (client *Client) updateCertificatePolicyHandleResponse(resp *http.Response)
 // the certificates/setissuers permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.5
+// Generated from API version 7.6-preview.2
 //   - issuerName - The name of the issuer.
 //   - parameter - Certificate issuer update parameter.
 //   - options - UpdateIssuerOptions contains the optional parameters for the Client.UpdateIssuer method.
@@ -1599,7 +1599,7 @@ func (client *Client) updateIssuerCreateRequest(ctx context.Context, issuerName 
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.5")
+	reqQP.Set("api-version", "7.6-preview.2")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}

--- a/sdk/security/keyvault/azcertificates/client_test.go
+++ b/sdk/security/keyvault/azcertificates/client_test.go
@@ -158,7 +158,10 @@ func TestCRUD(t *testing.T) {
 	client := startTest(t)
 
 	certName := getName(t, "")
-	createParams := azcertificates.CreateCertificateParameters{CertificatePolicy: &selfSignedPolicy}
+	createParams := azcertificates.CreateCertificateParameters{
+		CertificatePolicy: &selfSignedPolicy,
+		PreserveCertOrder: to.Ptr(true),
+	}
 	testSerde(t, &createParams)
 	createResp, err := client.CreateCertificate(ctx, certName, createParams, nil)
 	require.NoError(t, err)
@@ -171,6 +174,7 @@ func TestCRUD(t *testing.T) {
 	require.NotEmpty(t, createResp.Status)
 	require.NotEmpty(t, createResp.StatusDetails)
 	require.NotEmpty(t, createResp.ID)
+	require.True(t, *createResp.PreserveCertOrder)
 	pollCertOperation(t, client, certName)
 
 	getResp, err := client.GetCertificate(ctx, certName, "", nil)
@@ -316,6 +320,7 @@ func TestImportCertificate(t *testing.T) {
 	importParams := azcertificates.ImportCertificateParameters{
 		Base64EncodedCertificate: to.Ptr("MIIJsQIBAzCCCXcGCSqGSIb3DQEHAaCCCWgEgglkMIIJYDCCBBcGCSqGSIb3DQEHBqCCBAgwggQEAgEAMIID/QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIE7pdl4fTqmwCAggAgIID0MDlcRFQUH0YDxopuqVyuEd4OLfawucEAxGvdj9+SMs34Cz1tVyZgfFuU4MwlLk6cA1dog8iw9/f8/VlA6wS0DHhslLL3JzSxZoi6JQQ0IYgjWaIv4c+wT0IcBhc2USI3lPqoqALG15qcs8fAEpDIssUplDcmA7gLVvBvw1utAipib8y93J71tIIedDaf0pAuVuC6K1PRI3HWVnUetCaiq4AW2iQu7f0rxJVDcKubmNinEivyRi4yl2Q1g2OwGlqwZEAnIW02uE+FzgFk51OA357vvooKicb0fdDz+hsRuzlWMhs2ciFMg71jlCUIKnvAKXCR714ox+OK8pTN1KQy3ICAFy+m6lNpkwkozfRoMwJyRGt5Tm6N/k9nQM1ysu3xqw3hG8q4srCbWhxcUrvrDcxvWe5Q8WX8Sl8nJ4joPZipBxDSEKYPqk9qkPF+YZbAmjcS3mw0AI5V8v31WQaa/i6LxQGwKUVSyjHe6ZDskQjyogtRmt61z1MYHmv9iNuLyyWhq9w7hV/AyKTzQ7FsWcK2vdNZJA2lj8H7rSrYtaVFNPMBzOa4KsJmif9s9B0VyMlX37XB1tGEtRmRuJtA+EZYVzu50J/ZVx2QGr40IpmyYKwB6CTQpBE12W9RMgMLYy+YAykrexYOJaIh9wfzLi/bAH8uCNTKueeVREnMHrzSF1xNQzqW8okoEMvSdr6+uCjHxt1cmRhUOcGvocLfNOgNhz+qwztLr35QTE8zTnrjvhb0NKfT1vpGa0nXP3EBYDolRqTZgKlG9icupDI57wDNuHED/d63Ri+tCbs3VF+QjcPBO8q3xz0hMj38oYLnHYt1i4YQOvXSDdZLc4fW5GXB1cVmP9vxbM0lxBKCLA8V0wZ8P341Dknr5WhS21A0qs3b9FavwbUUCDTuvky/1qhA6MaxqbtzjeVm7mYJ7TnCQveH0Iy3RHEPQrzrGUQc0bEBfissGeVYlghNULlaDW9CobT6J+pYT0y85flg+qtTZX69NaI4mZuh11hkKLmbVx6gGouQ79XmpE3+vNycEQNota534gUs77qF0VACJHnbgh05Qhxkp9Xd/LSUt+6r9niTa9HWQ+SMdfXuu6ognA3lMGeO4i0NTFkXA1MNs+e0QQZqNX8CiCj09i6YeMNVTdIh1ufrEF9YlO8yjLitHVSJRuY65QCCpPsS5Ugdk+5tUD3H2l1j/ZA5f73z2JdFEAchPRLsNQKTx49ZvsSex2ikEJeNjHDBuMQZtVZZDs9DdVQL/i49Mc7N+/x37AcLFx+DelOKZ0F5LgiDDprfU8wggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQIwQ83ZA6tJFoCAggABIIEyHQt53aY9srYggLfYUSeD6Gcjm7uEA5F24s9r3FZF50YRSztbJIrqGd6oytw4LDCInANcGuCF3WQjSdEB6ABy+Igmbk9OAsFAy18txfg05UQb4JYN3M0XkYywh+GlMlZdcsZQakXqBGSj6kyG4J9ISgGPpvSqopo7fUHjc3QjWcG07d42u6lgkLxdQH2e+qiHWA+9C3mawA5AYWA6sciEoKzYOZkl7ZtWptpJJWD54HtIT7ENGkHM6y2LM+FyMC0axoUsFawoObzcbJLX29Zfohzq9yt169ZLcKDC1zpS6R0MIRE5rs4727vG9mJWMetDpIg/2fka4nkhfry2Wo+Pp/065aUSfHbQGMZ2Lw/zgU1Eo/Bau+fREft/DRX/sZpkd0ulPlbxmQ80Xf6IXRSGD5poq3B19dJpKHmJagFJu1IgXEovjpexrYEmEAuzLaH1wdMTMGViWHsxu+g066LuHbBfJQ4THnAOp0N2eUkcfO3oJ3thzGnvWXM4lKAkULcnBlQnnfKi2CrQYJCJMhyIicYYs+03gxXxNwQihZPm3VI3an/ci1otoh19WP4on3DqZ4KySU+PZ45XzDg1H00+nhyShwuyiFhDN6XuJ0VWIZZEvoPRY1Tmt2prP/1B1Kk9+lishvTJKkuZ3rqC1bkJioIWte1FEoktCtzQ3dVUwlvy1r2y1WL5OTdk6yIENvm9+xHSkJelkZjW+Jr/B9dyZ2o9+oJGuLW8J2gNixecnWJXlb/tPwmL7iwLmFfM5tw27LnYO54dfUnq00G5JM6yiAj9i73RLkZo4lq29HOsoi4T3s06KpkOVhrIud7VhPFdzWtptcV9gbidHKtX209oZKAVgXa538DyKownqHx3I8yjXs0eFlty1CJjBP9fuAvllyNpUteuZoDcS45Zwl3WOpPrL595gBwy5yGOADOJXA3ww2oqvlTcZv1lyteKght3hMkSgy2mIGYAa19v+ZK0LxKxvwCCkC+bMuyTduiaUJmHmI7k0lVIt/5WPzz9cnvCahhCovN/+C0LI1xbOTW9nDp2Ffsb0aC9XYBRf/amRCiHmMzB18E85aA05h3l7KXPdck/xrKEePdv4dnLWxvHw69O6sjssmdV3q6+cZgYYLZAEl1byIbZBTQaHT0GhzcmHJrW71L6Sl/9TEfmDSvctEEe4cZd8o29TXqzE10kmrt8dqoRbYiNq5CODPiithVtCRWQu3aFoLkT0ooWEYk+IWU6/WQ8rq7KkZ6BR8JV60I3WbXLejTyaTf79VMt8myIET5GjSc7r+tWyDRCHcU32Guyw7F+9ndkMlVuI5gB/zfrsfX6noSQnx72yF6NrIyhJWf/Zl3NMbnPKUHA+sZkjE4+Hwvf5yWkjFZhNeLq/4gaXQk7yEddjoCpN/cWsVjX8NxZFsRLs00Ag89+NAbgWkr2eejKcXB+I4TZHVee8IPKdEh8ga6RtDD8GV9VpwhnOpDHT5K1CtuX2CyTMl8fgUxobZ4kauiRr4dChd5n9Bgp7mvTarl7k2nVXptSJDmaPvZ0ETht+WF24+a/7XqV7fyHoYU/WOvEGPW34a7X8R5UJWaOwZTcpqmfp8iwapRtgvQoXAISy2wK20fS0nK79nlqnhp5KEddTElMCMGCSqGSIb3DQEJFTEWBBTsd3zCMw1XrWC/MBjgt8IbFbCL8jAxMCEwCQYFKw4DAhoFAAQUY8Q/ANtHMzVyl4asrQ/lPKRjd2AECOBKL60N+UaKAgIIAA=="),
 		CertificateAttributes:    &azcertificates.CertificateAttributes{Enabled: to.Ptr(false)},
+		PreserveCertOrder:        to.Ptr(true),
 	}
 	testSerde(t, &importParams)
 	impResp, err := client.ImportCertificate(ctx, certName, importParams, nil)
@@ -326,6 +331,7 @@ func TestImportCertificate(t *testing.T) {
 	require.Equal(t, certName, impResp.ID.Name())
 	require.NotEmpty(t, impResp.KID)
 	require.NotEmpty(t, impResp.SID)
+	require.True(t, *impResp.PreserveCertOrder)
 }
 
 func TestIssuerCRUD(t *testing.T) {

--- a/sdk/security/keyvault/azcertificates/models.go
+++ b/sdk/security/keyvault/azcertificates/models.go
@@ -38,6 +38,10 @@ type Certificate struct {
 	// The content type of the secret. eg. 'application/x-pem-file' or 'application/x-pkcs12',
 	ContentType *string
 
+	// Specifies whether the certificate chain preserves its original order. The default value is false, which sets the leaf certificate
+	// at index 0.
+	PreserveCertOrder *bool
+
 	// Application specific metadata in the form of key-value pairs
 	Tags map[string]*string
 
@@ -96,6 +100,10 @@ type CertificateOperation struct {
 
 	// Parameters for the issuer of the X509 component of a certificate.
 	IssuerParameters *IssuerParameters
+
+	// Specifies whether the certificate chain preserves its original order. The default value is false, which sets the leaf certificate
+	// at index 0.
+	PreserveCertOrder *bool
 
 	// Identifier for the certificate operation.
 	RequestID *string
@@ -190,6 +198,10 @@ type CreateCertificateParameters struct {
 	// The management policy for the certificate.
 	CertificatePolicy *CertificatePolicy
 
+	// Specifies whether the certificate chain preserves its original order. The default value is false, which sets the leaf certificate
+	// at index 0.
+	PreserveCertOrder *bool
+
 	// Application specific metadata in the form of key-value pairs.
 	Tags map[string]*string
 }
@@ -205,6 +217,10 @@ type DeletedCertificate struct {
 
 	// The content type of the secret. eg. 'application/x-pem-file' or 'application/x-pkcs12',
 	ContentType *string
+
+	// Specifies whether the certificate chain preserves its original order. The default value is false, which sets the leaf certificate
+	// at index 0.
+	PreserveCertOrder *bool
 
 	// The url of the recovery object, used to identify and recover the deleted certificate.
 	RecoveryID *string
@@ -282,6 +298,10 @@ type ImportCertificateParameters struct {
 
 	// If the private key in base64EncodedCertificate is encrypted, the password used for encryption.
 	Password *string
+
+	// Specifies whether the certificate chain preserves its original order. The default value is false, which sets the leaf certificate
+	// at index 0.
+	PreserveCertOrder *bool
 
 	// Application specific metadata in the form of key-value pairs.
 	Tags map[string]*string

--- a/sdk/security/keyvault/azcertificates/models_serde.go
+++ b/sdk/security/keyvault/azcertificates/models_serde.go
@@ -94,6 +94,7 @@ func (c Certificate) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "id", c.ID)
 	populate(objectMap, "kid", c.KID)
 	populate(objectMap, "policy", c.Policy)
+	populate(objectMap, "preserveCertOrder", c.PreserveCertOrder)
 	populate(objectMap, "sid", c.SID)
 	populate(objectMap, "tags", c.Tags)
 	populateByteArray(objectMap, "x5t", c.X509Thumbprint, func() any {
@@ -130,6 +131,9 @@ func (c *Certificate) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "policy":
 			err = unpopulate(val, "Policy", &c.Policy)
+			delete(rawMsg, key)
+		case "preserveCertOrder":
+			err = unpopulate(val, "PreserveCertOrder", &c.PreserveCertOrder)
 			delete(rawMsg, key)
 		case "sid":
 			err = unpopulate(val, "SID", &c.SID)
@@ -211,6 +215,7 @@ func (c CertificateOperation) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "error", c.Error)
 	populate(objectMap, "id", c.ID)
 	populate(objectMap, "issuer", c.IssuerParameters)
+	populate(objectMap, "preserveCertOrder", c.PreserveCertOrder)
 	populate(objectMap, "request_id", c.RequestID)
 	populate(objectMap, "status", c.Status)
 	populate(objectMap, "status_details", c.StatusDetails)
@@ -243,6 +248,9 @@ func (c *CertificateOperation) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "issuer":
 			err = unpopulate(val, "IssuerParameters", &c.IssuerParameters)
+			delete(rawMsg, key)
+		case "preserveCertOrder":
+			err = unpopulate(val, "PreserveCertOrder", &c.PreserveCertOrder)
 			delete(rawMsg, key)
 		case "request_id":
 			err = unpopulate(val, "RequestID", &c.RequestID)
@@ -460,6 +468,7 @@ func (c CreateCertificateParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "attributes", c.CertificateAttributes)
 	populate(objectMap, "policy", c.CertificatePolicy)
+	populate(objectMap, "preserveCertOrder", c.PreserveCertOrder)
 	populate(objectMap, "tags", c.Tags)
 	return json.Marshal(objectMap)
 }
@@ -478,6 +487,9 @@ func (c *CreateCertificateParameters) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "policy":
 			err = unpopulate(val, "CertificatePolicy", &c.CertificatePolicy)
+			delete(rawMsg, key)
+		case "preserveCertOrder":
+			err = unpopulate(val, "PreserveCertOrder", &c.PreserveCertOrder)
 			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &c.Tags)
@@ -502,6 +514,7 @@ func (d DeletedCertificate) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "id", d.ID)
 	populate(objectMap, "kid", d.KID)
 	populate(objectMap, "policy", d.Policy)
+	populate(objectMap, "preserveCertOrder", d.PreserveCertOrder)
 	populate(objectMap, "recoveryId", d.RecoveryID)
 	populate(objectMap, "sid", d.SID)
 	populateTimeUnix(objectMap, "scheduledPurgeDate", d.ScheduledPurgeDate)
@@ -543,6 +556,9 @@ func (d *DeletedCertificate) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "policy":
 			err = unpopulate(val, "Policy", &d.Policy)
+			delete(rawMsg, key)
+		case "preserveCertOrder":
+			err = unpopulate(val, "PreserveCertOrder", &d.PreserveCertOrder)
 			delete(rawMsg, key)
 		case "recoveryId":
 			err = unpopulate(val, "RecoveryID", &d.RecoveryID)
@@ -662,6 +678,7 @@ func (i ImportCertificateParameters) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "attributes", i.CertificateAttributes)
 	populate(objectMap, "policy", i.CertificatePolicy)
 	populate(objectMap, "pwd", i.Password)
+	populate(objectMap, "preserveCertOrder", i.PreserveCertOrder)
 	populate(objectMap, "tags", i.Tags)
 	return json.Marshal(objectMap)
 }
@@ -686,6 +703,9 @@ func (i *ImportCertificateParameters) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "pwd":
 			err = unpopulate(val, "Password", &i.Password)
+			delete(rawMsg, key)
+		case "preserveCertOrder":
+			err = unpopulate(val, "PreserveCertOrder", &i.PreserveCertOrder)
 			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &i.Tags)

--- a/sdk/security/keyvault/azcertificates/tsp-location.yaml
+++ b/sdk/security/keyvault/azcertificates/tsp-location.yaml
@@ -1,6 +1,6 @@
 directory: specification/keyvault/Security.KeyVault.Certificates
-commit: fcba95263cd564625f7a3560db2342afec574cfc
+commit: cac8bb6ffc89f41dcd9bffaa265ecc45ef2d83c1
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 
 - specification/keyvault/Security.KeyVault.Common/
-# https://github.com/Azure/azure-rest-api-specs/tree/fcba95263cd564625f7a3560db2342afec574cfc/specification/keyvault/Security.KeyVault.Certificates
+# https://github.com/Azure/azure-rest-api-specs/tree/cac8bb6ffc89f41dcd9bffaa265ecc45ef2d83c1/specification/keyvault/Security.KeyVault.Certificates


### PR DESCRIPTION
part of https://github.com/Azure/azure-sdk-for-go/issues/24022

Added `PreserveCertOrder` feature