### PR TITLE
Update CI to the latest two versions of Go

### DIFF
--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
-  GoLintCLIVersion: 'v2.6.2'
+  GoLintCLIVersion: 'v2.11.2'
   Package.EnableSBOMSigning: true
   # Enable go native component governance detection
   # https://docs.opensource.microsoft.com/tools/cg/index.html
@@ -19,5 +19,5 @@ variables:
   skipComponentGovernanceDetection: true
 
   # Supported versions for testing. These variables are referenced in test matrix files.
-  GO_VERSION_LATEST: 1.25.4
-  GO_VERSION_PREVIOUS: 1.24.10
+  GO_VERSION_LATEST: 1.26.1
+  GO_VERSION_PREVIOUS: 1.25.8


### PR DESCRIPTION
Also update golangci-lint to the latest version.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
