### PR TITLE
Vendor pkcs12 package

### DIFF
--- a/sdk/azidentity/NOTICE.txt
+++ b/sdk/azidentity/NOTICE.txt
@@ -1,0 +1,51 @@
+NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This software incorporates material from third parties. Microsoft makes certain
+open source code available at https://3rdpartysource.microsoft.com, or you may
+send a check or money order for US $5.00, including the product name, the open
+source component name, and version number, to:
+
+Source Code Compliance Team
+Microsoft Corporation
+One Microsoft Way
+Redmond, WA 98052
+USA
+
+Notwithstanding any other terms, you may reverse engineer this software to the
+extent required to debug changes to any libraries licensed under the GNU Lesser
+General Public License.
+
+------------------------------------------------------------------------------
+
+golang.org/x/crypto - BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------

--- a/sdk/azidentity/cgmanifest.json
+++ b/sdk/azidentity/cgmanifest.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+    "version": 1,
+    "registrations": [
+        {
+            "component": {
+                "type": "go",
+                "go": {
+                    "name": "golang.org/x/crypto",
+                    "version": "v0.35.0"
+                }
+            },
+            "developmentDependency": false
+        }
+    ]
+}

--- a/sdk/azidentity/client_certificate_credential.go
+++ b/sdk/azidentity/client_certificate_credential.go
@@ -16,8 +16,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/internal/pkcs12"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
-	"golang.org/x/crypto/pkcs12"
 )
 
 const credNameCert = "ClientCertificateCredential"

--- a/sdk/azidentity/go.mod
+++ b/sdk/azidentity/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.7.0
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/crypto v0.33.0
 )
 
 require (

--- a/sdk/azidentity/go.sum
+++ b/sdk/azidentity/go.sum
@@ -35,8 +35,6 @@ github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93Ge
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
-golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
 golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/sdk/azidentity/internal/pkcs12/LICENSE
+++ b/sdk/azidentity/internal/pkcs12/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/sdk/azidentity/internal/pkcs12/bmp-string.go
+++ b/sdk/azidentity/internal/pkcs12/bmp-string.go
@@ -1,0 +1,50 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"errors"
+	"unicode/utf16"
+)
+
+// bmpString returns s encoded in UCS-2 with a zero terminator.
+func bmpString(s string) ([]byte, error) {
+	// References:
+	// https://tools.ietf.org/html/rfc7292#appendix-B.1
+	// https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane
+	//  - non-BMP characters are encoded in UTF 16 by using a surrogate pair of 16-bit codes
+	//	  EncodeRune returns 0xfffd if the rune does not need special encoding
+	//  - the above RFC provides the info that BMPStrings are NULL terminated.
+
+	ret := make([]byte, 0, 2*len(s)+2)
+
+	for _, r := range s {
+		if t, _ := utf16.EncodeRune(r); t != 0xfffd {
+			return nil, errors.New("pkcs12: string contains characters that cannot be encoded in UCS-2")
+		}
+		ret = append(ret, byte(r/256), byte(r%256))
+	}
+
+	return append(ret, 0, 0), nil
+}
+
+func decodeBMPString(bmpString []byte) (string, error) {
+	if len(bmpString)%2 != 0 {
+		return "", errors.New("pkcs12: odd-length BMP string")
+	}
+
+	// strip terminator if present
+	if l := len(bmpString); l >= 2 && bmpString[l-1] == 0 && bmpString[l-2] == 0 {
+		bmpString = bmpString[:l-2]
+	}
+
+	s := make([]uint16, 0, len(bmpString)/2)
+	for len(bmpString) > 0 {
+		s = append(s, uint16(bmpString[0])<<8+uint16(bmpString[1]))
+		bmpString = bmpString[2:]
+	}
+
+	return string(utf16.Decode(s)), nil
+}

--- a/sdk/azidentity/internal/pkcs12/bmp-string_test.go
+++ b/sdk/azidentity/internal/pkcs12/bmp-string_test.go
@@ -1,0 +1,63 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+var bmpStringTests = []struct {
+	in          string
+	expectedHex string
+	shouldFail  bool
+}{
+	{"", "0000", false},
+	// Example from https://tools.ietf.org/html/rfc7292#appendix-B.
+	{"Beavis", "0042006500610076006900730000", false},
+	// Some characters from the "Letterlike Symbols Unicode block".
+	{"\u2115 - Double-struck N", "21150020002d00200044006f00750062006c0065002d00730074007200750063006b0020004e0000", false},
+	// any character outside the BMP should trigger an error.
+	{"\U0001f000 East wind (Mahjong)", "", true},
+}
+
+func TestBMPString(t *testing.T) {
+	for i, test := range bmpStringTests {
+		expected, err := hex.DecodeString(test.expectedHex)
+		if err != nil {
+			t.Fatalf("#%d: failed to decode expectation", i)
+		}
+
+		out, err := bmpString(test.in)
+		if err == nil && test.shouldFail {
+			t.Errorf("#%d: expected to fail, but produced %x", i, out)
+			continue
+		}
+
+		if err != nil && !test.shouldFail {
+			t.Errorf("#%d: failed unexpectedly: %s", i, err)
+			continue
+		}
+
+		if !test.shouldFail {
+			if !bytes.Equal(out, expected) {
+				t.Errorf("#%d: expected %s, got %x", i, test.expectedHex, out)
+				continue
+			}
+
+			roundTrip, err := decodeBMPString(out)
+			if err != nil {
+				t.Errorf("#%d: decoding output gave an error: %s", i, err)
+				continue
+			}
+
+			if roundTrip != test.in {
+				t.Errorf("#%d: decoding output resulted in %q, but it should have been %q", i, roundTrip, test.in)
+				continue
+			}
+		}
+	}
+}

--- a/sdk/azidentity/internal/pkcs12/crypto.go
+++ b/sdk/azidentity/internal/pkcs12/crypto.go
@@ -1,0 +1,131 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"crypto/des"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/internal/pkcs12/internal/rc2"
+)
+
+var (
+	oidPBEWithSHAAnd3KeyTripleDESCBC = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 1, 3})
+	oidPBEWithSHAAnd40BitRC2CBC      = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 1, 6})
+)
+
+// pbeCipher is an abstraction of a PKCS#12 cipher.
+type pbeCipher interface {
+	// create returns a cipher.Block given a key.
+	create(key []byte) (cipher.Block, error)
+	// deriveKey returns a key derived from the given password and salt.
+	deriveKey(salt, password []byte, iterations int) []byte
+	// deriveIV returns an IV derived from the given password and salt.
+	deriveIV(salt, password []byte, iterations int) []byte
+}
+
+type shaWithTripleDESCBC struct{}
+
+func (shaWithTripleDESCBC) create(key []byte) (cipher.Block, error) {
+	return des.NewTripleDESCipher(key)
+}
+
+func (shaWithTripleDESCBC) deriveKey(salt, password []byte, iterations int) []byte {
+	return pbkdf(sha1Sum, 20, 64, salt, password, iterations, 1, 24)
+}
+
+func (shaWithTripleDESCBC) deriveIV(salt, password []byte, iterations int) []byte {
+	return pbkdf(sha1Sum, 20, 64, salt, password, iterations, 2, 8)
+}
+
+type shaWith40BitRC2CBC struct{}
+
+func (shaWith40BitRC2CBC) create(key []byte) (cipher.Block, error) {
+	return rc2.New(key, len(key)*8)
+}
+
+func (shaWith40BitRC2CBC) deriveKey(salt, password []byte, iterations int) []byte {
+	return pbkdf(sha1Sum, 20, 64, salt, password, iterations, 1, 5)
+}
+
+func (shaWith40BitRC2CBC) deriveIV(salt, password []byte, iterations int) []byte {
+	return pbkdf(sha1Sum, 20, 64, salt, password, iterations, 2, 8)
+}
+
+type pbeParams struct {
+	Salt       []byte
+	Iterations int
+}
+
+func pbDecrypterFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher.BlockMode, int, error) {
+	var cipherType pbeCipher
+
+	switch {
+	case algorithm.Algorithm.Equal(oidPBEWithSHAAnd3KeyTripleDESCBC):
+		cipherType = shaWithTripleDESCBC{}
+	case algorithm.Algorithm.Equal(oidPBEWithSHAAnd40BitRC2CBC):
+		cipherType = shaWith40BitRC2CBC{}
+	default:
+		return nil, 0, NotImplementedError("algorithm " + algorithm.Algorithm.String() + " is not supported")
+	}
+
+	var params pbeParams
+	if err := unmarshal(algorithm.Parameters.FullBytes, &params); err != nil {
+		return nil, 0, err
+	}
+
+	key := cipherType.deriveKey(params.Salt, password, params.Iterations)
+	iv := cipherType.deriveIV(params.Salt, password, params.Iterations)
+
+	block, err := cipherType.create(key)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return cipher.NewCBCDecrypter(block, iv), block.BlockSize(), nil
+}
+
+func pbDecrypt(info decryptable, password []byte) (decrypted []byte, err error) {
+	cbc, blockSize, err := pbDecrypterFor(info.Algorithm(), password)
+	if err != nil {
+		return nil, err
+	}
+
+	encrypted := info.Data()
+	if len(encrypted) == 0 {
+		return nil, errors.New("pkcs12: empty encrypted data")
+	}
+	if len(encrypted)%blockSize != 0 {
+		return nil, errors.New("pkcs12: input is not a multiple of the block size")
+	}
+	decrypted = make([]byte, len(encrypted))
+	cbc.CryptBlocks(decrypted, encrypted)
+
+	psLen := int(decrypted[len(decrypted)-1])
+	if psLen == 0 || psLen > blockSize {
+		return nil, ErrDecryption
+	}
+
+	if len(decrypted) < psLen {
+		return nil, ErrDecryption
+	}
+	ps := decrypted[len(decrypted)-psLen:]
+	decrypted = decrypted[:len(decrypted)-psLen]
+	if !bytes.Equal(ps, bytes.Repeat([]byte{byte(psLen)}, psLen)) {
+		return nil, ErrDecryption
+	}
+
+	return
+}
+
+// decryptable abstracts an object that contains ciphertext.
+type decryptable interface {
+	Algorithm() pkix.AlgorithmIdentifier
+	Data() []byte
+}

--- a/sdk/azidentity/internal/pkcs12/crypto_test.go
+++ b/sdk/azidentity/internal/pkcs12/crypto_test.go
@@ -1,0 +1,125 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"bytes"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"testing"
+)
+
+var sha1WithTripleDES = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 1, 3})
+
+func TestPbDecrypterFor(t *testing.T) {
+	params, _ := asn1.Marshal(pbeParams{
+		Salt:       []byte{1, 2, 3, 4, 5, 6, 7, 8},
+		Iterations: 2048,
+	})
+	alg := pkix.AlgorithmIdentifier{
+		Algorithm: asn1.ObjectIdentifier([]int{1, 2, 3}),
+		Parameters: asn1.RawValue{
+			FullBytes: params,
+		},
+	}
+
+	pass, _ := bmpString("Sesame open")
+
+	_, _, err := pbDecrypterFor(alg, pass)
+	if _, ok := err.(NotImplementedError); !ok {
+		t.Errorf("expected not implemented error, got: %T %s", err, err)
+	}
+
+	alg.Algorithm = sha1WithTripleDES
+	cbc, blockSize, err := pbDecrypterFor(alg, pass)
+	if err != nil {
+		t.Errorf("unexpected error from pbDecrypterFor %v", err)
+	}
+	if blockSize != 8 {
+		t.Errorf("unexpected block size %d, wanted 8", blockSize)
+	}
+
+	plaintext := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	expectedCiphertext := []byte{185, 73, 135, 249, 137, 1, 122, 247}
+	ciphertext := make([]byte, len(plaintext))
+	cbc.CryptBlocks(ciphertext, plaintext)
+
+	if bytes.Compare(ciphertext, expectedCiphertext) != 0 {
+		t.Errorf("bad ciphertext, got %x but wanted %x", ciphertext, expectedCiphertext)
+	}
+}
+
+var pbDecryptTests = []struct {
+	in            []byte
+	expected      []byte
+	expectedError error
+}{
+	{
+		[]byte("\x33\x73\xf3\x9f\xda\x49\xae\xfc\xa0\x9a\xdf\x5a\x58\xa0\xea\x46"), // 7 padding bytes
+		[]byte("A secret!"),
+		nil,
+	},
+	{
+		[]byte("\x33\x73\xf3\x9f\xda\x49\xae\xfc\x96\x24\x2f\x71\x7e\x32\x3f\xe7"), // 8 padding bytes
+		[]byte("A secret"),
+		nil,
+	},
+	{
+		[]byte("\x35\x0c\xc0\x8d\xab\xa9\x5d\x30\x7f\x9a\xec\x6a\xd8\x9b\x9c\xd9"), // 9 padding bytes, incorrect
+		nil,
+		ErrDecryption,
+	},
+	{
+		[]byte("\xb2\xf9\x6e\x06\x60\xae\x20\xcf\x08\xa0\x7b\xd9\x6b\x20\xef\x41"), // incorrect padding bytes: [ ... 0x04 0x02 ]
+		nil,
+		ErrDecryption,
+	},
+}
+
+func TestPbDecrypt(t *testing.T) {
+	for i, test := range pbDecryptTests {
+		decryptable := testDecryptable{
+			data: test.in,
+			algorithm: pkix.AlgorithmIdentifier{
+				Algorithm: sha1WithTripleDES,
+				Parameters: pbeParams{
+					Salt:       []byte("\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8"),
+					Iterations: 4096,
+				}.RawASN1(),
+			},
+		}
+		password, _ := bmpString("sesame")
+
+		plaintext, err := pbDecrypt(decryptable, password)
+		if err != test.expectedError {
+			t.Errorf("#%d: got error %q, but wanted %q", i, err, test.expectedError)
+			continue
+		}
+
+		if !bytes.Equal(plaintext, test.expected) {
+			t.Errorf("#%d: got %x, but wanted %x", i, plaintext, test.expected)
+		}
+	}
+}
+
+type testDecryptable struct {
+	data      []byte
+	algorithm pkix.AlgorithmIdentifier
+}
+
+func (d testDecryptable) Algorithm() pkix.AlgorithmIdentifier { return d.algorithm }
+func (d testDecryptable) Data() []byte                        { return d.data }
+
+func (params pbeParams) RawASN1() (raw asn1.RawValue) {
+	asn1Bytes, err := asn1.Marshal(params)
+	if err != nil {
+		panic(err)
+	}
+	_, err = asn1.Unmarshal(asn1Bytes, &raw)
+	if err != nil {
+		panic(err)
+	}
+	return
+}

--- a/sdk/azidentity/internal/pkcs12/errors.go
+++ b/sdk/azidentity/internal/pkcs12/errors.go
@@ -1,0 +1,23 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import "errors"
+
+var (
+	// ErrDecryption represents a failure to decrypt the input.
+	ErrDecryption = errors.New("pkcs12: decryption error, incorrect padding")
+
+	// ErrIncorrectPassword is returned when an incorrect password is detected.
+	// Usually, P12/PFX data is signed to be able to verify the password.
+	ErrIncorrectPassword = errors.New("pkcs12: decryption password incorrect")
+)
+
+// NotImplementedError indicates that the input is not currently supported.
+type NotImplementedError string
+
+func (e NotImplementedError) Error() string {
+	return "pkcs12: " + string(e)
+}

--- a/sdk/azidentity/internal/pkcs12/internal/rc2/bench_test.go
+++ b/sdk/azidentity/internal/pkcs12/internal/rc2/bench_test.go
@@ -1,0 +1,27 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rc2
+
+import (
+	"testing"
+)
+
+func BenchmarkEncrypt(b *testing.B) {
+	r, _ := New([]byte{0, 0, 0, 0, 0, 0, 0, 0}, 64)
+	b.ResetTimer()
+	var src [8]byte
+	for i := 0; i < b.N; i++ {
+		r.Encrypt(src[:], src[:])
+	}
+}
+
+func BenchmarkDecrypt(b *testing.B) {
+	r, _ := New([]byte{0, 0, 0, 0, 0, 0, 0, 0}, 64)
+	b.ResetTimer()
+	var src [8]byte
+	for i := 0; i < b.N; i++ {
+		r.Decrypt(src[:], src[:])
+	}
+}

--- a/sdk/azidentity/internal/pkcs12/internal/rc2/rc2.go
+++ b/sdk/azidentity/internal/pkcs12/internal/rc2/rc2.go
@@ -1,0 +1,268 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package rc2 implements the RC2 cipher
+/*
+https://www.ietf.org/rfc/rfc2268.txt
+http://people.csail.mit.edu/rivest/pubs/KRRR98.pdf
+
+This code is licensed under the MIT license.
+*/
+package rc2
+
+import (
+	"crypto/cipher"
+	"encoding/binary"
+	"math/bits"
+)
+
+// The rc2 block size in bytes
+const BlockSize = 8
+
+type rc2Cipher struct {
+	k [64]uint16
+}
+
+// New returns a new rc2 cipher with the given key and effective key length t1
+func New(key []byte, t1 int) (cipher.Block, error) {
+	// TODO(dgryski): error checking for key length
+	return &rc2Cipher{
+		k: expandKey(key, t1),
+	}, nil
+}
+
+func (*rc2Cipher) BlockSize() int { return BlockSize }
+
+var piTable = [256]byte{
+	0xd9, 0x78, 0xf9, 0xc4, 0x19, 0xdd, 0xb5, 0xed, 0x28, 0xe9, 0xfd, 0x79, 0x4a, 0xa0, 0xd8, 0x9d,
+	0xc6, 0x7e, 0x37, 0x83, 0x2b, 0x76, 0x53, 0x8e, 0x62, 0x4c, 0x64, 0x88, 0x44, 0x8b, 0xfb, 0xa2,
+	0x17, 0x9a, 0x59, 0xf5, 0x87, 0xb3, 0x4f, 0x13, 0x61, 0x45, 0x6d, 0x8d, 0x09, 0x81, 0x7d, 0x32,
+	0xbd, 0x8f, 0x40, 0xeb, 0x86, 0xb7, 0x7b, 0x0b, 0xf0, 0x95, 0x21, 0x22, 0x5c, 0x6b, 0x4e, 0x82,
+	0x54, 0xd6, 0x65, 0x93, 0xce, 0x60, 0xb2, 0x1c, 0x73, 0x56, 0xc0, 0x14, 0xa7, 0x8c, 0xf1, 0xdc,
+	0x12, 0x75, 0xca, 0x1f, 0x3b, 0xbe, 0xe4, 0xd1, 0x42, 0x3d, 0xd4, 0x30, 0xa3, 0x3c, 0xb6, 0x26,
+	0x6f, 0xbf, 0x0e, 0xda, 0x46, 0x69, 0x07, 0x57, 0x27, 0xf2, 0x1d, 0x9b, 0xbc, 0x94, 0x43, 0x03,
+	0xf8, 0x11, 0xc7, 0xf6, 0x90, 0xef, 0x3e, 0xe7, 0x06, 0xc3, 0xd5, 0x2f, 0xc8, 0x66, 0x1e, 0xd7,
+	0x08, 0xe8, 0xea, 0xde, 0x80, 0x52, 0xee, 0xf7, 0x84, 0xaa, 0x72, 0xac, 0x35, 0x4d, 0x6a, 0x2a,
+	0x96, 0x1a, 0xd2, 0x71, 0x5a, 0x15, 0x49, 0x74, 0x4b, 0x9f, 0xd0, 0x5e, 0x04, 0x18, 0xa4, 0xec,
+	0xc2, 0xe0, 0x41, 0x6e, 0x0f, 0x51, 0xcb, 0xcc, 0x24, 0x91, 0xaf, 0x50, 0xa1, 0xf4, 0x70, 0x39,
+	0x99, 0x7c, 0x3a, 0x85, 0x23, 0xb8, 0xb4, 0x7a, 0xfc, 0x02, 0x36, 0x5b, 0x25, 0x55, 0x97, 0x31,
+	0x2d, 0x5d, 0xfa, 0x98, 0xe3, 0x8a, 0x92, 0xae, 0x05, 0xdf, 0x29, 0x10, 0x67, 0x6c, 0xba, 0xc9,
+	0xd3, 0x00, 0xe6, 0xcf, 0xe1, 0x9e, 0xa8, 0x2c, 0x63, 0x16, 0x01, 0x3f, 0x58, 0xe2, 0x89, 0xa9,
+	0x0d, 0x38, 0x34, 0x1b, 0xab, 0x33, 0xff, 0xb0, 0xbb, 0x48, 0x0c, 0x5f, 0xb9, 0xb1, 0xcd, 0x2e,
+	0xc5, 0xf3, 0xdb, 0x47, 0xe5, 0xa5, 0x9c, 0x77, 0x0a, 0xa6, 0x20, 0x68, 0xfe, 0x7f, 0xc1, 0xad,
+}
+
+func expandKey(key []byte, t1 int) [64]uint16 {
+
+	l := make([]byte, 128)
+	copy(l, key)
+
+	var t = len(key)
+	var t8 = (t1 + 7) / 8
+	var tm = byte(255 % uint(1<<(8+uint(t1)-8*uint(t8))))
+
+	for i := len(key); i < 128; i++ {
+		l[i] = piTable[l[i-1]+l[uint8(i-t)]]
+	}
+
+	l[128-t8] = piTable[l[128-t8]&tm]
+
+	for i := 127 - t8; i >= 0; i-- {
+		l[i] = piTable[l[i+1]^l[i+t8]]
+	}
+
+	var k [64]uint16
+
+	for i := range k {
+		k[i] = uint16(l[2*i]) + uint16(l[2*i+1])*256
+	}
+
+	return k
+}
+
+func (c *rc2Cipher) Encrypt(dst, src []byte) {
+
+	r0 := binary.LittleEndian.Uint16(src[0:])
+	r1 := binary.LittleEndian.Uint16(src[2:])
+	r2 := binary.LittleEndian.Uint16(src[4:])
+	r3 := binary.LittleEndian.Uint16(src[6:])
+
+	var j int
+
+	for j <= 16 {
+		// mix r0
+		r0 = r0 + c.k[j] + (r3 & r2) + ((^r3) & r1)
+		r0 = bits.RotateLeft16(r0, 1)
+		j++
+
+		// mix r1
+		r1 = r1 + c.k[j] + (r0 & r3) + ((^r0) & r2)
+		r1 = bits.RotateLeft16(r1, 2)
+		j++
+
+		// mix r2
+		r2 = r2 + c.k[j] + (r1 & r0) + ((^r1) & r3)
+		r2 = bits.RotateLeft16(r2, 3)
+		j++
+
+		// mix r3
+		r3 = r3 + c.k[j] + (r2 & r1) + ((^r2) & r0)
+		r3 = bits.RotateLeft16(r3, 5)
+		j++
+
+	}
+
+	r0 = r0 + c.k[r3&63]
+	r1 = r1 + c.k[r0&63]
+	r2 = r2 + c.k[r1&63]
+	r3 = r3 + c.k[r2&63]
+
+	for j <= 40 {
+		// mix r0
+		r0 = r0 + c.k[j] + (r3 & r2) + ((^r3) & r1)
+		r0 = bits.RotateLeft16(r0, 1)
+		j++
+
+		// mix r1
+		r1 = r1 + c.k[j] + (r0 & r3) + ((^r0) & r2)
+		r1 = bits.RotateLeft16(r1, 2)
+		j++
+
+		// mix r2
+		r2 = r2 + c.k[j] + (r1 & r0) + ((^r1) & r3)
+		r2 = bits.RotateLeft16(r2, 3)
+		j++
+
+		// mix r3
+		r3 = r3 + c.k[j] + (r2 & r1) + ((^r2) & r0)
+		r3 = bits.RotateLeft16(r3, 5)
+		j++
+
+	}
+
+	r0 = r0 + c.k[r3&63]
+	r1 = r1 + c.k[r0&63]
+	r2 = r2 + c.k[r1&63]
+	r3 = r3 + c.k[r2&63]
+
+	for j <= 60 {
+		// mix r0
+		r0 = r0 + c.k[j] + (r3 & r2) + ((^r3) & r1)
+		r0 = bits.RotateLeft16(r0, 1)
+		j++
+
+		// mix r1
+		r1 = r1 + c.k[j] + (r0 & r3) + ((^r0) & r2)
+		r1 = bits.RotateLeft16(r1, 2)
+		j++
+
+		// mix r2
+		r2 = r2 + c.k[j] + (r1 & r0) + ((^r1) & r3)
+		r2 = bits.RotateLeft16(r2, 3)
+		j++
+
+		// mix r3
+		r3 = r3 + c.k[j] + (r2 & r1) + ((^r2) & r0)
+		r3 = bits.RotateLeft16(r3, 5)
+		j++
+	}
+
+	binary.LittleEndian.PutUint16(dst[0:], r0)
+	binary.LittleEndian.PutUint16(dst[2:], r1)
+	binary.LittleEndian.PutUint16(dst[4:], r2)
+	binary.LittleEndian.PutUint16(dst[6:], r3)
+}
+
+func (c *rc2Cipher) Decrypt(dst, src []byte) {
+
+	r0 := binary.LittleEndian.Uint16(src[0:])
+	r1 := binary.LittleEndian.Uint16(src[2:])
+	r2 := binary.LittleEndian.Uint16(src[4:])
+	r3 := binary.LittleEndian.Uint16(src[6:])
+
+	j := 63
+
+	for j >= 44 {
+		// unmix r3
+		r3 = bits.RotateLeft16(r3, 16-5)
+		r3 = r3 - c.k[j] - (r2 & r1) - ((^r2) & r0)
+		j--
+
+		// unmix r2
+		r2 = bits.RotateLeft16(r2, 16-3)
+		r2 = r2 - c.k[j] - (r1 & r0) - ((^r1) & r3)
+		j--
+
+		// unmix r1
+		r1 = bits.RotateLeft16(r1, 16-2)
+		r1 = r1 - c.k[j] - (r0 & r3) - ((^r0) & r2)
+		j--
+
+		// unmix r0
+		r0 = bits.RotateLeft16(r0, 16-1)
+		r0 = r0 - c.k[j] - (r3 & r2) - ((^r3) & r1)
+		j--
+	}
+
+	r3 = r3 - c.k[r2&63]
+	r2 = r2 - c.k[r1&63]
+	r1 = r1 - c.k[r0&63]
+	r0 = r0 - c.k[r3&63]
+
+	for j >= 20 {
+		// unmix r3
+		r3 = bits.RotateLeft16(r3, 16-5)
+		r3 = r3 - c.k[j] - (r2 & r1) - ((^r2) & r0)
+		j--
+
+		// unmix r2
+		r2 = bits.RotateLeft16(r2, 16-3)
+		r2 = r2 - c.k[j] - (r1 & r0) - ((^r1) & r3)
+		j--
+
+		// unmix r1
+		r1 = bits.RotateLeft16(r1, 16-2)
+		r1 = r1 - c.k[j] - (r0 & r3) - ((^r0) & r2)
+		j--
+
+		// unmix r0
+		r0 = bits.RotateLeft16(r0, 16-1)
+		r0 = r0 - c.k[j] - (r3 & r2) - ((^r3) & r1)
+		j--
+
+	}
+
+	r3 = r3 - c.k[r2&63]
+	r2 = r2 - c.k[r1&63]
+	r1 = r1 - c.k[r0&63]
+	r0 = r0 - c.k[r3&63]
+
+	for j >= 0 {
+		// unmix r3
+		r3 = bits.RotateLeft16(r3, 16-5)
+		r3 = r3 - c.k[j] - (r2 & r1) - ((^r2) & r0)
+		j--
+
+		// unmix r2
+		r2 = bits.RotateLeft16(r2, 16-3)
+		r2 = r2 - c.k[j] - (r1 & r0) - ((^r1) & r3)
+		j--
+
+		// unmix r1
+		r1 = bits.RotateLeft16(r1, 16-2)
+		r1 = r1 - c.k[j] - (r0 & r3) - ((^r0) & r2)
+		j--
+
+		// unmix r0
+		r0 = bits.RotateLeft16(r0, 16-1)
+		r0 = r0 - c.k[j] - (r3 & r2) - ((^r3) & r1)
+		j--
+
+	}
+
+	binary.LittleEndian.PutUint16(dst[0:], r0)
+	binary.LittleEndian.PutUint16(dst[2:], r1)
+	binary.LittleEndian.PutUint16(dst[4:], r2)
+	binary.LittleEndian.PutUint16(dst[6:], r3)
+}

--- a/sdk/azidentity/internal/pkcs12/internal/rc2/rc2_test.go
+++ b/sdk/azidentity/internal/pkcs12/internal/rc2/rc2_test.go
@@ -1,0 +1,92 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rc2
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	// TODO(dgryski): add the rest of the test vectors from the RFC
+	var tests = []struct {
+		key    string
+		plain  string
+		cipher string
+		t1     int
+	}{
+		{
+			"0000000000000000",
+			"0000000000000000",
+			"ebb773f993278eff",
+			63,
+		},
+		{
+			"ffffffffffffffff",
+			"ffffffffffffffff",
+			"278b27e42e2f0d49",
+			64,
+		},
+		{
+			"3000000000000000",
+			"1000000000000001",
+			"30649edf9be7d2c2",
+			64,
+		},
+		{
+			"88",
+			"0000000000000000",
+			"61a8a244adacccf0",
+			64,
+		},
+		{
+			"88bca90e90875a",
+			"0000000000000000",
+			"6ccf4308974c267f",
+			64,
+		},
+		{
+			"88bca90e90875a7f0f79c384627bafb2",
+			"0000000000000000",
+			"1a807d272bbe5db1",
+			64,
+		},
+		{
+			"88bca90e90875a7f0f79c384627bafb2",
+			"0000000000000000",
+			"2269552ab0f85ca6",
+			128,
+		},
+		{
+			"88bca90e90875a7f0f79c384627bafb216f80a6f85920584c42fceb0be255daf1e",
+			"0000000000000000",
+			"5b78d3a43dfff1f1",
+			129,
+		},
+	}
+
+	for _, tt := range tests {
+		k, _ := hex.DecodeString(tt.key)
+		p, _ := hex.DecodeString(tt.plain)
+		c, _ := hex.DecodeString(tt.cipher)
+
+		b, _ := New(k, tt.t1)
+
+		var dst [8]byte
+
+		b.Encrypt(dst[:], p)
+
+		if !bytes.Equal(dst[:], c) {
+			t.Errorf("encrypt failed: got % 2x wanted % 2x\n", dst, c)
+		}
+
+		b.Decrypt(dst[:], c)
+
+		if !bytes.Equal(dst[:], p) {
+			t.Errorf("decrypt failed: got % 2x wanted % 2x\n", dst, p)
+		}
+	}
+}

--- a/sdk/azidentity/internal/pkcs12/mac.go
+++ b/sdk/azidentity/internal/pkcs12/mac.go
@@ -1,0 +1,45 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+)
+
+type macData struct {
+	Mac        digestInfo
+	MacSalt    []byte
+	Iterations int `asn1:"optional,default:1"`
+}
+
+// from PKCS#7:
+type digestInfo struct {
+	Algorithm pkix.AlgorithmIdentifier
+	Digest    []byte
+}
+
+var (
+	oidSHA1 = asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26})
+)
+
+func verifyMac(macData *macData, message, password []byte) error {
+	if !macData.Mac.Algorithm.Algorithm.Equal(oidSHA1) {
+		return NotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
+	}
+
+	key := pbkdf(sha1Sum, 20, 64, macData.MacSalt, password, macData.Iterations, 3, 20)
+
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	if !hmac.Equal(macData.Mac.Digest, expectedMAC) {
+		return ErrIncorrectPassword
+	}
+	return nil
+}

--- a/sdk/azidentity/internal/pkcs12/mac_test.go
+++ b/sdk/azidentity/internal/pkcs12/mac_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"encoding/asn1"
+	"testing"
+)
+
+func TestVerifyMac(t *testing.T) {
+	td := macData{
+		Mac: digestInfo{
+			Digest: []byte{0x18, 0x20, 0x3d, 0xff, 0x1e, 0x16, 0xf4, 0x92, 0xf2, 0xaf, 0xc8, 0x91, 0xa9, 0xba, 0xd6, 0xca, 0x9d, 0xee, 0x51, 0x93},
+		},
+		MacSalt:    []byte{1, 2, 3, 4, 5, 6, 7, 8},
+		Iterations: 2048,
+	}
+
+	message := []byte{11, 12, 13, 14, 15}
+	password, _ := bmpString("")
+
+	td.Mac.Algorithm.Algorithm = asn1.ObjectIdentifier([]int{1, 2, 3})
+	err := verifyMac(&td, message, password)
+	if _, ok := err.(NotImplementedError); !ok {
+		t.Errorf("err: %v", err)
+	}
+
+	td.Mac.Algorithm.Algorithm = asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26})
+	err = verifyMac(&td, message, password)
+	if err != ErrIncorrectPassword {
+		t.Errorf("Expected incorrect password, got err: %v", err)
+	}
+
+	password, _ = bmpString("Sesame open")
+	err = verifyMac(&td, message, password)
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
+
+}

--- a/sdk/azidentity/internal/pkcs12/pbkdf.go
+++ b/sdk/azidentity/internal/pkcs12/pbkdf.go
@@ -1,0 +1,170 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"math/big"
+)
+
+var (
+	one = big.NewInt(1)
+)
+
+// sha1Sum returns the SHA-1 hash of in.
+func sha1Sum(in []byte) []byte {
+	sum := sha1.Sum(in)
+	return sum[:]
+}
+
+// fillWithRepeats returns v*ceiling(len(pattern) / v) bytes consisting of
+// repeats of pattern.
+func fillWithRepeats(pattern []byte, v int) []byte {
+	if len(pattern) == 0 {
+		return nil
+	}
+	outputLen := v * ((len(pattern) + v - 1) / v)
+	return bytes.Repeat(pattern, (outputLen+len(pattern)-1)/len(pattern))[:outputLen]
+}
+
+func pbkdf(hash func([]byte) []byte, u, v int, salt, password []byte, r int, ID byte, size int) (key []byte) {
+	// implementation of https://tools.ietf.org/html/rfc7292#appendix-B.2 , RFC text verbatim in comments
+
+	//    Let H be a hash function built around a compression function f:
+
+	//       Z_2^u x Z_2^v -> Z_2^u
+
+	//    (that is, H has a chaining variable and output of length u bits, and
+	//    the message input to the compression function of H is v bits).  The
+	//    values for u and v are as follows:
+
+	//            HASH FUNCTION     VALUE u        VALUE v
+	//              MD2, MD5          128            512
+	//                SHA-1           160            512
+	//               SHA-224          224            512
+	//               SHA-256          256            512
+	//               SHA-384          384            1024
+	//               SHA-512          512            1024
+	//             SHA-512/224        224            1024
+	//             SHA-512/256        256            1024
+
+	//    Furthermore, let r be the iteration count.
+
+	//    We assume here that u and v are both multiples of 8, as are the
+	//    lengths of the password and salt strings (which we denote by p and s,
+	//    respectively) and the number n of pseudorandom bits required.  In
+	//    addition, u and v are of course non-zero.
+
+	//    For information on security considerations for MD5 [19], see [25] and
+	//    [1], and on those for MD2, see [18].
+
+	//    The following procedure can be used to produce pseudorandom bits for
+	//    a particular "purpose" that is identified by a byte called "ID".
+	//    This standard specifies 3 different values for the ID byte:
+
+	//    1.  If ID=1, then the pseudorandom bits being produced are to be used
+	//        as key material for performing encryption or decryption.
+
+	//    2.  If ID=2, then the pseudorandom bits being produced are to be used
+	//        as an IV (Initial Value) for encryption or decryption.
+
+	//    3.  If ID=3, then the pseudorandom bits being produced are to be used
+	//        as an integrity key for MACing.
+
+	//    1.  Construct a string, D (the "diversifier"), by concatenating v/8
+	//        copies of ID.
+	var D []byte
+	for i := 0; i < v; i++ {
+		D = append(D, ID)
+	}
+
+	//    2.  Concatenate copies of the salt together to create a string S of
+	//        length v(ceiling(s/v)) bits (the final copy of the salt may be
+	//        truncated to create S).  Note that if the salt is the empty
+	//        string, then so is S.
+
+	S := fillWithRepeats(salt, v)
+
+	//    3.  Concatenate copies of the password together to create a string P
+	//        of length v(ceiling(p/v)) bits (the final copy of the password
+	//        may be truncated to create P).  Note that if the password is the
+	//        empty string, then so is P.
+
+	P := fillWithRepeats(password, v)
+
+	//    4.  Set I=S||P to be the concatenation of S and P.
+	I := append(S, P...)
+
+	//    5.  Set c=ceiling(n/u).
+	c := (size + u - 1) / u
+
+	//    6.  For i=1, 2, ..., c, do the following:
+	A := make([]byte, c*20)
+	var IjBuf []byte
+	for i := 0; i < c; i++ {
+		//        A.  Set A2=H^r(D||I). (i.e., the r-th hash of D||1,
+		//            H(H(H(... H(D||I))))
+		Ai := hash(append(D, I...))
+		for j := 1; j < r; j++ {
+			Ai = hash(Ai)
+		}
+		copy(A[i*20:], Ai[:])
+
+		if i < c-1 { // skip on last iteration
+			// B.  Concatenate copies of Ai to create a string B of length v
+			//     bits (the final copy of Ai may be truncated to create B).
+			var B []byte
+			for len(B) < v {
+				B = append(B, Ai[:]...)
+			}
+			B = B[:v]
+
+			// C.  Treating I as a concatenation I_0, I_1, ..., I_(k-1) of v-bit
+			//     blocks, where k=ceiling(s/v)+ceiling(p/v), modify I by
+			//     setting I_j=(I_j+B+1) mod 2^v for each j.
+			{
+				Bbi := new(big.Int).SetBytes(B)
+				Ij := new(big.Int)
+
+				for j := 0; j < len(I)/v; j++ {
+					Ij.SetBytes(I[j*v : (j+1)*v])
+					Ij.Add(Ij, Bbi)
+					Ij.Add(Ij, one)
+					Ijb := Ij.Bytes()
+					// We expect Ijb to be exactly v bytes,
+					// if it is longer or shorter we must
+					// adjust it accordingly.
+					if len(Ijb) > v {
+						Ijb = Ijb[len(Ijb)-v:]
+					}
+					if len(Ijb) < v {
+						if IjBuf == nil {
+							IjBuf = make([]byte, v)
+						}
+						bytesShort := v - len(Ijb)
+						for i := 0; i < bytesShort; i++ {
+							IjBuf[i] = 0
+						}
+						copy(IjBuf[bytesShort:], Ijb)
+						Ijb = IjBuf
+					}
+					copy(I[j*v:(j+1)*v], Ijb)
+				}
+			}
+		}
+	}
+	//    7.  Concatenate A_1, A_2, ..., A_c together to form a pseudorandom
+	//        bit string, A.
+
+	//    8.  Use the first n bits of A as the output of this entire process.
+	return A[:size]
+
+	//    If the above process is being used to generate a DES key, the process
+	//    should be used to create 64 random bits, and the key's parity bits
+	//    should be set after the 64 bits have been produced.  Similar concerns
+	//    hold for 2-key and 3-key triple-DES keys, for CDMF keys, and for any
+	//    similar keys with parity bits "built into them".
+}

--- a/sdk/azidentity/internal/pkcs12/pbkdf_test.go
+++ b/sdk/azidentity/internal/pkcs12/pbkdf_test.go
@@ -1,0 +1,34 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestThatPBKDFWorksCorrectlyForLongKeys(t *testing.T) {
+	cipherInfo := shaWithTripleDESCBC{}
+
+	salt := []byte("\xff\xff\xff\xff\xff\xff\xff\xff")
+	password, _ := bmpString("sesame")
+	key := cipherInfo.deriveKey(salt, password, 2048)
+
+	if expected := []byte("\x7c\xd9\xfd\x3e\x2b\x3b\xe7\x69\x1a\x44\xe3\xbe\xf0\xf9\xea\x0f\xb9\xb8\x97\xd4\xe3\x25\xd9\xd1"); bytes.Compare(key, expected) != 0 {
+		t.Fatalf("expected key '%x', but found '%x'", expected, key)
+	}
+}
+
+func TestThatPBKDFHandlesLeadingZeros(t *testing.T) {
+	// This test triggers a case where I_j (in step 6C) ends up with leading zero
+	// byte, meaning that len(Ijb) < v (leading zeros get stripped by big.Int).
+	// This was previously causing bug whereby certain inputs would break the
+	// derivation and produce the wrong output.
+	key := pbkdf(sha1Sum, 20, 64, []byte("\xf3\x7e\x05\xb5\x18\x32\x4b\x4b"), []byte("\x00\x00"), 2048, 1, 24)
+	expected := []byte("\x00\xf7\x59\xff\x47\xd1\x4d\xd0\x36\x65\xd5\x94\x3c\xb3\xc4\xa3\x9a\x25\x55\xc0\x2a\xed\x66\xe1")
+	if bytes.Compare(key, expected) != 0 {
+		t.Fatalf("expected key '%x', but found '%x'", expected, key)
+	}
+}

--- a/sdk/azidentity/internal/pkcs12/pkcs12.go
+++ b/sdk/azidentity/internal/pkcs12/pkcs12.go
@@ -1,0 +1,360 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pkcs12 implements some of PKCS#12.
+//
+// This implementation is distilled from https://tools.ietf.org/html/rfc7292
+// and referenced documents. It is intended for decoding P12/PFX-stored
+// certificates and keys for use with the crypto/tls package.
+//
+// This package is frozen. If it's missing functionality you need, consider
+// an alternative like software.sslmate.com/src/go-pkcs12.
+package pkcs12
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+)
+
+var (
+	oidDataContentType          = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 7, 1})
+	oidEncryptedDataContentType = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 7, 6})
+
+	oidFriendlyName     = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 9, 20})
+	oidLocalKeyID       = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 9, 21})
+	oidMicrosoftCSPName = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 311, 17, 1})
+
+	errUnknownAttributeOID = errors.New("pkcs12: unknown attribute OID")
+)
+
+type pfxPdu struct {
+	Version  int
+	AuthSafe contentInfo
+	MacData  macData `asn1:"optional"`
+}
+
+type contentInfo struct {
+	ContentType asn1.ObjectIdentifier
+	Content     asn1.RawValue `asn1:"tag:0,explicit,optional"`
+}
+
+type encryptedData struct {
+	Version              int
+	EncryptedContentInfo encryptedContentInfo
+}
+
+type encryptedContentInfo struct {
+	ContentType                asn1.ObjectIdentifier
+	ContentEncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedContent           []byte `asn1:"tag:0,optional"`
+}
+
+func (i encryptedContentInfo) Algorithm() pkix.AlgorithmIdentifier {
+	return i.ContentEncryptionAlgorithm
+}
+
+func (i encryptedContentInfo) Data() []byte { return i.EncryptedContent }
+
+type safeBag struct {
+	Id         asn1.ObjectIdentifier
+	Value      asn1.RawValue     `asn1:"tag:0,explicit"`
+	Attributes []pkcs12Attribute `asn1:"set,optional"`
+}
+
+type pkcs12Attribute struct {
+	Id    asn1.ObjectIdentifier
+	Value asn1.RawValue `asn1:"set"`
+}
+
+type encryptedPrivateKeyInfo struct {
+	AlgorithmIdentifier pkix.AlgorithmIdentifier
+	EncryptedData       []byte
+}
+
+func (i encryptedPrivateKeyInfo) Algorithm() pkix.AlgorithmIdentifier {
+	return i.AlgorithmIdentifier
+}
+
+func (i encryptedPrivateKeyInfo) Data() []byte {
+	return i.EncryptedData
+}
+
+// PEM block types
+const (
+	certificateType = "CERTIFICATE"
+	privateKeyType  = "PRIVATE KEY"
+)
+
+// unmarshal calls asn1.Unmarshal, but also returns an error if there is any
+// trailing data after unmarshaling.
+func unmarshal(in []byte, out interface{}) error {
+	trailing, err := asn1.Unmarshal(in, out)
+	if err != nil {
+		return err
+	}
+	if len(trailing) != 0 {
+		return errors.New("pkcs12: trailing data found")
+	}
+	return nil
+}
+
+// ToPEM converts all "safe bags" contained in pfxData to PEM blocks.
+// Unknown attributes are discarded.
+//
+// Note that although the returned PEM blocks for private keys have type
+// "PRIVATE KEY", the bytes are not encoded according to PKCS #8, but according
+// to PKCS #1 for RSA keys and SEC 1 for ECDSA keys.
+func ToPEM(pfxData []byte, password string) ([]*pem.Block, error) {
+	encodedPassword, err := bmpString(password)
+	if err != nil {
+		return nil, ErrIncorrectPassword
+	}
+
+	bags, encodedPassword, err := getSafeContents(pfxData, encodedPassword)
+
+	if err != nil {
+		return nil, err
+	}
+
+	blocks := make([]*pem.Block, 0, len(bags))
+	for _, bag := range bags {
+		block, err := convertBag(&bag, encodedPassword)
+		if err != nil {
+			return nil, err
+		}
+		blocks = append(blocks, block)
+	}
+
+	return blocks, nil
+}
+
+func convertBag(bag *safeBag, password []byte) (*pem.Block, error) {
+	block := &pem.Block{
+		Headers: make(map[string]string),
+	}
+
+	for _, attribute := range bag.Attributes {
+		k, v, err := convertAttribute(&attribute)
+		if err == errUnknownAttributeOID {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		block.Headers[k] = v
+	}
+
+	switch {
+	case bag.Id.Equal(oidCertBag):
+		block.Type = certificateType
+		certsData, err := decodeCertBag(bag.Value.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		block.Bytes = certsData
+	case bag.Id.Equal(oidPKCS8ShroundedKeyBag):
+		block.Type = privateKeyType
+
+		key, err := decodePkcs8ShroudedKeyBag(bag.Value.Bytes, password)
+		if err != nil {
+			return nil, err
+		}
+
+		switch key := key.(type) {
+		case *rsa.PrivateKey:
+			block.Bytes = x509.MarshalPKCS1PrivateKey(key)
+		case *ecdsa.PrivateKey:
+			block.Bytes, err = x509.MarshalECPrivateKey(key)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, errors.New("found unknown private key type in PKCS#8 wrapping")
+		}
+	default:
+		return nil, errors.New("don't know how to convert a safe bag of type " + bag.Id.String())
+	}
+	return block, nil
+}
+
+func convertAttribute(attribute *pkcs12Attribute) (key, value string, err error) {
+	isString := false
+
+	switch {
+	case attribute.Id.Equal(oidFriendlyName):
+		key = "friendlyName"
+		isString = true
+	case attribute.Id.Equal(oidLocalKeyID):
+		key = "localKeyId"
+	case attribute.Id.Equal(oidMicrosoftCSPName):
+		// This key is chosen to match OpenSSL.
+		key = "Microsoft CSP Name"
+		isString = true
+	default:
+		return "", "", errUnknownAttributeOID
+	}
+
+	if isString {
+		if err := unmarshal(attribute.Value.Bytes, &attribute.Value); err != nil {
+			return "", "", err
+		}
+		if value, err = decodeBMPString(attribute.Value.Bytes); err != nil {
+			return "", "", err
+		}
+	} else {
+		var id []byte
+		if err := unmarshal(attribute.Value.Bytes, &id); err != nil {
+			return "", "", err
+		}
+		value = hex.EncodeToString(id)
+	}
+
+	return key, value, nil
+}
+
+// Decode extracts a certificate and private key from pfxData. This function
+// assumes that there is only one certificate and only one private key in the
+// pfxData; if there are more use ToPEM instead.
+func Decode(pfxData []byte, password string) (privateKey interface{}, certificate *x509.Certificate, err error) {
+	encodedPassword, err := bmpString(password)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bags, encodedPassword, err := getSafeContents(pfxData, encodedPassword)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(bags) != 2 {
+		err = errors.New("pkcs12: expected exactly two safe bags in the PFX PDU")
+		return
+	}
+
+	for _, bag := range bags {
+		switch {
+		case bag.Id.Equal(oidCertBag):
+			if certificate != nil {
+				err = errors.New("pkcs12: expected exactly one certificate bag")
+			}
+
+			certsData, err := decodeCertBag(bag.Value.Bytes)
+			if err != nil {
+				return nil, nil, err
+			}
+			certs, err := x509.ParseCertificates(certsData)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(certs) != 1 {
+				err = errors.New("pkcs12: expected exactly one certificate in the certBag")
+				return nil, nil, err
+			}
+			certificate = certs[0]
+
+		case bag.Id.Equal(oidPKCS8ShroundedKeyBag):
+			if privateKey != nil {
+				err = errors.New("pkcs12: expected exactly one key bag")
+				return nil, nil, err
+			}
+
+			if privateKey, err = decodePkcs8ShroudedKeyBag(bag.Value.Bytes, encodedPassword); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	if certificate == nil {
+		return nil, nil, errors.New("pkcs12: certificate missing")
+	}
+	if privateKey == nil {
+		return nil, nil, errors.New("pkcs12: private key missing")
+	}
+
+	return
+}
+
+func getSafeContents(p12Data, password []byte) (bags []safeBag, updatedPassword []byte, err error) {
+	pfx := new(pfxPdu)
+	if err := unmarshal(p12Data, pfx); err != nil {
+		return nil, nil, errors.New("pkcs12: error reading P12 data: " + err.Error())
+	}
+
+	if pfx.Version != 3 {
+		return nil, nil, NotImplementedError("can only decode v3 PFX PDU's")
+	}
+
+	if !pfx.AuthSafe.ContentType.Equal(oidDataContentType) {
+		return nil, nil, NotImplementedError("only password-protected PFX is implemented")
+	}
+
+	// unmarshal the explicit bytes in the content for type 'data'
+	if err := unmarshal(pfx.AuthSafe.Content.Bytes, &pfx.AuthSafe.Content); err != nil {
+		return nil, nil, err
+	}
+
+	if len(pfx.MacData.Mac.Algorithm.Algorithm) == 0 {
+		return nil, nil, errors.New("pkcs12: no MAC in data")
+	}
+
+	if err := verifyMac(&pfx.MacData, pfx.AuthSafe.Content.Bytes, password); err != nil {
+		if err == ErrIncorrectPassword && len(password) == 2 && password[0] == 0 && password[1] == 0 {
+			// some implementations use an empty byte array
+			// for the empty string password try one more
+			// time with empty-empty password
+			password = nil
+			err = verifyMac(&pfx.MacData, pfx.AuthSafe.Content.Bytes, password)
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var authenticatedSafe []contentInfo
+	if err := unmarshal(pfx.AuthSafe.Content.Bytes, &authenticatedSafe); err != nil {
+		return nil, nil, err
+	}
+
+	if len(authenticatedSafe) != 2 {
+		return nil, nil, NotImplementedError("expected exactly two items in the authenticated safe")
+	}
+
+	for _, ci := range authenticatedSafe {
+		var data []byte
+
+		switch {
+		case ci.ContentType.Equal(oidDataContentType):
+			if err := unmarshal(ci.Content.Bytes, &data); err != nil {
+				return nil, nil, err
+			}
+		case ci.ContentType.Equal(oidEncryptedDataContentType):
+			var encryptedData encryptedData
+			if err := unmarshal(ci.Content.Bytes, &encryptedData); err != nil {
+				return nil, nil, err
+			}
+			if encryptedData.Version != 0 {
+				return nil, nil, NotImplementedError("only version 0 of EncryptedData is supported")
+			}
+			if data, err = pbDecrypt(encryptedData.EncryptedContentInfo, password); err != nil {
+				return nil, nil, err
+			}
+		default:
+			return nil, nil, NotImplementedError("only data and encryptedData content types are supported in authenticated safe")
+		}
+
+		var safeContents []safeBag
+		if err := unmarshal(data, &safeContents); err != nil {
+			return nil, nil, err
+		}
+		bags = append(bags, safeContents...)
+	}
+
+	return bags, password, nil
+}

--- a/sdk/azidentity/internal/pkcs12/pkcs12_test.go
+++ b/sdk/azidentity/internal/pkcs12/pkcs12_test.go
@@ -1,0 +1,141 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"crypto/rsa"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/pem"
+	"testing"
+)
+
+func TestPfx(t *testing.T) {
+	for commonName, base64P12 := range testdata {
+		p12, _ := base64.StdEncoding.DecodeString(base64P12)
+
+		priv, cert, err := Decode(p12, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := priv.(*rsa.PrivateKey).Validate(); err != nil {
+			t.Errorf("error while validating private key: %v", err)
+		}
+
+		if cert.Subject.CommonName != commonName {
+			t.Errorf("expected common name to be %q, but found %q", commonName, cert.Subject.CommonName)
+		}
+	}
+}
+
+func TestPEM(t *testing.T) {
+	for commonName, base64P12 := range testdata {
+		p12, _ := base64.StdEncoding.DecodeString(base64P12)
+
+		blocks, err := ToPEM(p12, "")
+		if err != nil {
+			t.Fatalf("error while converting to PEM: %s", err)
+		}
+
+		var pemData []byte
+		for _, b := range blocks {
+			pemData = append(pemData, pem.EncodeToMemory(b)...)
+		}
+
+		cert, err := tls.X509KeyPair(pemData, pemData)
+		if err != nil {
+			t.Errorf("err while converting to key pair: %v", err)
+		}
+		config := tls.Config{
+			Certificates: []tls.Certificate{cert},
+		}
+		config.BuildNameToCertificate()
+
+		if _, exists := config.NameToCertificate[commonName]; !exists {
+			t.Errorf("did not find our cert in PEM?: %v", config.NameToCertificate)
+		}
+	}
+}
+
+func ExampleToPEM() {
+	p12, _ := base64.StdEncoding.DecodeString(`MIIJzgIBAzCCCZQGCS ... CA+gwggPk==`)
+
+	blocks, err := ToPEM(p12, "password")
+	if err != nil {
+		panic(err)
+	}
+
+	var pemData []byte
+	for _, b := range blocks {
+		pemData = append(pemData, pem.EncodeToMemory(b)...)
+	}
+
+	// then use PEM data for tls to construct tls certificate:
+	cert, err := tls.X509KeyPair(pemData, pemData)
+	if err != nil {
+		panic(err)
+	}
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	_ = config
+}
+
+var testdata = map[string]string{
+	// 'null' password test case
+	"Windows Azure Tools": `MIIKDAIBAzCCCcwGCSqGSIb3DQEHAaCCCb0Eggm5MIIJtTCCBe4GCSqGSIb3DQEHAaCCBd8EggXbMIIF1zCCBdMGCyqGSIb3DQEMCgECoIIE7jCCBOowHAYKKoZIhvcNAQwBAzAOBAhStUNnlTGV+gICB9AEggTIJ81JIossF6boFWpPtkiQRPtI6DW6e9QD4/WvHAVrM2bKdpMzSMsCML5NyuddANTKHBVq00Jc9keqGNAqJPKkjhSUebzQFyhe0E1oI9T4zY5UKr/I8JclOeccH4QQnsySzYUG2SnniXnQ+JrG3juetli7EKth9h6jLc6xbubPadY5HMB3wL/eG/kJymiXwU2KQ9Mgd4X6jbcV+NNCE/8jbZHvSTCPeYTJIjxfeX61Sj5kFKUCzERbsnpyevhY3X0eYtEDezZQarvGmXtMMdzf8HJHkWRdk9VLDLgjk8uiJif/+X4FohZ37ig0CpgC2+dP4DGugaZZ51hb8tN9GeCKIsrmWogMXDIVd0OACBp/EjJVmFB6y0kUCXxUE0TZt0XA1tjAGJcjDUpBvTntZjPsnH/4ZySy+s2d9OOhJ6pzRQBRm360TzkFdSwk9DLiLdGfv4pwMMu/vNGBlqjP/1sQtj+jprJiD1sDbCl4AdQZVoMBQHadF2uSD4/o17XG/Ci0r2h6Htc2yvZMAbEY4zMjjIn2a+vqIxD6onexaek1R3zbkS9j19D6EN9EWn8xgz80YRCyW65znZk8xaIhhvlU/mg7sTxeyuqroBZNcq6uDaQTehDpyH7bY2l4zWRpoj10a6JfH2q5shYz8Y6UZC/kOTfuGqbZDNZWro/9pYquvNNW0M847E5t9bsf9VkAAMHRGBbWoVoU9VpI0UnoXSfvpOo+aXa2DSq5sHHUTVY7A9eov3z5IqT+pligx11xcs+YhDWcU8di3BTJisohKvv5Y8WSkm/rloiZd4ig269k0jTRk1olP/vCksPli4wKG2wdsd5o42nX1yL7mFfXocOANZbB+5qMkiwdyoQSk+Vq+C8nAZx2bbKhUq2MbrORGMzOe0Hh0x2a0PeObycN1Bpyv7Mp3ZI9h5hBnONKCnqMhtyQHUj/nNvbJUnDVYNfoOEqDiEqqEwB7YqWzAKz8KW0OIqdlM8uiQ4JqZZlFllnWJUfaiDrdFM3lYSnFQBkzeVlts6GpDOOBjCYd7dcCNS6kq6pZC6p6HN60Twu0JnurZD6RT7rrPkIGE8vAenFt4iGe/yF52fahCSY8Ws4K0UTwN7bAS+4xRHVCWvE8sMRZsRCHizb5laYsVrPZJhE6+hux6OBb6w8kwPYXc+ud5v6UxawUWgt6uPwl8mlAtU9Z7Miw4Nn/wtBkiLL/ke1UI1gqJtcQXgHxx6mzsjh41+nAgTvdbsSEyU6vfOmxGj3Rwc1eOrIhJUqn5YjOWfzzsz/D5DzWKmwXIwdspt1p+u+kol1N3f2wT9fKPnd/RGCb4g/1hc3Aju4DQYgGY782l89CEEdalpQ/35bQczMFk6Fje12HykakWEXd/bGm9Unh82gH84USiRpeOfQvBDYoqEyrY3zkFZzBjhDqa+jEcAj41tcGx47oSfDq3iVYCdL7HSIjtnyEktVXd7mISZLoMt20JACFcMw+mrbjlug+eU7o2GR7T+LwtOp/p4LZqyLa7oQJDwde1BNZtm3TCK2P1mW94QDL0nDUps5KLtr1DaZXEkRbjSJub2ZE9WqDHyU3KA8G84Tq/rN1IoNu/if45jacyPje1Npj9IftUZSP22nV7HMwZtwQ4P4MYHRMBMGCSqGSIb3DQEJFTEGBAQBAAAAMFsGCSqGSIb3DQEJFDFOHkwAewBCADQAQQA0AEYARQBCADAALQBBADEAOABBAC0ANAA0AEIAQgAtAEIANQBGADIALQA0ADkAMQBFAEYAMQA1ADIAQgBBADEANgB9MF0GCSsGAQQBgjcRATFQHk4ATQBpAGMAcgBvAHMAbwBmAHQAIABTAG8AZgB0AHcAYQByAGUAIABLAGUAeQAgAFMAdABvAHIAYQBnAGUAIABQAHIAbwB2AGkAZABlAHIwggO/BgkqhkiG9w0BBwagggOwMIIDrAIBADCCA6UGCSqGSIb3DQEHATAcBgoqhkiG9w0BDAEGMA4ECEBk5ZAYpu0WAgIH0ICCA3hik4mQFGpw9Ha8TQPtk+j2jwWdxfF0+sTk6S8PTsEfIhB7wPltjiCK92Uv2tCBQnodBUmatIfkpnRDEySmgmdglmOCzj204lWAMRs94PoALGn3JVBXbO1vIDCbAPOZ7Z0Hd0/1t2hmk8v3//QJGUg+qr59/4y/MuVfIg4qfkPcC2QSvYWcK3oTf6SFi5rv9B1IOWFgN5D0+C+x/9Lb/myPYX+rbOHrwtJ4W1fWKoz9g7wwmGFA9IJ2DYGuH8ifVFbDFT1Vcgsvs8arSX7oBsJVW0qrP7XkuDRe3EqCmKW7rBEwYrFznhxZcRDEpMwbFoSvgSIZ4XhFY9VKYglT+JpNH5iDceYEBOQL4vBLpxNUk3l5jKaBNxVa14AIBxq18bVHJ+STInhLhad4u10v/Xbx7wIL3f9DX1yLAkPrpBYbNHS2/ew6H/ySDJnoIDxkw2zZ4qJ+qUJZ1S0lbZVG+VT0OP5uF6tyOSpbMlcGkdl3z254n6MlCrTifcwkzscysDsgKXaYQw06rzrPW6RDub+t+hXzGny799fS9jhQMLDmOggaQ7+LA4oEZsfT89HLMWxJYDqjo3gIfjciV2mV54R684qLDS+AO09U49e6yEbwGlq8lpmO/pbXCbpGbB1b3EomcQbxdWxW2WEkkEd/VBn81K4M3obmywwXJkw+tPXDXfBmzzaqqCR+onMQ5ME1nMkY8ybnfoCc1bDIupjVWsEL2Wvq752RgI6KqzVNr1ew1IdqV5AWN2fOfek+0vi3Jd9FHF3hx8JMwjJL9dZsETV5kHtYJtE7wJ23J68BnCt2eI0GEuwXcCf5EdSKN/xXCTlIokc4Qk/gzRdIZsvcEJ6B1lGovKG54X4IohikqTjiepjbsMWj38yxDmK3mtENZ9ci8FPfbbvIEcOCZIinuY3qFUlRSbx7VUerEoV1IP3clUwexVQo4lHFee2jd7ocWsdSqSapW7OWUupBtDzRkqVhE7tGria+i1W2d6YLlJ21QTjyapWJehAMO637OdbJCCzDs1cXbodRRE7bsP492ocJy8OX66rKdhYbg8srSFNKdb3pF3UDNbN9jhI/t8iagRhNBhlQtTr1me2E/c86Q18qcRXl4bcXTt6acgCeffK6Y26LcVlrgjlD33AEYRRUeyC+rpxbT0aMjdFderlndKRIyG23mSp0HaUwNzAfMAcGBSsOAwIaBBRlviCbIyRrhIysg2dc/KbLFTc2vQQUg4rfwHMM4IKYRD/fsd1x6dda+wQ=`,
+	// Windows IAS PEAP & LDAPS certificates test case
+	// Unknown OID 1.3.6.1.4.1.311.17.2 should be dropped
+	"Windows IAS PEAP & LDAPS certificates": `MIIHPQIBAzCCBwMGCSqGSIb3DQEHAaCCBvQEggbwMIIG7DCCAz8GCSqGSIb3DQEHBqCCAzAwggMsAgEAMIIDJQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIrosqK6kNi9sCAggAgIIC+IcOaLAkrLiBCnw06bFGOUMGkVsuiYZlkTBzW55DQS4JUefZ71CPMUofo7U4z7bL1JYGV2aO9REMnb8gm0jQYgVEFNQbsDDICZBA8Xfjki0MULw3kEyFxfk7AV51IMRVjAGImS2asDAWW+dVgLLbBV+Q8L+D917sS8pz0VLT4GzxZHLdGXVXKp2MHkHc3nx4eDeWkBAZoSqansgJXTM3JOWOSxUEFZA2Wb7UerykCLuzK+RmR2pkmV88JIFbneP/NjQg/nZDN4bGXGJf+3gRqq07T4q7QKzmZRrQgLJwSZ1wzhB2HoIfIm/ylOEUly5XzMbf6nzc94BrDXv6q4efXMApztTfAsq9hysMiImQrPGxYBj3CAxfWCfc7K4XlbdRwZTmbCutf5O93aYALVAkzPf4x2NWxcw5sLYfGH8ma9xF3VZk+h1DJw+6Iq0+g/8lZ7uGJPAZav40YIW+RZ3vsDx3uw7OkQNwP0b/lahgnftTa0WcF3OwocTVb1o3zbtAW+pQxTRvdvTX6jENVTJVk10probfq+iDoolGe382c9d5qo4Yh/AhZHWqL2YqU2ypq16rxz1RPGSpceHAtVVZYSTKk9VKg0fevz8P8wjUKboZmpLnSu2P5ABwkoSbrGQIKMtE3CSswxKQVzEreKbcyeNBt0A0vSTOrwSzDQxFE4Ur+lUnqJC8sHW2NpA84S+TCLEAzhPMIFo5MJ90jN8N3tfTYnXVZDk1mt0pJEmWRxRofVJm2/J6Slak6x51s+TKiss/rG3y1XpzCgN9Nzb7uOHs7G6l9pOP0Bd6Z4s4DIeddG5MgpZkdn+vQNuGNbhZretg80Wj0lNZ2Oor/q0TSE0UoGZNEK1bZ3SHWqtY4J87aBkKGDcBCMqyLU1pGXBtpdJ8xoW+Ya6nM+I47jUoAJi8ChKDY8ZSKBoYsi1OuFNWl9xdn382rvpYtXqqBtA+mCAGJXiSFXUNkhSjlIFU/87v/4gsdFcAxMZVYxJVLdx2ldSyBnuAv9AwggOlBgkqhkiG9w0BBwGgggOWBIIDkjCCA44wggOKBgsqhkiG9w0BDAoBAqCCAqYwggKiMBwGCiqGSIb3DQEMAQMwDgQI44fv4XLfEhoCAggABIICgC+Cc/yNrM3ovTargtsTI2Ut8MzmLSIVPOgc7K77xwz7daXkJ5ucDRVfYEOzIlY0NfKsWqiYc+2vfZRqm6fBrpj1/1zhC+A6wzxxNY1BxVXDdLVvigNBvPNxj5Z+K8kFApi3tqUOpz6uzj9B6PMywETQ/lKIQ0PUVa5KRbx3JztFfGIXq+zoGuUSxzzVpLQQE7ON7qtUJbkAA7x/vwq4fKKxC4nxXwPSFaUi+S4m6JDQ4XS02RcK/m2NEzKxPQBFQMSbfkqJd/HrjWbY9msebdTPI8Q+o2rrnQ5K225IZCxqcOwa//108rdx7fDJz28ywSv3rBgPynb9/1iSpeQ25C1gl+skTvgQmz5U/7DzSJkLNSwFIcEZUSyYM4uWjtKHSaTgCkh/D3+7AvloQKNgNSKJ9WM053jzYaYRs11BKCYm7UG9v0cgUbI84GJFomrzxRcOfX0ps2UVnXMTq6kJrGB/X1xM5Quvn7kvuK+S0ZMTn1yHpFaOxdn0Z1On/Y05XWz86Y316WfkSrBeuqbH5HTI74F2yWl4K4PEerIyqX14s3oEGdtlJ24o/kAQTbCrntPFu3ZKxF4z5bkpO3bZwaURRLCmT3sLenlthsLysE2riUbacFl33mkaGTvBeqUOofHfO5LNJcE/J8YBzekewLFBcOY59WZkZBbUasPzkOomdZtkrzlzMjJ1pTCd5RCyretHP6j681Wq3+tDvR/ycrgKO+JY8kwIk8HB3BX+xRn6rFULAcLsUhsGbsZ6ig9yeXTCx2xh97Rh5A0pzSkv9A7UFT155amZ3cVJuPdruWj9yLQ9JEIi83q1olMh7mbaA3qKbYDnou+Aj0OlDySAo+MxgdAwDQYJKwYBBAGCNxECMQAwIwYJKoZIhvcNAQkVMRYEFGclVjS+gkQdguj0myihwM1yC/1bMC8GCSqGSIb3DQEJFDEiHiAAUABFAEEAUAAgAEMAZQByAHQAaQBmAGkAYwBhAHQAZTBpBgkrBgEEAYI3EQExXB5aAE0AaQBjAHIAbwBzAG8AZgB0ACAAUgBTAEEAIABTAEMAaABhAG4AbgBlAGwAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMDEwITAJBgUrDgMCGgUABBSerVeCcXV8OLmAwfi2hYXAmA5I3gQIHpTh4gRG/3MCAggA`,
+	// empty string password test case
+	"testing@example.com": `MIIJzgIBAzCCCZQGCSqGSIb3DQEHAaCCCYUEggmBMIIJfTCCA/cGCSqGSIb3DQEHBqCCA+gwggPk
+AgEAMIID3QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIIszfRGqcmPcCAggAgIIDsOZ9Eg1L
+s5Wx8JhYoV3HAL4aRnkAWvTYB5NISZOgSgIQTssmt/3A7134dibTmaT/93LikkL3cTKLnQzJ4wDf
+YZ1bprpVJvUqz+HFT79m27bP9zYXFrvxWBJbxjYKTSjQMgz+h8LAEpXXGajCmxMJ1oCOtdXkhhzc
+LdZN6SAYgtmtyFnCdMEDskSggGuLb3fw84QEJ/Sj6FAULXunW/CPaS7Ce0TMsKmNU/jfFWj3yXXw
+ro0kwjKiVLpVFlnBlHo2OoVU7hmkm59YpGhLgS7nxLD3n7nBroQ0ID1+8R01NnV9XLGoGzxMm1te
+6UyTCkr5mj+kEQ8EP1Ys7g/TC411uhVWySMt/rcpkx7Vz1r9kYEAzJpONAfr6cuEVkPKrxpq4Fh0
+2fzlKBky0i/hrfIEUmngh+ERHUb/Mtv/fkv1j5w9suESbhsMLLiCXAlsP1UWMX+3bNizi3WVMEts
+FM2k9byn+p8IUD/A8ULlE4kEaWeoc+2idkCNQkLGuIdGUXUFVm58se0auUkVRoRJx8x4CkMesT8j
+b1H831W66YRWoEwwDQp2kK1lA2vQXxdVHWlFevMNxJeromLzj3ayiaFrfByeUXhR2S+Hpm+c0yNR
+4UVU9WED2kacsZcpRm9nlEa5sr28mri5JdBrNa/K02OOhvKCxr5ZGmbOVzUQKla2z4w+Ku9k8POm
+dfDNU/fGx1b5hcFWtghXe3msWVsSJrQihnN6q1ughzNiYZlJUGcHdZDRtiWwCFI0bR8h/Dmg9uO9
+4rawQQrjIRT7B8yF3UbkZyAqs8Ppb1TsMeNPHh1rxEfGVQknh/48ouJYsmtbnzugTUt3mJCXXiL+
+XcPMV6bBVAUu4aaVKSmg9+yJtY4/VKv10iw88ktv29fViIdBe3t6l/oPuvQgbQ8dqf4T8w0l/uKZ
+9lS1Na9jfT1vCoS7F5TRi+tmyj1vL5kr/amEIW6xKEP6oeAMvCMtbPAzVEj38zdJ1R22FfuIBxkh
+f0Zl7pdVbmzRxl/SBx9iIBJSqAvcXItiT0FIj8HxQ+0iZKqMQMiBuNWJf5pYOLWGrIyntCWwHuaQ
+wrx0sTGuEL9YXLEAsBDrsvzLkx/56E4INGZFrH8G7HBdW6iGqb22IMI4GHltYSyBRKbB0gadYTyv
+abPEoqww8o7/85aPSzOTJ/53ozD438Q+d0u9SyDuOb60SzCD/zPuCEd78YgtXJwBYTuUNRT27FaM
+3LGMX8Hz+6yPNRnmnA2XKPn7dx/IlaqAjIs8MIIFfgYJKoZIhvcNAQcBoIIFbwSCBWswggVnMIIF
+YwYLKoZIhvcNAQwKAQKgggTuMIIE6jAcBgoqhkiG9w0BDAEDMA4ECJr0cClYqOlcAgIIAASCBMhe
+OQSiP2s0/46ONXcNeVAkz2ksW3u/+qorhSiskGZ0b3dFa1hhgBU2Q7JVIkc4Hf7OXaT1eVQ8oqND
+uhqsNz83/kqYo70+LS8Hocj49jFgWAKrf/yQkdyP1daHa2yzlEw4mkpqOfnIORQHvYCa8nEApspZ
+wVu8y6WVuLHKU67mel7db2xwstQp7PRuSAYqGjTfAylElog8ASdaqqYbYIrCXucF8iF9oVgmb/Qo
+xrXshJ9aSLO4MuXlTPELmWgj07AXKSb90FKNihE+y0bWb9LPVFY1Sly3AX9PfrtkSXIZwqW3phpv
+MxGxQl/R6mr1z+hlTfY9Wdpb5vlKXPKA0L0Rt8d2pOesylFi6esJoS01QgP1kJILjbrV731kvDc0
+Jsd+Oxv4BMwA7ClG8w1EAOInc/GrV1MWFGw/HeEqj3CZ/l/0jv9bwkbVeVCiIhoL6P6lVx9pXq4t
+KZ0uKg/tk5TVJmG2vLcMLvezD0Yk3G2ZOMrywtmskrwoF7oAUpO9e87szoH6fEvUZlkDkPVW1NV4
+cZk3DBSQiuA3VOOg8qbo/tx/EE3H59P0axZWno2GSB0wFPWd1aj+b//tJEJHaaNR6qPRj4IWj9ru
+Qbc8eRAcVWleHg8uAehSvUXlFpyMQREyrnpvMGddpiTC8N4UMrrBRhV7+UbCOWhxPCbItnInBqgl
+1JpSZIP7iUtsIMdu3fEC2cdbXMTRul+4rdzUR7F9OaezV3jjvcAbDvgbK1CpyC+MJ1Mxm/iTgk9V
+iUArydhlR8OniN84GyGYoYCW9O/KUwb6ASmeFOu/msx8x6kAsSQHIkKqMKv0TUR3kZnkxUvdpBGP
+KTl4YCTvNGX4dYALBqrAETRDhua2KVBD/kEttDHwBNVbN2xi81+Mc7ml461aADfk0c66R/m2sjHB
+2tN9+wG12OIWFQjL6wF/UfJMYamxx2zOOExiId29Opt57uYiNVLOO4ourPewHPeH0u8Gz35aero7
+lkt7cZAe1Q0038JUuE/QGlnK4lESK9UkSIQAjSaAlTsrcfwtQxB2EjoOoLhwH5mvxUEmcNGNnXUc
+9xj3M5BD3zBz3Ft7G3YMMDwB1+zC2l+0UG0MGVjMVaeoy32VVNvxgX7jk22OXG1iaOB+PY9kdk+O
+X+52BGSf/rD6X0EnqY7XuRPkMGgjtpZeAYxRQnFtCZgDY4wYheuxqSSpdF49yNczSPLkgB3CeCfS
++9NTKN7aC6hBbmW/8yYh6OvSiCEwY0lFS/T+7iaVxr1loE4zI1y/FFp4Pe1qfLlLttVlkygga2UU
+SCunTQ8UB/M5IXWKkhMOO11dP4niWwb39Y7pCWpau7mwbXOKfRPX96cgHnQJK5uG+BesDD1oYnX0
+6frN7FOnTSHKruRIwuI8KnOQ/I+owmyz71wiv5LMQt+yM47UrEjB/EZa5X8dpEwOZvkdqL7utcyo
+l0XH5kWMXdW856LL/FYftAqJIDAmtX1TXF/rbP6mPyN/IlDC0gjP84Uzd/a2UyTIWr+wk49Ek3vQ
+/uDamq6QrwAxVmNh5Tset5Vhpc1e1kb7mRMZIzxSP8JcTuYd45oFKi98I8YjvueHVZce1g7OudQP
+SbFQoJvdT46iBg1TTatlltpOiH2mFaxWVS0xYjAjBgkqhkiG9w0BCRUxFgQUdA9eVqvETX4an/c8
+p8SsTugkit8wOwYJKoZIhvcNAQkUMS4eLABGAHIAaQBlAG4AZABsAHkAIABuAGEAbQBlACAAZgBv
+AHIAIABjAGUAcgB0MDEwITAJBgUrDgMCGgUABBRFsNz3Zd1O1GI8GTuFwCWuDOjEEwQIuBEfIcAy
+HQ8CAggA`,
+}

--- a/sdk/azidentity/internal/pkcs12/safebags.go
+++ b/sdk/azidentity/internal/pkcs12/safebags.go
@@ -1,0 +1,57 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+)
+
+var (
+	// see https://tools.ietf.org/html/rfc7292#appendix-D
+	oidCertTypeX509Certificate = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 9, 22, 1})
+	oidPKCS8ShroundedKeyBag    = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 10, 1, 2})
+	oidCertBag                 = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 10, 1, 3})
+)
+
+type certBag struct {
+	Id   asn1.ObjectIdentifier
+	Data []byte `asn1:"tag:0,explicit"`
+}
+
+func decodePkcs8ShroudedKeyBag(asn1Data, password []byte) (privateKey interface{}, err error) {
+	pkinfo := new(encryptedPrivateKeyInfo)
+	if err = unmarshal(asn1Data, pkinfo); err != nil {
+		return nil, errors.New("pkcs12: error decoding PKCS#8 shrouded key bag: " + err.Error())
+	}
+
+	pkData, err := pbDecrypt(pkinfo, password)
+	if err != nil {
+		return nil, errors.New("pkcs12: error decrypting PKCS#8 shrouded key bag: " + err.Error())
+	}
+
+	ret := new(asn1.RawValue)
+	if err = unmarshal(pkData, ret); err != nil {
+		return nil, errors.New("pkcs12: error unmarshaling decrypted private key: " + err.Error())
+	}
+
+	if privateKey, err = x509.ParsePKCS8PrivateKey(pkData); err != nil {
+		return nil, errors.New("pkcs12: error parsing PKCS#8 private key: " + err.Error())
+	}
+
+	return privateKey, nil
+}
+
+func decodeCertBag(asn1Data []byte) (x509Certificates []byte, err error) {
+	bag := new(certBag)
+	if err := unmarshal(asn1Data, bag); err != nil {
+		return nil, errors.New("pkcs12: error decoding cert bag: " + err.Error())
+	}
+	if !bag.Id.Equal(oidCertTypeX509Certificate) {
+		return nil, NotImplementedError("only X509 certificates are supported")
+	}
+	return bag.Data, nil
+}


### PR DESCRIPTION
This removes azidentity's x/crypto requirement and declares to CG that x/crypto is a dependency of azidentity. So, azidentity won't really depend on x/crypto but CG will behave as if it does