### PR TITLE
WorkloadIdentityCredential enhancement for AKS FIC limit

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+* enhanced support for AKS workloads
 
 ## 1.9.0 (2025-04-08)
 


### PR DESCRIPTION
This is the client part of a workaround for the per-application federated credentials limit. The feature is conceptually simple: instead of sending token requests to Entra ID, the client sends them to an endpoint specified by AKS, which also provides TLS configuration for that endpoint. The implementation is a little complex though, because AKS may provide configuration in a file whose content it may change.