### PR TITLE
Fix dump of `aztemplate.json`

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -21,12 +21,12 @@ function Get-GoModuleVersionInfo($modPath)
 
     # finding where the version number are
     if ($content -match $VERSION_LINE_REGEX) {
-        return "$($matches["version"])", $versionFile
+      return "$($matches["version"])", $versionFile.ToString()
     }
 
     # This is an easy mistake to make (X.Y.Z instead of vX.Y.Z) so add a very clear error log to make debugging easier
     if ($content -match $NO_PREFIX_VERSION_LINE_REGEX) {
-        LogError "Version in $versionFile should be 'v$($matches["bad_version"])' not '$($matches["bad_version"])'"
+      LogError "Version in $versionFile should be 'v$($matches["bad_version"])' not '$($matches["bad_version"])'"
     }
   }
 


### PR DESCRIPTION
I'm resolving a failure that looks like [this](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4796434&view=logs&jobId=76992fd1-2312-5fae-7c45-7baba86b87ae&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=d34cfe88-f3e1-5ca1-ec50-18a5cea1099a).

The issue is that during serialization of the `aztemplate.json` file to disk, we serialize _everything_ in the object. The issue isn't that the actual `PackageProps` details are infinitely looped, it's that the `VersionFile` is a pwsh `FileInfo` object with a TON of nested metadata. To me it almost feels like the FileInfo obj has a self-referential loop somewhere, and that's why we're just endlessly expanding into memory. This DID occur locally in my go integration tests for `Get-PrPkgProperties`. By changing this `VersionFile` to be a string, we resolve the issue with this super deep object.

What I still don't understand is why this started occurring _now_, versus any time before. This `VersionFile` attribute population hasn't changed with the `go - pullrequest` addition.

Proved out in [this draft PR](https://github.com/Azure/azure-sdk-for-go/pull/24510/checks)
[Also works with `azcore`](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4797026&view=results)