### PR TITLE
Enhance error message extraction for Azure Developer CLI to support multiple JSON formats

### DIFF
--- a/sdk/azidentity/developer_credential_util.go
+++ b/sdk/azidentity/developer_credential_util.go
@@ -50,16 +50,7 @@ var shellExec = func(ctx context.Context, credName, command string) ([]byte, err
 		}
 		switch credName {
 		case credNameAzureDeveloperCLI:
-			// azd writes JSON error messages to stderr: {"type":"consoleMessage","data":{"message":"..."}}
-			// Try to extract the message field for cleaner errors
-			var obj struct {
-				Data struct {
-					Message string `json:"message"`
-				} `json:"data"`
-			}
-			if err := json.Unmarshal([]byte(msg), &obj); err == nil && obj.Data.Message != "" {
-				msg = strings.TrimSpace(obj.Data.Message)
-			}
+			msg = extractAzdError(msg)
 		case credNameAzurePowerShell:
 			if strings.Contains(msg, "Connect-AzAccount") {
 				msg = `Please run "Connect-AzAccount" to set up an account`
@@ -95,4 +86,37 @@ func validScope(scope string) bool {
 		}
 	}
 	return true
+}
+
+// extractAzdError extracts a human-readable error message from azd's stderr JSON output.
+// azd writes JSON error messages to stderr. The format depends on the azd version:
+//   - v1.23.7+: {"error":"...","message":"...","suggestion":"..."} (may be preceded by an empty consoleMessage line)
+//   - pre-v1.23.7: {"type":"consoleMessage","data":{"message":"..."}}
+//
+// Prefer the structured "error" format, fall back to legacy consoleMessage.
+func extractAzdError(msg string) string {
+	lines := strings.Split(msg, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		var errObj struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal([]byte(line), &errObj) == nil && errObj.Error != "" {
+			return errObj.Error
+		}
+	}
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		var obj struct {
+			Data struct {
+				Message string `json:"message"`
+			} `json:"data"`
+		}
+		if json.Unmarshal([]byte(line), &obj) == nil && obj.Data.Message != "" {
+			if m := strings.TrimSpace(obj.Data.Message); m != "" {
+				return m
+			}
+		}
+	}
+	return msg
 }

--- a/sdk/azidentity/developer_credential_util.go
+++ b/sdk/azidentity/developer_credential_util.go
@@ -96,27 +96,32 @@ func validScope(scope string) bool {
 // Prefer the structured "error" format, fall back to legacy consoleMessage.
 func extractAzdError(msg string) string {
 	lines := strings.Split(msg, "\n")
+	fallback := ""
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
+
 		var errObj struct {
 			Error string `json:"error"`
 		}
 		if json.Unmarshal([]byte(line), &errObj) == nil && errObj.Error != "" {
 			return errObj.Error
 		}
-	}
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		var obj struct {
-			Data struct {
-				Message string `json:"message"`
-			} `json:"data"`
-		}
-		if json.Unmarshal([]byte(line), &obj) == nil && obj.Data.Message != "" {
-			if m := strings.TrimSpace(obj.Data.Message); m != "" {
-				return m
+
+		if fallback == "" {
+			var obj struct {
+				Data struct {
+					Message string `json:"message"`
+				} `json:"data"`
+			}
+			if json.Unmarshal([]byte(line), &obj) == nil {
+				if m := strings.TrimSpace(obj.Data.Message); m != "" {
+					fallback = m
+				}
 			}
 		}
+	}
+	if fallback != "" {
+		return fallback
 	}
 	return msg
 }

--- a/sdk/azidentity/developer_credential_util_test.go
+++ b/sdk/azidentity/developer_credential_util_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azidentity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractAzdError(t *testing.T) {
+	aadError := "AADSTS90002: Tenant 'test' not found. Check to make sure you have the correct tenant ID"
+
+	tests := []struct {
+		name     string
+		stderr   string
+		expected string
+	}{
+		{
+			name:     "v1.24.0+ structured error only",
+			stderr:   `{"error":"` + aadError + `","message":"Authentication with Azure failed.","suggestion":"Run 'azd auth login' to sign in again."}`,
+			expected: aadError,
+		},
+		{
+			name: "v1.23.7 structured error preceded by empty consoleMessage",
+			stderr: `{"type":"consoleMessage","timestamp":"2026-04-14T22:02:36.154700776Z","data":{"message":"\n"}}
+{"error":"` + aadError + `","message":"Authentication with Azure failed.","suggestion":"Run 'azd auth login' to sign in again."}`,
+			expected: aadError,
+		},
+		{
+			name:     "pre-v1.23.7 legacy consoleMessage",
+			stderr:   `{"type":"consoleMessage","timestamp":"2026-04-14T22:03:37.687535934Z","data":{"message":"\nERROR: ` + aadError + `\n\n"}}`,
+			expected: "ERROR: " + aadError,
+		},
+		{
+			name: "pre-v1.23.7 multiple consoleMessage lines",
+			stderr: `{"type":"consoleMessage","timestamp":"...","data":{"message":"\nERROR: ` + aadError + `\n"}}
+{"type":"consoleMessage","timestamp":"...","data":{"message":"Suggestion: reauthentication required\n"}}`,
+			expected: "ERROR: " + aadError,
+		},
+		{
+			name:     "non-JSON plain text preserved",
+			stderr:   "some plain error text",
+			expected: "some plain error text",
+		},
+		{
+			name:     "empty consoleMessage skipped",
+			stderr:   `{"type":"consoleMessage","data":{"message":"\n"}}`,
+			expected: `{"type":"consoleMessage","data":{"message":"\n"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := extractAzdError(tt.stderr)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/sdk/azidentity/developer_credential_util_test.go
+++ b/sdk/azidentity/developer_credential_util_test.go
@@ -45,7 +45,7 @@ func TestExtractAzdError(t *testing.T) {
 			expected: "some plain error text",
 		},
 		{
-			name:     "empty consoleMessage skipped",
+			name:     "empty consoleMessage not extracted",
 			stderr:   `{"type":"consoleMessage","data":{"message":"\n"}}`,
 			expected: `{"type":"consoleMessage","data":{"message":"\n"}}`,
 		},


### PR DESCRIPTION
Fixes #25983
Fixes https://github.com/Azure/azure-dev/issues/7728

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go

### Description

Starting with [azd v1.23.7](https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.23.7) (PR [Azure/azure-dev#6827](https://github.com/Azure/azure-dev/pull/6827)), `azd auth token` changed its stderr error format from the legacy `consoleMessage` JSON to a structured `{"error":"..."}` JSON object. The stderr output may also include an extraneous empty `consoleMessage` line preceding the error (fixed in v1.24.0 via [Azure/azure-dev#7701](https://github.com/Azure/azure-dev/pull/7701)).

This PR updates the `AzureDeveloperCLICredential` error parsing to handle all three formats:

| azd version | stderr format |
|---|---|
| pre-v1.23.7 | `{"type":"consoleMessage","data":{"message":"..."}}` |
| v1.23.7 – v1.23.15 | `{"type":"consoleMessage",...}\n{"error":"..."}` (two lines) |
| v1.24.0+ | `{"error":"..."}` (single line) |

The parser splits stderr by newline and scans for the structured `{"error":"..."}` format first. If not found, it falls back to extracting from the legacy `consoleMessage` `data.message` field.

### Testing

Added tests and validated changes manually with test program:

```go
cred, err := azidentity.NewAzureDeveloperCLICredential(&azidentity.AzureDeveloperCLICredentialOptions{
	TenantID: "tenant-id",
})
...
_, err = cred.GetToken(context.Background(), policy.TokenRequestOptions{
	Scopes: []string{"https://management.azure.com/.default"},
})
...
```

**Without change:**

<img width="3498" height="443" alt="image" src="https://github.com/user-attachments/assets/c4a04538-4398-4db5-98f3-31f2fe311675" />

**With change:**

<img width="3493" height="329" alt="image" src="https://github.com/user-attachments/assets/0cdc844f-385e-4e2c-9fb6-d5cd2abfde78" />
