### PR TITLE
DO NOT MERGE: Add SKU support to HealthDataAIServices Go SDK

### DIFF
--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/CHANGELOG.md
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+## 1.1.0 (2026-03-05)
+### Features Added
+
+- New enum type `SKUTier` with values `SKUTierBasic`, `SKUTierFree`, `SKUTierPremium`, `SKUTierStandard`
+- New struct `SKU`
+- New field `SKU` in struct `DeidService`
+- New field `SKU` in struct `DeidUpdate`
+
+
 ## 1.0.0 (2024-11-20)
 ### Breaking Changes
 

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/constants.go
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/constants.go
@@ -184,3 +184,28 @@ func PossiblePublicNetworkAccessValues() []PublicNetworkAccess {
 		PublicNetworkAccessEnabled,
 	}
 }
+
+// SKUTier - This field is required to be implemented by the Resource Provider if the service has more than one tier, but
+// is not required on a PUT.
+type SKUTier string
+
+const (
+	// SKUTierBasic - The Basic service tier.
+	SKUTierBasic SKUTier = "Basic"
+	// SKUTierFree - The Free service tier.
+	SKUTierFree SKUTier = "Free"
+	// SKUTierPremium - The Premium service tier.
+	SKUTierPremium SKUTier = "Premium"
+	// SKUTierStandard - The Standard service tier.
+	SKUTierStandard SKUTier = "Standard"
+)
+
+// PossibleSKUTierValues returns the possible values for the SKUTier const type.
+func PossibleSKUTierValues() []SKUTier {
+	return []SKUTier{
+		SKUTierBasic,
+		SKUTierFree,
+		SKUTierPremium,
+		SKUTierStandard,
+	}
+}

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/deidservices_client_example_test.go
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/deidservices_client_example_test.go
@@ -31,6 +31,10 @@ func ExampleDeidServicesClient_BeginCreate() {
 			Type:                   to.Ptr(armhealthdataaiservices.ManagedServiceIdentityTypeNone),
 			UserAssignedIdentities: map[string]*armhealthdataaiservices.UserAssignedIdentity{},
 		},
+		SKU: &armhealthdataaiservices.SKU{
+			Name: to.Ptr("Standard"),
+			Tier: to.Ptr(armhealthdataaiservices.SKUTierStandard),
+		},
 		Tags:     map[string]*string{},
 		Location: to.Ptr("qwyhvdwcsjulggagdqxlmazcl"),
 	}, nil)
@@ -86,6 +90,10 @@ func ExampleDeidServicesClient_BeginCreate() {
 	// 			},
 	// 			PrincipalID: to.Ptr("a82361f4-5320-4a26-8d1b-45832d2164dd"),
 	// 			TenantID: to.Ptr("53a6a686-ae15-4a1d-badf-3e7947918893"),
+	// 		},
+	// 		SKU: &armhealthdataaiservices.SKU{
+	// 			Name: to.Ptr("Standard"),
+	// 			Tier: to.Ptr(armhealthdataaiservices.SKUTierStandard),
 	// 		},
 	// 		Tags: map[string]*string{
 	// 		},
@@ -187,6 +195,10 @@ func ExampleDeidServicesClient_Get() {
 	// 			PrincipalID: to.Ptr("a82361f4-5320-4a26-8d1b-45832d2164dd"),
 	// 			TenantID: to.Ptr("53a6a686-ae15-4a1d-badf-3e7947918893"),
 	// 		},
+	// 		SKU: &armhealthdataaiservices.SKU{
+	// 			Name: to.Ptr("Standard"),
+	// 			Tier: to.Ptr(armhealthdataaiservices.SKUTierStandard),
+	// 		},
 	// 		Tags: map[string]*string{
 	// 		},
 	// 		Location: to.Ptr("qwyhvdwcsjulggagdqxlmazcl"),
@@ -271,6 +283,10 @@ func ExampleDeidServicesClient_NewListByResourceGroupPager() {
 		// 					Type: to.Ptr(armhealthdataaiservices.ManagedServiceIdentityTypeNone),
 		// 					UserAssignedIdentities: map[string]*armhealthdataaiservices.UserAssignedIdentity{
 		// 					},
+		// 				},
+		// 				SKU: &armhealthdataaiservices.SKU{
+		// 					Name: to.Ptr("Standard"),
+		// 					Tier: to.Ptr(armhealthdataaiservices.SKUTierStandard),
 		// 				},
 		// 				Tags: map[string]*string{
 		// 				},
@@ -361,6 +377,10 @@ func ExampleDeidServicesClient_NewListBySubscriptionPager() {
 		// 					UserAssignedIdentities: map[string]*armhealthdataaiservices.UserAssignedIdentity{
 		// 					},
 		// 				},
+		// 				SKU: &armhealthdataaiservices.SKU{
+		// 					Name: to.Ptr("Standard"),
+		// 					Tier: to.Ptr(armhealthdataaiservices.SKUTierStandard),
+		// 				},
 		// 				Tags: map[string]*string{
 		// 				},
 		// 				Location: to.Ptr("qwyhvdwcsjulggagdqxlmazcl"),
@@ -398,6 +418,10 @@ func ExampleDeidServicesClient_BeginUpdate() {
 		Identity: &armhealthdataaiservices.ManagedServiceIdentityUpdate{
 			Type:                   to.Ptr(armhealthdataaiservices.ManagedServiceIdentityTypeNone),
 			UserAssignedIdentities: map[string]*armhealthdataaiservices.UserAssignedIdentity{},
+		},
+		SKU: &armhealthdataaiservices.SKU{
+			Name: to.Ptr("Standard"),
+			Tier: to.Ptr(armhealthdataaiservices.SKUTierStandard),
 		},
 		Tags: map[string]*string{},
 		Properties: &armhealthdataaiservices.DeidPropertiesUpdate{
@@ -456,6 +480,10 @@ func ExampleDeidServicesClient_BeginUpdate() {
 	// 			},
 	// 			PrincipalID: to.Ptr("a82361f4-5320-4a26-8d1b-45832d2164dd"),
 	// 			TenantID: to.Ptr("53a6a686-ae15-4a1d-badf-3e7947918893"),
+	// 		},
+	// 		SKU: &armhealthdataaiservices.SKU{
+	// 			Name: to.Ptr("Standard"),
+	// 			Tier: to.Ptr(armhealthdataaiservices.SKUTierStandard),
 	// 		},
 	// 		Tags: map[string]*string{
 	// 		},

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/fake/internal.go
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/fake/internal.go
@@ -32,6 +32,14 @@ func contains[T comparable](s []T, v T) bool {
 	return false
 }
 
+func initServer[T any](mu *sync.Mutex, dst **T, src func() *T) {
+	mu.Lock()
+	if *dst == nil {
+		*dst = src()
+	}
+	mu.Unlock()
+}
+
 func newTracker[T any]() *tracker[T] {
 	return &tracker[T]{
 		items: map[string]*T{},

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/fake/server_factory.go
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/fake/server_factory.go
@@ -62,18 +62,18 @@ func (s *ServerFactoryTransport) Do(req *http.Request) (*http.Response, error) {
 
 	switch client {
 	case "DeidServicesClient":
-		initServer(s, &s.trDeidServicesServer, func() *DeidServicesServerTransport { return NewDeidServicesServerTransport(&s.srv.DeidServicesServer) })
+		initServer(&s.trMu, &s.trDeidServicesServer, func() *DeidServicesServerTransport { return NewDeidServicesServerTransport(&s.srv.DeidServicesServer) })
 		resp, err = s.trDeidServicesServer.Do(req)
 	case "OperationsClient":
-		initServer(s, &s.trOperationsServer, func() *OperationsServerTransport { return NewOperationsServerTransport(&s.srv.OperationsServer) })
+		initServer(&s.trMu, &s.trOperationsServer, func() *OperationsServerTransport { return NewOperationsServerTransport(&s.srv.OperationsServer) })
 		resp, err = s.trOperationsServer.Do(req)
 	case "PrivateEndpointConnectionsClient":
-		initServer(s, &s.trPrivateEndpointConnectionsServer, func() *PrivateEndpointConnectionsServerTransport {
+		initServer(&s.trMu, &s.trPrivateEndpointConnectionsServer, func() *PrivateEndpointConnectionsServerTransport {
 			return NewPrivateEndpointConnectionsServerTransport(&s.srv.PrivateEndpointConnectionsServer)
 		})
 		resp, err = s.trPrivateEndpointConnectionsServer.Do(req)
 	case "PrivateLinksClient":
-		initServer(s, &s.trPrivateLinksServer, func() *PrivateLinksServerTransport { return NewPrivateLinksServerTransport(&s.srv.PrivateLinksServer) })
+		initServer(&s.trMu, &s.trPrivateLinksServer, func() *PrivateLinksServerTransport { return NewPrivateLinksServerTransport(&s.srv.PrivateLinksServer) })
 		resp, err = s.trPrivateLinksServer.Do(req)
 	default:
 		err = fmt.Errorf("unhandled client %s", client)
@@ -84,12 +84,4 @@ func (s *ServerFactoryTransport) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	return resp, nil
-}
-
-func initServer[T any](s *ServerFactoryTransport, dst **T, src func() *T) {
-	s.trMu.Lock()
-	if *dst == nil {
-		*dst = src()
-	}
-	s.trMu.Unlock()
 }

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/models.go
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/models.go
@@ -23,6 +23,9 @@ type DeidService struct {
 	// The resource-specific properties for this resource.
 	Properties *DeidServiceProperties
 
+	// The SKU (Stock Keeping Unit) assigned to this resource.
+	SKU *SKU
+
 	// Resource tags.
 	Tags map[string]*string
 
@@ -70,6 +73,9 @@ type DeidUpdate struct {
 
 	// RP-specific properties
 	Properties *DeidPropertiesUpdate
+
+	// The SKU (Stock Keeping Unit) assigned to this resource.
+	SKU *SKU
 
 	// Resource tags.
 	Tags map[string]*string
@@ -267,6 +273,26 @@ type PrivateLinkServiceConnectionState struct {
 
 	// Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service.
 	Status *PrivateEndpointServiceConnectionStatus
+}
+
+// SKU - The resource model definition representing SKU
+type SKU struct {
+	// REQUIRED; The name of the SKU. Ex - P3. It is typically a letter+number code
+	Name *string
+
+	// If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not possible for the
+	// resource this may be omitted.
+	Capacity *int32
+
+	// If the service has different generations of hardware, for the same SKU, then that can be captured here.
+	Family *string
+
+	// The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code.
+	Size *string
+
+	// This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required
+	// on a PUT.
+	Tier *SKUTier
 }
 
 // SystemData - Metadata pertaining to creation and last modification of the resource.

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/models_serde.go
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/models_serde.go
@@ -48,6 +48,7 @@ func (d DeidService) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "location", d.Location)
 	populate(objectMap, "name", d.Name)
 	populate(objectMap, "properties", d.Properties)
+	populate(objectMap, "sku", d.SKU)
 	populate(objectMap, "systemData", d.SystemData)
 	populate(objectMap, "tags", d.Tags)
 	populate(objectMap, "type", d.Type)
@@ -77,6 +78,9 @@ func (d *DeidService) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &d.Properties)
+			delete(rawMsg, key)
+		case "sku":
+			err = unpopulate(val, "SKU", &d.SKU)
 			delete(rawMsg, key)
 		case "systemData":
 			err = unpopulate(val, "SystemData", &d.SystemData)
@@ -170,6 +174,7 @@ func (d DeidUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "identity", d.Identity)
 	populate(objectMap, "properties", d.Properties)
+	populate(objectMap, "sku", d.SKU)
 	populate(objectMap, "tags", d.Tags)
 	return json.Marshal(objectMap)
 }
@@ -188,6 +193,9 @@ func (d *DeidUpdate) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &d.Properties)
+			delete(rawMsg, key)
+		case "sku":
+			err = unpopulate(val, "SKU", &d.SKU)
 			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &d.Tags)
@@ -705,6 +713,49 @@ func (p *PrivateLinkServiceConnectionState) UnmarshalJSON(data []byte) error {
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", p, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SKU.
+func (s SKU) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "capacity", s.Capacity)
+	populate(objectMap, "family", s.Family)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "size", s.Size)
+	populate(objectMap, "tier", s.Tier)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type SKU.
+func (s *SKU) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", s, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "capacity":
+			err = unpopulate(val, "Capacity", &s.Capacity)
+			delete(rawMsg, key)
+		case "family":
+			err = unpopulate(val, "Family", &s.Family)
+			delete(rawMsg, key)
+		case "name":
+			err = unpopulate(val, "Name", &s.Name)
+			delete(rawMsg, key)
+		case "size":
+			err = unpopulate(val, "Size", &s.Size)
+			delete(rawMsg, key)
+		case "tier":
+			err = unpopulate(val, "Tier", &s.Tier)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", s, err)
 		}
 	}
 	return nil

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/testdata/_metadata.json
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/testdata/_metadata.json
@@ -1,4 +1,6 @@
 {
-  "apiVersion": "2024-09-20",
-  "emitterVersion": "0.9.1"
+  "apiVersions": {
+    "Microsoft.HealthDataAIServices": "2024-09-20"
+  },
+  "emitterVersion": "0.10.1"
 }

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/tsp-location.yaml
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/healthdataaiservices/HealthDataAIServices.Management
-commit: 217f332d35760fbe2034475504284f5d84bdd968
+commit: c174d8b5885809eaedf3b9ce6c917531501cafbc
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 

--- a/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/version.go
+++ b/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices/version.go
@@ -6,5 +6,5 @@ package armhealthdataaiservices
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices"
-	moduleVersion = "v1.0.0"
+	moduleVersion = "v1.1.0"
 )


### PR DESCRIPTION
## Summary

Regenerated Go SDK from updated TypeSpec specification that adds optional SKU (Stock Keeping Unit) property to DeidService resource with Free, Basic, and Standard tier support.

## Changes

- Added `Sku` field to `DeidService` struct
- Added `Sku` field to `DeidUpdate` struct
- Updated changelog and version to 1.1.0-beta.1

## Demo Only
This PR is for demonstration purposes only and should not be merged.