### PR TITLE
upgrade emitter version

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-go": "0.3.10"
+        "@azure-tools/typespec-go": "0.4.0"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.52.0",
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-go": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.3.10.tgz",
-      "integrity": "sha512-fwIGL4BCKIpaXaNkWC9fTRzqfhyVJnrnWNm+YFxQTinNEHPDexIGsbItCSqhgiDMYsrPd0KvzScyFrUg0scDiA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.4.0.tgz",
+      "integrity": "sha512-hrHvY21zleHFEU67qNGWJzwlQ/V6cLGUIJRYJighboNkcU5BX7jV8pDQhWVP6d5J4Vl5Usd2ZugqzGQQSvJchg==",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/codegen": "~2.9.2",

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,7 +1,7 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-go": "0.3.10"
+    "@azure-tools/typespec-go": "0.4.0"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.52.0",


### PR DESCRIPTION
upgrade typespec-go version to 0.4.0
issue: https://github.com/Azure/autorest.go/issues/1515
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
