### PR TITLE
[Generator] Filter out irrelevant error message "Error reading tsp-location.yaml

### DIFF
--- a/eng/tools/generator/CHANGELOG.md
+++ b/eng/tools/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.4.7 (2026-02-27)
+
+### Other Changes
+
+- Filter out irrelevant error message "Error reading tsp-location.yaml" in command execution output to avoid confusion for users.
+
 ## 0.4.6 (2026-02-26)
 
 ### Other Changes

--- a/eng/tools/generator/cmd/v2/common/cmdProcessor.go
+++ b/eng/tools/generator/cmd/v2/common/cmdProcessor.go
@@ -247,6 +247,9 @@ func ExecuteTspClient(path string, args ...string) error {
 				if strings.Contains(line, "npm warn") {
 					continue
 				}
+				if strings.Contains(line, "Error reading tsp-location.yaml") {
+					continue
+				}
 				newErrMsgs = append(newErrMsgs, line)
 			}
 

--- a/eng/tools/generator/version.go
+++ b/eng/tools/generator/version.go
@@ -5,5 +5,5 @@ package main
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/eng/tools/generator"
-	moduleVersion = "v0.4.6"
+	moduleVersion = "v0.4.7"
 )


### PR DESCRIPTION
Filter out irrelevant error message "Error reading tsp-location.yaml" in command execution output to avoid confusion for users.

### Test
before: 
<img width="895" height="229" alt="image" src="https://github.com/user-attachments/assets/e31e18e0-77ca-4f3d-8280-0a0af4e873be" />


after:
<img width="1754" height="783" alt="image" src="https://github.com/user-attachments/assets/bc673afe-b88d-4a4e-9fc2-71deacd6fc68" />

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
