### PR TITLE
Prevent race in ResourceID.String()

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 * Fixed incorrect request/response logging try info when logging a request that's being retried.
+* Fixed a data race in `ResourceID.String()`
 
 ### Other Changes
 

--- a/sdk/azcore/arm/internal/resource/resource_identifier_test.go
+++ b/sdk/azcore/arm/internal/resource/resource_identifier_test.go
@@ -8,8 +8,25 @@ package resource
 
 import (
 	"encoding"
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestRace(t *testing.T) {
+	rid, err := ParseResourceID("/subscriptions/0/resourceGroups/foo")
+	require.NoError(t, err)
+	wg := sync.WaitGroup{}
+	for i := 0; i < 42; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = rid.String()
+		}()
+	}
+	wg.Wait()
+}
 
 func TestParseResourceIdentifier(t *testing.T) {
 	testData := map[string]*ResourceID{
@@ -22,24 +39,28 @@ func TestParseResourceIdentifier(t *testing.T) {
 						ResourceType:   SubscriptionResourceType,
 						Name:           "17fecd63-33d8-4e43-ac6f-0aafa111b38d",
 						isChild:        true,
+						stringValue:    "/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d",
 					},
 					SubscriptionID:    "17fecd63-33d8-4e43-ac6f-0aafa111b38d",
 					ResourceType:      ResourceGroupResourceType,
 					ResourceGroupName: "myRg",
 					Name:              "myRg",
 					isChild:           true,
+					stringValue:       "/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/resourceGroups/myRg",
 				},
 				SubscriptionID:    "17fecd63-33d8-4e43-ac6f-0aafa111b38d",
 				ResourceGroupName: "myRg",
 				ResourceType:      NewResourceType("Microsoft.ApiManagement", "service"),
 				Name:              "myServiceName",
 				isChild:           false,
+				stringValue:       "/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/resourceGroups/myRg/providers/Microsoft.ApiManagement/service/myServiceName",
 			},
 			SubscriptionID:    "17fecd63-33d8-4e43-ac6f-0aafa111b38d",
 			ResourceGroupName: "myRg",
 			ResourceType:      NewResourceType("Microsoft.ApiManagement", "service/subscriptions"),
 			Name:              "mySubs",
 			isChild:           true,
+			stringValue:       "/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/resourceGroups/myRg/providers/Microsoft.ApiManagement/service/myServiceName/subscriptions/mySubs",
 		},
 		// valid resource identifiers
 		"/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c": {
@@ -48,11 +69,13 @@ func TestParseResourceIdentifier(t *testing.T) {
 			ResourceType:   SubscriptionResourceType,
 			Name:           "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
 			isChild:        true,
+			stringValue:    "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
 		},
 		"/providers/Microsoft.Billing/billingAccounts/3984c6f4-2d2a-4b04-93ce-43cf4824b698%3Ae2f1492a-a492-468d-909f-bf7fe6662c01_2019-05-31": {
 			Parent:       RootResourceID,
 			ResourceType: NewResourceType("Microsoft.Billing", "billingAccounts"),
 			Name:         "3984c6f4-2d2a-4b04-93ce-43cf4824b698%3Ae2f1492a-a492-468d-909f-bf7fe6662c01_2019-05-31",
+			stringValue:  "/providers/Microsoft.Billing/billingAccounts/3984c6f4-2d2a-4b04-93ce-43cf4824b698%3Ae2f1492a-a492-468d-909f-bf7fe6662c01_2019-05-31",
 		},
 		"/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/microsoft.insights": {
 			Parent: &ResourceID{
@@ -61,12 +84,14 @@ func TestParseResourceIdentifier(t *testing.T) {
 				ResourceType:   SubscriptionResourceType,
 				Name:           "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
 				isChild:        true,
+				stringValue:    "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
 			},
 			SubscriptionID: "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
 			Provider:       "microsoft.insights",
 			ResourceType:   ProviderResourceType,
 			Name:           "microsoft.insights",
 			isChild:        true,
+			stringValue:    "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/microsoft.insights",
 		},
 		"/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Compute/virtualMachines/myVm": {
 			Parent: &ResourceID{
@@ -76,18 +101,21 @@ func TestParseResourceIdentifier(t *testing.T) {
 					ResourceType:   SubscriptionResourceType,
 					Name:           "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 					isChild:        true,
+					stringValue:    "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 				},
 				SubscriptionID:    "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 				ResourceGroupName: "myRg",
 				ResourceType:      ResourceGroupResourceType,
 				Name:              "myRg",
 				isChild:           true,
+				stringValue:       "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg",
 			},
 			SubscriptionID:    "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 			ResourceGroupName: "myRg",
 			ResourceType:      NewResourceType("Microsoft.Compute", "virtualMachines"),
 			Name:              "myVm",
 			isChild:           false,
+			stringValue:       "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Compute/virtualMachines/myVm",
 		},
 		"/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myNet/subnets/mySubnet": {
 			Parent: &ResourceID{
@@ -98,24 +126,28 @@ func TestParseResourceIdentifier(t *testing.T) {
 						ResourceType:   SubscriptionResourceType,
 						Name:           "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 						isChild:        true,
+						stringValue:    "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 					},
 					SubscriptionID:    "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 					ResourceGroupName: "myRg",
 					ResourceType:      ResourceGroupResourceType,
 					Name:              "myRg",
 					isChild:           true,
+					stringValue:       "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg",
 				},
 				SubscriptionID:    "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 				ResourceGroupName: "myRg",
 				ResourceType:      NewResourceType("Microsoft.Network", "virtualNetworks"),
 				Name:              "myNet",
 				isChild:           false,
+				stringValue:       "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myNet",
 			},
 			SubscriptionID:    "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 			ResourceGroupName: "myRg",
 			ResourceType:      NewResourceType("Microsoft.Network", "virtualNetworks/subnets"),
 			Name:              "mySubnet",
 			isChild:           true,
+			stringValue:       "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myNet/subnets/mySubnet",
 		},
 		"/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg": {
 			Parent: &ResourceID{
@@ -124,12 +156,14 @@ func TestParseResourceIdentifier(t *testing.T) {
 				ResourceType:   SubscriptionResourceType,
 				Name:           "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 				isChild:        true,
+				stringValue:    "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 			},
 			SubscriptionID:    "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 			ResourceGroupName: "myRg",
 			ResourceType:      ResourceGroupResourceType,
 			Name:              "myRg",
 			isChild:           true,
+			stringValue:       "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg",
 		},
 		"/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/locations/MyLocation": {
 			Parent: &ResourceID{
@@ -138,12 +172,14 @@ func TestParseResourceIdentifier(t *testing.T) {
 				ResourceType:   SubscriptionResourceType,
 				Name:           "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 				isChild:        true,
+				stringValue:    "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 			},
 			SubscriptionID: "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 			ResourceType:   SubscriptionResourceType.AppendChild(locationsKey),
 			Name:           "MyLocation",
 			Location:       "MyLocation",
 			isChild:        true,
+			stringValue:    "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/locations/MyLocation",
 		},
 		"/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/locations/MyLocation/providers/Microsoft.Authorization/roleAssignments/myRa": {
 			Parent: &ResourceID{
@@ -153,17 +189,20 @@ func TestParseResourceIdentifier(t *testing.T) {
 					ResourceType:   SubscriptionResourceType,
 					Name:           "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 					isChild:        true,
+					stringValue:    "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 				},
 				SubscriptionID: "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 				ResourceType:   SubscriptionResourceType.AppendChild(locationsKey),
 				Name:           "MyLocation",
 				Location:       "MyLocation",
 				isChild:        true,
+				stringValue:    "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/locations/MyLocation",
 			},
 			SubscriptionID: "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 			ResourceType:   NewResourceType("Microsoft.Authorization", "roleAssignments"),
 			Name:           "myRa",
 			isChild:        false,
+			stringValue:    "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/locations/MyLocation/providers/Microsoft.Authorization/roleAssignments/myRa",
 		},
 		"/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/": {
 			Parent: &ResourceID{
@@ -174,24 +213,28 @@ func TestParseResourceIdentifier(t *testing.T) {
 						ResourceType:   SubscriptionResourceType,
 						Name:           "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 						isChild:        true,
+						stringValue:    "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 					},
 					SubscriptionID:    "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 					ResourceType:      ResourceGroupResourceType,
 					ResourceGroupName: "myRg",
 					Name:              "myRg",
 					isChild:           true,
+					stringValue:       "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg",
 				},
 				SubscriptionID:    "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 				ResourceGroupName: "myRg",
 				ResourceType:      NewResourceType("Microsoft.Network", "virtualNetworks"),
 				Name:              "myVnet",
 				isChild:           false,
+				stringValue:       "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet",
 			},
 			SubscriptionID:    "0c2f6471-1bf0-4dda-aec3-cb9272f09575",
 			ResourceGroupName: "myRg",
 			ResourceType:      NewResourceType("Microsoft.Network", "virtualNetworks/subnets"),
 			Name:              "",
 			isChild:           true,
+			stringValue:       "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet/subnets",
 		},
 		// invalid resource identifiers
 		"/providers/MicrosoftSomething/billingAccounts/":             nil,

--- a/sdk/azcore/arm/resource_identifier.go
+++ b/sdk/azcore/arm/resource_identifier.go
@@ -14,7 +14,8 @@ import (
 var RootResourceID = resource.RootResourceID
 
 // ResourceID represents a resource ID such as `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg`.
-// Don't create this type directly, use ParseResourceID instead.
+// Don't create this type directly, use [ParseResourceID] instead. Fields are considered immutable and shouldn't be
+// modified after creation.
 type ResourceID = resource.ResourceID
 
 // ParseResourceID parses a string to an instance of ResourceID


### PR DESCRIPTION
Fixes #24869 by computing the string representation of ResourceIDs at construction instead of during the first `String()` call. I also added a note to the docs that ResourceID fields are considered immutable, so readers don't expect a useable result after changing values.