### PR TITLE
Populate Request.values on creation

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Fixed incorrect request/response logging try info when logging a request that's being retried.
+
 ### Other Changes
 
 ## 1.18.0 (2025-04-03)

--- a/sdk/azcore/internal/exported/request.go
+++ b/sdk/azcore/internal/exported/request.go
@@ -71,7 +71,8 @@ func (ov opValues) get(value any) bool {
 // NewRequestFromRequest creates a new policy.Request with an existing *http.Request
 // Exported as runtime.NewRequestFromRequest().
 func NewRequestFromRequest(req *http.Request) (*Request, error) {
-	policyReq := &Request{req: req}
+	// populate values so that the same instance is propagated across policies
+	policyReq := &Request{req: req, values: opValues{}}
 
 	if req.Body != nil {
 		// we can avoid a body copy here if the underlying stream is already a
@@ -117,7 +118,8 @@ func NewRequest(ctx context.Context, httpMethod string, endpoint string) (*Reque
 	if !(req.URL.Scheme == "http" || req.URL.Scheme == "https") {
 		return nil, fmt.Errorf("unsupported protocol scheme %s", req.URL.Scheme)
 	}
-	return &Request{req: req}, nil
+	// populate values so that the same instance is propagated across policies
+	return &Request{req: req, values: opValues{}}, nil
 }
 
 // Body returns the original body specified when the Request was created.

--- a/sdk/azcore/runtime/policy_retry_test.go
+++ b/sdk/azcore/runtime/policy_retry_test.go
@@ -998,27 +998,15 @@ func TestRetryPolicyWithLoggingChecker(t *testing.T) {
 		PerRetryPolicies: []policy.Policy{&retryLoggingChecker{}},
 	})
 	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+
 	body := newRewindTrackingBody("stuff")
-	if err := req.SetBody(body, "text/plain"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, req.SetBody(body, "text/plain"))
+
 	resp, err := pl.Do(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected status code: %d", resp.StatusCode)
-	}
-	if r := srv.Requests(); r != 3 {
-		t.Fatalf("wrong retry count, got %d expected %d", r, 3)
-	}
-	if body.rcount != 2 {
-		t.Fatalf("unexpected rewind count: %d", body.rcount)
-	}
-	if !body.closed {
-		t.Fatal("request body wasn't closed")
-	}
+	require.NoError(t, err)
+	require.EqualValues(t, http.StatusOK, resp.StatusCode)
+	require.EqualValues(t, 3, srv.Requests())
+	require.EqualValues(t, 2, body.rcount)
+	require.True(t, body.closed)
 }


### PR DESCRIPTION
This ensures that the same instance is propagated across policies and that any values are retained across retries.