### PR TITLE
[keyvault] Switch to gofmt

### DIFF
--- a/sdk/security/keyvault/azadmin/backup/build.go
+++ b/sdk/security/keyvault/azadmin/backup/build.go
@@ -1,5 +1,5 @@
 //go:generate go run ./testdata/generate/transforms.go
-//go:generate goimports -w .
+//go:generate gofmt -w .
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/security/keyvault/azadmin/rbac/build.go
+++ b/sdk/security/keyvault/azadmin/rbac/build.go
@@ -1,5 +1,5 @@
 //go:generate go run ./testdata/generate/transforms.go
-//go:generate goimports -w .
+//go:generate gofmt -w .
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/security/keyvault/azcertificates/build.go
+++ b/sdk/security/keyvault/azcertificates/build.go
@@ -1,5 +1,5 @@
 //go:generate go run testdata/generate/transforms.go
-//go:generate goimports -w .
+//go:generate gofmt -w .
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/security/keyvault/azkeys/build.go
+++ b/sdk/security/keyvault/azkeys/build.go
@@ -1,5 +1,5 @@
 //go:generate go run ./testdata/generate/transforms.go
-//go:generate goimports -w .
+//go:generate gofmt -w .
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/sdk/security/keyvault/azsecrets/build.go
+++ b/sdk/security/keyvault/azsecrets/build.go
@@ -1,5 +1,5 @@
 //go:generate go run ./testdata/generate/transforms.go
-//go:generate goimports -w .
+//go:generate gofmt -w .
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.


### PR DESCRIPTION
Using `gofmt` over `goimports`

`goimports` requires extra installation, causing failures when running in pipelines
