### PR TITLE
Adjust the regex so it ensures it grabs the right-most 'sdk' in the path

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -54,7 +54,7 @@ function Get-GoModuleProperties($goModPath)
   $goModPath = $goModPath -replace "\\", "/"
   # We should keep this regex in sync with what is in the azure-sdk repo at https://github.com/Azure/azure-sdk/blob/main/eng/scripts/Query-Azure-Packages.ps1#L238
   # The serviceName named capture group is unused but used in azure-sdk, so it's kept here for parity
-  if (!$goModPath.Contains("testdata") -and !$goModPath.Contains("sdk/samples") -and $goModPath -match ".+(?<modPath>(sdk|profile|eng)/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
+  if (!$goModPath.Contains("testdata") -and !$goModPath.Contains("sdk/samples") -and $goModPath -match ".*(?<modPath>(sdk|profile|eng)/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
   {
     $modPath = $matches["modPath"]
     $modName = $matches["modName"] # We may need to start reading this from the go.mod file if the path and mod config start to differ


### PR DESCRIPTION
Without that, it'll match at the _first_ 'sdk' that occurs in the path, rather than the one closest to the end.

For example, if we were using this path: /home/me/src/_/sdk/p/test/azure-sdk-for-go/eng/common/scripts
BEFORE the fix: sdk/p/test/azure-sdk-for-go/eng/common/scripts
AFTER the fix: sdk/messaging/azservicebus

This also works fine with existing paths as well.

Fixes https://github.com/Azure/azure-sdk-tools/issues/13482