### PR TITLE
fixed incorrect surrounding quotes check

### DIFF
--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -92,7 +92,7 @@ func DecodeByteArray(s string, v *[]byte, format Base64Encoding) error {
 		return nil
 	}
 	payload := string(s)
-	if payload[0] == '"' {
+	if len(payload) >= 2 && payload[0] == '"' && payload[len(payload)-1] == '"' {
 		// remove surrounding quotes
 		payload = payload[1 : len(payload)-1]
 	}

--- a/sdk/azcore/internal/exported/exported_test.go
+++ b/sdk/azcore/internal/exported/exported_test.go
@@ -56,6 +56,7 @@ func TestDecodeByteArray(t *testing.T) {
 	require.NoError(t, DecodeByteArray(fmt.Sprintf("\"%s\"", stdEncoding), &out, Base64StdFormat))
 	require.EqualValues(t, decoded, string(out))
 	require.Error(t, DecodeByteArray(stdEncoding, &out, 123))
+	require.Error(t, DecodeByteArray("\"", &out, Base64StdFormat))
 }
 
 func TestNewKeyCredential(t *testing.T) {


### PR DESCRIPTION
# Description

Payloads containing only `"` caused slice out of bounds panic.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
