### PR TITLE
[azopenai] Fixing lint error that popped up because of redundant build tags

### DIFF
--- a/sdk/ai/azopenai/build.go
+++ b/sdk/ai/azopenai/build.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/client_audio_test.go
+++ b/sdk/ai/azopenai/client_audio_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/client_chat_completions_extensions_test.go
+++ b/sdk/ai/azopenai/client_chat_completions_extensions_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/client_chat_completions_test.go
+++ b/sdk/ai/azopenai/client_chat_completions_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/client_completions_test.go
+++ b/sdk/ai/azopenai/client_completions_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/client_rai_test.go
+++ b/sdk/ai/azopenai/client_rai_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/client_responses_test.go
+++ b/sdk/ai/azopenai/client_responses_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/custom_client_image_test.go
+++ b/sdk/ai/azopenai/custom_client_image_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/custom_errors.go
+++ b/sdk/ai/azopenai/custom_errors.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/custom_errors_test.go
+++ b/sdk/ai/azopenai/custom_errors_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/custom_models.go
+++ b/sdk/ai/azopenai/custom_models.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/helpers_requests.go
+++ b/sdk/ai/azopenai/helpers_requests.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 

--- a/sdk/ai/azopenai/internal/check_generation_test.go
+++ b/sdk/ai/azopenai/internal/check_generation_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-// +build go1.21
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 


### PR DESCRIPTION
The lint error was complaining that we had both go:build and +build tags, but it turns out that we actually don't need either of them.

