### PR TITLE
Prevent CLI credentials waiting indefinitely for subprocess output

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- `AzureCLICredential` and `AzureDeveloperCLICredential` could wait indefinitely for subprocess output
 
 ### Other Changes
 


### PR DESCRIPTION
By default, `Cmd.Output()` blocks indefinitely when the subprocess fails to exit after its Context is canceled or exits without closing stdout/err. This PR sets `Cmd.WaitDelay` to impose a timeout in these cases. If the subprocess wrote to stdout before exiting, credentials swallow the timeout error and try to unmarshal a token from stdout.