### PR TITLE
User module as the root of API view generation path

### DIFF
--- a/eng/tools/generator/cmd/v2/automation/automationCmd.go
+++ b/eng/tools/generator/cmd/v2/automation/automationCmd.go
@@ -209,7 +209,13 @@ func processNamespaceResult(generateCtx common.GenerateContext, namespaceResult 
 	breakingChangeItems := namespaceResult.Changelog.GetBreakingChangeItems()
 
 	srcFolder := filepath.Join(generateCtx.SDKPath, namespaceResult.PackageRelativePath)
-	apiViewArtifact := filepath.Join(generateCtx.SDKPath, namespaceResult.PackageRelativePath+".gosource")
+	goSourceArtifact := namespaceResult.PackageRelativePath + ".gosource"
+	apiViewArtifact := filepath.Join(generateCtx.SDKPath, goSourceArtifact)
+	if namespaceResult.ModuleRelativePath != "" {
+		srcFolder = filepath.Join(generateCtx.SDKPath, namespaceResult.ModuleRelativePath)
+		goSourceArtifact = namespaceResult.ModuleRelativePath + ".gosource"
+		apiViewArtifact = filepath.Join(generateCtx.SDKPath, goSourceArtifact)
+	}
 	err := zipDirectory(srcFolder, apiViewArtifact)
 	if err != nil {
 		fmt.Println(err)
@@ -225,7 +231,7 @@ func processNamespaceResult(generateCtx common.GenerateContext, namespaceResult 
 			HasBreakingChange:   &breaking,
 			BreakingChangeItems: &breakingChangeItems,
 		},
-		APIViewArtifact: namespaceResult.PackageRelativePath + ".gosource",
+		APIViewArtifact: goSourceArtifact,
 		Language:        "Go",
 	}
 }

--- a/eng/tools/generator/cmd/v2/common/generation.go
+++ b/eng/tools/generator/cmd/v2/common/generation.go
@@ -41,6 +41,7 @@ type GenerateResult struct {
 	ChangelogMD         string
 	PullRequestLabels   string
 	PackageRelativePath string
+	ModuleRelativePath  string
 	GenerationType      string
 }
 
@@ -729,6 +730,7 @@ func (t *TypeSpecOnBoardGenerator) AfterGenerate(generateParam *GenerateParam, c
 		ChangelogMD:         changelog.ToCompactMarkdown() + "\n" + changelog.GetChangeSummary(),
 		PullRequestLabels:   string(prl),
 		PackageRelativePath: packageRelativePath,
+		ModuleRelativePath:  t.ModuleRelativePath,
 		GenerationType:      "TypeSpecOnBoard",
 	}, nil
 }
@@ -873,6 +875,7 @@ func (t *TypeSpecUpdateGenerator) AfterGenerate(generateParam *GenerateParam, ch
 		ChangelogMD:         changelogMd + "\n" + changelog.GetChangeSummary(),
 		PullRequestLabels:   string(prl),
 		PackageRelativePath: packageRelativePath,
+		ModuleRelativePath:  moduleRelativePath,
 		GenerationType:      generationType,
 	}, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
