### PR TITLE
Add datetime.RFC7231 type

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.21.2-beta.1 (Unreleased)
+## 1.22.0 (Unreleased)
 
 ### Features Added
+
+* Added type `datetime.RFC7231` for date/time values in RFC 1123 format with a fixed GMT timezone.
 
 ### Breaking Changes
 

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -37,5 +37,5 @@ const (
 	Module = "azcore"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.21.2-beta.1"
+	Version = "v1.22.0"
 )

--- a/sdk/azcore/runtime/datetime/RFC7231.go
+++ b/sdk/azcore/runtime/datetime/RFC7231.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package datetime
+
+import (
+	"strings"
+	"time"
+)
+
+// used to convert times from UTC to GMT before sending across the wire
+var gmt = time.FixedZone("GMT", 0)
+
+// RFC7231 represents a date and time value in RFC 1123 format as defined in
+// https://tools.ietf.org/html/rfc1123.
+// The timezone is set to GMT as required by RFC 7231.
+type RFC7231 time.Time
+
+// MarshalJSON marshals the RFC7231 timestamp to a JSON byte slice.
+func (r RFC7231) MarshalJSON() ([]byte, error) {
+	return []byte(time.Time(r).In(gmt).Format(rfc1123JSON)), nil
+}
+
+// MarshalText returns a textual representation of RFC7231.
+func (r RFC7231) MarshalText() ([]byte, error) {
+	return []byte(time.Time(r).In(gmt).Format(time.RFC1123)), nil
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into an RFC7231 timestamp.
+func (r *RFC7231) UnmarshalJSON(data []byte) error {
+	t, err := time.Parse(rfc1123JSON, strings.ToUpper(string(data)))
+	*r = RFC7231(t.UTC())
+	return err
+}
+
+// UnmarshalText decodes the textual representation of RFC7231.
+func (r *RFC7231) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		// empty XML element means no value
+		return nil
+	}
+	t, err := time.Parse(time.RFC1123, string(data))
+	*r = RFC7231(t.UTC())
+	return err
+}
+
+// String returns the string of RFC7231.
+func (r RFC7231) String() string {
+	return time.Time(r).In(gmt).Format(time.RFC1123)
+}

--- a/sdk/azcore/runtime/datetime/RFC7231.go
+++ b/sdk/azcore/runtime/datetime/RFC7231.go
@@ -8,12 +8,13 @@ import (
 	"time"
 )
 
-// used to convert times from UTC to GMT before sending across the wire
+// used to format timestamps with a fixed GMT zone name before sending across the wire
 var gmt = time.FixedZone("GMT", 0)
 
 // RFC7231 represents a date and time value in RFC 1123 format as defined in
 // https://tools.ietf.org/html/rfc1123.
-// The timezone is set to GMT as required by RFC 7231.
+// The timezone is set to GMT as required by RFC 7231 HTTP-date / IMF-fixdate:
+// https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1.
 type RFC7231 time.Time
 
 // MarshalJSON marshals the RFC7231 timestamp to a JSON byte slice.

--- a/sdk/azcore/runtime/datetime/RFC7231_test.go
+++ b/sdk/azcore/runtime/datetime/RFC7231_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package datetime_test
+
+import (
+	"encoding/xml"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRFC7231(t *testing.T) {
+	originalTime := time.Date(2023, time.June, 15, 14, 30, 45, 0, time.UTC)
+	dt := datetime.RFC7231(originalTime)
+
+	// String should always use GMT
+	result := dt.String()
+	require.Equal(t, "Thu, 15 Jun 2023 14:30:45 GMT", result)
+
+	// MarshalJSON round-trip
+	jsonBytes, err := dt.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, `"Thu, 15 Jun 2023 14:30:45 GMT"`, string(jsonBytes))
+	var dt2 datetime.RFC7231
+	err = dt2.UnmarshalJSON(jsonBytes)
+	require.NoError(t, err)
+	require.Equal(t, originalTime, time.Time(dt2))
+
+	// MarshalText round-trip
+	textBytes, err := dt.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "Thu, 15 Jun 2023 14:30:45 GMT", string(textBytes))
+	var dt3 datetime.RFC7231
+	err = dt3.UnmarshalText(textBytes)
+	require.NoError(t, err)
+	require.Equal(t, originalTime, time.Time(dt3))
+}
+
+func TestRFC7231MarshalConvertsToGMT(t *testing.T) {
+	// a time in a non-GMT zone should be converted to GMT on marshal
+	est := time.FixedZone("EST", -5*60*60)
+	originalTime := time.Date(2023, time.June, 15, 9, 30, 45, 0, est) // 09:30 EST = 14:30 UTC/GMT
+	dt := datetime.RFC7231(originalTime)
+
+	result := dt.String()
+	require.Equal(t, "Thu, 15 Jun 2023 14:30:45 GMT", result)
+
+	jsonBytes, err := dt.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, `"Thu, 15 Jun 2023 14:30:45 GMT"`, string(jsonBytes))
+
+	textBytes, err := dt.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "Thu, 15 Jun 2023 14:30:45 GMT", string(textBytes))
+}
+
+func TestRFC7231UnmarshalJSONError(t *testing.T) {
+	var dt datetime.RFC7231
+	err := dt.UnmarshalJSON([]byte(`"not a valid date"`))
+	require.Error(t, err)
+}
+
+func TestRFC7231UnmarshalTextError(t *testing.T) {
+	var dt datetime.RFC7231
+	err := dt.UnmarshalText([]byte("not a valid date"))
+	require.Error(t, err)
+}
+
+func TestRFC7231_empty(t *testing.T) {
+	tt := datetime.RFC7231{}
+	require.NoError(t, xml.Unmarshal([]byte("<RFC7231/>"), &tt))
+	require.Zero(t, tt)
+}


### PR DESCRIPTION
It has the same format as RFC1123 but with a fixed GMT timezone.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
