### PR TITLE
Fix coverage goal evaluation

### DIFF
--- a/eng/tools/internal/coverage/coverage_test.go
+++ b/eng/tools/internal/coverage/coverage_test.go
@@ -40,3 +40,30 @@ func Test_ParseCoverageFloat(t *testing.T) {
 		t.Errorf("Expected coverage percent of .805 to be parsed as %f, found %f", expected, coveragePercent)
 	}
 }
+
+func Test_FindCoverageGoal(t *testing.T) {
+	configData := &codeCoverage{
+		Packages: []coveragePackage{
+			{Name: "module", CoverageGoal: 1},
+			{Name: "module/submodule", CoverageGoal: 2},
+			{Name: "module/submodule/submodule_2", CoverageGoal: 3},
+		},
+	}
+	for _, test := range []struct {
+		covFile string
+		want    float64
+	}{
+		{"default", 0.95},
+		{"module", 1},
+		{"module/foo", 1},
+		{`C:\prefix\sdk\module`, 1},
+		{"/prefix/sdk/module", 1},
+		{"/prefix/sdk/module/foo/bar", 1},
+		{"/prefix/sdk/module/submodule", 2},
+		{"/prefix/sdk/module/submodule/submodule_2/submodule", 3},
+	} {
+		if got := findCoverageGoal([]string{test.covFile}, configData); got != test.want {
+			t.Errorf("findCoverageGoal(%v) = %.2f; want %.2f", test.covFile, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
[config.json](https://github.com/Azure/azure-sdk-for-go/blob/main/eng/config.json) defines coverage goals for packages identified by substrings of their module paths, for example `keyvault/azkeys`. CI scripts specify the module under test to the coverage goal tool with a disk path like `/mnt/vss/_work/1/s/sdk/security/keyvault/azkeys`. Today, the tool searches config.json for a package whose name exactly matches that path or, failing that, the first package whose (partial) name is a substring of it. In practice the coverage tool always returns that first substring match because no package name in config.json equals any disk path in the repo.

That behavior introduces a couple bugs that weren't obvious until this week because pipelines were evaluating but not enforcing coverage goals:
- applying the wrong goal to a package e.g. `azidentity/cache` gets the goal for `azidentity`
- incorrectly applying the default goal to a package e.g. config.json has a goal for `keyvault/azkeys` but the tool doesn't find it on Windows because there it's given a disk path like `D:\...\keyvault\azkeys`

Now that pipelines do enforce coverage goals, these bugs are causing CI runs to fail. The fix here is to have the coverage tool normalize slashes in the given path and search config.json for the longest i.e. most specific matching package name.