### PR TITLE
Set default test proxy port for test runs in CI

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -84,6 +84,10 @@ steps:
 
   - ${{ if eq(parameters.TestProxy, true) }}:
     - template: /eng/common/testproxy/test-proxy-tool.yml
+    - pwsh:
+        Write-Host "set PROXY_PORT=5000"
+        Write-Host "##vso[task.setvariable variable=PROXY_PORT]5000"
+      displayName: Set test-proxy to default port
 
   # we do not need to change any conditional activation for this section, as it is only activated when
   # invoking a livetest run, which will never be the case for PRs. Devs will /azp run go - <service>

--- a/sdk/security/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/security/keyvault/azsecrets/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
-* Upgraded to API service version `7.6-preview.2` - Test change to be undone.
+* Upgraded to API service version `7.6-preview.2` - Test change to be undone
 
 ## 1.3.1 (2025-02-13)
 

--- a/sdk/security/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/security/keyvault/azsecrets/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
-* Upgraded to API service version `7.6-preview.2`
+* Upgraded to API service version `7.6-preview.2` - Test change to be undone.
 
 ## 1.3.1 (2025-02-13)
 


### PR DESCRIPTION
Another attempt to fix https://github.com/Azure/azure-sdk-for-go/pull/24394 that is being reverted in https://github.com/Azure/azure-sdk-for-go/pull/24425

If we are manually enabling test-proxy we should set the proxy port to the default of 5000, so that the test running picks that up https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/ai/azopenaiextensions/client_shared_test.go#L218C20-L218C30

