### PR TITLE
[azservicebus] Make it possible to settle and renew a message using a lock token

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 1.9.2-beta.1 (Unreleased)
+## 1.10.0 (Unreleased)
 
 ### Features Added
 
-### Breaking Changes
+- Allow a user to settle and renew message locks with only a lock token, so long as they are not using Service Bus sessions. This makes it possible to settle a message in a completely separate process or service. See [ExampleReceiver_CompleteMessage_settleWithLockToken](http://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus#example-package-SettleWithLockToken) for an example. (PR#TBD)
 
 ### Bugs Fixed
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Allow a user to settle and renew message locks with only a lock token, so long as they are not using Service Bus sessions. This makes it possible to settle a message in a completely separate process or service. See [ExampleReceiver_CompleteMessage_settleWithLockToken](http://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus#example-package-SettleWithLockToken) for an example. (PR#24966)
+- Allow a user to settle and renew message locks with only a lock token, so long as they are not using Service Bus sessions. This makes it possible to settle a message in a completely separate process or service. See [ExampleReceiver_CompleteMessage_settleWithLockToken](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus#example-package-SettleWithLockToken) for an example. (PR#24966)
 
 ### Bugs Fixed
 

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Allow a user to settle and renew message locks with only a lock token, so long as they are not using Service Bus sessions. This makes it possible to settle a message in a completely separate process or service. See [ExampleReceiver_CompleteMessage_settleWithLockToken](http://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus#example-package-SettleWithLockToken) for an example. (PR#TBD)
+- Allow a user to settle and renew message locks with only a lock token, so long as they are not using Service Bus sessions. This makes it possible to settle a message in a completely separate process or service. See [ExampleReceiver_CompleteMessage_settleWithLockToken](http://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus#example-package-SettleWithLockToken) for an example. (PR#24966)
 
 ### Bugs Fixed
 

--- a/sdk/messaging/azservicebus/example_receiver_test.go
+++ b/sdk/messaging/azservicebus/example_receiver_test.go
@@ -263,3 +263,70 @@ func ExampleReceiver_ReceiveMessages_second() {
 		}
 	}
 }
+
+func Example_settleWithLockToken() {
+	// This example shows you how to settle a message where you've only preserved the lock token. It's a bit more
+	// work, on your part, than settling using the entire message but it does allow you to serialize the lock token
+	// and then settle it in another process, or even on a completely separate machine.
+	//
+	// NOTE: this does not work if you're using Service Bus sessions.
+
+	// ReceiveMessages respects the passed in context, and will gracefully stop
+	// receiving when 'ctx' is cancelled.
+	ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
+	defer cancel()
+
+	// NOTE: we're receiving a single message, as an example - you can do this with multiple messages.
+	messages, err = receiver.ReceiveMessages(ctx, 1, nil)
+
+	if err != nil {
+		panic(err)
+	}
+
+	for _, message := range messages {
+		// The message body is a []byte. For this example we're just assuming that the body
+		// was a string, converted to bytes but any []byte payload is valid.
+		var body []byte = message.Body
+		fmt.Printf("Message received with body: %s\n", string(body))
+
+		// For more information about settling messages:
+		// https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations
+
+		// You can settle with just a lock token. This allows you to settle on a separate Receiver instance, or even
+		// a Receiver instance in a completely separate process.
+		//
+		// To do this:
+		// 1. Create a ReceivedMessage instance, like this:
+		completelySeparateMsg := &azservicebus.ReceivedMessage{
+			LockToken: message.LockToken,
+		}
+
+		// 2a. You can also renew the lock, with just the lock token.
+		err = receiver.RenewMessageLock(context.TODO(), completelySeparateMsg, nil)
+
+		if err != nil {
+			panic(err)
+		}
+
+		// 2b. And settle it like you would any other ReceivedMessage.
+		err = receiver.CompleteMessage(context.TODO(), completelySeparateMsg, nil)
+
+		if err != nil {
+			var sbErr *azservicebus.Error
+
+			if errors.As(err, &sbErr) && sbErr.Code == azservicebus.CodeLockLost {
+				// The message lock has expired. This isn't fatal for the client, but it does mean
+				// that this message can be received by another Receiver (or potentially this one!).
+				fmt.Printf("Message lock expired\n")
+
+				// You can extend the message lock by calling receiver.RenewMessageLock(msg) before the
+				// message lock has expired.
+				continue
+			}
+
+			panic(err)
+		}
+
+		fmt.Printf("Received and completed the message\n")
+	}
+}

--- a/sdk/messaging/azservicebus/internal/constants.go
+++ b/sdk/messaging/azservicebus/internal/constants.go
@@ -4,4 +4,4 @@
 package internal
 
 // Version is the semantic version number
-const Version = "v1.9.2-beta.1"
+const Version = "v1.10.0"


### PR DESCRIPTION
There is a useful pattern (cross-receiver settlement) where you serialize ONLY the lock token (16 bytes of data) for a message, and then keep the message alive and eventually complete it on a different machine/process than you got it. 

This PR enables this for non-SB-session usage (sessions would require service support). 

Prior art here: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample16_CrossReceiverMessageSettlement.md

Fixes #24952