### PR TITLE
CLI credentials handle claims

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -9,7 +9,10 @@
 ### Bugs Fixed
 
 ### Other Changes
-- `AzureDeveloperCliCredential` no longer hangs when AZD_DEBUG is set
+- `AzureDeveloperCLICredential` no longer hangs when AZD_DEBUG is set
+- `GetToken` methods of `AzureCLICredential` and `AzureDeveloperCLICredential` return an error when
+  `TokenRequestOptions.Claims` has a value because these credentials can't acquire a token in that
+  case. The error messages describe the action required to get a token.
 
 ## 1.11.0 (2025-08-05)
 

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -298,6 +298,20 @@ func (c *testCache) Replace(_ context.Context, u cache.Unmarshaler, _ cache.Repl
 	return u.Unmarshal(*c)
 }
 
+func TestUnavailableIfInDAC(t *testing.T) {
+	err := newAuthenticationFailedError(credNameOBO, "it didn't work", nil)
+	err = unavailableIfInDAC(err, false)
+	require.ErrorAs(t, err, new(*AuthenticationFailedError))
+
+	err = unavailableIfInDAC(err, true)
+	require.ErrorAs(t, err, new(credentialUnavailable))
+
+	err = unavailableIfInDAC(err, false)
+	require.ErrorAs(t, err, new(credentialUnavailable))
+
+	require.Equal(t, 1, strings.Count(err.Error(), credNameOBO))
+}
+
 func TestUserAuthentication(t *testing.T) {
 	type authenticater interface {
 		azcore.TokenCredential
@@ -671,9 +685,9 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 				o := AzureCLICredentialOptions{
 					AdditionallyAllowedTenants: tc.allowed,
 					TenantID:                   tc.ctorTenant,
-					tokenProvider: func(ctx context.Context, scopes []string, tenant, subscription string) ([]byte, error) {
-						require.Equal(t, tc.expected, tenant)
-						return mockAzTokenProviderSuccess(ctx, scopes, tenant, subscription)
+					exec: func(ctx context.Context, credName string, commandLine string) ([]byte, error) {
+						require.Contains(t, commandLine, " --tenant "+tc.expected)
+						return mockAzSuccess(ctx, credName, commandLine)
 					},
 				}
 				return NewAzureCLICredential(&o)
@@ -685,11 +699,9 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 			ctor: func(_ azcore.ClientOptions, tc testCase, t *testing.T) (azcore.TokenCredential, error) {
 				o := AzureDeveloperCLICredentialOptions{
 					AdditionallyAllowedTenants: tc.allowed,
-					tokenProvider: func(ctx context.Context, scopes []string, tenant string) ([]byte, error) {
-						if tenant != tc.expected {
-							t.Errorf("unexpected tenantID %q", tenant)
-						}
-						return mockAzdTokenProviderSuccess(ctx, scopes, tenant)
+					exec: func(ctx context.Context, credName string, command string) ([]byte, error) {
+						require.Contains(t, command, " --tenant-id "+tc.expected)
+						return mockAzdSuccess(ctx, credName, command)
 					},
 				}
 				return NewAzureDeveloperCLICredential(&o)
@@ -783,10 +795,10 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 				})
 				for _, source := range c.chain.sources {
 					if c, ok := source.(*AzureCLICredential); ok {
-						c.opts.tokenProvider = func(ctx context.Context, scopes []string, tenant, subscription string) ([]byte, error) {
+						c.opts.exec = func(ctx context.Context, credName string, commandLine string) ([]byte, error) {
 							called = true
-							require.Equal(t, tc.expected, tenant)
-							return mockAzTokenProviderSuccess(ctx, scopes, tenant, subscription)
+							require.Contains(t, commandLine, " --tenant "+tc.expected)
+							return mockAzSuccess(ctx, credName, commandLine)
 						}
 						break
 					}
@@ -818,14 +830,14 @@ func TestAdditionallyAllowedTenants(t *testing.T) {
 				for _, source := range c.chain.sources {
 					switch c := source.(type) {
 					case *AzureCLICredential:
-						c.opts.tokenProvider = func(context.Context, []string, string, string) ([]byte, error) {
+						c.opts.exec = func(context.Context, string, string) ([]byte, error) {
 							return nil, newCredentialUnavailableError(credNameAzureCLI, "...")
 						}
 					case *AzureDeveloperCLICredential:
-						c.opts.tokenProvider = func(ctx context.Context, scopes []string, tenant string) ([]byte, error) {
+						c.opts.exec = func(ctx context.Context, credName string, command string) ([]byte, error) {
 							called = true
-							require.Equal(t, tc.expected, tenant)
-							return mockAzdTokenProviderSuccess(ctx, scopes, tenant)
+							require.Contains(t, command, " --tenant-id "+tc.expected)
+							return mockAzdSuccess(ctx, credName, command)
 						}
 					}
 				}

--- a/sdk/azidentity/azure_cli_credential.go
+++ b/sdk/azidentity/azure_cli_credential.go
@@ -7,14 +7,11 @@
 package azidentity
 
 import (
-	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -25,8 +22,6 @@ import (
 )
 
 const credNameAzureCLI = "AzureCLICredential"
-
-type azTokenProvider func(ctx context.Context, scopes []string, tenant, subscription string) ([]byte, error)
 
 // AzureCLICredentialOptions contains optional parameters for AzureCLICredential.
 type AzureCLICredentialOptions struct {
@@ -45,15 +40,8 @@ type AzureCLICredentialOptions struct {
 
 	// inDefaultChain is true when the credential is part of DefaultAzureCredential
 	inDefaultChain bool
-	// tokenProvider is used by tests to fake invoking az
-	tokenProvider azTokenProvider
-}
-
-// init returns an instance of AzureCLICredentialOptions initialized with default values.
-func (o *AzureCLICredentialOptions) init() {
-	if o.tokenProvider == nil {
-		o.tokenProvider = defaultAzTokenProvider
-	}
+	// exec is used by tests to fake invoking az
+	exec executor
 }
 
 // AzureCLICredential authenticates as the identity logged in to the Azure CLI.
@@ -80,7 +68,9 @@ func NewAzureCLICredential(options *AzureCLICredentialOptions) (*AzureCLICredent
 	if cp.TenantID != "" && !validTenantID(cp.TenantID) {
 		return nil, errInvalidTenantID
 	}
-	cp.init()
+	if cp.exec == nil {
+		cp.exec = shellExec
+	}
 	cp.AdditionallyAllowedTenants = resolveAdditionalTenants(cp.AdditionallyAllowedTenants)
 	return &AzureCLICredential{mu: &sync.Mutex{}, opts: cp}, nil
 }
@@ -99,76 +89,42 @@ func (c *AzureCLICredential) GetToken(ctx context.Context, opts policy.TokenRequ
 	if err != nil {
 		return at, err
 	}
+	// pass the CLI a Microsoft Entra ID v1 resource because we don't know which CLI version is installed and older ones don't support v2 scopes
+	resource := strings.TrimSuffix(opts.Scopes[0], defaultSuffix)
+	command := "az account get-access-token -o json --resource " + resource
+	tenantArg := ""
+	if tenant != "" {
+		tenantArg = " --tenant " + tenant
+		command += tenantArg
+	}
+	if c.opts.Subscription != "" {
+		// subscription needs quotes because it may contain spaces
+		command += ` --subscription "` + c.opts.Subscription + `"`
+	}
+	if opts.Claims != "" {
+		encoded := base64.StdEncoding.EncodeToString([]byte(opts.Claims))
+		return at, fmt.Errorf(
+			"%s.GetToken(): Azure CLI requires multifactor authentication or additional claims. Run this command then retry the operation: az login%s --claims-challenge %s",
+			credNameAzureCLI,
+			tenantArg,
+			encoded,
+		)
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	b, err := c.opts.tokenProvider(ctx, opts.Scopes, tenant, c.opts.Subscription)
+
+	b, err := c.opts.exec(ctx, credNameAzureCLI, command)
 	if err == nil {
 		at, err = c.createAccessToken(b)
 	}
 	if err != nil {
-		err = unavailableIfInChain(err, c.opts.inDefaultChain)
+		err = unavailableIfInDAC(err, c.opts.inDefaultChain)
 		return at, err
 	}
 	msg := fmt.Sprintf("%s.GetToken() acquired a token for scope %q", credNameAzureCLI, strings.Join(opts.Scopes, ", "))
 	log.Write(EventAuthentication, msg)
 	return at, nil
-}
-
-// defaultAzTokenProvider invokes the Azure CLI to acquire a token. It assumes
-// callers have verified that all string arguments are safe to pass to the CLI.
-var defaultAzTokenProvider azTokenProvider = func(ctx context.Context, scopes []string, tenantID, subscription string) ([]byte, error) {
-	// pass the CLI a Microsoft Entra ID v1 resource because we don't know which CLI version is installed and older ones don't support v2 scopes
-	resource := strings.TrimSuffix(scopes[0], defaultSuffix)
-	// set a default timeout for this authentication iff the application hasn't done so already
-	var cancel context.CancelFunc
-	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-		ctx, cancel = context.WithTimeout(ctx, cliTimeout)
-		defer cancel()
-	}
-	commandLine := "az account get-access-token -o json --resource " + resource
-	if tenantID != "" {
-		commandLine += " --tenant " + tenantID
-	}
-	if subscription != "" {
-		// subscription needs quotes because it may contain spaces
-		commandLine += ` --subscription "` + subscription + `"`
-	}
-	var cliCmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		dir := os.Getenv("SYSTEMROOT")
-		if dir == "" {
-			return nil, newCredentialUnavailableError(credNameAzureCLI, "environment variable 'SYSTEMROOT' has no value")
-		}
-		cliCmd = exec.CommandContext(ctx, "cmd.exe", "/c", commandLine)
-		cliCmd.Dir = dir
-	} else {
-		cliCmd = exec.CommandContext(ctx, "/bin/sh", "-c", commandLine)
-		cliCmd.Dir = "/bin"
-	}
-	cliCmd.Env = os.Environ()
-	var stderr bytes.Buffer
-	cliCmd.Stderr = &stderr
-	cliCmd.WaitDelay = 100 * time.Millisecond
-
-	stdout, err := cliCmd.Output()
-	if errors.Is(err, exec.ErrWaitDelay) && len(stdout) > 0 {
-		// The child process wrote to stdout and exited without closing it.
-		// Swallow this error and return stdout because it may contain a token.
-		return stdout, nil
-	}
-	if err != nil {
-		msg := stderr.String()
-		var exErr *exec.ExitError
-		if errors.As(err, &exErr) && exErr.ExitCode() == 127 || strings.HasPrefix(msg, "'az' is not recognized") {
-			msg = "Azure CLI not found on path"
-		}
-		if msg == "" {
-			msg = err.Error()
-		}
-		return nil, newCredentialUnavailableError(credNameAzureCLI, msg)
-	}
-
-	return stdout, nil
 }
 
 func (c *AzureCLICredential) createAccessToken(tk []byte) (azcore.AccessToken, error) {

--- a/sdk/azidentity/azure_developer_cli_credential.go
+++ b/sdk/azidentity/azure_developer_cli_credential.go
@@ -7,14 +7,11 @@
 package azidentity
 
 import (
-	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -24,9 +21,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
-const credNameAzureDeveloperCLI = "AzureDeveloperCLICredential"
-
-type azdTokenProvider func(ctx context.Context, scopes []string, tenant string) ([]byte, error)
+const (
+	credNameAzureDeveloperCLI = "AzureDeveloperCLICredential"
+	mfaRequired               = "Azure Developer CLI requires multifactor authentication or additional claims"
+)
 
 // AzureDeveloperCLICredentialOptions contains optional parameters for AzureDeveloperCLICredential.
 type AzureDeveloperCLICredentialOptions struct {
@@ -41,8 +39,8 @@ type AzureDeveloperCLICredentialOptions struct {
 
 	// inDefaultChain is true when the credential is part of DefaultAzureCredential
 	inDefaultChain bool
-	// tokenProvider is used by tests to fake invoking azd
-	tokenProvider azdTokenProvider
+	// exec is used by tests to fake invoking azd
+	exec executor
 }
 
 // AzureDeveloperCLICredential authenticates as the identity logged in to the [Azure Developer CLI].
@@ -62,8 +60,8 @@ func NewAzureDeveloperCLICredential(options *AzureDeveloperCLICredentialOptions)
 	if cp.TenantID != "" && !validTenantID(cp.TenantID) {
 		return nil, errInvalidTenantID
 	}
-	if cp.tokenProvider == nil {
-		cp.tokenProvider = defaultAzdTokenProvider
+	if cp.exec == nil {
+		cp.exec = shellExec
 	}
 	return &AzureDeveloperCLICredential{mu: &sync.Mutex{}, opts: cp}, nil
 }
@@ -75,83 +73,57 @@ func (c *AzureDeveloperCLICredential) GetToken(ctx context.Context, opts policy.
 	if len(opts.Scopes) == 0 {
 		return at, errors.New(credNameAzureDeveloperCLI + ": GetToken() requires at least one scope")
 	}
+	command := "azd auth token -o json --no-prompt"
 	for _, scope := range opts.Scopes {
 		if !validScope(scope) {
 			return at, fmt.Errorf("%s.GetToken(): invalid scope %q", credNameAzureDeveloperCLI, scope)
 		}
+		command += " --scope " + scope
 	}
 	tenant, err := resolveTenant(c.opts.TenantID, opts.TenantID, credNameAzureDeveloperCLI, c.opts.AdditionallyAllowedTenants)
 	if err != nil {
 		return at, err
 	}
+	if tenant != "" {
+		command += " --tenant-id " + tenant
+	}
+	commandNoClaims := command
+	if opts.Claims != "" {
+		encoded := base64.StdEncoding.EncodeToString([]byte(opts.Claims))
+		command += " --claims " + encoded
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	b, err := c.opts.tokenProvider(ctx, opts.Scopes, tenant)
+
+	b, err := c.opts.exec(ctx, credNameAzureDeveloperCLI, command)
 	if err == nil {
 		at, err = c.createAccessToken(b)
 	}
 	if err != nil {
-		err = unavailableIfInChain(err, c.opts.inDefaultChain)
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "unknown flag: --claims"):
+			err = newAuthenticationFailedError(
+				credNameAzureDeveloperCLI,
+				mfaRequired+", however the installed version doesn't support this. Upgrade to version 1.18.1 or later",
+				nil,
+			)
+		case opts.Claims != "":
+			err = newAuthenticationFailedError(
+				credNameAzureDeveloperCLI,
+				mfaRequired+". Run this command then retry the operation: "+commandNoClaims,
+				nil,
+			)
+		case strings.Contains(msg, "azd auth login"):
+			err = newCredentialUnavailableError(credNameAzureDeveloperCLI, `please run "azd auth login" from a command prompt to authenticate before using this credential`)
+		}
+		err = unavailableIfInDAC(err, c.opts.inDefaultChain)
 		return at, err
 	}
 	msg := fmt.Sprintf("%s.GetToken() acquired a token for scope %q", credNameAzureDeveloperCLI, strings.Join(opts.Scopes, ", "))
 	log.Write(EventAuthentication, msg)
 	return at, nil
-}
-
-// defaultAzTokenProvider invokes the Azure Developer CLI to acquire a token. It assumes
-// callers have verified that all string arguments are safe to pass to the CLI.
-var defaultAzdTokenProvider azdTokenProvider = func(ctx context.Context, scopes []string, tenant string) ([]byte, error) {
-	// set a default timeout for this authentication iff the application hasn't done so already
-	var cancel context.CancelFunc
-	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-		ctx, cancel = context.WithTimeout(ctx, cliTimeout)
-		defer cancel()
-	}
-	commandLine := "azd auth token -o json --no-prompt"
-	if tenant != "" {
-		commandLine += " --tenant-id " + tenant
-	}
-	for _, scope := range scopes {
-		commandLine += " --scope " + scope
-	}
-	var cliCmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		dir := os.Getenv("SYSTEMROOT")
-		if dir == "" {
-			return nil, newCredentialUnavailableError(credNameAzureDeveloperCLI, "environment variable 'SYSTEMROOT' has no value")
-		}
-		cliCmd = exec.CommandContext(ctx, "cmd.exe", "/c", commandLine)
-		cliCmd.Dir = dir
-	} else {
-		cliCmd = exec.CommandContext(ctx, "/bin/sh", "-c", commandLine)
-		cliCmd.Dir = "/bin"
-	}
-	cliCmd.Env = os.Environ()
-	var stderr bytes.Buffer
-	cliCmd.Stderr = &stderr
-	cliCmd.WaitDelay = 100 * time.Millisecond
-
-	stdout, err := cliCmd.Output()
-	if errors.Is(err, exec.ErrWaitDelay) && len(stdout) > 0 {
-		// The child process wrote to stdout and exited without closing it.
-		// Swallow this error and return stdout because it may contain a token.
-		return stdout, nil
-	}
-	if err != nil {
-		msg := stderr.String()
-		var exErr *exec.ExitError
-		if errors.As(err, &exErr) && exErr.ExitCode() == 127 || strings.HasPrefix(msg, "'azd' is not recognized") {
-			msg = "Azure Developer CLI not found on path"
-		} else if strings.Contains(msg, "azd auth login") {
-			msg = `please run "azd auth login" from a command prompt to authenticate before using this credential`
-		}
-		if msg == "" {
-			msg = err.Error()
-		}
-		return nil, newCredentialUnavailableError(credNameAzureDeveloperCLI, msg)
-	}
-	return stdout, nil
 }
 
 func (c *AzureDeveloperCLICredential) createAccessToken(tk []byte) (azcore.AccessToken, error) {

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -179,8 +179,8 @@ func TestDefaultAzureCredential_ConstructorErrors(t *testing.T) {
 }
 
 func TestDefaultAzureCredential_TenantID(t *testing.T) {
-	azBefore := defaultAzTokenProvider
-	t.Cleanup(func() { defaultAzTokenProvider = azBefore })
+	before := shellExec
+	t.Cleanup(func() { shellExec = before })
 	expected := "expected"
 	for _, override := range []bool{false, true} {
 		name := "default tenant"
@@ -190,35 +190,26 @@ func TestDefaultAzureCredential_TenantID(t *testing.T) {
 		for _, credName := range []string{credNameAzureCLI, credNameAzureDeveloperCLI} {
 			t.Run(fmt.Sprintf("%s_%s", credName, name), func(t *testing.T) {
 				called := false
-				verifyTenant := func(tenantID string) {
+				shellExec = func(ctx context.Context, actualName string, command string) ([]byte, error) {
+					require.Equal(t, credName, actualName)
 					called = true
-					if (override && tenantID != expected) || (!override && tenantID != "") {
-						t.Fatalf("unexpected tenantID %q", tenantID)
+					tenantArg := "--tenant"
+					success, err := mockAzSuccess(ctx, actualName, command)
+					if credName == credNameAzureDeveloperCLI {
+						tenantArg = "--tenant-id"
+						success, err = mockAzdSuccess(ctx, actualName, command)
 					}
+					sm := regexp.MustCompile(tenantArg + ` (\w+)`).FindStringSubmatch(command)
+					if override {
+						require.Equal(t, 2, len(sm), "tenant not found in command line")
+						require.Equal(t, expected, sm[1], "unexpected tenant in command line")
+					} else {
+						require.Empty(t, sm)
+					}
+					return success, err
 				}
-				switch credName {
-				case credNameAzureCLI:
-					defaultAzTokenProvider = func(ctx context.Context, scopes []string, tenantID, subscription string) ([]byte, error) {
-						verifyTenant(tenantID)
-						return mockAzTokenProviderSuccess(ctx, scopes, tenantID, subscription)
-					}
-				case credNameAzureDeveloperCLI:
-					// ensure az returns an error so DefaultAzureCredential tries azd
-					defaultAzTokenProvider = func(context.Context, []string, string, string) ([]byte, error) {
-						return nil, newCredentialUnavailableError(credNameAzureCLI, "it didn't work")
-					}
-					azdBefore := defaultAzdTokenProvider
-					t.Cleanup(func() { defaultAzdTokenProvider = azdBefore })
-					defaultAzdTokenProvider = func(ctx context.Context, scopes []string, tenant string) ([]byte, error) {
-						verifyTenant(tenant)
-						return mockAzdTokenProviderSuccess(ctx, scopes, tenant)
-					}
-				}
-				// mock IMDS failure because managed identity precedes dev tools in the chain
-				srv, close := mock.NewTLSServer(mock.WithTransformAllRequestsToTestServerUrl())
-				defer close()
-				srv.SetResponse(mock.WithStatusCode(400))
-				o := DefaultAzureCredentialOptions{ClientOptions: policy.ClientOptions{Transport: srv}}
+				t.Setenv(azureTokenCredentials, credName)
+				o := DefaultAzureCredentialOptions{}
 				if override {
 					o.TenantID = expected
 				}
@@ -387,17 +378,7 @@ func (p *delayPolicy) Do(req *policy.Request) (resp *http.Response, err error) {
 }
 
 func TestDefaultAzureCredential_IMDS(t *testing.T) {
-	// unsetting environment variables to skip EnvironmentCredential and other managed identity sources
-	for _, k := range []string{azureTenantID, identityEndpoint, msiEndpoint} {
-		if v, set := os.LookupEnv(k); set {
-			require.NoError(t, os.Unsetenv(k))
-			defer os.Setenv(k, v)
-		}
-	}
-	// AzureCLICredential returning an error ensures we see fatal errors from ManagedIdentityCredential
-	before := defaultAzTokenProvider
-	defer func() { defaultAzTokenProvider = before }()
-	defaultAzTokenProvider = mockAzTokenProviderFailure
+	t.Setenv(azureTokenCredentials, credNameManagedIdentity)
 
 	t.Run("probe", func(t *testing.T) {
 		probed := false
@@ -432,11 +413,6 @@ func TestDefaultAzureCredential_IMDS(t *testing.T) {
 		require.Equal(t, tokenValue, tk.Token)
 
 		t.Run("Azure Container Instances", func(t *testing.T) {
-			// ensure GetToken returns an error if DefaultAzureCredential skips managed identity
-			before := defaultAzTokenProvider
-			defer func() { defaultAzTokenProvider = before }()
-			defaultAzTokenProvider = mockAzTokenProviderFailure
-
 			srv, close := mock.NewTLSServer(mock.WithTransformAllRequestsToTestServerUrl())
 			defer close()
 			srv.AppendResponse(mock.WithBody([]byte("Required metadata header not specified or not correct")), mock.WithStatusCode(http.StatusBadRequest))
@@ -493,9 +469,9 @@ func TestDefaultAzureCredential_IMDS(t *testing.T) {
 }
 
 func TestDefaultAzureCredential_UnexpectedIMDSResponse(t *testing.T) {
-	before := defaultAzTokenProvider
-	defer func() { defaultAzTokenProvider = before }()
-	defaultAzTokenProvider = mockAzTokenProviderSuccess
+	before := shellExec
+	defer func() { shellExec = before }()
+	shellExec = mockAzSuccess
 
 	const dockerDesktopPrefix = "connecting to 169.254.169.254:80: connecting to 169.254.169.254:80: dial tcp 169.254.169.254:80: connectex: A socket operation was attempted to an unreachable "
 	for _, test := range []struct {
@@ -572,13 +548,13 @@ func TestDefaultAzureCredential_UnexpectedIMDSResponse(t *testing.T) {
 
 func TestDefaultAzureCredential_UnsupportedMIClientID(t *testing.T) {
 	fail := true
-	before := defaultAzTokenProvider
-	defer func() { defaultAzTokenProvider = before }()
-	defaultAzTokenProvider = func(ctx context.Context, scopes []string, tenant, subscription string) ([]byte, error) {
+	before := shellExec
+	defer func() { shellExec = before }()
+	shellExec = func(ctx context.Context, credName string, commandLine string) ([]byte, error) {
 		if fail {
 			return nil, errors.New("fail")
 		}
-		return mockAzTokenProviderSuccess(ctx, scopes, tenant, subscription)
+		return mockAzSuccess(ctx, credName, commandLine)
 	}
 	t.Setenv(azureClientID, fakeClientID)
 	t.Setenv(msiEndpoint, fakeMIEndpoint)

--- a/sdk/azidentity/developer_credential_util.go
+++ b/sdk/azidentity/developer_credential_util.go
@@ -7,22 +7,73 @@
 package azidentity
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 )
 
 // cliTimeout is the default timeout for authentication attempts via CLI tools
 const cliTimeout = 10 * time.Second
 
-// unavailableIfInChain returns err or, if the credential was invoked by DefaultAzureCredential, a
+// executor runs a command and returns its output or an error
+type executor func(ctx context.Context, credName, command string) ([]byte, error)
+
+var shellExec = func(ctx context.Context, credName, command string) ([]byte, error) {
+	// set a default timeout for this authentication iff the caller hasn't done so already
+	var cancel context.CancelFunc
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		ctx, cancel = context.WithTimeout(ctx, cliTimeout)
+		defer cancel()
+	}
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		dir := os.Getenv("SYSTEMROOT")
+		if dir == "" {
+			return nil, newCredentialUnavailableError(credName, `environment variable "SYSTEMROOT" has no value`)
+		}
+		cmd = exec.CommandContext(ctx, "cmd.exe", "/c", command)
+		cmd.Dir = dir
+	} else {
+		cmd = exec.CommandContext(ctx, "/bin/sh", "-c", command)
+		cmd.Dir = "/bin"
+	}
+	cmd.Env = os.Environ()
+	stderr := bytes.Buffer{}
+	cmd.Stderr = &stderr
+	cmd.WaitDelay = 100 * time.Millisecond
+
+	stdout, err := cmd.Output()
+	if errors.Is(err, exec.ErrWaitDelay) && len(stdout) > 0 {
+		// The child process wrote to stdout and exited without closing it.
+		// Swallow this error and return stdout because it may contain a token.
+		return stdout, nil
+	}
+	if err != nil {
+		msg := stderr.String()
+		var exErr *exec.ExitError
+		if errors.As(err, &exErr) && exErr.ExitCode() == 127 || strings.Contains(msg, "' is not recognized") {
+			return nil, newCredentialUnavailableError(credName, "CLI executable not found on path")
+		}
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, newAuthenticationFailedError(credName, msg, nil)
+	}
+
+	return stdout, nil
+}
+
+// unavailableIfInDAC returns err or, if the credential was invoked by DefaultAzureCredential, a
 // credentialUnavailableError having the same message. This ensures DefaultAzureCredential will try
 // the next credential in its chain (another developer credential).
-func unavailableIfInChain(err error, inDefaultChain bool) error {
-	if err != nil && inDefaultChain {
-		var unavailableErr credentialUnavailable
-		if !errors.As(err, &unavailableErr) {
-			err = newCredentialUnavailableError(credNameAzureDeveloperCLI, err.Error())
-		}
+func unavailableIfInDAC(err error, inDefaultChain bool) error {
+	if err != nil && inDefaultChain && !errors.As(err, new(credentialUnavailable)) {
+		err = NewCredentialUnavailableError(err.Error())
 	}
 	return err
 }


### PR DESCRIPTION
...by returning errors explaining what must be done before they can acquire a token. For AzureCLICredential this means GetToken always returns an error when given claims because the user must run `az login`. AzureDeveloperCLICredential runs `azd` with the given claims and returns an error only when `azd` doesn't return a token. Most of this PR is from refactoring these credentials to share code for executing commands in a shell (doing so made the feature easier to implement and test).