### PR TITLE
Update for KeyVault CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,10 +54,10 @@
 # PRLabel: %Tables
 /sdk/data/aztables/           @jhendrixMSFT @richardpark-msft
 
-# AzureSDKOwners: @gracewilcox
+# AzureSDKOwners: @gracewilcox @Azure/azure-sdk-write-keyvault
 # ServiceLabel: %KeyVault
 # PRLabel: %KeyVault
-/sdk/security/keyvault/       @chlowell @jhendrixMSFT @gracewilcox
+/sdk/security/keyvault/       @chlowell @jhendrixMSFT @gracewilcox @Azure/azure-sdk-write-keyvault
 
 # AzureSDKOwners: @richardpark-msft
 # ServiceLabel: %Service Bus


### PR DESCRIPTION
This adds the `azure-sdk-write-keyvault` team as code owners.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
