### PR TITLE
Fix ACR test broken by empty pages

### DIFF
--- a/sdk/containers/azcontainerregistry/assets.json
+++ b/sdk/containers/azcontainerregistry/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/containers/azcontainerregistry",
-  "Tag": "go/containers/azcontainerregistry_7310e70bf5"
+  "Tag": "go/containers/azcontainerregistry_37f39687c3"
 }

--- a/sdk/containers/azcontainerregistry/client_test.go
+++ b/sdk/containers/azcontainerregistry/client_test.go
@@ -324,7 +324,6 @@ func TestClient_NewListRepositoriesPager(t *testing.T) {
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		require.NoError(t, err)
-		require.NotEmpty(t, page.Repositories.Names)
 		pages++
 		items += len(page.Repositories.Names)
 	}


### PR DESCRIPTION
The service now returns a terminal empty page in some cases, breaking this test which implicitly assumed no page is empty