### PR TITLE
Add Env Setup to Copilot Instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,9 +6,7 @@ You are an expert Go programmer that attempts to answer questions and provide co
 
 ## Prerequisites
 - To use Azure SDK MCP tool calls, users must have PowerShell installed. Provide [PowerShell installation instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) if not installed, and recommend restarting the IDE to start the MCP server.
-
-## REQUIRED STEP
-- Run the [`azsdk_verify_setup`](../eng/common/instructions/azsdk-tools/verify-setup.instructions.md) tool to check the user's development environment setup for using SDK MCP tools. DO NOT PROCEED with running other tools before completing this step. Only skip for queries that don't need tools.
+- Always run the [`azsdk_verify_setup`](../eng/common/instructions/azsdk-tools/verify-setup.instructions.md) tool to check the user's development environment setup for using SDK MCP tools. DO NOT PROCEED with running other tools before completing this step. Only skip for queries that don't need tools.
 
 ## SDK release
 


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-tools/issues/12592

- Adding instructions on using new Verify Setup MCP tool, which checks that requirements are installed in the environment

Example of implicitly running this tool before running a different requested tool
<img width="377" height="547" alt="image" src="https://github.com/user-attachments/assets/993e1b19-c0bb-47ac-a362-ab27043efce3" />

Explicit invokation:
<img width="365" height="347" alt="image" src="https://github.com/user-attachments/assets/a64422fd-6326-4bf0-a189-ec06ff67f2fc" />


Example of a non MCP related query (it doesn't try to run this tool)
<img width="369" height="446" alt="image" src="https://github.com/user-attachments/assets/141c2bdc-b926-4b03-9ea9-b76501b63b9a" />


ack:
- We want this check to be proactive and happen without explicit invokation. However, currently, Copilot would only remember if the tool is run in the current session, not in newer sessions, so it could be annoying for the user to constantly have to verify setup in new sessions due to a lack of a caching. This will be accepted for Scenario 1 and improved in future iterations