### PR TITLE
upgrade_emitter_version

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-go": "0.4.9"
+        "@azure-tools/typespec-go": "0.4.10"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.56.0",
@@ -38,14 +38,14 @@
       }
     },
     "node_modules/@azure-tools/codegen": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/codegen/-/codegen-2.10.0.tgz",
-      "integrity": "sha512-gdy0at3BUZAAARgiX9Ye6SNCKhcjLs5FNUewa/KV/dMGcPv7mBvbslt5VO3W8wj0n96ifk970aIFaivjacBxeQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/codegen/-/codegen-2.10.1.tgz",
+      "integrity": "sha512-fZfREKjQnBTscjObgK4LuyZNFaofoCNQDNz0jl1i8fYNwCM5EOF9BXwtEtobuEyCpPUNDxQ/KKO65eWzirqk4w==",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/async-io": "~3.0.0",
         "js-yaml": "~4.1.0",
-        "semver": "^7.3.5"
+        "semver": "^7.7.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-go": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.4.9.tgz",
-      "integrity": "sha512-DyzIVvznG2WBFRzjMkwOHmIk/L9jzxTAbLlhOtcyFKFAOZF9Rh5g497sAeGKI9E9HdZ2GQOx0HBZ36+1okgAkg==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.4.10.tgz",
+      "integrity": "sha512-dzX43fH/tFLbpzIGOFMz9Ma7gcFSrHnlIFW64d0ZuUFGJCPfxibN7UfZJKXuUrx2jlrZr/oHQLUeJJncgdcSJQ==",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/codegen": "^2.10.0",
@@ -216,14 +216,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.6.tgz",
-      "integrity": "sha512-62u896rWCtKKE43soodq5e/QcRsA22I+7/4Ov7LESWnKRO6BVo2A1DFLDmXL9e28TB0CfHc3YtkbPm7iwajqkg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
+      "integrity": "sha512-d/QAsnwuHX2OPolxvYcgSj7A9DO9H6gVOy2DvBTx+P2LH2iRTo/RSGV3iwCzW024nP9hw98KIuDmdyhZQj1UQg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -240,13 +240,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.10.tgz",
-      "integrity": "sha512-FxbQ9giWxUWKUk2O5XZ6PduVnH2CZ/fmMKMBkH71MHJvWr7WL5AHKevhzF1L5uYWB2P548o1RzVxrNd3dpmk6g==",
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
+      "integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/type": "^3.0.6"
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
       },
       "engines": {
         "node": ">=18"
@@ -261,13 +261,13 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
-      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
+      "integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -288,13 +288,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.11.tgz",
-      "integrity": "sha512-YoZr0lBnnLFPpfPSNsQ8IZyKxU47zPyVi9NLjCWtna52//M/xuL0PGPAxHxxYhdOhnvY2oBafoM+BI5w/JK7jw==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
+      "integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -310,13 +310,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.13.tgz",
-      "integrity": "sha512-HgYNWuZLHX6q5y4hqKhwyytqAghmx35xikOGY3TcgNiElqXGPas24+UzNPOwGUZa5Dn32y25xJqVeUcGlTv+QQ==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.15.tgz",
+      "integrity": "sha512-4Y+pbr/U9Qcvf+N/goHzPEXiHH8680lM3Dr3Y9h9FFw4gHS+zVpbj8LfbKWIb/jayIB4aSO4pWiBTrBYWkvi5A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -332,22 +332,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
-      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
+      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.10.tgz",
-      "integrity": "sha512-kV3BVne3wJ+j6reYQUZi/UN9NZGZLxgc/tfyjeK3mrx1QI7RXPxGp21IUTv+iVHcbP4ytZALF8vCHoxyNSC6qg==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.12.tgz",
+      "integrity": "sha512-xJ6PFZpDjC+tC1P8ImGprgcsrzQRsUh9aH3IZixm1lAZFK49UGHxM3ltFfuInN2kPYNfyoPRh+tU4ftsjPLKqQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/type": "^3.0.6"
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
       },
       "engines": {
         "node": ">=18"
@@ -362,13 +362,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.13.tgz",
-      "integrity": "sha512-IrLezcg/GWKS8zpKDvnJ/YTflNJdG0qSFlUM/zNFsdi4UKW/CO+gaJpbMgQ20Q58vNKDJbEzC6IebdkprwL6ew==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.15.tgz",
+      "integrity": "sha512-xWg+iYfqdhRiM55MvqiTCleHzszpoigUpN5+t1OMcRkJrUrw7va3AzXaxvS+Ak7Gny0j2mFSTv2JJj8sMtbV2g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/type": "^3.0.6"
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
       },
       "engines": {
         "node": ">=18"
@@ -383,13 +383,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.13.tgz",
-      "integrity": "sha512-NN0S/SmdhakqOTJhDwOpeBEEr8VdcYsjmZHDb0rblSh2FcbXQOr+2IApP7JG4WE3sxIdKytDn4ed3XYwtHxmJQ==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.15.tgz",
+      "integrity": "sha512-75CT2p43DGEnfGTaqFpbDC2p2EEMrq0S+IRrf9iJvYreMy5mAWj087+mdKyLHapUEPLjN10mNvABpGbk8Wdraw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -405,21 +405,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.1.tgz",
-      "integrity": "sha512-5AOrZPf2/GxZ+SDRZ5WFplCA2TAQgK3OYrXCYmJL5NaTu4ECcoWFlfUZuw7Es++6Njv7iu/8vpYJhuzxUH76Vg==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.3.tgz",
+      "integrity": "sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.1.6",
-        "@inquirer/confirm": "^5.1.10",
-        "@inquirer/editor": "^4.2.11",
-        "@inquirer/expand": "^4.0.13",
-        "@inquirer/input": "^4.1.10",
-        "@inquirer/number": "^3.0.13",
-        "@inquirer/password": "^4.0.13",
-        "@inquirer/rawlist": "^4.1.1",
-        "@inquirer/search": "^3.0.13",
-        "@inquirer/select": "^4.2.1"
+        "@inquirer/checkbox": "^4.1.8",
+        "@inquirer/confirm": "^5.1.12",
+        "@inquirer/editor": "^4.2.13",
+        "@inquirer/expand": "^4.0.15",
+        "@inquirer/input": "^4.1.12",
+        "@inquirer/number": "^3.0.15",
+        "@inquirer/password": "^4.0.15",
+        "@inquirer/rawlist": "^4.1.3",
+        "@inquirer/search": "^3.0.15",
+        "@inquirer/select": "^4.2.3"
       },
       "engines": {
         "node": ">=18"
@@ -434,13 +434,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.1.tgz",
-      "integrity": "sha512-VBUC0jPN2oaOq8+krwpo/mf3n/UryDUkKog3zi+oIi8/e5hykvdntgHUB9nhDM78RubiyR1ldIOfm5ue+2DeaQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.3.tgz",
+      "integrity": "sha512-7XrV//6kwYumNDSsvJIPeAqa8+p7GJh7H5kRuxirct2cgOcSWwwNGoXDRgpNFbY/MG2vQ4ccIWCi8+IXXyFMZA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -456,14 +456,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.13.tgz",
-      "integrity": "sha512-9g89d2c5Izok/Gw/U7KPC3f9kfe5rA1AJ24xxNZG0st+vWekSk7tB9oE+dJv5JXd0ZSijomvW0KPMoBd8qbN4g==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.15.tgz",
+      "integrity": "sha512-YBMwPxYBrADqyvP4nNItpwkBnGGglAvCLVW8u4pRmmvOsHUtCAUIMbUrLX5B3tFL1/WsLGdQ2HNzkqswMs5Uaw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -479,14 +479,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.1.tgz",
-      "integrity": "sha512-gt1Kd5XZm+/ddemcT3m23IP8aD8rC9drRckWoP/1f7OL46Yy2FGi8DSmNjEjQKtPl6SV96Kmjbl6p713KXJ/Jg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.3.tgz",
+      "integrity": "sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.11",
-        "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
-      "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
+      "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-go": "0.4.8"
+        "@azure-tools/typespec-go": "0.4.9"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.56.0",
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-go": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.4.8.tgz",
-      "integrity": "sha512-Ws7yABqxmb0s2UIkrIPkB3c3bRswduMh7oh8vfgu8G6HBTLYnL4Z3Fi4MHc67dxQDNlg9aufYHIa4wTe5Gd0sQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.4.9.tgz",
+      "integrity": "sha512-DyzIVvznG2WBFRzjMkwOHmIk/L9jzxTAbLlhOtcyFKFAOZF9Rh5g497sAeGKI9E9HdZ2GQOx0HBZ36+1okgAkg==",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/codegen": "^2.10.0",

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,7 +1,7 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-go": "0.4.8"
+    "@azure-tools/typespec-go": "0.4.9"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.56.0",

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,7 +1,7 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-go": "0.4.9"
+    "@azure-tools/typespec-go": "0.4.10"
   },
   "devDependencies": {
     "@azure-tools/typespec-autorest": "0.56.0",

--- a/eng/tools/generator/cmd/v2/common/cmdProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/cmdProcessor.go
@@ -50,7 +50,8 @@ func ExecuteGoGenerate(path string) error {
 
 	if stdoutBuffer.Len() > 0 {
 		// find generated successuly flag
-		if strings.Contains(stdoutBuffer.String(), "Autorest completed") {
+		infoRegex := regexp.MustCompile(`info\s+\|\s+Autorest completed`)
+		if infoRegex.MatchString(stdoutBuffer.String()) {
 			return nil
 		}
 		if strings.Contains(stdoutBuffer.String(), "error   |") {

--- a/eng/tools/generator/cmd/v2/common/cmdProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/cmdProcessor.go
@@ -44,16 +44,14 @@ func ExecuteGoGenerate(path string) error {
 	}
 
 	cmdWaitErr := cmd.Wait()
+	if cmdWaitErr == nil {
+		return nil
+	}
 
 	fmt.Println(stdoutBuffer.String())
 	fmt.Println(stderrBuffer.String())
 
 	if stdoutBuffer.Len() > 0 {
-		// find generated successuly flag
-		infoRegex := regexp.MustCompile(`info\s+\|\s+Autorest completed`)
-		if infoRegex.MatchString(stdoutBuffer.String()) {
-			return nil
-		}
 		if strings.Contains(stdoutBuffer.String(), "error   |") {
 			// find first error message until last
 			errMsgs := stdoutBuffer.Bytes()


### PR DESCRIPTION
1. upgrade typespec-go version to 0.4.9
2. resolve: https://github.com/Azure/azure-sdk-for-go/issues/24646

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
