### PR TITLE
[azquery] allow API version override

### DIFF
--- a/sdk/monitor/azquery/CHANGELOG.md
+++ b/sdk/monitor/azquery/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0-beta.2 (Unreleased)
 
 ### Features Added
+* Added API Version support for `MetricsClient`. Users can now change the default API Version by setting `MetricsClientOptions.APIVersion`.
 
 ### Breaking Changes
 

--- a/sdk/monitor/azquery/custom_client.go
+++ b/sdk/monitor/azquery/custom_client.go
@@ -72,7 +72,14 @@ func NewMetricsClient(credential azcore.TokenCredential, options *MetricsClientO
 	}
 
 	authPolicy := runtime.NewBearerTokenPolicy(credential, []string{c.Audience + "/.default"}, nil)
-	azcoreClient, err := azcore.NewClient(moduleName, version, runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}, &options.ClientOptions)
+	pipelineOptions := runtime.PipelineOptions{
+		APIVersion: runtime.APIVersionOptions{
+			Location: runtime.APIVersionLocationQueryParam,
+			Name:     "api-version",
+		},
+		PerRetry: []policy.Policy{authPolicy},
+	}
+	azcoreClient, err := azcore.NewClient(moduleName, version, pipelineOptions, &options.ClientOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
closes https://github.com/Azure/azure-sdk-for-go/issues/24460

Allows customers to override the API version for metrics clients.