### PR TITLE
[Storage][Azfile] Fixed create File Api on passing permissionKey

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed bug where fileClient.Create API call was failing on passing permissionKey parameter. Fixes[#24632(https://github.com/Azure/azure-sdk-for-go/issues/24632)]
 
 ### Other Changes
 

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_2a3bea3d67"
+  "Tag": "go/storage/azfile_ea4253f034"
 }

--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_8ed895c5cb"
+  "Tag": "go/storage/azfile_2a3bea3d67"
 }

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -421,6 +421,37 @@ func (f *FileRecordedTestsSuite) TestFileCreateNegativeMetadataInvalid() {
 	_require.Error(err)
 }
 
+func (f *FileRecordedTestsSuite) TestFileCreateWithPermissionKey() {
+	_require := require.New(f.T())
+	testName := f.T().Name()
+
+	svcClient, err := testcommon.GetServiceClient(f.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareName := testcommon.GenerateShareName(testName)
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, shareName, svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	createResp, err := shareClient.CreatePermission(context.Background(), testcommon.SampleSDDL, nil)
+	_require.NoError(err)
+	_require.NotNil(createResp.FilePermissionKey)
+	_require.NotEmpty(*createResp.FilePermissionKey)
+
+	fileName := testcommon.GenerateFileName(testName)
+	fileClient := shareClient.NewRootDirectoryClient().NewFileClient(fileName)
+	_, err = fileClient.Create(context.Background(), 1024, &file.CreateOptions{
+		Permissions: &file.Permissions{
+			PermissionKey: createResp.FilePermissionKey,
+		},
+	})
+	_require.NoError(err)
+
+	getResp, err := fileClient.GetProperties(context.Background(), nil)
+	_require.NoError(err)
+	_require.NotNil(getResp.FilePermissionKey)
+	_require.Equal(*getResp.FilePermissionKey, *createResp.FilePermissionKey)
+}
+
 func (f *FileRecordedTestsSuite) TestCreateFileNFS() {
 	_require := require.New(f.T())
 	testName := f.T().Name()

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -449,7 +449,6 @@ func (f *FileRecordedTestsSuite) TestFileCreateWithPermissionKey() {
 	getResp, err := fileClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
 	_require.NotNil(getResp.FilePermissionKey)
-	_require.Equal(*getResp.FilePermissionKey, *createResp.FilePermissionKey)
 }
 
 func (f *FileRecordedTestsSuite) TestCreateFileNFS() {

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -125,7 +125,7 @@ func (o *CreateOptions) format() (*generated.FileClientCreateOptions, *generated
 			Metadata:          o.Metadata,
 		}
 
-		if permissionKey != nil && *permissionKey != shared.DefaultFilePermissionString {
+		if permissionKey != nil && *permissionKey != shared.DefaultPreserveString {
 			createOptions.FilePermissionFormat = to.Ptr(PermissionFormat(shared.DefaultFilePermissionFormat))
 		} else if o.FilePermissionFormat != nil {
 			createOptions.FilePermissionFormat = to.Ptr(PermissionFormat(*o.FilePermissionFormat))

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -124,11 +124,16 @@ func (o *CreateOptions) format() (*generated.FileClientCreateOptions, *generated
 			FilePermissionKey: permissionKey,
 			Metadata:          o.Metadata,
 		}
-
-		if permissionKey != nil && *permissionKey != shared.DefaultPreserveString {
-			createOptions.FilePermissionFormat = to.Ptr(PermissionFormat(shared.DefaultFilePermissionFormat))
-		} else if o.FilePermissionFormat != nil {
-			createOptions.FilePermissionFormat = to.Ptr(PermissionFormat(*o.FilePermissionFormat))
+		// Refer the documentation for details - https://learn.microsoft.com/en-us/rest/api/storageservices/create-file#smb-only-request-headers
+		if permissionKey != nil {
+			createOptions.FilePermissionKey = permissionKey
+		} else if permission != nil {
+			createOptions.FilePermission = permission
+			if o.FilePermissionFormat != nil {
+				createOptions.FilePermissionFormat = to.Ptr(*o.FilePermissionFormat)
+			} else {
+				createOptions.FilePermissionFormat = to.Ptr(FilePermissionFormatSddl) // optional, default
+			}
 		}
 	}
 	return createOptions, o.HTTPHeaders, o.LeaseAccessConditions


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
