### PR TITLE
Persistent caching follows XDG directory spec on Linux

### DIFF
--- a/sdk/azidentity/cache/CHANGELOG.md
+++ b/sdk/azidentity/cache/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+* Linux caches are stored in $XDG_CACHE_HOME by default, falling back to $HOME/.cache
+
 ## 0.3.2 (2025-01-15)
 
 ### Other Changes

--- a/sdk/azidentity/cache/cache_linux.go
+++ b/sdk/azidentity/cache/cache_linux.go
@@ -23,8 +23,15 @@ const (
 )
 
 var (
-	cacheDir = os.UserHomeDir
-	storage  = func(name string) (accessor.Accessor, error) {
+	cacheDir = func() (d string, err error) {
+		if d = os.Getenv("XDG_CACHE_HOME"); d == "" {
+			if d, err = os.UserHomeDir(); err == nil {
+				d = filepath.Join(d, ".cache")
+			}
+		}
+		return
+	}
+	storage = func(name string) (accessor.Accessor, error) {
 		return newKeyring(name)
 	}
 )

--- a/sdk/azidentity/cache/cache_linux_test.go
+++ b/sdk/azidentity/cache/cache_linux_test.go
@@ -12,6 +12,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCacheDir(t *testing.T) {
+	t.Run("no XDG_CACHE_HOME", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+		expected := filepath.Join(home, ".cache")
+		t.Setenv("XDG_CACHE_HOME", "")
+		actual, err := cacheDir()
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+	t.Run("XDG_CACHE_HOME", func(t *testing.T) {
+		expected := string(filepath.Separator) + "foo"
+		t.Setenv("XDG_CACHE_HOME", expected)
+		actual, err := cacheDir()
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+}
+
 func TestKeyExistsButNotFile(t *testing.T) {
 	expected := []byte(t.Name())
 	a, err := storage(t.Name())


### PR DESCRIPTION
This aligns azidentity/cache's behavior with the [XDG base directory spec](https://specifications.freedesktop.org/basedir/latest), making it more conventional on Linux and enabling a workaround in the unusual case that $HOME isn't writeable (closes #25409). Users of an app that upgrades from a current version of azidentity/cache to one using this new path may have to log in again because the upgrade effectively discards existing caches. I don't consider this a blocker to adopting a new path unconditionally because the module isn't stable and caches are lost on system shutdown anyway--users already have to log in again after every reboot.

This change isn't relevant to any other SDK because azidentity/cache's storage implementation for Linux is unique.