### PR TITLE
Install azsdk mcp server in copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,20 @@
+name: Copilot Setup Steps
+
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install azsdk mcp server
+        shell: pwsh
+        run: |
+          ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $HOME/bin
+


### PR DESCRIPTION
Install azsdk mcp server in copilot setup steps.

This pairs with the coding agent config in the repo settings:

```
{
  "mcpServers": {
    "azure-sdk-mcp": {
      "type": "local",
      "command": "/home/runner/bin/azsdk",
      "tools": [
        "AnalyzePipeline",
        "GetFailedTestCaseData",
        "CheckPackageReleaseReadiness"
      ],
      "args": [
        "start"
      ]
    }
  }
}
```