### PR TITLE
azcosmos: prep changelog for 1.5.0-beta.3 release

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Release History
 
-## 1.5.0-beta.2 (2025-11-11)
-
-### Features Added
-
-* Added `ReadManyItems` API to read documents across partitions. See [PR 25522](https://github.com/Azure/azure-sdk-for-go/pull/25522)
-
 ## 1.5.0-beta.3 (2025-11-10)
 
 ### Features Added
 
 * Adjusted the query engine abstraction to support future enhancements and optimizations. See [PR 25503](https://github.com/Azure/azure-sdk-for-go/pull/25503)
+
+## 1.5.0-beta.2 (2025-11-03)
+
+### Features Added
+
+* Added `ReadManyItems` API to read documents across partitions. See [PR 25522](https://github.com/Azure/azure-sdk-for-go/pull/25522)
 
 ## 1.5.0-beta.1 (2025-10-16)
 


### PR DESCRIPTION
Prepare the changelog for a release of azcosmos 1.5.0-beta.3 next Monday. Also, the release date for 1.5.0-beta.2 is incorrect (Nov 11, which is tomorrow 😅 ). I corrected it to the actual date.