### PR TITLE
Ensure that service directory builds don't build overaggressively

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -145,13 +145,16 @@ function ResolveSearchPaths {
 }
 
 
-function Get-AllPackageInfoFromRepo($filterString)
+# this parameter can be a straightforward filter string. However the eng/common passes -ServiceDirectory
+# specifically to the function. We have to meet that function signature if we want to see this value here.
+# This filter string can be a comma separated list of package paths OR the standard service directories.
+function Get-AllPackageInfoFromRepo($ServiceDirectory)
 {
   $allPackageProps = @()
   $pkgFiles = @()
 
-  if ($filterString) {
-    $searchPaths = ResolveSearchPaths $filterString
+  if ($ServiceDirectory) {
+    $searchPaths = ResolveSearchPaths $ServiceDirectory
 
     foreach ($searchPath in $searchPaths) {
       Write-Host "Searching for go modules in $searchPath"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -145,9 +145,12 @@ function ResolveSearchPaths {
 }
 
 
-# this parameter can be a straightforward filter string. However the eng/common passes -ServiceDirectory
-# specifically to the function. We have to meet that function signature if we want to see this value here.
-# This filter string can be a comma separated list of package paths OR the standard service directories.
+# This parameter can be a straightforward filter string EG "sdk/template/aztemplate,sdk/core/azcore".
+# However the Save-Package-Properties call for a service directory context EXPLICITLY passes -ServiceDirectory
+# when passing the string through to the function. Due to that, we can't name this the more appropraite "filterString"
+# We have to meet that function signature that is called from Get-AllPkgProperties in `Package-Properties.ps1`.
+# This $ServiceDirectory argument can actually be a comma separated list of package paths OR the standard service directories,
+# but until we make a change over in eng/common/scripts/Package-Properties.ps1 to support that, we will just pass the string named $ServiceDirectory
 function Get-AllPackageInfoFromRepo($ServiceDirectory)
 {
   $allPackageProps = @()
@@ -157,7 +160,6 @@ function Get-AllPackageInfoFromRepo($ServiceDirectory)
     $searchPaths = ResolveSearchPaths $ServiceDirectory
 
     foreach ($searchPath in $searchPaths) {
-      Write-Host "Searching for go modules in $searchPath"
       $pkgFiles += @(Get-ChildItem (Join-Path $searchPath "go.mod"))
     }
   }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -150,7 +150,8 @@ function ResolveSearchPaths {
 # when passing the string through to the function. Due to that, we can't name this the more appropraite "filterString"
 # We have to meet that function signature that is called from Get-AllPkgProperties in `Package-Properties.ps1`.
 # This $ServiceDirectory argument can actually be a comma separated list of package paths OR the standard service directories,
-# but until we make a change over in eng/common/scripts/Package-Properties.ps1 to support that, we will just pass the string named $ServiceDirectory
+# but until we make a change over in eng/common/scripts/Package-Properties.ps1 to support that, we will just use the name $ServiceDirectory
+# here.
 function Get-AllPackageInfoFromRepo($ServiceDirectory)
 {
   $allPackageProps = @()


### PR DESCRIPTION
I noticed this:
![image](https://github.com/user-attachments/assets/c434f275-084b-4655-9478-a34b636266b6)

The reason is because I renamed the function argument in `Get-AllPackageInfoFromRepo` in `go - pullrequest` from `$ServiceDirectory` to the more correct-to-usage `$filterString`.

That is incompatible with [this line](https://github.com/Azure/azure-sdk-for-go/blob/4dce954538e4e89f983a2bbc3c4af4a36d1fa594/eng/common/scripts/Package-Properties.ps1#L492) in `Package-Properties.ps1`. This PR accomodates that function signature requirement while I update the eng/common to just pass the $ServiceDirectory without naming the argument.

There is only a single place in the common implementation that we call this Language-Settings function, so this should be a straightforward eng/common update.
