### PR TITLE
[azcore] JoinPaths don't add slash for query parameter in paths

### DIFF
--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -95,7 +95,7 @@ func JoinPaths(root string, paths ...string) string {
 
 	if strings.HasSuffix(root, "/") && strings.HasPrefix(p, "/") {
 		root = root[:len(root)-1]
-	} else if !strings.HasSuffix(root, "/") && !strings.HasPrefix(p, "/") {
+	} else if !strings.HasSuffix(root, "/") && !strings.HasPrefix(p, "/") && !strings.HasPrefix(p, "?") {
 		p = "/" + p
 	}
 	return root + p

--- a/sdk/azcore/runtime/request_test.go
+++ b/sdk/azcore/runtime/request_test.go
@@ -210,6 +210,21 @@ func TestJoinPaths(t *testing.T) {
 			paths:    []string{"/path/one", "path/two/"},
 			expected: "http://test.contoso.com/path/one/path/two/?qp1=abc&qp2=def",
 		},
+		{
+			root:     "https://fakestorage.blob.core.windows.net/path",
+			paths:    []string{"?comp=container"},
+			expected: "https://fakestorage.blob.core.windows.net/path?comp=container",
+		},
+		{
+			root:     "https://fakestorage.blob.core.windows.net/path1/path2",
+			paths:    []string{"?comp=snapshot"},
+			expected: "https://fakestorage.blob.core.windows.net/path1/path2?comp=snapshot",
+		},
+		{
+			root:     "https://fakestorage.blob.core.windows.net/",
+			paths:    []string{"?restype=service&comp=properties"},
+			expected: "https://fakestorage.blob.core.windows.net/?restype=service&comp=properties",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
With the storage migration to typespec, running into a special case where paths is a string beginning with "?". In that case, we don't want to add a "/" between root and paths.
