### PR TITLE
Use commonly defined go N0, N-1 versions in test matrix configs

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -1,7 +1,7 @@
 {
   "matrix": {
     "Agent": {
-      "ubuntu-20.04": {
+      "ubuntu": {
         "OSVmImage": "env:LINUXVMIMAGE",
         "Pool": "env:LINUXPOOL"
       },
@@ -11,8 +11,8 @@
       }
     },
     "GoVersion": [
-      "env:GO_VERSION_N0",
-      "env:GO_VERSION_N1"
+      "env:GO_VERSION_LATEST",
+      "env:GO_VERSION_PREVIOUS"
     ]
   }
 }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -11,8 +11,8 @@
       }
     },
     "GoVersion": [
-      "1.23.7",
-      "1.24.1"
+      "env:GO_VERSION_N0",
+      "env:GO_VERSION_N1"
     ]
   }
 }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -1,11 +1,11 @@
 {
   "matrix": {
     "Agent": {
-      "ubuntu": {
+      "ubuntu_go": {
         "OSVmImage": "env:LINUXVMIMAGE",
         "Pool": "env:LINUXPOOL"
       },
-      "windows-2022": {
+      "windows_go": {
         "OSVmImage": "env:WINDOWSVMIMAGE",
         "Pool": "env:WINDOWSPOOL"
       }

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -76,7 +76,7 @@ steps:
 
   - ${{ if parameters.UseFederatedAuth }}:
     - task: AzurePowerShell@5
-      displayName: Run Tests (Federated Auth)
+      displayName: Run Tests - v$(GoVersion) (Federated Auth)
       inputs:
         azureSubscription: ${{ parameters.ServiceConnection }}
         azurePowerShellVersion: LatestVersion
@@ -116,7 +116,7 @@ steps:
 
   - ${{ else }}:
     - task: PowerShell@2
-      displayName: 'Run Tests'
+      displayName: Run Tests - v$(GoVersion)
       inputs:
         targetType: 'filePath'
         filePath: ./eng/scripts/run_tests.ps1

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -20,3 +20,7 @@ variables:
 
   # disable code coverage redesign until it's been fixed (causes inadvertent deflation of CC numbers)
   GOEXPERIMENT: nocoverageredesign
+
+  # Supported versions for testing. These variables are referenced in test matrix files.
+  GO_VERSION_N0: 1.24.1
+  GO_VERSION_N1: 1.23.7

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -22,5 +22,5 @@ variables:
   GOEXPERIMENT: nocoverageredesign
 
   # Supported versions for testing. These variables are referenced in test matrix files.
-  GO_VERSION_N0: 1.24.1
-  GO_VERSION_N1: 1.23.7
+  GO_VERSION_LATEST: 1.24.1
+  GO_VERSION_PREVIOUS: 1.23.7

--- a/sdk/azidentity/managed-identity-matrix.json
+++ b/sdk/azidentity/managed-identity-matrix.json
@@ -9,7 +9,7 @@
                 }
             },
             "GoVersion": [
-                "env:GO_VERSION_N1"
+                "env:GO_VERSION_PREVIOUS"
             ],
             "IDENTITY_IMDS_AVAILABLE": "1"
         }

--- a/sdk/azidentity/managed-identity-matrix.json
+++ b/sdk/azidentity/managed-identity-matrix.json
@@ -9,7 +9,7 @@
                 }
             },
             "GoVersion": [
-                "1.22.1"
+                "env:GO_VERSION_N1"
             ],
             "IDENTITY_IMDS_AVAILABLE": "1"
         }

--- a/sdk/security/keyvault/azadmin/platform-matrix.json
+++ b/sdk/security/keyvault/azadmin/platform-matrix.json
@@ -11,7 +11,7 @@
                 }
             },
             "ArmTemplateParameters": "@{ enableHsm = $true }",
-            "GoVersion": ["env:GO_VERSION_N1"]
+            "GoVersion": ["env:GO_VERSION_PREVIOUS"]
         }
     ]
 }

--- a/sdk/security/keyvault/azadmin/platform-matrix.json
+++ b/sdk/security/keyvault/azadmin/platform-matrix.json
@@ -11,7 +11,7 @@
                 }
             },
             "ArmTemplateParameters": "@{ enableHsm = $true }",
-            "GoVersion": ["1.23.7"]
+            "GoVersion": ["env:GO_VERSION_N1"]
         }
     ]
 }

--- a/sdk/security/keyvault/azadmin/platform-matrix.json
+++ b/sdk/security/keyvault/azadmin/platform-matrix.json
@@ -5,13 +5,13 @@
     "include": [
         {
             "Agent": {
-                "ubuntu-20.04": {
+                "ubuntu_go": {
                     "OSVmImage": "env:LINUXVMIMAGE",
                     "Pool": "env:LINUXPOOL"
                 }
             },
-            "ArmTemplateParameters": "@{ enableHsm = $true }",
-            "GoVersion": ["env:GO_VERSION_PREVIOUS"]
+            "GoVersion": ["env:GO_VERSION_PREVIOUS"],
+            "ArmTemplateParameters": "@{ enableHsm = $true }"
         }
     ]
 }

--- a/sdk/security/keyvault/azkeys/platform-matrix.json
+++ b/sdk/security/keyvault/azkeys/platform-matrix.json
@@ -11,7 +11,7 @@
                 }
             },
             "ArmTemplateParameters": "@{ enableHsm = $true }",
-            "GoVersion": ["env:GO_VERSION_N1"]
+            "GoVersion": ["env:GO_VERSION_PREVIOUS"]
         }
     ]
 }

--- a/sdk/security/keyvault/azkeys/platform-matrix.json
+++ b/sdk/security/keyvault/azkeys/platform-matrix.json
@@ -11,7 +11,7 @@
                 }
             },
             "ArmTemplateParameters": "@{ enableHsm = $true }",
-            "GoVersion": ["1.23.7"]
+            "GoVersion": ["env:GO_VERSION_N1"]
         }
     ]
 }

--- a/sdk/security/keyvault/azkeys/platform-matrix.json
+++ b/sdk/security/keyvault/azkeys/platform-matrix.json
@@ -5,13 +5,13 @@
     "include": [
         {
             "Agent": {
-                "ubuntu-20.04": {
+                "ubuntu_go": {
                     "OSVmImage": "env:LINUXVMIMAGE",
                     "Pool": "env:LINUXPOOL"
                 }
             },
-            "ArmTemplateParameters": "@{ enableHsm = $true }",
-            "GoVersion": ["env:GO_VERSION_PREVIOUS"]
+            "GoVersion": ["env:GO_VERSION_PREVIOUS"],
+            "ArmTemplateParameters": "@{ enableHsm = $true }"
         }
     ]
 }


### PR DESCRIPTION
Defining these in `globals.yml` and referencing them via matrix environment variable syntax allows us to have one single place to rev versions for testing.