### PR TITLE
Fix AZIdentity Checks

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -161,7 +161,7 @@ extends:
                       - ".vscode/"
                   ${{ else }}:
                     Paths:
-                      - "sdk/${{ parameters.ServiceDirectory }}/*"
+                      - "sdk/${{ parameters.ServiceDirectory }}/"
                       - ".vscode/"
 
               - template: /eng/common/pipelines/templates/steps/check-spelling.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -161,7 +161,7 @@ extends:
                       - ".vscode/"
                   ${{ else }}:
                     Paths:
-                      - "sdk/${{ parameters.ServiceDirectory }}"
+                      - "sdk/${{ parameters.ServiceDirectory }}/*"
                       - ".vscode/"
 
               - template: /eng/common/pipelines/templates/steps/check-spelling.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -161,8 +161,9 @@ extends:
                       - ".vscode/"
                   ${{ else }}:
                     Paths:
-                      - "sdk/${{ parameters.ServiceDirectory }}/"
+                      - "sdk/${{ parameters.ServiceDirectory }}/**"
                       - ".vscode/"
+                      - "eng/**"
 
               - template: /eng/common/pipelines/templates/steps/check-spelling.yml
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -165,6 +165,10 @@ extends:
                       - ".vscode/"
                       - "eng/**"
 
+              - pwsh: |
+                  Get-ChildItem -R $(Build.SourcesDirectory) | % { Write-Host $_.FullName }
+                displayName: "Show the checked out files"
+
               - template: /eng/common/pipelines/templates/steps/check-spelling.yml
 
               - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -165,10 +165,6 @@ extends:
                       - ".vscode/"
                       - "eng/**"
 
-              - pwsh: |
-                  Get-ChildItem -R $(Build.SourcesDirectory) | % { Write-Host $_.FullName }
-                displayName: "Show the checked out files"
-
               - template: /eng/common/pipelines/templates/steps/check-spelling.yml
 
               - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -163,7 +163,7 @@ steps:
       $failed = $false
 
       foreach($serviceDirectory in $changedServices) {
-        $modDirs = ./eng/scripts/get_module_dirs.ps1 "$serviceDirectory"
+        $modDirs = & $(Build.SourcesDirectory)/eng/scripts/get_module_dirs.ps1 "$serviceDirectory"
         foreach ($md in $modDirs) {
           pushd $md
           Write-Host "##[command]Executing golangci-lint run -c $(System.DefaultWorkingDirectory)/eng/.golangci.yml in $md"
@@ -189,7 +189,7 @@ steps:
       $failed = $false
 
       foreach($serviceDirectory in $changedServices) {
-        $modDirs = ./eng/scripts/get_module_dirs.ps1 "$serviceDirectory"
+        $modDirs = & $(Build.SourcesDirectory)/eng/scripts/get_module_dirs.ps1 "$serviceDirectory"
         foreach ($md in $modDirs) {
           pushd $md
           Write-Host "##[command]Executing go get -u all in $md"
@@ -216,7 +216,7 @@ steps:
       $failed = $false
 
       foreach($serviceDirectory in $changedServices) {
-        $modDirs = ./eng/scripts/get_module_dirs.ps1 "$serviceDirectory"
+        $modDirs = & $(Build.SourcesDirectory)/eng/scripts/get_module_dirs.ps1 "$serviceDirectory"
         foreach ($md in $modDirs) {
           pushd $md
           Write-Host "##[command]Executing go mod tidy in $md"

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -311,13 +311,9 @@ steps:
 
   - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
 
-  - task: PowerShell@2
+  - pwsh: |
+      ./eng/scripts/Invoke-SmokeTests.ps1 "$(ChangedServices)"
     displayName: 'Run Nightly SmokeTests'
-    inputs:
-      targetType: 'filePath'
-      filePath: ./eng/scripts/Invoke-SmokeTests.ps1
-      pwsh: true
-      arguments: '$(ChangedServices)'
 
   # There are no more checks after this one, so simply removing all packageInfo that aren't shipping
   # to allow the default verify-changeslogs template to work correctly is probably better than any custom conditional code in that template.

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -139,16 +139,12 @@ steps:
       Get-ChildItem -R $(Build.SourcesDirectory) | % { Write-Host $_.FullName }
     displayName: "Show the visible files. Why can't we retrieve this?"
 
-  - task: Powershell@2
-    displayName: 'Dependency Check'
+  - pwsh: |
+      ./eng/scripts/Invoke-DependencyCheck.ps1 "$(Packages)"
+    displayName: Dependency Check
     condition: ne(variables['Skip.DependencyCheck'], 'true')
     env:
       GO111MODULE: 'on'
-    inputs:
-      targetType: filePath
-      pwsh: true
-      filePath: eng/scripts/Invoke-DependencyCheck.ps1
-      arguments: "$(Packages)"
 
   - script: |
       curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${{parameters.LintVersion}}

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -135,6 +135,10 @@ steps:
           not(endsWith(variables['Build.Repository.Name'], '-pr'))
         )
 
+  - pwsh: |
+      Get-ChildItem -R $(Build.SourcesDirectory) | % { Write-Host $_.FullName }
+    displayName: "Show the visible files. Why can't we retrieve this?"
+
   - task: Powershell@2
     displayName: 'Dependency Check'
     condition: ne(variables['Skip.DependencyCheck'], 'true')

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -92,7 +92,7 @@ steps:
       }
     displayName: "Detect Proxy eligibility"
 
-  - ${{ if and(eq(parameters.TestProxy, true) }}:
+  - ${{ if eq(parameters.TestProxy, true) }}:
     - template: /eng/common/testproxy/test-proxy-tool.yml
 
   # we do not need to change any conditional activation for this section, as it is only activated when

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -94,8 +94,6 @@ steps:
 
   - ${{ if and(eq(parameters.TestProxy, true) }}:
     - template: /eng/common/testproxy/test-proxy-tool.yml
-      parameters:
-        condition: eq(variables['ProxyRequired'], 'true')
 
   # we do not need to change any conditional activation for this section, as it is only activated when
   # invoking a livetest run, which will never be the case for PRs. Devs will /azp run go - <service>

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -82,8 +82,20 @@ steps:
     displayName: "Install Coverage and Junit Dependencies"
     retryCountOnTaskFailure: 3
 
-  - ${{ if eq(parameters.TestProxy, true) }}:
+  - pwsh:
+      $packageProps = Get-ChildItem -Recurse -Path "$(Build.ArtifactStagingDirectory)/PackageInfo" -Filter "*.json" `
+        | ForEach-Object { Get-Content -Raw -Path $_.FullName | ConvertFrom-Json }
+        | Where-Object { $_.CIParameters.UsePipelineProxy -eq $true }
+
+      if ($packageProps) {
+        Write-Host "##vso[task.setvariable variable=ProxyRequired]true"
+      }
+    displayName: "Detect Proxy eligibility"
+
+  - ${{ if and(eq(parameters.TestProxy, true) }}:
     - template: /eng/common/testproxy/test-proxy-tool.yml
+      parameters:
+        condition: eq(variables['ProxyRequired'], 'true')
 
   # we do not need to change any conditional activation for this section, as it is only activated when
   # invoking a livetest run, which will never be the case for PRs. Devs will /azp run go - <service>

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -154,6 +154,7 @@ function Get-AllPackageInfoFromRepo($filterString)
     $searchPaths = ResolveSearchPaths $filterString
 
     foreach ($searchPath in $searchPaths) {
+      Write-Host "Searching for go modules in $searchPath"
       $pkgFiles += @(Get-ChildItem (Join-Path $searchPath "go.mod"))
     }
   }

--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Release History
 
-## 1.8.3-beta.1 (Unreleased)
+## 1.9.0 (2025-04-08)
 
 ### Features Added
 * `GetToken()` sets `AccessToken.RefreshOn` when the token provider specifies a value
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 * `NewManagedIdentityCredential` logs the configured user-assigned identity, if any

--- a/sdk/azidentity/version.go
+++ b/sdk/azidentity/version.go
@@ -14,5 +14,5 @@ const (
 	module = "github.com/Azure/azure-sdk-for-go/sdk/" + component
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	version = "v1.8.3-beta.1"
+	version = "v1.9.0"
 )


### PR DESCRIPTION
1. Only run the proxy when a package that requires the test-proxy is detected (this is an issue in go - pullrequest because some do and some don't. we're going to need to run them separately)
2. update the sparse checkout, why don't we have the necessary eng scripts?

We're going to have to figure out how to handle when there is a proxy-disabled package among a bunch that are _enabled_. But what I'm more concerned about is fixing the issues with lint etc in `analyze` for `azidentity` itself.