### PR TITLE
Remove reference to validate-codeowners.instructions.md. This will be replaced with other tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,6 @@ AI agents should **NOT** perform the following actions without human approval:
 - **TypeSpec changes**: SDK generation from specifications requires specific tools and workflows (see [code generation docs](https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/development/generate.md))
 
 #### Security and Compliance
-- **CODEOWNERS modifications**: Changes require following [CODEOWNERS validation workflow](https://github.com/Azure/azure-sdk-for-go/blob/main/eng/common/instructions/azsdk-tools/validate-codeowners.instructions.md)
 - **Security issues**: Must be reported privately to <secure@microsoft.com>, not in public issues
 - **License changes**: No modifications to licensing without explicit approval
 


### PR DESCRIPTION
Cleanup of AGENTS.md link to deprecated CODEOWNERS tooling.