### PR TITLE
chore: Default Audience of ACR of all clouds to https://containerregistry.azure.net

### DIFF
--- a/sdk/containers/azcontainerregistry/CHANGELOG.md
+++ b/sdk/containers/azcontainerregistry/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+* Default audience of Azure Container Registry of all clouds to https://containerregistry.azure.net
 
 ## 0.2.2 (2024-09-19)
 

--- a/sdk/containers/azcontainerregistry/cloud_config.go
+++ b/sdk/containers/azcontainerregistry/cloud_config.go
@@ -15,13 +15,13 @@ const (
 
 func init() {
 	cloud.AzureChina.Services[ServiceName] = cloud.ServiceConfiguration{
-		Audience: "https://management.core.chinacloudapi.cn",
+		Audience: defaultAudience,
 	}
 	cloud.AzureGovernment.Services[ServiceName] = cloud.ServiceConfiguration{
-		Audience: "https://management.core.usgovcloudapi.net",
+		Audience: defaultAudience,
 	}
 	cloud.AzurePublic.Services[ServiceName] = cloud.ServiceConfiguration{
-		Audience: "https://management.core.windows.net/",
+		Audience: defaultAudience,
 	}
 }
 


### PR DESCRIPTION
Default Audience of ACR of all clouds to `https://containerregistry.azure.net` to narrow down the default scope of the audience.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
