### PR TITLE
cosmos: update CHANGELOG.md for 1.5.0-beta.1 release

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -11,10 +11,6 @@
 * Added support for reading Change Feed through Feed Ranges from a container. See [PR 24898](https://github.com/Azure/azure-sdk-for-go/pull/24898)
 * Additional logging in the query engine integration code. See [PR 25444](https://github.com/Azure/azure-sdk-for-go/pull/25444)
 
-### Bugs Fixed
-
-* Fixed bug where the correct header was not being sent for writes on multiple write region accounts. See [PR 25127](https://github.com/Azure/azure-sdk-for-go/pull/25127)
-
 ## 1.4.1 (2025-08-27)
 
 ### Bugs Fixed


### PR DESCRIPTION
Updates the changelog for the 1.5.0-beta.1 release of the CosmosDB SDK

Alas, @tvaron3 , the tooling did end up re-sorting by date rather than by version. It's not worth fighting it IMO, so we'll just leave it that way.