### PR TITLE
Fix AzureCLICredential argument quoting on Windows

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- `AzureCLICredential` quoted arguments incorrectly on Windows
+
 ### Other Changes
 
 ## 1.14.0-beta.1 (2025-10-07)

--- a/sdk/azidentity/developer_credential_util.go
+++ b/sdk/azidentity/developer_credential_util.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -30,17 +29,9 @@ var shellExec = func(ctx context.Context, credName, command string) ([]byte, err
 		ctx, cancel = context.WithTimeout(ctx, cliTimeout)
 		defer cancel()
 	}
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		dir := os.Getenv("SYSTEMROOT")
-		if dir == "" {
-			return nil, newCredentialUnavailableError(credName, `environment variable "SYSTEMROOT" has no value`)
-		}
-		cmd = exec.CommandContext(ctx, "cmd.exe", "/c", command)
-		cmd.Dir = dir
-	} else {
-		cmd = exec.CommandContext(ctx, "/bin/sh", "-c", command)
-		cmd.Dir = "/bin"
+	cmd, err := buildCmd(ctx, credName, command)
+	if err != nil {
+		return nil, err
 	}
 	cmd.Env = os.Environ()
 	stderr := bytes.Buffer{}

--- a/sdk/azidentity/developer_credential_util_nonwindows.go
+++ b/sdk/azidentity/developer_credential_util_nonwindows.go
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !windows
+
+package azidentity
+
+import (
+	"context"
+	"os/exec"
+)
+
+func buildCmd(ctx context.Context, _, command string) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command)
+	cmd.Dir = "/bin"
+	return cmd, nil
+}

--- a/sdk/azidentity/developer_credential_util_windows.go
+++ b/sdk/azidentity/developer_credential_util_windows.go
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func buildCmd(ctx context.Context, credName, command string) (*exec.Cmd, error) {
+	dir := os.Getenv("SYSTEMROOT")
+	if dir == "" {
+		return nil, newCredentialUnavailableError(credName, `environment variable "SYSTEMROOT" has no value`)
+	}
+	cmd := exec.CommandContext(ctx, "cmd.exe")
+	cmd.Dir = dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: "/c " + command}
+	return cmd, nil
+}


### PR DESCRIPTION
The docs for [exec.Command](https://pkg.go.dev/os/exec?GOOS=windows#Command) say it doesn't quote arguments reliably for `cmd.exe` and suggest an alternate approach using the package's Windows API, so this PR does that and fixes #25492