### PR TITLE
Fix live managed identity test deployment

### DIFF
--- a/sdk/azidentity/test-resources-post.ps1
+++ b/sdk/azidentity/test-resources-post.ps1
@@ -100,7 +100,7 @@ $idName = $DeploymentOutputs['AZIDENTITY_USER_ASSIGNED_IDENTITY_NAME']
 $issuer = az aks show -g $rg -n $aksName --query "oidcIssuerProfile.issuerUrl" -otsv
 $podName = "azidentity-test"
 $serviceAccountName = "workload-identity-sa"
-az identity federated-credential create -g $rg --identity-name $idName --issuer $issuer --name $idName --subject system:serviceaccount:default:$serviceAccountName
+az identity federated-credential create -g $rg --identity-name $idName --issuer $issuer --name $idName --subject system:serviceaccount:default:$serviceAccountName --audiences api://AzureADTokenExchange
 Write-Host "Deploying to AKS"
 az aks get-credentials -g $rg -n $aksName
 az aks update --attach-acr $DeploymentOutputs['AZIDENTITY_ACR_NAME'] -g $rg -n $aksName


### PR DESCRIPTION
azidentity's live managed identity test pipeline is failing because `az` made a breaking change to require an explicit audience when creating a federated identity. This PR addresses that by specifying the default audience used by the previous `az`.