### PR TITLE
Revert CODEOWNERS entry for sdk/monitor/ingestion/azlogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,9 +82,6 @@
 /sdk/monitor/                                                      @Azure/azure-sdk-write-monitor-data-plane @Azure/azure-sdk-write-monitor-query-logs @chlowell @gracewilcox @jhendrixMSFT
 
 # PRLabel: %Monitor
-/sdk/monitor/ingestion/azlogs/                                     @Azure/azure-sdk-write-monitor-data-plane
-
-# PRLabel: %Monitor
 /sdk/monitor/query/azmetrics/                                      @Azure/azure-sdk-write-monitor-query-metrics
 
 # AzureSdkOwners:                                                  @gracewilcox


### PR DESCRIPTION
Remove the entry for Logs Ingestion, per discussion with @RickWinter and @gracewilcox 
