### PR TITLE
fixed ParseSyncToken to better detect invalid tokens; added test cases

### DIFF
--- a/sdk/data/azappconfig/internal/exported/sync_token.go
+++ b/sdk/data/azappconfig/internal/exported/sync_token.go
@@ -52,12 +52,16 @@ func ParseSyncToken(syncToken SyncToken) ([]SyncTokenValues, error) {
 		tokenID := strings.TrimSpace(items[0][:assignmentIndex])
 		tokenValue := strings.TrimSpace(items[0][assignmentIndex+1:])
 
+		if tokenID == "" {
+			return nil, fmt.Errorf("empty token id in token %s", token)
+		}
+
 		// items[1] contains "sn=<sn>"
-		// parse the version number after the equals sign
 		assignmentIndex = strings.Index(items[1], "=")
-		if assignmentIndex < 0 {
+		if assignmentIndex < 0 || strings.TrimSpace(items[1][:assignmentIndex]) != "sn" {
 			return nil, fmt.Errorf("unexpected token version format %s", items[1])
 		}
+		// parse the version number after the equals sign
 		tokenVersion, err := strconv.ParseInt(strings.TrimSpace(items[1][assignmentIndex+1:]), 10, 64)
 		if err != nil {
 			return nil, err

--- a/sdk/data/azappconfig/internal/exported/sync_token_test.go
+++ b/sdk/data/azappconfig/internal/exported/sync_token_test.go
@@ -26,6 +26,14 @@ func TestCache(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, tokens)
 
+	tokens, err = ParseSyncToken(SyncToken("=;sn=1"))
+	require.Error(t, err)
+	require.Nil(t, tokens)
+
+	tokens, err = ParseSyncToken(SyncToken("id=val1;version=1"))
+	require.Error(t, err)
+	require.Nil(t, tokens)
+
 	tokens, err = ParseSyncToken(SyncToken(";sn=1"))
 	require.Error(t, err)
 	require.Nil(t, tokens)


### PR DESCRIPTION
# Description

Updated `ParseSyncToken` to return errors for invalid SyncTokens like `=;sn=1` or `id=val1;version=1`.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
