### PR TITLE
cosmos: add some extra logging in the query engine path

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -9,10 +9,12 @@
 * Added support for specifying Vector Search indexing policies when creating a container. See [PR 24833](https://github.com/Azure/azure-sdk-for-go/pull/24833)
 * Added support for reading Feed Ranges from a container. See [PR 24889](https://github.com/Azure/azure-sdk-for-go/pull/24889)
 * Added support for reading Change Feed through Feed Ranges from a container. See [PR 24898](https://github.com/Azure/azure-sdk-for-go/pull/24898)
+* Additional logging in the query engine integration code. See [PR 25444](https://github.com/Azure/azure-sdk-for-go/pull/25444)
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
 * Fixed bug where the correct header was not being sent for writes on multiple write region accounts. See [PR 25127](https://github.com/Azure/azure-sdk-for-go/pull/25127)
 
 ### Other Changes
@@ -26,6 +28,7 @@
 ## 1.4.1 (2025-08-27)
 
 ### Bugs Fixed
+
 * Fixed bug where the correct header was not being sent for writes on multiple write region accounts. See [PR 25127](https://github.com/Azure/azure-sdk-for-go/pull/25127)
 
 ## 1.4.0 (2025-04-29)

--- a/sdk/data/azcosmos/cosmos_container_query_engine.go
+++ b/sdk/data/azcosmos/cosmos_container_query_engine.go
@@ -1,16 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// cSpell:ignore Writef
+
 package azcosmos
 
 import (
 	"bytes"
 	"context"
 
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
+
+// EventQueryEngine contains logs related to the query engine.
+const EventQueryEngine log.Event = "QueryEngine"
 
 func (c *ContainerClient) getQueryPlanFromGateway(ctx context.Context, query string, supportedFeatures string, queryOptions *QueryOptions, operationContext pipelineRequestOptions) ([]byte, error) {
 	path, _ := generatePathForNameBased(resourceTypeDocument, operationContext.resourceAddress, true)
@@ -72,6 +79,7 @@ func (c *ContainerClient) executeQueryWithEngine(queryEngine queryengine.QueryEn
 	var queryPipeline queryengine.QueryPipeline
 	var lastResponse Response
 	path, _ := generatePathForNameBased(resourceTypeDocument, operationContext.resourceAddress, true)
+	log.Writef(EventQueryEngine, "Executing query using query engine")
 	return runtime.NewPager(runtime.PagingHandler[QueryItemsResponse]{
 		More: func(page QueryItemsResponse) bool {
 			if queryPipeline == nil {
@@ -107,6 +115,7 @@ func (c *ContainerClient) executeQueryWithEngine(queryEngine queryengine.QueryEn
 				if err != nil {
 					return QueryItemsResponse{}, err
 				}
+				log.Writef(EventQueryEngine, "Created query pipeline")
 
 				// The gateway may have rewritten the query, which would be encoded in the query plan.
 				// The pipeline parsed the query plan, so we can ask it for the rewritten query.
@@ -115,6 +124,7 @@ func (c *ContainerClient) executeQueryWithEngine(queryEngine queryengine.QueryEn
 
 			for {
 				if queryPipeline.IsComplete() {
+					log.Writef(EventQueryEngine, "Query pipeline is complete")
 					queryPipeline.Close()
 					return QueryItemsResponse{
 						Response: lastResponse,
@@ -122,6 +132,7 @@ func (c *ContainerClient) executeQueryWithEngine(queryEngine queryengine.QueryEn
 					}, nil
 				}
 				// Fetch more data from the pipeline
+				log.Writef(EventQueryEngine, "Fetching more data from query pipeline")
 				result, err := queryPipeline.Run()
 				if err != nil {
 					queryPipeline.Close()
@@ -131,6 +142,7 @@ func (c *ContainerClient) executeQueryWithEngine(queryEngine queryengine.QueryEn
 				// If we got items, we can return them, and we should do so now, to avoid making unnecessary requests.
 				// Even if there are requests in the queue, the pipeline should return the same requests again on the next call to NextBatch.
 				if len(result.Items) > 0 {
+					log.Writef(EventQueryEngine, "Query pipeline returned %d items", len(result.Items))
 					return QueryItemsResponse{
 						Response: lastResponse,
 						Items:    result.Items,
@@ -140,6 +152,7 @@ func (c *ContainerClient) executeQueryWithEngine(queryEngine queryengine.QueryEn
 				// If we didn't have any items to return, we need to make requests for the items in the queue.
 				// If there are no requests, the pipeline should return true for IsComplete, so we'll stop on the next iteration.
 				for _, request := range result.Requests {
+					log.Writef(azlog.EventRequest, "Query pipeline requested data for PKRange: %s", request.PartitionKeyRangeID)
 					// Make the single-partition query request
 					qryRequest := queryRequest(request) // Cast to our type, which has toHeaders defined on it.
 					azResponse, err := c.database.client.sendQueryRequest(
@@ -172,6 +185,7 @@ func (c *ContainerClient) executeQueryWithEngine(queryEngine queryengine.QueryEn
 						NextContinuation:    continuation,
 						Data:                data,
 					}
+					log.Writef(EventQueryEngine, "Received response for PKRange: %s. Continuation present: %v", request.PartitionKeyRangeID, continuation != "")
 					if err = queryPipeline.ProvideData(result); err != nil {
 						queryPipeline.Close()
 						return QueryItemsResponse{}, err


### PR DESCRIPTION
This just adds a little extra logging when a query ends up using the Query Engine. It might be too verbose, but while we're in beta I'd rather have more logging than not enough.