### PR TITLE
[Script] Refined dependency upgrade logic to use `go get` instead of `go get -u`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -662,6 +662,8 @@
 /.github/copilot-instructions.md   @richardpark-msft @praveenkuttappan @maririos
 
 # Add owners for go sdk tool
+/eng/scripts/automation_init.sh @lirenhe @tadelesh @JiaqiZhang-Dev
+/eng/scripts/build.ps1          @lirenhe @tadelesh @JiaqiZhang-Dev
 /eng/tools/generator            @lirenhe @tadelesh @JiaqiZhang-Dev
 /eng/tools/internal             @lirenhe @tadelesh @JiaqiZhang-Dev
 /eng/swagger_to_sdk_config.json @lirenhe @tadelesh @JiaqiZhang-Dev

--- a/eng/scripts/build.ps1
+++ b/eng/scripts/build.ps1
@@ -91,12 +91,12 @@ function Process-Sdk ()
 
     if ($tidy)
     {
-        Write-Host "##[command]Executing go get -u github.com/Azure/azure-sdk-for-go/sdk/azcore toolchain@none go@1.24.0 in " $currentDirectory
-        go get -u github.com/Azure/azure-sdk-for-go/sdk/azcore toolchain@none go@1.24.0
+        Write-Host "##[command]Executing go get github.com/Azure/azure-sdk-for-go/sdk/azcore toolchain@none go@1.24.0 in " $currentDirectory
+        go get github.com/Azure/azure-sdk-for-go/sdk/azcore toolchain@none go@1.24.0
         if ($LASTEXITCODE) { exit $LASTEXITCODE }
         
-        Write-Host "##[command]Executing go get -u github.com/Azure/azure-sdk-for-go/sdk/azidentity toolchain@none go@1.24.0 in " $currentDirectory
-        go get -u github.com/Azure/azure-sdk-for-go/sdk/azidentity toolchain@none go@1.24.0
+        Write-Host "##[command]Executing go get github.com/Azure/azure-sdk-for-go/sdk/azidentity toolchain@none go@1.24.0 in " $currentDirectory
+        go get github.com/Azure/azure-sdk-for-go/sdk/azidentity toolchain@none go@1.24.0
         if ($LASTEXITCODE) { exit $LASTEXITCODE }
         
         Write-Host "##[command]Executing go mod tidy in " $currentDirectory


### PR DESCRIPTION
Fix pipeline error: 
https://github.com/Azure/azure-rest-api-specs/pull/38941/checks?check_run_id=64931827621
<img width="2478" height="1032" alt="image" src="https://github.com/user-attachments/assets/7948f941-9ef7-4033-8f65-f7a0a447ebd8" />

### Change

1. Refined dependency upgrade logic to use `go get` instead of `go get -u` to prevent unintended upgrades of other dependencies.
2. Update code owners for go sdk tool

### Reference

<img width="780" height="227" alt="image" src="https://github.com/user-attachments/assets/7f74ee97-dff5-4cc7-b3eb-efeeefb16e94" />
<img width="1464" height="75" alt="image" src="https://github.com/user-attachments/assets/1755e55b-193a-426a-a44b-3ad2fb7a84f9" />

### Test
<img width="657" height="95" alt="image" src="https://github.com/user-attachments/assets/ec71cb5f-154a-4e45-9233-a01d89e3ea0a" />

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
