### PR TITLE
Cosmos changelog update for 1.4.0 release

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.4.0 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.4.0 (2025-04-29)
 
 ### Other Changes
 


### PR DESCRIPTION
This just updates the Cosmos Changelog to mark 1.4.0 as released. After merging this, we'll make the actual release.