### PR TITLE
Allow an additional retry for IMDS managed identity requests

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+- By default, `ManagedIdentityCredential` retries IMDS requests for a maximum of ~70 seconds as recommended
+  in IMDS documentation. In previous versions, it would stop retrying after ~54 seconds by default.
 
 ## 1.10.1 (2025-06-10)
 

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -54,10 +54,10 @@ type managedIdentityClient struct {
 // setIMDSRetryOptionDefaults sets zero-valued fields to default values appropriate for IMDS
 func setIMDSRetryOptionDefaults(o *policy.RetryOptions) {
 	if o.MaxRetries == 0 {
-		o.MaxRetries = 5
+		o.MaxRetries = 6
 	}
 	if o.MaxRetryDelay == 0 {
-		o.MaxRetryDelay = 1 * time.Minute
+		o.MaxRetryDelay = 25 * time.Second
 	}
 	if o.RetryDelay == 0 {
 		o.RetryDelay = 2 * time.Second
@@ -81,9 +81,6 @@ func setIMDSRetryOptionDefaults(o *policy.RetryOptions) {
 			http.StatusNotExtended,                   // 510
 			http.StatusNetworkAuthenticationRequired, // 511
 		}
-	}
-	if o.TryTimeout == 0 {
-		o.TryTimeout = 1 * time.Minute
 	}
 }
 

--- a/sdk/azidentity/managed_identity_client.go
+++ b/sdk/azidentity/managed_identity_client.go
@@ -82,6 +82,9 @@ func setIMDSRetryOptionDefaults(o *policy.RetryOptions) {
 			http.StatusNetworkAuthenticationRequired, // 511
 		}
 	}
+	if o.TryTimeout == 0 {
+		o.TryTimeout = 1 * time.Minute
+	}
 }
 
 // newManagedIdentityClient creates a new instance of the ManagedIdentityClient with the ManagedIdentityCredentialOptions


### PR DESCRIPTION
Closes #24842 with a small tweak to IMDS retry configuration. Our retry policy doesn't allow setting retry options based on a response, so this PR allows another retry in any case and shortens the `MaxRetryDelay` so the total retry period is about 70 seconds.

Here's a sample of the change's effect. Delays for retries 1-3 are unchanged (jitter causes the variation) but now there's a 5th retry, which like the 4th is limited to 25s.
| Retry | Delay before | Delay after |
|-------|----------------|---------------|
| 1     | 2.11s          | 1.71s         |
| 2     | 5.69s          | 7.46s         |
| 3     | 12.37s         | 13.38s        |
| 4     | 31.80s         | 25.00s        |
| 5     | —              | 25.00s        |
| **Total** | **51.97s**     | **72.55s**      |
