### PR TITLE
Make temporal.Resource refreshing configurable

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Added function `tracing.NewSpanValidator` to create a span validator for use with in unit tests.
 * Added type `tracing.SpanMatcher` to match spans in a span validator.
+* `temporal.NewResourceWithOptions` enables overriding default `temporal.Resource` refresh behavior
 
 ### Breaking Changes
 

--- a/sdk/internal/temporal/resource.go
+++ b/sdk/internal/temporal/resource.go
@@ -89,7 +89,6 @@ func (er *Resource[TResource, TState]) Get(state TState) (TResource, error) {
 			if !er.acquiring {
 				// If another thread/goroutine is not acquiring/updating the resource, this thread/goroutine will do it
 				er.acquiring, acquire = true, true
-				er.lastAttempt = now
 				break
 			}
 			// Getting here means that this thread/goroutine will wait for the updated resource

--- a/sdk/internal/temporal/resource.go
+++ b/sdk/internal/temporal/resource.go
@@ -98,7 +98,6 @@ func (er *Resource[TResource, TState]) Get(state TState) (TResource, error) {
 				// If another thread/goroutine is not acquiring/renewing the resource, and none has attempted
 				// to do so within the last 30 seconds, this thread/goroutine will do it
 				er.acquiring, acquire = true, true
-				er.lastAttempt = now
 				break
 			}
 			// This thread/goroutine will use the existing resource value while another updates it
@@ -119,6 +118,7 @@ func (er *Resource[TResource, TState]) Get(state TState) (TResource, error) {
 		// This thread/goroutine has been selected to acquire/update the resource
 		var expiration time.Time
 		var newValue TResource
+		er.lastAttempt = now
 		newValue, expiration, err = er.acquireResource(state)
 
 		// Atomically, update the shared resource's new value & expiration.
@@ -150,6 +150,5 @@ func (er *Resource[TResource, TState]) Expire() {
 }
 
 func (er *Resource[TResource, TState]) expiringSoon(TResource, TState) bool {
-	now := time.Now()
-	return er.expiration.Add(-5*time.Minute).Before(now) && er.lastAttempt.Add(30*time.Second).Before(now)
+	return er.expiration.Add(-5 * time.Minute).Before(time.Now())
 }

--- a/sdk/internal/temporal/resource.go
+++ b/sdk/internal/temporal/resource.go
@@ -87,6 +87,7 @@ func (er *Resource[TResource, TState]) Get(state TState) (TResource, error) {
 			if !er.acquiring {
 				// If another thread/goroutine is not acquiring/updating the resource, this thread/goroutine will do it
 				er.acquiring, acquire = true, true
+				er.lastAttempt = now
 				break
 			}
 			// Getting here means that this thread/goroutine will wait for the updated resource
@@ -95,6 +96,7 @@ func (er *Resource[TResource, TState]) Get(state TState) (TResource, error) {
 				// If another thread/goroutine is not acquiring/renewing the resource, and none has attempted
 				// to do so within the last 30 seconds, this thread/goroutine will do it
 				er.acquiring, acquire = true, true
+				er.lastAttempt = now
 				break
 			}
 			// This thread/goroutine will use the existing resource value while another updates it
@@ -115,7 +117,6 @@ func (er *Resource[TResource, TState]) Get(state TState) (TResource, error) {
 		// This thread/goroutine has been selected to acquire/update the resource
 		var expiration time.Time
 		var newValue TResource
-		er.lastAttempt = now
 		newValue, expiration, err = er.acquireResource(state)
 
 		// Atomically, update the shared resource's new value & expiration.

--- a/sdk/internal/temporal/resource.go
+++ b/sdk/internal/temporal/resource.go
@@ -149,5 +149,6 @@ func (er *Resource[TResource, TState]) Expire() {
 }
 
 func (er *Resource[TResource, TState]) expiringSoon(TResource, TState) bool {
+	// call time.Now() instead of using Get's value so ShouldRefresh doesn't need a time.Time parameter
 	return er.expiration.Add(-5 * time.Minute).Before(time.Now())
 }

--- a/sdk/internal/temporal/resource.go
+++ b/sdk/internal/temporal/resource.go
@@ -11,8 +11,14 @@ import (
 	"time"
 )
 
+// backoff is the minimum wait time between eager update attempts. It's a variable so tests can manipulate it.
+var backoff = 30 * time.Second
+
 // AcquireResource abstracts a method for refreshing a temporal resource.
 type AcquireResource[TResource, TState any] func(state TState) (newResource TResource, newExpiration time.Time, err error)
+
+// ShouldRefresh abstracts a method for indicating whether a resource should be refreshed before expiration.
+type ShouldRefresh[TResource, TState any] func(TResource, TState) bool
 
 // Resource is a temporal resource (usually a credential) that requires periodic refreshing.
 type Resource[TResource, TState any] struct {
@@ -31,24 +37,43 @@ type Resource[TResource, TState any] struct {
 	// lastAttempt indicates when a thread/goroutine last attempted to acquire/update the resource
 	lastAttempt time.Time
 
+	// shouldRefresh indicates whether the resource should be refreshed before expiration
+	shouldRefresh ShouldRefresh[TResource, TState]
+
 	// acquireResource is the callback function that actually acquires the resource
 	acquireResource AcquireResource[TResource, TState]
 }
 
 // NewResource creates a new Resource that uses the specified AcquireResource for refreshing.
 func NewResource[TResource, TState any](ar AcquireResource[TResource, TState]) *Resource[TResource, TState] {
-	return &Resource[TResource, TState]{cond: sync.NewCond(&sync.Mutex{}), acquireResource: ar}
+	r := &Resource[TResource, TState]{acquireResource: ar, cond: sync.NewCond(&sync.Mutex{})}
+	r.shouldRefresh = r.expiringSoon
+	return r
+}
+
+// ResourceOptions contains optional configuration for Resource
+type ResourceOptions[TResource, TState any] struct {
+	// ShouldRefresh indicates whether [Resource.Get] should acquire an updated resource despite
+	// the currently held resource not having expired. [Resource.Get] ignores all errors from
+	// refresh attempts triggered by ShouldRefresh returning true, and doesn't call ShouldRefresh
+	// when the resource has expired (it unconditionally updates expired resources). When
+	// ShouldRefresh is nil, [Resource.Get] refreshes the resource if it will expire within 5
+	// minutes.
+	ShouldRefresh ShouldRefresh[TResource, TState]
+}
+
+// NewResourceWithOptions creates a new Resource that uses the specified AcquireResource for refreshing.
+func NewResourceWithOptions[TResource, TState any](ar AcquireResource[TResource, TState], opts ResourceOptions[TResource, TState]) *Resource[TResource, TState] {
+	r := NewResource(ar)
+	if opts.ShouldRefresh != nil {
+		r.shouldRefresh = opts.ShouldRefresh
+	}
+	return r
 }
 
 // Get returns the underlying resource.
 // If the resource is fresh, no refresh is performed.
 func (er *Resource[TResource, TState]) Get(state TState) (TResource, error) {
-	// If the resource is expiring within this time window, update it eagerly.
-	// This allows other threads/goroutines to keep running by using the not-yet-expired
-	// resource value while one thread/goroutine updates the resource.
-	const window = 5 * time.Minute   // This example updates the resource 5 minutes prior to expiration
-	const backoff = 30 * time.Second // Minimum wait time between eager update attempts
-
 	now, acquire, expired := time.Now(), false, false
 
 	// acquire exclusive lock
@@ -65,8 +90,7 @@ func (er *Resource[TResource, TState]) Get(state TState) (TResource, error) {
 				break
 			}
 			// Getting here means that this thread/goroutine will wait for the updated resource
-		} else if er.expiration.Add(-window).Before(now) {
-			// The resource is valid but is expiring within the time window
+		} else if er.shouldRefresh(resource, state) {
 			if !er.acquiring && er.lastAttempt.Add(backoff).Before(now) {
 				// If another thread/goroutine is not acquiring/renewing the resource, and none has attempted
 				// to do so within the last 30 seconds, this thread/goroutine will do it
@@ -120,4 +144,9 @@ func (er *Resource[TResource, TState]) Expire() {
 
 	// Reset the expiration as if we never got this resource to begin with
 	er.expiration = time.Time{}
+}
+
+func (r *Resource[TResource, TState]) expiringSoon(TResource, TState) bool {
+	now := time.Now()
+	return r.expiration.Add(-5*time.Minute).Before(now) && r.lastAttempt.Add(30*time.Second).Before(now)
 }

--- a/sdk/internal/temporal/resource.go
+++ b/sdk/internal/temporal/resource.go
@@ -149,7 +149,7 @@ func (er *Resource[TResource, TState]) Expire() {
 	er.expiration = time.Time{}
 }
 
-func (r *Resource[TResource, TState]) expiringSoon(TResource, TState) bool {
+func (er *Resource[TResource, TState]) expiringSoon(TResource, TState) bool {
 	now := time.Now()
-	return r.expiration.Add(-5*time.Minute).Before(now) && r.lastAttempt.Add(30*time.Second).Before(now)
+	return er.expiration.Add(-5*time.Minute).Before(now) && er.lastAttempt.Add(30*time.Second).Before(now)
 }

--- a/sdk/internal/temporal/resource_test.go
+++ b/sdk/internal/temporal/resource_test.go
@@ -95,7 +95,7 @@ func TestShouldRefresh(t *testing.T) {
 		t.Run(fmt.Sprint(shouldRefresh), func(t *testing.T) {
 			before := backoff
 			defer func() { backoff = before }()
-			backoff = 0
+			backoff = func(time.Time, time.Time) bool { return false }
 			called := false
 			initial, updated := "initial", "updated"
 			states := []string{"a", "b"}

--- a/sdk/internal/temporal/resource_test.go
+++ b/sdk/internal/temporal/resource_test.go
@@ -8,6 +8,7 @@ package temporal
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -87,4 +88,83 @@ func TestNewExpiringResourceConcurrent(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestShouldRefresh(t *testing.T) {
+	for _, shouldRefresh := range []bool{true, false} {
+		t.Run(fmt.Sprint(shouldRefresh), func(t *testing.T) {
+			before := backoff
+			defer func() { backoff = before }()
+			backoff = 0
+			called := false
+			initial, updated := "initial", "updated"
+			states := []string{"a", "b"}
+			r := NewResourceWithOptions(
+				func(state string) (string, time.Time, error) {
+					rsrc := initial
+					if called {
+						require.Equal(t, states[1], state)
+						rsrc = updated
+					} else {
+						require.Equal(t, states[0], state)
+					}
+					return rsrc, time.Now().Add(time.Hour), nil
+				},
+				ResourceOptions[string, string]{
+					ShouldRefresh: func(resource, state string) bool {
+						require.False(t, called)
+						require.Equal(t, states[1], state)
+						require.Equal(t, initial, resource)
+						called = true
+						return shouldRefresh
+					},
+				},
+			)
+			resources := []string{initial, updated}
+			for _, state := range states {
+				actual, err := r.Get(state)
+				require.NoError(t, err)
+				expected := resources[0]
+				if shouldRefresh {
+					resources = resources[1:]
+				}
+				require.Equal(t, expected, actual)
+			}
+			require.True(t, called)
+		})
+	}
+	t.Run("backoff", func(t *testing.T) {
+		gets := 0
+		r := NewResourceWithOptions(
+			func(string) (string, time.Time, error) {
+				gets++
+				return "", time.Now().Add(time.Hour), nil
+			},
+			ResourceOptions[string, string]{
+				ShouldRefresh: func(string, string) bool { return true },
+			},
+		)
+		for i := 0; i < 42; i++ {
+			_, err := r.Get("")
+			require.NoError(t, err)
+		}
+		require.Equal(t, 1, gets, "Get should apply backoff when ShouldRefresh returns true")
+	})
+	t.Run("expired resource", func(t *testing.T) {
+		r := NewResourceWithOptions(
+			func(string) (string, time.Time, error) {
+				return "expired", time.Now().Add(-time.Hour), nil
+			},
+			ResourceOptions[string, string]{
+				ShouldRefresh: func(string, string) bool {
+					t.Fatal("Resource shouldn't call ShouldRefresh when it's expired")
+					return true
+				},
+			},
+		)
+		for i := 0; i < 3; i++ {
+			_, err := r.Get("")
+			require.NoError(t, err)
+		}
+	})
 }


### PR DESCRIPTION
This adds a callback that indicates whether the underlying resource should be refreshed despite its not having expired. Part of #22837