### PR TITLE
add code to remove the installation package of Go in automation.sh script file

### DIFF
--- a/eng/scripts/automation_init.sh
+++ b/eng/scripts/automation_init.sh
@@ -26,18 +26,14 @@ current_version=$(go version | awk '{print $3}' | sed 's/go//')
 if ! semver -r ">=1.24.10" "$current_version"; then
   wget -q https://go.dev/dl/go1.24.10.linux-amd64.tar.gz
   tar -C $TMPDIR -xzf go1.24.10.linux-amd64.tar.gz
-  found=0
+
   for file in go*.linux-amd64.tar.gz*; do
       if [ -e "$file" ]; then
           echo "Deleting $file"
           rm -f "$file"
-          found=1
       fi
   done
 
-  if [ "$found" -eq 0 ]; then
-      echo "No matching files found."
-  fi
   export GOROOT=$TMPDIR/go
   export PATH=$GOROOT/bin:$PATH
 fi


### PR DESCRIPTION
Because previously initiated the download action for the go installation package but did not perform the deletion operation, this resulted in AUTOPR submitting information about the go installation package. Therefore, we are now adding the deletion operation to avoid this issue.