### PR TITLE
Increase timeout for azcontainerregistry test builds

### DIFF
--- a/sdk/containers/azcontainerregistry/utils_test.go
+++ b/sdk/containers/azcontainerregistry/utils_test.go
@@ -135,7 +135,7 @@ func buildImage(t *testing.T) (string, string) {
 
 	// build images in parallel, in separate goroutines, because building can be slow and may require retries in CI
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 6*time.Minute)
 	defer cancel()
 
 	ch := make(chan struct{})


### PR DESCRIPTION
A couple recent CI runs failed due to a timeout building test images so, let's allow more time for that