### PR TITLE
Add diagnostic string support

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added operation diagnostics on responses and `DiagnosticsFromError` for retrieving diagnostics from failed operations. See [PR 26548](https://github.com/Azure/azure-sdk-for-go/pull/26548)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/data/azcosmos/README.md
+++ b/sdk/data/azcosmos/README.md
@@ -68,6 +68,7 @@ The following section provides several code snippets covering some of the most c
 * [Create Database](#create-database "Create Database")
 * [Create Container](#create-container "Create Container")
 * [CRUD operation on Items](#crud-operation-on-items "CRUD operation on Items")
+* [Request diagnostics](#request-diagnostics "Request diagnostics")
 
 ### Create Cosmos DB Client
 
@@ -183,6 +184,33 @@ itemResponse, err = container.DeleteItem(context, pk, id, nil)
 handle(err)
 ```
 
+### Request diagnostics
+
+Responses include request diagnostics that can help investigate operation latency, retries, contacted regions, and backend failures.
+
+```go
+itemResponse, err := container.ReadItem(context, pk, id, nil)
+handle(err)
+
+log.Printf("Diagnostics: %s", itemResponse.Diagnostics.String())
+log.Printf("Client elapsed time: %s", itemResponse.Diagnostics.ClientElapsedTime())
+log.Printf("Failed backend requests: %d", itemResponse.Diagnostics.FailedRequestCount())
+```
+
+When an operation fails, use `DiagnosticsFromError` to retrieve diagnostics from the returned error.
+
+```go
+_, err := container.ReadItem(context, pk, id, nil)
+if err != nil {
+	diagnostics, ok := azcosmos.DiagnosticsFromError(err)
+	if ok {
+		log.Printf("Diagnostics: %s", diagnostics.String())
+	}
+
+	handle(err)
+}
+```
+
 ## Next steps
 
 - [Resource Model of Azure Cosmos DB Service](https://learn.microsoft.com/azure/cosmos-db/sql-api-resources)
@@ -213,5 +241,4 @@ do this once across all repos using our CLA.
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 

--- a/sdk/data/azcosmos/cosmos_change_feed_response.go
+++ b/sdk/data/azcosmos/cosmos_change_feed_response.go
@@ -44,10 +44,10 @@ func newChangeFeedResponse(resp *http.Response) (ChangeFeedResponse, error) {
 	defer func() { _ = resp.Body.Close() }()
 	body, err := azruntime.Payload(resp)
 	if err != nil {
-		return response, err
+		return response, wrapResponseError(err, response.Response)
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return response, err
+		return response, wrapResponseError(err, response.Response)
 	}
 
 	return response, nil

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -526,8 +526,10 @@ func (c *Client) attachContent(content interface{}, req *policy.Request) error {
 func (c *Client) executeAndEnsureSuccessResponse(ctx context.Context, request *policy.Request) (*http.Response, error) {
 	log.Write(azlog.EventResponse, fmt.Sprintf("\n===== Client preferred regions:\n%v\n=====\n", c.gem.preferredLocations))
 	state := requestDiagnosticsStateFromContext(request.Raw().Context())
-	if state != nil && state.requestTrace != nil {
-		defer state.requestTrace.End()
+	finalizeRequestTrace := func() {
+		if state != nil && state.requestTrace != nil {
+			state.requestTrace.End()
+		}
 	}
 
 	response, err := c.internal.Pipeline().Do(request)
@@ -535,9 +537,11 @@ func (c *Client) executeAndEnsureSuccessResponse(ctx context.Context, request *p
 		var responseErr *azcore.ResponseError
 		if errors.As(err, &responseErr) && responseErr.RawResponse != nil {
 			addPointOperationStatisticsFromResponse(responseErr.RawResponse, responseErr.Error(), traceDatumKeyPointOperationStatistics)
+			finalizeRequestTrace()
 			return nil, err
 		}
 
+		finalizeRequestTrace()
 		return nil, wrapRequestError(err, diagnosticsFromContext(request.Raw().Context()))
 	}
 
@@ -546,10 +550,12 @@ func (c *Client) executeAndEnsureSuccessResponse(ctx context.Context, request *p
 	successResponse := (response.StatusCode >= 200 && response.StatusCode < 300) || response.StatusCode == 304
 	if successResponse {
 		addPointOperationStatisticsFromResponse(response, "", traceDatumKeyPointOperationStatistics)
+		finalizeRequestTrace()
 		return response, nil
 	}
 
 	addPointOperationStatisticsFromResponse(response, response.Status, traceDatumKeyPointOperationStatistics)
+	finalizeRequestTrace()
 	return nil, azruntime.NewResponseErrorWithErrorCode(response, response.Status)
 }
 
@@ -560,7 +566,7 @@ func (c *Client) accountEndpointUrl() *url.URL {
 func (c *Client) addResponseValuesToSpan(ctx context.Context, resp *http.Response) {
 	span := c.internal.Tracer().SpanFromContext(ctx)
 	span.SetAttributes(
-		tracing.Attribute{Key: "db.cosmosdb.request_charge", Value: newResponse(resp).RequestCharge},
+		tracing.Attribute{Key: "db.cosmosdb.request_charge", Value: readRequestCharge(resp)},
 		tracing.Attribute{Key: "db.cosmosdb.status_code", Value: resp.StatusCode},
 	)
 }

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -234,7 +234,7 @@ func (c *Client) CreateDatabase(
 	if err != nil {
 		return DatabaseResponse{}, err
 	}
-	ctx, endSpan := azruntime.StartSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 
 	if o == nil {
@@ -299,7 +299,7 @@ func (c *Client) NewQueryDatabasesPager(query string, o *QueryDatabasesOptions) 
 			if err != nil {
 				return QueryDatabasesResponse{}, err
 			}
-			ctx, endSpan := azruntime.StartSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
+			ctx, endSpan := startSpan(ctx, spanName.name, c.internal.Tracer(), &spanName.options)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
@@ -500,6 +500,8 @@ func (c *Client) createRequest(
 		requestEnricher(req)
 	}
 
+	req = attachRequestDiagnostics(req, operationContext)
+
 	return req, nil
 }
 
@@ -523,18 +525,31 @@ func (c *Client) attachContent(content interface{}, req *policy.Request) error {
 
 func (c *Client) executeAndEnsureSuccessResponse(ctx context.Context, request *policy.Request) (*http.Response, error) {
 	log.Write(azlog.EventResponse, fmt.Sprintf("\n===== Client preferred regions:\n%v\n=====\n", c.gem.preferredLocations))
+	state := requestDiagnosticsStateFromContext(request.Raw().Context())
+	if state != nil && state.requestTrace != nil {
+		defer state.requestTrace.End()
+	}
+
 	response, err := c.internal.Pipeline().Do(request)
 	if err != nil {
-		return nil, err
+		var responseErr *azcore.ResponseError
+		if errors.As(err, &responseErr) && responseErr.RawResponse != nil {
+			addPointOperationStatisticsFromResponse(responseErr.RawResponse, responseErr.Error(), traceDatumKeyPointOperationStatistics)
+			return nil, err
+		}
+
+		return nil, wrapRequestError(err, diagnosticsFromContext(request.Raw().Context()))
 	}
 
 	c.addResponseValuesToSpan(ctx, response)
 
 	successResponse := (response.StatusCode >= 200 && response.StatusCode < 300) || response.StatusCode == 304
 	if successResponse {
+		addPointOperationStatisticsFromResponse(response, "", traceDatumKeyPointOperationStatistics)
 		return response, nil
 	}
 
+	addPointOperationStatisticsFromResponse(response, response.Status, traceDatumKeyPointOperationStatistics)
 	return nil, azruntime.NewResponseErrorWithErrorCode(response, response.Status)
 }
 

--- a/sdk/data/azcosmos/cosmos_client_retry_policy.go
+++ b/sdk/data/azcosmos/cosmos_client_retry_policy.go
@@ -41,10 +41,15 @@ func (p *clientRetryPolicy) Do(req *policy.Request) (*http.Response, error) {
 		// Update the retry context with the latest retry values
 		req.SetOperationValue(retryContext)
 		resolvedEndpoint := p.gem.ResolveServiceEndpoint(retryContext.retryCount, o.resourceType, o.isWriteOperation, retryContext.useWriteEndpoint)
+		regionName := p.gem.GetEndpointLocation(resolvedEndpoint)
 		req.Raw().Host = resolvedEndpoint.Host
 		req.Raw().URL.Host = resolvedEndpoint.Host
+		attemptStartTime := time.Now().UTC()
 		response, err := req.Next() // err can happen in weird scenarios (connectivity, etc)
 		if err != nil {
+			if state := requestDiagnosticsStateFromContext(req.Raw().Context()); state != nil && state.clientSideStats != nil {
+				state.clientSideStats.recordHTTPError(attemptStartTime, req.Raw(), err, o.resourceType, regionName)
+			}
 			if p.isNetworkConnectionError(err) {
 				shouldRetry, errRetry := p.attemptRetryOnNetworkError(req, &retryContext)
 				if errRetry != nil {
@@ -61,6 +66,9 @@ func (p *clientRetryPolicy) Do(req *policy.Request) (*http.Response, error) {
 				continue
 			}
 			return nil, err
+		}
+		if state := requestDiagnosticsStateFromContext(req.Raw().Context()); state != nil && state.clientSideStats != nil {
+			state.clientSideStats.recordHTTPResponse(attemptStartTime, response, o.resourceType, regionName)
 		}
 		subStatus := response.Header.Get(cosmosHeaderSubstatus)
 		if p.shouldRetryStatus(response.StatusCode, subStatus) {

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -480,7 +480,8 @@ func (c *ContainerClient) ReadManyItems(
 		resourceAddress: c.link,
 	}
 
-	ctx = ensureOperationTrace(ctx, fmt.Sprintf("read_many_items %s", c.id))
+	ctx, endTrace := ensureOperationTrace(ctx, fmt.Sprintf("read_many_items %s", c.id))
+	defer endTrace()
 
 	response, err := c.executeReadManyWithQueries(ctx, itemIdentities, readManyOptions, operationContext)
 	if err != nil {

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -63,7 +63,7 @@ func (c *ContainerClient) Read(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadContainerOptions{}
@@ -105,7 +105,7 @@ func (c *ContainerClient) Replace(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReplaceContainerOptions{}
@@ -148,7 +148,7 @@ func (c *ContainerClient) Delete(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteContainerOptions{}
@@ -190,7 +190,7 @@ func (c *ContainerClient) ReadThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -219,7 +219,7 @@ func (c *ContainerClient) ReplaceThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -250,7 +250,7 @@ func (c *ContainerClient) CreateItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -303,7 +303,7 @@ func (c *ContainerClient) UpsertItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -362,7 +362,7 @@ func (c *ContainerClient) ReplaceItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -415,7 +415,7 @@ func (c *ContainerClient) ReadItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -480,7 +480,15 @@ func (c *ContainerClient) ReadManyItems(
 		resourceAddress: c.link,
 	}
 
-	return c.executeReadManyWithQueries(ctx, itemIdentities, readManyOptions, operationContext)
+	ctx = ensureOperationTrace(ctx, fmt.Sprintf("read_many_items %s", c.id))
+
+	response, err := c.executeReadManyWithQueries(ctx, itemIdentities, readManyOptions, operationContext)
+	if err != nil {
+		return ReadManyItemsResponse{}, err
+	}
+
+	response.Diagnostics = diagnosticsFromContext(ctx)
+	return response, nil
 }
 
 // GetFeedRanges retrieves all the feed ranges for which changefeed could be fetched.
@@ -520,7 +528,7 @@ func (c *ContainerClient) DeleteItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -615,7 +623,7 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 			if err != nil {
 				return QueryItemsResponse{}, err
 			}
-			ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+			ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
@@ -659,7 +667,7 @@ func (c *ContainerClient) PatchItem(
 	if err != nil {
 		return ItemResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	h := headerOptionsOverride{
 		partitionKey: &partitionKey,
@@ -711,7 +719,7 @@ func (c *ContainerClient) ExecuteTransactionalBatch(ctx context.Context, b Trans
 	if err != nil {
 		return TransactionalBatchResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if len(b.operations) == 0 {
 		return TransactionalBatchResponse{}, errors.New("no operations in batch")
@@ -807,7 +815,7 @@ func (c *ContainerClient) getChangeFeedForEPKRange(
 	if err != nil {
 		return ChangeFeedResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 
 	if options == nil {
@@ -885,7 +893,7 @@ func (c *ContainerClient) getPartitionKeyRanges(ctx context.Context, o *partitio
 	if err != nil {
 		return partitionKeyRangeResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, c.database.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 
 	operationContext := pipelineRequestOptions{

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -481,9 +481,8 @@ func (c *ContainerClient) ReadManyItems(
 	}
 
 	ctx, endTrace := ensureOperationTrace(ctx, fmt.Sprintf("read_many_items %s", c.id))
-	defer endTrace()
-
 	response, err := c.executeReadManyWithQueries(ctx, itemIdentities, readManyOptions, operationContext)
+	endTrace()
 	if err != nil {
 		return ReadManyItemsResponse{}, err
 	}

--- a/sdk/data/azcosmos/cosmos_container_response.go
+++ b/sdk/data/azcosmos/cosmos_container_response.go
@@ -23,7 +23,7 @@ func newContainerResponse(resp *http.Response) (ContainerResponse, error) {
 	properties := &ContainerProperties{}
 	err := azruntime.UnmarshalAsJSON(resp, properties)
 	if err != nil {
-		return response, err
+		return response, wrapResponseError(err, response.Response)
 	}
 	response.ContainerProperties = properties
 	return response, nil

--- a/sdk/data/azcosmos/cosmos_database.go
+++ b/sdk/data/azcosmos/cosmos_database.go
@@ -55,7 +55,7 @@ func (db *DatabaseClient) CreateContainer(
 	if err != nil {
 		return ContainerResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &CreateContainerOptions{}
@@ -119,7 +119,7 @@ func (c *DatabaseClient) NewQueryContainersPager(query string, o *QueryContainer
 			if err != nil {
 				return QueryContainersResponse{}, err
 			}
-			ctx, endSpan := runtime.StartSpan(ctx, spanName.name, c.client.internal.Tracer(), &spanName.options)
+			ctx, endSpan := startSpan(ctx, spanName.name, c.client.internal.Tracer(), &spanName.options)
 			defer func() { endSpan(err) }()
 			if page != nil {
 				if page.ContinuationToken != nil {
@@ -157,7 +157,7 @@ func (db *DatabaseClient) Read(
 	if err != nil {
 		return DatabaseResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ReadDatabaseOptions{}
@@ -198,7 +198,7 @@ func (db *DatabaseClient) ReadThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -227,7 +227,7 @@ func (db *DatabaseClient) ReplaceThroughput(
 	if err != nil {
 		return ThroughputResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &ThroughputOptions{}
@@ -254,7 +254,7 @@ func (db *DatabaseClient) Delete(
 	if err != nil {
 		return DatabaseResponse{}, err
 	}
-	ctx, endSpan := runtime.StartSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
+	ctx, endSpan := startSpan(ctx, spanName.name, db.client.internal.Tracer(), &spanName.options)
 	defer func() { endSpan(err) }()
 	if o == nil {
 		o = &DeleteDatabaseOptions{}

--- a/sdk/data/azcosmos/cosmos_database_response.go
+++ b/sdk/data/azcosmos/cosmos_database_response.go
@@ -23,7 +23,7 @@ func newDatabaseResponse(resp *http.Response) (DatabaseResponse, error) {
 	properties := &DatabaseProperties{}
 	err := azruntime.UnmarshalAsJSON(resp, properties)
 	if err != nil {
-		return response, err
+		return response, wrapResponseError(err, response.Response)
 	}
 	response.DatabaseProperties = properties
 	return response, nil

--- a/sdk/data/azcosmos/cosmos_item_response.go
+++ b/sdk/data/azcosmos/cosmos_item_response.go
@@ -29,7 +29,7 @@ func newItemResponse(resp *http.Response) (ItemResponse, error) {
 	defer func() { _ = resp.Body.Close() }()
 	body, err := azruntime.Payload(resp)
 	if err != nil {
-		return response, err
+		return response, wrapResponseError(err, response.Response)
 	}
 	response.Value = body
 	return response, nil

--- a/sdk/data/azcosmos/cosmos_offers.go
+++ b/sdk/data/azcosmos/cosmos_offers.go
@@ -52,7 +52,7 @@ func (c cosmosOffers) ReadThroughputIfExists(
 		return ThroughputResponse{}, err
 	}
 
-	queryRequestCharge := newResponse(azResponse).RequestCharge
+	queryRequestCharge := readRequestCharge(azResponse)
 	if len(theOffers.Offers) == 0 {
 		azResponse.StatusCode = http.StatusNotFound
 		azResponse.Header.Add(cosmosHeaderRequestCharge, fmt.Sprint(queryRequestCharge))

--- a/sdk/data/azcosmos/cosmos_partition_key_range_response.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_response.go
@@ -35,11 +35,11 @@ func newPartitionKeyRangeResponse(resp *http.Response) (partitionKeyRangeRespons
 
 	body, err := azruntime.Payload(resp)
 	if err != nil {
-		return response, err
+		return response, wrapResponseError(err, response.Response)
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {
-		return response, err
+		return response, wrapResponseError(err, response.Response)
 	}
 
 	return response, nil

--- a/sdk/data/azcosmos/cosmos_query_response.go
+++ b/sdk/data/azcosmos/cosmos_query_response.go
@@ -45,14 +45,14 @@ func newQueryResponse(resp *http.Response) (QueryItemsResponse, error) {
 
 	result := queryServiceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return QueryItemsResponse{}, err
+		return response, wrapResponseError(err, response.Response)
 	}
 
 	marshalledValue := make([][]byte, 0)
 	for _, e := range result.Documents {
 		m, err := json.Marshal(e)
 		if err != nil {
-			return QueryItemsResponse{}, err
+			return response, wrapResponseError(err, response.Response)
 		}
 		marshalledValue = append(marshalledValue, m)
 	}
@@ -86,7 +86,7 @@ func newContainersQueryResponse(resp *http.Response) (QueryContainersResponse, e
 	}
 	result := queryContainersServiceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return QueryContainersResponse{}, err
+		return response, wrapResponseError(err, response.Response)
 	}
 
 	response.Containers = result.Containers
@@ -120,7 +120,7 @@ func newDatabasesQueryResponse(resp *http.Response) (QueryDatabasesResponse, err
 
 	result := queryDatabasesServiceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return QueryDatabasesResponse{}, err
+		return response, wrapResponseError(err, response.Response)
 	}
 
 	response.Databases = result.Databases

--- a/sdk/data/azcosmos/cosmos_query_response.go
+++ b/sdk/data/azcosmos/cosmos_query_response.go
@@ -36,6 +36,7 @@ func newQueryResponse(resp *http.Response) (QueryItemsResponse, error) {
 	queryMetrics := resp.Header.Get(cosmosHeaderQueryMetrics)
 	if queryMetrics != "" {
 		response.QueryMetrics = &queryMetrics
+		recordQueryMetricsFromResponse(resp)
 	}
 	queryIndexUtilization := resp.Header.Get(cosmosHeaderIndexUtilization)
 	if queryIndexUtilization != "" {
@@ -135,6 +136,8 @@ type queryDatabasesServiceResponse struct {
 type ReadManyItemsResponse struct {
 	// The total cost of the operation in RUs
 	RequestCharge float32
+	// Diagnostics contains request diagnostics for the operation.
+	Diagnostics Diagnostics
 	// List of items.
 	Items [][]byte
 }

--- a/sdk/data/azcosmos/cosmos_query_response.go
+++ b/sdk/data/azcosmos/cosmos_query_response.go
@@ -25,18 +25,21 @@ type QueryItemsResponse struct {
 }
 
 func newQueryResponse(resp *http.Response) (QueryItemsResponse, error) {
+	continuationToken := resp.Header.Get(cosmosHeaderContinuationToken)
+	queryMetrics := resp.Header.Get(cosmosHeaderQueryMetrics)
+	if queryMetrics != "" {
+		recordQueryMetricsFromResponse(resp)
+	}
+
 	response := QueryItemsResponse{
 		Response: newResponse(resp),
 	}
 
-	continuationToken := resp.Header.Get(cosmosHeaderContinuationToken)
 	if continuationToken != "" {
 		response.ContinuationToken = &continuationToken
 	}
-	queryMetrics := resp.Header.Get(cosmosHeaderQueryMetrics)
 	if queryMetrics != "" {
 		response.QueryMetrics = &queryMetrics
-		recordQueryMetricsFromResponse(resp)
 	}
 	queryIndexUtilization := resp.Header.Get(cosmosHeaderIndexUtilization)
 	if queryIndexUtilization != "" {

--- a/sdk/data/azcosmos/cosmos_response.go
+++ b/sdk/data/azcosmos/cosmos_response.go
@@ -21,6 +21,8 @@ type Response struct {
 	ActivityID string
 	// ETag contains the value from the ETag header.
 	ETag azcore.ETag
+	// Diagnostics contains request diagnostics for the operation.
+	Diagnostics Diagnostics
 }
 
 func newResponse(resp *http.Response) Response {
@@ -29,6 +31,7 @@ func newResponse(resp *http.Response) Response {
 	response.RequestCharge = response.readRequestCharge()
 	response.ActivityID = resp.Header.Get(cosmosHeaderActivityId)
 	response.ETag = azcore.ETag(resp.Header.Get(cosmosHeaderEtag))
+	response.Diagnostics = diagnosticsFromResponse(resp)
 	return response
 }
 

--- a/sdk/data/azcosmos/cosmos_response.go
+++ b/sdk/data/azcosmos/cosmos_response.go
@@ -28,15 +28,19 @@ type Response struct {
 func newResponse(resp *http.Response) Response {
 	response := Response{}
 	response.RawResponse = resp
-	response.RequestCharge = response.readRequestCharge()
+	response.RequestCharge = readRequestCharge(resp)
 	response.ActivityID = resp.Header.Get(cosmosHeaderActivityId)
 	response.ETag = azcore.ETag(resp.Header.Get(cosmosHeaderEtag))
 	response.Diagnostics = diagnosticsFromResponse(resp)
 	return response
 }
 
-func (c *Response) readRequestCharge() float32 {
-	requestChargeString := c.RawResponse.Header.Get(cosmosHeaderRequestCharge)
+func readRequestCharge(resp *http.Response) float32 {
+	if resp == nil {
+		return 0
+	}
+
+	requestChargeString := resp.Header.Get(cosmosHeaderRequestCharge)
 	if requestChargeString == "" {
 		return 0
 	}

--- a/sdk/data/azcosmos/cosmos_transactional_batch_response.go
+++ b/sdk/data/azcosmos/cosmos_transactional_batch_response.go
@@ -36,7 +36,7 @@ func newTransactionalBatchResponse(resp *http.Response) (TransactionalBatchRespo
 	response.Success = resp.StatusCode != http.StatusMultiStatus
 
 	if err := runtime.UnmarshalAsJSON(resp, &response.OperationResults); err != nil {
-		return TransactionalBatchResponse{}, err
+		return response, wrapResponseError(err, response.Response)
 	}
 
 	return response, nil

--- a/sdk/data/azcosmos/diagnostics.go
+++ b/sdk/data/azcosmos/diagnostics.go
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// Diagnostics contains request diagnostics for an Azure Cosmos DB operation.
+// The diagnostics string is materialized lazily when String is called.
+type Diagnostics struct {
+	root *trace
+}
+
+func newDiagnostics(t *trace) Diagnostics {
+	if t == nil {
+		return Diagnostics{}
+	}
+
+	return Diagnostics{root: t.root()}
+}
+
+// String returns the lazily materialized diagnostics payload.
+func (d Diagnostics) String() string {
+	if d.root == nil {
+		return ""
+	}
+
+	d.root.setWalkingStateRecursively()
+	return writeTraceJSON(d.root)
+}
+
+// ClientElapsedTime returns the end-to-end duration of the request.
+func (d Diagnostics) ClientElapsedTime() time.Duration {
+	if d.root == nil {
+		return 0
+	}
+
+	return d.root.duration()
+}
+
+// StartTimeUTC returns the UTC start time of the request.
+func (d Diagnostics) StartTimeUTC() *time.Time {
+	if d.root == nil {
+		return nil
+	}
+
+	snapshot := d.root.snapshot()
+	start := snapshot.startTime
+	return &start
+}
+
+// FailedRequestCount returns the number of failed backend attempts recorded for the request.
+func (d Diagnostics) FailedRequestCount() int {
+	if d.root == nil || d.root.summary == nil {
+		return 0
+	}
+
+	return d.root.summary.failedCount()
+}
+
+// DiagnosticsFromError extracts diagnostics from an operation error, if present.
+func DiagnosticsFromError(err error) (Diagnostics, bool) {
+	if err == nil {
+		return Diagnostics{}, false
+	}
+
+	var reqErr *requestError
+	if errors.As(err, &reqErr) {
+		return reqErr.diagnostics, reqErr.diagnostics.root != nil
+	}
+
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) && responseErr.RawResponse != nil {
+		diagnostics := diagnosticsFromResponse(responseErr.RawResponse)
+		return diagnostics, diagnostics.root != nil
+	}
+
+	return Diagnostics{}, false
+}
+
+func diagnosticsFromResponse(resp *http.Response) Diagnostics {
+	if resp == nil || resp.Request == nil {
+		return Diagnostics{}
+	}
+
+	state := requestDiagnosticsStateFromContext(resp.Request.Context())
+	if state != nil {
+		return newDiagnostics(state.requestTrace)
+	}
+
+	return diagnosticsFromContext(resp.Request.Context())
+}
+
+type requestError struct {
+	cause       error
+	diagnostics Diagnostics
+}
+
+func (e *requestError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *requestError) Unwrap() error {
+	return e.cause
+}
+
+func wrapRequestError(err error, diagnostics Diagnostics) error {
+	if err == nil || diagnostics.root == nil {
+		return err
+	}
+
+	return &requestError{
+		cause:       err,
+		diagnostics: diagnostics,
+	}
+}

--- a/sdk/data/azcosmos/diagnostics.go
+++ b/sdk/data/azcosmos/diagnostics.go
@@ -120,3 +120,7 @@ func wrapRequestError(err error, diagnostics Diagnostics) error {
 		diagnostics: diagnostics,
 	}
 }
+
+func wrapResponseError(err error, response Response) error {
+	return wrapRequestError(err, response.Diagnostics)
+}

--- a/sdk/data/azcosmos/diagnostics.go
+++ b/sdk/data/azcosmos/diagnostics.go
@@ -12,9 +12,10 @@ import (
 )
 
 // Diagnostics contains request diagnostics for an Azure Cosmos DB operation.
-// The diagnostics string is materialized lazily when String is called.
+// The diagnostics string is materialized lazily when String is called from immutable finalized state.
 type Diagnostics struct {
-	root *trace
+	root               *finalizedTrace
+	failedRequestCount int
 }
 
 func newDiagnostics(t *trace) Diagnostics {
@@ -22,7 +23,20 @@ func newDiagnostics(t *trace) Diagnostics {
 		return Diagnostics{}
 	}
 
-	return Diagnostics{root: t.root()}
+	root := t.root()
+	if root == nil {
+		return Diagnostics{}
+	}
+
+	failedRequestCount := 0
+	if root.summary != nil {
+		failedRequestCount = root.summary.failedCount()
+	}
+
+	return Diagnostics{
+		root:               root.finalize(time.Now().UTC()),
+		failedRequestCount: failedRequestCount,
+	}
 }
 
 // String returns the lazily materialized diagnostics payload.
@@ -31,17 +45,16 @@ func (d Diagnostics) String() string {
 		return ""
 	}
 
-	d.root.setWalkingStateRecursively()
 	return writeTraceJSON(d.root)
 }
 
 // ClientElapsedTime returns the end-to-end duration of the request.
 func (d Diagnostics) ClientElapsedTime() time.Duration {
-	if d.root == nil {
+	if d.root == nil || d.root.endTime == nil {
 		return 0
 	}
 
-	return d.root.duration()
+	return d.root.endTime.Sub(d.root.startTime)
 }
 
 // StartTimeUTC returns the UTC start time of the request.
@@ -50,18 +63,17 @@ func (d Diagnostics) StartTimeUTC() *time.Time {
 		return nil
 	}
 
-	snapshot := d.root.snapshot()
-	start := snapshot.startTime
+	start := d.root.startTime
 	return &start
 }
 
 // FailedRequestCount returns the number of failed backend attempts recorded for the request.
 func (d Diagnostics) FailedRequestCount() int {
-	if d.root == nil || d.root.summary == nil {
+	if d.root == nil {
 		return 0
 	}
 
-	return d.root.summary.failedCount()
+	return d.failedRequestCount
 }
 
 // DiagnosticsFromError extracts diagnostics from an operation error, if present.

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiagnosticsSummaryIncludesRetriedGatewayCalls(t *testing.T) {
+	rootTrace := newRootTrace("test_operation")
+	requestTrace := rootTrace.StartChild(traceDatumKeyTransportRequest)
+	clientStats := newClientSideRequestStatisticsTraceDatum(time.Now().UTC(), requestTrace)
+	requestTrace.AddDatum(traceDatumKeyClientSideRequestStats, clientStats)
+	requestTrace.AddDatum(traceDatumKeyPointOperationStatistics, pointOperationStatisticsTraceDatum{
+		ActivityID:      "activity-2",
+		ResponseTimeUTC: time.Now().UTC(),
+		StatusCode:      http.StatusOK,
+		RequestCharge:   2.5,
+		RequestURI:      "https://example.com/dbs/test",
+		BELatencyInMs:   "12",
+	})
+
+	req503, err := http.NewRequest(http.MethodGet, "https://example.com/dbs/test", nil)
+	require.NoError(t, err)
+	resp503 := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Header: http.Header{
+			cosmosHeaderActivityId:    []string{"activity-1"},
+			cosmosHeaderRequestCharge: []string{"1.5"},
+		},
+		Request: req503,
+	}
+	clientStats.recordHTTPResponse(time.Now().Add(-20*time.Millisecond), resp503, resourceTypeDatabase, "local")
+
+	req200, err := http.NewRequest(http.MethodGet, "https://example.com/dbs/test", nil)
+	require.NoError(t, err)
+	resp200 := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			cosmosHeaderActivityId:    []string{"activity-2"},
+			cosmosHeaderRequestCharge: []string{"2.5"},
+			cosmosHeaderSessionToken:  []string{"response-session"},
+		},
+		Request: req200,
+	}
+	clientStats.recordHTTPResponse(time.Now().Add(-10*time.Millisecond), resp200, resourceTypeDatabase, "local")
+
+	requestTrace.End()
+	rootTrace.End()
+
+	diagnosticsPayload := newDiagnostics(requestTrace).String()
+	require.NotEmpty(t, diagnosticsPayload)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(diagnosticsPayload), &parsed))
+
+	summary := parsed["Summary"].(map[string]any)
+	gatewayCalls := summary["GatewayCalls"].(map[string]any)
+	require.Equal(t, float64(1), gatewayCalls["(200, 0)"])
+	require.Equal(t, float64(1), gatewayCalls["(503, 0)"])
+	require.Equal(t, float64(1), summary["RegionsContacted"])
+
+	children := parsed["children"].([]any)
+	require.Len(t, children, 1)
+
+	child := children[0].(map[string]any)
+	data := child["data"].(map[string]any)
+	require.Contains(t, data, traceDatumKeyClientSideRequestStats)
+	require.Contains(t, data, traceDatumKeyPointOperationStatistics)
+}
+
+func TestDiagnosticsFromErrorReturnsResponseDiagnostics(t *testing.T) {
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusNotFound),
+		mock.WithHeader(cosmosHeaderActivityId, "activity-404"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "3.25"),
+	)
+
+	client := newTestDiagnosticsClient(t, srv, false)
+	operationContext := pipelineRequestOptions{
+		resourceType:    resourceTypeDatabase,
+		resourceAddress: "",
+	}
+
+	_, err := client.sendGetRequest("/", context.Background(), operationContext, &ReadContainerOptions{}, nil)
+	require.Error(t, err)
+
+	var responseErr *azcore.ResponseError
+	require.True(t, errors.As(err, &responseErr))
+
+	diagnostics, ok := DiagnosticsFromError(err)
+	require.True(t, ok)
+	require.NotEmpty(t, diagnostics.String())
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(diagnostics.String()), &parsed))
+
+	data := parsed["data"].(map[string]any)
+	pointStats := data[traceDatumKeyPointOperationStatistics].(map[string]any)
+	require.Equal(t, float64(http.StatusNotFound), pointStats["StatusCode"])
+}
+
+func TestQueryResponseDiagnosticsIncludeQueryMetrics(t *testing.T) {
+	queryResponseRaw := map[string][]map[string]string{
+		"Documents": {
+			{"id": "id1"},
+		},
+	}
+
+	jsonString, err := json.Marshal(queryResponseRaw)
+	require.NoError(t, err)
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	srv.SetResponse(
+		mock.WithBody(jsonString),
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithHeader(cosmosHeaderActivityId, "query-activity"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "5.5"),
+		mock.WithHeader(cosmosHeaderQueryMetrics, "retrievedDocumentCount=1"),
+	)
+
+	client := newTestDiagnosticsClient(t, srv, false)
+	operationContext := pipelineRequestOptions{
+		resourceType:    resourceTypeDocument,
+		resourceAddress: "dbs/test/colls/test",
+	}
+
+	resp, err := client.sendQueryRequest("/", context.Background(), "SELECT * FROM c", nil, operationContext, &QueryOptions{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	parsedResponse, err := newQueryResponse(resp)
+	require.NoError(t, err)
+	require.NotNil(t, parsedResponse.QueryMetrics)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(parsedResponse.Diagnostics.String()), &parsed))
+
+	data := parsed["data"].(map[string]any)
+	require.Equal(t, "retrievedDocumentCount=1", data[traceDatumKeyQueryMetrics])
+}
+
+func newTestDiagnosticsClient(t *testing.T, transport policy.Transporter, withRetryPolicy bool) *Client {
+	t.Helper()
+
+	serverURL := transport.(*mock.Server).URL()
+	endpointURL, err := url.Parse(serverURL)
+	require.NoError(t, err)
+
+	gem := &globalEndpointManager{
+		preferredLocations: []string{"local"},
+		locationCache:      newLocationCache([]string{"local"}, *endpointURL, true),
+	}
+
+	pipelineOptions := azruntime.PipelineOptions{}
+	if withRetryPolicy {
+		pipelineOptions.PerRetry = []policy.Policy{
+			&clientRetryPolicy{gem: gem},
+		}
+	}
+
+	internalClient, err := azcore.NewClient("azcosmostest", "v1.0.0", pipelineOptions, &policy.ClientOptions{Transport: transport})
+	require.NoError(t, err)
+
+	return &Client{
+		endpoint:    serverURL,
+		endpointUrl: endpointURL,
+		internal:    internalClient,
+		gem:         gem,
+	}
+}

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -573,7 +573,7 @@ func TestReadManyItemsDiagnosticsAreStableAfterReturn(t *testing.T) {
 
 	firstDuration := resp.Diagnostics.ClientElapsedTime()
 	firstPayload := resp.Diagnostics.String()
-	require.Greater(t, firstDuration, time.Duration(0))
+	require.NotNil(t, resp.Diagnostics.root.endTime)
 	require.NotEmpty(t, firstPayload)
 
 	time.Sleep(20 * time.Millisecond)

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -158,6 +158,114 @@ func TestQueryResponseDiagnosticsIncludeQueryMetrics(t *testing.T) {
 	require.Equal(t, "retrievedDocumentCount=1", data[traceDatumKeyQueryMetrics])
 }
 
+func TestDiagnosticsFromErrorReturnsQueryParseDiagnostics(t *testing.T) {
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	srv.SetResponse(
+		mock.WithBody([]byte(`{"Documents":[`)),
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithHeader(cosmosHeaderActivityId, "query-activity"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "5.5"),
+	)
+
+	client := newTestDiagnosticsClient(t, srv, false)
+	operationContext := pipelineRequestOptions{
+		resourceType:    resourceTypeDocument,
+		resourceAddress: "dbs/test/colls/test",
+	}
+
+	resp, err := client.sendQueryRequest("/", context.Background(), "SELECT * FROM c", nil, operationContext, &QueryOptions{}, nil)
+	require.NoError(t, err)
+
+	_, err = newQueryResponse(resp)
+	require.Error(t, err)
+
+	diagnostics, ok := DiagnosticsFromError(err)
+	require.True(t, ok)
+	require.NotEmpty(t, diagnostics.String())
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(diagnostics.String()), &parsed))
+
+	data := parsed["data"].(map[string]any)
+	pointStats := data[traceDatumKeyPointOperationStatistics].(map[string]any)
+	require.Equal(t, float64(http.StatusOK), pointStats["StatusCode"])
+	require.Equal(t, float64(5.5), pointStats["RequestCharge"])
+}
+
+func TestReadManyItemsDiagnosticsAreStableAfterReturn(t *testing.T) {
+	containerBody, err := json.Marshal(ContainerProperties{
+		ID: "testcontainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths: []string{"/pk"},
+		},
+	})
+	require.NoError(t, err)
+
+	rangeBody, err := json.Marshal(partitionKeyRangeResponse{
+		PartitionKeyRanges: []partitionKeyRange{
+			{
+				ID:           "0",
+				MinInclusive: "",
+				MaxExclusive: "",
+			},
+		},
+		Count: 1,
+	})
+	require.NoError(t, err)
+
+	queryBody, err := json.Marshal(map[string][]map[string]string{
+		"Documents": {
+			{"id": "item1", "pk": "pk1"},
+		},
+	})
+	require.NoError(t, err)
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	srv.AppendResponse(
+		mock.WithBody(containerBody),
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithHeader(cosmosHeaderActivityId, "container-read"),
+	)
+	srv.AppendResponse(
+		mock.WithBody(rangeBody),
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithHeader(cosmosHeaderActivityId, "range-read"),
+	)
+	srv.AppendResponse(
+		mock.WithBody(queryBody),
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithHeader(cosmosHeaderActivityId, "query-read"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "1.5"),
+	)
+
+	container := newTestDiagnosticsContainer(t, srv, false)
+
+	resp, err := container.ReadManyItems(context.Background(), []ItemIdentity{
+		{
+			ID:           "item1",
+			PartitionKey: NewPartitionKeyString("pk1"),
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+
+	firstDuration := resp.Diagnostics.ClientElapsedTime()
+	firstPayload := resp.Diagnostics.String()
+	require.Greater(t, firstDuration, time.Duration(0))
+	require.NotEmpty(t, firstPayload)
+
+	time.Sleep(20 * time.Millisecond)
+
+	secondDuration := resp.Diagnostics.ClientElapsedTime()
+	secondPayload := resp.Diagnostics.String()
+	require.Equal(t, firstDuration, secondDuration)
+	require.Equal(t, firstPayload, secondPayload)
+}
+
 func newTestDiagnosticsClient(t *testing.T, transport policy.Transporter, withRetryPolicy bool) *Client {
 	t.Helper()
 
@@ -186,4 +294,18 @@ func newTestDiagnosticsClient(t *testing.T, transport policy.Transporter, withRe
 		internal:    internalClient,
 		gem:         gem,
 	}
+}
+
+func newTestDiagnosticsContainer(t *testing.T, transport policy.Transporter, withRetryPolicy bool) *ContainerClient {
+	t.Helper()
+
+	client := newTestDiagnosticsClient(t, transport, withRetryPolicy)
+
+	database, err := newDatabase("testdb", client)
+	require.NoError(t, err)
+
+	container, err := database.NewContainer("testcontainer")
+	require.NoError(t, err)
+
+	return container
 }

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -4,6 +4,7 @@
 package azcosmos
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -82,6 +83,125 @@ func TestDiagnosticsSummaryIncludesRetriedGatewayCalls(t *testing.T) {
 	require.Contains(t, data, traceDatumKeyPointOperationStatistics)
 }
 
+func TestDiagnosticsStringRendersSampleGatewayJSON(t *testing.T) {
+	rootTrace := newFixedTrace("sample_operation", fixedDiagnosticsTime(0), fixedDiagnosticsTime(100*time.Millisecond), nil)
+	requestTrace := newFixedTrace(traceDatumKeyTransportRequest, fixedDiagnosticsTime(5*time.Millisecond), fixedDiagnosticsTime(95*time.Millisecond), rootTrace)
+
+	requestTrace.AddDatum(traceDatumKeyClientSideRequestStats, &clientSideRequestStatisticsTraceDatum{
+		trace:               requestTrace,
+		requestStartTimeUTC: fixedDiagnosticsTime(5 * time.Millisecond),
+		requestEndTimeUTC:   timePtr(fixedDiagnosticsTime(24 * time.Millisecond)),
+		regionsContacted: []contactedRegion{
+			{name: "local", uri: "https://example.com/dbs/test"},
+		},
+		regionsContactedByURI: map[string]struct{}{
+			"https://example.com/dbs/test": {},
+		},
+		httpResponseStatistics: []httpResponseStatistics{
+			{
+				startTimeUTC:   fixedDiagnosticsTime(10 * time.Millisecond),
+				duration:       3 * time.Millisecond,
+				requestURI:     "https://example.com/dbs/test",
+				resourceType:   resourceTypeDatabase,
+				httpMethod:     http.MethodGet,
+				activityID:     "activity-1",
+				statusCode:     http.StatusServiceUnavailable,
+				statusCodeText: "ServiceUnavailable",
+				reasonPhrase:   "Service Unavailable",
+			},
+			{
+				startTimeUTC:   fixedDiagnosticsTime(20 * time.Millisecond),
+				duration:       4 * time.Millisecond,
+				requestURI:     "https://example.com/dbs/test",
+				resourceType:   resourceTypeDatabase,
+				httpMethod:     http.MethodGet,
+				activityID:     "activity-2",
+				statusCode:     http.StatusOK,
+				statusCodeText: "OK",
+				reasonPhrase:   "OK",
+			},
+		},
+	})
+	requestTrace.AddDatum(traceDatumKeyPointOperationStatistics, pointOperationStatisticsTraceDatum{
+		ActivityID:      "activity-2",
+		ResponseTimeUTC: fixedDiagnosticsTime(25 * time.Millisecond),
+		StatusCode:      http.StatusOK,
+		RequestCharge:   2.5,
+		RequestURI:      "https://example.com/dbs/test",
+		BELatencyInMs:   "12",
+	})
+	rootTrace.summary.incrementFailedCount()
+
+	diagnostics := newDiagnostics(rootTrace)
+	require.Equal(t, 1, diagnostics.FailedRequestCount())
+	requireRenderedDiagnosticsJSON(t, `
+{
+  "Summary": {
+    "RegionsContacted": 1,
+    "GatewayCalls": {
+      "(200, 0)": 1,
+      "(503, 0)": 1
+    }
+  },
+  "name": "sample_operation",
+  "start datetime": "2024-01-02T03:04:05.000Z",
+  "duration in milliseconds": 100,
+  "children": [
+    {
+      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+      "duration in milliseconds": 90,
+      "data": {
+        "Client Side Request Stats": {
+          "Id": "AggregatedClientSideRequestStatistics",
+          "ContactedReplicas": [],
+          "RegionsContacted": [
+            "https://example.com/dbs/test"
+          ],
+          "FailedReplicas": [],
+          "AddressResolutionStatistics": [],
+          "StoreResponseStatistics": [],
+          "HttpResponseStats": [
+            {
+              "StartTimeUTC": "2024-01-02T03:04:05.0100000Z",
+              "DurationInMs": 3,
+              "RequestUri": "https://example.com/dbs/test",
+              "ResourceType": "Database",
+              "HttpMethod": "GET",
+              "ActivityId": "activity-1",
+              "StatusCode": "ServiceUnavailable",
+              "ReasonPhrase": "Service Unavailable"
+            },
+            {
+              "StartTimeUTC": "2024-01-02T03:04:05.0200000Z",
+              "DurationInMs": 4,
+              "RequestUri": "https://example.com/dbs/test",
+              "ResourceType": "Database",
+              "HttpMethod": "GET",
+              "ActivityId": "activity-2",
+              "StatusCode": "OK"
+            }
+          ]
+        },
+        "PointOperationStatisticsTraceDatum": {
+          "Id": "PointOperationStatistics",
+          "ActivityId": "activity-2",
+          "ResponseTimeUtc": "2024-01-02T03:04:05.0250000Z",
+          "StatusCode": 200,
+          "SubStatusCode": 0,
+          "RequestCharge": 2.5,
+          "RequestUri": "https://example.com/dbs/test",
+          "ErrorMessage": null,
+          "RequestSessionToken": null,
+          "ResponseSessionToken": null,
+          "BELatencyInMs": "12"
+        }
+      }
+    }
+  ]
+}
+`, diagnostics.String())
+}
+
 func TestDiagnosticsFromErrorReturnsResponseDiagnostics(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()
@@ -114,6 +234,53 @@ func TestDiagnosticsFromErrorReturnsResponseDiagnostics(t *testing.T) {
 	data := parsed["data"].(map[string]any)
 	pointStats := data[traceDatumKeyPointOperationStatistics].(map[string]any)
 	require.Equal(t, float64(http.StatusNotFound), pointStats["StatusCode"])
+}
+
+func TestDiagnosticsFromErrorRendersSampleJSON(t *testing.T) {
+	requestTrace := newFixedTrace(traceDatumKeyTransportRequest, fixedDiagnosticsTime(0), fixedDiagnosticsTime(40*time.Millisecond), nil)
+	requestTrace.AddDatum(traceDatumKeyPointOperationStatistics, pointOperationStatisticsTraceDatum{
+		ActivityID:      "missing-activity",
+		ResponseTimeUTC: fixedDiagnosticsTime(30 * time.Millisecond),
+		StatusCode:      http.StatusNotFound,
+		RequestCharge:   3.25,
+		RequestURI:      "https://example.com/dbs/test",
+		ErrorMessage:    "resource missing",
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/dbs/test", nil)
+	require.NoError(t, err)
+	req = req.WithContext(withRequestDiagnosticsState(context.Background(), &requestDiagnosticsState{
+		requestTrace: requestTrace,
+	}))
+
+	diagnostics, ok := DiagnosticsFromError(&azcore.ResponseError{
+		StatusCode:  http.StatusNotFound,
+		RawResponse: &http.Response{StatusCode: http.StatusNotFound, Request: req},
+	})
+	require.True(t, ok)
+	requireRenderedDiagnosticsJSON(t, `
+{
+  "Summary": {},
+  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+  "start datetime": "2024-01-02T03:04:05.000Z",
+  "duration in milliseconds": 40,
+  "data": {
+    "PointOperationStatisticsTraceDatum": {
+      "Id": "PointOperationStatistics",
+      "ActivityId": "missing-activity",
+      "ResponseTimeUtc": "2024-01-02T03:04:05.0300000Z",
+      "StatusCode": 404,
+      "SubStatusCode": 0,
+      "RequestCharge": 3.25,
+      "RequestUri": "https://example.com/dbs/test",
+      "ErrorMessage": "resource missing",
+      "RequestSessionToken": null,
+      "ResponseSessionToken": null,
+      "BELatencyInMs": null
+    }
+  }
+}
+`, diagnostics.String())
 }
 
 func TestQueryResponseDiagnosticsIncludeQueryMetrics(t *testing.T) {
@@ -156,6 +323,47 @@ func TestQueryResponseDiagnosticsIncludeQueryMetrics(t *testing.T) {
 
 	data := parsed["data"].(map[string]any)
 	require.Equal(t, "retrievedDocumentCount=1", data[traceDatumKeyQueryMetrics])
+}
+
+func TestDiagnosticsStringRendersSampleQueryMetricsJSON(t *testing.T) {
+	rootTrace := newFixedTrace("sample_query", fixedDiagnosticsTime(0), fixedDiagnosticsTime(50*time.Millisecond), nil)
+	rootTrace.AddDatum(traceDatumKeyPointOperationStatistics, pointOperationStatisticsTraceDatum{
+		ActivityID:           "query-activity",
+		ResponseTimeUTC:      fixedDiagnosticsTime(20 * time.Millisecond),
+		StatusCode:           http.StatusOK,
+		RequestCharge:        5.5,
+		RequestURI:           "https://example.com/dbs/test/colls/test",
+		RequestSessionToken:  "request-session",
+		ResponseSessionToken: "response-session",
+		BELatencyInMs:        "7",
+	})
+	rootTrace.AddDatum(traceDatumKeyQueryMetrics, "retrievedDocumentCount=1")
+
+	diagnostics := newDiagnostics(rootTrace)
+	requireRenderedDiagnosticsJSON(t, `
+{
+  "Summary": {},
+  "name": "sample_query",
+  "start datetime": "2024-01-02T03:04:05.000Z",
+  "duration in milliseconds": 50,
+  "data": {
+    "PointOperationStatisticsTraceDatum": {
+      "Id": "PointOperationStatistics",
+      "ActivityId": "query-activity",
+      "ResponseTimeUtc": "2024-01-02T03:04:05.0200000Z",
+      "StatusCode": 200,
+      "SubStatusCode": 0,
+      "RequestCharge": 5.5,
+      "RequestUri": "https://example.com/dbs/test/colls/test",
+      "ErrorMessage": null,
+      "RequestSessionToken": "request-session",
+      "ResponseSessionToken": "response-session",
+      "BELatencyInMs": "7"
+    },
+    "Query Metrics": "retrievedDocumentCount=1"
+  }
+}
+`, diagnostics.String())
 }
 
 func TestDiagnosticsFromErrorReturnsQueryParseDiagnostics(t *testing.T) {
@@ -308,4 +516,41 @@ func newTestDiagnosticsContainer(t *testing.T, transport policy.Transporter, wit
 	require.NoError(t, err)
 
 	return container
+}
+
+func fixedDiagnosticsTime(offset time.Duration) time.Time {
+	return time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC).Add(offset)
+}
+
+func newFixedTrace(name string, start, end time.Time, parent *trace) *trace {
+	endUTC := end.UTC()
+	fixedTrace := &trace{
+		name:      name,
+		startTime: start.UTC(),
+		endTime:   &endUTC,
+		parent:    parent,
+		children:  []*trace{},
+	}
+
+	if parent != nil {
+		fixedTrace.summary = parent.summary
+		parent.AddChild(fixedTrace)
+	} else {
+		fixedTrace.summary = &traceSummary{}
+	}
+
+	return fixedTrace
+}
+
+func timePtr(value time.Time) *time.Time {
+	value = value.UTC()
+	return &value
+}
+
+func requireRenderedDiagnosticsJSON(t *testing.T, expected string, actual string) {
+	t.Helper()
+
+	var compact bytes.Buffer
+	require.NoError(t, json.Compact(&compact, []byte(expected)))
+	require.Equal(t, compact.String(), actual)
 }

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -570,6 +570,68 @@ func TestReadManyItemsDiagnosticsAreStableAfterReturn(t *testing.T) {
 	require.Equal(t, firstPayload, secondPayload)
 }
 
+func TestReadManyItemsErrorPreservesDiagnostics(t *testing.T) {
+	containerBody, err := json.Marshal(ContainerProperties{
+		ID: "testcontainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths: []string{"/pk"},
+		},
+	})
+	require.NoError(t, err)
+
+	rangeBody, err := json.Marshal(partitionKeyRangeResponse{
+		PartitionKeyRanges: []partitionKeyRange{
+			{
+				ID:           "0",
+				MinInclusive: "",
+				MaxExclusive: "",
+			},
+		},
+		Count: 1,
+	})
+	require.NoError(t, err)
+
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	srv.AppendResponse(
+		mock.WithBody(containerBody),
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithHeader(cosmosHeaderActivityId, "container-read"),
+	)
+	srv.AppendResponse(
+		mock.WithBody(rangeBody),
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithHeader(cosmosHeaderActivityId, "range-read"),
+	)
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{"Documents":[`)),
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithHeader(cosmosHeaderActivityId, "query-read"),
+		mock.WithHeader(cosmosHeaderRequestCharge, "1.5"),
+	)
+
+	container := newTestDiagnosticsContainer(t, srv, false)
+
+	_, err = container.ReadManyItems(context.Background(), []ItemIdentity{
+		{
+			ID:           "item1",
+			PartitionKey: NewPartitionKeyString("pk1"),
+		},
+	}, nil)
+	require.Error(t, err)
+
+	diagnostics, ok := DiagnosticsFromError(err)
+	require.True(t, ok)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(diagnostics.String()), &parsed))
+	require.Equal(t, "read_many_items testcontainer", parsed["name"])
+
+	children := parsed["children"].([]any)
+	require.NotEmpty(t, children)
+}
+
 func newTestDiagnosticsClient(t *testing.T, transport policy.Transporter, withRetryPolicy bool) *Client {
 	t.Helper()
 

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -518,7 +518,10 @@ func TestReadManyItemsDiagnosticsAreStableAfterReturn(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rangeBody, err := json.Marshal(partitionKeyRangeResponse{
+	rangeBody, err := json.Marshal(struct {
+		PartitionKeyRanges []partitionKeyRange `json:"PartitionKeyRanges"`
+		Count              int                 `json:"_count"`
+	}{
 		PartitionKeyRanges: []partitionKeyRange{
 			{
 				ID:           "0",
@@ -590,7 +593,10 @@ func TestReadManyItemsErrorPreservesDiagnostics(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rangeBody, err := json.Marshal(partitionKeyRangeResponse{
+	rangeBody, err := json.Marshal(struct {
+		PartitionKeyRanges []partitionKeyRange `json:"PartitionKeyRanges"`
+		Count              int                 `json:"_count"`
+	}{
 		PartitionKeyRanges: []partitionKeyRange{
 			{
 				ID:           "0",

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -164,6 +164,17 @@ func TestDiagnosticsStringRendersMapDatumWithStableKeyOrder(t *testing.T) {
 `, newDiagnostics(rootTrace).String())
 }
 
+func TestFinalizedTraceUsesSnapshotTimeForActiveTrace(t *testing.T) {
+	rootTrace := newRootTrace("sample_operation")
+	rootTrace.startTime = fixedDiagnosticsTime(0)
+
+	finalized := rootTrace.finalize(fixedDiagnosticsTime(40 * time.Millisecond))
+
+	require.NotNil(t, finalized.endTime)
+	require.Equal(t, 40*time.Millisecond, finalized.endTime.Sub(finalized.startTime))
+	require.Nil(t, rootTrace.endTime)
+}
+
 func TestDiagnosticsStringRendersSampleGatewayJSON(t *testing.T) {
 	rootTrace := newFixedTrace("sample_operation", fixedDiagnosticsTime(0), fixedDiagnosticsTime(100*time.Millisecond), nil)
 	requestTrace := newFixedTrace(traceDatumKeyTransportRequest, fixedDiagnosticsTime(5*time.Millisecond), fixedDiagnosticsTime(95*time.Millisecond), rootTrace)

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -80,7 +80,47 @@ func TestDiagnosticsSummaryIncludesRetriedGatewayCalls(t *testing.T) {
 	child := children[0].(map[string]any)
 	data := child["data"].(map[string]any)
 	require.Contains(t, data, traceDatumKeyClientSideRequestStats)
+	clientStatsData := data[traceDatumKeyClientSideRequestStats].(map[string]any)
+	require.Equal(t, []any{"local"}, clientStatsData["RegionsContacted"])
 	require.Contains(t, data, traceDatumKeyPointOperationStatistics)
+}
+
+func TestDiagnosticsRegionsContactedDedupesByRegion(t *testing.T) {
+	rootTrace := newRootTrace("test_operation")
+	requestTrace := rootTrace.StartChild(traceDatumKeyTransportRequest)
+	clientStats := newClientSideRequestStatisticsTraceDatum(time.Now().UTC(), requestTrace)
+	requestTrace.AddDatum(traceDatumKeyClientSideRequestStats, clientStats)
+
+	reqDB, err := http.NewRequest(http.MethodGet, "https://example.com/dbs/test", nil)
+	require.NoError(t, err)
+	clientStats.recordHTTPResponse(time.Now().Add(-20*time.Millisecond), &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Request:    reqDB,
+	}, resourceTypeDatabase, "local")
+
+	reqColl, err := http.NewRequest(http.MethodGet, "https://example.com/dbs/test/colls/test", nil)
+	require.NoError(t, err)
+	clientStats.recordHTTPResponse(time.Now().Add(-10*time.Millisecond), &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Request:    reqColl,
+	}, resourceTypeCollection, "local")
+
+	requestTrace.End()
+	rootTrace.End()
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(newDiagnostics(rootTrace).String()), &parsed))
+
+	summary := parsed["Summary"].(map[string]any)
+	require.Equal(t, float64(1), summary["RegionsContacted"])
+
+	children := parsed["children"].([]any)
+	child := children[0].(map[string]any)
+	data := child["data"].(map[string]any)
+	clientStatsData := data[traceDatumKeyClientSideRequestStats].(map[string]any)
+	require.Equal(t, []any{"local"}, clientStatsData["RegionsContacted"])
 }
 
 func TestDiagnosticsStringRendersSampleGatewayJSON(t *testing.T) {
@@ -92,10 +132,10 @@ func TestDiagnosticsStringRendersSampleGatewayJSON(t *testing.T) {
 		requestStartTimeUTC: fixedDiagnosticsTime(5 * time.Millisecond),
 		requestEndTimeUTC:   timePtr(fixedDiagnosticsTime(24 * time.Millisecond)),
 		regionsContacted: []contactedRegion{
-			{name: "local", uri: "https://example.com/dbs/test"},
+			{id: "local"},
 		},
-		regionsContactedByURI: map[string]struct{}{
-			"https://example.com/dbs/test": {},
+		regionsContactedByID: map[string]struct{}{
+			"local": {},
 		},
 		httpResponseStatistics: []httpResponseStatistics{
 			{
@@ -155,7 +195,7 @@ func TestDiagnosticsStringRendersSampleGatewayJSON(t *testing.T) {
           "Id": "AggregatedClientSideRequestStatistics",
           "ContactedReplicas": [],
           "RegionsContacted": [
-            "https://example.com/dbs/test"
+            "local"
           ],
           "FailedReplicas": [],
           "AddressResolutionStatistics": [],

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -317,6 +317,21 @@ func TestDiagnosticsFromErrorReturnsResponseDiagnostics(t *testing.T) {
 	require.Equal(t, float64(http.StatusNotFound), pointStats["StatusCode"])
 }
 
+func TestWrappedRequestErrorPreservesErrorsAs(t *testing.T) {
+	rootTrace := newFixedTrace("sample_operation", fixedDiagnosticsTime(0), fixedDiagnosticsTime(40*time.Millisecond), nil)
+	originalErr := &diagnosticsTestError{message: "network failure"}
+
+	wrappedErr := wrapRequestError(originalErr, newDiagnostics(rootTrace))
+
+	var target *diagnosticsTestError
+	require.True(t, errors.As(wrappedErr, &target))
+	require.Same(t, originalErr, target)
+
+	diagnostics, ok := DiagnosticsFromError(wrappedErr)
+	require.True(t, ok)
+	require.NotEmpty(t, diagnostics.String())
+}
+
 func TestDiagnosticsFromErrorRendersSampleJSON(t *testing.T) {
 	requestTrace := newFixedTrace(traceDatumKeyTransportRequest, fixedDiagnosticsTime(0), fixedDiagnosticsTime(40*time.Millisecond), nil)
 	requestTrace.AddDatum(traceDatumKeyPointOperationStatistics, pointOperationStatisticsTraceDatum{
@@ -634,4 +649,12 @@ func requireRenderedDiagnosticsJSON(t *testing.T, expected string, actual string
 	var compact bytes.Buffer
 	require.NoError(t, json.Compact(&compact, []byte(expected)))
 	require.Equal(t, compact.String(), actual)
+}
+
+type diagnosticsTestError struct {
+	message string
+}
+
+func (e *diagnosticsTestError) Error() string {
+	return e.message
 }

--- a/sdk/data/azcosmos/diagnostics_test.go
+++ b/sdk/data/azcosmos/diagnostics_test.go
@@ -123,6 +123,47 @@ func TestDiagnosticsRegionsContactedDedupesByRegion(t *testing.T) {
 	require.Equal(t, []any{"local"}, clientStatsData["RegionsContacted"])
 }
 
+func TestDiagnosticsStringRendersMapDatumWithStableKeyOrder(t *testing.T) {
+	rootTrace := newFixedTrace("sample_operation", fixedDiagnosticsTime(0), fixedDiagnosticsTime(100*time.Millisecond), nil)
+	rootTrace.AddDatum("map", map[string]any{
+		"z": "last",
+		"a": map[string]any{
+			"z": "nested last",
+			"a": "nested first",
+		},
+		"m": []any{
+			map[string]any{
+				"z": "array nested last",
+				"a": "array nested first",
+			},
+		},
+	})
+
+	requireRenderedDiagnosticsJSON(t, `
+{
+  "Summary": {},
+  "name": "sample_operation",
+  "start datetime": "2024-01-02T03:04:05.000Z",
+  "duration in milliseconds": 100,
+  "data": {
+    "map": {
+      "a": {
+        "a": "nested first",
+        "z": "nested last"
+      },
+      "m": [
+        {
+          "a": "array nested first",
+          "z": "array nested last"
+        }
+      ],
+      "z": "last"
+    }
+  }
+}
+`, newDiagnostics(rootTrace).String())
+}
+
 func TestDiagnosticsStringRendersSampleGatewayJSON(t *testing.T) {
 	rootTrace := newFixedTrace("sample_operation", fixedDiagnosticsTime(0), fixedDiagnosticsTime(100*time.Millisecond), nil)
 	requestTrace := newFixedTrace(traceDatumKeyTransportRequest, fixedDiagnosticsTime(5*time.Millisecond), fixedDiagnosticsTime(95*time.Millisecond), rootTrace)

--- a/sdk/data/azcosmos/throughput_response.go
+++ b/sdk/data/azcosmos/throughput_response.go
@@ -58,7 +58,7 @@ func newThroughputResponse(resp *http.Response, extraRequestCharge *float32) (Th
 	properties := &ThroughputProperties{}
 	err := azruntime.UnmarshalAsJSON(resp, properties)
 	if err != nil {
-		return response, err
+		return response, wrapResponseError(err, response.Response)
 	}
 	response.ThroughputProperties = properties
 

--- a/sdk/data/azcosmos/trace.go
+++ b/sdk/data/azcosmos/trace.go
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	aztracing "github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
+)
+
+type trace struct {
+	mu            sync.Mutex
+	name          string
+	startTime     time.Time
+	endTime       *time.Time
+	parent        *trace
+	children      []*trace
+	data          map[string]any
+	dataOrder     []string
+	isBeingWalked bool
+	summary       *traceSummary
+}
+
+type traceSnapshot struct {
+	name      string
+	startTime time.Time
+	endTime   *time.Time
+	children  []*trace
+	data      map[string]any
+	dataOrder []string
+}
+
+type traceSummary struct {
+	mu                 sync.Mutex
+	failedRequestCount int
+}
+
+func newRootTrace(name string) *trace {
+	return &trace{
+		name:      name,
+		startTime: time.Now().UTC(),
+		children:  []*trace{},
+		summary:   &traceSummary{},
+	}
+}
+
+func (t *trace) root() *trace {
+	current := t
+	for current != nil && current.parent != nil {
+		current = current.parent
+	}
+
+	return current
+}
+
+func (t *trace) StartChild(name string) *trace {
+	child := &trace{
+		name:      name,
+		startTime: time.Now().UTC(),
+		parent:    t,
+		children:  []*trace{},
+		summary:   t.summary,
+	}
+
+	t.AddChild(child)
+	return child
+}
+
+func (t *trace) End() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.endTime != nil {
+		return
+	}
+
+	endTime := time.Now().UTC()
+	t.endTime = &endTime
+}
+
+func (t *trace) duration() time.Duration {
+	t.mu.Lock()
+	startTime := t.startTime
+	endTime := t.endTime
+	t.mu.Unlock()
+
+	if endTime != nil {
+		return endTime.Sub(startTime)
+	}
+
+	return time.Since(startTime)
+}
+
+func (t *trace) AddChild(child *trace) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.isBeingWalked {
+		t.children = append(t.children, child)
+		return
+	}
+
+	child.setWalkingStateRecursively()
+
+	nextChildren := make([]*trace, 0, len(t.children)+1)
+	nextChildren = append(nextChildren, t.children...)
+	nextChildren = append(nextChildren, child)
+	t.children = nextChildren
+}
+
+func (t *trace) AddDatum(key string, value any) {
+	t.addOrUpdateDatum(key, value, false)
+}
+
+func (t *trace) AddOrUpdateDatum(key string, value any) {
+	t.addOrUpdateDatum(key, value, true)
+}
+
+func (t *trace) addOrUpdateDatum(key string, value any, overwrite bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.data == nil {
+		t.data = map[string]any{}
+	}
+
+	_, exists := t.data[key]
+	if exists && !overwrite {
+		return
+	}
+
+	if !t.isBeingWalked {
+		t.data[key] = value
+		if !exists {
+			t.dataOrder = append(t.dataOrder, key)
+		}
+		return
+	}
+
+	nextData := make(map[string]any, len(t.data)+1)
+	for k, v := range t.data {
+		nextData[k] = v
+	}
+	nextData[key] = value
+	t.data = nextData
+
+	if !exists {
+		nextOrder := make([]string, 0, len(t.dataOrder)+1)
+		nextOrder = append(nextOrder, t.dataOrder...)
+		nextOrder = append(nextOrder, key)
+		t.dataOrder = nextOrder
+	}
+}
+
+func (t *trace) setWalkingStateRecursively() {
+	t.mu.Lock()
+	if t.isBeingWalked {
+		t.mu.Unlock()
+		return
+	}
+
+	children := append([]*trace(nil), t.children...)
+	t.mu.Unlock()
+
+	for _, child := range children {
+		child.setWalkingStateRecursively()
+	}
+
+	t.mu.Lock()
+	t.isBeingWalked = true
+	t.mu.Unlock()
+}
+
+func (t *trace) snapshot() traceSnapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return traceSnapshot{
+		name:      t.name,
+		startTime: t.startTime,
+		endTime:   t.endTime,
+		children:  t.children,
+		data:      t.data,
+		dataOrder: t.dataOrder,
+	}
+}
+
+func (s *traceSummary) incrementFailedCount() {
+	s.mu.Lock()
+	s.failedRequestCount++
+	s.mu.Unlock()
+}
+
+func (s *traceSummary) failedCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.failedRequestCount
+}
+
+type traceContextKey struct{}
+
+func traceFromContext(ctx context.Context) *trace {
+	current, _ := ctx.Value(traceContextKey{}).(*trace)
+	return current
+}
+
+func withTrace(ctx context.Context, t *trace) context.Context {
+	return context.WithValue(ctx, traceContextKey{}, t)
+}
+
+func diagnosticsFromContext(ctx context.Context) Diagnostics {
+	return newDiagnostics(traceFromContext(ctx))
+}
+
+func ensureOperationTrace(ctx context.Context, name string) context.Context {
+	if traceFromContext(ctx) != nil {
+		return ctx
+	}
+
+	return withTrace(ctx, newRootTrace(name))
+}
+
+func startSpan(ctx context.Context, name string, tracer aztracing.Tracer, options *azruntime.StartSpanOptions) (context.Context, func(error)) {
+	ctx, endSpan := azruntime.StartSpan(ctx, name, tracer, options)
+
+	currentTrace := traceFromContext(ctx)
+	if currentTrace == nil {
+		root := newRootTrace(name)
+		ctx = withTrace(ctx, root)
+
+		return ctx, func(err error) {
+			root.End()
+			endSpan(err)
+		}
+	}
+
+	child := currentTrace.StartChild(name)
+	ctx = withTrace(ctx, child)
+
+	return ctx, func(err error) {
+		child.End()
+		endSpan(err)
+	}
+}

--- a/sdk/data/azcosmos/trace.go
+++ b/sdk/data/azcosmos/trace.go
@@ -217,12 +217,15 @@ func diagnosticsFromContext(ctx context.Context) Diagnostics {
 	return newDiagnostics(traceFromContext(ctx))
 }
 
-func ensureOperationTrace(ctx context.Context, name string) context.Context {
+func ensureOperationTrace(ctx context.Context, name string) (context.Context, func()) {
 	if traceFromContext(ctx) != nil {
-		return ctx
+		return ctx, func() {}
 	}
 
-	return withTrace(ctx, newRootTrace(name))
+	root := newRootTrace(name)
+	return withTrace(ctx, root), func() {
+		root.End()
+	}
 }
 
 func startSpan(ctx context.Context, name string, tracer aztracing.Tracer, options *azruntime.StartSpanOptions) (context.Context, func(error)) {

--- a/sdk/data/azcosmos/trace.go
+++ b/sdk/data/azcosmos/trace.go
@@ -29,6 +29,7 @@ type trace struct {
 type finalizedTrace struct {
 	name      string
 	startTime time.Time
+	// endTime is the trace's end time, or the diagnostics snapshot time if the trace was still active when finalized.
 	endTime   *time.Time
 	children  []*finalizedTrace
 	data      map[string]any
@@ -124,7 +125,7 @@ func (t *trace) finalize(freezeTime time.Time) *finalizedTrace {
 	t.mu.Lock()
 	name := t.name
 	startTime := t.startTime
-	endTime := cloneTraceTime(t.endTime, freezeTime)
+	endTime := snapshotTraceEndTime(t.endTime, freezeTime)
 	children := append([]*trace(nil), t.children...)
 	dataOrder := append([]string(nil), t.dataOrder...)
 	data := make(map[string]any, len(dataOrder))
@@ -148,7 +149,7 @@ func (t *trace) finalize(freezeTime time.Time) *finalizedTrace {
 	}
 }
 
-func cloneTraceTime(value *time.Time, freezeTime time.Time) *time.Time {
+func snapshotTraceEndTime(value *time.Time, freezeTime time.Time) *time.Time {
 	frozen := freezeTime.UTC()
 	if value != nil {
 		frozen = value.UTC()

--- a/sdk/data/azcosmos/trace.go
+++ b/sdk/data/azcosmos/trace.go
@@ -5,6 +5,8 @@ package azcosmos
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -13,23 +15,22 @@ import (
 )
 
 type trace struct {
-	mu            sync.Mutex
-	name          string
-	startTime     time.Time
-	endTime       *time.Time
-	parent        *trace
-	children      []*trace
-	data          map[string]any
-	dataOrder     []string
-	isBeingWalked bool
-	summary       *traceSummary
-}
-
-type traceSnapshot struct {
+	mu        sync.Mutex
 	name      string
 	startTime time.Time
 	endTime   *time.Time
+	parent    *trace
 	children  []*trace
+	data      map[string]any
+	dataOrder []string
+	summary   *traceSummary
+}
+
+type finalizedTrace struct {
+	name      string
+	startTime time.Time
+	endTime   *time.Time
+	children  []*finalizedTrace
 	data      map[string]any
 	dataOrder []string
 }
@@ -82,34 +83,10 @@ func (t *trace) End() {
 	t.endTime = &endTime
 }
 
-func (t *trace) duration() time.Duration {
-	t.mu.Lock()
-	startTime := t.startTime
-	endTime := t.endTime
-	t.mu.Unlock()
-
-	if endTime != nil {
-		return endTime.Sub(startTime)
-	}
-
-	return time.Since(startTime)
-}
-
 func (t *trace) AddChild(child *trace) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if !t.isBeingWalked {
-		t.children = append(t.children, child)
-		return
-	}
-
-	child.setWalkingStateRecursively()
-
-	nextChildren := make([]*trace, 0, len(t.children)+1)
-	nextChildren = append(nextChildren, t.children...)
-	nextChildren = append(nextChildren, child)
-	t.children = nextChildren
+	t.children = append(t.children, child)
+	t.mu.Unlock()
 }
 
 func (t *trace) AddDatum(key string, value any) {
@@ -133,59 +110,82 @@ func (t *trace) addOrUpdateDatum(key string, value any, overwrite bool) {
 		return
 	}
 
-	if !t.isBeingWalked {
-		t.data[key] = value
-		if !exists {
-			t.dataOrder = append(t.dataOrder, key)
-		}
-		return
-	}
-
-	nextData := make(map[string]any, len(t.data)+1)
-	for k, v := range t.data {
-		nextData[k] = v
-	}
-	nextData[key] = value
-	t.data = nextData
-
+	t.data[key] = value
 	if !exists {
-		nextOrder := make([]string, 0, len(t.dataOrder)+1)
-		nextOrder = append(nextOrder, t.dataOrder...)
-		nextOrder = append(nextOrder, key)
-		t.dataOrder = nextOrder
+		t.dataOrder = append(t.dataOrder, key)
 	}
 }
 
-func (t *trace) setWalkingStateRecursively() {
-	t.mu.Lock()
-	if t.isBeingWalked {
-		t.mu.Unlock()
-		return
+func (t *trace) finalize(freezeTime time.Time) *finalizedTrace {
+	if t == nil {
+		return nil
 	}
 
+	t.mu.Lock()
+	name := t.name
+	startTime := t.startTime
+	endTime := cloneTraceTime(t.endTime, freezeTime)
 	children := append([]*trace(nil), t.children...)
+	dataOrder := append([]string(nil), t.dataOrder...)
+	data := make(map[string]any, len(dataOrder))
+	for _, key := range dataOrder {
+		data[key] = finalizeTraceDatum(t.data[key])
+	}
 	t.mu.Unlock()
 
-	for _, child := range children {
-		child.setWalkingStateRecursively()
+	finalizedChildren := make([]*finalizedTrace, len(children))
+	for index, child := range children {
+		finalizedChildren[index] = child.finalize(freezeTime)
 	}
 
-	t.mu.Lock()
-	t.isBeingWalked = true
-	t.mu.Unlock()
+	return &finalizedTrace{
+		name:      name,
+		startTime: startTime,
+		endTime:   endTime,
+		children:  finalizedChildren,
+		data:      data,
+		dataOrder: dataOrder,
+	}
 }
 
-func (t *trace) snapshot() traceSnapshot {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+func cloneTraceTime(value *time.Time, freezeTime time.Time) *time.Time {
+	frozen := freezeTime.UTC()
+	if value != nil {
+		frozen = value.UTC()
+	}
+	return &frozen
+}
 
-	return traceSnapshot{
-		name:      t.name,
-		startTime: t.startTime,
-		endTime:   t.endTime,
-		children:  t.children,
-		data:      t.data,
-		dataOrder: t.dataOrder,
+func finalizeTraceDatum(value any) any {
+	switch typed := value.(type) {
+	case *clientSideRequestStatisticsTraceDatum:
+		return typed.snapshot()
+	case clientSideRequestStatisticsSnapshot:
+		return typed
+	case pointOperationStatisticsTraceDatum:
+		return typed
+	case *pointOperationStatisticsTraceDatum:
+		return *typed
+	case json.RawMessage:
+		return append(json.RawMessage(nil), typed...)
+	case string, float64, float32, int, int32, int64, bool, nil:
+		return typed
+	case []string:
+		return append([]string(nil), typed...)
+	case []any:
+		next := make([]any, len(typed))
+		for index, item := range typed {
+			next[index] = finalizeTraceDatum(item)
+		}
+		return next
+	case map[string]any:
+		next := make(map[string]any, len(typed))
+		for key, item := range typed {
+			next[key] = finalizeTraceDatum(item)
+		}
+		return next
+	default:
+		return fmt.Sprint(value)
 	}
 }
 

--- a/sdk/data/azcosmos/trace_data.go
+++ b/sdk/data/azcosmos/trace_data.go
@@ -1,0 +1,356 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+const (
+	traceDatumKeyClientSideRequestStats        = "Client Side Request Stats"
+	traceDatumKeyTransportRequest              = "Microsoft.Azure.Documents.ServerStoreModel Transport Request"
+	traceDatumKeyPointOperationStatistics      = "PointOperationStatisticsTraceDatum"
+	traceDatumKeyPointOperationStatisticsError = "Point Operation Statistics"
+	traceDatumKeyQueryMetrics                  = "Query Metrics"
+)
+
+type requestDiagnosticsState struct {
+	requestTrace        *trace
+	clientSideStats     *clientSideRequestStatisticsTraceDatum
+	resourceType        resourceType
+	requestSessionToken string
+}
+
+type requestDiagnosticsStateKey struct{}
+
+func requestDiagnosticsStateFromContext(ctx context.Context) *requestDiagnosticsState {
+	state, _ := ctx.Value(requestDiagnosticsStateKey{}).(*requestDiagnosticsState)
+	return state
+}
+
+func withRequestDiagnosticsState(ctx context.Context, state *requestDiagnosticsState) context.Context {
+	return context.WithValue(ctx, requestDiagnosticsStateKey{}, state)
+}
+
+func attachRequestDiagnostics(req *policy.Request, operationContext pipelineRequestOptions) *policy.Request {
+	requestContext := req.Raw().Context()
+	parentTrace := traceFromContext(requestContext)
+
+	var requestTrace *trace
+	if parentTrace != nil {
+		requestTrace = parentTrace.StartChild(traceDatumKeyTransportRequest)
+	} else {
+		requestTrace = newRootTrace(traceDatumKeyTransportRequest)
+	}
+
+	clientSideStats := newClientSideRequestStatisticsTraceDatum(time.Now().UTC(), requestTrace)
+	requestTrace.AddDatum(traceDatumKeyClientSideRequestStats, clientSideStats)
+
+	state := &requestDiagnosticsState{
+		requestTrace:        requestTrace,
+		clientSideStats:     clientSideStats,
+		resourceType:        operationContext.resourceType,
+		requestSessionToken: req.Raw().Header.Get(cosmosHeaderSessionToken),
+	}
+
+	requestContext = withTrace(requestContext, requestTrace)
+	requestContext = withRequestDiagnosticsState(requestContext, state)
+
+	return req.WithContext(requestContext)
+}
+
+func addPointOperationStatisticsFromResponse(resp *http.Response, errorMessage string, key string) {
+	if resp == nil || resp.Request == nil {
+		return
+	}
+
+	state := requestDiagnosticsStateFromContext(resp.Request.Context())
+	if state == nil || state.requestTrace == nil {
+		return
+	}
+
+	requestURI := ""
+	if resp.Request.URL != nil {
+		requestURI = resp.Request.URL.String()
+	}
+
+	pointStats := pointOperationStatisticsTraceDatum{
+		ActivityID:           resp.Header.Get(cosmosHeaderActivityId),
+		ResponseTimeUTC:      time.Now().UTC(),
+		StatusCode:           resp.StatusCode,
+		SubStatusCode:        parseSubStatusCode(resp.Header.Get(cosmosHeaderSubstatus)),
+		RequestCharge:        newResponse(resp).RequestCharge,
+		RequestURI:           requestURI,
+		ErrorMessage:         errorMessage,
+		RequestSessionToken:  state.requestSessionToken,
+		ResponseSessionToken: resp.Header.Get(cosmosHeaderSessionToken),
+		BELatencyInMs:        resp.Header.Get(headerXmsRequestDurationMs),
+	}
+
+	state.requestTrace.AddOrUpdateDatum(key, pointStats)
+}
+
+func recordQueryMetricsFromResponse(resp *http.Response) {
+	if resp == nil || resp.Request == nil {
+		return
+	}
+
+	queryMetrics := resp.Header.Get(cosmosHeaderQueryMetrics)
+	if queryMetrics == "" {
+		return
+	}
+
+	state := requestDiagnosticsStateFromContext(resp.Request.Context())
+	if state == nil || state.requestTrace == nil {
+		return
+	}
+
+	state.requestTrace.AddOrUpdateDatum(traceDatumKeyQueryMetrics, queryMetrics)
+}
+
+type clientSideRequestStatisticsTraceDatum struct {
+	mu                          sync.Mutex
+	trace                       *trace
+	requestStartTimeUTC         time.Time
+	requestEndTimeUTC           *time.Time
+	regionsContacted            []contactedRegion
+	regionsContactedByURI       map[string]struct{}
+	httpResponseStatistics      []httpResponseStatistics
+	addressResolutionStatistics []addressResolutionStatistics
+	forceAddressRefreshes       []forceAddressRefresh
+}
+
+type clientSideRequestStatisticsSnapshot struct {
+	regionsContacted            []contactedRegion
+	httpResponseStatistics      []httpResponseStatistics
+	addressResolutionStatistics []addressResolutionStatistics
+	forceAddressRefreshes       []forceAddressRefresh
+}
+
+type contactedRegion struct {
+	name string
+	uri  string
+}
+
+type httpResponseStatistics struct {
+	startTimeUTC     time.Time
+	duration         time.Duration
+	requestURI       string
+	resourceType     resourceType
+	httpMethod       string
+	activityID       string
+	exceptionType    string
+	exceptionMessage string
+	statusCode       int
+	statusCodeText   string
+	reasonPhrase     string
+	subStatusCode    int
+}
+
+type addressResolutionStatistics struct {
+	startTimeUTC   time.Time
+	endTimeUTC     *time.Time
+	targetEndpoint string
+}
+
+type forceAddressRefresh struct {
+	noChangeToCache []string
+	original        []string
+	newValues       []string
+}
+
+type pointOperationStatisticsTraceDatum struct {
+	ActivityID           string
+	ResponseTimeUTC      time.Time
+	StatusCode           int
+	SubStatusCode        int
+	RequestCharge        float32
+	RequestURI           string
+	ErrorMessage         string
+	RequestSessionToken  string
+	ResponseSessionToken string
+	BELatencyInMs        string
+}
+
+func newClientSideRequestStatisticsTraceDatum(startTime time.Time, trace *trace) *clientSideRequestStatisticsTraceDatum {
+	return &clientSideRequestStatisticsTraceDatum{
+		trace:                       trace,
+		requestStartTimeUTC:         startTime,
+		regionsContacted:            []contactedRegion{},
+		regionsContactedByURI:       map[string]struct{}{},
+		httpResponseStatistics:      []httpResponseStatistics{},
+		addressResolutionStatistics: []addressResolutionStatistics{},
+		forceAddressRefreshes:       []forceAddressRefresh{},
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) recordHTTPResponse(startTime time.Time, response *http.Response, resourceType resourceType, regionName string) {
+	if response == nil {
+		return
+	}
+
+	requestURI := ""
+	if response.Request != nil && response.Request.URL != nil {
+		requestURI = response.Request.URL.String()
+	}
+
+	d.recordRegion(regionName, requestURI)
+
+	endTime := time.Now().UTC()
+	d.updateRequestEndTime(endTime)
+
+	stat := httpResponseStatistics{
+		startTimeUTC:   startTime.UTC(),
+		duration:       endTime.Sub(startTime),
+		requestURI:     requestURI,
+		resourceType:   resourceType,
+		httpMethod:     response.Request.Method,
+		activityID:     response.Header.Get(cosmosHeaderActivityId),
+		statusCode:     response.StatusCode,
+		statusCodeText: formatHTTPStatusCodeString(response.StatusCode),
+		reasonPhrase:   http.StatusText(response.StatusCode),
+		subStatusCode:  parseSubStatusCode(response.Header.Get(cosmosHeaderSubstatus)),
+	}
+
+	d.mu.Lock()
+	d.httpResponseStatistics = append(d.httpResponseStatistics, stat)
+	d.mu.Unlock()
+
+	if response.StatusCode >= http.StatusBadRequest && d.trace != nil && d.trace.summary != nil {
+		d.trace.summary.incrementFailedCount()
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) recordHTTPError(startTime time.Time, req *http.Request, err error, resourceType resourceType, regionName string) {
+	requestURI := ""
+	method := http.MethodGet
+	if req != nil {
+		method = req.Method
+		if req.URL != nil {
+			requestURI = req.URL.String()
+		}
+	}
+
+	d.recordRegion(regionName, requestURI)
+
+	endTime := time.Now().UTC()
+	d.updateRequestEndTime(endTime)
+
+	stat := httpResponseStatistics{
+		startTimeUTC:     startTime.UTC(),
+		duration:         endTime.Sub(startTime),
+		requestURI:       requestURI,
+		resourceType:     resourceType,
+		httpMethod:       method,
+		exceptionType:    fmt.Sprintf("%T", err),
+		exceptionMessage: err.Error(),
+	}
+
+	d.mu.Lock()
+	d.httpResponseStatistics = append(d.httpResponseStatistics, stat)
+	d.mu.Unlock()
+
+	if d.trace != nil && d.trace.summary != nil {
+		d.trace.summary.incrementFailedCount()
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) snapshot() clientSideRequestStatisticsSnapshot {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	regionsContacted := append([]contactedRegion(nil), d.regionsContacted...)
+	httpResponseStatistics := append([]httpResponseStatistics(nil), d.httpResponseStatistics...)
+	addressResolutionStatistics := append([]addressResolutionStatistics(nil), d.addressResolutionStatistics...)
+	forceAddressRefreshes := append([]forceAddressRefresh(nil), d.forceAddressRefreshes...)
+
+	return clientSideRequestStatisticsSnapshot{
+		regionsContacted:            regionsContacted,
+		httpResponseStatistics:      httpResponseStatistics,
+		addressResolutionStatistics: addressResolutionStatistics,
+		forceAddressRefreshes:       forceAddressRefreshes,
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) updateRequestEndTime(endTime time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.requestEndTimeUTC == nil || endTime.After(*d.requestEndTimeUTC) {
+		value := endTime.UTC()
+		d.requestEndTimeUTC = &value
+	}
+}
+
+func (d *clientSideRequestStatisticsTraceDatum) recordRegion(regionName string, requestURI string) {
+	if requestURI == "" {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, ok := d.regionsContactedByURI[requestURI]; ok {
+		return
+	}
+
+	d.regionsContactedByURI[requestURI] = struct{}{}
+	d.regionsContacted = append(d.regionsContacted, contactedRegion{
+		name: regionName,
+		uri:  requestURI,
+	})
+}
+
+func parseSubStatusCode(value string) int {
+	if value == "" {
+		return 0
+	}
+
+	subStatusCode, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+
+	return subStatusCode
+}
+
+func formatHTTPStatusCodeString(statusCode int) string {
+	if statusCode == 0 {
+		return ""
+	}
+
+	if text := http.StatusText(statusCode); text != "" {
+		replacer := strings.NewReplacer(" ", "", "-", "", "'", "", ".", "")
+		return replacer.Replace(text)
+	}
+
+	return strconv.Itoa(statusCode)
+}
+
+func resourceTypeName(resourceType resourceType) string {
+	switch resourceType {
+	case resourceTypeDatabase:
+		return "Database"
+	case resourceTypeCollection:
+		return "DocumentCollection"
+	case resourceTypeDocument:
+		return "Document"
+	case resourceTypeOffer:
+		return "Offer"
+	case resourceTypeDatabaseAccount:
+		return "DatabaseAccount"
+	case resourceTypePartitionKeyRange:
+		return "PartitionKeyRange"
+	default:
+		return fmt.Sprintf("%d", resourceType)
+	}
+}

--- a/sdk/data/azcosmos/trace_data.go
+++ b/sdk/data/azcosmos/trace_data.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -123,7 +124,7 @@ type clientSideRequestStatisticsTraceDatum struct {
 	requestStartTimeUTC         time.Time
 	requestEndTimeUTC           *time.Time
 	regionsContacted            []contactedRegion
-	regionsContactedByURI       map[string]struct{}
+	regionsContactedByID        map[string]struct{}
 	httpResponseStatistics      []httpResponseStatistics
 	addressResolutionStatistics []addressResolutionStatistics
 	forceAddressRefreshes       []forceAddressRefresh
@@ -137,8 +138,7 @@ type clientSideRequestStatisticsSnapshot struct {
 }
 
 type contactedRegion struct {
-	name string
-	uri  string
+	id string
 }
 
 type httpResponseStatistics struct {
@@ -186,7 +186,7 @@ func newClientSideRequestStatisticsTraceDatum(startTime time.Time, trace *trace)
 		trace:                       trace,
 		requestStartTimeUTC:         startTime,
 		regionsContacted:            []contactedRegion{},
-		regionsContactedByURI:       map[string]struct{}{},
+		regionsContactedByID:        map[string]struct{}{},
 		httpResponseStatistics:      []httpResponseStatistics{},
 		addressResolutionStatistics: []addressResolutionStatistics{},
 		forceAddressRefreshes:       []forceAddressRefresh{},
@@ -292,22 +292,38 @@ func (d *clientSideRequestStatisticsTraceDatum) updateRequestEndTime(endTime tim
 }
 
 func (d *clientSideRequestStatisticsTraceDatum) recordRegion(regionName string, requestURI string) {
-	if requestURI == "" {
+	regionID := regionName
+	if regionID == "" {
+		regionID = endpointHostFromURI(requestURI)
+	}
+	if regionID == "" {
 		return
 	}
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if _, ok := d.regionsContactedByURI[requestURI]; ok {
+	if _, ok := d.regionsContactedByID[regionID]; ok {
 		return
 	}
 
-	d.regionsContactedByURI[requestURI] = struct{}{}
+	d.regionsContactedByID[regionID] = struct{}{}
 	d.regionsContacted = append(d.regionsContacted, contactedRegion{
-		name: regionName,
-		uri:  requestURI,
+		id: regionID,
 	})
+}
+
+func endpointHostFromURI(requestURI string) string {
+	if requestURI == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(requestURI)
+	if err != nil {
+		return ""
+	}
+
+	return parsed.Host
 }
 
 func parseSubStatusCode(value string) int {

--- a/sdk/data/azcosmos/trace_data.go
+++ b/sdk/data/azcosmos/trace_data.go
@@ -88,7 +88,7 @@ func addPointOperationStatisticsFromResponse(resp *http.Response, errorMessage s
 		ResponseTimeUTC:      time.Now().UTC(),
 		StatusCode:           resp.StatusCode,
 		SubStatusCode:        parseSubStatusCode(resp.Header.Get(cosmosHeaderSubstatus)),
-		RequestCharge:        newResponse(resp).RequestCharge,
+		RequestCharge:        readRequestCharge(resp),
 		RequestURI:           requestURI,
 		ErrorMessage:         errorMessage,
 		RequestSessionToken:  state.requestSessionToken,

--- a/sdk/data/azcosmos/trace_json_writer.go
+++ b/sdk/data/azcosmos/trace_json_writer.go
@@ -1,0 +1,545 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+)
+
+const (
+	rootTraceTimeFormat   = "2006-01-02T15:04:05.000Z"
+	nestedTraceTimeFormat = "2006-01-02T15:04:05.0000000Z07:00"
+)
+
+type summaryDiagnostics struct {
+	directCalls    map[[2]int]int
+	gatewayCalls   map[[2]int]int
+	regionsByURI   map[string]struct{}
+	regionURICount int
+}
+
+func writeTraceJSON(root *trace) string {
+	var buffer bytes.Buffer
+	writeTrace(&buffer, root, true)
+	return buffer.String()
+}
+
+func writeTrace(buffer *bytes.Buffer, current *trace, isRoot bool) {
+	snapshot := current.snapshot()
+
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	if isRoot {
+		writeField("Summary", func() {
+			writeSummaryDiagnostics(buffer, current)
+		})
+	}
+
+	writeField("name", func() {
+		writeJSONString(buffer, snapshot.name)
+	})
+
+	if isRoot {
+		writeField("start datetime", func() {
+			writeJSONString(buffer, snapshot.startTime.UTC().Format(rootTraceTimeFormat))
+		})
+	}
+
+	writeField("duration in milliseconds", func() {
+		writeNumber(buffer, durationInMilliseconds(snapshot.startTime, snapshot.endTime))
+	})
+
+	if len(snapshot.dataOrder) > 0 {
+		writeField("data", func() {
+			writeTraceDataObject(buffer, snapshot.dataOrder, snapshot.data)
+		})
+	}
+
+	if len(snapshot.children) > 0 {
+		writeField("children", func() {
+			buffer.WriteByte('[')
+			for index, child := range snapshot.children {
+				if index > 0 {
+					buffer.WriteByte(',')
+				}
+				writeTrace(buffer, child, false)
+			}
+			buffer.WriteByte(']')
+		})
+	}
+
+	buffer.WriteByte('}')
+}
+
+func writeSummaryDiagnostics(buffer *bytes.Buffer, root *trace) {
+	summary := collectSummaryDiagnostics(root)
+
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	if len(summary.directCalls) > 0 {
+		writeField("DirectCalls", func() {
+			writeCallSummaryObject(buffer, summary.directCalls)
+		})
+	}
+
+	if summary.regionURICount > 0 {
+		writeField("RegionsContacted", func() {
+			writeNumber(buffer, float64(summary.regionURICount))
+		})
+	}
+
+	if len(summary.gatewayCalls) > 0 {
+		writeField("GatewayCalls", func() {
+			writeCallSummaryObject(buffer, summary.gatewayCalls)
+		})
+	}
+
+	buffer.WriteByte('}')
+}
+
+func collectSummaryDiagnostics(root *trace) summaryDiagnostics {
+	summary := summaryDiagnostics{
+		directCalls:  map[[2]int]int{},
+		gatewayCalls: map[[2]int]int{},
+		regionsByURI: map[string]struct{}{},
+	}
+
+	var walk func(*trace)
+	walk = func(current *trace) {
+		snapshot := current.snapshot()
+		for _, key := range snapshot.dataOrder {
+			value := snapshot.data[key]
+			stats, ok := value.(*clientSideRequestStatisticsTraceDatum)
+			if !ok {
+				continue
+			}
+
+			statsSnapshot := stats.snapshot()
+			for _, region := range statsSnapshot.regionsContacted {
+				if _, exists := summary.regionsByURI[region.uri]; !exists {
+					summary.regionsByURI[region.uri] = struct{}{}
+					summary.regionURICount++
+				}
+			}
+
+			for _, gatewayCall := range statsSnapshot.httpResponseStatistics {
+				key := [2]int{gatewayCall.statusCode, gatewayCall.subStatusCode}
+				summary.gatewayCalls[key]++
+			}
+		}
+
+		for _, child := range snapshot.children {
+			walk(child)
+		}
+	}
+
+	walk(root)
+	return summary
+}
+
+func writeCallSummaryObject(buffer *bytes.Buffer, values map[[2]int]int) {
+	keys := make([][2]int, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i int, j int) bool {
+		if keys[i][0] == keys[j][0] {
+			return keys[i][1] < keys[j][1]
+		}
+		return keys[i][0] < keys[j][0]
+	})
+
+	buffer.WriteByte('{')
+	firstField := true
+	for _, key := range keys {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, fmt.Sprintf("(%d, %d)", key[0], key[1]))
+		buffer.WriteByte(':')
+		writeNumber(buffer, float64(values[key]))
+	}
+	buffer.WriteByte('}')
+}
+
+func writeTraceDataObject(buffer *bytes.Buffer, order []string, values map[string]any) {
+	buffer.WriteByte('{')
+	for index, key := range order {
+		if index > 0 {
+			buffer.WriteByte(',')
+		}
+		writeJSONString(buffer, key)
+		buffer.WriteByte(':')
+		writeTraceDatum(buffer, values[key])
+	}
+	buffer.WriteByte('}')
+}
+
+func writeTraceDatum(buffer *bytes.Buffer, value any) {
+	switch typed := value.(type) {
+	case *clientSideRequestStatisticsTraceDatum:
+		writeClientSideRequestStatistics(buffer, typed.snapshot())
+	case pointOperationStatisticsTraceDatum:
+		writePointOperationStatistics(buffer, typed)
+	case *pointOperationStatisticsTraceDatum:
+		writePointOperationStatistics(buffer, *typed)
+	case json.RawMessage:
+		buffer.Write(typed)
+	case string:
+		writeJSONString(buffer, typed)
+	case float64:
+		writeNumber(buffer, typed)
+	case float32:
+		writeNumber(buffer, float64(typed))
+	case int:
+		writeNumber(buffer, float64(typed))
+	case int32:
+		writeNumber(buffer, float64(typed))
+	case int64:
+		writeNumber(buffer, float64(typed))
+	case bool:
+		if typed {
+			buffer.WriteString("true")
+		} else {
+			buffer.WriteString("false")
+		}
+	case []string:
+		buffer.WriteByte('[')
+		for index, item := range typed {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			writeJSONString(buffer, item)
+		}
+		buffer.WriteByte(']')
+	case []any:
+		buffer.WriteByte('[')
+		for index, item := range typed {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			writeTraceDatum(buffer, item)
+		}
+		buffer.WriteByte(']')
+	case map[string]any:
+		buffer.WriteByte('{')
+		firstField := true
+		for key, item := range typed {
+			if !firstField {
+				buffer.WriteByte(',')
+			}
+			firstField = false
+			writeJSONString(buffer, key)
+			buffer.WriteByte(':')
+			writeTraceDatum(buffer, item)
+		}
+		buffer.WriteByte('}')
+	case nil:
+		buffer.WriteString("null")
+	default:
+		writeJSONString(buffer, fmt.Sprint(value))
+	}
+}
+
+func writeClientSideRequestStatistics(buffer *bytes.Buffer, snapshot clientSideRequestStatisticsSnapshot) {
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	writeField("Id", func() {
+		writeJSONString(buffer, "AggregatedClientSideRequestStatistics")
+	})
+
+	writeField("ContactedReplicas", func() {
+		buffer.WriteByte('[')
+		buffer.WriteByte(']')
+	})
+
+	writeField("RegionsContacted", func() {
+		buffer.WriteByte('[')
+		for index, region := range snapshot.regionsContacted {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			writeJSONString(buffer, region.uri)
+		}
+		buffer.WriteByte(']')
+	})
+
+	writeField("FailedReplicas", func() {
+		buffer.WriteByte('[')
+		buffer.WriteByte(']')
+	})
+
+	if len(snapshot.forceAddressRefreshes) > 0 {
+		writeField("ForceAddressRefresh", func() {
+			buffer.WriteByte('[')
+			for index, refresh := range snapshot.forceAddressRefreshes {
+				if index > 0 {
+					buffer.WriteByte(',')
+				}
+				buffer.WriteByte('{')
+				firstRefreshField := true
+				writeRefreshField := func(name string, values []string) {
+					if !firstRefreshField {
+						buffer.WriteByte(',')
+					}
+					firstRefreshField = false
+					writeJSONString(buffer, name)
+					buffer.WriteByte(':')
+					writeTraceDatum(buffer, values)
+				}
+				if len(refresh.noChangeToCache) > 0 {
+					writeRefreshField("No change to cache", refresh.noChangeToCache)
+				} else {
+					writeRefreshField("Original", refresh.original)
+					writeRefreshField("New", refresh.newValues)
+				}
+				buffer.WriteByte('}')
+			}
+			buffer.WriteByte(']')
+		})
+	}
+
+	writeField("AddressResolutionStatistics", func() {
+		buffer.WriteByte('[')
+		for index, stat := range snapshot.addressResolutionStatistics {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			buffer.WriteByte('{')
+			writeJSONString(buffer, "StartTimeUTC")
+			buffer.WriteByte(':')
+			writeJSONString(buffer, stat.startTimeUTC.UTC().Format(nestedTraceTimeFormat))
+			buffer.WriteByte(',')
+			writeJSONString(buffer, "EndTimeUTC")
+			buffer.WriteByte(':')
+			if stat.endTimeUTC != nil {
+				writeJSONString(buffer, stat.endTimeUTC.UTC().Format(nestedTraceTimeFormat))
+			} else {
+				writeJSONString(buffer, "EndTime Never Set.")
+			}
+			buffer.WriteByte(',')
+			writeJSONString(buffer, "TargetEndpoint")
+			buffer.WriteByte(':')
+			if stat.targetEndpoint == "" {
+				buffer.WriteString("null")
+			} else {
+				writeJSONString(buffer, stat.targetEndpoint)
+			}
+			buffer.WriteByte('}')
+		}
+		buffer.WriteByte(']')
+	})
+
+	writeField("StoreResponseStatistics", func() {
+		buffer.WriteByte('[')
+		buffer.WriteByte(']')
+	})
+
+	if len(snapshot.httpResponseStatistics) > 0 {
+		writeField("HttpResponseStats", func() {
+			buffer.WriteByte('[')
+			for index, stat := range snapshot.httpResponseStatistics {
+				if index > 0 {
+					buffer.WriteByte(',')
+				}
+				writeHTTPResponseStatistic(buffer, stat)
+			}
+			buffer.WriteByte(']')
+		})
+	}
+
+	buffer.WriteByte('}')
+}
+
+func writeHTTPResponseStatistic(buffer *bytes.Buffer, stat httpResponseStatistics) {
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	writeField("StartTimeUTC", func() {
+		writeJSONString(buffer, stat.startTimeUTC.UTC().Format(nestedTraceTimeFormat))
+	})
+	writeField("DurationInMs", func() {
+		writeNumber(buffer, float64(stat.duration)/float64(time.Millisecond))
+	})
+	writeField("RequestUri", func() {
+		writeJSONString(buffer, stat.requestURI)
+	})
+	writeField("ResourceType", func() {
+		writeJSONString(buffer, resourceTypeName(stat.resourceType))
+	})
+	writeField("HttpMethod", func() {
+		writeJSONString(buffer, stat.httpMethod)
+	})
+	writeField("ActivityId", func() {
+		if stat.activityID == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.activityID)
+		}
+	})
+
+	if stat.exceptionType != "" {
+		writeField("ExceptionType", func() {
+			writeJSONString(buffer, stat.exceptionType)
+		})
+		writeField("ExceptionMessage", func() {
+			writeJSONString(buffer, stat.exceptionMessage)
+		})
+	}
+
+	if stat.statusCodeText != "" {
+		writeField("StatusCode", func() {
+			writeJSONString(buffer, stat.statusCodeText)
+		})
+		if stat.statusCode >= http.StatusBadRequest && stat.reasonPhrase != "" {
+			writeField("ReasonPhrase", func() {
+				writeJSONString(buffer, stat.reasonPhrase)
+			})
+		}
+	}
+
+	buffer.WriteByte('}')
+}
+
+func writePointOperationStatistics(buffer *bytes.Buffer, stat pointOperationStatisticsTraceDatum) {
+	buffer.WriteByte('{')
+	firstField := true
+
+	writeField := func(name string, writeValue func()) {
+		if !firstField {
+			buffer.WriteByte(',')
+		}
+		firstField = false
+		writeJSONString(buffer, name)
+		buffer.WriteByte(':')
+		writeValue()
+	}
+
+	writeField("Id", func() {
+		writeJSONString(buffer, "PointOperationStatistics")
+	})
+	writeField("ActivityId", func() {
+		if stat.ActivityID == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.ActivityID)
+		}
+	})
+	writeField("ResponseTimeUtc", func() {
+		writeJSONString(buffer, stat.ResponseTimeUTC.UTC().Format(nestedTraceTimeFormat))
+	})
+	writeField("StatusCode", func() {
+		writeNumber(buffer, float64(stat.StatusCode))
+	})
+	writeField("SubStatusCode", func() {
+		writeNumber(buffer, float64(stat.SubStatusCode))
+	})
+	writeField("RequestCharge", func() {
+		writeNumber(buffer, float64(stat.RequestCharge))
+	})
+	writeField("RequestUri", func() {
+		if stat.RequestURI == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.RequestURI)
+		}
+	})
+	writeField("ErrorMessage", func() {
+		if stat.ErrorMessage == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.ErrorMessage)
+		}
+	})
+	writeField("RequestSessionToken", func() {
+		if stat.RequestSessionToken == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.RequestSessionToken)
+		}
+	})
+	writeField("ResponseSessionToken", func() {
+		if stat.ResponseSessionToken == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.ResponseSessionToken)
+		}
+	})
+	writeField("BELatencyInMs", func() {
+		if stat.BELatencyInMs == "" {
+			buffer.WriteString("null")
+		} else {
+			writeJSONString(buffer, stat.BELatencyInMs)
+		}
+	})
+
+	buffer.WriteByte('}')
+}
+
+func writeJSONString(buffer *bytes.Buffer, value string) {
+	encoded, _ := json.Marshal(value)
+	buffer.Write(encoded)
+}
+
+func writeNumber(buffer *bytes.Buffer, value float64) {
+	buffer.WriteString(strconv.FormatFloat(value, 'f', -1, 64))
+}
+
+func durationInMilliseconds(start time.Time, end *time.Time) float64 {
+	if end != nil {
+		return float64(end.Sub(start)) / float64(time.Millisecond)
+	}
+
+	return float64(time.Since(start)) / float64(time.Millisecond)
+}

--- a/sdk/data/azcosmos/trace_json_writer.go
+++ b/sdk/data/azcosmos/trace_json_writer.go
@@ -25,15 +25,13 @@ type summaryDiagnostics struct {
 	regionURICount int
 }
 
-func writeTraceJSON(root *trace) string {
+func writeTraceJSON(root *finalizedTrace) string {
 	var buffer bytes.Buffer
 	writeTrace(&buffer, root, true)
 	return buffer.String()
 }
 
-func writeTrace(buffer *bytes.Buffer, current *trace, isRoot bool) {
-	snapshot := current.snapshot()
-
+func writeTrace(buffer *bytes.Buffer, current *finalizedTrace, isRoot bool) {
 	buffer.WriteByte('{')
 	firstField := true
 
@@ -54,29 +52,29 @@ func writeTrace(buffer *bytes.Buffer, current *trace, isRoot bool) {
 	}
 
 	writeField("name", func() {
-		writeJSONString(buffer, snapshot.name)
+		writeJSONString(buffer, current.name)
 	})
 
 	if isRoot {
 		writeField("start datetime", func() {
-			writeJSONString(buffer, snapshot.startTime.UTC().Format(rootTraceTimeFormat))
+			writeJSONString(buffer, current.startTime.UTC().Format(rootTraceTimeFormat))
 		})
 	}
 
 	writeField("duration in milliseconds", func() {
-		writeNumber(buffer, durationInMilliseconds(snapshot.startTime, snapshot.endTime))
+		writeNumber(buffer, durationInMilliseconds(current.startTime, current.endTime))
 	})
 
-	if len(snapshot.dataOrder) > 0 {
+	if len(current.dataOrder) > 0 {
 		writeField("data", func() {
-			writeTraceDataObject(buffer, snapshot.dataOrder, snapshot.data)
+			writeTraceDataObject(buffer, current.dataOrder, current.data)
 		})
 	}
 
-	if len(snapshot.children) > 0 {
+	if len(current.children) > 0 {
 		writeField("children", func() {
 			buffer.WriteByte('[')
-			for index, child := range snapshot.children {
+			for index, child := range current.children {
 				if index > 0 {
 					buffer.WriteByte(',')
 				}
@@ -89,7 +87,7 @@ func writeTrace(buffer *bytes.Buffer, current *trace, isRoot bool) {
 	buffer.WriteByte('}')
 }
 
-func writeSummaryDiagnostics(buffer *bytes.Buffer, root *trace) {
+func writeSummaryDiagnostics(buffer *bytes.Buffer, root *finalizedTrace) {
 	summary := collectSummaryDiagnostics(root)
 
 	buffer.WriteByte('{')
@@ -126,38 +124,35 @@ func writeSummaryDiagnostics(buffer *bytes.Buffer, root *trace) {
 	buffer.WriteByte('}')
 }
 
-func collectSummaryDiagnostics(root *trace) summaryDiagnostics {
+func collectSummaryDiagnostics(root *finalizedTrace) summaryDiagnostics {
 	summary := summaryDiagnostics{
 		directCalls:  map[[2]int]int{},
 		gatewayCalls: map[[2]int]int{},
 		regionsByURI: map[string]struct{}{},
 	}
 
-	var walk func(*trace)
-	walk = func(current *trace) {
-		snapshot := current.snapshot()
-		for _, key := range snapshot.dataOrder {
-			value := snapshot.data[key]
-			stats, ok := value.(*clientSideRequestStatisticsTraceDatum)
+	var walk func(*finalizedTrace)
+	walk = func(current *finalizedTrace) {
+		for _, key := range current.dataOrder {
+			stats, ok := current.data[key].(clientSideRequestStatisticsSnapshot)
 			if !ok {
 				continue
 			}
 
-			statsSnapshot := stats.snapshot()
-			for _, region := range statsSnapshot.regionsContacted {
+			for _, region := range stats.regionsContacted {
 				if _, exists := summary.regionsByURI[region.uri]; !exists {
 					summary.regionsByURI[region.uri] = struct{}{}
 					summary.regionURICount++
 				}
 			}
 
-			for _, gatewayCall := range statsSnapshot.httpResponseStatistics {
+			for _, gatewayCall := range stats.httpResponseStatistics {
 				key := [2]int{gatewayCall.statusCode, gatewayCall.subStatusCode}
 				summary.gatewayCalls[key]++
 			}
 		}
 
-		for _, child := range snapshot.children {
+		for _, child := range current.children {
 			walk(child)
 		}
 	}
@@ -207,6 +202,8 @@ func writeTraceDataObject(buffer *bytes.Buffer, order []string, values map[strin
 
 func writeTraceDatum(buffer *bytes.Buffer, value any) {
 	switch typed := value.(type) {
+	case clientSideRequestStatisticsSnapshot:
+		writeClientSideRequestStatistics(buffer, typed)
 	case *clientSideRequestStatisticsTraceDatum:
 		writeClientSideRequestStatistics(buffer, typed.snapshot())
 	case pointOperationStatisticsTraceDatum:
@@ -537,9 +534,9 @@ func writeNumber(buffer *bytes.Buffer, value float64) {
 }
 
 func durationInMilliseconds(start time.Time, end *time.Time) float64 {
-	if end != nil {
-		return float64(end.Sub(start)) / float64(time.Millisecond)
+	if end == nil {
+		return 0
 	}
 
-	return float64(time.Since(start)) / float64(time.Millisecond)
+	return float64(end.Sub(start)) / float64(time.Millisecond)
 }

--- a/sdk/data/azcosmos/trace_json_writer.go
+++ b/sdk/data/azcosmos/trace_json_writer.go
@@ -19,10 +19,10 @@ const (
 )
 
 type summaryDiagnostics struct {
-	directCalls    map[[2]int]int
-	gatewayCalls   map[[2]int]int
-	regionsByURI   map[string]struct{}
-	regionURICount int
+	directCalls   map[[2]int]int
+	gatewayCalls  map[[2]int]int
+	regionsByID   map[string]struct{}
+	regionIDCount int
 }
 
 func writeTraceJSON(root *finalizedTrace) string {
@@ -109,9 +109,9 @@ func writeSummaryDiagnostics(buffer *bytes.Buffer, root *finalizedTrace) {
 		})
 	}
 
-	if summary.regionURICount > 0 {
+	if summary.regionIDCount > 0 {
 		writeField("RegionsContacted", func() {
-			writeNumber(buffer, float64(summary.regionURICount))
+			writeNumber(buffer, float64(summary.regionIDCount))
 		})
 	}
 
@@ -128,7 +128,7 @@ func collectSummaryDiagnostics(root *finalizedTrace) summaryDiagnostics {
 	summary := summaryDiagnostics{
 		directCalls:  map[[2]int]int{},
 		gatewayCalls: map[[2]int]int{},
-		regionsByURI: map[string]struct{}{},
+		regionsByID:  map[string]struct{}{},
 	}
 
 	var walk func(*finalizedTrace)
@@ -140,9 +140,9 @@ func collectSummaryDiagnostics(root *finalizedTrace) summaryDiagnostics {
 			}
 
 			for _, region := range stats.regionsContacted {
-				if _, exists := summary.regionsByURI[region.uri]; !exists {
-					summary.regionsByURI[region.uri] = struct{}{}
-					summary.regionURICount++
+				if _, exists := summary.regionsByID[region.id]; !exists {
+					summary.regionsByID[region.id] = struct{}{}
+					summary.regionIDCount++
 				}
 			}
 
@@ -297,7 +297,7 @@ func writeClientSideRequestStatistics(buffer *bytes.Buffer, snapshot clientSideR
 			if index > 0 {
 				buffer.WriteByte(',')
 			}
-			writeJSONString(buffer, region.uri)
+			writeJSONString(buffer, region.id)
 		}
 		buffer.WriteByte(']')
 	})

--- a/sdk/data/azcosmos/trace_json_writer.go
+++ b/sdk/data/azcosmos/trace_json_writer.go
@@ -250,15 +250,19 @@ func writeTraceDatum(buffer *bytes.Buffer, value any) {
 		buffer.WriteByte(']')
 	case map[string]any:
 		buffer.WriteByte('{')
-		firstField := true
-		for key, item := range typed {
-			if !firstField {
+		// Sort keys so diagnostics output is stable for tests and easier to diff.
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for index, key := range keys {
+			if index > 0 {
 				buffer.WriteByte(',')
 			}
-			firstField = false
 			writeJSONString(buffer, key)
 			buffer.WriteByte(':')
-			writeTraceDatum(buffer, item)
+			writeTraceDatum(buffer, typed[key])
 		}
 		buffer.WriteByte('}')
 	case nil:

--- a/sdk/data/azcosmos/trace_json_writer.go
+++ b/sdk/data/azcosmos/trace_json_writer.go
@@ -19,7 +19,6 @@ const (
 )
 
 type summaryDiagnostics struct {
-	directCalls   map[[2]int]int
 	gatewayCalls  map[[2]int]int
 	regionsByID   map[string]struct{}
 	regionIDCount int
@@ -103,12 +102,6 @@ func writeSummaryDiagnostics(buffer *bytes.Buffer, root *finalizedTrace) {
 		writeValue()
 	}
 
-	if len(summary.directCalls) > 0 {
-		writeField("DirectCalls", func() {
-			writeCallSummaryObject(buffer, summary.directCalls)
-		})
-	}
-
 	if summary.regionIDCount > 0 {
 		writeField("RegionsContacted", func() {
 			writeNumber(buffer, float64(summary.regionIDCount))
@@ -126,7 +119,6 @@ func writeSummaryDiagnostics(buffer *bytes.Buffer, root *finalizedTrace) {
 
 func collectSummaryDiagnostics(root *finalizedTrace) summaryDiagnostics {
 	summary := summaryDiagnostics{
-		directCalls:  map[[2]int]int{},
 		gatewayCalls: map[[2]int]int{},
 		regionsByID:  map[string]struct{}{},
 	}


### PR DESCRIPTION
This PR adds diagnostic string support to the `azcosmos` package. Responses now carry a `Diagnostics` value, and callers can also recover diagnostics from failures via `DiagnosticsFromError(err)`. The diagnostics render as a structured JSON payload for troubleshooting latency and failures, including request timing, retry/gateway history, regions contacted, HTTP stats, RU charges, and query metrics.

### Architecture

The implementation now uses a mutable collection phase plus an immutable finalized diagnostics phase.

**`trace.go`** — Trace collection and finalization
- `trace` is the mutable tree used while an operation is in flight.
- `finalizedTrace` is an immutable snapshot created when diagnostics are handed off to a response or error.
- `traceSummary` tracks failed backend attempts across the tree.
- `startSpan()` mirrors the `azruntime.StartSpan` hierarchy into the diagnostics tree.

**`trace_data.go`** — Trace datum types and request-scoped state
- `requestDiagnosticsState` stores the request trace, client-side stats, resource type, and request session token in `context.Context`.
- `clientSideRequestStatisticsTraceDatum` records per-attempt HTTP response/error stats, regions contacted, address-resolution stats, and force-refresh data.
- `pointOperationStatisticsTraceDatum` captures point-operation metadata such as activity ID, status/substatus, RU charge, session tokens, and backend latency.
- Helpers attach diagnostics to outgoing requests and record point-operation/query-metric data from responses.

**`trace_json_writer.go`** — JSON serialization
- Serializes finalized diagnostics into the JSON shape exposed to callers.
- Produces the `Summary`, root trace, nested `data`, and `children` sections from immutable snapshots.
- Summary collection walks finalized state instead of live mutable traces.

**`diagnostics.go`** — Public API surface
- `Diagnostics` holds finalized immutable state plus the failed-request count.
- `String()`, `ClientElapsedTime()`, `StartTimeUTC()`, and `FailedRequestCount()` read from that finalized snapshot.
- `DiagnosticsFromError(err)` works with both wrapped request errors and `azcore.ResponseError`.

### Integration points (modified files)

| File | Changes |
|------|---------|
| `cosmos_client.go` | Attaches request diagnostics during request creation, records point-operation stats, and finalizes request traces before surfacing responses or errors. |
| `cosmos_container.go` / `cosmos_database.go` | Use `startSpan()` so operation trees flow into diagnostics; `ReadManyItems` now finalizes its operation trace before returning diagnostics. |
| `cosmos_client_retry_policy.go` | Records per-attempt HTTP response/error statistics into client-side diagnostics. |
| `cosmos_response.go` and response helpers | Add/populate `Diagnostics` on response types from the request context. |
| `cosmos_query_response.go` | Records query metrics before diagnostics are finalized and includes `Diagnostics` on `ReadManyItemsResponse`. |
| `cosmos_offers.go` / `trace_data.go` | Use lightweight request-charge parsing where only charge data is needed, avoiding accidental mid-request diagnostics capture. |

### Tests

- `diagnostics_test.go` covers:
  - summary diagnostics for a retried gateway call (503 → 200)
  - diagnostics extracted from `azcore.ResponseError`
  - query response diagnostics including query metrics
  - `ReadManyItems` diagnostics remaining stable after return
  - representative exact rendered JSON samples for gateway-summary, response-error, and query-metrics scenarios

### Checklist

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
