### PR TITLE
apply diagnostic string to v1.4.2

### DIFF
--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -221,7 +221,7 @@ func (c *Client) CreateDatabase(
 	if err != nil {
 		return DatabaseResponse{}, err
 	}
-	ctx, endSpan := azruntime.StartSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 
 	if o == nil {
@@ -286,7 +286,7 @@ func (c *Client) NewQueryDatabasesPager(query string, o *QueryDatabasesOptions) 
 			if err != nil {
 				return QueryDatabasesResponse{}, err
 			}
-			ctx, endSpan := azruntime.StartSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
+			ctx, endSpan := startSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
@@ -487,6 +487,8 @@ func (c *Client) createRequest(
 		requestEnricher(req)
 	}
 
+	req = attachRequestDiagnostics(req, operationContext)
+
 	return req, nil
 }
 
@@ -510,18 +512,31 @@ func (c *Client) attachContent(content interface{}, req *policy.Request) error {
 
 func (c *Client) executeAndEnsureSuccessResponse(ctx context.Context, request *policy.Request) (*http.Response, error) {
 	log.Write(azlog.EventResponse, fmt.Sprintf("\n===== Client preferred regions:\n%v\n=====\n", c.gem.preferredLocations))
+	state := requestDiagnosticsStateFromContext(request.Raw().Context())
+	if state != nil && state.requestTrace != nil {
+		defer state.requestTrace.End()
+	}
+
 	response, err := c.internal.Pipeline().Do(request)
 	if err != nil {
-		return nil, err
+		var responseErr *azcore.ResponseError
+		if errors.As(err, &responseErr) && responseErr.RawResponse != nil {
+			addPointOperationStatisticsFromResponse(responseErr.RawResponse, responseErr.Error(), traceDatumKeyPointOperationStatistics)
+			return nil, err
+		}
+
+		return nil, wrapRequestError(err, diagnosticsFromContext(request.Raw().Context()))
 	}
 
 	c.addResponseValuesToSpan(ctx, response)
 
 	successResponse := (response.StatusCode >= 200 && response.StatusCode < 300) || response.StatusCode == 304
 	if successResponse {
+		addPointOperationStatisticsFromResponse(response, "", traceDatumKeyPointOperationStatistics)
 		return response, nil
 	}
 
+	addPointOperationStatisticsFromResponse(response, response.Status, traceDatumKeyPointOperationStatistics)
 	return nil, azruntime.NewResponseErrorWithErrorCode(response, response.Status)
 }
 

--- a/sdk/data/azcosmos/cosmos_client_retry_policy.go
+++ b/sdk/data/azcosmos/cosmos_client_retry_policy.go
@@ -41,10 +41,15 @@ func (p *clientRetryPolicy) Do(req *policy.Request) (*http.Response, error) {
 		// Update the retry context with the latest retry values
 		req.SetOperationValue(retryContext)
 		resolvedEndpoint := p.gem.ResolveServiceEndpoint(retryContext.retryCount, o.resourceType, o.isWriteOperation, retryContext.useWriteEndpoint)
+		regionName := string(p.gem.GetEndpointLocation(resolvedEndpoint))
 		req.Raw().Host = resolvedEndpoint.Host
 		req.Raw().URL.Host = resolvedEndpoint.Host
+		attemptStartTime := time.Now().UTC()
 		response, err := req.Next() // err can happen in weird scenarios (connectivity, etc)
 		if err != nil {
+			if state := requestDiagnosticsStateFromContext(req.Raw().Context()); state != nil && state.clientSideStats != nil {
+				state.clientSideStats.recordHTTPError(attemptStartTime, req.Raw(), err, o.resourceType, regionName)
+			}
 			if p.isNetworkConnectionError(err) {
 				shouldRetry, errRetry := p.attemptRetryOnNetworkError(req, &retryContext)
 				if errRetry != nil {
@@ -61,6 +66,9 @@ func (p *clientRetryPolicy) Do(req *policy.Request) (*http.Response, error) {
 				continue
 			}
 			return nil, err
+		}
+		if state := requestDiagnosticsStateFromContext(req.Raw().Context()); state != nil && state.clientSideStats != nil {
+			state.clientSideStats.recordHTTPResponse(attemptStartTime, response, o.resourceType, regionName)
 		}
 		subStatus := response.Header.Get(cosmosHeaderSubstatus)
 		if p.shouldRetryStatus(response.StatusCode, subStatus) {

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -46,7 +46,7 @@ func (c *ContainerClient) Read(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadContainerOptions{}
@@ -88,7 +88,7 @@ func (c *ContainerClient) Replace(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReplaceContainerOptions{}
@@ -131,7 +131,7 @@ func (c *ContainerClient) Delete(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteContainerOptions{}
@@ -173,7 +173,7 @@ func (c *ContainerClient) ReadThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -202,7 +202,7 @@ func (c *ContainerClient) ReplaceThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -233,7 +233,7 @@ func (c *ContainerClient) CreateItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -286,7 +286,7 @@ func (c *ContainerClient) UpsertItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -345,7 +345,7 @@ func (c *ContainerClient) ReplaceItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -398,7 +398,7 @@ func (c *ContainerClient) ReadItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -447,7 +447,7 @@ func (c *ContainerClient) DeleteItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -535,7 +535,7 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 			if err != nil {
 				return QueryItemsResponse{}, err
 			}
-			ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+			ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
@@ -579,7 +579,7 @@ func (c *ContainerClient) PatchItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -631,7 +631,7 @@ func (c *ContainerClient) ExecuteTransactionalBatch(ctx context.Context, b Trans
 	if err != nil {
 		return TransactionalBatchResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if len(b.operations) == 0 {
 		return TransactionalBatchResponse{}, errors.New("no operations in batch")

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -55,7 +55,7 @@ func (db *DatabaseClient) CreateContainer(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &CreateContainerOptions{}
@@ -119,7 +119,7 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 			if err != nil {
 				return QueryContainersResponse{}, err
 			}
-			ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.client.internal.Tracer(), &spanName.options)
+			ctx, endSpan := startSpan(ctx, spanName.name, c.client.internal.Tracer(), &spanName.options)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
@@ -157,7 +157,7 @@ func (db *DatabaseClient) Read(
 	if err != nil {
 		return DatabaseResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadDatabaseOptions{}
@@ -198,7 +198,7 @@ func (db *DatabaseClient) ReadThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -227,7 +227,7 @@ func (db *DatabaseClient) ReplaceThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -254,7 +254,7 @@ func (db *DatabaseClient) Delete(
 	if err != nil {
 		return DatabaseResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteDatabaseOptions{}

--- a/sdk/data/azcosmos/cosmos_query_response.go
+++ b/sdk/data/azcosmos/cosmos_query_response.go
@@ -36,6 +36,7 @@ func newQueryResponse(resp *http.Response) (QueryItemsResponse, error) {
 	queryMetrics := resp.Header.Get(cosmosHeaderQueryMetrics)
 	if queryMetrics != "" {
 		response.QueryMetrics = &queryMetrics
+		recordQueryMetricsFromResponse(resp)
 	}
 	queryIndexUtilization := resp.Header.Get(cosmosHeaderIndexUtilization)
 	if queryIndexUtilization != "" {

--- a/sdk/data/azcosmos/cosmos_response.go
+++ b/sdk/data/azcosmos/cosmos_response.go
@@ -21,6 +21,8 @@ type Response struct {
 	ActivityID string
 	// ETag contains the value from the ETag header.
 	ETag azcore.ETag
+	// Diagnostics contains request diagnostics for the operation.
+	Diagnostics Diagnostics
 }
 
 func newResponse(resp *http.Response) Response {
@@ -29,6 +31,7 @@ func newResponse(resp *http.Response) Response {
 	response.RequestCharge = response.readRequestCharge()
 	response.ActivityID = resp.Header.Get(cosmosHeaderActivityId)
 	response.ETag = azcore.ETag(resp.Header.Get(cosmosHeaderEtag))
+	response.Diagnostics = diagnosticsFromResponse(resp)
 	return response
 }
 

--- a/sdk/data/azcosmos/diagnostics.go
+++ b/sdk/data/azcosmos/diagnostics.go
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// Diagnostics contains request diagnostics for an Azure Cosmos DB operation.
+// The diagnostics string is materialized lazily when String is called.
+type Diagnostics struct {
+	root *trace
+}
+
+func newDiagnostics(t *trace) Diagnostics {
+	if t == nil {
+		return Diagnostics{}
+	}
+
+	return Diagnostics{root: t.root()}
+}
+
+// String returns the lazily materialized diagnostics payload.
+func (d Diagnostics) String() string {
+	if d.root == nil {
+		return ""
+	}
+
+	d.root.setWalkingStateRecursively()
+	return writeTraceJSON(d.root)
+}
+
+// ClientElapsedTime returns the end-to-end duration of the request.
+func (d Diagnostics) ClientElapsedTime() time.Duration {
+	if d.root == nil {
+		return 0
+	}
+
+	return d.root.duration()
+}
+
+// StartTimeUTC returns the UTC start time of the request.
+func (d Diagnostics) StartTimeUTC() *time.Time {
+	if d.root == nil {
+		return nil
+	}
+
+	snapshot := d.root.snapshot()
+	start := snapshot.startTime
+	return &start
+}
+
+// FailedRequestCount returns the number of failed backend attempts recorded for the request.
+func (d Diagnostics) FailedRequestCount() int {
+	if d.root == nil || d.root.summary == nil {
+		return 0
+	}
+
+	return d.root.summary.failedCount()
+}
+
+// DiagnosticsFromError extracts diagnostics from an operation error, if present.
+func DiagnosticsFromError(err error) (Diagnostics, bool) {
+	if err == nil {
+		return Diagnostics{}, false
+	}
+
+	var reqErr *requestError
+	if errors.As(err, &reqErr) {
+		return reqErr.diagnostics, reqErr.diagnostics.root != nil
+	}
+
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) && responseErr.RawResponse != nil {
+		diagnostics := diagnosticsFromResponse(responseErr.RawResponse)
+		return diagnostics, diagnostics.root != nil
+	}
+
+	return Diagnostics{}, false
+}
+
+func diagnosticsFromResponse(resp *http.Response) Diagnostics {
+	if resp == nil || resp.Request == nil {
+		return Diagnostics{}
+	}
+
+	state := requestDiagnosticsStateFromContext(resp.Request.Context())
+	if state != nil {
+		return newDiagnostics(state.requestTrace)
+	}
+
+	return diagnosticsFromContext(resp.Request.Context())
+}
+
+type requestError struct {
+	cause       error
+	diagnostics Diagnostics
+}
+
+func (e *requestError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *requestError) Unwrap() error {
+	return e.cause
+}
+
+func wrapRequestError(err error, diagnostics Diagnostics) error {
+	if err == nil || diagnostics.root == nil {
+		return err
+	}
+
+	return &requestError{
+		cause:       err,
+		diagnostics: diagnostics,
+	}
+}

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiagnosticsSummaryIncludesRetriedGatewayCalls(t *testing.T) {
+	rootTrace := newRootTrace("test_operation")
+	requestTrace := rootTrace.StartChild(traceDatumKeyTransportRequest)
+	clientStats := newClientSideRequestStatisticsTraceDatum(time.Now().UTC(), requestTrace)
+	requestTrace.AddDatum(traceDatumKeyClientSideRequestStats, clientStats)
+	requestTrace.AddDatum(traceDatumKeyPointOperationStatistics, pointOperationStatisticsTraceDatum{
+		ActivityID:      "activity-2",
+		ResponseTimeUTC: time.Now().UTC(),
+		StatusCode:      http.StatusOK,
+		RequestCharge:   2.5,
+		RequestURI:      "https://example.com/dbs/test",
+		BELatencyInMs:   "12",
+	})
+
+	req503, err := http.NewRequest(http.MethodGet, "https://example.com/dbs/test", nil)
+	require.NoError(t, err)
+	resp503 := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Header: http.Header{
+			cosmosHeaderActivityId:    []string{"activity-1"},
+			cosmosHeaderRequestCharge: []string{"1.5"},
+		},
+		Request: req503,
+	}
+	clientStats.recordHTTPResponse(time.Now().Add(-20*time.Millisecond), resp503, resourceTypeDatabase, "local")
+
+	req200, err := http.NewRequest(http.MethodGet, "https://example.com/dbs/test", nil)
+	require.NoError(t, err)
+	resp200 := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			cosmosHeaderActivityId:    []string{"activity-2"},
+			cosmosHeaderRequestCharge: []string{"2.5"},
+			cosmosHeaderSessionToken:  []string{"response-session"},
+		},
+		Request: req200,
+	}
+	clientStats.recordHTTPResponse(time.Now().Add(-10*time.Millisecond), resp200, resourceTypeDatabase, "local")
+
+	requestTrace.End()
+	rootTrace.End()
+
+	diagnosticsPayload := newDiagnostics(requestTrace).String()
+	require.NotEmpty(t, diagnosticsPayload)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(diagnosticsPayload), &parsed))
+
+	summary := parsed["Summary"].(map[string]any)
+	gatewayCalls := summary["GatewayCalls"].(map[string]any)
+	require.Equal(t, float64(1), gatewayCalls["(200, 0)"])
+	require.Equal(t, float64(1), gatewayCalls["(503, 0)"])
+	require.Equal(t, float64(1), summary["RegionsContacted"])
+
+	children := parsed["children"].([]any)
+	require.Len(t, children, 1)
+
+	child := children[0].(map[string]any)
+	data := child["data"].(map[string]any)
+	require.Contains(t, data, traceDatumKeyClientSideRequestStats)
+	require.Contains(t, data, traceDatumKeyPointOperationStatistics)
+}
+
+func TestDiagnosticsFromErrorReturnsResponseDiagnostics(t *testing.T) {
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusNotFound),
+		mock.WithHeader(cosmosHeaderActivityId, "activity-404"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "3.25"),
+	)
+
+	client := newTestDiagnosticsClient(t, srv, false)
+	operationContext := pipelineRequestOptions{
+		resourceType:    resourceTypeDatabase,
+		resourceAddress: "",
+	}
+
+	_, err := client.sendGetRequest("/", context.Background(), operationContext, &ReadContainerOptions{}, nil)
+	require.Error(t, err)
+
+	var responseErr *azcore.ResponseError
+	require.True(t, errors.As(err, &responseErr))
+
+	diagnostics, ok := DiagnosticsFromError(err)
+	require.True(t, ok)
+	require.NotEmpty(t, diagnostics.String())
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(diagnostics.String()), &parsed))
+
+	data := parsed["data"].(map[string]any)
+	pointStats := data[traceDatumKeyPointOperationStatistics].(map[string]any)
+	require.Equal(t, float64(http.StatusNotFound), pointStats["StatusCode"])
+}
+
+func TestQueryResponseDiagnosticsIncludeQueryMetrics(t *testing.T) {
+	queryResponseRaw := map[string][]map[string]string{
+		"Documents": {
+			{"id": "id1"},
+		},
+	}
+
+	jsonString, err := json.Marshal(queryResponseRaw)
+	require.NoError(t, err)
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	srv.SetResponse(
+		mock.WithBody(jsonString),
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithHeader(cosmosHeaderActivityId, "query-activity"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "5.5"),
+		mock.WithHeader(cosmosHeaderQueryMetrics, "retrievedDocumentCount=1"),
+	)
+
+	client := newTestDiagnosticsClient(t, srv, false)
+	operationContext := pipelineRequestOptions{
+		resourceType:    resourceTypeDocument,
+		resourceAddress: "dbs/test/colls/test",
+	}
+
+	resp, err := client.sendQueryRequest("/", context.Background(), "SELECT * FROM c", nil, operationContext, &QueryOptions{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	parsedResponse, err := newQueryResponse(resp)
+	require.NoError(t, err)
+	require.NotNil(t, parsedResponse.QueryMetrics)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(parsedResponse.Diagnostics.String()), &parsed))
+
+	data := parsed["data"].(map[string]any)
+	require.Equal(t, "retrievedDocumentCount=1", data[traceDatumKeyQueryMetrics])
+}
+
+func newTestDiagnosticsClient(t *testing.T, transport policy.Transporter, withRetryPolicy bool) *Client {
+	t.Helper()
+
+	serverURL := transport.(*mock.Server).URL()
+	endpointURL, err := url.Parse(serverURL)
+	require.NoError(t, err)
+
+	gem := &globalEndpointManager{
+		preferredLocations: []string{"local"},
+		locationCache:      newLocationCache([]string{"local"}, *endpointURL, true),
+	}
+
+	pipelineOptions := azruntime.PipelineOptions{}
+	if withRetryPolicy {
+		pipelineOptions.PerRetry = []policy.Policy{
+			&clientRetryPolicy{gem: gem},
+		}
+	}
+
+	internalClient, err := azcore.NewClient("azcosmostest", "v1.0.0", pipelineOptions, &policy.ClientOptions{Transport: transport})
+	require.NoError(t, err)
+
+	return &Client{
+		endpoint:    serverURL,
+		endpointUrl: endpointURL,
+		internal:    internalClient,
+		gem:         gem,
+	}
+}

--- a/sdk/data/azcosmos/trace.go
+++ b/sdk/data/azcosmos/trace.go
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	aztracing "github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
+)
+
+type trace struct {
+	mu            sync.Mutex
+	name          string
+	startTime     time.Time
+	endTime       *time.Time
+	parent        *trace
+	children      []*trace
+	data          map[string]any
+	dataOrder     []string
+	isBeingWalked bool
+	summary       *traceSummary
+}
+
+type traceSnapshot struct {
+	name      string
+	startTime time.Time
+	endTime   *time.Time
+	children  []*trace
+	data      map[string]any
+	dataOrder []string
+}
+
+type traceSummary struct {
+	mu                 sync.Mutex
+	failedRequestCount int
+}
+
+func newRootTrace(name string) *trace {
+	return &trace{
+		name:      name,
+		startTime: time.Now().UTC(),
+		children:  []*trace{},
+		summary:   &traceSummary{},
+	}
+}
+
+func (t *trace) root() *trace {
+	current := t
+	for current != nil && current.parent != nil {
+		current = current.parent
+	}
+
+	return current
+}
+
+func (t *trace) StartChild(name string) *trace {
+	child := &trace{
+		name:      name,
+		startTime: time.Now().UTC(),
+		parent:    t,
+		children:  []*trace{},
+		summary:   t.summary,
+	}
+
+	t.AddChild(child)
+	return child
+}
+
+func (t *trace) End() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.endTime != nil {
+		return
+	}
+
+	endTime := time.Now().UTC()
+	t.endTime = &endTime
+}
+
+func (t *trace) duration() time.Duration {
+	t.mu.Lock()
+	startTime := t.startTime
+	endTime := t.endTime
+	t.mu.Unlock()
+
+	if endTime != nil {
+		return endTime.Sub(startTime)
+	}
+
+	return time.Since(startTime)
+}
+
+func (t *trace) AddChild(child *trace) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.isBeingWalked {
+		t.children = append(t.children, child)
+		return
+	}
+
+	child.setWalkingStateRecursively()
+
+	nextChildren := make([]*trace, 0, len(t.children)+1)
+	nextChildren = append(nextChildren, t.children...)
+	nextChildren = append(nextChildren, child)
+	t.children = nextChildren
+}
+
+func (t *trace) AddDatum(key string, value any) {
+	t.addOrUpdateDatum(key, value, false)
+}
+
+func (t *trace) AddOrUpdateDatum(key string, value any) {
+	t.addOrUpdateDatum(key, value, true)
+}
+
+func (t *trace) addOrUpdateDatum(key string, value any, overwrite bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.data == nil {
+		t.data = map[string]any{}
+	}
+
+	_, exists := t.data[key]
+	if exists && !overwrite {
+		return
+	}
+
+	if !t.isBeingWalked {
+		t.data[key] = value
+		if !exists {
+			t.dataOrder = append(t.dataOrder, key)
+		}
+		return
+	}
+
+	nextData := make(map[string]any, len(t.data)+1)
+	for k, v := range t.data {
+		nextData[k] = v
+	}
+	nextData[key] = value
+	t.data = nextData
+
+	if !exists {
+		nextOrder := make([]string, 0, len(t.dataOrder)+1)
+		nextOrder = append(nextOrder, t.dataOrder...)
+		nextOrder = append(nextOrder, key)
+		t.dataOrder = nextOrder
+	}
+}
+
+func (t *trace) setWalkingStateRecursively() {
+	t.mu.Lock()
+	if t.isBeingWalked {
+		t.mu.Unlock()
+		return
+	}
+
+	children := append([]*trace(nil), t.children...)
+	t.mu.Unlock()
+
+	for _, child := range children {
+		child.setWalkingStateRecursively()
+	}
+
+	t.mu.Lock()
+	t.isBeingWalked = true
+	t.mu.Unlock()
+}
+
+func (t *trace) snapshot() traceSnapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return traceSnapshot{
+		name:      t.name,
+		startTime: t.startTime,
+		endTime:   t.endTime,
+		children:  t.children,
+		data:      t.data,
+		dataOrder: t.dataOrder,
+	}
+}
+
+func (s *traceSummary) incrementFailedCount() {
+	s.mu.Lock()
+	s.failedRequestCount++
+	s.mu.Unlock()
+}
+
+func (s *traceSummary) failedCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.failedRequestCount
+}
+
+type traceContextKey struct{}
+
+func traceFromContext(ctx context.Context) *trace {
+	current, _ := ctx.Value(traceContextKey{}).(*trace)
+	return current
+}
+
+func withTrace(ctx context.Context, t *trace) context.Context {
+	return context.WithValue(ctx, traceContextKey{}, t)
+}
+
+func diagnosticsFromContext(ctx context.Context) Diagnostics {
+	return newDiagnostics(traceFromContext(ctx))
+}
+
+func ensureOperationTrace(ctx context.Context, name string) context.Context {
+	if traceFromContext(ctx) != nil {
+		return ctx
+	}
+
+	return withTrace(ctx, newRootTrace(name))
+}
+
+func startSpan(ctx context.Context, name string, tracer aztracing.Tracer, options *azruntime.StartSpanOptions) (context.Context, func(error)) {
+	ctx, endSpan := azruntime.StartSpan(ctx, name, tracer, options)
+
+	currentTrace := traceFromContext(ctx)
+	if currentTrace == nil {
+		root := newRootTrace(name)
+		ctx = withTrace(ctx, root)
+
+		return ctx, func(err error) {
+			root.End()
+			endSpan(err)
+		}
+	}
+
+	child := currentTrace.StartChild(name)
+	ctx = withTrace(ctx, child)
+
+	return ctx, func(err error) {
+		child.End()
+		endSpan(err)
+	}
+}

--- a/sdk/data/azcosmos/trace_data.go
+++ b/sdk/data/azcosmos/trace_data.go
@@ -1,0 +1,356 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+const (
+	traceDatumKeyClientSideRequestStats        = "Client Side Request Stats"
+	traceDatumKeyTransportRequest              = "Microsoft.Azure.Documents.ServerStoreModel Transport Request"
+	traceDatumKeyPointOperationStatistics      = "PointOperationStatisticsTraceDatum"
+	traceDatumKeyPointOperationStatisticsError = "Point Operation Statistics"
+	traceDatumKeyQueryMetrics                  = "Query Metrics"
+)
+
+type requestDiagnosticsState struct {
+	requestTrace        *trace
+	clientSideStats     *clientSideRequestStatisticsTraceDatum
+	resourceType        resourceType
+	requestSessionToken string
+}
+
+type requestDiagnosticsStateKey struct{}
+
+func requestDiagnosticsStateFromContext(ctx context.Context) *requestDiagnosticsState {
+	state, _ := ctx.Value(requestDiagnosticsStateKey{}).(*requestDiagnosticsState)
+	return state
+}
+
+func withRequestDiagnosticsState(ctx context.Context, state *requestDiagnosticsState) context.Context {
+	return context.WithValue(ctx, requestDiagnosticsStateKey{}, state)
+}
+
+func attachRequestDiagnostics(req *policy.Request, operationContext pipelineRequestOptions) *policy.Request {
+	requestContext := req.Raw().Context()
+	parentTrace := traceFromContext(requestContext)
+
+	var requestTrace *trace
+	if parentTrace != nil {
+		requestTrace = parentTrace.StartChild(traceDatumKeyTransportRequest)
+	} else {
+		requestTrace = newRootTrace(traceDatumKeyTransportRequest)
+	}
+
+	clientSideStats := newClientSideRequestStatisticsTraceDatum(time.Now().UTC(), requestTrace)
+	requestTrace.AddDatum(traceDatumKeyClientSideRequestStats, clientSideStats)
+
+	state := &requestDiagnosticsState{
+		requestTrace:        requestTrace,
+		clientSideStats:     clientSideStats,
+		resourceType:        operationContext.resourceType,
+		requestSessionToken: req.Raw().Header.Get(cosmosHeaderSessionToken),
+	}
+
+	requestContext = withTrace(requestContext, requestTrace)
+	requestContext = withRequestDiagnosticsState(requestContext, state)
+
+	return req.WithContext(requestContext)
+}
+
+func addPointOperationStatisticsFromResponse(resp *http.Response, errorMessage string, key string) {
+	if resp == nil || resp.Request == nil {
+		return
+	}
+
+	state := requestDiagnosticsStateFromContext(resp.Request.Context())
+	if state == nil || state.requestTrace == nil {
+		return
+	}
+
+	requestURI := ""
+	if resp.Request.URL != nil {
+		requestURI = resp.Request.URL.String()
+	}
+
+	pointStats := pointOperationStatisticsTraceDatum{
+		ActivityID:           resp.Header.Get(cosmosHeaderActivityId),
+		ResponseTimeUTC:      time.Now().UTC(),
+		StatusCode:           resp.StatusCode,
+		SubStatusCode:        parseSubStatusCode(resp.Header.Get(cosmosHeaderSubstatus)),
+		RequestCharge:        newResponse(resp).RequestCharge,
+		RequestURI:           requestURI,
+		ErrorMessage:         errorMessage,
+		RequestSessionToken:  state.requestSessionToken,
+		ResponseSessionToken: resp.Header.Get(cosmosHeaderSessionToken),
+		BELatencyInMs:        resp.Header.Get(headerXmsRequestDurationMs),
+	}
+
+	state.requestTrace.AddOrUpdateDatum(key, pointStats)
+}
+
+func recordQueryMetricsFromResponse(resp *http.Response) {
+	if resp == nil || resp.Request == nil {
+		return
+	}
+
+	queryMetrics := resp.Header.Get(cosmosHeaderQueryMetrics)
+	if queryMetrics == "" {
+		return
+	}
+
+	state := requestDiagnosticsStateFromContext(resp.Request.Context())
+	if state == nil || state.requestTrace == nil {
+		return
+	}
+
+	state.requestTrace.AddOrUpdateDatum(traceDatumKeyQueryMetrics, queryMetrics)
+}
+
+type clientSideRequestStatisticsTraceDatum struct {
+	mu                          sync.Mutex
+	trace                       *trace
+	requestStartTimeUTC         time.Time
+	requestEndTimeUTC           *time.Time
+	regionsContacted            []contactedRegion
+	regionsContactedByURI       map[string]struct{}
+	httpResponseStatistics      []httpResponseStatistics
+	addressResolutionStatistics []addressResolutionStatistics
+	forceAddressRefreshes       []forceAddressRefresh
+}
+
+type clientSideRequestStatisticsSnapshot struct {
+	regionsContacted            []contactedRegion
+	httpResponseStatistics      []httpResponseStatistics
+	addressResolutionStatistics []addressResolutionStatistics
+	forceAddressRefreshes       []forceAddressRefresh
+}
+
+type contactedRegion struct {
+	name string
+	uri  string
+}
+
+type httpResponseStatistics struct {
+	startTimeUTC     time.Time
+	duration         time.Duration
+	requestURI       string
+	resourceType     resourceType
+	httpMethod       string
+	activityID       string
+	exceptionType    string
+	exceptionMessage string
+	statusCode       int
+	statusCodeText   string
+	reasonPhrase     string
+	subStatusCode    int
+}
+
+type addressResolutionStatistics struct {
+	startTimeUTC   time.Time
+	endTimeUTC     *time.Time
+	targetEndpoint string
+}
+
+type forceAddressRefresh struct {
+	noChangeToCache []string
+	original        []string
+	newValues       []string
+}
+
+type pointOperationStatisticsTraceDatum struct {
+	ActivityID           string
+	ResponseTimeUTC      time.Time
+	StatusCode           int
+	SubStatusCode        int
+	RequestCharge        float32
+	RequestURI           string
+	ErrorMessage         string
+	RequestSessionToken  string
+	ResponseSessionToken string
+	BELatencyInMs        string
+}
+
+func newClientSideRequestStatisticsTraceDatum(startTime time.Time, trace *trace) *clientSideRequestStatisticsTraceDatum {
+	return &clientSideRequestStatisticsTraceDatum{
+		trace:                       trace,
+		requestStartTimeUTC:         startTime,
+		regionsContacted:            []contactedRegion{},
+		regionsContactedByURI:       map[string]struct{}{},
+		httpResponseStatistics:      []httpResponseStatistics{},
+		addressResolutionStatistics: []addressResolutionStatistics{},
+		forceAddressRefreshes:       []forceAddressRefresh{},
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) recordHTTPResponse(startTime time.Time, response *http.Response, resourceType resourceType, regionName string) {
+	if response == nil {
+		return
+	}
+
+	requestURI := ""
+	if response.Request != nil && response.Request.URL != nil {
+		requestURI = response.Request.URL.String()
+	}
+
+	d.recordRegion(regionName, requestURI)
+
+	endTime := time.Now().UTC()
+	d.updateRequestEndTime(endTime)
+
+	stat := httpResponseStatistics{
+		startTimeUTC:   startTime.UTC(),
+		duration:       endTime.Sub(startTime),
+		requestURI:     requestURI,
+		resourceType:   resourceType,
+		httpMethod:     response.Request.Method,
+		activityID:     response.Header.Get(cosmosHeaderActivityId),
+		statusCode:     response.StatusCode,
+		statusCodeText: formatHTTPStatusCodeString(response.StatusCode),
+		reasonPhrase:   http.StatusText(response.StatusCode),
+		subStatusCode:  parseSubStatusCode(response.Header.Get(cosmosHeaderSubstatus)),
+	}
+
+	d.mu.Lock()
+	d.httpResponseStatistics = append(d.httpResponseStatistics, stat)
+	d.mu.Unlock()
+
+	if response.StatusCode >= http.StatusBadRequest && d.trace != nil && d.trace.summary != nil {
+		d.trace.summary.incrementFailedCount()
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) recordHTTPError(startTime time.Time, req *http.Request, err error, resourceType resourceType, regionName string) {
+	requestURI := ""
+	method := http.MethodGet
+	if req != nil {
+		method = req.Method
+		if req.URL != nil {
+			requestURI = req.URL.String()
+		}
+	}
+
+	d.recordRegion(regionName, requestURI)
+
+	endTime := time.Now().UTC()
+	d.updateRequestEndTime(endTime)
+
+	stat := httpResponseStatistics{
+		startTimeUTC:     startTime.UTC(),
+		duration:         endTime.Sub(startTime),
+		requestURI:       requestURI,
+		resourceType:     resourceType,
+		httpMethod:       method,
+		exceptionType:    fmt.Sprintf("%T", err),
+		exceptionMessage: err.Error(),
+	}
+
+	d.mu.Lock()
+	d.httpResponseStatistics = append(d.httpResponseStatistics, stat)
+	d.mu.Unlock()
+
+	if d.trace != nil && d.trace.summary != nil {
+		d.trace.summary.incrementFailedCount()
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) snapshot() clientSideRequestStatisticsSnapshot {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	regionsContacted := append([]contactedRegion(nil), d.regionsContacted...)
+	httpResponseStatistics := append([]httpResponseStatistics(nil), d.httpResponseStatistics...)
+	addressResolutionStatistics := append([]addressResolutionStatistics(nil), d.addressResolutionStatistics...)
+	forceAddressRefreshes := append([]forceAddressRefresh(nil), d.forceAddressRefreshes...)
+
+	return clientSideRequestStatisticsSnapshot{
+		regionsContacted:            regionsContacted,
+		httpResponseStatistics:      httpResponseStatistics,
+		addressResolutionStatistics: addressResolutionStatistics,
+		forceAddressRefreshes:       forceAddressRefreshes,
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) updateRequestEndTime(endTime time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.requestEndTimeUTC == nil || endTime.After(*d.requestEndTimeUTC) {
+		value := endTime.UTC()
+		d.requestEndTimeUTC = &value
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) recordRegion(regionName string, requestURI string) {
+	if requestURI == "" {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, ok := d.regionsContactedByURI[requestURI]; ok {
+		return
+	}
+
+	d.regionsContactedByURI[requestURI] = struct{}{}
+	d.regionsContacted = append(d.regionsContacted, contactedRegion{
+		name: regionName,
+		uri:  requestURI,
+	})
+}
+
+func parseSubStatusCode(value string) int {
+	if value == "" {
+		return 0
+	}
+
+	subStatusCode, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+
+	return subStatusCode
+}
+
+func formatHTTPStatusCodeString(statusCode int) string {
+	if statusCode == 0 {
+		return ""
+	}
+
+	if text := http.StatusText(statusCode); text != "" {
+		replacer := strings.NewReplacer(" ", "", "-", "", "'", "", ".", "")
+		return replacer.Replace(text)
+	}
+
+	return strconv.Itoa(statusCode)
+}
+
+func resourceTypeName(resourceType resourceType) string {
+	switch resourceType {
+	case resourceTypeDatabase:
+		return "Database"
+	case resourceTypeCollection:
+		return "DocumentCollection"
+	case resourceTypeDocument:
+		return "Document"
+	case resourceTypeOffer:
+		return "Offer"
+	case resourceTypeDatabaseAccount:
+		return "DatabaseAccount"
+	case resourceTypePartitionKeyRange:
+		return "PartitionKeyRange"
+	default:
+		return fmt.Sprintf("%d", resourceType)
+	}
+}

--- a/sdk/data/azcosmos/trace_json_writer.go
+++ b/sdk/data/azcosmos/trace_json_writer.go
@@ -1,0 +1,545 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+)
+
+const (
+	rootTraceTimeFormat   = "2006-01-02T15:04:05.000Z"
+	nestedTraceTimeFormat = "2006-01-02T15:04:05.0000000Z07:00"
+)
+
+type summaryDiagnostics struct {
+	directCalls    map[[2]int]int
+	gatewayCalls   map[[2]int]int
+	regionsByURI   map[string]struct{}
+	regionURICount int
+}
+
+func writeTraceJSON(root *trace) string {
+	var buffer bytes.Buffer
+	writeTrace(&buffer, root, true)
+	return buffer.String()
+}
+
+func writeTrace(buffer *bytes.Buffer, current *trace, isRoot bool) {
+	snapshot := current.snapshot()
+
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	if isRoot {
+		writeField("Summary", func() {
+			writeSummaryDiagnostics(buffer, current)
+		})
+	}
+
+	writeField("name", func() {
+		writeJSONString(buffer, snapshot.name)
+	})
+
+	if isRoot {
+		writeField("start datetime", func() {
+			writeJSONString(buffer, snapshot.startTime.UTC().Format(rootTraceTimeFormat))
+		})
+	}
+
+	writeField("duration in milliseconds", func() {
+		writeNumber(buffer, durationInMilliseconds(snapshot.startTime, snapshot.endTime))
+	})
+
+	if len(snapshot.dataOrder) > 0 {
+		writeField("data", func() {
+			writeTraceDataObject(buffer, snapshot.dataOrder, snapshot.data)
+		})
+	}
+
+	if len(snapshot.children) > 0 {
+		writeField("children", func() {
+			buffer.WriteByte('[')
+			for index, child := range snapshot.children {
+				if index > 0 {
+					buffer.WriteByte(',')
+				}
+				writeTrace(buffer, child, false)
+			}
+			buffer.WriteByte(']')
+		})
+	}
+
+	buffer.WriteByte('}')
+}
+
+func writeSummaryDiagnostics(buffer *bytes.Buffer, root *trace) {
+	summary := collectSummaryDiagnostics(root)
+
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	if len(summary.directCalls) > 0 {
+		writeField("DirectCalls", func() {
+			writeCallSummaryObject(buffer, summary.directCalls)
+		})
+	}
+
+	if summary.regionURICount > 0 {
+		writeField("RegionsContacted", func() {
+			writeNumber(buffer, float64(summary.regionURICount))
+		})
+	}
+
+	if len(summary.gatewayCalls) > 0 {
+		writeField("GatewayCalls", func() {
+			writeCallSummaryObject(buffer, summary.gatewayCalls)
+		})
+	}
+
+	buffer.WriteByte('}')
+}
+
+func collectSummaryDiagnostics(root *trace) summaryDiagnostics {
+	summary := summaryDiagnostics{
+		directCalls:  map[[2]int]int{},
+		gatewayCalls: map[[2]int]int{},
+		regionsByURI: map[string]struct{}{},
+	}
+
+	var walk func(*trace)
+	walk = func(current *trace) {
+		snapshot := current.snapshot()
+		for _, key := range snapshot.dataOrder {
+			value := snapshot.data[key]
+			stats, ok := value.(*clientSideRequestStatisticsTraceDatum)
+			if !ok {
+				continue
+			}
+
+			statsSnapshot := stats.snapshot()
+			for _, region := range statsSnapshot.regionsContacted {
+				if _, exists := summary.regionsByURI[region.uri]; !exists {
+					summary.regionsByURI[region.uri] = struct{}{}
+					summary.regionURICount++
+				}
+			}
+
+			for _, gatewayCall := range statsSnapshot.httpResponseStatistics {
+				key := [2]int{gatewayCall.statusCode, gatewayCall.subStatusCode}
+				summary.gatewayCalls[key]++
+			}
+		}
+
+		for _, child := range snapshot.children {
+			walk(child)
+		}
+	}
+
+	walk(root)
+	return summary
+}
+
+func writeCallSummaryObject(buffer *bytes.Buffer, values map[[2]int]int) {
+	keys := make([][2]int, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i int, j int) bool {
+		if keys[i][0] == keys[j][0] {
+			return keys[i][1] < keys[j][1]
+		}
+		return keys[i][0] < keys[j][0]
+	})
+
+	buffer.WriteByte('{')
+	firstField := true
+	for _, key := range keys {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, fmt.Sprintf("(%d, %d)", key[0], key[1]))
+		buffer.WriteByte(':')
+		writeNumber(buffer, float64(values[key]))
+	}
+	buffer.WriteByte('}')
+}
+
+func writeTraceDataObject(buffer *bytes.Buffer, order []string, values map[string]any) {
+	buffer.WriteByte('{')
+	for index, key := range order {
+		if index > 0 {
+			buffer.WriteByte(',')
+		}
+		writeJSONString(buffer, key)
+		buffer.WriteByte(':')
+		writeTraceDatum(buffer, values[key])
+	}
+	buffer.WriteByte('}')
+}
+
+func writeTraceDatum(buffer *bytes.Buffer, value any) {
+	switch typed := value.(type) {
+	case *clientSideRequestStatisticsTraceDatum:
+		writeClientSideRequestStatistics(buffer, typed.snapshot())
+	case pointOperationStatisticsTraceDatum:
+		writePointOperationStatistics(buffer, typed)
+	case *pointOperationStatisticsTraceDatum:
+		writePointOperationStatistics(buffer, *typed)
+	case json.RawMessage:
+		buffer.Write(typed)
+	case string:
+		writeJSONString(buffer, typed)
+	case float64:
+		writeNumber(buffer, typed)
+	case float32:
+		writeNumber(buffer, float64(typed))
+	case int:
+		writeNumber(buffer, float64(typed))
+	case int32:
+		writeNumber(buffer, float64(typed))
+	case int64:
+		writeNumber(buffer, float64(typed))
+	case bool:
+		if typed {
+			buffer.WriteString("true")
+		} else {
+			buffer.WriteString("false")
+		}
+	case []string:
+		buffer.WriteByte('[')
+		for index, item := range typed {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			writeJSONString(buffer, item)
+		}
+		buffer.WriteByte(']')
+	case []any:
+		buffer.WriteByte('[')
+		for index, item := range typed {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			writeTraceDatum(buffer, item)
+		}
+		buffer.WriteByte(']')
+	case map[string]any:
+		buffer.WriteByte('{')
+		firstField := true
+		for key, item := range typed {
+			if !firstField {
+				buffer.WriteByte(',')
+			}
+			firstField = false
+			writeJSONString(buffer, key)
+			buffer.WriteByte(':')
+			writeTraceDatum(buffer, item)
+		}
+		buffer.WriteByte('}')
+	case nil:
+		buffer.WriteString("null")
+	default:
+		writeJSONString(buffer, fmt.Sprint(value))
+	}
+}
+
+func writeClientSideRequestStatistics(buffer *bytes.Buffer, snapshot clientSideRequestStatisticsSnapshot) {
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	writeField("Id", func() {
+		writeJSONString(buffer, "AggregatedClientSideRequestStatistics")
+	})
+
+	writeField("ContactedReplicas", func() {
+		buffer.WriteByte('[')
+		buffer.WriteByte(']')
+	})
+
+	writeField("RegionsContacted", func() {
+		buffer.WriteByte('[')
+		for index, region := range snapshot.regionsContacted {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			writeJSONString(buffer, region.uri)
+		}
+		buffer.WriteByte(']')
+	})
+
+	writeField("FailedReplicas", func() {
+		buffer.WriteByte('[')
+		buffer.WriteByte(']')
+	})
+
+	if len(snapshot.forceAddressRefreshes) > 0 {
+		writeField("ForceAddressRefresh", func() {
+			buffer.WriteByte('[')
+			for index, refresh := range snapshot.forceAddressRefreshes {
+				if index > 0 {
+					buffer.WriteByte(',')
+				}
+				buffer.WriteByte('{')
+				firstRefreshField := true
+				writeRefreshField := func(name string, values []string) {
+					if !firstRefreshField {
+						buffer.WriteByte(',')
+					}
+					firstRefreshField = false
+					writeJSONString(buffer, name)
+					buffer.WriteByte(':')
+					writeTraceDatum(buffer, values)
+				}
+				if len(refresh.noChangeToCache) > 0 {
+					writeRefreshField("No change to cache", refresh.noChangeToCache)
+				} else {
+					writeRefreshField("Original", refresh.original)
+					writeRefreshField("New", refresh.newValues)
+				}
+				buffer.WriteByte('}')
+			}
+			buffer.WriteByte(']')
+		})
+	}
+
+	writeField("AddressResolutionStatistics", func() {
+		buffer.WriteByte('[')
+		for index, stat := range snapshot.addressResolutionStatistics {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			buffer.WriteByte('{')
+			writeJSONString(buffer, "StartTimeUTC")
+			buffer.WriteByte(':')
+			writeJSONString(buffer, stat.startTimeUTC.UTC().Format(nestedTraceTimeFormat))
+			buffer.WriteByte(',')
+			writeJSONString(buffer, "EndTimeUTC")
+			buffer.WriteByte(':')
+			if stat.endTimeUTC != nil {
+				writeJSONString(buffer, stat.endTimeUTC.UTC().Format(nestedTraceTimeFormat))
+			} else {
+				writeJSONString(buffer, "EndTime Never Set.")
+			}
+			buffer.WriteByte(',')
+			writeJSONString(buffer, "TargetEndpoint")
+			buffer.WriteByte(':')
+			if stat.targetEndpoint == "" {
+				buffer.WriteString("null")
+			} else {
+				writeJSONString(buffer, stat.targetEndpoint)
+			}
+			buffer.WriteByte('}')
+		}
+		buffer.WriteByte(']')
+	})
+
+	writeField("StoreResponseStatistics", func() {
+		buffer.WriteByte('[')
+		buffer.WriteByte(']')
+	})
+
+	if len(snapshot.httpResponseStatistics) > 0 {
+		writeField("HttpResponseStats", func() {
+			buffer.WriteByte('[')
+			for index, stat := range snapshot.httpResponseStatistics {
+				if index > 0 {
+					buffer.WriteByte(',')
+				}
+				writeHTTPResponseStatistic(buffer, stat)
+			}
+			buffer.WriteByte(']')
+		})
+	}
+
+	buffer.WriteByte('}')
+}
+
+func writeHTTPResponseStatistic(buffer *bytes.Buffer, stat httpResponseStatistics) {
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	writeField("StartTimeUTC", func() {
+		writeJSONString(buffer, stat.startTimeUTC.UTC().Format(nestedTraceTimeFormat))
+	})
+	writeField("DurationInMs", func() {
+		writeNumber(buffer, float64(stat.duration)/float64(time.Millisecond))
+	})
+	writeField("RequestUri", func() {
+		writeJSONString(buffer, stat.requestURI)
+	})
+	writeField("ResourceType", func() {
+		writeJSONString(buffer, resourceTypeName(stat.resourceType))
+	})
+	writeField("HttpMethod", func() {
+		writeJSONString(buffer, stat.httpMethod)
+	})
+	writeField("ActivityId", func() {
+		if stat.activityID == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.activityID)
+		}
+	})
+
+	if stat.exceptionType != "" {
+		writeField("ExceptionType", func() {
+			writeJSONString(buffer, stat.exceptionType)
+		})
+		writeField("ExceptionMessage", func() {
+			writeJSONString(buffer, stat.exceptionMessage)
+		})
+	}
+
+	if stat.statusCodeText != "" {
+		writeField("StatusCode", func() {
+			writeJSONString(buffer, stat.statusCodeText)
+		})
+		if stat.statusCode >= http.StatusBadRequest && stat.reasonPhrase != "" {
+			writeField("ReasonPhrase", func() {
+				writeJSONString(buffer, stat.reasonPhrase)
+			})
+		}
+	}
+
+	buffer.WriteByte('}')
+}
+
+func writePointOperationStatistics(buffer *bytes.Buffer, stat pointOperationStatisticsTraceDatum) {
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	writeField("Id", func() {
+		writeJSONString(buffer, "PointOperationStatistics")
+	})
+	writeField("ActivityId", func() {
+		if stat.ActivityID == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.ActivityID)
+		}
+	})
+	writeField("ResponseTimeUtc", func() {
+		writeJSONString(buffer, stat.ResponseTimeUTC.UTC().Format(nestedTraceTimeFormat))
+	})
+	writeField("StatusCode", func() {
+		writeNumber(buffer, float64(stat.StatusCode))
+	})
+	writeField("SubStatusCode", func() {
+		writeNumber(buffer, float64(stat.SubStatusCode))
+	})
+	writeField("RequestCharge", func() {
+		writeNumber(buffer, float64(stat.RequestCharge))
+	})
+	writeField("RequestUri", func() {
+		if stat.RequestURI == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.RequestURI)
+		}
+	})
+	writeField("ErrorMessage", func() {
+		if stat.ErrorMessage == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.ErrorMessage)
+		}
+	})
+	writeField("RequestSessionToken", func() {
+		if stat.RequestSessionToken == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.RequestSessionToken)
+		}
+	})
+	writeField("ResponseSessionToken", func() {
+		if stat.ResponseSessionToken == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.ResponseSessionToken)
+		}
+	})
+	writeField("BELatencyInMs", func() {
+		if stat.BELatencyInMs == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.BELatencyInMs)
+		}
+	})
+
+	buffer.WriteByte('}')
+}
+
+func writeJSONString(buffer *bytes.Buffer, value string) {
+	encoded, _ := json.Marshal(value)
+	buffer.Write(encoded)
+}
+
+func writeNumber(buffer *bytes.Buffer, value float64) {
+	buffer.WriteString(strconv.FormatFloat(value, 'f', -1, 64))
+}
+
+func durationInMilliseconds(start time.Time, end *time.Time) float64 {
+	if end != nil {
+		return float64(end.Sub(start)) / float64(time.Millisecond)
+	}
+
+	return float64(time.Since(start)) / float64(time.Millisecond)
+}


### PR DESCRIPTION
## Diagnostic Strings for Azure Cosmos DB Go SDK (`azcosmos` `v1.4.2` backport)

This PR adds diagnostic string support to the `azcosmos` package on top of the `v1.4.2` code line, adapting the [.NET Cosmos SDK `CosmosDiagnostics`](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk?tabs=diagnostics-v3#capture-diagnostics) model for the older, application-compatible module surface.

Diagnostic strings provide a structured JSON payload that captures end-to-end request telemetry — timing, retry history, contacted regions, HTTP response statistics, RU charges, point-operation metadata, and query metrics — so callers can troubleshoot latency and failure issues without depending on external tracing infrastructure.

### Architecture

The implementation follows the .NET SDK's hierarchical trace-tree model:

**`trace.go`** — Core trace tree structure
- `trace` forms a parent/child tree of diagnostic spans with start/end timestamps, ordered trace data, and a shared `traceSummary` used for failed-request aggregation.
- The implementation is concurrency-safe via `sync.Mutex` and supports copy-on-write style updates while the tree is being serialized.
- Traces flow through `context.Context` using a `traceContextKey`.
- `startSpan()` wraps the existing Azure SDK span creation so each existing `azcosmos` operation also participates in the diagnostics trace tree.

**`trace_data.go`** — Trace datum types and request state
- `requestDiagnosticsState` stores request-local diagnostic state in context, including the transport trace node, client-side stats, resource type, and session token.
- `clientSideRequestStatisticsTraceDatum` records retry-attempt HTTP response/error statistics and the regions contacted during the request.
- `pointOperationStatisticsTraceDatum` records activity ID, status/sub-status, RU charge, backend latency, URI, and session-token details.
- `attachRequestDiagnostics()` attaches diagnostic state in `createRequest()`.
- `addPointOperationStatisticsFromResponse()` and `recordQueryMetricsFromResponse()` capture response metadata for inclusion in the final JSON payload.

**`trace_json_writer.go`** — Custom JSON serializer for diagnostics strings
- Produces a JSON tree containing `Summary`, trace name, timestamps, duration, ordered `data`, and nested `children`.
- Serializes `clientSideRequestStatisticsTraceDatum` into a Cosmos-style payload including regions contacted and per-attempt HTTP stats.
- Uses dedicated timestamp formats to keep root and nested trace output stable.

**`diagnostics.go`** — Public API surface
- Adds a public `Diagnostics` type that lazily materializes the diagnostics JSON in `String()`.
- Exposes `ClientElapsedTime()`, `StartTimeUTC()`, and `FailedRequestCount()` for programmatic inspection.
- `DiagnosticsFromError(err)` extracts diagnostics from wrapped request failures and `azcore.ResponseError` values.

### Integration Points (modified files)

| File | Changes |
|------|---------|
| `cosmos_client.go` | Replaces the two client-level `azruntime.StartSpan` calls with `startSpan`; attaches request diagnostics in `createRequest`; records point-operation statistics in `executeAndEnsureSuccessResponse`; wraps non-response transport failures with diagnostics via `wrapRequestError`. |
| `cosmos_container.go` | Replaces all existing container/item/query/batch span creation sites with `startSpan` so the existing `v1.4.2` operations participate in the diagnostics tree. No new APIs were added here; newer-branch features such as `ReadManyItems`, feed-range helpers, and change-feed helpers were intentionally not backported. |
| `cosmos_database.go` | Replaces all existing database/container-pager span creation sites with `startSpan`. |
| `cosmos_client_retry_policy.go` | Records per-attempt HTTP responses and transport errors into client-side request statistics, including attempt timing and resolved region name. |
| `cosmos_response.go` | Adds a `Diagnostics` field to `Response` and populates it from the request context in `newResponse`. |
| `cosmos_query_response.go` | Records query metrics into the trace so they appear in diagnostics for item queries. |

### Compatibility Notes

This implementation is intentionally scoped to the `azcosmos` `v1.4.2` surface area.

That means the diagnostics support is backported for the operations that already exist on `v1.4.2`, while later features from the newer branch — including `ReadManyItems` diagnostics wiring and feed-range/change-feed additions — are not included here.

### Example Diagnostic Output

```json
{
  "Summary": {
    "RegionsContacted": 1,
    "GatewayCalls": { "(200, 0)": 1 }
  },
  "name": "create_item mycontainer",
  "start datetime": "2026-03-24T20:00:00.000Z",
  "duration in milliseconds": 42.5,
  "data": {
    "PointOperationStatisticsTraceDatum": {
      "ActivityId": "abc-123",
      "StatusCode": 201,
      "SubStatusCode": 0,
      "RequestCharge": 6.29
    }
  },
  "children": [...]
}
```

### Tests

- `diagnostics_test.go` covers:
  - Summary diagnostics with retried gateway calls (`503 -> 200` retry scenario)
  - Extracting diagnostics from `azcore.ResponseError` via `DiagnosticsFromError`
  - Query response diagnostics, including query-metrics propagation
- Validation on the backport branch: `cd sdk/data/azcosmos && go test ./...`

### Checklist

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
