### PR TITLE
Fix azcontainerregistry live test authentication

### DIFF
--- a/sdk/containers/azcontainerregistry/CHANGELOG.md
+++ b/sdk/containers/azcontainerregistry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.3 (2025-04-09)
+## 0.2.3 (2025-04-15)
 
 ### Other Changes
 * Default audience of Azure Container Registry of all clouds to https://containerregistry.azure.net

--- a/sdk/containers/azcontainerregistry/CHANGELOG.md
+++ b/sdk/containers/azcontainerregistry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.3 (2025-04-08)
+## 0.2.3 (2025-04-09)
 
 ### Other Changes
 * Default audience of Azure Container Registry of all clouds to https://containerregistry.azure.net

--- a/sdk/containers/azcontainerregistry/test-resources-pre.ps1
+++ b/sdk/containers/azcontainerregistry/test-resources-pre.ps1
@@ -20,6 +20,9 @@ param (
     [ValidateNotNullOrEmpty()]
     [string] $Environment,
 
+    [Parameter()]
+    [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
+
     # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
     [Parameter(ValueFromRemainingArguments = $true)]
     $RemainingArguments
@@ -27,3 +30,11 @@ param (
 
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+
+if ($CI) {
+    az cloud set -n $Environment
+    az login --federated-token $env:ARM_OIDC_TOKEN --service-principal -t $TenantId -u $TestApplicationId
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+    az account set --subscription $SubscriptionId
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+}

--- a/sdk/containers/azcontainerregistry/utils_test.go
+++ b/sdk/containers/azcontainerregistry/utils_test.go
@@ -157,7 +157,7 @@ func buildImage(t *testing.T) (string, string) {
 				cmd := exec.CommandContext(ctx, "az", "acr", "build", "-r", testConfig.registryName, "--image", repository, "--build-arg", "ID="+repository, ".")
 				cmd.Dir = "testdata"
 				out, err = cmd.CombinedOutput()
-				if err == nil {
+				if err == nil || strings.Contains(string(out), "az login") {
 					return
 				}
 			}


### PR DESCRIPTION
It appears making post-deploy scripts "self-contained" (https://github.com/Azure/azure-sdk-tools/pull/10099) made this pipeline's script ineffective in that its `az login` no longer applies during the test run (this module is unique in using the CLI during live test runs). The quick fix here is to move the login step to a pre-deployment script; deployment is too fast for this to cause problems. I kept the no-op post script because `PersistOidcToken: true`, which we need to log in to the CLI in either a pre- or post-script, makes a post-deploy script mandatory.

@benbp I imagine there's a better way to address this but finding one isn't urgent because only this module needs a logged-in CLI to run live tests