### PR TITLE
Use go versions pre-installed on agents

### DIFF
--- a/eng/pipelines/mgmt-auto-release.yml
+++ b/eng/pipelines/mgmt-auto-release.yml
@@ -31,7 +31,7 @@ extends:
 
               - task: GoTool@0
                 inputs:
-                  version: '1.24'
+                  version: '1.24.7'
 
               - task: ShellScript@2
                 inputs:

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -22,5 +22,5 @@ variables:
   GOEXPERIMENT: nocoverageredesign
 
   # Supported versions for testing. These variables are referenced in test matrix files.
-  GO_VERSION_LATEST: 1.24
-  GO_VERSION_PREVIOUS: 1.23
+  GO_VERSION_LATEST: 1.24.7
+  GO_VERSION_PREVIOUS: 1.23.12


### PR DESCRIPTION
This enables the GoTool to use the cached version. Fix URL to download in helper script.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
