### PR TITLE
[azcore/runtime] Add ModuleName to StartSpanOptions

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Added type `Propagator` to the `tracing` package to support context propagation.
 * Added type `Carrier` to the `tracing` package to support context propagation.
 * Added method `NewPropagator()` to type `tracing.Provider` to support context propagation.
+* Added option `ModuleName` to `runtime.StartSpanOptions` to support custom module names in error type.
 
 ### Breaking Changes
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

The error type is hardcoded as `azcore` in `runtime.StartSpan`. It will miscategorize all exported errors from modules external to `azcore` to `azcore.Error`.

This PR supports customization of the ModuleName in `runtime.StartSpanOptions`

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
