### PR TITLE
Replace `azd config list` with `azd auth status` in TROUBLESHOOTING.md

### DIFF
--- a/sdk/azidentity/TROUBLESHOOTING.md
+++ b/sdk/azidentity/TROUBLESHOOTING.md
@@ -193,17 +193,26 @@ az account get-access-token --output json --resource https://management.core.win
 
 #### Verify the Azure Developer CLI can obtain tokens
 
-You can manually verify that the Azure Developer CLI is properly authenticated and can obtain tokens. First, use the `auth status` command to verify the account that is currently logged in to the Azure Developer CLI.
+You can manually verify that the Azure Developer CLI is properly authenticated and can obtain tokens. Execute the command corresponding to your CLI version to verify the account currently logged in.
 
-```sh
-azd auth status
-```
+- In Azure Developer CLI versions >= 1.23.0:
+
+    ```sh
+    azd auth status
+    ```
+
+- In Azure Developer CLI versions < 1.23.0:
+
+    ```sh
+    azd config list
+    ```
 
 Once you've verified the Azure Developer CLI is using correct account, you can validate that it's able to obtain tokens for this account.
 
 ```sh
 azd auth token --output json --scope https://management.core.windows.net/.default
 ```
+
 >Note that output of this command will contain a valid access token, and SHOULD NOT BE SHARED to avoid compromising account security.
 
 <a id="azure-pwsh"></a>


### PR DESCRIPTION
The `azd config list` command is no longer the recommended way to verify the logged-in Azure Developer CLI account. Update the troubleshooting guide to use `azd auth status` instead.