### PR TITLE
[DRAFT] Add support for custom JSON unmarshalers

### DIFF
--- a/sdk/azcore/go.mod
+++ b/sdk/azcore/go.mod
@@ -15,3 +15,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/Azure/azure-sdk-for-go/sdk/internal => ../../sdk/internal

--- a/sdk/azcore/runtime/json.go
+++ b/sdk/azcore/runtime/json.go
@@ -1,0 +1,95 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package runtime
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/exported"
+)
+
+// Unmarshaler is an interface for custom JSON unmarshaling implementations.
+// By default, the Azure SDK uses encoding/json from the standard library.
+// You can replace this with high-performance alternatives like sonic or jsoniter.
+//
+// Example using sonic:
+//
+//	import "github.com/bytedance/sonic"
+//
+//	type SonicUnmarshaler struct{}
+//
+//	func (s *SonicUnmarshaler) Unmarshal(data []byte, v any) error {
+//	    return sonic.Unmarshal(data, v)
+//	}
+//
+//	func init() {
+//	    runtime.SetUnmarshaler(&SonicUnmarshaler{})
+//	}
+//
+// This will affect ALL JSON unmarshaling in the SDK including:
+//   - Single response operations (Get, Create, Update, Delete)
+//   - Pagination (Pager.NextPage)
+//   - Long-running operations (Poller.PollUntilDone, Poller.Result)
+//   - Resume tokens (NewPollerFromResumeToken)
+type Unmarshaler interface {
+	// Unmarshal parses the JSON-encoded data and stores the result
+	// in the value pointed to by v.
+	//
+	// Unmarshal uses the same semantics as encoding/json.Unmarshal:
+	// - If v is nil or not a pointer, Unmarshal returns an error
+	// - Unmarshal uses the inverse of the encoding rules that Marshal uses
+	Unmarshal(data []byte, v any) error
+}
+
+// SetUnmarshaler replaces the default JSON unmarshaler with a custom implementation.
+// This affects all subsequent JSON unmarshaling operations in the Azure SDK.
+//
+// IMPORTANT: This is a global setting and should typically be called once during
+// application initialization (e.g., in init() or early in main()).
+// It is NOT goroutine-safe and should not be called concurrently with SDK operations.
+//
+// For thread-safe per-request customization, use WithUnmarshaler() instead.
+//
+// Example:
+//
+//	import "github.com/bytedance/sonic"
+//
+//	func init() {
+//	    runtime.SetUnmarshaler(&SonicUnmarshaler{})
+//	}
+func SetUnmarshaler(u Unmarshaler) {
+	exported.SetUnmarshaler(u)
+}
+
+// WithUnmarshaler returns a new context with the specified Unmarshaler attached.
+// This is THREAD-SAFE and allows per-request unmarshaler customization without
+// affecting global state or other concurrent operations.
+//
+// The unmarshaler is used for all JSON unmarshaling operations within the context,
+// including single operations, pagination, and long-running operations.
+//
+// Example for concurrent operations with different unmarshalers:
+//
+//	import "github.com/bytedance/sonic"
+//
+//	type SonicUnmarshaler struct{}
+//	func (s *SonicUnmarshaler) Unmarshal(data []byte, v any) error {
+//	    return sonic.Unmarshal(data, v)
+//	}
+//
+//	// This is thread-safe - each goroutine uses its own unmarshaler
+//	go func() {
+//	    ctx := runtime.WithUnmarshaler(context.Background(), &SonicUnmarshaler{})
+//	    vmssClient.Get(ctx, "rg", "vmss", nil)  // Uses sonic
+//	}()
+//
+//	go func() {
+//	    vmClient.Get(context.Background(), "rg", "vm", nil)  // Uses default
+//	}()
+func WithUnmarshaler(ctx context.Context, u Unmarshaler) context.Context {
+	return exported.WithUnmarshaler(ctx, u)
+}


### PR DESCRIPTION
This change introduces the ability to customize JSON unmarshaling in the Azure SDK for Go, enabling users to use high-performance JSON libraries like sonic or jsoniter as alternatives to the standard library's encoding/json.

Key Features:
- Global unmarshaler configuration via runtime.SetUnmarshaler()
- Thread-safe per-request configuration via runtime.WithUnmarshaler(ctx, unmarshaler)
- 100% backward compatible - defaults to stdlib encoding/json
- Covers all SDK operations: single requests, pagination, long-running operations, and resume tokens

Changes:
- sdk/internal/exported/exported.go: Core unmarshaler interface and context-based selection
- sdk/azcore/runtime/json.go: Public API for custom unmarshaler configuration
- sdk/azcore/runtime/response.go: Modified UnmarshalAsJSON to use context-based unmarshaler
- sdk/azcore/internal/pollers/util.go: Updated poller operations to support custom unmarshalers
- sdk/azcore/go.mod: Added local replace directive for development

Benefits:
- Performance optimization for high-volume operations (e.g., listing large VMSS fleets)
- Flexibility to choose JSON library based on specific requirements
- Thread-safe design enables concurrent operations with different unmarshalers

Example Usage:

Global configuration (affects all SDK operations):
```go
import (
    "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
    "github.com/bytedance/sonic"
)

type SonicUnmarshaler struct{}
func (s *SonicUnmarshaler) Unmarshal(data []byte, v any) error {
    return sonic.Unmarshal(data, v)
}

func init() {
    runtime.SetUnmarshaler(&SonicUnmarshaler{})
}
```

Per-request configuration (thread-safe):
```go
ctx := runtime.WithUnmarshaler(context.Background(), &SonicUnmarshaler{})
vmssClient.Get(ctx, resourceGroup, vmssName, nil)
```

Testing:
- All existing tests pass
- Race detector clean
- Nil safety verified

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
