### PR TITLE
Remove Azure AD reference from Identity README

### DIFF
--- a/sdk/azidentity/README.md
+++ b/sdk/azidentity/README.md
@@ -1,6 +1,6 @@
 # Azure Identity Client Module for Go
 
-The Azure Identity module provides Microsoft Entra ID ([formerly Azure Active Directory](https://learn.microsoft.com/entra/fundamentals/new-name)) token authentication support across the Azure SDK. It includes a set of `TokenCredential` implementations, which can be used with Azure SDK clients supporting token authentication.
+The Azure Identity module provides [Microsoft Entra ID](https://learn.microsoft.com/entra/fundamentals/whatis) token-based authentication support across the Azure SDK. It includes a set of `TokenCredential` implementations, which can be used with Azure SDK clients supporting token authentication.
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/Azure/azure-sdk-for-go/sdk/azidentity)](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity)
 | [Microsoft Entra ID documentation](https://learn.microsoft.com/entra/identity/)


### PR DESCRIPTION
Removes the Azure AD reference from the Identity library's README, per the recommendation at https://learn.microsoft.com/entra/fundamentals/how-to-rename-azure-ad#communicate-the-change-to-your-customers to keep the old name reference for only 1 year.