### PR TITLE
DefaultAzureCredential: disable IMDS probe when ManagedIdentityCredential selected

### DIFF
--- a/sdk/azidentity/default_azure_credential.go
+++ b/sdk/azidentity/default_azure_credential.go
@@ -168,7 +168,11 @@ func NewDefaultAzureCredential(options *DefaultAzureCredentialOptions) (*Default
 		}
 	}
 	if selected&managedIdentity != 0 {
-		o := &ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions, dac: true}
+		o := &ManagedIdentityCredentialOptions{
+			ClientOptions: options.ClientOptions,
+			// enable special DefaultAzureCredential behavior (IMDS probing) only when the chain contains another credential
+			dac: selected^managedIdentity != 0,
+		}
 		if ID, ok := os.LookupEnv(azureClientID); ok {
 			o.ID = ClientID(ID)
 		}

--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -107,6 +107,10 @@ func TestDefaultAzureCredential_AZURE_TOKEN_CREDENTIALS(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, len(actual.chain.sources))
 			require.Equal(t, "*azidentity."+c, fmt.Sprintf("%T", actual.chain.sources[0]))
+			if c == credNameManagedIdentity {
+				mic := actual.chain.sources[0].(*ManagedIdentityCredential)
+				require.False(t, mic.mic.probeIMDS, "probeIMDS should be false when ManagedIdentityCredential is selected")
+			}
 		})
 	}
 
@@ -368,7 +372,11 @@ func (p *delayPolicy) Do(req *policy.Request) (resp *http.Response, err error) {
 }
 
 func TestDefaultAzureCredential_IMDS(t *testing.T) {
-	t.Setenv(azureTokenCredentials, credNameManagedIdentity)
+	before := shellExec
+	defer func() { shellExec = before }()
+	shellExec = func(context.Context, string, string) ([]byte, error) {
+		return nil, NewCredentialUnavailableError("CLI credentials are disabled for this test")
+	}
 
 	t.Run("probe", func(t *testing.T) {
 		probed := false


### PR DESCRIPTION
Cherry-picking #25325, which shipped from a release branch in v1.13.0, to main