### PR TITLE
[storage] switch to `recording.Sleep` to make playback tests 10x faster

### DIFF
--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -2300,7 +2300,7 @@ func (s *AppendBlobUnrecordedTestsSuite) TestCreateAppendBlobWithTags() {
 	createResp, err := abClient.Create(context.Background(), &createAppendBlobOptions)
 	_require.NoError(err)
 	_require.NotNil(createResp.VersionID)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	_, err = abClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -2954,7 +2954,7 @@ func (s *AppendBlobRecordedTestsSuite) TestUndeleteAppendBlobVersion() {
 	}
 
 	// adding wait after delete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Versions: true},
@@ -2965,7 +2965,7 @@ func (s *AppendBlobRecordedTestsSuite) TestUndeleteAppendBlobVersion() {
 	_require.NoError(err)
 
 	// adding wait after undelete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Versions: true},
@@ -3011,7 +3011,7 @@ func (s *AppendBlobRecordedTestsSuite) TestUndeleteAppendBlobSnapshot() {
 	}
 
 	// adding wait after delete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Snapshots: true},
@@ -3022,7 +3022,7 @@ func (s *AppendBlobRecordedTestsSuite) TestUndeleteAppendBlobSnapshot() {
 	_require.NoError(err)
 
 	// adding wait after undelete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Snapshots: true},
@@ -3085,7 +3085,7 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendBlobSetExpiryRelativeToNow() {
 	_require.NoError(err)
 	_require.NotNil(resp.ExpiresOn)
 
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	_, err = abClient.GetProperties(context.Background(), nil)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.BlobNotFound)
@@ -3118,7 +3118,7 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendBlobSetExpiryRelativeToCreation
 	_require.NoError(err)
 	_require.NotNil(resp.ExpiresOn)
 
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	_, err = abClient.GetProperties(context.Background(), nil)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.BlobNotFound)
@@ -3153,7 +3153,7 @@ func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlobSetExpiryToAbsolute() {
 	_require.NotNil(resp.ExpiresOn)
 	_require.Equal(expiryTimeAbsolute.UTC().Format(http.TimeFormat), resp.ExpiresOn.UTC().Format(http.TimeFormat))
 
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	_, err = abClient.GetProperties(context.Background(), nil)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.BlobNotFound)
@@ -3675,7 +3675,7 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendBlobSetBlobTags() {
 
 	_, err = abClient.SetTags(context.Background(), tagsMap, nil)
 	_require.NoError(err)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	blobGetTagsResponse, err := abClient.GetTags(context.Background(), nil)
 	_require.NoError(err)
@@ -3713,7 +3713,7 @@ func (s *AppendBlobUnrecordedTestsSuite) TestSetBlobTagsWithLeaseId() {
 
 	_, err = abClient.SetTags(ctx, testcommon.BasicBlobTagsMap, nil)
 	_require.Error(err)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	// add lease conditions
 	_, err = abClient.SetTags(ctx, testcommon.BasicBlobTagsMap, &blob.SetTagsOptions{AccessConditions: &blob.AccessConditions{

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3699,7 +3699,7 @@ func (s *BlobRecordedTestsSuite) TestBlobSetExpiry() {
 	_require.NoError(err)
 	_require.NotNil(resp.ExpiresOn)
 
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	_, err = bbClient.GetProperties(context.Background(), nil)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.BlobNotFound)

--- a/sdk/storage/azblob/blob/examples_test.go
+++ b/sdk/storage/azblob/blob/examples_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
@@ -221,7 +220,7 @@ func Example_blob_Client_StartCopyFromURL() {
 	copyID := *startCopy.CopyID
 	copyStatus := *startCopy.CopyStatus
 	for copyStatus == blob.CopyStatusTypePending {
-		recording.Sleep(time.Second * 2)
+		time.Sleep(time.Second * 2)
 		getMetadata, err := blobClient.GetProperties(context.TODO(), nil)
 		if err != nil {
 			log.Fatal(err)

--- a/sdk/storage/azblob/blob/examples_test.go
+++ b/sdk/storage/azblob/blob/examples_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
@@ -220,7 +221,7 @@ func Example_blob_Client_StartCopyFromURL() {
 	copyID := *startCopy.CopyID
 	copyStatus := *startCopy.CopyStatus
 	for copyStatus == blob.CopyStatusTypePending {
-		time.Sleep(time.Second * 2)
+		recording.Sleep(time.Second * 2)
 		getMetadata, err := blobClient.GetProperties(context.TODO(), nil)
 		if err != nil {
 			log.Fatal(err)

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -1912,7 +1912,7 @@ func (s *BlockBlobRecordedTestsSuite) TestPutBlockListWithImmutabilityPolicy() {
 	policy1 := blob.ImmutabilityPolicyMode("unlocked")
 	_require.Equal(resp.ImmutabilityPolicyMode, &policy1)
 
-	time.Sleep(time.Second * 7)
+	recording.Sleep(time.Second * 7)
 
 	_, err = bbClient.SetLegalHold(context.Background(), false, nil)
 	_require.NoError(err)
@@ -3502,7 +3502,7 @@ func (s *BlockBlobRecordedTestsSuite) TestUndeleteBlockBlobVersion() {
 	}
 
 	// adding wait after delete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Versions: true},
@@ -3513,7 +3513,7 @@ func (s *BlockBlobRecordedTestsSuite) TestUndeleteBlockBlobVersion() {
 	_require.NoError(err)
 
 	// adding wait after undelete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Versions: true},
@@ -3556,7 +3556,7 @@ func (s *BlockBlobRecordedTestsSuite) TestUndeleteBlockBlobSnapshot() {
 	}
 
 	// adding wait after delete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Snapshots: true},
@@ -3567,7 +3567,7 @@ func (s *BlockBlobRecordedTestsSuite) TestUndeleteBlockBlobSnapshot() {
 	_require.NoError(err)
 
 	// adding wait after undelete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Snapshots: true},
@@ -3753,7 +3753,7 @@ func (s *BlockBlobRecordedTestsSuite) TestORSSource() {
 //	if err != nil {
 //		s.T().Fatal(err)
 //	}
-//	time.Sleep(time.Second * 2)
+//	recording.Sleep(time.Second * 2)
 //
 //	//Attach SAS query to block blob URL
 //	snapParts := NewBlobURLParts(blobURL.URL())
@@ -4429,7 +4429,7 @@ func (s *BlockBlobUnrecordedTestsSuite) TestFilterBlobsWithTags() {
 	blobClient2 := testcommon.CreateNewBlockBlob(context.Background(), _require, blobName2, containerClient)
 	_, err = blobClient2.SetTags(context.Background(), blobTagsMap2, nil)
 	_require.NoError(err)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	blobTagsResp, err := blobClient2.GetTags(context.Background(), nil)
 	_require.NoError(err)
@@ -4509,7 +4509,7 @@ func (s *BlockBlobUnrecordedTestsSuite) TestFilterBlobsWithTags() {
 //		_assert(blobTagsMap[blobTag.Key], chk.Equals, blobTag.Value)
 //	}
 //
-//	time.Sleep(30 * time.Second)
+//	recording.Sleep(30 * time.Second)
 //	where := "\"tag1\"='firsttag'AND\"tag2\"='secondtag'AND@container='" + containerName + "'"
 //	_, err = serviceURL.FindBlobsByTags(context.Background(), nil, nil, &where, Marker{}, nil)
 //	_require.NoError(err)
@@ -5490,7 +5490,7 @@ func (s *BlockBlobRecordedTestsSuite) TestBlockBlobSetExpiryRelativeToNow() {
 	_require.NoError(err)
 	_require.NotNil(resp.ExpiresOn)
 
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	_, err = bbClient.GetProperties(context.Background(), nil)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.BlobNotFound)
@@ -5518,7 +5518,7 @@ func (s *BlockBlobRecordedTestsSuite) TestBlockBlobSetExpiryRelativeToCreation()
 	_require.NoError(err)
 	_require.NotNil(resp.ExpiresOn)
 
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	_, err = bbClient.GetProperties(context.Background(), nil)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.BlobNotFound)
@@ -5548,7 +5548,7 @@ func (s *BlockBlobUnrecordedTestsSuite) TestBlockBlobSetExpiryToAbsolute() {
 	_require.NotNil(resp.ExpiresOn)
 	_require.Equal(expiryTimeAbsolute.UTC().Format(http.TimeFormat), resp.ExpiresOn.UTC().Format(http.TimeFormat))
 
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	_, err = bbClient.GetProperties(context.Background(), nil)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.BlobNotFound)
@@ -5570,7 +5570,7 @@ func (s *BlockBlobUnrecordedTestsSuite) TestBlockBlobSetExpiryToPast() {
 	_require.Nil(resp.ExpiresOn)
 
 	expiryTimeAbsolute := time.Now().Add(8 * time.Second)
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 	_, err = bbClient.SetExpiry(context.Background(), blockblob.ExpiryTypeAbsolute(expiryTimeAbsolute), nil)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.InvalidHeaderValue)
 

--- a/sdk/storage/azblob/client_test.go
+++ b/sdk/storage/azblob/client_test.go
@@ -766,7 +766,7 @@ func (s *AZBlobUnrecordedTestsSuite) TestDoBatchTransferWithError() {
 		Operation: func(ctx context.Context, offset int64, chunkSize int64) error {
 			// simulate doing some work (HTTP call in real scenarios)
 			// later chunks later longer to finish
-			time.Sleep(time.Second * time.Duration(offset))
+			recording.Sleep(time.Second * time.Duration(offset))
 			// simulate having gotten data and write it to the memory mapped file
 			mmf.write("input")
 
@@ -791,7 +791,7 @@ func (s *AZBlobUnrecordedTestsSuite) TestDoBatchTransferWithError() {
 
 	// simulate closing the mmf and make sure no panic occurs (as reported in #139)
 	mmf.isClosed = true
-	time.Sleep(time.Second * 5)
+	recording.Sleep(time.Second * 5)
 }
 
 func (s *AZBlobRecordedTestsSuite) TestAzBlobClientDefaultAudience() {

--- a/sdk/storage/azblob/container/client_test.go
+++ b/sdk/storage/azblob/container/client_test.go
@@ -1001,7 +1001,7 @@ func (s *ContainerRecordedTestsSuite) TestContainerListBlobsIncludeMultipleImpl(
 	_require.NoError(err)
 
 	// Copy should finish within one minute
-	time.Sleep(60 * time.Second)
+	recording.Sleep(60 * time.Second)
 
 	bbClient3 := testcommon.CreateNewBlockBlob(context.Background(), _require, "deleted"+blobName, containerClient)
 	_, err = bbClient3.Delete(context.Background(), nil)
@@ -2248,7 +2248,7 @@ func (s *ContainerRecordedTestsSuite) TestContainerUndelete() {
 
 	// it appears that deleting the container involves acquiring a lease.
 	// since leases can only be 15-60s or infinite, we just wait for 60 seconds.
-	time.Sleep(60 * time.Second)
+	recording.Sleep(60 * time.Second)
 
 	prefix := testcommon.ContainerPrefix
 	listOptions := service.ListContainersOptions{Prefix: &prefix, Include: service.ListContainersInclude{Metadata: true, Deleted: true}}
@@ -2282,7 +2282,7 @@ func (s *ContainerRecordedTestsSuite) TestContainerUndelete() {
 			break
 		} else if bloberror.HasCode(err, bloberror.Code("ConcurrentContainerOperationInProgress")) {
 			// the container is still being restored, sleep a bit then try again
-			time.Sleep(10 * time.Second)
+			recording.Sleep(10 * time.Second)
 		} else {
 			// some other error
 			break
@@ -2474,7 +2474,7 @@ func (s *ContainerUnrecordedTestsSuite) TestFilterBlobsByBasicTags() {
 	createResp, err := abClient.Create(context.Background(), &createAppendBlobOptions)
 	_require.NoError(err)
 	_require.NotNil(createResp.VersionID)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	// Use container client to filter blobs by tag
 	where := "\"azure\"='blob'"
@@ -2522,7 +2522,7 @@ func (s *ContainerUnrecordedTestsSuite) TestFilterBlobsBySpecialCharTags() {
 	createResp, err := abClient.Create(context.Background(), &createAppendBlobOptions)
 	_require.NoError(err)
 	_require.NotNil(createResp.VersionID)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	// Use container client to filter blobs by tag
 
@@ -2571,7 +2571,7 @@ func (s *ContainerUnrecordedTestsSuite) TestFilterBlobsByTagsNegative() {
 	createResp, err := abClient.Create(context.Background(), &createAppendBlobOptions)
 	_require.NoError(err)
 	_require.NotNil(createResp.VersionID)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	// Use container client to filter blobs by tag
 	where := "\"azure\"='blob'"
@@ -2607,7 +2607,7 @@ func (s *ContainerUnrecordedTestsSuite) TestFilterBlobsOnContainer() {
 	blobClient2 := testcommon.CreateNewBlockBlob(context.Background(), _require, blobName2, containerClient)
 	_, err = blobClient2.SetTags(context.Background(), blobTagsMap2, nil)
 	_require.NoError(err)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	blobTagsResp, err := blobClient2.GetTags(context.Background(), nil)
 	_require.NoError(err)
@@ -3465,7 +3465,7 @@ func (s *ContainerUnrecordedTestsSuite) TestContainerSASUsingAccessPolicy() {
 	_require.NoError(err)
 	_require.Len(gResp.SignedIdentifiers, 1)
 
-	time.Sleep(30 * time.Second)
+	recording.Sleep(30 * time.Second)
 
 	sasQueryParams, err := sas.BlobSignatureValues{
 		Protocol:      sas.ProtocolHTTPS,

--- a/sdk/storage/azblob/internal/testcommon/clients_auth.go
+++ b/sdk/storage/azblob/internal/testcommon/clients_auth.go
@@ -291,7 +291,7 @@ func RunTestRequiringServiceProperties(ctx context.Context, _require *require.As
 	err := testImplFunc(ctx, _require, svcClient)
 	// We cannot assume that the error indicative of slow update will necessarily be a StorageError. As in ListBlobs.
 	if err != nil && err.Error() == code {
-		time.Sleep(time.Second * 30)
+		recording.Sleep(time.Second * 30)
 		err = testImplFunc(ctx, _require, svcClient)
 		_require.NoError(err)
 	}

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -740,7 +740,7 @@ func (s *PageBlobUnrecordedTestsSuite) TestIncrementalCopyErrorCode() {
 	_require.NoError(err)
 
 	// Sleep to ensure time difference between snapshots
-	time.Sleep(1 * time.Millisecond)
+	recording.Sleep(1 * time.Millisecond)
 
 	// Create second snapshot (newer)
 	r2 := testcommon.GetReaderToGeneratedBytes(contentSize)
@@ -4275,7 +4275,7 @@ func (s *PageBlobUnrecordedTestsSuite) TestCreatePageBlobWithTags() {
 
 	_, err = pbClient.SetTags(context.Background(), testcommon.BasicBlobTagsMap, nil)
 	_require.NoError(err)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 	// _require.Equal(setTagResp.RawResponse.StatusCode, 204)
 
 	gpResp, err := pbClient.GetProperties(context.Background(), nil)
@@ -4338,7 +4338,7 @@ func (s *PageBlobUnrecordedTestsSuite) TestPageBlobSetBlobTagForSnapshot() {
 
 	_, err = pbClient.SetTags(context.Background(), testcommon.SpecialCharBlobTagsMap, nil)
 	_require.NoError(err)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	resp, err := pbClient.CreateSnapshot(context.Background(), nil)
 	_require.NoError(err)
@@ -4512,7 +4512,7 @@ func (s *PageBlobRecordedTestsSuite) TestPageBlockPermanentDelete() {
 	deleteBlobOptions := blob.DeleteOptions{
 		BlobDeleteType: &perm,
 	}
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	// Execute Delete with DeleteTypePermanent
 	pdResp, err := snapshotURL.Delete(context.Background(), &deleteBlobOptions)
@@ -4965,7 +4965,7 @@ func (s *PageBlobRecordedTestsSuite) TestUndeletePageBlobVersion() {
 	}
 
 	// adding wait after delete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Versions: true},
@@ -4976,7 +4976,7 @@ func (s *PageBlobRecordedTestsSuite) TestUndeletePageBlobVersion() {
 	_require.NoError(err)
 
 	// adding wait after undelete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Versions: true},
@@ -5025,7 +5025,7 @@ func (s *PageBlobRecordedTestsSuite) TestUndeletePageBlobSnapshot() {
 	}
 
 	// adding wait after delete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Snapshots: true},
@@ -5036,7 +5036,7 @@ func (s *PageBlobRecordedTestsSuite) TestUndeletePageBlobSnapshot() {
 	_require.NoError(err)
 
 	// adding wait after undelete
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 
 	listPager = containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Snapshots: true},

--- a/sdk/storage/azblob/service/client_test.go
+++ b/sdk/storage/azblob/service/client_test.go
@@ -618,7 +618,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicy() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	resp, err := svcClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -630,7 +630,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicy() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	resp, err = svcClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -649,7 +649,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicyEmpty() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	resp, err := svcClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -672,7 +672,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicyNil() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	resp, err := svcClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -683,7 +683,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicyNil() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	// If an element of service properties is not passed, the service keeps the current settings.
 	resp, err = svcClient.GetProperties(context.Background(), nil)
@@ -978,7 +978,7 @@ func (s *ServiceRecordedTestsSuite) TestContainerRestore() {
 
 	// it appears that deleting the container involves acquiring a lease.
 	// since leases can only be 15-60s or infinite, we just wait for 60 seconds.
-	time.Sleep(60 * time.Second)
+	recording.Sleep(60 * time.Second)
 	prefix := testcommon.ContainerPrefix
 	listOptions := service.ListContainersOptions{Prefix: &prefix, Include: service.ListContainersInclude{Metadata: true, Deleted: true}}
 	pager := svcClient.NewListContainersPager(&listOptions)
@@ -1011,7 +1011,7 @@ func (s *ServiceRecordedTestsSuite) TestContainerRestore() {
 			break
 		} else if bloberror.HasCode(err, bloberror.Code("ConcurrentContainerOperationInProgress")) {
 			// the container is still being restored, sleep a bit then try again
-			time.Sleep(10 * time.Second)
+			recording.Sleep(10 * time.Second)
 		} else {
 			// some other error
 			break
@@ -1178,7 +1178,7 @@ func (s *ServiceUnrecordedTestsSuite) TestFilterBlobsTagsWithServiceSAS() {
 	createResp, err := abClient.Create(context.Background(), &createAppendBlobOptions)
 	_require.NoError(err)
 	_require.NotNil(createResp.VersionID)
-	time.Sleep(10 * time.Second)
+	recording.Sleep(10 * time.Second)
 
 	_, err = abClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)


### PR DESCRIPTION
Replacing `time.Sleep` with `recording.Sleep`. 

Now, the test execution will only pause in `live` or `record` mode, not `playback` mode. This speeds up test execution. For example, azblobs would take around 5 minutes to run, now it's only 30 seconds (10x increase in speed).