### PR TITLE
Update CODEOWNERS to include swagger_to_sdk_config.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -659,8 +659,9 @@
 /.github/CODEOWNERS           @rickwinter @sandeep-sen @Azure/azure-sdk-eng
 
 # Add owners for go sdk tool
-/eng/tools/generator          @lirenhe @tadelesh @JiaqiZhang-Dev
-/eng/tools/internal           @lirenhe @tadelesh @JiaqiZhang-Dev
+/eng/tools/generator            @lirenhe @tadelesh @JiaqiZhang-Dev
+/eng/tools/internal             @lirenhe @tadelesh @JiaqiZhang-Dev
+/eng/swagger_to_sdk_config.json @lirenhe @tadelesh @JiaqiZhang-Dev
 
 # Add owners for typespec emitter config
 /eng/emitter-package-lock.json  @lirenhe @tadelesh @JiaqiZhang-Dev @richardpark-msft @jhendrixMSFT @rickwinter @chlowell @gracewilcox


### PR DESCRIPTION
Added CODEOWNERS for swagger_to_sdk_config.json

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
