### PR TITLE
Update auto release script for issues labeled `SDK released by service owner`

### DIFF
--- a/eng/scripts/mgmt-auto-release.sh
+++ b/eng/scripts/mgmt-auto-release.sh
@@ -1,17 +1,6 @@
 #!/bin/bash
 set -ex
 
-today=`date "+%Y%m%d"`
-firstDay=`date -d "${today}" +%Y%m01`
-week=`date -d "$firstDay" +%w`
-secondSaturday=$((firstDay+(12 - week) % 7 + 8))
-
-if [ $today -gt $secondSaturday ]
-then
- echo "The PR generation time of the current month is: [$firstDay-$secondSaturday]"
- exit 0
-fi
-
 export PATH=$PATH:$HOME/go/bin
 git config --global user.email "ReleaseHelper"
 git config --global user.name "ReleaseHelper"

--- a/eng/tools/generator/cmd/issue/issueCmd.go
+++ b/eng/tools/generator/cmd/issue/issueCmd.go
@@ -200,6 +200,7 @@ const (
 	AutoLinkLabel        IssueLabel = "auto-link"
 	PRreadyLabel         IssueLabel = "PRready"
 	InconsistentTagLabel IssueLabel = "Inconsistent tag"
+	SdkReleasedByServiceTeamLabel IssueLabel = "SDK released by service owner"
 )
 
 func isGoReleaseRequest(issue *github.Issue) bool {
@@ -218,6 +219,10 @@ func isInconsistentTag(issue *github.Issue) bool {
 	return issueHasLabel(issue, InconsistentTagLabel)
 }
 
+func isSdkReleasedByServiceTeam(issue *github.Issue) bool {
+	return issueHasLabel(issue, SdkReleasedByServiceTeamLabel)
+}
+
 func (c *commandContext) parseIssues(issues []*github.Issue) ([]request.Request, error) {
 	var requests []request.Request
 	var errResult error
@@ -231,7 +236,7 @@ func (c *commandContext) parseIssues(issues []*github.Issue) ([]request.Request,
 		if !isAutoLink(issue) {
 			continue
 		}
-		if isInconsistentTag(issue) {
+		if isInconsistentTag(issue) && !isSdkReleasedByServiceTeam(issue) {
 			log.Printf("[ERROR] %s Readme tag is inconsistent with default tag\n", issue.GetHTMLURL())
 			errResult = errors.Join(errResult, fmt.Errorf("%s: readme tag is inconsistent with default tag", issue.GetHTMLURL()))
 			continue
@@ -247,6 +252,13 @@ func (c *commandContext) parseIssues(issues []*github.Issue) ([]request.Request,
 			continue
 		}
 		if req == nil {
+			continue
+		}
+		if isSdkReleasedByServiceTeam(issue) {
+			requests = append(requests, *req)
+			continue
+		} 
+		if !isNormalPeriod() {
 			continue
 		}
 		requests = append(requests, *req)
@@ -298,4 +310,26 @@ func (c *commandContext) validateConfig(cfg config.Config) error {
 
 func timePtr(t time.Time) *time.Time {
 	return &t
+}
+
+func isNormalPeriod()bool{
+	now := time.Now()
+	firstDay := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	// Find the weekday of the first day (0 = Sunday, ..., 6 = Saturday)
+	weekday := int(firstDay.Weekday())
+	// Days until the first Saturday
+	daysToFirstSaturday := (6 - weekday + 7) % 7
+	// Add 7 more days to get the second Saturday
+	daysToSecondSaturday := daysToFirstSaturday + 7
+	// Calculate the second Saturday
+	secondSaturday := firstDay.AddDate(0, 0, daysToSecondSaturday)
+
+	// Compare today's date with second Saturday
+	if now.After(secondSaturday) {
+		log.Printf("The PR generation time of the current month is: [%s - %s]\n",
+			firstDay.Format("2006-01-02"),
+			secondSaturday.Format("2006-01-02"))
+			return true
+	}
+	return false
 }

--- a/eng/tools/generator/cmd/issue/issueCmd.go
+++ b/eng/tools/generator/cmd/issue/issueCmd.go
@@ -230,6 +230,10 @@ func (c *commandContext) parseIssues(issues []*github.Issue) ([]request.Request,
 		if issue == nil {
 			continue
 		}
+		log.Printf("isNormal(%t) isSdkReleasedByServiceTeam(%t) issueId(%d) issueTitle(%s)", isNormalPeriod(), isSdkReleasedByServiceTeam(issue), issue.GetID(), issue.GetTitle())
+		if !isNormalPeriod() && !isSdkReleasedByServiceTeam(issue) {
+			continue
+		}
 		if isPRReady(issue) {
 			continue
 		}
@@ -252,13 +256,6 @@ func (c *commandContext) parseIssues(issues []*github.Issue) ([]request.Request,
 			continue
 		}
 		if req == nil {
-			continue
-		}
-		if isSdkReleasedByServiceTeam(issue) {
-			requests = append(requests, *req)
-			continue
-		} 
-		if !isNormalPeriod() {
 			continue
 		}
 		requests = append(requests, *req)


### PR DESCRIPTION
 This change aims to change the auto release script to daily auto generate the PRs of the issue that labeled `SDK released by service owner` , [like this issue](https://github.com/Azure/sdk-release-request/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22SDK%20released%20by%20service%20owner%22)