### PR TITLE
Update CODEOWNERS for Monitor Query Metrics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -89,6 +89,9 @@
 # PRLabel: %Monitor
 /sdk/monitor/                 @gracewilcox @chlowell @jhendrixMSFT @Azure/azure-sdk-write-monitor-data-plane
 
+# PRLabel: %Monitor
+/sdk/monitor/query/azmetrics/ @Azure/azure-sdk-write-monitor-query-metrics
+
 # AzureSDKOwners: @lirenhe
 # ServiceLabel: %Mgmt
 # PRLabel: %Mgmt


### PR DESCRIPTION
Adds a new entry for the Monitor Query Metrics SDK, which is owned by the service team. A new team is assigned to it, and that team contains the service team engineers.