### PR TITLE
Add support for BypassIntegratedCache option

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added support for BypassIntegratedCache option
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/data/azcosmos/cosmos_dedicated_gateway_request_options.go
+++ b/sdk/data/azcosmos/cosmos_dedicated_gateway_request_options.go
@@ -12,4 +12,7 @@ type DedicatedGatewayRequestOptions struct {
 	// responses from the integrated cache are guaranteed to be no staler than value indicated by this MaxIntegratedCacheStaleness.
 	// Cache Staleness is supported in milliseconds granularity. Anything smaller than milliseconds will be ignored.
 	MaxIntegratedCacheStaleness *time.Duration
+
+	// When set to true, the request will not be served from the integrated cache, and the response will not be cached either.
+	BypassIntegratedCache bool
 }

--- a/sdk/data/azcosmos/cosmos_http_constants.go
+++ b/sdk/data/azcosmos/cosmos_http_constants.go
@@ -83,6 +83,7 @@ const (
 	cosmosHeaderQueryExecutionInfo                 string = "x-ms-cosmos-query-execution-info"
 	headerXmsItemCount                             string = "x-ms-item-count"
 	headerDedicatedGatewayMaxAge                   string = "x-ms-dedicatedgateway-max-age"
+	headerDedicatedGatewayBypassCache              string = "x-ms-dedicatedgateway-bypass-cache"
 )
 
 const (

--- a/sdk/data/azcosmos/cosmos_item_request_options.go
+++ b/sdk/data/azcosmos/cosmos_item_request_options.go
@@ -73,6 +73,10 @@ func (options *ItemOptions) toHeaders() *map[string]string {
 			milliseconds := dedicatedGatewayRequestOptions.MaxIntegratedCacheStaleness.Milliseconds()
 			headers[headerDedicatedGatewayMaxAge] = strconv.FormatInt(milliseconds, 10)
 		}
+
+		if dedicatedGatewayRequestOptions.BypassIntegratedCache {
+			headers[headerDedicatedGatewayBypassCache] = "true"
+		}
 	}
 
 	return &headers

--- a/sdk/data/azcosmos/cosmos_item_request_options_test.go
+++ b/sdk/data/azcosmos/cosmos_item_request_options_test.go
@@ -25,6 +25,7 @@ func TestItemRequestOptionsToHeaders(t *testing.T) {
 	options.DedicatedGatewayRequestOptions = &DedicatedGatewayRequestOptions{
 		MaxIntegratedCacheStaleness: &maxIntegratedCacheStalenessDuration,
 	}
+	options.DedicatedGatewayRequestOptions.BypassIntegratedCache = true
 	header := options.toHeaders()
 	if header == nil {
 		t.Fatal("toHeaders should return non-nil")
@@ -51,5 +52,8 @@ func TestItemRequestOptionsToHeaders(t *testing.T) {
 	}
 	if headers[headerDedicatedGatewayMaxAge] != strconv.FormatInt(300000, 10) {
 		t.Errorf("headerDedicatedGatewayMaxAge should be 300000 but got %v", headers[headerDedicatedGatewayMaxAge])
+	}
+	if headers[headerDedicatedGatewayBypassCache] != "true" {
+		t.Errorf("headerDedicatedGatewayBypassCache should be true but got %v", headers[headerDedicatedGatewayBypassIntegratedCache])
 	}
 }

--- a/sdk/data/azcosmos/cosmos_query_request_options.go
+++ b/sdk/data/azcosmos/cosmos_query_request_options.go
@@ -84,6 +84,10 @@ func (options *QueryOptions) toHeaders() *map[string]string {
 			milliseconds := dedicatedGatewayRequestOptions.MaxIntegratedCacheStaleness.Milliseconds()
 			headers[headerDedicatedGatewayMaxAge] = strconv.FormatInt(milliseconds, 10)
 		}
+
+		if dedicatedGatewayRequestOptions.BypassIntegratedCache {
+			headers[headerDedicatedGatewayBypassCache] = "true"
+		}
 	}
 
 	headers[cosmosHeaderPopulateQueryMetrics] = "true"

--- a/sdk/data/azcosmos/cosmos_query_request_options_test.go
+++ b/sdk/data/azcosmos/cosmos_query_request_options_test.go
@@ -24,6 +24,7 @@ func TestQueryRequestOptionsToHeaders(t *testing.T) {
 	options.DedicatedGatewayRequestOptions = &DedicatedGatewayRequestOptions{
 		MaxIntegratedCacheStaleness: &maxIntegratedCacheStalenessDuration,
 	}
+	options.DedicatedGatewayRequestOptions.BypassIntegratedCache = true
 	header := options.toHeaders()
 	if header == nil {
 		t.Fatal("toHeaders should return non-nil")
@@ -56,5 +57,8 @@ func TestQueryRequestOptionsToHeaders(t *testing.T) {
 	}
 	if headers[headerDedicatedGatewayMaxAge] != strconv.FormatInt(300000, 10) {
 		t.Errorf("headerDedicatedGatewayMaxAge should be 300000 but got %v", headers[headerDedicatedGatewayMaxAge])
+	}
+	if headers[headerDedicatedGatewayBypassCache] != "true" {
+		t.Errorf("headerDedicatedGatewayBypassCache should be true but got %v", headers[headerDedicatedGatewayBypassCache])
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

Add support for the BypassIntegratedCache param as Azure docs point to this being a way to have requests to the dedicated gateway bypass the integrated cache: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-integrated-cache?tabs=dotnet#bypass-the-integrated-cache.

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
