### PR TITLE
Return ResponseError for LROs with an unsuccessful initial response

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+* Improved error fall-back for improperly authored long-running operations.
+
 ## 1.19.0 (2025-08-21)
 
 ### Features Added

--- a/sdk/azcore/runtime/poller.go
+++ b/sdk/azcore/runtime/poller.go
@@ -91,7 +91,7 @@ func NewPoller[T any](resp *http.Response, pl exported.Pipeline, options *NewPol
 	// this is a back-stop in case the swagger is incorrect (i.e. missing one or more status codes for success).
 	// ideally the codegen should return an error if the initial response failed and not even create a poller.
 	if !poller.StatusCodeValid(resp) {
-		return nil, errors.New("the operation failed or was cancelled")
+		return nil, exported.NewResponseError(resp)
 	}
 
 	// determine the polling method


### PR DESCRIPTION
This is a back-stop to handle legacy services that misbehave.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
