### PR TITLE
Rename EnableAzureTokenProxy -> EnableAzureProxy

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Breaking Changes
 
+> These changes affect only code written against a beta version such as v1.14.0-beta.2
+- Renamed `WorkloadIdentityCredentialOptions.EnableAzureTokenProxy` to `EnableAzureProxy`
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/azidentity/workload_identity.go
+++ b/sdk/azidentity/workload_identity.go
@@ -55,10 +55,14 @@ type WorkloadIdentityCredentialOptions struct {
 	// the application responsible for ensuring the configured authority is valid and trustworthy.
 	DisableInstanceDiscovery bool
 
-	// EnableAzureTokenProxy determines whether the credential reads token proxy configuration from environment variables.
-	// When this value is true and proxy configuration isn't present or this value is false, the credential will request
+	// EnableAzureProxy determines whether the credential reads proxy configuration from environment variables. When
+	// this value is true and proxy configuration isn't present or this value is false, the credential will request
 	// tokens directly from Entra ID.
-	EnableAzureTokenProxy bool
+	//
+	// The proxy feature is designed for applications that deploy to many clusters and clusters that host many
+	// applications. See the Azure Kubernetes Service identity bindings documentation for more information on when
+	// to set this option: https://learn.microsoft.com/azure/aks/identity-bindings-concepts
+	EnableAzureProxy bool
 
 	// TenantID of the service principal. Defaults to the value of the environment variable AZURE_TENANT_ID.
 	TenantID string
@@ -102,7 +106,7 @@ func NewWorkloadIdentityCredential(options *WorkloadIdentityCredentialOptions) (
 		DisableInstanceDiscovery:   options.DisableInstanceDiscovery,
 	}
 
-	if options.EnableAzureTokenProxy {
+	if options.EnableAzureProxy {
 		if err := customtokenproxy.Configure(&caco.ClientOptions); err != nil {
 			return nil, err
 		}

--- a/sdk/azidentity/workload_identity_test.go
+++ b/sdk/azidentity/workload_identity_test.go
@@ -105,7 +105,7 @@ func TestWorkloadIdentityCredential_Recorded(t *testing.T) {
 				ClientID:                 liveSP.clientID,
 				ClientOptions:            co,
 				DisableInstanceDiscovery: b,
-				EnableAzureTokenProxy:    true,
+				EnableAzureProxy:         true,
 				TenantID:                 liveSP.tenantID,
 				TokenFilePath:            f,
 			})
@@ -142,11 +142,11 @@ func TestWorkloadIdentityCredential(t *testing.T) {
 		return nil
 	}}
 	cred, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
-		ClientID:              fakeClientID,
-		ClientOptions:         policy.ClientOptions{Transport: &sts},
-		EnableAzureTokenProxy: true,
-		TenantID:              fakeTenantID,
-		TokenFilePath:         tempFile,
+		ClientID:         fakeClientID,
+		ClientOptions:    policy.ClientOptions{Transport: &sts},
+		EnableAzureProxy: true,
+		TenantID:         fakeTenantID,
+		TokenFilePath:    tempFile,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -174,11 +174,11 @@ func TestWorkloadIdentityCredential_Expiration(t *testing.T) {
 		return nil
 	}}
 	cred, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
-		ClientID:              fakeClientID,
-		ClientOptions:         policy.ClientOptions{Transport: &sts},
-		EnableAzureTokenProxy: true,
-		TenantID:              fakeTenantID,
-		TokenFilePath:         tempFile,
+		ClientID:         fakeClientID,
+		ClientOptions:    policy.ClientOptions{Transport: &sts},
+		EnableAzureProxy: true,
+		TenantID:         fakeTenantID,
+		TokenFilePath:    tempFile,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -233,8 +233,8 @@ func TestWorkloadIdentityCredential_NoFile(t *testing.T) {
 		t.Setenv(k, v)
 	}
 	cred, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
-		ClientOptions:         policy.ClientOptions{Transport: &mockSTS{}},
-		EnableAzureTokenProxy: true,
+		ClientOptions:    policy.ClientOptions{Transport: &mockSTS{}},
+		EnableAzureProxy: true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -283,11 +283,11 @@ func TestWorkloadIdentityCredential_Options(t *testing.T) {
 		t.Setenv(k, v)
 	}
 	cred, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
-		ClientID:              clientID,
-		ClientOptions:         policy.ClientOptions{Transport: &sts},
-		EnableAzureTokenProxy: true,
-		TenantID:              tenantID,
-		TokenFilePath:         rightFile,
+		ClientID:         clientID,
+		ClientOptions:    policy.ClientOptions{Transport: &sts},
+		EnableAzureProxy: true,
+		TenantID:         tenantID,
+		TokenFilePath:    rightFile,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -428,11 +428,11 @@ func TestWorkloadIdentityCredential_CustomTokenEndpoint_WithCAData(t *testing.T)
 		},
 	}
 	cred, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
-		ClientID:              fakeClientID,
-		ClientOptions:         clientOptions,
-		EnableAzureTokenProxy: true,
-		TenantID:              fakeTenantID,
-		TokenFilePath:         tempFile,
+		ClientID:         fakeClientID,
+		ClientOptions:    clientOptions,
+		EnableAzureProxy: true,
+		TenantID:         fakeTenantID,
+		TokenFilePath:    tempFile,
 	})
 	require.NoError(t, err)
 	require.Nil(t, clientOptions.Transport, "constructor shouldn't mutate caller's ClientOptions")
@@ -445,10 +445,10 @@ func TestWorkloadIdentityCredential_CustomTokenEndpoint_WithCAData(t *testing.T)
 func TestWorkloadIdentityCredential_CustomTokenEndpoint_InvalidSettings(t *testing.T) {
 	t.Setenv(customtokenproxy.AzureKubernetesTokenProxy, "invalid-token-endpoint")
 	_, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
-		ClientID:              fakeClientID,
-		EnableAzureTokenProxy: true,
-		TenantID:              fakeTenantID,
-		TokenFilePath:         filepath.Join(t.TempDir(), "test-workload-token-file"),
+		ClientID:         fakeClientID,
+		EnableAzureProxy: true,
+		TenantID:         fakeTenantID,
+		TokenFilePath:    filepath.Join(t.TempDir(), "test-workload-token-file"),
 	})
 	require.Error(t, err)
 }
@@ -493,11 +493,11 @@ func TestWorkloadIdentityCredential_CustomTokenEndpoint_WithCAFile(t *testing.T)
 		},
 	}
 	cred, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
-		ClientID:              fakeClientID,
-		ClientOptions:         clientOptions,
-		EnableAzureTokenProxy: true,
-		TenantID:              fakeTenantID,
-		TokenFilePath:         tempFile,
+		ClientID:         fakeClientID,
+		ClientOptions:    clientOptions,
+		EnableAzureProxy: true,
+		TenantID:         fakeTenantID,
+		TokenFilePath:    tempFile,
 	})
 	require.NoError(t, err)
 	require.Nil(t, clientOptions.Transport, "constructor shouldn't mutate caller's ClientOptions")
@@ -553,11 +553,11 @@ func TestWorkloadIdentityCredential_CustomTokenEndpoint_AKSSetup(t *testing.T) {
 		},
 	}
 	cred, err := NewWorkloadIdentityCredential(&WorkloadIdentityCredentialOptions{
-		ClientID:              fakeClientID,
-		ClientOptions:         clientOptions,
-		EnableAzureTokenProxy: true,
-		TenantID:              fakeTenantID,
-		TokenFilePath:         tempFile,
+		ClientID:         fakeClientID,
+		ClientOptions:    clientOptions,
+		EnableAzureProxy: true,
+		TenantID:         fakeTenantID,
+		TokenFilePath:    tempFile,
 	})
 	require.NoError(t, err)
 	require.Nil(t, clientOptions.Transport, "constructor shouldn't mutate caller's ClientOptions")


### PR DESCRIPTION
"Token" is inaccurate because the proxy handles all requests, not just token requests, and also somewhat redundant because tokens are the credential's only output. Also added a little more detail about the end-to-end feature and a link to its new docs for AKS.