### PR TITLE
export acr audience

### DIFF
--- a/sdk/containers/azcontainerregistry/CHANGELOG.md
+++ b/sdk/containers/azcontainerregistry/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Other Changes
 * Default audience of Azure Container Registry of all clouds to https://containerregistry.azure.net
+* Export ACR audience variable
 
 ## 0.2.2 (2024-09-19)
 

--- a/sdk/containers/azcontainerregistry/cloud_config.go
+++ b/sdk/containers/azcontainerregistry/cloud_config.go
@@ -15,16 +15,16 @@ const (
 
 func init() {
 	cloud.AzureChina.Services[ServiceName] = cloud.ServiceConfiguration{
-		Audience: defaultAudience,
+		Audience: AcrAudience,
 	}
 	cloud.AzureGovernment.Services[ServiceName] = cloud.ServiceConfiguration{
-		Audience: defaultAudience,
+		Audience: AcrAudience,
 	}
 	cloud.AzurePublic.Services[ServiceName] = cloud.ServiceConfiguration{
-		Audience: defaultAudience,
+		Audience: AcrAudience,
 	}
 }
 
 var defaultCloud = cloud.Configuration{
-	Services: map[cloud.ServiceName]cloud.ServiceConfiguration{ServiceName: {Audience: defaultAudience}},
+	Services: map[cloud.ServiceName]cloud.ServiceConfiguration{ServiceName: {Audience: AcrAudience}},
 }

--- a/sdk/containers/azcontainerregistry/custom_constants.go
+++ b/sdk/containers/azcontainerregistry/custom_constants.go
@@ -7,7 +7,13 @@
 package azcontainerregistry
 
 const (
-	moduleName      = "github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry"
-	moduleVersion   = "v0.2.3"
-	defaultAudience = "https://containerregistry.azure.net"
+	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry"
+	moduleVersion = "v0.2.3"
+)
+
+const (
+	// AcrAudience is the audience for Azure Container Registry.
+	// acr audience token provides permissions with a smaller scope than ARM audience token,
+	// and is preferable as the default audience for Azure Container Registry in all clouds.
+	AcrAudience = "https://containerregistry.azure.net"
 )


### PR DESCRIPTION
The intention of the PR is to export the preferable ACR audience to let other Azure client and for clouds like azure stack to refer this variable.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
