### PR TITLE
[Go] Updated copilot instruction for local SDK generation workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,18 @@ You are an expert Go programmer that attempts to answer questions and provide co
   - **Do not proceed** with any other tool execution until this step is complete.
   - **Skip this check only** for queries that do not require tool execution.
 
+## Local SDK Generation and Package Lifecycle (TypeSpec)
+
+### AUTHORITATIVE REFERENCE
+For all TypeSpec-based SDK workflows (generation, building, validation, testing, versioning, and release preparation), follow #file:../eng/common/instructions/azsdk-tools/local-sdk-workflow.instructions.md
+
+### DEFAULT BEHAVIORS
+- **Repository:** Use the current workspace as the local SDK repository unless the user specifies a different path.
+- **Configuration:** Identify `tsp-location.yaml` from files open in the editor. If unclear, ask the user.
+
+### REQUIRED CONFIRMATIONS
+Ask the user for clarification if repository path or configuration file is ambiguous.
+
 ## SDK release
 
 For detailed workflow instructions, see [SDK Release](../eng/common/instructions/copilot/sdk-release.instructions.md).


### PR DESCRIPTION
References the workflow instruction file from the `eng/common` folder.

**Test screenshots:**

Code generation and compile:

<img width="937" height="1228" alt="image" src="https://github.com/user-attachments/assets/10157498-0f18-4fec-be95-3337c1dc51cc" />

Running checks and test:

<img width="950" height="1003" alt="image" src="https://github.com/user-attachments/assets/811f7a60-9085-4321-bd03-41e18a3fa606" />

Update changelog, and version:

<img width="938" height="875" alt="image" src="https://github.com/user-attachments/assets/69556f8e-1a44-46f1-91e2-d5e098ee7b51" />

