### PR TITLE
SDK MCP Server 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ _testmain.go
 *.swp
 *~
 .DS_Store
-.vscode
 .vs
 .idea
 
@@ -47,6 +46,7 @@ vendor/
 # vscode
 **/.vscode/*
 !.vscode/cspell.json
+!.vscode/mcp.json
 
 # api view file
 *.gosource

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{  
+    "servers": {
+      "azure-sdk-mcp": {
+        "type": "stdio",
+        "command": "pwsh",        
+        "args": ["${workspaceFolder}/eng/common/mcp/azure-sdk-mcp.ps1", "-Run"]
+    },
+  }
+}


### PR DESCRIPTION
- Enable SDK MCP server so TypeSpec workflow can be started from language repo. This will also enable language team to use package readiness and release SDK tool.
- Also seems like you were excluding vscode twice. Not sure how the cspell was getting through I assume because it was there before the exclude was included. 