### PR TITLE
errorinfo.NonRetriable() doesn't wrap errors which are already NonRetriable

### DIFF
--- a/sdk/internal/CHANGELOG.md
+++ b/sdk/internal/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.11.2-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.11.2 (2025-07-30)
 
 ### Other Changes
+
+* `errorinfo.NonRetriable()` doesn't wrap errors which are already `NonRetriable`
 
 ## 1.11.1 (2025-04-07)
 

--- a/sdk/internal/errorinfo/errorinfo.go
+++ b/sdk/internal/errorinfo/errorinfo.go
@@ -6,6 +6,8 @@
 
 package errorinfo
 
+import "errors"
+
 // NonRetriable represents a non-transient error.  This works in
 // conjunction with the retry policy, indicating that the error condition
 // is idempotent, so no retries will be attempted.
@@ -15,10 +17,14 @@ type NonRetriable interface {
 	NonRetriable()
 }
 
-// NonRetriableError marks the specified error as non-retriable.
-// This function takes an error as input and returns a new error that is marked as non-retriable.
+// NonRetriableError ensures the specified error is [NonRetriable]. If
+// the error is already [NonRetriable], it returns that error unchanged.
+// Otherwise, it returns a new, [NonRetriable] error.
 func NonRetriableError(err error) error {
-	return &nonRetriableError{err}
+	if !errors.As(err, new(NonRetriable)) {
+		err = &nonRetriableError{err}
+	}
+	return err
 }
 
 // nonRetriableError is a struct that embeds the error interface.

--- a/sdk/internal/errorinfo/errorinfo_test.go
+++ b/sdk/internal/errorinfo/errorinfo_test.go
@@ -7,6 +7,7 @@
 package errorinfo
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,11 @@ func TestNonRetriableError(t *testing.T) {
 
 	var e NonRetriable
 	require.ErrorAs(t, err, &e)
+
+	// Check that NonRetriableError does not wrap a NonRetriable error
+	err = NonRetriableError(err)
+	unwrapped := errors.Unwrap(err)
+	require.NotErrorAs(t, unwrapped, new(NonRetriable), "NonRetriableError shouldn't wrap a NonRetriable error")
 
 	// Check Unwrap method on NonRetriable error type
 	var fe *fakeError

--- a/sdk/internal/version.go
+++ b/sdk/internal/version.go
@@ -9,5 +9,5 @@ package internal
 const (
 	// version is the semantic version (see http://semver.org) of this module.
 	//lint:ignore U1000 reason: "this constant is used by release automation"
-	version = "v1.11.2-beta.1"
+	version = "v1.11.2"
 )


### PR DESCRIPTION
This lets callers write code like
```go
if err != nil {
    err = errorinfo.NonRetriable(err)
}
return err
```
when they want to guarantee an error is `NonRetriable`, without considering whether they might add a redundant layer of wrapping to an error that's already `NonRetriable`