### PR TITLE
BearerTokenPolicy observes issuer's suggested token refresh time

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added `AccessToken.RefreshOn` and updated `BearerTokenPolicy` to consider nonzero values of it when deciding whether to request a new token
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-sdk-for-go/sdk/azcore
 go 1.23.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/net v0.38.0
 )

--- a/sdk/azcore/go.sum
+++ b/sdk/azcore/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.0 h1:Bg8m3nq/X1DeePkAbCfb6ml6F3F0IunEhE8TMh+lY48=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.0/go.mod h1:j2chePtV91HrC22tGoRX3sGY42uF13WzmmV80/OdVAA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -47,8 +47,13 @@ func HasStatusCode(resp *http.Response, statusCodes ...int) bool {
 // AccessToken represents an Azure service bearer access token with expiry information.
 // Exported as azcore.AccessToken.
 type AccessToken struct {
-	Token     string
+	// Token is the access token
+	Token string
+	// ExpiresOn indicates when the token expires
 	ExpiresOn time.Time
+	// RefreshOn is a suggested time to refresh the token.
+	// Clients should ignore this value when it's zero.
+	RefreshOn time.Time
 }
 
 // TokenRequestOptions contain specific parameter that may be used by credentials types when attempting to get a token.

--- a/sdk/azcore/runtime/policy_bearer_token.go
+++ b/sdk/azcore/runtime/policy_bearer_token.go
@@ -51,6 +51,14 @@ func acquire(state acquiringResourceState) (newResource exported.AccessToken, ne
 	return tk, tk.ExpiresOn, nil
 }
 
+// shouldRefresh determines whether the token should be refreshed. It's a variable so tests can replace it.
+var shouldRefresh = func(tk exported.AccessToken, _ acquiringResourceState) bool {
+	if tk.RefreshOn.IsZero() {
+		return tk.ExpiresOn.Add(-5 * time.Minute).Before(time.Now())
+	}
+	return tk.RefreshOn.Before(time.Now())
+}
+
 // NewBearerTokenPolicy creates a policy object that authorizes requests with bearer tokens.
 // cred: an azcore.TokenCredential implementation such as a credential object from azidentity
 // scopes: the list of permission scopes required for the token.
@@ -69,11 +77,14 @@ func NewBearerTokenPolicy(cred exported.TokenCredential, scopes []string, opts *
 			return authNZ(policy.TokenRequestOptions{Scopes: scopes})
 		}
 	}
+	mr := temporal.NewResourceWithOptions(acquire, temporal.ResourceOptions[exported.AccessToken, acquiringResourceState]{
+		ShouldRefresh: shouldRefresh,
+	})
 	return &BearerTokenPolicy{
 		authzHandler: ah,
 		cred:         cred,
 		scopes:       scopes,
-		mainResource: temporal.NewResource(acquire),
+		mainResource: mr,
 		allowHTTP:    opts.InsecureAllowCredentialWithHTTP,
 	}
 }

--- a/sdk/azcore/runtime/policy_bearer_token.go
+++ b/sdk/azcore/runtime/policy_bearer_token.go
@@ -56,6 +56,7 @@ var shouldRefresh = func(tk exported.AccessToken, _ acquiringResourceState) bool
 	if tk.RefreshOn.IsZero() {
 		return tk.ExpiresOn.Add(-5 * time.Minute).Before(time.Now())
 	}
+	// no offset in this case because the authority suggested a refresh window--between RefreshOn and ExpiresOn
 	return tk.RefreshOn.Before(time.Now())
 }
 

--- a/sdk/azcore/testdata/perf/go.mod
+++ b/sdk/azcore/testdata/perf/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.0
 )
 
 require (

--- a/sdk/azcore/testdata/perf/go.sum
+++ b/sdk/azcore/testdata/perf/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.0 h1:Bg8m3nq/X1DeePkAbCfb6ml6F3F0IunEhE8TMh+lY48=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.0/go.mod h1:j2chePtV91HrC22tGoRX3sGY42uF13WzmmV80/OdVAA=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Continuing on from #24268, this adds AccessToken.RefreshOn and updates BearerTokenPolicy to observe it when deciding whether to request a token. Part of #22837