### PR TITLE
Prepare changelog and version file for release of the internal package

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.11.1-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.11.1
 
 ### Other Changes
+
+The recording framework now always starts a requested test-proxy instance when in CI even if PROXY_MANUAL_START is set to `true`.
 
 ## 1.11.0 (2025-04-01)
 

--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.11.1
+## 1.11.1 (2025-04-07)
 
 ### Other Changes
 

--- a/sdk/internal/version.go
+++ b/sdk/internal/version.go
@@ -9,5 +9,5 @@ package internal
 const (
 	// version is the semantic version (see http://semver.org) of this module.
 	//lint:ignore U1000 reason: "this constant is used by release automation"
-	version = "v1.11.1-beta.1"
+	version = "v1.11.1"
 )


### PR DESCRIPTION
We need to get the version from #24394 available so that `go - pullrequest` can stop crashing on every package that has `UsePipelineProxy` set to false.