### PR TITLE
Restructuring of NFSProperties

### DIFF
--- a/sdk/storage/azfile/directory/client_test.go
+++ b/sdk/storage/azfile/directory/client_test.go
@@ -298,9 +298,11 @@ func (d *DirectoryRecordedTestsSuite) TestDirCreateNfs() {
 	_require.NoError(err)
 
 	cResp, err := dirClient.Create(context.Background(), &directory.CreateOptions{
-		Owner:    to.Ptr(owner),
-		Group:    to.Ptr(group),
-		FileMode: to.Ptr(mode),
+		FileNFSProperties: &file.NFSProperties{
+			Owner:    to.Ptr(owner),
+			Group:    to.Ptr(group),
+			FileMode: to.Ptr(mode),
+		},
 	})
 	_require.NoError(err)
 	_require.NotNil(cResp.ETag)
@@ -537,9 +539,11 @@ func (d *DirectoryRecordedTestsSuite) TestDirSetPropertiesNfs() {
 
 	// Set the custom permissions
 	_, err = dirClient.SetProperties(context.Background(), &directory.SetPropertiesOptions{
-		Owner:    to.Ptr(owner),
-		Group:    to.Ptr(group),
-		FileMode: to.Ptr(mode),
+		FileNFSProperties: &file.NFSProperties{
+			Owner:    to.Ptr(owner),
+			Group:    to.Ptr(group),
+			FileMode: to.Ptr(mode),
+		},
 	})
 	_require.NoError(err)
 

--- a/sdk/storage/azfile/directory/examples_test.go
+++ b/sdk/storage/azfile/directory/examples_test.go
@@ -309,9 +309,11 @@ func Example_client_CreateDirectoryNFS() {
 	dirClient := shareClient.NewDirectoryClient(dirName)
 
 	_, err = dirClient.Create(context.Background(), &directory.CreateOptions{
-		Owner:    to.Ptr("123"),
-		Group:    to.Ptr("345"),
-		FileMode: to.Ptr("7774"),
+		FileNFSProperties: &file.NFSProperties{
+			Owner:    to.Ptr("123"),
+			Group:    to.Ptr("345"),
+			FileMode: to.Ptr("7774"),
+		},
 	})
 	handleError(err)
 }
@@ -351,9 +353,11 @@ func Example_client_SetHTTPHeadersNFS() {
 
 	// Set the custom permissions
 	_, err = dirClient.SetProperties(context.Background(), &directory.SetPropertiesOptions{
-		Owner:    to.Ptr(owner),
-		Group:    to.Ptr(group),
-		FileMode: to.Ptr(mode),
+		FileNFSProperties: &file.NFSProperties{
+			Owner:    to.Ptr(owner),
+			Group:    to.Ptr(group),
+			FileMode: to.Ptr(mode),
+		},
 	})
 	handleError(err)
 }

--- a/sdk/storage/azfile/directory/models.go
+++ b/sdk/storage/azfile/directory/models.go
@@ -33,6 +33,7 @@ type DestinationLeaseAccessConditions = generated.DestinationLeaseAccessConditio
 type CreateOptions struct {
 	// The default value is 'Directory' for Attributes and 'now' for CreationTime and LastWriteTime fields in file.SMBProperties.
 	FileSMBProperties *file.SMBProperties
+	FileNFSProperties *file.NFSProperties
 	// The default value is 'inherit' for Permission field in file.Permissions.
 	FilePermissions *file.Permissions
 	// A name-value pair to associate with a file storage object.
@@ -43,12 +44,6 @@ type CreateOptions struct {
 	// binary, the permission is returned as a base64 string representing the binary
 	// encoding of the permission
 	FilePermissionFormat *FilePermissionFormat
-	// NFS only. The file mode of the file or directory
-	FileMode *string
-	// NFS only. The owner of the file or directory.
-	Owner *string
-	// NFS only. The owning group of the file or directory.
-	Group *string
 }
 
 func (o *CreateOptions) format() *generated.DirectoryClientCreateOptions {
@@ -56,25 +51,40 @@ func (o *CreateOptions) format() *generated.DirectoryClientCreateOptions {
 		return nil
 	}
 
-	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := exported.FormatSMBProperties(o.FileSMBProperties, true)
-	permission, permissionKey := exported.FormatPermissions(o.FilePermissions)
-	createOptions := &generated.DirectoryClientCreateOptions{
-		FileAttributes:    fileAttributes,
-		FileChangeTime:    fileChangeTime,
-		FileCreationTime:  fileCreationTime,
-		FileLastWriteTime: fileLastWriteTime,
-		FilePermission:    permission,
-		FilePermissionKey: permissionKey,
-		Metadata:          o.Metadata,
-		FileMode:          o.FileMode,
-		Owner:             o.Owner,
-		Group:             o.Group,
-	}
+	var createOptions *generated.DirectoryClientCreateOptions
 
-	if permissionKey != nil && *permissionKey != shared.DefaultFilePermissionString {
-		createOptions.FilePermissionFormat = to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat))
-	} else if o.FilePermissionFormat != nil {
-		createOptions.FilePermissionFormat = to.Ptr(FilePermissionFormat(*o.FilePermissionFormat))
+	if o.FileSMBProperties != nil {
+		fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := exported.FormatSMBProperties(o.FileSMBProperties, true)
+		permission, permissionKey := exported.FormatPermissions(o.FilePermissions)
+
+		createOptions = &generated.DirectoryClientCreateOptions{
+			FileAttributes:    fileAttributes,
+			FileChangeTime:    fileChangeTime,
+			FileCreationTime:  fileCreationTime,
+			FileLastWriteTime: fileLastWriteTime,
+			FilePermission:    permission,
+			FilePermissionKey: permissionKey,
+			Metadata:          o.Metadata,
+		}
+
+		if permissionKey != nil && *permissionKey != shared.DefaultFilePermissionString {
+			createOptions.FilePermissionFormat = to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat))
+		} else if o.FilePermissionFormat != nil {
+			createOptions.FilePermissionFormat = to.Ptr(FilePermissionFormat(*o.FilePermissionFormat))
+		}
+
+	} else if o.FileNFSProperties != nil {
+		fileCreationTime, fileLastWriteTime := exported.FormatNFSProperties(o.FileNFSProperties, true)
+
+		createOptions = &generated.DirectoryClientCreateOptions{
+			FileCreationTime:  fileCreationTime,
+			FileLastWriteTime: fileLastWriteTime,
+			FileMode:          o.FileNFSProperties.FileMode,
+			Group:             o.FileNFSProperties.Group,
+			Owner:             o.FileNFSProperties.Owner,
+			Metadata:          o.Metadata,
+		}
+
 	}
 
 	return createOptions
@@ -171,16 +181,11 @@ func (o *GetPropertiesOptions) format() *generated.DirectoryClientGetPropertiesO
 type SetPropertiesOptions struct {
 	// The default value is 'preserve' for Attributes, CreationTime and LastWriteTime fields in file.SMBProperties.
 	FileSMBProperties *file.SMBProperties
+	FileNFSProperties *file.NFSProperties
 	// The default value is 'preserve' for Permission field in file.Permissions.
 	FilePermissions *file.Permissions
 	// FilePermissionFormat contains the format of the file permissions, Can be sddl (Default) or Binary.
 	FilePermissionFormat *FilePermissionFormat
-	// NFS only. The file mode of the file or directory
-	FileMode *string
-	// NFS only. The owner of the file or directory.
-	Owner *string
-	// NFS only. The owning group of the file or directory.
-	Group *string
 }
 
 func (o *SetPropertiesOptions) format() *generated.DirectoryClientSetPropertiesOptions {
@@ -188,26 +193,42 @@ func (o *SetPropertiesOptions) format() *generated.DirectoryClientSetPropertiesO
 		return nil
 	}
 
-	fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := exported.FormatSMBProperties(o.FileSMBProperties, true)
-	permission, permissionKey := exported.FormatPermissions(o.FilePermissions)
+	var setPropertiesOptions *generated.DirectoryClientSetPropertiesOptions
 
-	setPropertiesOptions := &generated.DirectoryClientSetPropertiesOptions{
-		FileAttributes:    fileAttributes,
-		FileChangeTime:    fileChangeTime,
-		FileCreationTime:  fileCreationTime,
-		FileLastWriteTime: fileLastWriteTime,
-		FilePermission:    permission,
-		FilePermissionKey: permissionKey,
-		FileMode:          o.FileMode,
-		Owner:             o.Owner,
-		Group:             o.Group,
+	if o.FileSMBProperties != nil {
+		fileAttributes, fileCreationTime, fileLastWriteTime, fileChangeTime := exported.FormatSMBProperties(o.FileSMBProperties, true)
+		permission, permissionKey := exported.FormatPermissions(o.FilePermissions)
+
+		setPropertiesOptions = &generated.DirectoryClientSetPropertiesOptions{
+			FileAttributes:    fileAttributes,
+			FileChangeTime:    fileChangeTime,
+			FileCreationTime:  fileCreationTime,
+			FileLastWriteTime: fileLastWriteTime,
+			FilePermission:    permission,
+			FilePermissionKey: permissionKey,
+			FileMode:          o.FileNFSProperties.FileMode,
+			Owner:             o.FileNFSProperties.Owner,
+			Group:             o.FileNFSProperties.Group,
+		}
+
+		if permissionKey != nil && *permissionKey != shared.DefaultPreserveString {
+			setPropertiesOptions.FilePermissionFormat = to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat))
+		} else if o.FilePermissionFormat != nil {
+			setPropertiesOptions.FilePermissionFormat = to.Ptr(FilePermissionFormat(*o.FilePermissionFormat))
+		}
+	} else if o.FileNFSProperties != nil {
+		fileCreationTime, fileLastWriteTime := exported.FormatNFSProperties(o.FileNFSProperties, true)
+
+		setPropertiesOptions = &generated.DirectoryClientSetPropertiesOptions{
+			FileCreationTime:  fileCreationTime,
+			FileLastWriteTime: fileLastWriteTime,
+			FileMode:          o.FileNFSProperties.FileMode,
+			Owner:             o.FileNFSProperties.Owner,
+			Group:             o.FileNFSProperties.Group,
+		}
+
 	}
 
-	if permissionKey != nil && *permissionKey != shared.DefaultPreserveString {
-		setPropertiesOptions.FilePermissionFormat = to.Ptr(FilePermissionFormat(shared.DefaultFilePermissionFormat))
-	} else if o.FilePermissionFormat != nil {
-		setPropertiesOptions.FilePermissionFormat = to.Ptr(FilePermissionFormat(*o.FilePermissionFormat))
-	}
 	return setPropertiesOptions
 }
 

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -445,9 +445,11 @@ func (f *FileRecordedTestsSuite) TestCreateFileNFS() {
 	_require.NoError(err)
 	fClient := premiumShareClient.NewRootDirectoryClient().NewFileClient(testcommon.GenerateFileName(testName))
 	resp, err := fClient.Create(context.Background(), 1024, &file.CreateOptions{
-		Owner:    to.Ptr(owner),
-		Group:    to.Ptr(group),
-		FileMode: to.Ptr(fileMode),
+		NFSProperties: &file.NFSProperties{
+			Owner:    to.Ptr(owner),
+			Group:    to.Ptr(group),
+			FileMode: to.Ptr(fileMode),
+		},
 	})
 	_require.NoError(err)
 	_require.Equal(*resp.FileMode, fileMode)
@@ -680,9 +682,11 @@ func (f *FileRecordedTestsSuite) TestFileSetHTTPHeadersNfs() {
 			CacheControl:       to.Ptr("no-transform"),
 			ContentDisposition: to.Ptr("attachment"),
 		},
-		Owner:    to.Ptr(owner),
-		Group:    to.Ptr(group),
-		FileMode: to.Ptr(fileMode),
+		NFSProperties: &file.NFSProperties{
+			Owner:    to.Ptr(owner),
+			Group:    to.Ptr(group),
+			FileMode: to.Ptr(fileMode),
+		},
 	}
 	setResp, err := fClient.SetHTTPHeaders(context.Background(), opts)
 	_require.NoError(err)
@@ -1736,9 +1740,11 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyModeCopyModeNfs() {
 	_require.NoError(err)
 
 	_, err = copyFClient.StartCopyFromURL(context.Background(), fClient.URL(), &file.StartCopyFromURLOptions{
-		Owner:             to.Ptr(owner),
-		Group:             to.Ptr(group),
-		FileMode:          to.Ptr(mode),
+		NFSProperties: &file.NFSProperties{
+			Owner:    to.Ptr(owner),
+			Group:    to.Ptr(group),
+			FileMode: to.Ptr(mode),
+		},
 		FileOwnerCopyMode: to.Ptr(file.OwnerCopyModeOverride),
 		FileModeCopyMode:  to.Ptr(file.ModeCopyModeOverride),
 	})

--- a/sdk/storage/azfile/file/examples_test.go
+++ b/sdk/storage/azfile/file/examples_test.go
@@ -851,9 +851,11 @@ func Example_fileClient_CreateNFSShare() {
 
 	fClient := premiumShareClient.NewRootDirectoryClient().NewFileClient(testcommon.GenerateFileName(shareName))
 	_, err = fClient.Create(context.Background(), 1024, &file.CreateOptions{
-		Owner:    to.Ptr(owner),
-		Group:    to.Ptr(group),
-		FileMode: to.Ptr(fileMode),
+		NFSProperties: &file.NFSProperties{
+			Owner:    to.Ptr(owner),
+			Group:    to.Ptr(group),
+			FileMode: to.Ptr(fileMode),
+		},
 	})
 	handleError(err)
 	fmt.Println("NFS Share created with given properties")
@@ -906,9 +908,11 @@ func Example_fileClient_SetHttpHeadersNFS() {
 			CacheControl:       to.Ptr("no-transform"),
 			ContentDisposition: to.Ptr("attachment"),
 		},
-		Owner:    to.Ptr(owner),
-		Group:    to.Ptr(group),
-		FileMode: to.Ptr(fileMode),
+		NFSProperties: &file.NFSProperties{
+			Owner:    to.Ptr(owner),
+			Group:    to.Ptr(group),
+			FileMode: to.Ptr(fileMode),
+		},
 	}
 	_, err = fClient.SetHTTPHeaders(context.Background(), opts)
 

--- a/sdk/storage/azfile/internal/exported/nfs_property.go
+++ b/sdk/storage/azfile/internal/exported/nfs_property.go
@@ -1,0 +1,51 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package exported
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/generated"
+	"time"
+)
+
+// NFSProperties contains the optional parameters regarding the NFS properties for a file.
+type NFSProperties struct {
+	// The Coordinated Universal Time (UTC) creation time for the file/directory. Default value is 'now'.
+	CreationTime *time.Time
+	// The Coordinated Universal Time (UTC) last write time for the file/directory. Default value is 'now'.
+	LastWriteTime *time.Time
+	//The file mode of the file or directory
+	FileMode *string
+	//The owner of the file or directory.
+	Owner *string
+	//The owning group of the file or directory.
+	Group *string
+}
+
+// Format returns file attributes, creation time and last write time.
+func (np *NFSProperties) Format(isDir bool, defaultFileAttributes string, defaultCurrentTimeString string) (fileAttributes string, creationTime string, lastWriteTime string) {
+	return
+}
+
+// FormatNFSProperties returns creation time, last write time.
+func FormatNFSProperties(np *NFSProperties, isDir bool) (creationTime *string, lastWriteTime *string) {
+	if np == nil {
+		return nil, nil
+	}
+
+	creationTime = nil
+	if np.CreationTime != nil {
+		creationTime = to.Ptr(np.CreationTime.UTC().Format(generated.ISO8601))
+	}
+
+	lastWriteTime = nil
+	if np.LastWriteTime != nil {
+		lastWriteTime = to.Ptr(np.LastWriteTime.UTC().Format(generated.ISO8601))
+	}
+
+	return
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

Restructured all NFS Properties together.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
