### PR TITLE
Accessing GetPartitionProperties function from PartitionClient instance #25038

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Accessing GetPartitionProperties function from PartitionClient instance (PR#25039)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/messaging/azeventhubs/partition_client.go
+++ b/sdk/messaging/azeventhubs/partition_client.go
@@ -380,3 +380,10 @@ func getStartExpression(startPosition StartPosition) (string, error) {
 func formatStartExpressionForSequence(op string, sequenceNumber int64) string {
 	return fmt.Sprintf("amqp.annotation.x-opt-sequence-number %s '%d'", op, sequenceNumber)
 }
+
+// GetPartitionProperties gets properties for the partition. This includes data like the
+// last enqueued sequence number, the first sequence number and when an event was last enqueued
+// to the partition.
+func (pc *PartitionClient) GetPartitionProperties(ctx context.Context, options *GetPartitionPropertiesOptions) (PartitionProperties, error) {
+	return getPartitionProperties(ctx, EventConsumer, pc.namespace, pc.links, pc.eventHub, pc.partitionID, pc.retryOptions, options)
+}

--- a/sdk/messaging/azeventhubs/partition_client.go
+++ b/sdk/messaging/azeventhubs/partition_client.go
@@ -64,6 +64,7 @@ type PartitionClient struct {
 	eventHub         string
 	instanceID       string
 	links            internal.LinksForPartitionClient[amqpwrap.AMQPReceiverCloser]
+	namespace        internal.NamespaceForAMQPLinks
 	offsetExpression string
 	ownerLevel       *int64
 	partitionID      string
@@ -296,6 +297,7 @@ func newPartitionClient(args partitionClientArgs, options *PartitionClientOption
 		prefetch:         options.Prefetch,
 		retryOptions:     args.retryOptions,
 		instanceID:       args.instanceID,
+		namespace:        args.namespace,
 	}
 
 	client.links = internal.NewLinks(args.namespace, fmt.Sprintf("%s/$management", client.eventHub), client.getEntityPath, client.newEventHubConsumerLink)


### PR DESCRIPTION
Accessing GetPartitionProperties function from PartitionClient instance. [https://github.com/Azure/azure-sdk-for-go/issues/25038](#25038)

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
