### PR TITLE
[azservicebus] Check that an annotation isn't nil before casting it to a string.

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.8.1 (TBD)
+
+### Bugs Fixed
+
+- Some Service Bus annotation values can be set to nil values, which would panic our Receiver. These are now checked, and set to nil appropriately. (PR#TBD)
+
 ## 1.8.0 (2025-02-11)
 
 ### Features Added

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.8.0"
+const Version = "v1.8.1"

--- a/sdk/messaging/azservicebus/message.go
+++ b/sdk/messaging/azservicebus/message.go
@@ -366,7 +366,7 @@ func newReceivedMessage(amqpMsg *amqp.Message, receiver amqpwrap.AMQPReceiver) *
 			msg.SequenceNumber = to.Ptr(sequenceNumber.(int64))
 		}
 
-		if partitionKey, ok := amqpMsg.Annotations[partitionKeyAnnotation]; ok {
+		if partitionKey, ok := amqpMsg.Annotations[partitionKeyAnnotation]; ok && partitionKey != nil {
 			msg.PartitionKey = to.Ptr(partitionKey.(string))
 		}
 
@@ -375,7 +375,7 @@ func newReceivedMessage(amqpMsg *amqp.Message, receiver amqpwrap.AMQPReceiver) *
 			msg.EnqueuedTime = &t
 		}
 
-		if deadLetterSource, ok := amqpMsg.Annotations[deadLetterSourceAnnotation]; ok {
+		if deadLetterSource, ok := amqpMsg.Annotations[deadLetterSourceAnnotation]; ok && deadLetterSource != nil {
 			msg.DeadLetterSource = to.Ptr(deadLetterSource.(string))
 		}
 

--- a/sdk/messaging/azservicebus/receiver_test.go
+++ b/sdk/messaging/azservicebus/receiver_test.go
@@ -1171,6 +1171,60 @@ SendLoop:
 	}
 }
 
+func TestNilPartitionKey(t *testing.T) {
+	client, cleanup, queueName := setupLiveTest(t, nil)
+	defer cleanup()
+
+	receiver, err := client.NewReceiverForQueue(queueName, nil)
+	require.NoError(t, err)
+
+	sender, err := client.NewSender(queueName, nil)
+	require.NoError(t, err)
+
+	err = sender.SendAMQPAnnotatedMessage(context.Background(), &AMQPAnnotatedMessage{
+		MessageAnnotations: map[any]any{
+			// accepted, and the values are forwarded, so we need to handle them being nil.
+			"x-opt-partition-key":     nil,
+			"x-opt-deadletter-source": nil,
+
+			// can't be set to nil, results in the service rejecting the message so no need
+			// to check them.
+			// "x-opt-scheduled-enqueue-time": nil,
+			// "x-opt-message-state": nil,
+			// "x-opt-enqueue-sequence-number": nil,
+
+			// accepted but ignored - they'll be filled out when the broker
+			// sends the message to one of our receivers.
+			"x-opt-locked-until":    nil,
+			"x-opt-sequence-number": nil,
+			"x-opt-enqueued-time":   nil,
+			"xopt-lock-token":       nil,
+		},
+		Body: AMQPAnnotatedMessageBody{
+			Value: "hello world, with a nil partition key",
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
+	require.NoError(t, err)
+
+	m := messages[0]
+	require.Nil(t, m.PartitionKey)
+	require.Nil(t, m.DeadLetterSource)
+
+	// these are always set, by the broker, so nothing we set in our
+	// sent message will take effect
+	require.NotNil(t, m.LockToken)
+	require.NotNil(t, m.LockedUntil)
+	require.NotNil(t, m.SequenceNumber)
+	require.NotNil(t, m.EnqueuedTime)
+
+	require.Equal(t, "hello world, with a nil partition key", m.RawAMQPMessage.Body.Value)
+	err = receiver.CompleteMessage(context.Background(), m, nil)
+	require.NoError(t, err)
+}
+
 type receivedMessageSlice []*ReceivedMessage
 
 func (messages receivedMessageSlice) Len() int {


### PR DESCRIPTION
These annotations are considered internal to Service Bus, but they are settable and nil is a perfectly valid AMQP value, even for the expected type of string.

Fixes #24305