### PR TITLE
Adding in some copilot instructions that are targeted at specific file names as well as a devcontainer update

### DIFF
--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
 
+set -ex
+
+# a better version of gofmt - reorganizes/adds/removes imports automatically.
 go install golang.org/x/tools/cmd/goimports@latest
+
+# useful for previewing how docs will look on pkg.go.dev
+go install golang.org/x/pkgsite/cmd/pkgsite@latest
+
+# installs 'tsp' - the TypeSpec compiler
+npm install -g @typespec/compiler
+
+# installs 'tsp-client' - The TypeSpec+Azure client generator
+npm install -g @azure-tools/typespec-client-generator-cli
+
+# NOTE: 
 npm install -g autorest

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -14,5 +14,5 @@ npm install -g @typespec/compiler
 # installs 'tsp-client' - The TypeSpec+Azure client generator
 npm install -g @azure-tools/typespec-client-generator-cli
 
-# NOTE: 
+# NOTE: you probably won't need this as most libraries should be using TypeSpec
 npm install -g autorest

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+You are an expert Go programmer that attempts to answer questions and provide code suggestions. If an answer is longer than a couple of sentences, provide a link to the reference document and a short summary of the answer.
+
+- Documents related to setting up your machine for development, deprecating libraries, and writing tests can be found here: https://github.com/Azure/azure-sdk-for-go/tree/main/documentation.
+- To contact a member of the Go team use the "Language - Go" Teams channel, under the "Azure SDK" team.
+- To determine who owns a module, use the [CODEOWNERS file](https://github.com/Azure/azure-sdk-for-go/tree/main/.github/CODEOWNERS), and find the line that matches the module path. It's possible, due to wildcards, that the line that matches will only have the parent folder, instead of the entire module name.

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -1,0 +1,6 @@
+These files are picked up by Copilot Chat. 
+
+If you're working in a file that matches the wildcards, listed in the header, then that instruction file will automatically 
+get included in your context.
+
+More about this here: https://code.visualstudio.com/docs/copilot/copilot-customization

--- a/.github/instructions/go-code.instructions.md
+++ b/.github/instructions/go-code.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: '**/*.go'
+---
+
+All code should follow the guidelines from the [Azure Go SDK Guidelines](https://azure.github.io/azure-sdk/golang_introduction.html). This document is a summary of the most important guidelines to follow when contributing to the Azure Go SDK.
+
+Some additional rules:
+- Acronyms in exported type/struct/function names (for instance, 'id' in UserID, or 'acs' in ACSRecordedEvent) should be uppercased. This rule does not apply to string constants.
+- All Go files should have a copyright header. The header might be after go build directives, like "//go:build go1.18"

--- a/.github/instructions/go-examples.instructions.md
+++ b/.github/instructions/go-examples.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: '**/example*_test.go'
+---
+
+- Error handling code should look like this (include all comments):
+  ```go
+  if err != nil {
+    // TODO: Update the following line with your application specific error handling logic
+    log.Fatalf(\"ERROR: %s\", err)
+  }
+  ```
+- Don't make examples executable (ie, don't include `//Output:`).
+- Use `context.TODO()` in places that require a context, NOT `context.Background()`. This lets the user know they need to provide a context.

--- a/.github/instructions/go-mod-standards.instructions.md
+++ b/.github/instructions/go-mod-standards.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: '**/go.mod'
+---
+
+- go.mod should only have direct reference to modules within the azure-sdk-for-go (ie: github.com/Azure/azure-sdk-for-go/sdk/<modules>), standard library modules or modules that begin with `golang.org/x/`
+- go.mod can have indirect dependencies to 3rd party modules, with the exception of:
+  - github.com/stretchr/testify
+  

--- a/.github/instructions/go-tests.instructions.md
+++ b/.github/instructions/go-tests.instructions.md
@@ -1,0 +1,6 @@
+---
+applyTo: '**/*_test.go'
+---
+
+- Use github.com/stretchr/testify/require for assertions. Some commonly used functions: `require.Equal`, `require.NoError`.
+- Environment variables required for live testing can be found by looking for recording.Getenv() calls, or os.Getenv() calls in the code. You should place these into a .env file at the root of the module, before testing.

--- a/.github/instructions/tsp-location.instructions.md
+++ b/.github/instructions/tsp-location.instructions.md
@@ -13,7 +13,7 @@ applyTo: '**/tsp-location.yaml'
 You can regen this client by running:
 
 1. cd to the directory containing this file, for example `cd sdk/location/azlocation`
-2.`go generate` in the root of the module. If there are any errors related to tsp-client, or tsp not being installed they probably follow the instructions in "Pre-requisites".
+2. `go generate` in the root of the module. If there are any errors related to tsp-client, or tsp not being installed they probably follow the instructions in "Pre-requisites".
 3. Create Go examples (in examples*_test.go files) for the new methods.
 4. Update the CHANGELOG describing the features, bug fixes, or breaking changes in this client.
 

--- a/.github/instructions/tsp-location.instructions.md
+++ b/.github/instructions/tsp-location.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: '**/tsp-location.yaml'
+---
+
+## Pre-requisites
+
+1. Install the latest node LTS package (on Windows, you can use `winget install OpenJS.NodeJS.LTS`)
+2. Install the TypeSpec compiler (`npm install -g @typespec/compiler`)
+3. Install tsp-client (`npm install -g @azure-tools/typespec-client-generator-cli`)
+
+## Regen
+
+You can regen this client by running:
+
+1. cd to the directory containing this file, for example `cd sdk/location/azlocation`
+2.`go generate` in the root of the module. If there are any errors related to tsp-client, or tsp not being installed they probably follow the instructions in "Pre-requisites".
+3. Create Go examples (in examples*_test.go files) for the new methods.
+4. Update the CHANGELOG describing the features, bug fixes, or breaking changes in this client.
+
+## Shortcuts
+
+- You can browse to the URL/commit for this repo by going to https://github.com/<repo>/tree/<commit>/<directory>, using the fields from this file.


### PR DESCRIPTION
This is a "demo" that I think we can just check in. The instructions.md files are split out, based on file type, which lets me give more specific instructions for different types of files, and keeps it more readable.

For instance, I have a specific instructions for go.mod files: https://github.com/Azure/azure-sdk-for-go/pull/24872/files#diff-d3692df77e0694faf2a712cde75a5a4117d8ede6ff4a84678cfccaf1529354ae, and one specifically for [examples](https://github.com/Azure/azure-sdk-for-go/pull/24872/files#diff-9610976b8147e9ff3c72954b763729b4ab8c357a0cb38fb5d883edcc3f1ebda6), vs tests vs just normal package code. Since we have a fairly solid naming convention we could easily add in more, and keep them small.

When you are working with a file that has a corresponding instruction sfile, Copilot will automatically add the appropriate instructions file to your context, which looks like this:
<img width="487" alt="image" src="https://github.com/user-attachments/assets/93a522ff-9f8d-4727-a791-562463849b3c" />

And you get nice advice, with this current set, like this (my prompt was "help me") while looking at a _test.go file in azcore:

<img width="349" alt="image" src="https://github.com/user-attachments/assets/55b7e1c6-8856-4307-bc74-8b3e327df00f" />
