### PR TITLE
cosmos: Cherry-Pick Vector/FT container policies to 1.5.0 branch

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features Added
 
+* Added support for BypassIntegratedCache option See [PR 24772](https://github.com/Azure/azure-sdk-for-go/pull/24772)
+* Added support for specifying Full-Text Search indexing policies when creating a container. See [PR 24833](https://github.com/Azure/azure-sdk-for-go/pull/24833)
+* Added support for specifying Vector Search indexing policies when creating a container. See [PR 24833](https://github.com/Azure/azure-sdk-for-go/pull/24833)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/data/azcosmos/cosmos_container_properties.go
+++ b/sdk/data/azcosmos/cosmos_container_properties.go
@@ -39,6 +39,14 @@ type ContainerProperties struct {
 	UniqueKeyPolicy *UniqueKeyPolicy
 	// ConflictResolutionPolicy contains the conflict resolution policy of the container.
 	ConflictResolutionPolicy *ConflictResolutionPolicy
+	// VectorEmbeddingPolicy contains the vector embedding policy of the container.
+	// This policy defines how vector embeddings are stored and searched within the container.
+	// For more information see https://docs.microsoft.com/azure/cosmos-db/nosql/vector-search
+	VectorEmbeddingPolicy *VectorEmbeddingPolicy
+	// FullTextPolicy contains the full-text policy of the container.
+	// This policy defines how text properties are indexed for full-text search operations.
+	// For more information see https://docs.microsoft.com/azure/cosmos-db/gen-ai/full-text-search
+	FullTextPolicy *FullTextPolicy
 }
 
 // MarshalJSON implements the json.Marshaler interface
@@ -108,6 +116,24 @@ func (tp ContainerProperties) MarshalJSON() ([]byte, error) {
 		}
 		buffer.WriteString(",\"conflictResolutionPolicy\":")
 		buffer.Write(conflictPolicy)
+	}
+
+	if tp.VectorEmbeddingPolicy != nil {
+		vectorPolicy, err := json.Marshal(tp.VectorEmbeddingPolicy)
+		if err != nil {
+			return nil, err
+		}
+		buffer.WriteString(",\"vectorEmbeddingPolicy\":")
+		buffer.Write(vectorPolicy)
+	}
+
+	if tp.FullTextPolicy != nil {
+		fullTextPolicy, err := json.Marshal(tp.FullTextPolicy)
+		if err != nil {
+			return nil, err
+		}
+		buffer.WriteString(",\"fullTextPolicy\":")
+		buffer.Write(fullTextPolicy)
 	}
 
 	buffer.WriteString("}")
@@ -186,6 +212,18 @@ func (tp *ContainerProperties) UnmarshalJSON(b []byte) error {
 
 	if cp, ok := attributes["conflictResolutionPolicy"]; ok {
 		if err := json.Unmarshal(cp, &tp.ConflictResolutionPolicy); err != nil {
+			return err
+		}
+	}
+
+	if vp, ok := attributes["vectorEmbeddingPolicy"]; ok {
+		if err := json.Unmarshal(vp, &tp.VectorEmbeddingPolicy); err != nil {
+			return err
+		}
+	}
+
+	if fp, ok := attributes["fullTextPolicy"]; ok {
+		if err := json.Unmarshal(fp, &tp.FullTextPolicy); err != nil {
 			return err
 		}
 	}

--- a/sdk/data/azcosmos/cosmos_container_properties_test.go
+++ b/sdk/data/azcosmos/cosmos_container_properties_test.go
@@ -43,6 +43,24 @@ func TestContainerPropertiesSerialization(t *testing.T) {
 					{Path: "/someCompositeIndex",
 						Order: CompositeIndexAscending},
 				}},
+			VectorIndexes: []VectorIndex{
+				{
+					Path: "/vector1",
+					Type: VectorIndexTypeFlat,
+				},
+				{
+					Path: "/embeddings/textVector",
+					Type: VectorIndexTypeDiskANN,
+				},
+			},
+			FullTextIndexes: []FullTextIndex{
+				{
+					Path: "/text",
+				},
+				{
+					Path: "/description",
+				},
+			},
 		},
 		UniqueKeyPolicy: &UniqueKeyPolicy{
 			UniqueKeys: []UniqueKey{
@@ -52,6 +70,35 @@ func TestContainerPropertiesSerialization(t *testing.T) {
 		ConflictResolutionPolicy: &ConflictResolutionPolicy{
 			Mode:           ConflictResolutionModeLastWriteWins,
 			ResolutionPath: "/someResolutionPath",
+		},
+		VectorEmbeddingPolicy: &VectorEmbeddingPolicy{
+			VectorEmbeddings: []VectorEmbedding{
+				{
+					Path:             "/vector1",
+					DataType:         VectorDataTypeFloat32,
+					DistanceFunction: VectorDistanceFunctionCosine,
+					Dimensions:       1536,
+				},
+				{
+					Path:             "/embeddings/textVector",
+					DataType:         VectorDataTypeUint8,
+					DistanceFunction: VectorDistanceFunctionEuclidean,
+					Dimensions:       768,
+				},
+			},
+		},
+		FullTextPolicy: &FullTextPolicy{
+			DefaultLanguage: "en-US",
+			FullTextPaths: []FullTextPath{
+				{
+					Path:     "/text",
+					Language: "en-US",
+				},
+				{
+					Path:     "/description",
+					Language: "en-US",
+				},
+			},
 		},
 	}
 
@@ -134,6 +181,38 @@ func TestContainerPropertiesSerialization(t *testing.T) {
 		t.Errorf("Expected IndexingPolicy.CompositeIndexes[0][0].Path to be %s, but got %s", properties.IndexingPolicy.CompositeIndexes[0][0].Path, otherProperties.IndexingPolicy.CompositeIndexes[0][0].Path)
 	}
 
+	if len(otherProperties.IndexingPolicy.VectorIndexes) != len(properties.IndexingPolicy.VectorIndexes) {
+		t.Errorf("Expected VectorIndexes length to be %d, but got %d", len(properties.IndexingPolicy.VectorIndexes), len(otherProperties.IndexingPolicy.VectorIndexes))
+	}
+
+	if otherProperties.IndexingPolicy.VectorIndexes[0].Path != properties.IndexingPolicy.VectorIndexes[0].Path {
+		t.Errorf("Expected VectorIndexes[0].Path to be %s, but got %s", properties.IndexingPolicy.VectorIndexes[0].Path, otherProperties.IndexingPolicy.VectorIndexes[0].Path)
+	}
+
+	if otherProperties.IndexingPolicy.VectorIndexes[0].Type != properties.IndexingPolicy.VectorIndexes[0].Type {
+		t.Errorf("Expected VectorIndexes[0].Type to be %s, but got %s", properties.IndexingPolicy.VectorIndexes[0].Type, otherProperties.IndexingPolicy.VectorIndexes[0].Type)
+	}
+
+	if otherProperties.IndexingPolicy.VectorIndexes[1].Path != properties.IndexingPolicy.VectorIndexes[1].Path {
+		t.Errorf("Expected VectorIndexes[1].Path to be %s, but got %s", properties.IndexingPolicy.VectorIndexes[1].Path, otherProperties.IndexingPolicy.VectorIndexes[1].Path)
+	}
+
+	if otherProperties.IndexingPolicy.VectorIndexes[1].Type != properties.IndexingPolicy.VectorIndexes[1].Type {
+		t.Errorf("Expected VectorIndexes[1].Type to be %s, but got %s", properties.IndexingPolicy.VectorIndexes[1].Type, otherProperties.IndexingPolicy.VectorIndexes[1].Type)
+	}
+
+	if len(otherProperties.IndexingPolicy.FullTextIndexes) != len(properties.IndexingPolicy.FullTextIndexes) {
+		t.Errorf("Expected FullTextIndexes length to be %d, but got %d", len(properties.IndexingPolicy.FullTextIndexes), len(otherProperties.IndexingPolicy.FullTextIndexes))
+	}
+
+	if otherProperties.IndexingPolicy.FullTextIndexes[0].Path != properties.IndexingPolicy.FullTextIndexes[0].Path {
+		t.Errorf("Expected FullTextIndexes[0].Path to be %s, but got %s", properties.IndexingPolicy.FullTextIndexes[0].Path, otherProperties.IndexingPolicy.FullTextIndexes[0].Path)
+	}
+
+	if otherProperties.IndexingPolicy.FullTextIndexes[1].Path != properties.IndexingPolicy.FullTextIndexes[1].Path {
+		t.Errorf("Expected FullTextIndexes[1].Path to be %s, but got %s", properties.IndexingPolicy.FullTextIndexes[1].Path, otherProperties.IndexingPolicy.FullTextIndexes[1].Path)
+	}
+
 	if otherProperties.UniqueKeyPolicy == nil {
 		t.Errorf("Expected UniqueKeyPolicy to be not nil, but got nil")
 	}
@@ -152,6 +231,78 @@ func TestContainerPropertiesSerialization(t *testing.T) {
 
 	if otherProperties.ConflictResolutionPolicy.ResolutionPath != properties.ConflictResolutionPolicy.ResolutionPath {
 		t.Errorf("Expected ConflictResolutionPolicy.ResolutionPath to be %s, but got %s", properties.ConflictResolutionPolicy.ResolutionPath, otherProperties.ConflictResolutionPolicy.ResolutionPath)
+	}
+
+	if otherProperties.VectorEmbeddingPolicy == nil {
+		t.Errorf("Expected VectorEmbeddingPolicy to be not nil, but got nil")
+	}
+
+	if len(otherProperties.VectorEmbeddingPolicy.VectorEmbeddings) != len(properties.VectorEmbeddingPolicy.VectorEmbeddings) {
+		t.Errorf("Expected VectorEmbeddings length to be %d, but got %d", len(properties.VectorEmbeddingPolicy.VectorEmbeddings), len(otherProperties.VectorEmbeddingPolicy.VectorEmbeddings))
+	}
+
+	// Test first vector embedding
+	if otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[0].Path != properties.VectorEmbeddingPolicy.VectorEmbeddings[0].Path {
+		t.Errorf("Expected VectorEmbeddings[0].Path to be %s, but got %s", properties.VectorEmbeddingPolicy.VectorEmbeddings[0].Path, otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[0].Path)
+	}
+
+	if otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[0].DataType != properties.VectorEmbeddingPolicy.VectorEmbeddings[0].DataType {
+		t.Errorf("Expected VectorEmbeddings[0].DataType to be %s, but got %s", properties.VectorEmbeddingPolicy.VectorEmbeddings[0].DataType, otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[0].DataType)
+	}
+
+	if otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[0].DistanceFunction != properties.VectorEmbeddingPolicy.VectorEmbeddings[0].DistanceFunction {
+		t.Errorf("Expected VectorEmbeddings[0].DistanceFunction to be %s, but got %s", properties.VectorEmbeddingPolicy.VectorEmbeddings[0].DistanceFunction, otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[0].DistanceFunction)
+	}
+
+	if otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[0].Dimensions != properties.VectorEmbeddingPolicy.VectorEmbeddings[0].Dimensions {
+		t.Errorf("Expected VectorEmbeddings[0].Dimensions to be %d, but got %d", properties.VectorEmbeddingPolicy.VectorEmbeddings[0].Dimensions, otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[0].Dimensions)
+	}
+
+	// Test second vector embedding
+	if otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[1].Path != properties.VectorEmbeddingPolicy.VectorEmbeddings[1].Path {
+		t.Errorf("Expected VectorEmbeddings[1].Path to be %s, but got %s", properties.VectorEmbeddingPolicy.VectorEmbeddings[1].Path, otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[1].Path)
+	}
+
+	if otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[1].DataType != properties.VectorEmbeddingPolicy.VectorEmbeddings[1].DataType {
+		t.Errorf("Expected VectorEmbeddings[1].DataType to be %s, but got %s", properties.VectorEmbeddingPolicy.VectorEmbeddings[1].DataType, otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[1].DataType)
+	}
+
+	if otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[1].DistanceFunction != properties.VectorEmbeddingPolicy.VectorEmbeddings[1].DistanceFunction {
+		t.Errorf("Expected VectorEmbeddings[1].DistanceFunction to be %s, but got %s", properties.VectorEmbeddingPolicy.VectorEmbeddings[1].DistanceFunction, otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[1].DistanceFunction)
+	}
+
+	if otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[1].Dimensions != properties.VectorEmbeddingPolicy.VectorEmbeddings[1].Dimensions {
+		t.Errorf("Expected VectorEmbeddings[1].Dimensions to be %d, but got %d", properties.VectorEmbeddingPolicy.VectorEmbeddings[1].Dimensions, otherProperties.VectorEmbeddingPolicy.VectorEmbeddings[1].Dimensions)
+	}
+
+	if otherProperties.FullTextPolicy == nil {
+		t.Errorf("Expected FullTextPolicy to be not nil, but got nil")
+	}
+
+	if otherProperties.FullTextPolicy.DefaultLanguage != properties.FullTextPolicy.DefaultLanguage {
+		t.Errorf("Expected FullTextPolicy.DefaultLanguage to be %s, but got %s", properties.FullTextPolicy.DefaultLanguage, otherProperties.FullTextPolicy.DefaultLanguage)
+	}
+
+	if len(otherProperties.FullTextPolicy.FullTextPaths) != len(properties.FullTextPolicy.FullTextPaths) {
+		t.Errorf("Expected FullTextPaths length to be %d, but got %d", len(properties.FullTextPolicy.FullTextPaths), len(otherProperties.FullTextPolicy.FullTextPaths))
+	}
+
+	// Test first full text path
+	if otherProperties.FullTextPolicy.FullTextPaths[0].Path != properties.FullTextPolicy.FullTextPaths[0].Path {
+		t.Errorf("Expected FullTextPaths[0].Path to be %s, but got %s", properties.FullTextPolicy.FullTextPaths[0].Path, otherProperties.FullTextPolicy.FullTextPaths[0].Path)
+	}
+
+	if otherProperties.FullTextPolicy.FullTextPaths[0].Language != properties.FullTextPolicy.FullTextPaths[0].Language {
+		t.Errorf("Expected FullTextPaths[0].Language to be %s, but got %s", properties.FullTextPolicy.FullTextPaths[0].Language, otherProperties.FullTextPolicy.FullTextPaths[0].Language)
+	}
+
+	// Test second full text path
+	if otherProperties.FullTextPolicy.FullTextPaths[1].Path != properties.FullTextPolicy.FullTextPaths[1].Path {
+		t.Errorf("Expected FullTextPaths[1].Path to be %s, but got %s", properties.FullTextPolicy.FullTextPaths[1].Path, otherProperties.FullTextPolicy.FullTextPaths[1].Path)
+	}
+
+	if otherProperties.FullTextPolicy.FullTextPaths[1].Language != properties.FullTextPolicy.FullTextPaths[1].Language {
+		t.Errorf("Expected FullTextPaths[1].Language to be %s, but got %s", properties.FullTextPolicy.FullTextPaths[1].Language, otherProperties.FullTextPolicy.FullTextPaths[1].Language)
 	}
 }
 

--- a/sdk/data/azcosmos/emulator_cosmos_container_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_container_test.go
@@ -5,6 +5,7 @@ package azcosmos
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 )
 
@@ -196,6 +197,341 @@ func TestContainerAutoscaleCRUD(t *testing.T) {
 	}
 
 	resp, err = container.Delete(context.TODO(), nil)
+	if err != nil {
+		t.Fatalf("Failed to delete container: %v", err)
+	}
+}
+
+func TestContainerVectorSearch(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
+		ExpectedSpans: []string{"create_container vectorContainer", "read_container vectorContainer", "delete_container vectorContainer"},
+	}))
+
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "vectorSearch")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+
+	// Create container with vector embedding and indexing policies
+	properties := ContainerProperties{
+		ID: "vectorContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths: []string{"/pk"},
+		},
+		VectorEmbeddingPolicy: &VectorEmbeddingPolicy{
+			VectorEmbeddings: []VectorEmbedding{
+				{
+					Path:             "/embedding",
+					DataType:         VectorDataTypeFloat32,
+					DistanceFunction: VectorDistanceFunctionCosine,
+					Dimensions:       3,
+				},
+				{
+					Path:             "/textEmbedding",
+					DataType:         VectorDataTypeFloat32,
+					DistanceFunction: VectorDistanceFunctionDotProduct,
+					Dimensions:       384, // Use smaller dimension for flat index compatibility
+				},
+			},
+		},
+		IndexingPolicy: &IndexingPolicy{
+			Automatic:    true,
+			IndexingMode: IndexingModeConsistent,
+			IncludedPaths: []IncludedPath{
+				{Path: "/*"},
+			},
+			ExcludedPaths: []ExcludedPath{
+				{Path: "/\"_etag\"/?"},
+				{Path: "/embedding/*"},     // Exclude vector path from standard indexing
+				{Path: "/textEmbedding/*"}, // Exclude vector path from standard indexing
+			},
+			VectorIndexes: []VectorIndex{
+				{
+					Path: "/embedding",
+					Type: VectorIndexTypeFlat,
+				},
+				{
+					Path: "/textEmbedding",
+					Type: VectorIndexTypeFlat, // Use flat instead of diskANN for emulator compatibility
+				},
+			},
+		},
+	}
+
+	throughput := NewManualThroughputProperties(400)
+	_, err := database.CreateContainer(context.TODO(), properties, &CreateContainerOptions{ThroughputProperties: &throughput})
+	if err != nil {
+		t.Fatalf("Failed to create vector container: %v", err)
+	}
+
+	container, _ := database.NewContainer("vectorContainer")
+
+	// Read the container back to validate properties were set correctly
+	resp, err := container.Read(context.TODO(), nil)
+	if err != nil {
+		t.Fatalf("Failed to read container: %v", err)
+	}
+
+	readProperties := resp.ContainerProperties
+
+	// Validate basic properties
+	if readProperties.ID != properties.ID {
+		t.Errorf("Expected container ID %s, got %s", properties.ID, readProperties.ID)
+	}
+
+	// Validate vector embedding policy
+	if readProperties.VectorEmbeddingPolicy == nil {
+		t.Fatalf("Expected VectorEmbeddingPolicy to be set, but it was nil")
+	}
+
+	if len(readProperties.VectorEmbeddingPolicy.VectorEmbeddings) != 2 {
+		t.Fatalf("Expected 2 vector embeddings, got %d", len(readProperties.VectorEmbeddingPolicy.VectorEmbeddings))
+	}
+
+	// Validate first vector embedding
+	embedding1 := readProperties.VectorEmbeddingPolicy.VectorEmbeddings[0]
+	if embedding1.Path != "/embedding" {
+		t.Errorf("Expected first embedding path /embedding, got %s", embedding1.Path)
+	}
+	if embedding1.DataType != VectorDataTypeFloat32 {
+		t.Errorf("Expected first embedding data type float32, got %s", embedding1.DataType)
+	}
+	if embedding1.DistanceFunction != VectorDistanceFunctionCosine {
+		t.Errorf("Expected first embedding distance function cosine, got %s", embedding1.DistanceFunction)
+	}
+	if embedding1.Dimensions != 3 {
+		t.Errorf("Expected first embedding dimensions 3, got %d", embedding1.Dimensions)
+	}
+
+	// Validate second vector embedding
+	embedding2 := readProperties.VectorEmbeddingPolicy.VectorEmbeddings[1]
+	if embedding2.Path != "/textEmbedding" {
+		t.Errorf("Expected second embedding path /textEmbedding, got %s", embedding2.Path)
+	}
+	if embedding2.DataType != VectorDataTypeFloat32 {
+		t.Errorf("Expected second embedding data type float32, got %s", embedding2.DataType)
+	}
+	if embedding2.DistanceFunction != VectorDistanceFunctionDotProduct {
+		t.Errorf("Expected second embedding distance function dotproduct, got %s", embedding2.DistanceFunction)
+	}
+	if embedding2.Dimensions != 384 {
+		t.Errorf("Expected second embedding dimensions 384, got %d", embedding2.Dimensions)
+	}
+
+	// Validate vector indexing policy
+	if readProperties.IndexingPolicy == nil {
+		t.Fatalf("Expected IndexingPolicy to be set, but it was nil")
+	}
+
+	if len(readProperties.IndexingPolicy.VectorIndexes) != 2 {
+		t.Fatalf("Expected 2 vector indexes, got %d", len(readProperties.IndexingPolicy.VectorIndexes))
+	}
+
+	// Validate first vector index
+	index1 := readProperties.IndexingPolicy.VectorIndexes[0]
+	if index1.Path != "/embedding" {
+		t.Errorf("Expected first vector index path /embedding, got %s", index1.Path)
+	}
+	if index1.Type != VectorIndexTypeFlat {
+		t.Errorf("Expected first vector index type flat, got %s", index1.Type)
+	}
+
+	// Validate second vector index
+	index2 := readProperties.IndexingPolicy.VectorIndexes[1]
+	if index2.Path != "/textEmbedding" {
+		t.Errorf("Expected second vector index path /textEmbedding, got %s", index2.Path)
+	}
+	if index2.Type != VectorIndexTypeFlat {
+		t.Errorf("Expected second vector index type flat, got %s", index2.Type)
+	}
+
+	// Clean up
+	_, err = container.Delete(context.TODO(), nil)
+	if err != nil {
+		t.Fatalf("Failed to delete container: %v", err)
+	}
+}
+
+func TestContainerFullTextSearch(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{
+		ExpectedSpans: []string{"create_container fullTextContainer", "read_container fullTextContainer", "delete_container fullTextContainer"},
+	}))
+
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "fullTextSearch")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+
+	// Create container with full-text policy and indexing
+	properties := ContainerProperties{
+		ID: "fullTextContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths: []string{"/pk"},
+		},
+		FullTextPolicy: &FullTextPolicy{
+			DefaultLanguage: "en-US",
+			FullTextPaths: []FullTextPath{
+				{
+					Path:     "/title",
+					Language: "en-US",
+				},
+				{
+					Path:     "/description",
+					Language: "en-US",
+				},
+			},
+		},
+		IndexingPolicy: &IndexingPolicy{
+			Automatic:    true,
+			IndexingMode: IndexingModeConsistent,
+			IncludedPaths: []IncludedPath{
+				{Path: "/*"},
+			},
+			ExcludedPaths: []ExcludedPath{
+				{Path: "/\"_etag\"/?"},
+			},
+			FullTextIndexes: []FullTextIndex{
+				{
+					Path: "/title",
+				},
+				{
+					Path: "/description",
+				},
+			},
+		},
+	}
+
+	throughput := NewManualThroughputProperties(400)
+	_, err := database.CreateContainer(context.TODO(), properties, &CreateContainerOptions{ThroughputProperties: &throughput})
+	if err != nil {
+		t.Fatalf("Failed to create full-text container: %v", err)
+	}
+
+	container, _ := database.NewContainer("fullTextContainer")
+
+	// Read the container back to validate properties were set correctly
+	resp, err := container.Read(context.TODO(), nil)
+	if err != nil {
+		t.Fatalf("Failed to read container: %v", err)
+	}
+
+	readProperties := resp.ContainerProperties
+
+	// Validate basic properties
+	if readProperties.ID != properties.ID {
+		t.Errorf("Expected container ID %s, got %s", properties.ID, readProperties.ID)
+	}
+
+	// Validate full-text policy
+	if readProperties.FullTextPolicy == nil {
+		t.Fatalf("Expected FullTextPolicy to be set, but it was nil")
+	}
+
+	if readProperties.FullTextPolicy.DefaultLanguage != "en-US" {
+		t.Errorf("Expected default language en-US, got %s", readProperties.FullTextPolicy.DefaultLanguage)
+	}
+
+	if len(readProperties.FullTextPolicy.FullTextPaths) != 2 {
+		t.Fatalf("Expected 2 full text paths, got %d", len(readProperties.FullTextPolicy.FullTextPaths))
+	}
+
+	// Validate first full text path
+	path1 := readProperties.FullTextPolicy.FullTextPaths[0]
+	if path1.Path != "/title" {
+		t.Errorf("Expected first path /title, got %s", path1.Path)
+	}
+	if path1.Language != "en-US" {
+		t.Errorf("Expected first path language en-US, got %s", path1.Language)
+	}
+
+	// Validate second full text path
+	path2 := readProperties.FullTextPolicy.FullTextPaths[1]
+	if path2.Path != "/description" {
+		t.Errorf("Expected second path /description, got %s", path2.Path)
+	}
+	if path2.Language != "en-US" {
+		t.Errorf("Expected second path language en-US, got %s", path2.Language)
+	}
+
+	// Validate full-text indexing policy
+	if readProperties.IndexingPolicy == nil {
+		t.Fatalf("Expected IndexingPolicy to be set, but it was nil")
+	}
+
+	if len(readProperties.IndexingPolicy.FullTextIndexes) != 2 {
+		t.Fatalf("Expected 2 full text indexes, got %d", len(readProperties.IndexingPolicy.FullTextIndexes))
+	}
+
+	// Validate first full text index
+	index1 := readProperties.IndexingPolicy.FullTextIndexes[0]
+	if index1.Path != "/title" {
+		t.Errorf("Expected first full text index path /title, got %s", index1.Path)
+	}
+
+	// Validate second full text index
+	index2 := readProperties.IndexingPolicy.FullTextIndexes[1]
+	if index2.Path != "/description" {
+		t.Errorf("Expected second full text index path /description, got %s", index2.Path)
+	}
+	// Try to insert some sample data for full-text search testing
+	sampleItems := []map[string]interface{}{
+		{
+			"id":          "1",
+			"pk":          "test",
+			"title":       "Azure Cosmos DB Full Text Search",
+			"description": "Learn about the powerful full-text search capabilities in Azure Cosmos DB",
+		},
+		{
+			// An item that should not match the full-text search query.
+			// This means it should not contain the word "search" in the title or description.
+			"id":          "2",
+			"pk":          "test",
+			"title":       "Not related",
+			"description": "An unrelated item that should not match the query",
+		},
+	}
+
+	partitionKey := NewPartitionKeyString("test")
+	for _, item := range sampleItems {
+		itemBytes, err := json.Marshal(item)
+		if err != nil {
+			t.Fatalf("Failed to marshal sample item: %v", err)
+		}
+		_, err = container.CreateItem(context.TODO(), partitionKey, itemBytes, nil)
+		if err != nil {
+			t.Fatalf("Failed to create sample item: %v", err)
+		}
+	}
+
+	// Try to execute a full-text search query (this may fail if the SDK doesn't support it yet)
+	queryText := `SELECT * FROM c WHERE FullTextContains(c.title, "search") OR FullTextContains(c.description, "search")`
+	queryPager := container.NewQueryItemsPager(queryText, partitionKey, nil)
+
+	if !queryPager.More() {
+		t.Errorf("Expected results from full-text search query, but got none")
+	}
+
+	page, err := queryPager.NextPage(context.TODO())
+	if err != nil {
+		t.Errorf("Failed to execute full-text search query: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Errorf("Expected 1 result from full-text search query, but got %d", len(page.Items))
+	}
+
+	var resultItem map[string]interface{}
+	err = json.Unmarshal(page.Items[0], &resultItem)
+	if err != nil {
+		t.Errorf("Failed to unmarshal full-text search result: %v", err)
+	} else {
+		if resultItem["id"] != "1" {
+			t.Errorf("Expected result item ID '1', got '%s'", resultItem["id"])
+		}
+		if resultItem["title"] != "Azure Cosmos DB Full Text Search" {
+			t.Errorf("Expected result item title 'Azure Cosmos DB Full Text Search', got '%s'", resultItem["title"])
+		}
+	}
+
+	// Clean up
+	_, err = container.Delete(context.TODO(), nil)
 	if err != nil {
 		t.Fatalf("Failed to delete container: %v", err)
 	}

--- a/sdk/data/azcosmos/full_text_policy.go
+++ b/sdk/data/azcosmos/full_text_policy.go
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+// FullTextPolicy represents a full-text policy for a container.
+// This policy defines how text properties are indexed for full-text search operations.
+// For more information see https://docs.microsoft.com/azure/cosmos-db/gen-ai/full-text-search
+type FullTextPolicy struct {
+	// DefaultLanguage specifies the default language for full-text indexing and search.
+	// Supported languages include: en-US (English), de-DE (German), es-ES (Spanish), fr-FR (French).
+	DefaultLanguage string `json:"defaultLanguage"`
+	// FullTextPaths defines the text properties and their languages for full-text indexing.
+	FullTextPaths []FullTextPath `json:"fullTextPaths"`
+}
+
+// FullTextPath represents a path to a text property with its associated language for full-text indexing.
+type FullTextPath struct {
+	// Path to the text property in the document.
+	Path string `json:"path"`
+	// Language specifies the language for this specific text property.
+	// This can override the default language specified in the FullTextPolicy.
+	Language string `json:"language"`
+}

--- a/sdk/data/azcosmos/indexing_policy.go
+++ b/sdk/data/azcosmos/indexing_policy.go
@@ -16,8 +16,12 @@ type IndexingPolicy struct {
 	ExcludedPaths []ExcludedPath `json:"excludedPaths,omitempty"`
 	// Spatial indexes.
 	SpatialIndexes []SpatialIndex `json:"spatialIndexes,omitempty"`
-	// Spatial indexes.
+	// Composite indexes.
 	CompositeIndexes [][]CompositeIndex `json:"compositeIndexes,omitempty"`
+	// Vector indexes for vector search capabilities.
+	VectorIndexes []VectorIndex `json:"vectorIndexes,omitempty"`
+	// Full text indexes for full-text search capabilities.
+	FullTextIndexes []FullTextIndex `json:"fullTextIndexes,omitempty"`
 }
 
 // IncludedPath represents a json path to be included in indexing.
@@ -48,4 +52,37 @@ type CompositeIndex struct {
 	// For example if you want to run the query "SELECT * FROM c ORDER BY c.age asc, c.height desc",
 	// then you need to make the order for "/age" "ascending" and the order for "/height" "descending".
 	Order CompositeIndexOrder `json:"order"`
+}
+
+// VectorIndex represents a vector index for efficient vector search operations.
+type VectorIndex struct {
+	// Path to the vector property in the document.
+	Path string `json:"path"`
+	// Type of vector index algorithm to use.
+	Type VectorIndexType `json:"type"`
+}
+
+// VectorIndexType represents the supported vector index algorithms in Azure Cosmos DB.
+type VectorIndexType string
+
+const (
+	// VectorIndexTypeFlat uses a flat (brute-force) index that provides 100% accuracy.
+	// Suitable for smaller datasets and has a limitation of 505 dimensions.
+	VectorIndexTypeFlat VectorIndexType = "flat"
+
+	// VectorIndexTypeQuantizedFlat uses a quantized flat index that compresses vectors
+	// before storing on the index. Provides high accuracy with better performance than flat.
+	// Supports up to 4,096 dimensions and is recommended for up to ~50,000 vectors per partition.
+	VectorIndexTypeQuantizedFlat VectorIndexType = "quantizedFlat"
+
+	// VectorIndexTypeDiskANN uses DiskANN algorithm for high-performance vector search.
+	// Provides the best performance for large datasets with more than 50,000 vectors per partition.
+	// Supports up to 4,096 dimensions.
+	VectorIndexTypeDiskANN VectorIndexType = "diskANN"
+)
+
+// FullTextIndex represents a full-text index for efficient text search operations.
+type FullTextIndex struct {
+	// Path to the text property in the document.
+	Path string `json:"path"`
 }

--- a/sdk/data/azcosmos/vector_embedding_policy.go
+++ b/sdk/data/azcosmos/vector_embedding_policy.go
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+// VectorEmbeddingPolicy represents the vector embedding policy for a container.
+// This policy defines the vector embedding configurations that specify how vectors
+// are stored and searched within the container.
+type VectorEmbeddingPolicy struct {
+	// VectorEmbeddings contains the list of vector embedding definitions for the container.
+	VectorEmbeddings []VectorEmbedding `json:"vectorEmbeddings"`
+}
+
+// VectorEmbedding represents a single vector embedding definition within a container.
+type VectorEmbedding struct {
+	// Path contains the JSON path to the vector property in the document.
+	// Example: "/vector1" or "/embeddings/textVector"
+	Path string `json:"path"`
+
+	// DataType specifies the data type of the vector elements.
+	// Supported values: "float32" (default), "int8", "uint8"
+	DataType VectorDataType `json:"dataType"`
+
+	// DistanceFunction specifies the metric used to compute distance/similarity.
+	// Supported values: "cosine", "dotproduct", "euclidean"
+	DistanceFunction VectorDistanceFunction `json:"distanceFunction"`
+
+	// Dimensions specifies the dimensionality or length of each vector in the path.
+	// All vectors in a path should have the same number of dimensions.
+	// Default: 1536
+	Dimensions int32 `json:"dimensions"`
+}
+
+// VectorDataType represents the supported data types for vector elements.
+type VectorDataType string
+
+const (
+	// VectorDataTypeFloat32 represents 32-bit floating point numbers (default).
+	VectorDataTypeFloat32 VectorDataType = "float32"
+
+	// VectorDataTypeInt8 represents 8-bit signed integers.
+	VectorDataTypeInt8 VectorDataType = "int8"
+
+	// VectorDataTypeUint8 represents 8-bit unsigned integers.
+	VectorDataTypeUint8 VectorDataType = "uint8"
+)
+
+// VectorDistanceFunction represents the supported distance functions for vector similarity.
+type VectorDistanceFunction string
+
+const (
+	// VectorDistanceFunctionCosine uses cosine similarity.
+	// Values range from -1 (least similar) to +1 (most similar).
+	VectorDistanceFunctionCosine VectorDistanceFunction = "cosine"
+
+	// VectorDistanceFunctionDotProduct uses dot product similarity.
+	// Values range from -inf (least similar) to +inf (most similar).
+	VectorDistanceFunctionDotProduct VectorDistanceFunction = "dotproduct"
+
+	// VectorDistanceFunctionEuclidean uses Euclidean distance.
+	// Values range from 0 (most similar) to +inf (least similar).
+	VectorDistanceFunctionEuclidean VectorDistanceFunction = "euclidean"
+)


### PR DESCRIPTION
This PR is a simple cherry-pick of the changes in #24833 from `main` over to the release branch for the preview release that includes query engine support. That seemed like the smoothest way to get something into this branch quickly to unblock vector scenarios there. I expect we'll release a `1.5.0` and move the query engine preview over to `1.6.0-beta` soon, and I'll reconcile things like CHANGELOG when that happens. Until then, I'd like to be able to make a preview release to allow folks to actually try Vector search with the query engine.