### PR TITLE
cosmos: enable support for obtaining feed ranges from a pkrange in a container

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added support for BypassIntegratedCache option See [PR 24772](https://github.com/Azure/azure-sdk-for-go/pull/24772)
 * Added support for specifying Full-Text Search indexing policies when creating a container. See [PR 24833](https://github.com/Azure/azure-sdk-for-go/pull/24833)
 * Added support for specifying Vector Search indexing policies when creating a container. See [PR 24833](https://github.com/Azure/azure-sdk-for-go/pull/24833)
+* Added support for reading Feed Ranges from a container. See [PR 24889](https://github.com/Azure/azure-sdk-for-go/pull/24889)
 
 
 ### Breaking Changes

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -432,6 +432,28 @@ func (c *ContainerClient) ReadItem(
 	return response, err
 }
 
+// GetFeedRanges retrieves all the feed ranges for which changefeed could be fetched.
+// ctx - The context for the request.
+func (c *ContainerClient) GetFeedRanges(ctx context.Context) ([]FeedRange, error) {
+	// Get the partition key ranges from the container
+	response, err := c.getPartitionKeyRanges(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert partition key ranges to feed ranges
+	feedRanges := make([]FeedRange, 0, len(response.PartitionKeyRanges))
+	for _, pkr := range response.PartitionKeyRanges {
+		feedRange := FeedRange{
+			MinInclusive: pkr.MinInclusive,
+			MaxExclusive: pkr.MaxExclusive,
+		}
+		feedRanges = append(feedRanges, feedRange)
+	}
+
+	return feedRanges, nil
+}
+
 // DeleteItem deletes an item in a Cosmos container.
 // ctx - The context for the request.
 // partitionKey - The partition key for the item.

--- a/sdk/data/azcosmos/cosmos_feed_range.go
+++ b/sdk/data/azcosmos/cosmos_feed_range.go
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+// FeedRange represents a range of partition key values for a Cosmos container.
+// It is used to identify a specific range of documents for change feed processing.
+type FeedRange struct {
+	// MinInclusive contains the minimum inclusive value of the partition key range.
+	MinInclusive string
+	// MaxExclusive contains the maximum exclusive value of the partition key range.
+	MaxExclusive string
+}
+
+// NewFeedRange creates a new FeedRange with the specified minimum inclusive and maximum exclusive values.
+func NewFeedRange(minInclusive, maxExclusive string) FeedRange {
+	return FeedRange{
+		MinInclusive: minInclusive,
+		MaxExclusive: maxExclusive,
+	}
+}

--- a/sdk/data/azcosmos/cosmos_feed_range_test.go
+++ b/sdk/data/azcosmos/cosmos_feed_range_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+)
+
+func TestContainerGetFeedRanges(t *testing.T) {
+	expectedJsonResponse := []byte(`{
+	"_rid": "lypXAMSZ-Cs=",
+	"PartitionKeyRanges": [
+        {
+            "_rid": "lypXAMSZ-CuZAAAAAAAAUA==",
+            "id": "151",
+            "_etag": "\"0000cc70-0000-0100-0000-682306240000\"",
+            "minInclusive": "05C1E18D2D7F08",
+            "maxExclusive": "05C1E18D2D83FA",
+            "ridPrefix": 151,
+            "_self": "dbs/lypXAA==/colls/lypXAMSZ-Cs=/pkranges/lypXAMSZ-CuZAAAAAAAAUA==/",
+            "throughputFraction": 0.0125,
+            "status": "online",
+            "parents": [
+                "5",
+                "10",
+                "31"
+            ],
+            "ownedArchivalPKRangeIds": [
+                "31"
+            ],
+            "_ts": 1747125796,
+            "lsn": 22874
+        },
+        {
+            "_rid": "lypXAMSZ-CulAAAAAAAAUA==",
+            "id": "163",
+            "_etag": "\"0000dd1b-0000-0100-0000-67f6d6a70000\"",
+            "minInclusive": "05C1C7FF3903F8",
+            "maxExclusive": "05C1C9CD673390",
+            "ridPrefix": 163,
+            "_self": "dbs/lypXAA==/colls/lypXAMSZ-Cs=/pkranges/lypXAMSZ-CulAAAAAAAAUA==/",
+            "throughputFraction": 0.0125,
+            "status": "online",
+            "parents": [
+                "1",
+                "19",
+                "39"
+            ],
+            "ownedArchivalPKRangeIds": [
+                "39"
+            ],
+            "_ts": 1744230055,
+            "lsn": 22599
+        }
+	],
+	"_count": 2
+	}`)
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithBody(expectedJsonResponse),
+		mock.WithHeader(cosmosHeaderEtag, "someEtag"),
+		mock.WithHeader(cosmosHeaderActivityId, "someActivityId"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "13.42"),
+		mock.WithStatusCode(200),
+	)
+
+	defaultEndpoint, _ := url.Parse(srv.URL())
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	gem := &globalEndpointManager{preferredLocations: []string{}}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
+
+	database, _ := newDatabase("databaseId", client)
+	container, _ := newContainer("containerId", database)
+
+	feedRanges, err := container.GetFeedRanges(context.TODO())
+	if err != nil {
+		t.Fatalf("GetFeedRanges failed: %v", err)
+	}
+
+	if len(feedRanges) != 2 {
+		t.Fatalf("Expected 2 feed ranges, got %d", len(feedRanges))
+	}
+
+	if feedRanges[0].MinInclusive != "05C1E18D2D7F08" {
+		t.Errorf("Expected MinInclusive to be 05C1E18D2D7F08, got %s", feedRanges[0].MinInclusive)
+	}
+
+	if feedRanges[0].MaxExclusive != "05C1E18D2D83FA" {
+		t.Errorf("Expected MaxExclusive to be 05C1E18D2D83FA, got %s", feedRanges[0].MaxExclusive)
+	}
+
+	if feedRanges[1].MinInclusive != "05C1C7FF3903F8" {
+		t.Errorf("Expected MinInclusive to be 05C1C7FF3903F8, got %s", feedRanges[1].MinInclusive)
+	}
+
+	if feedRanges[1].MaxExclusive != "05C1C9CD673390" {
+		t.Errorf("Expected MaxExclusive to be 05C1C9CD673390, got %s", feedRanges[1].MaxExclusive)
+	}
+}
+
+func TestContainerGetFeedRangesEmpty(t *testing.T) {
+	expectedJsonResponse := `{
+    "_rid": "lypXAMSZ-Cs=",
+    "PartitionKeyRanges": [],
+    "_count": 0
+	}`
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.SetResponse(
+		mock.WithBody([]byte(expectedJsonResponse)),
+		mock.WithHeader(cosmosHeaderEtag, "someEtag"),
+		mock.WithHeader(cosmosHeaderActivityId, "someActivityId"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "13.42"),
+		mock.WithStatusCode(200),
+	)
+
+	defaultEndpoint, _ := url.Parse(srv.URL())
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
+	gem := &globalEndpointManager{preferredLocations: []string{}}
+	client := &Client{endpoint: srv.URL(), endpointUrl: defaultEndpoint, internal: internalClient, gem: gem}
+
+	database, _ := newDatabase("databaseId", client)
+	container, _ := newContainer("containerId", database)
+
+	feedRanges, err := container.GetFeedRanges(context.TODO())
+	if err != nil {
+		t.Fatalf("GetFeedRanges failed: %v", err)
+	}
+
+	if len(feedRanges) != 0 {
+		t.Fatalf("Expected 0 feed ranges, got %d", len(feedRanges))
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

Add a method to the Go SDK as a Cosmos container operation to retrieve the `MinInclusive` and `MaxExclusive` values from a pkrange and store them in a `FeedRange` struct.

FeedRanges allow the SDK to encapsulate the complexity of partition management, making client code simpler and more robust to backend changes. With this, we can parallelize change feed processing based on logical key ranges, independent of the number or identity of physical partitions.

## Note

- This PR builds on:
  - https://github.com/Azure/azure-sdk-for-go/pull/24835

- **Please review after** the above PRs are merged, as this change set is rebased on top of them.
- Changes in this PR start from commit: [0e9704e](https://github.com/Azure/azure-sdk-for-go/pull/24889/commits/0e9704ec97bc74086f61eabea0fc23317ce935ca) (first unique commit)

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
