### PR TITLE
Update CODEOWNERS for Monitor Query Logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,6 +90,9 @@
 /sdk/monitor/                 @gracewilcox @chlowell @jhendrixMSFT @Azure/azure-sdk-write-monitor-data-plane
 
 # PRLabel: %Monitor
+/sdk/monitor/query/azlogs/    @Azure/azure-sdk-write-monitor-query-logs
+
+# PRLabel: %Monitor
 /sdk/monitor/query/azmetrics/ @Azure/azure-sdk-write-monitor-query-metrics
 
 # AzureSDKOwners: @lirenhe


### PR DESCRIPTION
The Monitor Query Logs library is now owned by the service team. Add a CODEOWNERS entry with their GitHub team.