### PR TITLE
[Cosmos] some tidy up to Cosmos query engine API

### DIFF
--- a/sdk/data/azcosmos/internal/mock_query_engine.go
+++ b/sdk/data/azcosmos/internal/mock_query_engine.go
@@ -195,7 +195,7 @@ func (m *MockQueryPipeline) Run() (*queryengine.PipelineResult, error) {
 	}
 
 	return &queryengine.PipelineResult{
-		IsCompleted: false,
+		IsCompleted: m.completed,
 		Items:       items,
 		Requests:    requests,
 	}, nil

--- a/sdk/data/azcosmos/unstable/queryengine/cosmos_query_engine.go
+++ b/sdk/data/azcosmos/unstable/queryengine/cosmos_query_engine.go
@@ -56,9 +56,8 @@ type QueryPipeline interface {
 	Query() string
 	// IsComplete gets a boolean indicating if the pipeline has concluded
 	IsComplete() bool
-	// NextBatch gets the next batch of items, which will be empty if there are no more items in the buffer, and the next set of QueryRequests which must be fulfilled, which will be empty if there are no more requests.
-	// If both the items and requests are empty, the pipeline has concluded.
-	NextBatch() ([][]byte, []QueryRequest, error)
+	// Run executes a single turn of the pipeline, yielding a PipelineResult containing the items and requests for more data.
+	Run() (*PipelineResult, error)
 	// ProvideData provides more data for a given partition key range ID, using data retrieved from the server in response to making a DataRequest.
 	ProvideData(data QueryResult) error
 	// Close frees the resources associated with the pipeline.


### PR DESCRIPTION
This PR has some small tidy-ups to the preview Query Engine API:

* I had introduced a `PipelineResult` type to combine "Items" and "Requests", but wasn't actually using it. This PR fixes that.
* I renamed `NextBatch` to `Run` to align with some changes happening in the query engine