### PR TITLE
Convert datetime tests to use _test

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.21.0 (Unreleased)
 
 ### Features Added
+
 * Added `runtime/datetime` package which provides specialized time type wrappers for serializing and deserializing
 time values in various formats used by Azure services.
 

--- a/sdk/azcore/runtime/datetime/RFC1123_test.go
+++ b/sdk/azcore/runtime/datetime/RFC1123_test.go
@@ -1,39 +1,40 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package datetime
+package datetime_test
 
 import (
 	"encoding/xml"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRFC1123(t *testing.T) {
 	originalTime := time.Date(2023, time.June, 15, 14, 30, 45, 0, time.UTC)
-	dt := RFC1123(originalTime)
+	dt := datetime.RFC1123(originalTime)
 	result := dt.String()
 	require.Equal(t, "Thu, 15 Jun 2023 14:30:45 UTC", result)
 
 	jsonBytes, err := dt.MarshalJSON()
 	require.NoError(t, err)
-	var dt2 RFC1123
+	var dt2 datetime.RFC1123
 	err = dt2.UnmarshalJSON(jsonBytes)
 	require.NoError(t, err)
 	require.Equal(t, originalTime, time.Time(dt2))
 
 	textBytes, err := dt.MarshalText()
 	require.NoError(t, err)
-	var dt3 RFC1123
+	var dt3 datetime.RFC1123
 	err = dt3.UnmarshalText(textBytes)
 	require.NoError(t, err)
 	require.Equal(t, originalTime, time.Time(dt3))
 }
 
 func TestRFC1123_empty(t *testing.T) {
-	tt := RFC1123{}
+	tt := datetime.RFC1123{}
 	require.NoError(t, xml.Unmarshal([]byte("<RFC1123/>"), &tt))
 	require.Zero(t, tt)
 }

--- a/sdk/azcore/runtime/datetime/RFC3339_test.go
+++ b/sdk/azcore/runtime/datetime/RFC3339_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package datetime
+package datetime_test
 
 import (
 	"encoding/json"
@@ -9,37 +9,38 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime"
 	"github.com/stretchr/testify/require"
 )
 
 type timeInfoJSON struct {
-	StartTime *RFC3339
+	StartTime *datetime.RFC3339
 }
 
 type timeInfoXML struct {
-	Expiry *RFC3339
+	Expiry *datetime.RFC3339
 }
 
 type timeInfoSlice struct {
-	Expiry *[]RFC3339
+	Expiry *[]datetime.RFC3339
 }
 
 func TestRFC3339(t *testing.T) {
 	originalTime := time.Date(2023, time.June, 15, 14, 30, 45, 0, time.UTC)
-	dt := RFC3339(originalTime)
+	dt := datetime.RFC3339(originalTime)
 	result := dt.String()
 	require.NotEmpty(t, result)
 
 	jsonBytes, err := dt.MarshalJSON()
 	require.NoError(t, err)
-	var dt2 RFC3339
+	var dt2 datetime.RFC3339
 	err = dt2.UnmarshalJSON(jsonBytes)
 	require.NoError(t, err)
 	require.Equal(t, originalTime, time.Time(dt2))
 
 	textBytes, err := dt.MarshalText()
 	require.NoError(t, err)
-	var dt3 RFC3339
+	var dt3 datetime.RFC3339
 	err = dt3.UnmarshalText(textBytes)
 	require.NoError(t, err)
 	require.Equal(t, originalTime, time.Time(dt3))
@@ -98,7 +99,7 @@ func TestEmptyAndNullTime(t *testing.T) {
 }
 
 func TestRFC3339_empty(t *testing.T) {
-	tt := RFC3339{}
+	tt := datetime.RFC3339{}
 	require.NoError(t, xml.Unmarshal([]byte("<RFC3339/>"), &tt))
 	require.Zero(t, tt)
 }

--- a/sdk/azcore/runtime/datetime/plain_date_test.go
+++ b/sdk/azcore/runtime/datetime/plain_date_test.go
@@ -1,24 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package datetime
+package datetime_test
 
 import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPlainDate(t *testing.T) {
 	originalDate := time.Date(2023, time.January, 15, 0, 0, 0, 0, time.UTC)
-	pd := PlainDate(originalDate)
+	pd := datetime.PlainDate(originalDate)
 
 	jsonBytes, err := pd.MarshalJSON()
 	require.NoError(t, err)
 	require.Equal(t, `"2023-01-15"`, string(jsonBytes))
 
-	var pd2 PlainDate
+	var pd2 datetime.PlainDate
 	err = pd2.UnmarshalJSON(jsonBytes)
 	require.NoError(t, err)
 
@@ -29,8 +30,8 @@ func TestPlainDate_TimeIgnored(t *testing.T) {
 	date1 := time.Date(2023, time.January, 15, 0, 0, 0, 0, time.UTC)
 	date2 := time.Date(2023, time.January, 15, 23, 59, 59, 999999999, time.UTC)
 
-	pd1 := PlainDate(date1)
-	pd2 := PlainDate(date2)
+	pd1 := datetime.PlainDate(date1)
+	pd2 := datetime.PlainDate(date2)
 
 	result1, _ := pd1.MarshalJSON()
 	result2, _ := pd2.MarshalJSON()
@@ -41,36 +42,36 @@ func TestPlainDate_TimeIgnored(t *testing.T) {
 }
 
 func TestPlainDate_UnmarshalJSON_Invalid_Format(t *testing.T) {
-	var pd PlainDate
+	var pd datetime.PlainDate
 	err := pd.UnmarshalJSON([]byte("2023/01/15"))
 	require.Error(t, err)
 }
 
 func TestPlainDate_UnmarshalJSON_Invalid_Month(t *testing.T) {
-	var pd PlainDate
+	var pd datetime.PlainDate
 	err := pd.UnmarshalJSON([]byte("2023-13-01"))
 	require.Error(t, err)
 }
 
 func TestPlainDate_UnmarshalJSON_Invalid_Day(t *testing.T) {
-	var pd PlainDate
+	var pd datetime.PlainDate
 	err := pd.UnmarshalJSON([]byte("2023-01-32"))
 	require.Error(t, err)
 }
 
 func TestPlainDate_UnmarshalJSON_Empty(t *testing.T) {
-	var pd PlainDate
+	var pd datetime.PlainDate
 	err := pd.UnmarshalJSON([]byte(""))
 	require.Error(t, err)
 }
 
 func TestPlainDate_UnmarshalJSON_PartialDate(t *testing.T) {
-	var pd PlainDate
+	var pd datetime.PlainDate
 	err := pd.UnmarshalJSON([]byte("2023-01"))
 	require.Error(t, err)
 }
 
 func TestPlainDate_String(t *testing.T) {
-	plainDate := PlainDate(time.Date(2023, time.January, 15, 0, 0, 0, 0, time.UTC))
+	plainDate := datetime.PlainDate(time.Date(2023, time.January, 15, 0, 0, 0, 0, time.UTC))
 	require.Equal(t, "2023-01-15", plainDate.String())
 }

--- a/sdk/azcore/runtime/datetime/plain_time_test.go
+++ b/sdk/azcore/runtime/datetime/plain_time_test.go
@@ -1,24 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package datetime
+package datetime_test
 
 import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPlainTime(t *testing.T) {
 	originalTime := time.Date(2023, time.June, 15, 10, 30, 45, 0, time.UTC)
-	pt := PlainTime(originalTime)
+	pt := datetime.PlainTime(originalTime)
 	result := pt.String()
 	require.Equal(t, "10:30:45", result)
 
 	jsonBytes, err := pt.MarshalJSON()
 	require.NoError(t, err)
-	var pt2 PlainTime
+	var pt2 datetime.PlainTime
 	err = pt2.UnmarshalJSON(jsonBytes)
 	require.NoError(t, err)
 	require.Equal(t, originalTime.Hour(), time.Time(pt2).Hour())
@@ -27,7 +28,7 @@ func TestPlainTime(t *testing.T) {
 
 	textBytes, err := pt.MarshalText()
 	require.NoError(t, err)
-	var pt3 PlainTime
+	var pt3 datetime.PlainTime
 	err = pt3.UnmarshalText(textBytes)
 	require.NoError(t, err)
 	require.Equal(t, originalTime.Hour(), time.Time(pt3).Hour())
@@ -51,12 +52,12 @@ func TestPlainTime_Various(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			originalTime := time.Date(2023, time.January, 15, tt.hour, tt.minute, tt.second, 0, time.UTC)
-			pt := PlainTime(originalTime)
+			pt := datetime.PlainTime(originalTime)
 
 			textBytes, err := pt.MarshalText()
 			require.NoError(t, err)
 
-			var pt2 PlainTime
+			var pt2 datetime.PlainTime
 			err = pt2.UnmarshalText(textBytes)
 			require.NoError(t, err)
 

--- a/sdk/azcore/runtime/datetime/unix_test.go
+++ b/sdk/azcore/runtime/datetime/unix_test.go
@@ -1,51 +1,52 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package datetime
+package datetime_test
 
 import (
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUnix(t *testing.T) {
 	originalTime := time.Date(2023, time.June, 15, 14, 30, 45, 0, time.Local)
-	tu := Unix(originalTime)
+	tu := datetime.Unix(originalTime)
 	result := tu.String()
 	expected := fmt.Sprintf("%d", originalTime.Unix())
 	require.Equal(t, expected, result)
 
 	jsonBytes, err := tu.MarshalJSON()
 	require.NoError(t, err)
-	var tu2 Unix
+	var tu2 datetime.Unix
 	err = tu2.UnmarshalJSON(jsonBytes)
 	require.NoError(t, err)
 	require.Equal(t, originalTime, time.Time(tu2))
 }
 
 func TestUnix_Invalid(t *testing.T) {
-	var tu Unix
+	var tu datetime.Unix
 	err := tu.UnmarshalJSON([]byte("not-a-number"))
 	require.Error(t, err)
 }
 
 func TestUnix_Epoch(t *testing.T) {
-	tu := Unix(time.Unix(0, 0).UTC())
+	tu := datetime.Unix(time.Unix(0, 0).UTC())
 	result := tu.String()
 	require.Equal(t, "0", result)
 }
 
 func TestUnix_NegativeTimestamp(t *testing.T) {
 	beforeEpoch := time.Date(1969, time.December, 31, 23, 59, 59, 0, time.UTC)
-	tu := Unix(beforeEpoch)
+	tu := datetime.Unix(beforeEpoch)
 
 	jsonBytes, err := tu.MarshalJSON()
 	require.NoError(t, err)
 
-	var tu2 Unix
+	var tu2 datetime.Unix
 	err = tu2.UnmarshalJSON(jsonBytes)
 	require.NoError(t, err)
 	require.Equal(t, beforeEpoch.Unix(), time.Time(tu2).Unix())


### PR DESCRIPTION
Ensures no inadvertent usage of unexported content.