### PR TITLE
Exit test.ps1 specifically when coverage checks fail

### DIFF
--- a/eng/scripts/test.ps1
+++ b/eng/scripts/test.ps1
@@ -49,6 +49,10 @@ if (Select-String -path ./report.xml -pattern '<testsuites></testsuites>' -simpl
         -config $repoRoot/eng/config.json `
         -serviceDirectory $targetDirectory `
         -searchDirectory $repoRoot
+
+    if ($LASTEXITCODE -gt 0) {
+        exit $LASTEXITCODE
+    }
 }
 
 if ($GOTESTEXITCODE) {


### PR DESCRIPTION
The current way the scripts are written do not actually bubble up errors from `go run coverage` but previous behavior that failed on stderr has been changed, exposing this bug.