### PR TITLE
Simplify WIC identity binding mode implementation

### DIFF
--- a/sdk/azidentity/internal/customtokenproxy/transport.go
+++ b/sdk/azidentity/internal/customtokenproxy/transport.go
@@ -146,9 +146,8 @@ func (t *transport) Do(req *http.Request) (*http.Response, error) {
 
 	resp, err := tr.RoundTrip(req)
 	if err == nil && resp == nil {
-		// this policy is effectively a transport, so it must handle
-		// this rare case. Returning an error makes the retry policy
-		// try the request again
+		// transports must handle this rare case.
+		// Returning an error makes the retry policy try the request again
 		err = errors.New("received nil response")
 	}
 	return resp, err
@@ -204,7 +203,7 @@ func (t *transport) getTokenTransporter() (*http.Transport, error) {
 	}
 	if !bytes.Equal(b, t.caData) {
 		// CA has changed, rebuild the transport with new CA pool
-		// invariant: p.transport is nil when p.caData is nil (initial call)
+		// invariant: t.transport is nil when t.caData is nil (initial call)
 		caPool := x509.NewCertPool()
 		if !caPool.AppendCertsFromPEM([]byte(b)) {
 			return nil, fmt.Errorf("parse CA file %q: no valid certificates found", t.caFile)

--- a/sdk/azidentity/workload_identity_test.go
+++ b/sdk/azidentity/workload_identity_test.go
@@ -429,6 +429,7 @@ func TestWorkloadIdentityCredential_CustomTokenEndpoint_WithCAData(t *testing.T)
 		TokenFilePath: tempFile,
 	})
 	require.NoError(t, err)
+	require.Nil(t, clientOptions.Transport, "constructor shouldn't mutate caller's ClientOptions")
 
 	testGetTokenSuccess(t, cred)
 
@@ -491,6 +492,7 @@ func TestWorkloadIdentityCredential_CustomTokenEndpoint_WithCAFile(t *testing.T)
 		TokenFilePath: tempFile,
 	})
 	require.NoError(t, err)
+	require.Nil(t, clientOptions.Transport, "constructor shouldn't mutate caller's ClientOptions")
 
 	testGetTokenSuccess(t, cred)
 
@@ -549,6 +551,7 @@ func TestWorkloadIdentityCredential_CustomTokenEndpoint_AKSSetup(t *testing.T) {
 		TokenFilePath: tempFile,
 	})
 	require.NoError(t, err)
+	require.Nil(t, clientOptions.Transport, "constructor shouldn't mutate caller's ClientOptions")
 
 	testGetTokenSuccess(t, cred)
 


### PR DESCRIPTION
A Policy implementation made sense when this feature was first designed because at that time only token requests were sent to the proxy; other requests were to proceed via the Pipeline's configured Transporter. However, the design now has all requests going to the proxy so it's more logical and (a tiny bit) simpler to implement the feature as a Transporter.