### PR TITLE
Update azidentity live test region

### DIFF
--- a/sdk/azidentity/ci.yml
+++ b/sdk/azidentity/ci.yml
@@ -29,7 +29,7 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-identity-test-resources)
       EnableRaceDetector: true
-      Location: westus2
+      Location: westus3
       RunLiveTests: true
       ServiceDirectory: azidentity
       UsePipelineProxy: false


### PR DESCRIPTION
Moving to westus3 because the last couple of runs have failed due to our core quota in westus2