### PR TITLE
Reinstate nocoverageredesign

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -60,13 +60,13 @@ steps:
       arguments: -vet -skipBuild -filter '${{ parameters.ServiceDirectory }}'
 
   - pwsh: |
-      go install github.com/jstemmer/go-junit-report@v0.9.1
+      go install github.com/jstemmer/go-junit-report/v2@v2.1.0
       if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-      go install github.com/axw/gocov/gocov@v1.1.0
+      go install github.com/axw/gocov/gocov@v1.2.1
       if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-      go install github.com/AlekSi/gocov-xml@v1.0.0
+      go install github.com/AlekSi/gocov-xml@v1.1.0
       if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-      go install github.com/matm/gocov-html@v0.0.0-20200509184451-71874e2e203b
+      go install github.com/matm/gocov-html/cmd/gocov-html@v1.4.0
       if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     displayName: "Install Coverage and Junit Dependencies"
     retryCountOnTaskFailure: 3

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -17,3 +17,6 @@ variables:
 
   # We enable this selectively to avoid overloading CG scanning/reporting on PR pipelines
   skipComponentGovernanceDetection: true
+
+  # disable code coverage redesign until it's been fixed (causes inadvertent deflation of CC numbers)
+  GOEXPERIMENT: nocoverageredesign

--- a/eng/scripts/MgmtTestLib.ps1
+++ b/eng/scripts/MgmtTestLib.ps1
@@ -328,16 +328,18 @@ function TestAndGenerateReport($dir)
 {
     Set-Location $dir
     # dependencies for go coverage report generation
-    go install github.com/jstemmer/go-junit-report@v0.9.1
-    go install github.com/axw/gocov/gocov@v1.1.0
-    go install github.com/AlekSi/gocov-xml@v1.0.0
-    go install github.com/matm/gocov-html@v0.0.0-20200509184451-71874e2e203b
+    go install github.com/jstemmer/go-junit-report/v2@v2.1.0
+    go install github.com/axw/gocov/gocov@v1.2.1
+    go install github.com/AlekSi/gocov-xml@v1.1.0
+    go install github.com/matm/gocov-html/cmd/gocov-html@v1.4.0
 
     # set azidentity env for mock test
     $Env:AZURE_TENANT_ID = "mock-test"
     $Env:AZURE_CLIENT_ID = "mock-test"
     $Env:AZURE_USERNAME = "mock-test"
     $Env:AZURE_PASSWORD = "mock-test"
+
+    $Env:GOEXPERIMENT="nocoverageredesign"
 
     # do test with corage report and convert to cobertura format
     Write-Host "go cmd: go test -v -coverprofile coverage.txt | Tee-Object -FilePath outfile.txt"

--- a/eng/scripts/MgmtTestLib.ps1
+++ b/eng/scripts/MgmtTestLib.ps1
@@ -339,8 +339,6 @@ function TestAndGenerateReport($dir)
     $Env:AZURE_USERNAME = "mock-test"
     $Env:AZURE_PASSWORD = "mock-test"
 
-    $Env:GOEXPERIMENT="nocoverageredesign"
-
     # do test with corage report and convert to cobertura format
     Write-Host "go cmd: go test -v -coverprofile coverage.txt | Tee-Object -FilePath outfile.txt"
     go test -v -coverprofile coverage.txt -run TestMockTest | Tee-Object -FilePath outfile.txt

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -10,8 +10,6 @@ Param(
 $ErrorActionPreference = 'Stop'
 Push-Location sdk/$serviceDirectory
 
-$Env:GOEXPERIMENT="nocoverageredesign"
-
 if ($enableRaceDetector) {
     Write-Host "##[command] Executing 'go test -timeout $testTimeout -race -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
     go test -timeout $testTimeout -race -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt

--- a/eng/scripts/run_tests.ps1
+++ b/eng/scripts/run_tests.ps1
@@ -10,6 +10,8 @@ Param(
 $ErrorActionPreference = 'Stop'
 Push-Location sdk/$serviceDirectory
 
+$Env:GOEXPERIMENT="nocoverageredesign"
+
 if ($enableRaceDetector) {
     Write-Host "##[command] Executing 'go test -timeout $testTimeout -race -v -coverprofile coverage.txt ./...' in sdk/$serviceDirectory"
     go test -timeout $testTimeout -race -v -coverprofile coverage.txt ./... | Tee-Object -FilePath outfile.txt


### PR DESCRIPTION
It appears the underlying issues in the redesign have not yet been fully fixed, causing discrepancies in code coverage numbers. Update test and code coverage tools used in CI.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
