### PR TITLE
Fix flaky DefaultAzureCredential test

### DIFF
--- a/sdk/azidentity/default_azure_credential_test.go
+++ b/sdk/azidentity/default_azure_credential_test.go
@@ -366,7 +366,7 @@ func TestDefaultAzureCredential_WorkloadIdentity(t *testing.T) {
 		require.NoError(t, err)
 
 		// ...but ensure a timeout should it try the proxy anyway
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		_, err = cred.GetToken(ctx, testTRO)
 		require.NoError(t, err)


### PR DESCRIPTION
This test has failed a couple times, apparently due to reaching the 2 ms timeout.