### PR TITLE
Add CODEOWNERS entry for sdk/monitor/ingestion/azlogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,6 +82,9 @@
 /sdk/monitor/                                                      @Azure/azure-sdk-write-monitor-data-plane @Azure/azure-sdk-write-monitor-query-logs @chlowell @gracewilcox @jhendrixMSFT
 
 # PRLabel: %Monitor
+/sdk/monitor/ingestion/azlogs/                                     @Azure/azure-sdk-write-monitor-data-plane
+
+# PRLabel: %Monitor
 /sdk/monitor/query/azmetrics/                                      @Azure/azure-sdk-write-monitor-query-metrics
 
 # AzureSdkOwners:                                                  @gracewilcox


### PR DESCRIPTION
This pull request adds a new CODEOWNERS entry for the `azlogs` ingestion directory within the Monitor SDK. This ensures that the correct service team is assigned ownership and responsibility for changes in this area.

Ownership assignment:

* Added `/sdk/monitor/ingestion/azlogs/` to `.github/CODEOWNERS`, assigning it to the `azure-sdk-write-monitor-data-plane` team.