### PR TITLE
DefaultAzureCredential: disable IMDS probe when ManagedIdentityCredential selected

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.13.0-beta.2 (Unreleased)
+## 1.13.0 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,10 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- When `AZURE_TOKEN_CREDENTIALS` is set to `ManagedIdentityCredential`, `DefaultAzureCredential` behaves the same as
+  does `ManagedIdentityCredential` when used directly. It doesn't apply special retry configuration or attempt to
+  determine whether IMDS is available. ([#25265](https://github.com/Azure/azure-sdk-for-go/issues/25265))
 
 ## 1.13.0-beta.1 (2025-09-17)
 

--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -164,7 +164,11 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		}
 	}
 	if selected&managedIdentity != 0 {
-		o := &ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions, dac: true}
+		o := &ManagedIdentityCredentialOptions{
+			ClientOptions: options.ClientOptions,
+			// enable special DefaultAzureCredential behavior (IMDS probing) only when the chain contains another credential
+			dac: selected^managedIdentity != 0,
+		}
 		if ID, ok := os.LookupEnv(azureClientID); ok {
 			o.ID = ClientID(ID)
 		}

--- a/sdk/azidentity/version.go
+++ b/sdk/azidentity/version.go
@@ -14,5 +14,5 @@ const (
 	module = "github.com/Azure/azure-sdk-for-go/sdk/" + component
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	version = "v1.13.0-beta.2"
+	version = "v1.13.0"
 )


### PR DESCRIPTION
Closes #25265. Targeting a release branch based on [sdk/azidentity/v1.12.0](https://github.com/Azure/azure-sdk-for-go/tree/sdk/azidentity/v1.12.0) to keep #25057 in beta