### PR TITLE
Add support for one extra subdirectory for ARM modules

### DIFF
--- a/eng/tools/generator/typespec/typespec-go.go
+++ b/eng/tools/generator/typespec/typespec-go.go
@@ -46,16 +46,17 @@ func NewGoEmitterOptions(emitOption any) (*GoEmitterOptions, error) {
 	return &option, err
 }
 
+// NOTE: for ARM modules, we support one extra sub-path: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/service/subpath/armservice
 const moduleRegex = `^github.com/Azure/azure-sdk-for-go/sdk/` +
 	`(` +
-	`resourcemanager/\w+/arm\w+` + // either an ARM package (ie: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus)
+	`resourcemanager/(?:\w+/){1,2}arm\w+` + // either an ARM package (ie: github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus)
 	`|` +
 	`.+?/az[^/]+` + // or a data plane package (ie, github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/aznamespaces)
 	`)$`
 
 var (
 	ErrModuleEmpty  = errors.New("typesepec-go option `module` is required")
-	ErrModuleFormat = errors.New("module must be in the format of github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/xxx/armxxx or github.com/Azure/azure-sdk-for-go/sdk/xxx/azxxx")
+	ErrModuleFormat = errors.New("module must be in the format of github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/xxx/[yyy/]armxxx or github.com/Azure/azure-sdk-for-go/sdk/xxx/azxxx")
 )
 
 func (o *GoEmitterOptions) Validate() error {

--- a/eng/tools/generator/typespec/typespec-go_test.go
+++ b/eng/tools/generator/typespec/typespec-go_test.go
@@ -39,6 +39,24 @@ func TestGoEmitterOptionsValidate(t *testing.T) {
 	err = goEmitOptions.Validate()
 	assert.NoError(t, err)
 
+	// module has extra sub-path
+	goOption = map[string]any{
+		"module": "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/xxx/yyy/armxxx",
+	}
+	goEmitOptions, err = typespec.NewGoEmitterOptions(goOption)
+	assert.NoError(t, err)
+	err = goEmitOptions.Validate()
+	assert.NoError(t, err)
+
+	// module has too many sub-paths
+	goOption = map[string]any{
+		"module": "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/xxx/yyy/zzz/armxxx",
+	}
+	goEmitOptions, err = typespec.NewGoEmitterOptions(goOption)
+	assert.NoError(t, err)
+	err = goEmitOptions.Validate()
+	assert.EqualError(t, err, typespec.ErrModuleFormat.Error())
+
 	// module format is wrong
 	goOption = map[string]any{
 		"module": "github.com/Azure/azure-sdk-for-go/sdk/xxx/armxxx",


### PR DESCRIPTION
Support /resourcemanager/service/subpath/armservice.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
