### PR TITLE
[azservicebus] Adding tracing.StartSpanOptions to amqpLink.Retry()

### DIFF
--- a/sdk/messaging/azservicebus/go.mod
+++ b/sdk/messaging/azservicebus/go.mod
@@ -7,7 +7,7 @@ retract v1.1.2 // Breaks customers in situations where close is slow/infinite.
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1-0.20250408001805-0ffd48d3672e
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1-0.20250407225617-9ad800486946
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1-0.20250408173140-a42592db08e0
 	github.com/Azure/go-amqp v1.4.0
 )
 

--- a/sdk/messaging/azservicebus/go.sum
+++ b/sdk/messaging/azservicebus/go.sum
@@ -4,8 +4,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2 h1:F0gBpfdPLGsw+nsgk6aqq
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2/go.mod h1:SqINnQ9lVVdRlyC8cd1lCI0SdX4n2paeABd2K8ggfnE=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+8ez6T3HWXPmwOK7Yvq8QxDBD3SKY=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1-0.20250407225617-9ad800486946 h1:m0/WpWQ59Byol9xC/SadCYRIII3Wj6vtx3ZflbtrMEg=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1-0.20250407225617-9ad800486946/go.mod h1:rocFjQi6FS6alaanTgyrku75M2XnpPRSoW+P48TV8c4=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1-0.20250408173140-a42592db08e0 h1:dxN8OAGs6i5m+xLZBwsDBx7D2dMdJFgqBTuaCS0KrCU=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1-0.20250408173140-a42592db08e0/go.mod h1:rocFjQi6FS6alaanTgyrku75M2XnpPRSoW+P48TV8c4=
 github.com/Azure/go-amqp v1.4.0 h1:Xj3caqi4comOF/L1Uc5iuBxR/pB6KumejC01YQOqOR4=
 github.com/Azure/go-amqp v1.4.0/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -11,6 +11,7 @@ import (
 	azlog "github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/amqpwrap"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/tracing"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/utils"
 	"github.com/Azure/go-amqp"
 )
@@ -198,7 +199,7 @@ func (l *FakeAMQPLinks) Get(ctx context.Context) (*LinksWithID, error) {
 	}
 }
 
-func (l *FakeAMQPLinks) Retry(ctx context.Context, eventName log.Event, operation string, fn RetryWithLinksFn, o exported.RetryOptions) error {
+func (l *FakeAMQPLinks) Retry(ctx context.Context, eventName log.Event, operation string, fn RetryWithLinksFn, o exported.RetryOptions, to *tracing.StartSpanOptions) error {
 	lwr, err := l.Get(ctx)
 
 	if err != nil {

--- a/sdk/messaging/azservicebus/internal/amqplinks_unit_test.go
+++ b/sdk/messaging/azservicebus/internal/amqplinks_unit_test.go
@@ -80,7 +80,7 @@ func TestAMQPLinksRetriesUnit(t *testing.T) {
 				return testData.Err
 			}, exported.RetryOptions{
 				RetryDelay: time.Millisecond,
-			})
+			}, nil)
 
 			require.Equal(t, testData.Err, err)
 			require.Equal(t, testData.Attempts, attempts)
@@ -222,7 +222,7 @@ func TestAMQPCloseLinkTimeout_Receiver_CancellationDuringClose(t *testing.T) {
 	err := links.Retry(userCtx, exported.EventConn, "Test", func(ctx context.Context, tmpLWID *LinksWithID, args *utils.RetryFnArgs) error {
 		lwid = tmpLWID
 		return nil
-	}, exported.RetryOptions{})
+	}, exported.RetryOptions{}, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, lwid)
@@ -241,7 +241,7 @@ func TestAMQPCloseLinkTimeout_Receiver_CancellationDuringClose(t *testing.T) {
 	err = links.Retry(context.Background(), exported.EventConn, "Test", func(ctx context.Context, tmpLWID *LinksWithID, args *utils.RetryFnArgs) error {
 		lwid = tmpLWID
 		return nil
-	}, exported.RetryOptions{})
+	}, exported.RetryOptions{}, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, lwid)
@@ -280,7 +280,7 @@ func TestAMQPCloseLinkTimeout_Receiver_RecoverIfNeeded(t *testing.T) {
 	err := links.Retry(userCtx, exported.EventConn, "Test", func(ctx context.Context, tmpLWID *LinksWithID, args *utils.RetryFnArgs) error {
 		lwid = tmpLWID
 		return nil
-	}, exported.RetryOptions{})
+	}, exported.RetryOptions{}, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, lwid)

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -3,5 +3,8 @@
 
 package internal
 
+// ModuleName is the module name for the SDK
+const ModuleName = "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+
 // Version is the semantic version number
 const Version = "v1.9.0-beta.1"

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -442,7 +442,7 @@ func (ns *Namespace) startNegotiateClaimRenewer(ctx context.Context,
 
 						expiresOn = tmpExpiresOn
 						return nil
-					}, IsFatalSBError, ns.RetryOptions)
+					}, IsFatalSBError, ns.RetryOptions, nil)
 
 					if err == nil {
 						break

--- a/sdk/messaging/azservicebus/internal/utils/retrier.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/tracing"
 )
 
 // EventRetry is the name for retry events
@@ -37,7 +38,9 @@ func (rf *RetryFnArgs) ResetAttempts() {
 
 // Retry runs a standard retry loop. It executes your passed in fn as the body of the loop.
 // It returns if it exceeds the number of configured retry options or if 'isFatal' returns true.
-func Retry(ctx context.Context, eventName log.Event, operation string, fn func(ctx context.Context, args *RetryFnArgs) error, isFatalFn func(err error) bool, o exported.RetryOptions) error {
+func Retry(ctx context.Context, eventName log.Event, operation string,
+	fn func(ctx context.Context, args *RetryFnArgs) error, isFatalFn func(err error) bool,
+	o exported.RetryOptions, to *tracing.StartSpanOptions) (err error) {
 	if isFatalFn == nil {
 		panic("isFatalFn is nil, errors would panic")
 	}
@@ -45,7 +48,8 @@ func Retry(ctx context.Context, eventName log.Event, operation string, fn func(c
 	var ro exported.RetryOptions = o
 	setDefaults(&ro)
 
-	var err error
+	ctx, endSpan := tracing.StartSpan(ctx, to)
+	defer func() { endSpan(err) }()
 
 	for i := int32(0); i <= ro.MaxRetries; i++ {
 		if i > 0 {

--- a/sdk/messaging/azservicebus/internal/utils/retrier_test.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier_test.go
@@ -13,8 +13,10 @@ import (
 	"time"
 
 	azlog "github.com/Azure/azure-sdk-for-go/sdk/internal/log"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/test/tracingvalidator"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/test"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/tracing"
 	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +34,20 @@ func TestRetrier(t *testing.T) {
 			return nil
 		}, func(err error) bool {
 			panic("won't get called")
-		}, exported.RetryOptions{})
+		}, exported.RetryOptions{}, &tracing.StartSpanOptions{
+			Tracer: tracing.NewTracer(tracingvalidator.NewSpanValidator(t, tracingvalidator.SpanMatcher{
+				Name:   "notused queue",
+				Kind:   tracing.SpanKindInternal,
+				Status: tracing.SpanStatusUnset,
+				Attributes: []tracing.Attribute{
+					{Key: tracing.AttrMessagingSystem, Value: "servicebus"},
+					{Key: tracing.AttrServerAddress, Value: "fake.something"},
+					{Key: tracing.AttrDestinationName, Value: "queue"},
+					{Key: tracing.AttrOperationName, Value: "notused"},
+				}}, nil),
+				"module", "version", "fake.something", "queue", ""),
+			OperationName: "notused",
+		})
 
 		require.Nil(t, err)
 		require.EqualValues(t, 1, called)
@@ -60,7 +75,20 @@ func TestRetrier(t *testing.T) {
 			}
 
 			return fmt.Errorf("Error, iteration %d", args.I)
-		}, isFatalFn, fastRetryOptions)
+		}, isFatalFn, fastRetryOptions, &tracing.StartSpanOptions{
+			Tracer: tracing.NewTracer(tracingvalidator.NewSpanValidator(t, tracingvalidator.SpanMatcher{
+				Name:   "notused queue",
+				Kind:   tracing.SpanKindInternal,
+				Status: tracing.SpanStatusUnset,
+				Attributes: []tracing.Attribute{
+					{Key: tracing.AttrMessagingSystem, Value: "servicebus"},
+					{Key: tracing.AttrServerAddress, Value: "fake.something"},
+					{Key: tracing.AttrDestinationName, Value: "queue"},
+					{Key: tracing.AttrOperationName, Value: "notused"},
+				}}, nil),
+				"module", "version", "fake.something", "queue", ""),
+			OperationName: "notused",
+		})
 
 		require.EqualValues(t, 4, called)
 		require.EqualValues(t, 3, isFatalCalled)
@@ -81,7 +109,21 @@ func TestRetrier(t *testing.T) {
 		err := Retry(ctx, testLogEvent, "notused", func(ctx context.Context, args *RetryFnArgs) error {
 			called++
 			return errors.New("isFatalFn says this is a fatal error")
-		}, isFatalFn, exported.RetryOptions{})
+		}, isFatalFn, exported.RetryOptions{}, &tracing.StartSpanOptions{
+			Tracer: tracing.NewTracer(tracingvalidator.NewSpanValidator(t, tracingvalidator.SpanMatcher{
+				Name:   "notused queue",
+				Kind:   tracing.SpanKindInternal,
+				Status: tracing.SpanStatusError,
+				Attributes: []tracing.Attribute{
+					{Key: tracing.AttrMessagingSystem, Value: "servicebus"},
+					{Key: tracing.AttrServerAddress, Value: "fake.something"},
+					{Key: tracing.AttrDestinationName, Value: "queue"},
+					{Key: tracing.AttrOperationName, Value: "notused"},
+					{Key: tracing.AttrErrorType, Value: "*errors.errorString"},
+				}}, nil),
+				"module", "version", "fake.something", "queue", ""),
+			OperationName: "notused",
+		})
 
 		require.EqualValues(t, "isFatalFn says this is a fatal error", err.Error())
 		require.EqualValues(t, 1, called)
@@ -108,7 +150,7 @@ func TestRetrier(t *testing.T) {
 			MaxRetries:    maxRetries,
 			RetryDelay:    time.Millisecond,
 			MaxRetryDelay: time.Millisecond,
-		})
+		}, nil)
 
 		expectedAttempts := []int32{
 			0, 1, 2, // we resetted attempts here.
@@ -132,7 +174,7 @@ func TestRetrier(t *testing.T) {
 		err := Retry(context.Background(), testLogEvent, "notused", func(ctx context.Context, args *RetryFnArgs) error {
 			called++
 			return errors.New("whatever")
-		}, isFatalFn, customRetryOptions)
+		}, isFatalFn, customRetryOptions, nil)
 
 		require.EqualValues(t, 1, called)
 		require.EqualValues(t, "whatever", err.Error())
@@ -154,7 +196,7 @@ func TestCancellationCancelsSleep(t *testing.T) {
 		return errors.New("try again")
 	}, isFatalFn, exported.RetryOptions{
 		RetryDelay: time.Hour,
-	})
+	}, nil)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)
@@ -182,7 +224,7 @@ func TestCancellationFromUserFunc(t *testing.T) {
 		default:
 			panic("Context should have been cancelled")
 		}
-	}, isFatalFn, exported.RetryOptions{})
+	}, isFatalFn, exported.RetryOptions{}, nil)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, canceledfromFunc)
@@ -203,7 +245,7 @@ func TestCancellationTimeoutsArentPropagatedToUser(t *testing.T) {
 		return tryAgainErr
 	}, isFatalFn, exported.RetryOptions{
 		RetryDelay: time.Millisecond,
-	})
+	}, nil)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, tryAgainErr, "error should be propagated from user callback")
@@ -298,7 +340,7 @@ func TestRetryLogging(t *testing.T) {
 			return false
 		}, exported.RetryOptions{
 			RetryDelay: time.Microsecond,
-		})
+		}, nil)
 		require.EqualError(t, err, "hello")
 
 		require.Equal(t, []string{
@@ -329,7 +371,7 @@ func TestRetryLogging(t *testing.T) {
 			return false
 		}, exported.RetryOptions{
 			RetryDelay: time.Microsecond,
-		})
+		}, nil)
 		require.EqualError(t, err, "hello")
 	})
 
@@ -344,7 +386,7 @@ func TestRetryLogging(t *testing.T) {
 			return errors.Is(err, context.Canceled)
 		}, exported.RetryOptions{
 			RetryDelay: time.Microsecond,
-		})
+		}, nil)
 		require.ErrorIs(t, err, context.Canceled)
 
 		require.Equal(t, []string{
@@ -364,7 +406,7 @@ func TestRetryLogging(t *testing.T) {
 			return true
 		}, exported.RetryOptions{
 			RetryDelay: time.Microsecond,
-		})
+		}, nil)
 		require.EqualError(t, err, "custom fatal error")
 
 		require.Equal(t, []string{
@@ -398,7 +440,7 @@ func TestRetryLogging(t *testing.T) {
 			return errors.Is(err, &de)
 		}, exported.RetryOptions{
 			RetryDelay: time.Microsecond,
-		})
+		}, nil)
 		require.Nil(t, err)
 
 		require.Equal(t, []string{

--- a/sdk/messaging/azservicebus/messageSettler.go
+++ b/sdk/messaging/azservicebus/messageSettler.go
@@ -42,7 +42,7 @@ func (s *messageSettler) settleWithRetries(ctx context.Context, settleFn func(re
 		}
 
 		return nil
-	}, RetryOptions{})
+	}, RetryOptions{}, nil)
 
 	return internal.TransformError(err)
 }

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -234,7 +234,7 @@ func (r *Receiver) ReceiveDeferredMessages(ctx context.Context, sequenceNumbers 
 		}
 
 		return nil
-	}, r.retryOptions)
+	}, r.retryOptions, nil)
 
 	return receivedMessages, internal.TransformError(err)
 }
@@ -288,7 +288,7 @@ func (r *Receiver) PeekMessages(ctx context.Context, maxMessageCount int, option
 		}
 
 		return nil
-	}, r.retryOptions)
+	}, r.retryOptions, nil)
 
 	return receivedMessages, internal.TransformError(err)
 }
@@ -312,7 +312,7 @@ func (r *Receiver) RenewMessageLock(ctx context.Context, msg *ReceivedMessage, o
 
 		msg.LockedUntil = &newExpirationTime[0]
 		return nil
-	}, r.retryOptions)
+	}, r.retryOptions, nil)
 
 	return internal.TransformError(err)
 }
@@ -377,7 +377,7 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 	err := r.amqpLinks.Retry(ctx, EventReceiver, "receiveMessages.getlinks", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		linksWithID = lwid
 		return nil
-	}, r.retryOptions)
+	}, r.retryOptions, nil)
 
 	if err != nil {
 		return nil, err

--- a/sdk/messaging/azservicebus/session_receiver.go
+++ b/sdk/messaging/azservicebus/session_receiver.go
@@ -228,7 +228,7 @@ func (sr *SessionReceiver) GetSessionState(ctx context.Context, options *GetSess
 
 		sessionState = s
 		return nil
-	}, sr.inner.retryOptions)
+	}, sr.inner.retryOptions, nil)
 
 	return sessionState, internal.TransformError(err)
 }
@@ -244,7 +244,7 @@ type SetSessionStateOptions struct {
 func (sr *SessionReceiver) SetSessionState(ctx context.Context, state []byte, options *SetSessionStateOptions) error {
 	err := sr.inner.amqpLinks.Retry(ctx, EventReceiver, "SetSessionState", func(ctx context.Context, lwv *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		return internal.SetSessionState(ctx, lwv.RPC, lwv.Receiver.LinkName(), sr.SessionID(), state)
-	}, sr.inner.retryOptions)
+	}, sr.inner.retryOptions, nil)
 
 	return internal.TransformError(err)
 }
@@ -267,7 +267,7 @@ func (sr *SessionReceiver) RenewSessionLock(ctx context.Context, options *RenewS
 
 		sr.lockedUntil = newLockedUntil
 		return nil
-	}, sr.inner.retryOptions)
+	}, sr.inner.retryOptions, nil)
 
 	return internal.TransformError(err)
 }


### PR DESCRIPTION
Adding `tracing.StartSpanOptions` to `amqpLink.Retry()` and make span start calls in the retry layer. In this PR this is a no-op because we haven't enable tracer in the layers above.

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
