### PR TITLE
upgrade emitter version

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-go": "0.4.7"
+        "@azure-tools/typespec-go": "0.4.8"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.56.0",
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-go": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.4.7.tgz",
-      "integrity": "sha512-T60rDT0S73O9huVqjFrf9QCMJ1WDOhB7X1Ax5NPpr2FLaYcgqzlOgPl30ICjAtSRTHmVIPADvcFX7S2ir7R9Sg==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.4.8.tgz",
+      "integrity": "sha512-Ws7yABqxmb0s2UIkrIPkB3c3bRswduMh7oh8vfgu8G6HBTLYnL4Z3Fi4MHc67dxQDNlg9aufYHIa4wTe5Gd0sQ==",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/codegen": "^2.10.0",

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,7 +1,7 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-go": "0.4.7"
+    "@azure-tools/typespec-go": "0.4.8"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.56.0",


### PR DESCRIPTION
upgrade to typepspec-go@0.4.8

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
