### PR TITLE
 [Storage][azqueue] Deprecate existing QueueProperties.ApproximateMessagesCount and convert int32 to int64 

### DIFF
--- a/sdk/storage/azqueue/CHANGELOG.md
+++ b/sdk/storage/azqueue/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features Added
 
 #### Breaking Changes
+* The type of ApproximateMessagesCount has changed from *int32 to *int64 to support large queues with more than int32 max value messages.
 
 #### Bugs Fixed
 

--- a/sdk/storage/azqueue/internal/generated/autorest.md
+++ b/sdk/storage/azqueue/internal/generated/autorest.md
@@ -7,7 +7,7 @@ go: true
 clear-output-folder: false
 version: "^3.0.0"
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: " https://raw.githubusercontent.com/Azure/azure-rest-api-specs/39970688f01821bbb1d2a09182d882da86a51a18/specification/storage/data-plane/Microsoft.QueueStorage/stable/2018-03-28/queue.json"
+input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/39970688f01821bbb1d2a09182d882da86a51a18/specification/storage/data-plane/Microsoft.QueueStorage/stable/2018-03-28/queue.json"
 credential-scope: "https://storage.azure.com/.default"
 output-folder: ../generated
 file-prefix: "zz_"

--- a/sdk/storage/azqueue/internal/generated/autorest.md
+++ b/sdk/storage/azqueue/internal/generated/autorest.md
@@ -7,7 +7,7 @@ go: true
 clear-output-folder: false
 version: "^3.0.0"
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5da3c08b92d05858b728b013b69502dc93485373/specification/storage/data-plane/Microsoft.QueueStorage/preview/2018-03-28/queue.json"
+input-file: " https://raw.githubusercontent.com/Azure/azure-rest-api-specs/39970688f01821bbb1d2a09182d882da86a51a18/specification/storage/data-plane/Microsoft.QueueStorage/stable/2018-03-28/queue.json"
 credential-scope: "https://storage.azure.com/.default"
 output-folder: ../generated
 file-prefix: "zz_"

--- a/sdk/storage/azqueue/internal/generated/zz_queue_client.go
+++ b/sdk/storage/azqueue/internal/generated/zz_queue_client.go
@@ -278,8 +278,7 @@ func (client *QueueClient) getPropertiesHandleResponse(resp *http.Response) (Que
 		}
 	}
 	if val := resp.Header.Get("x-ms-approximate-messages-count"); val != "" {
-		approximateMessagesCount32, err := strconv.ParseInt(val, 10, 32)
-		approximateMessagesCount := int32(approximateMessagesCount32)
+		approximateMessagesCount, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return QueueClientGetPropertiesResponse{}, err
 		}

--- a/sdk/storage/azqueue/internal/generated/zz_response_types.go
+++ b/sdk/storage/azqueue/internal/generated/zz_response_types.go
@@ -140,7 +140,7 @@ type QueueClientGetAccessPolicyResponse struct {
 // QueueClientGetPropertiesResponse contains the response from method QueueClient.GetProperties.
 type QueueClientGetPropertiesResponse struct {
 	// ApproximateMessagesCount contains the information returned from the x-ms-approximate-messages-count header response.
-	ApproximateMessagesCount *int32
+	ApproximateMessagesCount *int64
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
