### PR TITLE
cosmos: changelog for 1.5.0-beta.0

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.5.0-beta.0 (Unreleased)
+## 1.5.0-beta.0 (2025-06-09)
 
 ### Features Added
 
 * Added an initial API for integrating an external client-side Query Engine with the Cosmos DB Go SDK. This API is unstable and not recommended for production use. See [PR 24273](https://github.com/Azure/azure-sdk-for-go/pull/24273) for more details.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.4.0 (2025-04-29)
 


### PR DESCRIPTION
This PR updates the Changelog in preparation for a 1.5.0-beta.0 release of the Azure Cosmos DB SDK for Go. The main functionality added here is initial support for an external query engine (i.e. the Cosmos Client Engine, under development).

I'm not planning to release this until Monday, after I've done a few more tests to make sure things work together, but I wanted to get this PR ready to merge. I'll merge it and make the release on Monday (assuming it's approved by then).