### PR TITLE
fix- get webapp keys as key value map

### DIFF
--- a/sdk/resourcemanager/appservice/armappservice/webapps_client.go
+++ b/sdk/resourcemanager/appservice/armappservice/webapps_client.go
@@ -17613,7 +17613,7 @@ func (client *WebAppsClient) listFunctionKeysCreateRequest(ctx context.Context, 
 // listFunctionKeysHandleResponse handles the ListFunctionKeys response.
 func (client *WebAppsClient) listFunctionKeysHandleResponse(resp *http.Response) (WebAppsClientListFunctionKeysResponse, error) {
 	result := WebAppsClientListFunctionKeysResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.StringDictionary); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.StringDictionary.Properties); err != nil {
 		return WebAppsClientListFunctionKeysResponse{}, err
 	}
 	return result, nil


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->
Response from List Keys API is in the form of key value pair via API: https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/functions/{functionName}/listkeys?api-version=2024-04-01

![Screenshot 2025-03-27 at 3 42 06 PM](https://github.com/user-attachments/assets/3a9dc72a-bd38-492e-bc56-714096cf90ae)

Current Parsing Logic takes this body in the **StringDictionary** struct, which will return in empty response always, hence changing it to **Properties** of **StringDictionary** , which will result in a key value map


- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
