### PR TITLE
Fix `FuncFilter` to be compatible with unchanged parameter signatures.

### DIFF
--- a/eng/tools/generator/CHANGELOG.md
+++ b/eng/tools/generator/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Secure tsp-client usage by using pinned tsp-client versions from `eng/common/tsp-client`.
 
+### Bugs Fixed
+
+- Fixed `FuncFilter` to be compatible with unchanged parameter signatures.
+
 ## 0.2.0 (2025-09-18)
 
 ### Features Added

--- a/eng/tools/generator/changelog/changelog_filter.go
+++ b/eng/tools/generator/changelog/changelog_filter.go
@@ -101,6 +101,9 @@ func FuncFilter(changelog *Changelog) {
 
 		// function operation parameters from interface{} to any is not a breaking change
 		for f, v := range changelog.Modified.BreakingChanges.Funcs {
+			if v.Params == nil {
+				continue
+			}
 			from := strings.Split(v.Params.From, ",")
 			to := strings.Split(v.Params.To, ",")
 			if len(from) != len(to) {

--- a/eng/tools/generator/changelog/changelog_filter_test.go
+++ b/eng/tools/generator/changelog/changelog_filter_test.go
@@ -50,7 +50,7 @@ func TestFuncFilter(t *testing.T) {
 
 	FilterChangelog(changelog, FuncFilter)
 
-	excepted := "### Breaking Changes\n\n- Function `*Client.BeingDelete` has been removed\n- Function `*Client.NewListPager` has been removed\n- Function `*Client.Update` has been removed\n\n### Features Added\n\n- New function `*Client.BeginCreateOrUpdate(string, *ClientBeginCreateOrUpdateOptions) (ClientBeginCreateOrUpdateResponse, error)`\n- New function `*Client.NewListBySubscriptionPager(*ClientListBySubscriptionOptions) *runtime.Pager[ClientListBySubscriptionResponse]`\n"
+	excepted := "### Breaking Changes\n\n- Function `*Client.Get` return value(s) have been changed from `(error)` to `(ClientGetResponse, error)`\n- Function `*Client.BeingDelete` has been removed\n- Function `*Client.NewListPager` has been removed\n- Function `*Client.Update` has been removed\n\n### Features Added\n\n- New function `*Client.BeginCreateOrUpdate(string, *ClientBeginCreateOrUpdateOptions) (ClientBeginCreateOrUpdateResponse, error)`\n- New function `*Client.NewListBySubscriptionPager(*ClientListBySubscriptionOptions) *runtime.Pager[ClientListBySubscriptionResponse]`\n- New struct `ClientGetResponse`\n"
 	assert.Equal(t, excepted, changelog.ToCompactMarkdown())
 }
 

--- a/eng/tools/generator/changelog/testdata/new/operation/funcfilter.go
+++ b/eng/tools/generator/changelog/testdata/new/operation/funcfilter.go
@@ -3,6 +3,8 @@
 
 package operation
 
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+
 type Client struct{}
 
 func (client *Client) BeginCreateOrUpdate(resourceGroupName string, options *ClientBeginCreateOrUpdateOptions) (ClientBeginCreateOrUpdateResponse, error) {
@@ -21,3 +23,14 @@ func (client *Client) NewListBySubscriptionPager(options *ClientListBySubscripti
 type ClientListBySubscriptionOptions struct{}
 
 type ClientListBySubscriptionResponse struct{}
+
+// This function has same params but different return type - creates breaking change with nil params
+func (client *Client) Get(resourceGroupName string, options *ClientGetOptions) (ClientGetResponse, error) {
+	return ClientGetResponse{Data: "data"}, nil
+}
+
+type ClientGetOptions struct{}
+
+type ClientGetResponse struct {
+	Data string
+}

--- a/eng/tools/generator/changelog/testdata/old/operation/funcfilter.go
+++ b/eng/tools/generator/changelog/testdata/old/operation/funcfilter.go
@@ -3,6 +3,8 @@
 
 package operation
 
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+
 type Client struct{}
 
 func (client *Client) Update(resourceGroupName string, options *ClientUpdateOptions) (ClientUpdateResponse, error) {
@@ -30,3 +32,10 @@ func (client *Client) NewListPager(resourceGroupName string, options *ClientList
 type ClientListOptions struct{}
 
 type ClientListResponse struct{}
+
+// This function has same params but different return type - creates breaking change with nil params
+func (client *Client) Get(resourceGroupName string, options *ClientGetOptions) error {
+	return nil
+}
+
+type ClientGetOptions struct{}


### PR DESCRIPTION
resolve automation failure for this PR: https://github.com/Azure/azure-rest-api-specs/pull/37303
pipeline: https://dev.azure.com/azure-sdk/public/_build/results?buildId=5330747&view=logs&j=406f67d9-8952-5074-7a53-dcb346cb6a5f&t=ccc7497c-4498-591f-65a2-fc3e28e61219&l=364

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
