### PR TITLE
Upgrade emitter version

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,23 +5,23 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-go": "0.4.1"
+        "@azure-tools/typespec-go": "0.4.2"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "0.53.0",
-        "@azure-tools/typespec-azure-core": "0.53.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.53.0",
-        "@azure-tools/typespec-azure-rulesets": "0.53.0",
-        "@azure-tools/typespec-client-generator-core": "0.53.1",
+        "@azure-tools/typespec-autorest": "0.54.0",
+        "@azure-tools/typespec-azure-core": "0.54.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.54.0",
+        "@azure-tools/typespec-azure-rulesets": "0.54.0",
+        "@azure-tools/typespec-client-generator-core": "0.54.0",
         "@azure-tools/typespec-liftr-base": "0.8.0",
-        "@typespec/compiler": "0.67.1",
-        "@typespec/events": "0.67.1",
-        "@typespec/http": "0.67.1",
-        "@typespec/openapi": "0.67.1",
-        "@typespec/rest": "0.67.1",
-        "@typespec/sse": "0.67.1",
-        "@typespec/streams": "0.67.1",
-        "@typespec/versioning": "0.67.1"
+        "@typespec/compiler": "1.0.0-rc.0",
+        "@typespec/events": "0.68.0",
+        "@typespec/http": "1.0.0-rc.0",
+        "@typespec/openapi": "1.0.0-rc.0",
+        "@typespec/rest": "0.68.0",
+        "@typespec/sse": "0.68.0",
+        "@typespec/streams": "0.68.0",
+        "@typespec/versioning": "0.68.0"
       }
     },
     "node_modules/@azure-tools/async-io": {
@@ -82,43 +82,43 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.53.0.tgz",
-      "integrity": "sha512-9eAOTU/so8QOigMcy9YKA43jtMxccSP22wa7Is0ZiX59YTcaUDGlpI+6cFfmGH0tATGCOm5TvjyOkdrhNyKrPw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.54.0.tgz",
+      "integrity": "sha512-7Oh8R48CQfeiFFfrMTKdEozpx/riQe+KENkd6wn1Oku7aZJ/GDsPidwiu98sCBeSXeJhc3/UlHmxMZWgiat5KQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.53.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.53.0",
-        "@azure-tools/typespec-client-generator-core": "^0.53.0",
-        "@typespec/compiler": "^0.67.0",
-        "@typespec/http": "^0.67.0",
-        "@typespec/openapi": "^0.67.0",
-        "@typespec/rest": "^0.67.0",
-        "@typespec/versioning": "^0.67.0"
+        "@azure-tools/typespec-azure-core": "^0.54.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.54.0",
+        "@azure-tools/typespec-client-generator-core": "^0.54.0",
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/http": "^1.0.0-rc.0",
+        "@typespec/openapi": "^1.0.0-rc.0",
+        "@typespec/rest": "^0.68.0",
+        "@typespec/versioning": "^0.68.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.53.0.tgz",
-      "integrity": "sha512-zG+DV58ApChmkIIoTZ+XMIRsYLm6DnysMofg0o1UEuY50mS71sjzavcwceT8pXekPHtcXkLyYfdd7FyxirCuUA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.54.0.tgz",
+      "integrity": "sha512-rlUK9j/1mHUHaNPzOibz1aeeUnROOrNlTPDmnHOfbo4WP0NwV4tDU3rnoUCZxwabVQGKb9U7VTsunb74AzAafg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^0.67.0",
-        "@typespec/http": "^0.67.0",
-        "@typespec/rest": "^0.67.0"
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/http": "^1.0.0-rc.0",
+        "@typespec/rest": "^0.68.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.53.0.tgz",
-      "integrity": "sha512-sHeB+HqETYiHoRgcUjr61rxzCn+ITnYrg2gFQ0ExIK/B26hQv50t+VHe1YdrprlqzSvElJD+CtoqQQZffridNw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.54.0.tgz",
+      "integrity": "sha512-SKBMvBy3wD44ZIHjOmQcvYgWYnk4WcDOhXn1kLSgiYiX74zpv48G9sl8ic1AneREq5UtGNwZ4rdMFWY7BW+8hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -129,34 +129,34 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.53.0",
-        "@typespec/compiler": "^0.67.0",
-        "@typespec/http": "^0.67.0",
-        "@typespec/openapi": "^0.67.0",
-        "@typespec/rest": "^0.67.0",
-        "@typespec/versioning": "^0.67.0"
+        "@azure-tools/typespec-azure-core": "^0.54.0",
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/http": "^1.0.0-rc.0",
+        "@typespec/openapi": "^1.0.0-rc.0",
+        "@typespec/rest": "^0.68.0",
+        "@typespec/versioning": "^0.68.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.53.0.tgz",
-      "integrity": "sha512-TsQeFKNQEG0juFzf0dQt8iikPSXGHNyW9hbDrUNrbnjnFvpxUZlL+1aLyI2hBmhHvJQJpLzHViVgKhXTLLBvIQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.54.0.tgz",
+      "integrity": "sha512-Pupm5D76JEV4SMesXEEpei7JcErJSt0agVMXH9KjFXRfUYX+coBwfkP+mu3ViZQ+DRgC21qyHk8SxT2ffxxK2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.53.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.53.0",
-        "@azure-tools/typespec-client-generator-core": "^0.53.0",
-        "@typespec/compiler": "^0.67.0"
+        "@azure-tools/typespec-azure-core": "^0.54.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.54.0",
+        "@azure-tools/typespec-client-generator-core": "^0.54.0",
+        "@typespec/compiler": "^1.0.0-rc.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.53.1.tgz",
-      "integrity": "sha512-BWHQQ9Kjsk23Rb0eZ6V6HI2Gr20n/LhxAKEuBChCFWLjrFMYyXrHtlUBK6j/9D2VqwjaurRQA2SVXx/wzGyvAg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.54.0.tgz",
+      "integrity": "sha512-qZR6FgB+wKfF5aRQtEwjUo6xgw1MomqyFwJf6WL+xstHDs7np3jBja43OCdJaooPzAknYWh2V+Hv77/fLFd9Aw==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -167,22 +167,22 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.53.0",
-        "@typespec/compiler": "^0.67.0",
-        "@typespec/events": "^0.67.0",
-        "@typespec/http": "^0.67.0",
-        "@typespec/openapi": "^0.67.0",
-        "@typespec/rest": "^0.67.0",
-        "@typespec/sse": "^0.67.0",
-        "@typespec/streams": "^0.67.0",
-        "@typespec/versioning": "^0.67.0",
-        "@typespec/xml": "^0.67.0"
+        "@azure-tools/typespec-azure-core": "^0.54.0",
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/events": "^0.68.0",
+        "@typespec/http": "^1.0.0-rc.0",
+        "@typespec/openapi": "^1.0.0-rc.0",
+        "@typespec/rest": "^0.68.0",
+        "@typespec/sse": "^0.68.0",
+        "@typespec/streams": "^0.68.0",
+        "@typespec/versioning": "^0.68.0",
+        "@typespec/xml": "^0.68.0"
       }
     },
     "node_modules/@azure-tools/typespec-go": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.4.1.tgz",
-      "integrity": "sha512-nFdLA6TmBwxgmv3kTfCWS0LD3BxGsJAJKR4l/reeUEn9euNvd5fIQUO4CNt3y0Ew0VrkrkzwxasqzTL4MN35VQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.4.2.tgz",
+      "integrity": "sha512-fQSmwcHDKnWo8ohxKr1gMYc9v3ANHixfIRmDizFBjDQ1ftHWQlfHHLjUfiRymGjfmGSqQVTxytchGdMZJDjEWg==",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/codegen": "~2.9.2",
@@ -194,9 +194,9 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.53.1 <1.0.0",
-        "@typespec/compiler": ">=0.67.1 <1.0.0",
-        "@typespec/http": ">=0.67.1 <1.0.0"
+        "@azure-tools/typespec-client-generator-core": ">=0.54.0 <1.0.0",
+        "@typespec/compiler": "^1.0.0-0",
+        "@typespec/http": "^1.0.0-0"
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
@@ -229,14 +229,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.2.tgz",
-      "integrity": "sha512-PL9ixC5YsPXzXhAZFUPmkXGxfgjkdfZdPEPPmt4kFwQ4LBMDG9n/nHXYRGGZSKZJs+d1sGKWgS2GiPzVRKUdtQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.4.tgz",
+      "integrity": "sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -253,13 +253,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.6.tgz",
-      "integrity": "sha512-6ZXYK3M1XmaVBZX6FCfChgtponnL0R6I7k8Nu+kaoNkT828FVZTcca1MqmWQipaW2oNREQl5AaPCUOOCVNdRMw==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.8.tgz",
+      "integrity": "sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -274,13 +274,13 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.7.tgz",
-      "integrity": "sha512-AA9CQhlrt6ZgiSy6qoAigiA1izOa751ugX6ioSjqgJ+/Gd+tEN/TORk5sUYNjXuHWfW0r1n/a6ak4u/NqHHrtA==",
+      "version": "10.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
+      "integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -301,13 +301,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.7.tgz",
-      "integrity": "sha512-gktCSQtnSZHaBytkJKMKEuswSk2cDBuXX5rxGFv306mwHfBPjg5UAldw9zWGoEyvA9KpRDkeM4jfrx0rXn0GyA==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.9.tgz",
+      "integrity": "sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -323,13 +323,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.9.tgz",
-      "integrity": "sha512-Xxt6nhomWTAmuSX61kVgglLjMEFGa+7+F6UUtdEUeg7fg4r9vaFttUUKrtkViYYrQBA5Ia1tkOJj2koP9BuLig==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.11.tgz",
+      "integrity": "sha512-OZSUW4hFMW2TYvX/Sv+NnOZgO8CHT2TU1roUCUIF2T+wfw60XFRRp9MRUPCT06cRnKL+aemt2YmTWwt7rOrNEA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -345,22 +345,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.10.tgz",
-      "integrity": "sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.6.tgz",
-      "integrity": "sha512-1f5AIsZuVjPT4ecA8AwaxDFNHny/tSershP/cTvTDxLdiIGTeILNcKozB0LaYt6mojJLUbOYhpIxicaYf7UKIQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.8.tgz",
+      "integrity": "sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -375,13 +375,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.9.tgz",
-      "integrity": "sha512-iN2xZvH3tyIYXLXBvlVh0npk1q/aVuKXZo5hj+K3W3D4ngAEq/DkLpofRzx6oebTUhBvOgryZ+rMV0yImKnG3w==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.11.tgz",
+      "integrity": "sha512-pQK68CsKOgwvU2eA53AG/4npRTH2pvs/pZ2bFvzpBhrznh8Mcwt19c+nMO7LHRr3Vreu1KPhNBF3vQAKrjIulw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -396,13 +396,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.9.tgz",
-      "integrity": "sha512-xBEoOw1XKb0rIN208YU7wM7oJEHhIYkfG7LpTJAEW913GZeaoQerzf5U/LSHI45EVvjAdgNXmXgH51cUXKZcJQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.11.tgz",
+      "integrity": "sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -418,21 +418,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.2.tgz",
-      "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.0.tgz",
+      "integrity": "sha512-EZiJidQOT4O5PYtqnu1JbF0clv36oW2CviR66c7ma4LsupmmQlUwmdReGKRp456OWPWMz3PdrPiYg3aCk3op2w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.1.2",
-        "@inquirer/confirm": "^5.1.6",
-        "@inquirer/editor": "^4.2.7",
-        "@inquirer/expand": "^4.0.9",
-        "@inquirer/input": "^4.1.6",
-        "@inquirer/number": "^3.0.9",
-        "@inquirer/password": "^4.0.9",
-        "@inquirer/rawlist": "^4.0.9",
-        "@inquirer/search": "^3.0.9",
-        "@inquirer/select": "^4.0.9"
+        "@inquirer/checkbox": "^4.1.4",
+        "@inquirer/confirm": "^5.1.8",
+        "@inquirer/editor": "^4.2.9",
+        "@inquirer/expand": "^4.0.11",
+        "@inquirer/input": "^4.1.8",
+        "@inquirer/number": "^3.0.11",
+        "@inquirer/password": "^4.0.11",
+        "@inquirer/rawlist": "^4.0.11",
+        "@inquirer/search": "^3.0.11",
+        "@inquirer/select": "^4.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -447,13 +447,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.9.tgz",
-      "integrity": "sha512-+5t6ebehKqgoxV8fXwE49HkSF2Rc9ijNiVGEQZwvbMI61/Q5RcD+jWD6Gs1tKdz5lkI8GRBL31iO0HjGK1bv+A==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.11.tgz",
+      "integrity": "sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -469,14 +469,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.9.tgz",
-      "integrity": "sha512-DWmKztkYo9CvldGBaRMr0ETUHgR86zE6sPDVOHsqz4ISe9o1LuiWfgJk+2r75acFclA93J/lqzhT0dTjCzHuoA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.11.tgz",
+      "integrity": "sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -492,14 +492,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.9.tgz",
-      "integrity": "sha512-BpJyJe7Dkhv2kz7yG7bPSbJLQuu/rqyNlF1CfiiFeFwouegfH+zh13KDyt6+d9DwucKo7hqM3wKLLyJxZMO+Xg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.0.tgz",
+      "integrity": "sha512-z0a2fmgTSRN+YBuiK1ROfJ2Nvrpij5lVN3gPDkQGhavdvIVGHGW29LwYZfM/j42Ai2hUghTI/uoBuTbrJk42bA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -516,9 +516,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.4.tgz",
-      "integrity": "sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+      "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -648,13 +648,13 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.67.1.tgz",
-      "integrity": "sha512-inaJUlbwvFBNiT8ViXZ4O2m0ECiLPkkp0Ek1wNquxpWNHxgvfFDH/JTv5SXXwL5FXY+uym9hNcyjmHQB7RJExw==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.0.0-rc.0.tgz",
+      "integrity": "sha512-2N5DCFzuPt5rPXReE4T1boZrG60sr3dTMgZOS/WX+Rosc6iFj2v1ULTI2ySXk/Abd3oxS5OR24l8veIWEi0lzw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.26.2",
-        "@inquirer/prompts": "^7.3.1",
+        "@inquirer/prompts": "^7.4.0",
         "ajv": "~8.17.1",
         "change-case": "~5.4.4",
         "env-paths": "^3.0.0",
@@ -680,28 +680,28 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.67.1.tgz",
-      "integrity": "sha512-4pd/FEd+y72h2eUOlwGavK+nv3SDp7ZUJkGTcARyjLH5aSIAOl4uYW+WzQjGJylu/9t+xmoHy47siOvYBxONkQ==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.68.0.tgz",
+      "integrity": "sha512-U2y9K8QJ6HsmNxEyHz2aG2bmD05FIsLkmIZgmNaHDwhN1oyI8EH1NkxvwZCnEkPAN7ReuLYK6blouWFWX3s5eg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^0.67.1"
+        "@typespec/compiler": "^1.0.0-rc.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.67.1.tgz",
-      "integrity": "sha512-pkLFdKLA5ObCptUuwL8mhiy6EqVbqmtvHK89zqiTfYYGw2qm76+EUHaK0P/g2aAmjcwlrDGhJ0EhzbVp87H0mg==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.0.0-rc.0.tgz",
+      "integrity": "sha512-Or2hhDXy8DZZoy3B/HudSrRHTFomiv6DI3vRpPKYT9ocIAxMGo1hQvqKye8uVk/QIMn/ouv6JUlP+pqjpfnPyw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^0.67.1",
-        "@typespec/streams": "^0.67.1"
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/streams": "^0.68.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -710,81 +710,81 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.67.1.tgz",
-      "integrity": "sha512-9/122dHw6ZA+laqHM1mqa0CWxg0lBhEqdVX74YoAOlE+NR2wIpUwwC4WIVTvIllDIl6hwV+zVgILtbvD8W5+1A==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.0.0-rc.0.tgz",
+      "integrity": "sha512-aswkRlzFI44CGe05qkzInA7jEhUKNxZYToYi5kXz05Jl5d4nh4VeEkCweb2pRL+4LKd2SZiOn09nXm+OKp5EoQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^0.67.1",
-        "@typespec/http": "^0.67.1"
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/http": "^1.0.0-rc.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.67.1.tgz",
-      "integrity": "sha512-19IzFoaM0yFBSXpfrJgZEBVXtvEkMEprKc5B0kF4ylEPs32ShtZj05BXYrAkmMZbCsk0AC/VZdmVgcWP+AT6GQ==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.68.0.tgz",
+      "integrity": "sha512-VJBEpC0MCFPPN6acc5o0fwQm4WMjMEl3aBHE+71XYkagsqb31rYSyfgfBMvHWaEMJV4dVk5T787/q6AWDzEE8g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^0.67.1",
-        "@typespec/http": "^0.67.1"
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/http": "^1.0.0-rc.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.67.1.tgz",
-      "integrity": "sha512-Y7O002u89nM55hc81/wadMG0+gnj9hr0i4icqOxjP7auWsYDwMoK7arxC+qM7tyyFGMgv/F0ZxNJmc2Ajq7kpQ==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.68.0.tgz",
+      "integrity": "sha512-sePc+14iw8BZjBPwBaCL23y7lDWrUtmoYuPbfxJhRcIzbv2ww5d7mjvv5C2fjWyfRvG7tJ6wDk8YoHQJDoqtVA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^0.67.1",
-        "@typespec/events": "^0.67.1",
-        "@typespec/http": "^0.67.1",
-        "@typespec/streams": "^0.67.1"
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/events": "^0.68.0",
+        "@typespec/http": "^1.0.0-rc.0",
+        "@typespec/streams": "^0.68.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.67.1.tgz",
-      "integrity": "sha512-it+WNzurrk+TEzLvqlbCreyATmSR/g61/YX/k1D+B/QThPv8bh2S1sQqKtUMeThCu4/MHhZL9xTtdxWcLww+lg==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.68.0.tgz",
+      "integrity": "sha512-FsyPYOcPA6CDptdsAI0kiwR9tG6pngf5Bi4PiKTsXwseu93v5Y4keLNr4SR+bNQQK6uYIm0OkoK34Z6qn6uZEw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^0.67.1"
+        "@typespec/compiler": "^1.0.0-rc.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.67.1.tgz",
-      "integrity": "sha512-i1eZT8JlCthkRHJS3NH/nZTHUD7gJozP6pVy8wyHBx6TbnDOTfQ1P5YVlL2pF4ZdeRbGFhOKiUF/usEIOrkaVw==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.68.0.tgz",
+      "integrity": "sha512-nsK0hbOeqfsNo1dsP64A4Ks0C/FEk5WJ5LEfgTwvFGdE48mHrj7UJdp58Ps5F6moiR9U20P1rHbo+mE0LDIRvA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^0.67.1"
+        "@typespec/compiler": "^1.0.0-rc.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.67.1.tgz",
-      "integrity": "sha512-WDCxdtvlcUvD4AunpSje22Hb0BZzpluHATkx07/ru6HhdJsiwrc//IgGbV5eah9M6gK76sGXLicBLAFlxDfvDw==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.68.0.tgz",
+      "integrity": "sha512-uB904g9KMkuYKmGZnJsuozjPX+AKzZNStdXvMLq8+TkOitpJcb1dHtFH6KufG21xWuF0bmRUSkJvO4MOsuQNLA==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^0.67.1"
+        "@typespec/compiler": "^1.0.0-rc.0"
       }
     },
     "node_modules/ajv": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,22 +1,22 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-go": "0.4.1"
+    "@azure-tools/typespec-go": "0.4.2"
   },
   "devDependencies": {
-    "@azure-tools/typespec-autorest": "0.53.0",
-    "@azure-tools/typespec-azure-core": "0.53.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.53.0",
-    "@azure-tools/typespec-azure-rulesets": "0.53.0",
-    "@azure-tools/typespec-client-generator-core": "0.53.1",
-    "@typespec/compiler": "0.67.1",
-    "@typespec/http": "0.67.1",
-    "@typespec/openapi": "0.67.1",
-    "@typespec/rest": "0.67.1",
-    "@typespec/versioning": "0.67.1",
-    "@typespec/streams": "0.67.1",
-    "@typespec/events": "0.67.1",
-    "@typespec/sse": "0.67.1",
+    "@azure-tools/typespec-autorest": "0.54.0",
+    "@azure-tools/typespec-azure-core": "0.54.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.54.0",
+    "@azure-tools/typespec-azure-rulesets": "0.54.0",
+    "@azure-tools/typespec-client-generator-core": "0.54.0",
+    "@typespec/compiler": "1.0.0-rc.0",
+    "@typespec/http": "1.0.0-rc.0",
+    "@typespec/openapi": "1.0.0-rc.0",
+    "@typespec/rest": "0.68.0",
+    "@typespec/versioning": "0.68.0",
+    "@typespec/streams": "0.68.0",
+    "@typespec/events": "0.68.0",
+    "@typespec/sse": "0.68.0",
     "@azure-tools/typespec-liftr-base": "0.8.0"
   }
 }


### PR DESCRIPTION
- Upgrade emitter version: typespec-go(0.4.1 -> 0.4.2)
- Upgrade typespec@1.0.0-rc.0

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
