### PR TITLE
If in CI, always allow `proxy` to start

### DIFF
--- a/sdk/internal/recording/server.go
+++ b/sdk/internal/recording/server.go
@@ -377,9 +377,13 @@ func waitForProxyStart(cmd *exec.Cmd, options *RecordingOptions) (*TestProxyInst
 	return nil, fmt.Errorf("test proxy server did not become available in the allotted time")
 }
 
+func inCI() bool {
+	return os.Getenv("TF_BUILD") != "" || os.Getenv("GITHUB_ACTIONS") != ""
+}
+
 func StartTestProxy(pathToRecordings string, options *RecordingOptions) (*TestProxyInstance, error) {
 	manualStart := strings.ToLower(os.Getenv(proxyManualStartEnv))
-	if manualStart == "true" {
+	if manualStart == "true" && !inCI() {
 		log.Printf("%s env variable is set to true, not starting test proxy...\n", proxyManualStartEnv)
 		return nil, nil
 	}


### PR DESCRIPTION
The failure  [here](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4721712&view=logs&j=61e427a2-922a-5e90-f757-655b788f203e&t=c9ee2177-f099-57dc-a461-780ae6f4ee65&s=6884a131-87da-5381-61f3-d7acc3b91d76) ISNT that identity has a specific config, it's just that it expects the proxy to be on the port that it assigns, and it's NOT because PROXY_MANUAL_START was set.