### PR TITLE
DefaultAzureCredential continues past developer tool errors

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+- `DefaultAzureCredential` tries its next credential when a dev tool credential such as
+  `AzureCLICredential` returns an error
 
 ## 1.11.0-beta.1 (2025-07-15)
 

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -166,7 +166,11 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		}
 	}
 	if selected&az != 0 {
-		azCred, err := NewAzureCLICredential(&AzureCLICredentialOptions{AdditionallyAllowedTenants: additionalTenants, TenantID: options.TenantID})
+		azCred, err := NewAzureCLICredential(&AzureCLICredentialOptions{
+			AdditionallyAllowedTenants: additionalTenants,
+			TenantID:                   options.TenantID,
+			inDefaultChain:             true,
+		})
 		if err == nil {
 			creds = append(creds, azCred)
 		} else {
@@ -178,6 +182,7 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		azdCred, err := NewAzureDeveloperCLICredential(&AzureDeveloperCLICredentialOptions{
 			AdditionallyAllowedTenants: additionalTenants,
 			TenantID:                   options.TenantID,
+			inDefaultChain:             true,
 		})
 		if err == nil {
 			creds = append(creds, azdCred)

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -113,6 +113,27 @@ func TestDefaultAzureCredential_AZURE_TOKEN_CREDENTIALS(t *testing.T) {
 	})
 }
 
+func TestDefaultAzureCredential_CLICredentialOptions(t *testing.T) {
+	require := require.New(t)
+	cred, err := NewDefaultAzureCredential(nil)
+	require.NoError(err)
+	var (
+		az  *AzureCLICredential
+		azd *AzureDeveloperCLICredential
+	)
+	for _, s := range cred.chain.sources {
+		if az == nil {
+			az, _ = s.(*AzureCLICredential)
+		} else if azd == nil {
+			azd, _ = s.(*AzureDeveloperCLICredential)
+		}
+	}
+	require.NotNil(az, "%T should be in the default chain", az)
+	require.True(az.opts.inDefaultChain)
+	require.NotNil(azd, "%T should be in the default chain", azd)
+	require.True(azd.opts.inDefaultChain)
+}
+
 func TestDefaultAzureCredential_ConstructorErrors(t *testing.T) {
 	// ensure NewEnvironmentCredential returns an error
 	t.Setenv(azureTenantID, "")


### PR DESCRIPTION
#21328 added the `inDefaultChain` option but neglected making `NewDefaultAzureCredential` set it