### PR TITLE
[Release-regeneration] sdk/resourcemanager/chaos/armchaos

### DIFF
--- a/sdk/resourcemanager/chaos/armchaos/testdata/_metadata.json
+++ b/sdk/resourcemanager/chaos/armchaos/testdata/_metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2025-01-01",
-  "emitterVersion": "0.8.1"
+  "emitterVersion": "0.8.2"
 }

--- a/sdk/resourcemanager/chaos/armchaos/tsp-location.yaml
+++ b/sdk/resourcemanager/chaos/armchaos/tsp-location.yaml
@@ -1,4 +1,4 @@
-directory: specification/chaos/Chaos.Management
-commit: 34b917e73ab4372df2066aae259cbf86910cf8cf
+directory: specification/chaos/resource-manager/Microsoft.Chaos/Chaos
+commit: 520e1f6bc250b4ce51a22eaa7583cc0b24564b71
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
 generation for these services which regenerated failed in this pipeline:https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5347370&view=logs&j=c28f120c-e125-5ec5-8d4c-ba1a4d871fcc&t=8400cb88-1923-54fa-d487-70fbfcd5d927