### PR TITLE
[Storage][Azblob] Add support for request intent for File->Blob Copy 

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.1-beta.2 (Unreleased)
 
 ### Features Added
+* Add support for x-ms-file-request-intent header for blob copy APIs.
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -489,6 +489,66 @@ func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlockFromURL() {
 	_require.Equal(destBuffer, sourceData)
 }
 
+func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlockFromURWithLRequestIntentHeader() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	contentSize := 4 * 1024 // 4KB
+	r, sourceData := testcommon.GetDataAndReader(testName, contentSize)
+	contentMD5 := md5.Sum(sourceData)
+	srcBlob := containerClient.NewAppendBlobClient(testcommon.GenerateBlobName("appendsrc"))
+	destBlob := containerClient.NewAppendBlobClient(testcommon.GenerateBlobName("appenddest"))
+
+	// Prepare source abClient for copy.
+	_, err = srcBlob.Create(context.Background(), nil)
+	_require.NoError(err)
+
+	_, err = srcBlob.AppendBlock(context.Background(), streaming.NopCloser(r), nil)
+	_require.NoError(err)
+
+	// Get source abClient URL with SAS for AppendBlockFromURL.
+	srcBlobParts, _ := blob.ParseURL(srcBlob.URL())
+
+	keyCredential, err := testcommon.GetGenericSharedKeyCredential(testcommon.TestAccountDefault)
+	_require.NoError(err)
+	perms := sas.BlobPermissions{Read: true}
+
+	srcBlobParts.SAS, err = sas.BlobSignatureValues{
+		Protocol:      sas.ProtocolHTTPS,                    // Users MUST use HTTPS (not HTTP)
+		ExpiryTime:    time.Now().UTC().Add(48 * time.Hour), // 48-hours before expiration
+		ContainerName: srcBlobParts.ContainerName,
+		BlobName:      srcBlobParts.BlobName,
+		Permissions:   perms.String(),
+	}.SignWithSharedKey(keyCredential)
+	_require.NoError(err)
+
+	srcBlobURLWithSAS := srcBlobParts.String()
+
+	// Append block from URL.
+	_, err = destBlob.Create(context.Background(), nil)
+	_require.NoError(err)
+	requestIntent := blob.FileShareTokenIntentBackup
+	appendFromURLResp, err := destBlob.AppendBlockFromURL(context.Background(), srcBlobURLWithSAS, &appendblob.AppendBlockFromURLOptions{
+		SourceContentValidation: blob.SourceContentValidationTypeMD5(contentMD5[:]),
+		FileRequestIntent:       &requestIntent,
+	})
+
+	_require.NoError(err)
+	_require.Equal(*appendFromURLResp.BlobAppendOffset, "0")
+
+	// Check data integrity through downloading.
+	destBuffer := make([]byte, 4*1024)
+	downloadBufferOptions := blob.DownloadBufferOptions{Range: blob.HTTPRange{Offset: 0, Count: 4096}}
+	_, err = destBlob.DownloadBuffer(context.Background(), destBuffer, &downloadBufferOptions)
+	_require.NoError(err)
+	_require.Equal(destBuffer, sourceData)
+}
+
 func (s *AppendBlobUnrecordedTestsSuite) TestBlobEncryptionScopeSAS() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/appendblob/models.go
+++ b/sdk/storage/azblob/appendblob/models.go
@@ -112,6 +112,8 @@ type AppendBlockFromURLOptions struct {
 
 	CPKScopeInfo *blob.CPKScopeInfo
 
+	FileRequestIntent *blob.FileShareTokenIntent
+
 	SourceModifiedAccessConditions *blob.SourceModifiedAccessConditions
 
 	AccessConditions *blob.AccessConditions
@@ -130,6 +132,7 @@ func (o *AppendBlockFromURLOptions) format() (*generated.AppendBlobClientAppendB
 	options := &generated.AppendBlobClientAppendBlockFromURLOptions{
 		SourceRange:             exported.FormatHTTPRange(o.Range),
 		CopySourceAuthorization: o.CopySourceAuthorization,
+		FileRequestIntent:       o.FileRequestIntent,
 	}
 
 	if o.SourceContentValidation != nil {

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -267,6 +267,60 @@ func (s *BlobUnrecordedTestsSuite) TestCopyBlobFromUrlSourceContentMD5() {
 	_require.Error(err)
 }
 
+func (s *BlobUnrecordedTestsSuite) TestCopyBlobFromUrlOptions() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	if err != nil {
+		s.Fail("Unable to fetch service client because " + err.Error())
+	}
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	const contentSize = 8 * 1024 // 8 KB
+	content := make([]byte, contentSize)
+	body := bytes.NewReader(content)
+
+	srcBlob := containerClient.NewBlockBlobClient("srcblob")
+	destBlob := containerClient.NewBlockBlobClient("destblob")
+
+	// Prepare source bbClient for copy.
+	_, err = srcBlob.Upload(context.Background(), streaming.NopCloser(body), nil)
+	_require.NoError(err)
+
+	expiryTime, err := time.Parse(time.UnixDate, "Fri Jun 11 20:00:00 UTC 2049")
+	_require.NoError(err)
+
+	credential, err := testcommon.GetGenericSharedKeyCredential(testcommon.TestAccountDefault)
+	if err != nil {
+		s.T().Fatal("Couldn't fetch credential because " + err.Error())
+	}
+
+	// Get source blob url with SAS for StageFromURL.
+	sasQueryParams, err := sas.AccountSignatureValues{
+		Protocol:      sas.ProtocolHTTPS,
+		ExpiryTime:    expiryTime,
+		Permissions:   to.Ptr(sas.AccountPermissions{Read: true, List: true}).String(),
+		ResourceTypes: to.Ptr(sas.AccountResourceTypes{Container: true, Object: true}).String(),
+	}.SignWithSharedKey(credential)
+	_require.NoError(err)
+
+	srcBlobParts, _ := blob.ParseURL(srcBlob.URL())
+	srcBlobParts.SAS = sasQueryParams
+	srcBlobURLWithSAS := srcBlobParts.String()
+
+	requestIntent := blob.FileShareTokenIntentBackup
+
+	// Invoke CopyFromURL.
+	resp, err := destBlob.CopyFromURL(context.Background(), srcBlobURLWithSAS, &blob.CopyFromURLOptions{
+		FileRequestIntent: &requestIntent,
+	})
+	_require.NoError(err)
+	_require.NotNil(resp)
+}
+
 // This test simulates DownloadFile/Buffer methods,
 // and verifies length and content of file
 func (s *BlobUnrecordedTestsSuite) TestUploadDownloadBlockBlob() {

--- a/sdk/storage/azblob/blob/constants.go
+++ b/sdk/storage/azblob/blob/constants.go
@@ -233,3 +233,17 @@ func (s SourceContentValidationTypeMD5) Apply(src generated.SourceContentSetter)
 func (SourceContentValidationTypeMD5) notPubliclyImplementable() {}
 
 var _ SourceContentValidationType = (SourceContentValidationTypeMD5)(nil)
+
+// FileShareTokenIntent is file request intent with  valid value as Backup
+type FileShareTokenIntent = generated.FileShareTokenIntent
+
+const (
+	FileShareTokenIntentBackup FileShareTokenIntent = "backup"
+)
+
+// PossibleFileShareTokenIntentValues returns the possible values for the FileShareTokenIntent const type.
+func PossibleFileShareTokenIntentValues() []FileShareTokenIntent {
+	return []FileShareTokenIntent{
+		FileShareTokenIntentBackup,
+	}
+}

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -523,6 +523,8 @@ type CopyFromURLOptions struct {
 	BlobTags map[string]string
 	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
 	CopySourceAuthorization *string
+	// File request Intent. Valid value is backup.
+	FileRequestIntent *FileShareTokenIntent
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
 	// Specifies the immutability policy mode to set on the blob.
@@ -558,6 +560,7 @@ func (o *CopyFromURLOptions) format() (*generated.BlobClientCopyFromURLOptions, 
 		CopySourceAuthorization:  o.CopySourceAuthorization,
 		ImmutabilityPolicyExpiry: o.ImmutabilityPolicyExpiry,
 		ImmutabilityPolicyMode:   o.ImmutabilityPolicyMode,
+		FileRequestIntent:        o.FileRequestIntent,
 		LegalHold:                o.LegalHold,
 		Metadata:                 o.Metadata,
 		SourceContentMD5:         o.SourceContentMD5,

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -565,6 +565,62 @@ func (s *BlockBlobUnrecordedTestsSuite) TestStageBlockFromURLWithCRC64() {
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.CRC64Mismatch)
 }
 
+func (s *BlockBlobUnrecordedTestsSuite) TestStageBlockFromURLWithRequestIntent() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	contentSize := 4 * 1024 // 4 KB
+	r, _ := testcommon.GetDataAndReader(testName, contentSize)
+	rsc := streaming.NopCloser(r)
+
+	srcBlob := containerClient.NewBlockBlobClient("src" + testcommon.GenerateBlobName(testName))
+	destBlob := containerClient.NewBlockBlobClient("dst" + testcommon.GenerateBlobName(testName))
+
+	// Prepare source bbClient for copy.
+	_, err = srcBlob.Upload(context.Background(), rsc, nil)
+	_require.NoError(err)
+
+	// Get source blob url with SAS for StageFromURL.
+	srcBlobParts, _ := blob.ParseURL(srcBlob.URL())
+	sharedKeyCredential, err := testcommon.GetGenericSharedKeyCredential(testcommon.TestAccountDefault)
+	_require.NoError(err)
+	perms := sas.BlobPermissions{Read: true}
+
+	srcBlobParts.SAS, err = sas.BlobSignatureValues{
+		Protocol:      sas.ProtocolHTTPS,                    // Users MUST use HTTPS (not HTTP)
+		ExpiryTime:    time.Now().UTC().Add(48 * time.Hour), // 48-hours before expiration
+		ContainerName: srcBlobParts.ContainerName,
+		BlobName:      srcBlobParts.BlobName,
+		Permissions:   perms.String(),
+	}.SignWithSharedKey(sharedKeyCredential)
+	_require.NoError(err)
+
+	srcBlobURLWithSAS := srcBlobParts.String()
+
+	// Stage blocks from URL.
+	blockIDs := testcommon.GenerateBlockIDsList(2)
+	requestIntent := blob.FileShareTokenIntentBackup
+
+	opts := blockblob.StageBlockFromURLOptions{
+		FileRequestIntent: &requestIntent,
+	}
+
+	stageResponse, err := destBlob.StageBlockFromURL(context.Background(), blockIDs[0], srcBlobURLWithSAS, &opts)
+	_require.NoError(err)
+	_require.NotNil(stageResponse)
+
+	// Check block list.
+	blockList, err := destBlob.GetBlockList(context.Background(), blockblob.BlockListTypeAll, nil)
+	_require.NoError(err)
+	_require.NotNil(blockList.BlockList)
+	_require.Nil(blockList.BlockList.CommittedBlocks)
+}
+
 //
 //	func (s *BlockBlobUnrecordedTestsSuite) TestCopyBlockBlobFromURL() {
 //		_require := require.New(s.T())
@@ -1178,6 +1234,33 @@ func (s *BlockBlobUnrecordedTestsSuite) TestPutBlobFromURLWithHeaders() {
 	tagcount := int64(len(testcommon.BasicBlobTagsMap))
 	_require.EqualValues(resp.TagCount, &tagcount)
 	_require.EqualValues(resp.Metadata, testcommon.BasicMetadata)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestPutBlobFromURLWithIntent() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	requestIntent := blob.FileShareTokenIntentBackup
+
+	containerClient, _, destBlob, srcBlobURLWithSAS, _ := setUpPutBlobFromURLTest(testName, _require, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	options := blockblob.UploadBlobFromURLOptions{
+		Tags:              testcommon.BasicBlobTagsMap,
+		HTTPHeaders:       &testcommon.BasicHeaders,
+		Metadata:          testcommon.BasicMetadata,
+		FileRequestIntent: &requestIntent,
+	}
+
+	pbResp, err := destBlob.UploadBlobFromURL(context.Background(), srcBlobURLWithSAS, &options)
+	_require.NotNil(pbResp)
+	_require.NoError(err)
+
+	// Check dest and source properties
+	_, err = destBlob.GetProperties(context.Background(), nil)
+	_require.NoError(err)
 }
 
 func (s *BlockBlobUnrecordedTestsSuite) TestPutBlobFromUrlWithCPK() {

--- a/sdk/storage/azblob/blockblob/models.go
+++ b/sdk/storage/azblob/blockblob/models.go
@@ -82,6 +82,9 @@ type UploadBlobFromURLOptions struct {
 	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
 	CopySourceAuthorization *string
 
+	// Valid value is backup
+	FileRequestIntent *blob.FileShareTokenIntent
+
 	// Optional, default is true. Indicates if properties from the source blob should be copied.
 	CopySourceBlobProperties *bool
 
@@ -115,6 +118,7 @@ func (o *UploadBlobFromURLOptions) format() (*generated.BlockBlobClientPutBlobFr
 	options := generated.BlockBlobClientPutBlobFromURLOptions{
 		BlobTagsString:           shared.SerializeBlobTagsToStrPtr(o.Tags),
 		CopySourceAuthorization:  o.CopySourceAuthorization,
+		FileRequestIntent:        o.FileRequestIntent,
 		CopySourceBlobProperties: o.CopySourceBlobProperties,
 		CopySourceTags:           o.CopySourceTags,
 		Metadata:                 o.Metadata,
@@ -164,6 +168,9 @@ type StageBlockFromURLOptions struct {
 	// SourceContentValidation contains the validation mechanism used on the range of bytes read from the source.
 	SourceContentValidation blob.SourceContentValidationType
 
+	// File request Intent. Valid value is backup.
+	FileRequestIntent *blob.FileShareTokenIntent
+
 	// Range specifies a range of bytes.  The default value is all bytes.
 	Range blob.HTTPRange
 
@@ -180,6 +187,7 @@ func (o *StageBlockFromURLOptions) format() (*generated.BlockBlobClientStageBloc
 	options := &generated.BlockBlobClientStageBlockFromURLOptions{
 		CopySourceAuthorization: o.CopySourceAuthorization,
 		SourceRange:             exported.FormatHTTPRange(o.Range),
+		FileRequestIntent:       o.FileRequestIntent,
 	}
 
 	if o.SourceContentValidation != nil {

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -517,6 +517,61 @@ func (s *PageBlobUnrecordedTestsSuite) TestUploadPagesFromURLWithCRC64Negative()
 	_require.Error(err) // TODO: UploadPagesFromURL should fail, but is currently not working due to service issue.
 }
 
+func (s *PageBlobUnrecordedTestsSuite) TestUploadPagesFromURLWithRequestIntentHeader() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	contentSize := 4 * 1024 * 1024 // 4MB
+	r, sourceData := testcommon.GetDataAndReader(testName, contentSize)
+	srcBlob := createNewPageBlobWithSize(context.Background(), _require, "srcblob"+testName, containerClient, int64(contentSize))
+	destBlob := createNewPageBlobWithSize(context.Background(), _require, "dstblob"+testName, containerClient, int64(contentSize))
+
+	// Prepare source pbClient for copy.
+	offset, _, count := int64(0), int64(contentSize-1), int64(contentSize)
+	requestIntent := blob.FileShareTokenIntentBackup
+
+	_, err = srcBlob.UploadPages(context.Background(), streaming.NopCloser(r), blob.HTTPRange{Offset: offset, Count: count}, nil)
+	_require.NoError(err)
+
+	// Get source pbClient URL with SAS for UploadPagesFromURL.
+	keyCredential, err := testcommon.GetGenericSharedKeyCredential(testcommon.TestAccountDefault)
+	_require.NoError(err)
+
+	srcBlobParts, _ := blob.ParseURL(srcBlob.URL())
+
+	srcBlobParts.SAS, err = sas.BlobSignatureValues{
+		Protocol:      sas.ProtocolHTTPS,                      // Users MUST use HTTPS (not HTTP)
+		ExpiryTime:    time.Now().UTC().Add(15 * time.Minute), // 15 minutes before expiration
+		ContainerName: srcBlobParts.ContainerName,
+		BlobName:      srcBlobParts.BlobName,
+		Permissions:   to.Ptr(sas.BlobPermissions{Read: true}).String(),
+	}.SignWithSharedKey(keyCredential)
+	_require.NoError(err)
+
+	srcBlobURLWithSAS := srcBlobParts.String()
+
+	// Upload page from URL with MD5.
+	uploadPagesFromURLOptions := pageblob.UploadPagesFromURLOptions{
+		FileRequestIntent: &requestIntent,
+	}
+	pResp1, err := destBlob.UploadPagesFromURL(context.Background(), srcBlobURLWithSAS, 0, 0, int64(contentSize), &uploadPagesFromURLOptions)
+	_require.NoError(err)
+	_require.NotNil(pResp1)
+
+	// Download blob.
+	downloadResp, err := destBlob.DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+	destData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.EqualValues(destData, sourceData)
+}
+
 func (s *PageBlobUnrecordedTestsSuite) TestClearDiffPages() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/pageblob/models.go
+++ b/sdk/storage/azblob/pageblob/models.go
@@ -120,6 +120,8 @@ type UploadPagesFromURLOptions struct {
 
 	CPKScopeInfo *blob.CPKScopeInfo
 
+	FileRequestIntent *blob.FileShareTokenIntent
+
 	SequenceNumberAccessConditions *SequenceNumberAccessConditions
 
 	SourceModifiedAccessConditions *blob.SourceModifiedAccessConditions
@@ -135,6 +137,7 @@ func (o *UploadPagesFromURLOptions) format() (*generated.PageBlobClientUploadPag
 
 	options := &generated.PageBlobClientUploadPagesFromURLOptions{
 		CopySourceAuthorization: o.CopySourceAuthorization,
+		FileRequestIntent:       o.FileRequestIntent,
 	}
 
 	if o.SourceContentValidation != nil {

--- a/sdk/storage/azblob/sas/service.go
+++ b/sdk/storage/azblob/sas/service.go
@@ -210,6 +210,8 @@ func (v BlobSignatureValues) SignWithUserDelegation(userDelegationCredential *Us
 		v.AuthorizedObjectID,
 		v.UnauthorizedObjectID,
 		v.CorrelationID,
+		"", // Placeholder for SignedKeyDelegatedUserTenantId (future field)
+		"", // Placeholder for SignedDelegatedUserObjectId (future field)
 		v.IPRange.String(),
 		string(v.Protocol),
 		v.Version,

--- a/sdk/storage/azdatalake/sas/service.go
+++ b/sdk/storage/azdatalake/sas/service.go
@@ -195,6 +195,8 @@ func (v DatalakeSignatureValues) SignWithUserDelegation(userDelegationCredential
 		v.AuthorizedObjectID,
 		v.UnauthorizedObjectID,
 		v.CorrelationID,
+		"", // Placeholder for SignedKeyDelegatedUserTenantId (future field)
+		"", // Placeholder for SignedDelegatedUserObjectId (future field)
 		v.IPRange.String(),
 		string(v.Protocol),
 		v.Version,


### PR DESCRIPTION
Apart from support for request intent for File->Blob Copy, this PR also contains changes about user delegation sas where newlines were added.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
