### PR TITLE
eng/tools/generator: release v0.4.7 which fixed GenerateChangelog to bypass errors when the module doesn't contain any exports.

### DIFF
--- a/eng/tools/generator/CHANGELOG.md
+++ b/eng/tools/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.4.7 (2026-03-03)
+
+### Bugs Fixed
+
+- Fixed `GenerateChangelog` to bypass errors when the module doesn't contain any exports instead of failing.
+
 ## 0.4.6 (2026-02-26)
 
 ### Other Changes

--- a/eng/tools/generator/changelog/changelog_tool.go
+++ b/eng/tools/generator/changelog/changelog_tool.go
@@ -369,8 +369,9 @@ func GenerateChangelog(modulePath string, sdkRepo repo.SDKRepository, isCurrentP
 		return ChangelogResult{}, err
 	}
 
+	// bypass the error if the module doesn't contain any exports, return empty content
 	newExports, err := exports.Get(modulePath)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "doesn't contain any exports") {
 		return ChangelogResult{}, err
 	}
 

--- a/eng/tools/generator/version.go
+++ b/eng/tools/generator/version.go
@@ -5,5 +5,5 @@ package main
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/eng/tools/generator"
-	moduleVersion = "v0.4.6"
+	moduleVersion = "v0.4.7"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
