### PR TITLE
[Do not merge] Manually enable internal golang module proxy

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -36,6 +36,10 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
+    featureFlags:
+      golang:                
+        internalModuleProxy:
+          enabled: true
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'go - azcore'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:


### PR DESCRIPTION
This PR is only to manually enable the internal module proxy just for testing in validation pipeline https://dev.azure.com/azure-sdk/public/_build?definitionId=7557

Not intended for merging to `main`
