### PR TITLE
fix(azeventhubs): swap OwnerID/PartitionID log args in BlobStore.ClaimOwnership

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - Fixed missing `consumers.Delete()` call when checkpoint initialization fails, which could block future consumer creation for the affected partition. (#24983)
+- Fixed swapped `OwnerID`/`PartitionID` format arguments in `BlobStore.ClaimOwnership` log message for ownership claims with no etags.
 
 ## 2.0.2 (2026-03-10)
 

--- a/sdk/messaging/azeventhubs/checkpoints/blob_store.go
+++ b/sdk/messaging/azeventhubs/checkpoints/blob_store.go
@@ -218,7 +218,7 @@ func (b *BlobStore) setOwnershipMetadata(ctx context.Context, blobName string, o
 		return setMetadataResp.LastModified, *setMetadataResp.ETag, nil
 	}
 
-	log.Writef(azeventhubs.EventConsumer, "[%s] claiming ownership for %s with NO etags", ownership.PartitionID, ownership.OwnerID)
+	log.Writef(azeventhubs.EventConsumer, "[%s] claiming ownership for %s with NO etags", ownership.OwnerID, ownership.PartitionID)
 	uploadResp, err := blobClient.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte{})), &blockblob.UploadOptions{
 		Metadata: blobMetadata,
 		AccessConditions: &blob.AccessConditions{


### PR DESCRIPTION
The log.Writef call at checkpoints/blob_store.go:221 had its two format arguments (OwnerID, PartitionID) reversed compared to the format string and the identical log pattern on line 205. This caused [PartitionID] to appear in the bracket prefix instead of [OwnerID], breaking log attribution.

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
