### PR TITLE
[azcore] Cherry-pick tracing changes into v1.19.0-beta branch

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added type `Link` to the `tracing` package to support Span Links.
 * Added method `LinkFromContext()` to `tracing.Tracer` to support Span Links.
 * Added method `AddLink()` to `tracing.Span` to support Span Links.
+* Added field `Links` to `runtime.StartSpanOptions` to support Span Links.
 * Added type `Propagator` to the `tracing` package to support context propagation.
 * Added type `Carrier` to the `tracing` package to support context propagation.
 * Added method `NewPropagator()` to type `tracing.Provider` to support context propagation.
@@ -21,12 +22,13 @@
 
 ### Other Changes
 
+* Added Span Attribute `error.type` to report an error when ending a span with `runtime.StartSpan`.
+
 ## 1.18.0 (2025-04-03)
 
 ### Features Added
 
 * Added `AccessToken.RefreshOn` and updated `BearerTokenPolicy` to consider nonzero values of it when deciding whether to request a new token
-
 
 ## 1.17.1 (2025-03-20)
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Release History
 
-## 1.18.1-beta.1 (Unreleased)
+## 1.19.0-beta.1 (Unreleased)
 
 ### Features Added
+
+* Added field `NewPropagatorFn` to `tracing.ProviderOptions` to support custom propagators.
+* Added type `SpanContext` to the `tracing` package to support Span Context.
+* Added method `SpanContext()` to `tracing.Span` to support Span Context.
+* Added func `NewSpanContext()` to the `tracing` package to support Span Context.
+* Added type `Link` to the `tracing` package to support Span Links.
+* Added method `LinkFromContext()` to `tracing.Tracer` to support Span Links.
+* Added method `AddLink()` to `tracing.Span` to support Span Links.
+* Added type `Propagator` to the `tracing` package to support context propagation.
+* Added type `Carrier` to the `tracing` package to support context propagation.
+* Added method `NewPropagator()` to type `tracing.Provider` to support context propagation.
 
 ### Breaking Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Bugs Fixed
 
+* Removed hardcoded `azcore` replacement in the error type for `runtime.StartSpan()`.
+
 ### Other Changes
 
 * Added Span Attribute `error.type` to report an error when ending a span with `runtime.StartSpan`.

--- a/sdk/azcore/runtime/policy_http_trace.go
+++ b/sdk/azcore/runtime/policy_http_trace.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
@@ -148,7 +147,7 @@ func StartSpan(ctx context.Context, name string, tracer tracing.Tracer, options 
 	ctx = context.WithValue(ctx, ctxActiveSpan{}, options.Kind)
 	return ctx, func(err error) {
 		if err != nil {
-			errType := strings.Replace(fmt.Sprintf("%T", err), "*exported.", "*azcore.", 1)
+			errType := fmt.Sprintf("%T", err)
 			span.SetAttributes(tracing.Attribute{Key: attrErrType, Value: errType})
 			span.SetStatus(tracing.SpanStatusError, fmt.Sprintf("%s:\n%s", errType, err.Error()))
 		}

--- a/sdk/azcore/runtime/policy_http_trace_test.go
+++ b/sdk/azcore/runtime/policy_http_trace_test.go
@@ -179,9 +179,9 @@ func TestStartSpan(t *testing.T) {
 	}
 	end(exported.NewResponseError(resp))
 	require.EqualValues(t, tracing.SpanStatusError, spanStatus)
-	require.Contains(t, errStr, "*azcore.ResponseError")
+	require.Contains(t, errStr, "*exported.ResponseError")
 	require.Contains(t, errStr, "ERROR CODE: ErrorItFailed")
-	require.Contains(t, spanAttrs, tracing.Attribute{Key: attrErrType, Value: "*azcore.ResponseError"})
+	require.Contains(t, spanAttrs, tracing.Attribute{Key: attrErrType, Value: "*exported.ResponseError"})
 }
 
 func TestStartSpansDontNest(t *testing.T) {

--- a/sdk/azcore/tracing/tracing.go
+++ b/sdk/azcore/tracing/tracing.go
@@ -13,22 +13,29 @@ import (
 
 // ProviderOptions contains the optional values when creating a Provider.
 type ProviderOptions struct {
-	// for future expansion
+	// NewPropagatorFn contains the underlying implementation for creating Propagator instances.
+	// If not set, a no-op propagator will be used.
+	NewPropagatorFn func() Propagator
 }
 
 // NewProvider creates a new Provider with the specified values.
 //   - newTracerFn is the underlying implementation for creating Tracer instances
 //   - options contains optional values; pass nil to accept the default value
 func NewProvider(newTracerFn func(name, version string) Tracer, options *ProviderOptions) Provider {
+	if options == nil {
+		options = &ProviderOptions{}
+	}
 	return Provider{
-		newTracerFn: newTracerFn,
+		newTracerFn:     newTracerFn,
+		newPropagatorFn: options.NewPropagatorFn,
 	}
 }
 
-// Provider is the factory that creates Tracer instances.
+// Provider is the factory that creates Tracer and Propagator instances.
 // It defaults to a no-op provider.
 type Provider struct {
-	newTracerFn func(name, version string) Tracer
+	newTracerFn     func(name, version string) Tracer
+	newPropagatorFn func() Propagator
 }
 
 // NewTracer creates a new Tracer for the specified module name and version.
@@ -41,12 +48,22 @@ func (p Provider) NewTracer(module, version string) (tracer Tracer) {
 	return
 }
 
+// NewPropagator creates a new Propagator.
+func (p Provider) NewPropagator() Propagator {
+	if p.newPropagatorFn != nil {
+		return p.newPropagatorFn()
+	}
+	return Propagator{}
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // TracerOptions contains the optional values when creating a Tracer.
 type TracerOptions struct {
 	// SpanFromContext contains the implementation for the Tracer.SpanFromContext method.
 	SpanFromContext func(context.Context) Span
+	// LinkFromContext contains the implementation for the Tracer.LinkFromContext method.
+	LinkFromContext func(context.Context, ...Attribute) Link
 }
 
 // NewTracer creates a Tracer with the specified values.
@@ -59,14 +76,17 @@ func NewTracer(newSpanFn func(ctx context.Context, spanName string, options *Spa
 	return Tracer{
 		newSpanFn:         newSpanFn,
 		spanFromContextFn: options.SpanFromContext,
+		linkFromContextFn: options.LinkFromContext,
 	}
 }
 
 // Tracer is the factory that creates Span instances.
 type Tracer struct {
 	attrs             []Attribute
+	links             []Link
 	newSpanFn         func(ctx context.Context, spanName string, options *SpanOptions) (context.Context, Span)
 	spanFromContextFn func(ctx context.Context) Span
+	linkFromContextFn func(ctx context.Context, attrs ...Attribute) Link
 }
 
 // Start creates a new span and a context.Context that contains it.
@@ -80,6 +100,7 @@ func (t Tracer) Start(ctx context.Context, spanName string, options *SpanOptions
 			opts = *options
 		}
 		opts.Attributes = append(opts.Attributes, t.attrs...)
+		opts.Links = append(opts.Links, t.links...)
 		return t.newSpanFn(ctx, spanName, &opts)
 	}
 	return ctx, Span{}
@@ -106,6 +127,16 @@ func (t Tracer) SpanFromContext(ctx context.Context) Span {
 	return Span{}
 }
 
+// LinkFromContext returns a link encapsulating the SpanContext of the current context.
+// The provided attributes are added to the link.
+// If the provided context has no Span, an empty Link is returned.
+func (t Tracer) LinkFromContext(ctx context.Context, attrs ...Attribute) Link {
+	if t.linkFromContextFn != nil {
+		return t.linkFromContextFn(ctx, attrs...)
+	}
+	return Link{}
+}
+
 // SpanOptions contains optional settings for creating a span.
 type SpanOptions struct {
 	// Kind indicates the kind of Span.
@@ -113,6 +144,9 @@ type SpanOptions struct {
 
 	// Attributes contains key-value pairs of attributes for the span.
 	Attributes []Attribute
+
+	// Links contains the links to other spans.
+	Links []Link
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -129,6 +163,12 @@ type SpanImpl struct {
 
 	// AddEvent contains the implementation for the Span.AddEvent method.
 	AddEvent func(string, ...Attribute)
+
+	// AddLink contains the implementation for the Span.AddLink method.
+	AddLink func(Link)
+
+	// SpanContext returns the SpanContext of the Span.
+	SpanContext func() SpanContext
 
 	// SetStatus contains the implementation for the Span.SetStatus method.
 	SetStatus func(SpanStatus, string)
@@ -170,6 +210,21 @@ func (s Span) AddEvent(name string, attrs ...Attribute) {
 	}
 }
 
+// AddLink adds a link to the span.
+func (s Span) AddLink(link Link) {
+	if s.impl.AddLink != nil {
+		s.impl.AddLink(link)
+	}
+}
+
+// SpanContext returns the SpanContext of the Span.
+func (s Span) SpanContext() SpanContext {
+	if s.impl.SpanContext != nil {
+		return s.impl.SpanContext()
+	}
+	return SpanContext{}
+}
+
 // SetStatus sets the status on the span along with a description.
 func (s Span) SetStatus(code SpanStatus, desc string) {
 	if s.impl.SetStatus != nil {
@@ -188,4 +243,185 @@ type Attribute struct {
 	// Types that are natively supported include int64, float64, int, bool, string.
 	// Any other type will be formatted per rules of fmt.Sprintf("%v").
 	Value any
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Link is the relationship between two Spans.
+type Link struct {
+	// SpanContext of the linked Span.
+	SpanContext SpanContext
+
+	// Attributes describe the aspects of the link.
+	Attributes []Attribute
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// SpanID is a unique identity of a span in a trace.
+type SpanID [8]byte
+
+// TraceID is a unique identity of a trace.
+type TraceID [16]byte
+
+// TraceFlags contains flags that can be set on a SpanContext.
+type TraceFlags byte
+
+// TraceState provides additional vendor-specific trace identification information across different distributed tracing systems.
+type TraceState string
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// SpanContext contains identifying trace information about a Span.
+type SpanContext struct {
+	spanID     SpanID
+	traceID    TraceID
+	traceFlags TraceFlags
+	traceState TraceState
+	remote     bool
+}
+
+// SpanID returns the SpanID from the SpanContext.
+func (sc SpanContext) SpanID() SpanID {
+	return sc.spanID
+}
+
+// TraceID returns the TraceID from the SpanContext.
+func (sc SpanContext) TraceID() TraceID {
+	return sc.traceID
+}
+
+// TraceFlags returns the flags from the SpanContext.
+func (sc SpanContext) TraceFlags() TraceFlags {
+	return sc.traceFlags
+}
+
+// TraceState returns the TraceState from the SpanContext.
+func (sc SpanContext) TraceState() TraceState {
+	return sc.traceState
+}
+
+// IsRemote indicates whether the SpanContext represents a remotely-created Span.
+func (sc SpanContext) IsRemote() bool {
+	return sc.remote
+}
+
+// SpanContextConfig contains mutable fields usable for constructing an immutable SpanContext.
+type SpanContextConfig struct {
+	TraceID    TraceID
+	SpanID     SpanID
+	TraceFlags TraceFlags
+	TraceState TraceState
+	Remote     bool
+}
+
+// NewSpanContext constructs a SpanContext using values from the provided SpanContextConfig.
+func NewSpanContext(config SpanContextConfig) SpanContext {
+	return SpanContext{
+		traceID:    config.TraceID,
+		spanID:     config.SpanID,
+		traceFlags: config.TraceFlags,
+		traceState: config.TraceState,
+		remote:     config.Remote,
+	}
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// PropagatorImpl contains the implementation for the Propagator.
+type PropagatorImpl struct {
+	// Inject contains the implementation for the Propagator.Inject method.
+	Inject func(ctx context.Context, carrier Carrier)
+
+	// Extract contains the implementation for the Propagator.Extract method.
+	Extract func(ctx context.Context, carrier Carrier) context.Context
+
+	// Fields contains the implementation for the Propagator.Fields method.
+	Fields func() []string
+}
+
+// NewPropagator creates a Propagator with the specified implementation.
+func NewPropagator(impl PropagatorImpl) Propagator {
+	return Propagator{
+		impl: impl,
+	}
+}
+
+// Propagator is used to extract and inject context data from and into messages exchanged by applications.
+type Propagator struct {
+	impl PropagatorImpl
+}
+
+// Inject injects the span context into the carrier.
+func (p Propagator) Inject(ctx context.Context, carrier Carrier) {
+	if p.impl.Inject != nil {
+		p.impl.Inject(ctx, carrier)
+	}
+}
+
+// Extract extracts the span context from the carrier.
+func (p Propagator) Extract(ctx context.Context, carrier Carrier) context.Context {
+	if p.impl.Extract != nil {
+		return p.impl.Extract(ctx, carrier)
+	}
+	return ctx
+}
+
+// Fields returns the fields that the propagator can inject and extract.
+func (p Propagator) Fields() []string {
+	if p.impl.Fields != nil {
+		return p.impl.Fields()
+	}
+	return nil
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// CarrierImpl abstracts the underlying implementation for Carrier,
+// allowing it to work with various tracing implementations.
+// Any zero-values will have their default, no-op behavior.
+type CarrierImpl struct {
+	// Get contains the implementation for the Carrier.Get method.
+	Get func(key string) string
+
+	// Set contains the implementation for the Carrier.Set method.
+	Set func(key string, value string)
+
+	// Keys contains the implementation for the Carrier.Keys method.
+	Keys func() []string
+}
+
+// NewCarrier creates a Carrier with the specified implementation.
+func NewCarrier(impl CarrierImpl) Carrier {
+	return Carrier{
+		impl: impl,
+	}
+}
+
+// Carrier is the storage medium used by the Propagator.
+type Carrier struct {
+	impl CarrierImpl
+}
+
+// Get returns the value associated with the passed key.
+func (c Carrier) Get(key string) string {
+	if c.impl.Get != nil {
+		return c.impl.Get(key)
+	}
+	return ""
+}
+
+// Set stores the key-value pair.
+func (c Carrier) Set(key string, value string) {
+	if c.impl.Set != nil {
+		c.impl.Set(key, value)
+	}
+}
+
+// Keys lists the keys stored in this carrier.
+func (c Carrier) Keys() []string {
+	if c.impl.Keys != nil {
+		return c.impl.Keys()
+	}
+	return nil
 }

--- a/sdk/azcore/tracing/tracing_test.go
+++ b/sdk/azcore/tracing/tracing_test.go
@@ -28,19 +28,39 @@ func TestProviderZeroValues(t *testing.T) {
 	sp.SetStatus(SpanStatusError, "boom")
 	spCtx := tr.SpanFromContext(ctx)
 	require.Zero(t, spCtx)
+	link := tr.LinkFromContext(ctx)
+	require.Zero(t, link)
+	pp := pr.NewPropagator()
+	pp.Inject(context.Background(), Carrier{})
+	pp.Extract(context.Background(), Carrier{})
+	require.Zero(t, pp.Fields())
 }
 
 func TestProvider(t *testing.T) {
 	var addEventCalled bool
+	var addLinkCalled bool
+	var spanContextCalled bool
 	var endCalled bool
 	var setAttributesCalled bool
 	var setStatusCalled bool
 	var spanFromContextCalled bool
+	var linkFromContextCalled bool
+	var injectCalled bool
+	var extractCalled bool
+	var fieldsCalled bool
 
 	pr := NewProvider(func(name, version string) Tracer {
 		return NewTracer(func(context.Context, string, *SpanOptions) (context.Context, Span) {
 			return nil, NewSpan(SpanImpl{
-				AddEvent:      func(string, ...Attribute) { addEventCalled = true },
+				AddEvent: func(string, ...Attribute) { addEventCalled = true },
+				AddLink:  func(link Link) { addLinkCalled = true },
+				SpanContext: func() SpanContext {
+					spanContextCalled = true
+					return NewSpanContext(SpanContextConfig{
+						TraceState: "key1=val1,key2=val2",
+						Remote:     true,
+					})
+				},
 				End:           func() { endCalled = true },
 				SetAttributes: func(...Attribute) { setAttributesCalled = true },
 				SetStatus:     func(SpanStatus, string) { setStatusCalled = true },
@@ -50,13 +70,37 @@ func TestProvider(t *testing.T) {
 				spanFromContextCalled = true
 				return Span{}
 			},
+			LinkFromContext: func(ctx context.Context, attribute ...Attribute) Link {
+				linkFromContextCalled = true
+				return Link{}
+			},
 		})
-	}, nil)
+	}, &ProviderOptions{
+		NewPropagatorFn: func() Propagator {
+			return NewPropagator(PropagatorImpl{
+				Inject: func(ctx context.Context, cr Carrier) {
+					injectCalled = true
+					cr.Set("injected", "true")
+				},
+				Extract: func(ctx context.Context, cr Carrier) context.Context {
+					extractCalled = true
+					require.EqualValues(t, "true", cr.Get("injected"))
+					return context.Background()
+				},
+				Fields: func() []string {
+					fieldsCalled = true
+					return nil
+				},
+			})
+		},
+	})
 	tr := pr.NewTracer("name", "version")
 	require.NotZero(t, tr)
 	require.True(t, tr.Enabled())
 	sp := tr.SpanFromContext(context.Background())
 	require.Zero(t, sp)
+	lk := tr.LinkFromContext(context.Background())
+	require.Zero(t, lk)
 	tr.SetAttributes(Attribute{Key: "some", Value: "attribute"})
 	require.Len(t, tr.attrs, 1)
 	require.EqualValues(t, tr.attrs[0].Key, "some")
@@ -67,12 +111,64 @@ func TestProvider(t *testing.T) {
 	require.NotZero(t, sp)
 
 	sp.AddEvent("event")
+
+	sp.AddLink(Link{})
+	sc := sp.SpanContext()
+	require.NotNil(t, sc)
+	require.Zero(t, sc.TraceID())
+	require.Zero(t, sc.SpanID())
+	require.Zero(t, sc.TraceFlags())
+	require.NotZero(t, sc.TraceState())
+	require.EqualValues(t, "key1=val1,key2=val2", sc.TraceState())
+	require.True(t, sc.IsRemote())
+
 	sp.End()
 	sp.SetAttributes()
 	sp.SetStatus(SpanStatusError, "desc")
 	require.True(t, addEventCalled)
+	require.True(t, addLinkCalled)
+	require.True(t, spanContextCalled)
 	require.True(t, endCalled)
 	require.True(t, setAttributesCalled)
 	require.True(t, setStatusCalled)
 	require.True(t, spanFromContextCalled)
+	require.True(t, linkFromContextCalled)
+
+	tc := testCarrier{inner: map[string]string{}}
+	cr := NewCarrier(CarrierImpl{
+		Get:  tc.Get,
+		Set:  tc.Set,
+		Keys: tc.Keys,
+	})
+	pp := pr.NewPropagator()
+	pp.Inject(context.Background(), cr)
+	pp.Extract(context.Background(), cr)
+	require.Zero(t, pp.Fields())
+	require.EqualValues(t, 1, len(cr.Keys()))
+	require.True(t, injectCalled)
+	require.True(t, extractCalled)
+	require.True(t, fieldsCalled)
+}
+
+type testCarrier struct {
+	inner map[string]string
+}
+
+func (tc testCarrier) Get(key string) string {
+	if v, ok := tc.inner[key]; ok {
+		return v
+	}
+	return ""
+}
+
+func (tc testCarrier) Set(key string, value string) {
+	tc.inner[key] = value
+}
+
+func (tc testCarrier) Keys() []string {
+	keys := make([]string, 0, len(tc.inner))
+	for k := range tc.inner {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
Cherry-pick tracing changes into v1.19.0-beta branch

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
