### PR TITLE
docs(playwrighttesting): Readme update with deprecation message

### DIFF
--- a/sdk/resourcemanager/playwrighttesting/armplaywrighttesting/README.md
+++ b/sdk/resourcemanager/playwrighttesting/armplaywrighttesting/README.md
@@ -1,5 +1,9 @@
 # Azure Playwrighttesting Module for Go
 
+**Deprecation message**
+ 
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **sdk/resourcemanager/playwright/armplaywright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guidance) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+
 The `armplaywrighttesting` module provides operations for working with Azure Playwrighttesting.
 
 [Source code](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/playwrighttesting/armplaywrighttesting)


### PR DESCRIPTION
**Deprecation of Microsoft Playwright Testing SDKs (Control Plane) _Note: This PR should not be merged before September 8th._**

As part of the retirement of Microsoft Playwright Testing (MPT) and its merger into Azure App Testing, we plan to deprecate the SDK packages associated with this service. This aligns with Azure’s service retirement policy and the ARM API Deprecation guidelines.

MPT’s core web testing capabilities are being integrated into Azure App Testing to provide a unified experience for both Load Testing and Playwright-based web testing. The standalone MPT service will be retired, and customers will need to migrate to Azure App Testing.
