### PR TITLE
[Storage][Azdatalake][BugFix] Fix panic on auth failure

### DIFF
--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fix panic in File and Directory client DownloadStream and Get Properties on authentication failure.
 
 ### Other Changes
 

--- a/sdk/storage/azdatalake/directory/client.go
+++ b/sdk/storage/azdatalake/directory/client.go
@@ -283,7 +283,6 @@ func (d *Client) GetProperties(ctx context.Context, options *GetPropertiesOption
 		return GetPropertiesResponse{}, exported.ConvertToDFSError(err)
 	}
 	newResp := path.FormatGetPropertiesResponse(&resp, respFromCtx)
-	err = exported.ConvertToDFSError(err)
 	return newResp, nil
 }
 

--- a/sdk/storage/azdatalake/directory/client.go
+++ b/sdk/storage/azdatalake/directory/client.go
@@ -279,9 +279,12 @@ func (d *Client) GetProperties(ctx context.Context, options *GetPropertiesOption
 	var respFromCtx *http.Response
 	ctxWithResp := shared.WithCaptureBlobResponse(ctx, &respFromCtx)
 	resp, err := d.blobClient().GetProperties(ctxWithResp, opts)
+	if err != nil {
+		return GetPropertiesResponse{}, exported.ConvertToDFSError(err)
+	}
 	newResp := path.FormatGetPropertiesResponse(&resp, respFromCtx)
 	err = exported.ConvertToDFSError(err)
-	return newResp, err
+	return newResp, nil
 }
 
 // Rename renames a directory. The original directory will no longer exist and the client will be stale.

--- a/sdk/storage/azdatalake/file/client.go
+++ b/sdk/storage/azdatalake/file/client.go
@@ -558,6 +558,9 @@ func (f *Client) DownloadStream(ctx context.Context, o *DownloadStreamOptions) (
 	var respFromCtx *http.Response
 	ctxWithResp := shared.WithCaptureBlobResponse(ctx, &respFromCtx)
 	resp, err := f.blobClient().DownloadStream(ctxWithResp, opts)
+	if err != nil {
+		return DownloadStreamResponse{}, exported.ConvertToDFSError(err)
+	}
 	newResp := FormatDownloadStreamResponse(&resp, respFromCtx)
 	fullResp := DownloadStreamResponse{
 		client:           f,
@@ -567,7 +570,7 @@ func (f *Client) DownloadStream(ctx context.Context, o *DownloadStreamOptions) (
 		cpkScope:         o.CPKScopeInfo,
 	}
 
-	return fullResp, exported.ConvertToDFSError(err)
+	return fullResp, nil
 }
 
 // DownloadBuffer downloads an Azure file to a buffer with parallel.


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
