### PR TITLE
Revert "If in CI, always allow `proxy` to start"

### DIFF
--- a/sdk/internal/recording/server.go
+++ b/sdk/internal/recording/server.go
@@ -377,13 +377,9 @@ func waitForProxyStart(cmd *exec.Cmd, options *RecordingOptions) (*TestProxyInst
 	return nil, fmt.Errorf("test proxy server did not become available in the allotted time")
 }
 
-func inCI() bool {
-	return os.Getenv("TF_BUILD") != "" || os.Getenv("GITHUB_ACTIONS") != ""
-}
-
 func StartTestProxy(pathToRecordings string, options *RecordingOptions) (*TestProxyInstance, error) {
 	manualStart := strings.ToLower(os.Getenv(proxyManualStartEnv))
-	if manualStart == "true" && !inCI() {
+	if manualStart == "true" {
 		log.Printf("%s env variable is set to true, not starting test proxy...\n", proxyManualStartEnv)
 		return nil, nil
 	}


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-go#24394

I don't believe this is doing what we want it to. We should still key off PROXY_MANUAL_START to control this. See https://dev.azure.com/azure-sdk/public/_build/results?buildId=4721712&view=logs&j=61e427a2-922a-5e90-f757-655b788f203e&t=c9ee2177-f099-57dc-a461-780ae6f4ee65&s=6884a131-87da-5381-61f3-d7acc3b91d76

I think the thing missing is setting PROXY_PORT (https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/ai/azopenaiextensions/client_shared_test.go#L218C20-L218C30) which I'm going to try and do in another change.