### PR TITLE
Fix wrong versioning logic for generation tool

### DIFF
--- a/eng/tools/generator/CHANGELOG.md
+++ b/eng/tools/generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 0.4.2 (2025-12-08)
+
+### Bugs Fixed
+
+- Move logic of determining preview version after code generation to avoid incorrect version calculation.
+- Fix wrong override logic for stable/beta version determination.
+
 ## 0.4.1 (2025-12-02)
 
 ### Bugs Fixed

--- a/eng/tools/generator/cmd/v2/common/cmdProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/cmdProcessor.go
@@ -62,7 +62,7 @@ func ExecuteGoGenerate(path string) error {
 		}
 	}
 
-	if cmdWaitErr != nil || stderrBuffer.Len() > 0 {
+	if stderrBuffer.Len() > 0 {
 		if stderrBuffer.Len() > 0 {
 			// filter go downloading log
 			// https://github.com/golang/go/blob/1f0c044d60211e435dc58844127544dd3ecb6a41/src/cmd/go/internal/modfetch/fetch.go#L201
@@ -123,7 +123,7 @@ func ExecuteGoimports(path string) error {
 }
 
 func ExecuteGitPush(path, remoteName, branchName string) (string, error) {
-	refName := fmt.Sprintf("%s", branchName+":"+branchName)
+	refName := branchName + ":" + branchName
 	cmd := exec.Command("git", "push", remoteName, refName)
 	cmd.Dir = path
 	msg, err := cmd.CombinedOutput()

--- a/eng/tools/generator/cmd/v2/common/fileProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/fileProcessor.go
@@ -27,31 +27,11 @@ const (
 )
 
 var (
-	v2BeginRegex                    = regexp.MustCompile("^```\\s*yaml\\s*\\$\\(go\\)\\s*&&\\s*\\$\\((track2|v2)\\)")
-	v2EndRegex                      = regexp.MustCompile("^\\s*```\\s*$")
-	newClientMethodNameRegex        = regexp.MustCompile("^New.*Client$")
-	versionLineRegex                = regexp.MustCompile(`moduleVersion\s*=\s*\".*v.+"`)
-	changelogPosWithPreviewRegex    = regexp.MustCompile(`##\s*(?P<version>.+)\s*\((\d{4}-\d{2}-\d{2}|Unreleased)\)`)
-	changelogPosWithoutPreviewRegex = regexp.MustCompile(`##\s*(?P<version>\d+\.\d+\.\d+)\s*\((\d{4}-\d{2}-\d{2}|Unreleased)\)`)
-	packageConfigRegex              = regexp.MustCompile(`\$\((package-.+)\)`)
+	v2BeginRegex             = regexp.MustCompile("^```\\s*yaml\\s*\\$\\(go\\)\\s*&&\\s*\\$\\((track2|v2)\\)")
+	v2EndRegex               = regexp.MustCompile("^\\s*```\\s*$")
+	newClientMethodNameRegex = regexp.MustCompile("^New.*Client$")
+	packageConfigRegex       = regexp.MustCompile(`\$\((package-.+)\)`)
 )
-
-// paramsToString converts a parameter list to a comma-delimited string with names and types
-func paramsToString(params []exports.Param) string {
-	if len(params) == 0 {
-		return ""
-	}
-
-	var parts []string
-	for _, p := range params {
-		if p.Name != "" {
-			parts = append(parts, p.Name+" "+p.Type)
-		} else {
-			parts = append(parts, p.Type)
-		}
-	}
-	return strings.Join(parts, ", ")
-}
 
 // hasExpectedClientParams checks if params match the expected ARM client constructor signature
 func hasExpectedClientParams(params []exports.Param) bool {
@@ -260,7 +240,7 @@ func GetSpecRpName(packageRootPath string) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("cannot get sepc rp name from config")
+	return "", fmt.Errorf("cannot get spec rp name from config")
 }
 
 // ReplaceNewClientNamePlaceholder replaces `{{NewClientName}}` placeholder in README.md by first func name according to `^New.+Method$` pattern
@@ -431,9 +411,9 @@ func UpdateReadmeClientFactory(path string) error {
 	}
 	noOptionalFactoryReg := regexp.MustCompile(`NewClientFactory\((.*?)(?:,\s*)?cred,\s*nil\)`)
 	withOptionalFactoryReg := regexp.MustCompile(`NewClientFactory\((.*?)(?:,\s*)?cred,\s*&options\)`)
-	oldnoOptionalFactory := noOptionalFactoryReg.FindString(string(readmeFile))
-	oldwithOptionalFactory := withOptionalFactoryReg.FindString(string(readmeFile))
-	if oldnoOptionalFactory == "" && oldwithOptionalFactory == "" {
+	oldNoOptionalFactory := noOptionalFactoryReg.FindString(string(readmeFile))
+	oldWithOptionalFactory := withOptionalFactoryReg.FindString(string(readmeFile))
+	if oldNoOptionalFactory == "" && oldWithOptionalFactory == "" {
 		return nil
 	}
 	clientFactoryFile, err := os.ReadFile(filepath.Join(path, utils.ClientFactoryFileName))
@@ -469,10 +449,10 @@ func UpdateReadmeClientFactory(path string) error {
 	withOptionsParams := append(factoryParams, []string{"cred", "&options"}...)
 	newNoOptionalFactory := fmt.Sprintf("NewClientFactory(%s)", strings.Join(noOptionsParams, ", "))
 	newWithOptionalFactory := fmt.Sprintf("NewClientFactory(%s)", strings.Join(withOptionsParams, ", "))
-	if oldnoOptionalFactory == newNoOptionalFactory && oldwithOptionalFactory == newWithOptionalFactory {
+	if oldNoOptionalFactory == newNoOptionalFactory && oldWithOptionalFactory == newWithOptionalFactory {
 		return nil
 	}
-	content := strings.ReplaceAll(string(readmeFile), oldnoOptionalFactory, newNoOptionalFactory)
-	content = strings.ReplaceAll(content, oldwithOptionalFactory, newWithOptionalFactory)
+	content := strings.ReplaceAll(string(readmeFile), oldNoOptionalFactory, newNoOptionalFactory)
+	content = strings.ReplaceAll(content, oldWithOptionalFactory, newWithOptionalFactory)
 	return os.WriteFile(readmePath, []byte(content), 0644)
 }

--- a/eng/tools/generator/cmd/version/versionCmd.go
+++ b/eng/tools/generator/cmd/version/versionCmd.go
@@ -178,9 +178,10 @@ func processVersionUpdate(sdkRoot, packagePath, sdkVersion, sdkReleaseType strin
 		}
 
 		override := new(bool)
-		if sdkReleaseType == "stable" {
+		switch sdkReleaseType {
+		case "stable":
 			*override = false
-		} else if sdkReleaseType == "beta" {
+		case "beta":
 			*override = true
 		}
 		// Determine if this should be a preview version

--- a/eng/tools/generator/version.go
+++ b/eng/tools/generator/version.go
@@ -5,5 +5,5 @@ package main
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/eng/tools/generator"
-	moduleVersion = "v0.4.1"
+	moduleVersion = "v0.4.2"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
