### PR TITLE
[monitor] update tsp-location and emitter

### DIFF
--- a/sdk/monitor/ingestion/azlogs/build.go
+++ b/sdk/monitor/ingestion/azlogs/build.go
@@ -1,7 +1,0 @@
-//go:generate tsp-client update
-//go:generate goimports -w .
-
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
-package azlogs

--- a/sdk/monitor/ingestion/azlogs/testdata/_metadata.json
+++ b/sdk/monitor/ingestion/azlogs/testdata/_metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2023-01-01",
-  "emitterVersion": "0.5.1"
+  "emitterVersion": "0.7.0"
 }

--- a/sdk/monitor/ingestion/azlogs/tsp-location.yaml
+++ b/sdk/monitor/ingestion/azlogs/tsp-location.yaml
@@ -1,3 +1,3 @@
-directory: specification/monitor/Azure.Monitor.Ingestion
-commit: 717f57e015a6ff2542eca5e7830c4d2daeb9414d
+directory: specification/monitor/Monitor.Ingestion
+commit: 3d00012653b43a88016fb7af01653f4916d9bcfa
 repo: Azure/azure-rest-api-specs

--- a/sdk/monitor/query/azmetrics/build.go
+++ b/sdk/monitor/query/azmetrics/build.go
@@ -1,7 +1,0 @@
-//go:generate tsp-client update
-//go:generate goimports -w .
-
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
-package azmetrics

--- a/sdk/monitor/query/azmetrics/client.go
+++ b/sdk/monitor/query/azmetrics/client.go
@@ -7,14 +7,13 @@ package azmetrics
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
 // Client contains the methods for the group.

--- a/sdk/monitor/query/azmetrics/fake/server.go
+++ b/sdk/monitor/query/azmetrics/fake/server.go
@@ -8,15 +8,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
-	"regexp"
-	"strconv"
-
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
 )
 
 // Server is a fake server for instances of the azmetrics.Client type.

--- a/sdk/monitor/query/azmetrics/models_serde.go
+++ b/sdk/monitor/query/azmetrics/models_serde.go
@@ -7,9 +7,8 @@ package azmetrics
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"reflect"
 )
 
 // MarshalJSON implements the json.Marshaller interface for type LocalizableString.

--- a/sdk/monitor/query/azmetrics/testdata/_metadata.json
+++ b/sdk/monitor/query/azmetrics/testdata/_metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2024-02-01",
-  "emitterVersion": "0.5.1"
+  "emitterVersion": "0.7.0"
 }

--- a/sdk/monitor/query/azmetrics/time_rfc3339.go
+++ b/sdk/monitor/query/azmetrics/time_rfc3339.go
@@ -7,12 +7,11 @@ package azmetrics
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"reflect"
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.

--- a/sdk/monitor/query/azmetrics/tsp-location.yaml
+++ b/sdk/monitor/query/azmetrics/tsp-location.yaml
@@ -1,3 +1,3 @@
-directory: specification/monitor/Azure.Monitor.Query.Metrics
-commit: 8d08893df3fcaa35795a905ff9f0d2beafc350ff
+directory: specification/monitor/Monitor.Query.Metrics
+commit: 8ba4310e0ebcc4c41ba1ac18ab88563ec99497f9
 repo: Azure/azure-rest-api-specs


### PR DESCRIPTION
* Updating location of the typespec files
* Updating to new emitter, `build.go` file no longer necessary. Run `tsp-client` update instead.