### PR TITLE
Remove deprecated flow content from README

### DIFF
--- a/sdk/azidentity/README.md
+++ b/sdk/azidentity/README.md
@@ -146,7 +146,6 @@ client := armresources.NewResourceGroupsClient("subscription ID", chain, nil)
 |-|-
 |[InteractiveBrowserCredential](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#InteractiveBrowserCredential)|Interactively authenticate a user with the default web browser
 |[DeviceCodeCredential](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#DeviceCodeCredential)|Interactively authenticate a user on a device with limited UI
-|[UsernamePasswordCredential](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#UsernamePasswordCredential) (**deprecated**)|Authenticate a user with a username and password
 
 ### Authenticating via Development Tools
 
@@ -159,7 +158,7 @@ client := armresources.NewResourceGroupsClient("subscription ID", chain, nil)
 
 `DefaultAzureCredential` and `EnvironmentCredential` can be configured with environment variables. Each type of authentication requires values for specific variables:
 
-#### Service principal with secret
+### Service principal with secret
 
 |variable name|value
 |-|-
@@ -167,7 +166,7 @@ client := armresources.NewResourceGroupsClient("subscription ID", chain, nil)
 |`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
 |`AZURE_CLIENT_SECRET`|one of the application's client secrets
 
-#### Service principal with certificate
+### Service principal with certificate
 
 |variable name|value
 |-|-
@@ -176,18 +175,7 @@ client := armresources.NewResourceGroupsClient("subscription ID", chain, nil)
 |`AZURE_CLIENT_CERTIFICATE_PATH`|path to a certificate file including private key
 |`AZURE_CLIENT_CERTIFICATE_PASSWORD`|password of the certificate file, if any
 
-#### Username and password
-
-> **Warning**: User password authentication is deprecated because it can't support multifactor authentication. See https://aka.ms/azsdk/identity/mfa for migration guidance.
-
-|variable name|value
-|-|-
-|`AZURE_CLIENT_ID`|ID of a Microsoft Entra application
-|`AZURE_USERNAME`|a username (usually an email address)
-|`AZURE_PASSWORD`|that user's password
-
-Configuration is attempted in the above order. For example, if values for a
-client secret and certificate are both present, the client secret will be used.
+Configuration is attempted in the above order. For example, if values for a client secret and certificate are both present, the client secret will be used.
 
 ## Token caching
 


### PR DESCRIPTION
Removes mention of `UsernamePasswordCredential` and the env vars that support it. We want to shift the README to demonstrating best practices, as it's a starting point for many customers.