### PR TITLE
Remove cosmos filter from pullrequest build definition

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -10,9 +10,6 @@ pr:
     include:
     - "*"
 
-    exclude:
-    - sdk/data/azcosmos/
-
 parameters:
   - name: Service
     type: string


### PR DESCRIPTION
Remove `sdk/data/azcosmos/` exclusion from `pullrequest.yml` trigger paths so cosmos changes go through the standard PR validation pipeline.

A dummy `.trigger-test` file is included under `sdk/data/azcosmos/` to ensure the PR pipeline triggers for cosmos paths.

Related to Azure/azure-sdk-tools#15160