### PR TITLE
[Storage][Files] Making SMB Directory leases configurable on a share level 

### DIFF
--- a/sdk/storage/azfile/assets.json
+++ b/sdk/storage/azfile/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azfile",
-  "Tag": "go/storage/azfile_b37562db68"
+  "Tag": "go/storage/azfile_3df590928a"
 }

--- a/sdk/storage/azfile/share/models.go
+++ b/sdk/storage/azfile/share/models.go
@@ -38,6 +38,10 @@ type CreateOptions struct {
 	// Specifies whether the snapshot virtual directory should be accessible at the root of share mount point
 	// when NFS is enabled.
 	EnableSnapshotVirtualDirectoryAccess *bool
+
+	// EnableSmbDirectoryLease contains the information returned from the x-ms-enable-smb-directory-lease header response.
+	EnableSmbDirectoryLease *bool
+
 	// Optional. Boolean. Default if not specified is false. This property enables paid bursting.
 	PaidBurstingEnabled *bool
 
@@ -70,6 +74,7 @@ func (o *CreateOptions) format() *generated.ShareClientCreateOptions {
 		Quota:                                o.Quota,
 		RootSquash:                           o.RootSquash,
 		EnableSnapshotVirtualDirectoryAccess: o.EnableSnapshotVirtualDirectoryAccess,
+		EnableSmbDirectoryLease:              o.EnableSmbDirectoryLease,
 		PaidBurstingEnabled:                  o.PaidBurstingEnabled,
 		PaidBurstingMaxBandwidthMibps:        o.PaidBurstingMaxBandwidthMibps,
 		PaidBurstingMaxIops:                  o.PaidBurstingMaxIops,
@@ -146,6 +151,8 @@ type SetPropertiesOptions struct {
 	// Specifies whether the snapshot virtual directory should be accessible at the root of share mount point
 	// when NFS is enabled.
 	EnableSnapshotVirtualDirectoryAccess *bool
+	// EnableSmbDirectoryLease contains the information returned from the x-ms-enable-smb-directory-lease header response.
+	EnableSMBDirectoryLease *bool
 	// Optional. Boolean. Default if not specified is false. This property enables paid bursting.
 	PaidBurstingEnabled *bool
 	// Optional. Integer. Default if not specified is the maximum throughput the file share can support. Current maximum for a
@@ -173,6 +180,7 @@ func (o *SetPropertiesOptions) format() (*generated.ShareClientSetPropertiesOpti
 		Quota:                                o.Quota,
 		RootSquash:                           o.RootSquash,
 		EnableSnapshotVirtualDirectoryAccess: o.EnableSnapshotVirtualDirectoryAccess,
+		EnableSmbDirectoryLease:              o.EnableSMBDirectoryLease,
 		PaidBurstingEnabled:                  o.PaidBurstingEnabled,
 		PaidBurstingMaxBandwidthMibps:        o.PaidBurstingMaxBandwidthMibps,
 		PaidBurstingMaxIops:                  o.PaidBurstingMaxIops,


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
