### PR TITLE
fixed index out of range error for invalid host values

### DIFF
--- a/sdk/storage/azblob/internal/shared/shared.go
+++ b/sdk/storage/azblob/internal/shared/shared.go
@@ -231,11 +231,11 @@ func GetClientOptions[T any](o *T) *T {
 // http(s)://IP(:port)/storageaccount/container/...
 // As url's Host property, host could be both host or host:port
 func IsIPEndpointStyle(host string) bool {
-	if host == "" {
-		return false
-	}
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
+	}
+	if host == "" {
+		return false
 	}
 	// For IPv6, there could be case where SplitHostPort fails for cannot finding port.
 	// In this case, eliminate the '[' and ']' in the URL.

--- a/sdk/storage/azblob/internal/shared/shared_test.go
+++ b/sdk/storage/azblob/internal/shared/shared_test.go
@@ -202,3 +202,11 @@ func TestSerializeBlobTagsToStrPtr(t *testing.T) {
 	}
 	require.Len(t, tags, 0)
 }
+
+func TestIsIPEndpointStyle(t *testing.T) {
+	require.False(t, IsIPEndpointStyle(""))
+	require.False(t, IsIPEndpointStyle(":0"))
+
+	require.True(t, IsIPEndpointStyle("127.0.0.1"))
+	require.True(t, IsIPEndpointStyle("127.0.0.1:80"))
+}


### PR DESCRIPTION
# Description

`IsIPEndpointStyle` was panicking for invalid host values like `:0` or `:`.

# Fix 

Moved the guard clause after the `SplitHostPort`.
Added tests. 

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
