### PR TITLE
Support module config with major version suffix

### DIFF
--- a/eng/tools/generator/CHANGELOG.md
+++ b/eng/tools/generator/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 - Add `environment` command to check and validate environment prerequisites for Azure Go SDK generation.
 - Add `generate` command to generate Azure Go SDK packages from TypeSpec specifications.
+- Support major version suffix in the `module` flag to specify the major version of the generated module.
 
 ### Breaking Changes
 
 - Remove `go-version` flag from all commands. It is useless since the code generator could handle it.
+- Remove `version-number` flag from all commands. It is no longer supported since the version is now configured in the `module` flag.
 
 ### Bugs Fixed
 

--- a/eng/tools/generator/README.md
+++ b/eng/tools/generator/README.md
@@ -248,7 +248,6 @@ generator release-v2 <azure-sdk-for-go directory> <azure-rest-api-specs director
 - `namespaceName`: Namespace name (default: "arm" + rp-name)
 
 **Flags:**
-- `--version-number`: Specify the version number for release
 - `--package-title`: Package title for the release
 - `--sdk-repo`: SDK repository URL (default: https://github.com/Azure/azure-sdk-for-go)
 - `--spec-repo`: Spec repository URL (default: https://github.com/Azure/azure-rest-api-specs)
@@ -274,9 +273,8 @@ generator release-v2 <azure-sdk-for-go directory> <azure-rest-api-specs director
 # Generate release for a specific RP
 generator release-v2 /path/to/azure-sdk-for-go /path/to/azure-rest-api-specs network
 
-# Generate with custom version and TypeSpec config
+# Generate with custom TypeSpec config
 generator release-v2 /path/to/azure-sdk-for-go /path/to/azure-rest-api-specs network \
-  --version-number v2.0.0 \
   --tsp-config specification/network/tspconfig.yaml
 
 # Generate from release request config file
@@ -301,7 +299,6 @@ generator refresh-v2 <azure-sdk-for-go directory> <azure-rest-api-specs director
 - `azure-rest-api-specs directory`: Path to azure-rest-api-specs repository
 
 **Flags:**
-- `--version-number`: Specify version number for refresh
 - `--sdk-repo`: SDK repository URL
 - `--spec-repo`: Spec repository URL  
 - `--release-date`: Release date for changelog
@@ -330,9 +327,9 @@ generator refresh-v2 /path/to/azure-sdk-for-go /path/to/azure-rest-api-specs \
 generator refresh-v2 /path/to/azure-sdk-for-go /path/to/azure-rest-api-specs \
   --skip-create-branch --skip-generate-example
 
-# Refresh with custom version and release date
+# Refresh with custom release date
 generator refresh-v2 /path/to/azure-sdk-for-go /path/to/azure-rest-api-specs \
-  --version-number v1.1.0 --release-date 2024-01-15
+  --release-date 2024-01-15
 ```
 
 ### The `template` command

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -547,103 +546,6 @@ func GetTag(path string) (string, error) {
 	return "", nil
 }
 
-func replaceModuleImport(path, rpName, namespaceName, previousVersion, currentVersion, subPath string, suffixes ...string) error {
-	previous, err := semver.NewVersion(previousVersion)
-	if err != nil {
-		return err
-	}
-
-	current, err := semver.NewVersion(currentVersion)
-	if err != nil {
-		return err
-	}
-
-	if previous.Major() == current.Major() {
-		return nil
-	}
-
-	oldModule := fmt.Sprintf("github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/%s/%s", rpName, namespaceName)
-	if previous.Major() > 1 {
-		oldModule = fmt.Sprintf("%s/v%d", oldModule, previous.Major())
-	}
-
-	newModule := fmt.Sprintf("github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/%s/%s", rpName, namespaceName)
-	if current.Major() > 1 {
-		newModule = fmt.Sprintf("%s/v%d", newModule, current.Major())
-	}
-
-	if oldModule == newModule {
-		return nil
-	}
-
-	return filepath.WalkDir(filepath.Join(path, subPath), func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		suffix := false
-		for i := 0; i < len(suffixes) && !suffix; i++ {
-			suffix = strings.HasSuffix(d.Name(), suffixes[i])
-		}
-
-		if suffix {
-			b, err := os.ReadFile(path)
-			if err != nil {
-				return err
-			}
-
-			newFile := strings.ReplaceAll(string(b), fmt.Sprintf("\"%s\"", oldModule), fmt.Sprintf("\"%s\"", newModule))
-			if newFile != string(b) {
-				if err = os.WriteFile(path, []byte(newFile), 0666); err != nil {
-					return err
-				}
-			}
-		}
-		return nil
-	})
-}
-
-func getModuleVersion(autorestPath string) (*semver.Version, error) {
-	data, err := os.ReadFile(autorestPath)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.HasPrefix(line, autorest_md_module_version_prefix) {
-			return semver.NewVersion(strings.TrimSpace(line[len(autorest_md_module_version_prefix):]))
-		}
-	}
-
-	return nil, errors.New("module-version does not exist in autorest.md")
-}
-
-func existSuffixFile(path, suffix string) bool {
-
-	existed := false
-	err := filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() {
-			return nil
-		}
-
-		if strings.HasSuffix(d.Name(), suffix) {
-			existed = true
-		}
-		return nil
-	})
-	if err != nil {
-		return false
-	}
-
-	return existed
-}
-
 func replaceReadmeModule(path, packageModuleRelativePath, currentVersion string) error {
 	readmeFile, err := os.ReadFile(filepath.Join(path, "README.md"))
 	if err != nil {
@@ -732,7 +634,7 @@ func ReplaceConstModuleVersion(packagePath string, newVersion string) error {
 	return os.WriteFile(path, []byte(contents), 0644)
 }
 
-func ReplaceModule(newVersion *semver.Version, packagePath, baseModule string, suffixs ...string) error {
+func ReplaceModule(newVersion *semver.Version, packagePath, baseModule string, suffixes ...string) error {
 	return filepath.WalkDir(packagePath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -742,8 +644,8 @@ func ReplaceModule(newVersion *semver.Version, packagePath, baseModule string, s
 			return nil
 		}
 
-		hasSuffix := slices.ContainsFunc(suffixs, func(s string) bool { return strings.HasSuffix(d.Name(), s) })
-		if len(suffixs) == 0 || hasSuffix {
+		hasSuffix := slices.ContainsFunc(suffixes, func(s string) bool { return strings.HasSuffix(d.Name(), s) })
+		if len(suffixes) == 0 || hasSuffix {
 			if err = ReplaceImport(path, baseModule, newVersion.Major()); err != nil {
 				return err
 			}

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -48,7 +48,6 @@ type GenerateParam struct {
 	RPName               string
 	NamespaceName        string
 	NamespaceConfig      string
-	SpecificVersion      string
 	SpecificPackageTitle string
 	SpecRPName           string
 	ReleaseDate          string
@@ -144,7 +143,6 @@ func (ctx *GenerateContext) GenerateFromSwagger(rpMap map[string][]PackageInfo, 
 				ReleaseDate:          commonGenerateParam.ReleaseDate,
 				RemoveTagSet:         commonGenerateParam.RemoveTagSet,
 				SkipGenerateExample:  commonGenerateParam.SkipGenerateExample,
-				SpecificVersion:      commonGenerateParam.SpecificVersion,
 				SpecificPackageTitle: commonGenerateParam.SpecificPackageTitle,
 			})
 			if err != nil {
@@ -165,13 +163,6 @@ func (ctx *GenerateContext) GenerateForSingleRPNamespace(generateParam *Generate
 	version, err := semver.NewVersion("0.1.0")
 	if err != nil {
 		return nil, err
-	}
-	if generateParam.SpecificVersion != "" {
-		log.Printf("Use specific version: %s", generateParam.SpecificVersion)
-		version, err = semver.NewVersion(generateParam.SpecificVersion)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// check if the package is onboard or update, to init different generator
@@ -433,11 +424,9 @@ func (t *SwaggerUpdateGenerator) AfterGenerate(generateParam *GenerateParam, cha
 	packagePath := t.PackagePath
 
 	log.Printf("Calculate new version...")
-	if generateParam.SpecificVersion == "" {
-		version, prl, err = CalculateNewVersion(changelog, previousVersion, isCurrentPreview)
-		if err != nil {
-			return nil, err
-		}
+	version, prl, err = CalculateNewVersion(changelog, previousVersion, isCurrentPreview)
+	if err != nil {
+		return nil, err
 	}
 
 	log.Printf("Add changelog to file...")
@@ -555,13 +544,6 @@ func (ctx *GenerateContext) GenerateForSingleTypeSpec(generateParam *GeneratePar
 	version, err := semver.NewVersion("0.1.0")
 	if err != nil {
 		return nil, err
-	}
-	if generateParam.SpecificVersion != "" {
-		log.Printf("Use specific version: %s", generateParam.SpecificVersion)
-		version, err = semver.NewVersion(generateParam.SpecificVersion)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// check if the package is onboard or update, to init different generator
@@ -775,7 +757,6 @@ func (t *TypeSpecUpdateGenerator) PreGenerate(generateParam *GenerateParam) erro
 
 func (t *TypeSpecUpdateGenerator) PreChangeLog(generateParam *GenerateParam) (*exports.Content, error) {
 	var err error
-	version := t.Version
 	packagePath := t.PackagePath
 
 	previousVersion := ""
@@ -785,11 +766,6 @@ func (t *TypeSpecUpdateGenerator) PreChangeLog(generateParam *GenerateParam) (*e
 		isCurrentPreview = true
 	} else if generateParam.SdkReleaseType == SDKReleaseTypeStable {
 		isCurrentPreview = false
-	} else if generateParam.SpecificVersion != "" {
-		isCurrentPreview, err = IsBetaVersion(version.String())
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		isCurrentPreview, err = changelog.ContainsPreviewAPIVersion(packagePath)
 		if err != nil {
@@ -833,11 +809,9 @@ func (t *TypeSpecUpdateGenerator) AfterGenerate(generateParam *GenerateParam, ch
 	isCurrentPreview := t.IsCurrentPreview
 
 	log.Printf("Calculate new version...")
-	if generateParam.SpecificVersion == "" {
-		version, prl, err = CalculateNewVersion(changelog, previousVersion, isCurrentPreview)
-		if err != nil {
-			return nil, err
-		}
+	version, prl, err = CalculateNewVersion(changelog, previousVersion, isCurrentPreview)
+	if err != nil {
+		return nil, err
 	}
 
 	log.Printf("Add changelog to file...")

--- a/eng/tools/generator/cmd/v2/refresh/refreshCmd.go
+++ b/eng/tools/generator/cmd/v2/refresh/refreshCmd.go
@@ -47,7 +47,6 @@ azure-rest-api-specs directory: the directory path of the azure-rest-api-specs w
 }
 
 type Flags struct {
-	VersionNumber       string
 	SwaggerRepo         string
 	SDKRepo             string
 	ReleaseDate         string
@@ -58,7 +57,6 @@ type Flags struct {
 }
 
 func BindFlags(flagSet *pflag.FlagSet) {
-	flagSet.String("version-number", "", "Specify the version number of this release")
 	flagSet.String("sdk-repo", "https://github.com/Azure/azure-sdk-for-go", "Specifies the sdk repo URL for generation")
 	flagSet.String("spec-repo", "https://github.com/Azure/azure-rest-api-specs", "Specifies the swagger repo URL for generation")
 	flagSet.String("release-date", "", "Specifies the release date in changelog")
@@ -70,7 +68,6 @@ func BindFlags(flagSet *pflag.FlagSet) {
 
 func ParseFlags(flagSet *pflag.FlagSet) Flags {
 	return Flags{
-		VersionNumber:       flags.GetString(flagSet, "version-number"),
 		SDKRepo:             flags.GetString(flagSet, "sdk-repo"),
 		SwaggerRepo:         flags.GetString(flagSet, "spec-repo"),
 		ReleaseDate:         flags.GetString(flagSet, "release-date"),
@@ -141,7 +138,6 @@ func (c *commandContext) execute(sdkRepoParam, specRepoParam string) error {
 				RPName:               rpName,
 				NamespaceName:        namespace.Name(),
 				SpecificPackageTitle: "",
-				SpecificVersion:      c.flags.VersionNumber,
 				SpecRPName:           specRpName,
 				ReleaseDate:          c.flags.ReleaseDate,
 				SkipGenerateExample:  c.flags.SkipGenerateExample,

--- a/eng/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/eng/tools/generator/cmd/v2/release/releaseCmd.go
@@ -63,7 +63,6 @@ namespaceName: name of namespace to be released, default value is arm+rp-name
 }
 
 type Flags struct {
-	VersionNumber       string
 	SwaggerRepo         string
 	PackageTitle        string
 	SDKRepo             string
@@ -96,7 +95,6 @@ func BindFlags(flagSet *pflag.FlagSet) {
 
 func ParseFlags(flagSet *pflag.FlagSet) Flags {
 	return Flags{
-		VersionNumber:       flags.GetString(flagSet, "version-number"),
 		PackageTitle:        flags.GetString(flagSet, "package-title"),
 		SDKRepo:             flags.GetString(flagSet, "sdk-repo"),
 		SwaggerRepo:         flags.GetString(flagSet, "spec-repo"),
@@ -166,7 +164,6 @@ func (c *commandContext) generate(sdkRepo repo.SDKRepository, specCommitHash str
 			RPName:               c.rpName,
 			NamespaceName:        c.namespaceName,
 			SpecificPackageTitle: c.flags.PackageTitle,
-			SpecificVersion:      c.flags.VersionNumber,
 			SpecRPName:           c.flags.SpecRPName,
 			ReleaseDate:          c.flags.ReleaseDate,
 			SkipGenerateExample:  c.flags.SkipGenerateExample,
@@ -186,7 +183,6 @@ func (c *commandContext) generate(sdkRepo repo.SDKRepository, specCommitHash str
 			NamespaceName:        c.namespaceName,
 			NamespaceConfig:      c.flags.PackageConfig,
 			SpecificPackageTitle: c.flags.PackageTitle,
-			SpecificVersion:      c.flags.VersionNumber,
 			SpecRPName:           c.flags.SpecRPName,
 			ReleaseDate:          c.flags.ReleaseDate,
 			SkipGenerateExample:  c.flags.SkipGenerateExample,

--- a/eng/tools/generator/cmd/v2/release/releaseCmd.go
+++ b/eng/tools/generator/cmd/v2/release/releaseCmd.go
@@ -78,7 +78,6 @@ type Flags struct {
 }
 
 func BindFlags(flagSet *pflag.FlagSet) {
-	flagSet.String("version-number", "", "Specify the version number of this release")
 	flagSet.String("package-title", "", "Specifies the title of this package")
 	flagSet.String("sdk-repo", "https://github.com/Azure/azure-sdk-for-go", "Specifies the sdk repo URL for generation")
 	flagSet.String("spec-repo", "https://github.com/Azure/azure-rest-api-specs", "Specifies the swagger repo URL for generation")

--- a/eng/tools/generator/typespec/tspconfig.go
+++ b/eng/tools/generator/typespec/tspconfig.go
@@ -144,7 +144,9 @@ func (tc *TypeSpecConfig) GetModuleRelativePath() string {
 		}
 		return m
 	})
-	return strings.ReplaceAll(module, "github.com/Azure/azure-sdk-for-go/", "")
+
+	re = regexp.MustCompile(`github\.com/Azure/azure-sdk-for-go/|/v\d+$`)
+	return re.ReplaceAllString(module, "")
 }
 
 func (tc *TypeSpecConfig) EditOptions(emit string, option map[string]any, append bool) {

--- a/eng/tools/generator/typespec/tspconfig_test.go
+++ b/eng/tools/generator/typespec/tspconfig_test.go
@@ -138,6 +138,45 @@ func TestTypeSpecConfig_GetModuleRelativePath(t *testing.T) {
 			},
 			expected: "sdk/security/keyvault/azadmin",
 		},
+		{
+			name: "Module with major version suffix removed",
+			config: typespec.TypeSpecConfig{
+				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
+					Options: map[string]any{
+						"@azure-tools/typespec-go": map[string]any{
+							"module": "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5",
+						},
+					},
+				},
+			},
+			expected: "sdk/resourcemanager/compute/armcompute",
+		},
+		{
+			name: "Module with v2 major version suffix removed",
+			config: typespec.TypeSpecConfig{
+				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
+					Options: map[string]any{
+						"@azure-tools/typespec-go": map[string]any{
+							"module": "github.com/Azure/azure-sdk-for-go/sdk/messaging/eventgrid/azsystemevents/v2",
+						},
+					},
+				},
+			},
+			expected: "sdk/messaging/eventgrid/azsystemevents",
+		},
+		{
+			name: "Module with double-digit major version suffix removed",
+			config: typespec.TypeSpecConfig{
+				TypeSpecProjectSchema: typespec.TypeSpecProjectSchema{
+					Options: map[string]any{
+						"@azure-tools/typespec-go": map[string]any{
+							"module": "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/v12",
+						},
+					},
+				},
+			},
+			expected: "sdk/storage/azblob",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR update generator tool to adopt the new emitter config changes.

1. Remove `version-number` config for `release` and `refresh` command because we have no scenario to hard code the module version. Accordingly, remove the `SpecificVersion` in `GenerateParam`.
2. Support `module` setting with major version suffix to extract the module path.

