### PR TITLE
refine automation script

### DIFF
--- a/eng/scripts/automation_init.sh
+++ b/eng/scripts/automation_init.sh
@@ -60,7 +60,7 @@ if [ "$outputFile" != "" ]; then
   cat > $outputFile << EOF
 {
   "envs": {
-    "PATH": "$PATH",
+    "PATH": "$GOPATH:$PATH",
     "GOPATH": "$GOPATH",
     "GOROOT": "$GOROOT"
   }
@@ -70,7 +70,7 @@ else
   # Output environment information to terminal
   echo '{
   "envs": {
-    "PATH": "'"$PATH"'",
+    "PATH": "'"$GOPATH:$PATH"'",
     "GOPATH": "'"$GOPATH"'",
     "GOROOT": "'"$GOROOT"'"
   }

--- a/eng/scripts/automation_init.sh
+++ b/eng/scripts/automation_init.sh
@@ -1,23 +1,29 @@
-if [ -z $1 ]; then
-    echo "Please input outputfile"
-    exit 1
-fi
-echo $1
+set -e
+outputFile=""
 
-outputFile=$1
+if [ "$1" ]; then
+  echo $1
+  outputFile=$1
+fi
 
 if [ "$2" ]; then
   echo $2
   outputFile=$2
 fi
 
-set -e
-outputFile="$(realpath $outputFile)"
-echo "output json file: $outputFile"
+if [ "$outputFile" != "" ]; then
+  outputFile="$(realpath $outputFile)"
+  echo "output json file: $outputFile"
+fi
+
 
 TMPDIR="/tmp"
-if [ ! "$(go version | awk '{print $3}' | cut -c 3-6)" = "1.23" ]
-then
+if ! command -v semver &> /dev/null; then
+    echo "Install semver"
+    npm install -g semver
+fi
+current_version=$(go version | awk '{print $3}' | sed 's/go//')
+if ! semver -r ">=1.23.0" "$current_version"; then
   wget -q https://golang.org/dl/go1.23.2.linux-amd64.tar.gz
   tar -C $TMPDIR -xzf go1.23.2.linux-amd64.tar.gz
   export GOROOT=$TMPDIR/go
@@ -28,7 +34,7 @@ DIRECTORY=$(cd `dirname $0` && pwd)
 
 if [ "$GOPATH" = "" ]; then
   WORKFOLDER="$(realpath $DIRECTORY/../../../)"
-  echo $WORKFOLDER
+  echo "WORKFOLDER: $WORKFOLDER"
   export GOPATH=$WORKFOLDER/gofolder
 fi
 
@@ -36,27 +42,40 @@ if [ ! -d "$GOPATH/bin" ]; then
   echo "create gopath folder"
   mkdir -p $GOPATH/bin
 fi
-echo $GOPATH
+echo "GOPATH: $GOPATH"
 
 export GO111MODULE=on
 
 generatorDirectory="$(realpath $DIRECTORY/../tools/generator)"
 cd $generatorDirectory
+echo "Install generator..."
 go build 2>&1
 
 cp generator $GOPATH/bin/
 export PATH=$GOPATH/bin:$PATH
 cd $DIRECTORY
 
-cat > $outputFile << EOF
+if [ "$outputFile" != "" ]; then
+  # Output environment information to the specified file
+  cat > $outputFile << EOF
 {
   "envs": {
-    "PATH": "$GOPATH:$PATH",
+    "PATH": "$PATH",
     "GOPATH": "$GOPATH",
     "GOROOT": "$GOROOT"
   }
 }
 EOF
+else
+  # Output environment information to terminal
+  echo '{
+  "envs": {
+    "PATH": "'"$PATH"'",
+    "GOPATH": "'"$GOPATH"'",
+    "GOROOT": "'"$GOROOT"'"
+  }
+}'
+fi
 
 echo Install tsp-client
 sudo npm install -g @azure-tools/typespec-client-generator-cli@v0.10.0 2>&1


### PR DESCRIPTION
Customer can not successfully install generator by referencing this doc: https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/code-generation.md. Since the automation_init.sh write some hard code to check if go'version is 1.23 and required an outputfile (It should not be required for customer scenario).

fix: https://teams.microsoft.com/l/message/19:104f00188bb64ef48d1b4d94ccb7a361@thread.skype/1741136820626?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1741136820626&teamName=Azure%20SDK&channelName=Language%20-%20Go&createdTime=1741136820626
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
