### PR TITLE
[Storage] returning err in appendblob.Client.AppendBlock 

### DIFF
--- a/sdk/storage/azblob/appendblob/client.go
+++ b/sdk/storage/azblob/appendblob/client.go
@@ -168,7 +168,7 @@ func (ab *Client) Create(ctx context.Context, o *CreateOptions) (CreateResponse,
 func (ab *Client) AppendBlock(ctx context.Context, body io.ReadSeekCloser, o *AppendBlockOptions) (AppendBlockResponse, error) {
 	count, err := shared.ValidateSeekableStreamAt0AndGetCount(body)
 	if err != nil {
-		return AppendBlockResponse{}, nil
+		return AppendBlockResponse{}, err
 	}
 
 	appendOptions, appendPositionAccessConditions, cpkInfo, cpkScope, modifiedAccessConditions, leaseAccessConditions := o.format()
@@ -176,7 +176,7 @@ func (ab *Client) AppendBlock(ctx context.Context, body io.ReadSeekCloser, o *Ap
 	if o != nil && o.TransactionalValidation != nil {
 		body, err = o.TransactionalValidation.Apply(body, appendOptions)
 		if err != nil {
-			return AppendBlockResponse{}, nil
+			return AppendBlockResponse{}, err
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the return values of `AppendBlock()` of `appendblob.Client`.

`AppendBlock()` is supposed to return an error if

- `shared.ValidateSeekableStreamAt0AndGetCount` returns `err`;
- `o.TransactionalValidation.Apply` returns `err`.
 
But in both cases, a `nil` value is returned, instead of `err`:

```go
count, err := shared.ValidateSeekableStreamAt0AndGetCount(body)
if err != nil {
	return AppendBlockResponse{}, nil
}

// ...
body, err = o.TransactionalValidation.Apply(body, appendOptions)
if err != nil {
	return AppendBlockResponse{}, nil
}
```

I could not find any motives or explanations on why this behaviour exists, so I understand this is a bug.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
