### PR TITLE
Add Expect: 100-continue pipeline policy to storage sdk

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## 1.8.0-beta.2 (Unreleased)
 
 ### Features Added
+* Added support for the `Expect: 100-continue` HTTP header on requests with a body. The new
+  `ExpectContinueBehavior` field on `ClientOptions` configures the behavior via
+  `ExpectContinueOptions`. By default (`ExpectContinueModeApplyOnThrottle`) the header is sent for
+  one minute after a 429, 500, or 503 response is received; the interval can be overridden via
+  `ExpectContinueOptions.AutoInterval`. Other modes are `ExpectContinueModeOn` (always send) and
+  `ExpectContinueModeOff` (never send). Set the environment variable
+  `AZURE_STORAGE_DISABLE_EXPECT_CONTINUE_HEADER=true` to disable the feature regardless of
+  `ClientOptions`.
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/appendblob/client.go
+++ b/sdk/storage/azblob/appendblob/client.go
@@ -36,6 +36,9 @@ func NewClient(blobURL string, cred azcore.TokenCredential, options *ClientOptio
 	conOptions := shared.GetClientOptions(options)
 	authPolicy := shared.NewStorageChallengePolicy(cred, audience, conOptions.InsecureAllowCredentialWithHTTP)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
@@ -51,8 +54,12 @@ func NewClient(blobURL string, cred azcore.TokenCredential, options *ClientOptio
 //   - options - client options; pass nil to accept the default values
 func NewClientWithNoCredential(blobURL string, options *ClientOptions) (*Client, error) {
 	conOptions := shared.GetClientOptions(options)
+	plOpts := runtime.PipelineOptions{}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
-	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +75,9 @@ func NewClientWithSharedKeyCredential(blobURL string, cred *blob.SharedKeyCreden
 	authPolicy := exported.NewSharedKeyCredPolicy(cred)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -38,6 +38,9 @@ func NewClient(blobURL string, cred azcore.TokenCredential, options *ClientOptio
 	conOptions := shared.GetClientOptions(options)
 	authPolicy := shared.NewStorageChallengePolicy(cred, audience, conOptions.InsecureAllowCredentialWithHTTP)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
@@ -52,8 +55,12 @@ func NewClient(blobURL string, cred azcore.TokenCredential, options *ClientOptio
 //   - options - client options; pass nil to accept the default values
 func NewClientWithNoCredential(blobURL string, options *ClientOptions) (*Client, error) {
 	conOptions := shared.GetClientOptions(options)
+	plOpts := runtime.PipelineOptions{}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
-	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +75,9 @@ func NewClientWithSharedKeyCredential(blobURL string, cred *SharedKeyCredential,
 	authPolicy := exported.NewSharedKeyCredPolicy(cred)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -20,6 +20,29 @@ func NewSharedKeyCredential(accountName, accountKey string) (*SharedKeyCredentia
 	return exported.NewSharedKeyCredential(accountName, accountKey)
 }
 
+// ExpectContinueMode is the mode for applying the HTTP "Expect: 100-continue" header to
+// operations that include a request body.
+type ExpectContinueMode = exported.ExpectContinueMode
+
+const (
+	// ExpectContinueModeApplyOnThrottle indicates that Expect-Continue will not be applied
+	// until specific errors are encountered from the service, at which point it will be
+	// applied for a fixed window of time after the last triggering error. This is the default.
+	ExpectContinueModeApplyOnThrottle = exported.ExpectContinueModeApplyOnThrottle
+
+	// ExpectContinueModeOn indicates Expect-Continue will be applied regardless of recent
+	// error status. The ContentLengthThreshold option still applies.
+	ExpectContinueModeOn = exported.ExpectContinueModeOn
+
+	// ExpectContinueModeOff indicates Expect-Continue will never be applied.
+	ExpectContinueModeOff = exported.ExpectContinueModeOff
+)
+
+// ExpectContinueOptions configures the behavior for applying the HTTP "Expect: 100-continue"
+// header to operations that include a request body.
+type ExpectContinueOptions = exported.ExpectContinueOptions
+
+
 // Type Declarations ---------------------------------------------------------------------
 
 // AccessConditions identifies blob-specific access conditions which you optionally set.

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -46,6 +46,9 @@ func NewClient(blobURL string, cred azcore.TokenCredential, options *ClientOptio
 	conOptions := shared.GetClientOptions(options)
 	authPolicy := shared.NewStorageChallengePolicy(cred, audience, conOptions.InsecureAllowCredentialWithHTTP)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
@@ -60,8 +63,12 @@ func NewClient(blobURL string, cred azcore.TokenCredential, options *ClientOptio
 //   - options - client options; pass nil to accept the default values
 func NewClientWithNoCredential(blobURL string, options *ClientOptions) (*Client, error) {
 	conOptions := shared.GetClientOptions(options)
+	plOpts := runtime.PipelineOptions{}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
-	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -77,6 +84,9 @@ func NewClientWithSharedKeyCredential(blobURL string, cred *blob.SharedKeyCreden
 	authPolicy := exported.NewSharedKeyCredPolicy(cred)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -7037,3 +7037,62 @@ func (s *BlockBlobUnrecordedTestsSuite) TestCommitBlockListWithUDSCreatePermissi
 	_require.Error(err)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.UnauthorizedBlobOverwrite)
 }
+
+// expectHeaderObserver records the value of the Expect header on every outgoing request.
+type expectHeaderObserver struct {
+	seen []string
+}
+
+func (e *expectHeaderObserver) Do(req *policy.Request) (*http.Response, error) {
+	e.seen = append(e.seen, req.Raw().Header.Get("Expect"))
+	return req.Next()
+}
+
+// TestUploadExpectContinue verifies that, when ExpectContinueModeOn is configured, requests with
+// a body carry the Expect: 100-continue header.
+func TestUploadExpectContinue(t *testing.T) {
+	fbb := &fakeBlockBlob{}
+	observer := &expectHeaderObserver{}
+	client, err := blockblob.NewClientWithNoCredential("https://fake/blob/testpath", &blockblob.ClientOptions{
+		ExpectContinueBehavior: &azblob.ExpectContinueOptions{Mode: azblob.ExpectContinueModeOn},
+		ClientOptions: policy.ClientOptions{
+			Transport:        fbb,
+			PerRetryPolicies: []policy.Policy{observer},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	buffer := bytes.Repeat([]byte{1}, 4*1024)
+	_, err = client.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(buffer)), nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, observer.seen)
+	for _, v := range observer.seen {
+		require.Equal(t, "100-continue", v)
+	}
+}
+
+// TestUploadExpectContinueOff verifies the header is not set when the mode is Off.
+func TestUploadExpectContinueOff(t *testing.T) {
+	fbb := &fakeBlockBlob{}
+	observer := &expectHeaderObserver{}
+	client, err := blockblob.NewClientWithNoCredential("https://fake/blob/testpath", &blockblob.ClientOptions{
+		ExpectContinueBehavior: &azblob.ExpectContinueOptions{Mode: azblob.ExpectContinueModeOff},
+		ClientOptions: policy.ClientOptions{
+			Transport:        fbb,
+			PerRetryPolicies: []policy.Policy{observer},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	buffer := bytes.Repeat([]byte{1}, 4*1024)
+	_, err = client.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(buffer)), nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, observer.seen)
+	for _, v := range observer.seen {
+		require.Empty(t, v)
+	}
+}

--- a/sdk/storage/azblob/common.go
+++ b/sdk/storage/azblob/common.go
@@ -31,3 +31,25 @@ func ParseURL(u string) (URLParts, error) {
 // ending at offset+count. A zero-value HTTPRange indicates the entire resource. An HTTPRange
 // which has an offset and zero value count indicates from the offset to the resource's end.
 type HTTPRange = exported.HTTPRange
+
+// ExpectContinueMode is the mode for applying the HTTP "Expect: 100-continue" header to
+// operations that include a request body.
+type ExpectContinueMode = exported.ExpectContinueMode
+
+const (
+	// ExpectContinueModeApplyOnThrottle indicates that Expect-Continue will not be applied
+	// until specific errors are encountered from the service, at which point it will be
+	// applied for a fixed window of time after the last triggering error. This is the default.
+	ExpectContinueModeApplyOnThrottle = exported.ExpectContinueModeApplyOnThrottle
+
+	// ExpectContinueModeOn indicates Expect-Continue will be applied regardless of recent
+	// error status. The ContentLengthThreshold option still applies.
+	ExpectContinueModeOn = exported.ExpectContinueModeOn
+
+	// ExpectContinueModeOff indicates Expect-Continue will never be applied.
+	ExpectContinueModeOff = exported.ExpectContinueModeOff
+)
+
+// ExpectContinueOptions configures the behavior for applying the HTTP "Expect: 100-continue"
+// header to operations that include a request body.
+type ExpectContinueOptions = exported.ExpectContinueOptions

--- a/sdk/storage/azblob/container/client.go
+++ b/sdk/storage/azblob/container/client.go
@@ -43,6 +43,9 @@ func NewClient(containerURL string, cred azcore.TokenCredential, options *Client
 	conOptions := shared.GetClientOptions(options)
 	authPolicy := shared.NewStorageChallengePolicy(cred, audience, conOptions.InsecureAllowCredentialWithHTTP)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
@@ -57,8 +60,12 @@ func NewClient(containerURL string, cred azcore.TokenCredential, options *Client
 //   - options - client options; pass nil to accept the default values
 func NewClientWithNoCredential(containerURL string, options *ClientOptions) (*Client, error) {
 	conOptions := shared.GetClientOptions(options)
+	plOpts := runtime.PipelineOptions{}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
-	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -73,6 +80,9 @@ func NewClientWithSharedKeyCredential(containerURL string, cred *SharedKeyCreden
 	authPolicy := exported.NewSharedKeyCredPolicy(cred)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {

--- a/sdk/storage/azblob/container/models.go
+++ b/sdk/storage/azblob/container/models.go
@@ -22,6 +22,28 @@ func NewSharedKeyCredential(accountName, accountKey string) (*SharedKeyCredentia
 	return exported.NewSharedKeyCredential(accountName, accountKey)
 }
 
+// ExpectContinueMode is the mode for applying the HTTP "Expect: 100-continue" header to
+// operations that include a request body.
+type ExpectContinueMode = exported.ExpectContinueMode
+
+const (
+	// ExpectContinueModeApplyOnThrottle indicates that Expect-Continue will not be applied
+	// until specific errors are encountered from the service, at which point it will be
+	// applied for a fixed window of time after the last triggering error. This is the default.
+	ExpectContinueModeApplyOnThrottle = exported.ExpectContinueModeApplyOnThrottle
+
+	// ExpectContinueModeOn indicates Expect-Continue will be applied regardless of recent
+	// error status. The ContentLengthThreshold option still applies.
+	ExpectContinueModeOn = exported.ExpectContinueModeOn
+
+	// ExpectContinueModeOff indicates Expect-Continue will never be applied.
+	ExpectContinueModeOff = exported.ExpectContinueModeOff
+)
+
+// ExpectContinueOptions configures the behavior for applying the HTTP "Expect: 100-continue"
+// header to operations that include a request body.
+type ExpectContinueOptions = exported.ExpectContinueOptions
+
 // Request Model Declaration -------------------------------------------------------------------------------------------
 
 // CPKScopeInfo contains a group of parameters for the ContainerClient.Create method.

--- a/sdk/storage/azblob/internal/base/clients.go
+++ b/sdk/storage/azblob/internal/base/clients.go
@@ -20,6 +20,15 @@ type ClientOptions struct {
 	// Only has an effect when credential is of type TokenCredential. The value could be
 	// https://storage.azure.com/ (default) or https://<account>.blob.core.windows.net.
 	Audience string
+
+	// ExpectContinueBehavior configures the application of the HTTP "Expect: 100-continue"
+	// header on operations that include a request body. If nil, the default behavior is used,
+	// which conditionally applies the header for a short window after the service responds
+	// with a throttle/server-error status (429, 500, or 503).
+	//
+	// Setting the environment variable AZURE_STORAGE_DISABLE_EXPECT_CONTINUE_HEADER to a
+	// truthy value disables this behavior entirely, regardless of this setting.
+	ExpectContinueBehavior *exported.ExpectContinueOptions
 }
 
 type Client[T any] struct {

--- a/sdk/storage/azblob/internal/base/expect_continue.go
+++ b/sdk/storage/azblob/internal/base/expect_continue.go
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package base
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
+)
+
+const (
+	// expectContinueHeader is the name of the HTTP "Expect" header.
+	expectContinueHeader = "Expect"
+
+	// expectContinueHeaderValue is the value used when applying the "Expect: 100-continue" header.
+	expectContinueHeaderValue = "100-continue"
+
+	// DisableExpectContinueHeaderEnvVar is the name of the environment variable used to disable
+	// the automatic application of the "Expect: 100-continue" header. When the value parses to
+	// true (e.g. "1", "true", "TRUE"), no Expect: 100-continue policy will be added to the pipeline.
+	DisableExpectContinueHeaderEnvVar = "AZURE_STORAGE_DISABLE_EXPECT_CONTINUE_HEADER"
+
+	// defaultThrottleInterval is the time window during which Expect: 100-continue will be applied
+	// after a triggering response status code (429, 500, or 503) has been observed.
+	defaultThrottleInterval = time.Minute
+)
+
+// envCheckExpectContinueDisabled lazily reads DisableExpectContinueHeaderEnvVar exactly once
+// per process and caches the result. Reassigning this variable (see newExpectContinueEnvCheck)
+// resets the cache; this is used by tests that mutate the environment.
+var envCheckExpectContinueDisabled = newExpectContinueEnvCheck()
+
+// newExpectContinueEnvCheck returns a memoized check for the disable env variable. The
+// returned function reads os.Environ on first invocation and reuses the cached result on
+// subsequent invocations.
+func newExpectContinueEnvCheck() func() bool {
+	return sync.OnceValue(func() bool {
+		v, ok := os.LookupEnv(DisableExpectContinueHeaderEnvVar)
+		if !ok {
+			return false
+		}
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return false
+		}
+		return b
+	})
+}
+
+// NewExpectContinuePolicy returns a per-call policy that applies the "Expect: 100-continue" HTTP
+// header to outgoing requests according to the provided options.
+//
+// When opts is nil the default behavior is ExpectContinueModeApplyOnThrottle, equivalent to
+// passing &exported.ExpectContinueOptions{}.
+//
+// When the environment variable AZURE_STORAGE_DISABLE_EXPECT_CONTINUE_HEADER is set to a truthy
+// value, the returned policy is nil regardless of the supplied options.
+//
+// Returns nil when no policy should be added to the pipeline (mode is Off or env disables it).
+func NewExpectContinuePolicy(opts *exported.ExpectContinueOptions) policy.Policy {
+	if envCheckExpectContinueDisabled() {
+		return nil
+	}
+	if opts == nil {
+		opts = &exported.ExpectContinueOptions{}
+	}
+	var threshold int64
+	if opts.ContentLengthThreshold != nil {
+		threshold = *opts.ContentLengthThreshold
+	}
+	switch opts.Mode {
+	case exported.ExpectContinueModeOff:
+		return nil
+	case exported.ExpectContinueModeOn:
+		return &expectContinuePolicy{contentLengthThreshold: threshold}
+	case exported.ExpectContinueModeApplyOnThrottle:
+		fallthrough
+	default:
+		interval := defaultThrottleInterval
+		if opts.AutoInterval != nil {
+			interval = *opts.AutoInterval
+		}
+		return &expectContinueOnThrottlePolicy{
+			contentLengthThreshold: threshold,
+			throttleInterval:       interval,
+		}
+	}
+}
+
+// expectContinuePolicy unconditionally sets the "Expect: 100-continue" header on requests whose
+// body length is at least contentLengthThreshold.
+type expectContinuePolicy struct {
+	contentLengthThreshold int64
+}
+
+func (p *expectContinuePolicy) Do(req *policy.Request) (*http.Response, error) {
+	if shouldApplyExpectContinue(req, p.contentLengthThreshold) {
+		req.Raw().Header.Set(expectContinueHeader, expectContinueHeaderValue)
+	}
+	return req.Next()
+}
+
+// expectContinueOnThrottlePolicy sets the "Expect: 100-continue" header on requests for a fixed
+// time window after the service responds with status code 429, 500, or 503.
+type expectContinueOnThrottlePolicy struct {
+	contentLengthThreshold int64
+	throttleInterval       time.Duration
+	// lastThrottleUnixNanos stores the UnixNano timestamp of the most recent triggering response.
+	// Accessed atomically to allow concurrent use across requests sharing a pipeline.
+	lastThrottleUnixNanos atomic.Int64
+}
+
+func (p *expectContinueOnThrottlePolicy) Do(req *policy.Request) (*http.Response, error) {
+	if shouldApplyExpectContinue(req, p.contentLengthThreshold) {
+		last := p.lastThrottleUnixNanos.Load()
+		if last != 0 && time.Now().UnixNano()-last < p.throttleInterval.Nanoseconds() {
+			req.Raw().Header.Set(expectContinueHeader, expectContinueHeaderValue)
+		}
+	}
+	resp, err := req.Next()
+	if resp != nil {
+		switch resp.StatusCode {
+		case http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable:
+			p.lastThrottleUnixNanos.Store(time.Now().UnixNano())
+		}
+	}
+	return resp, err
+}
+
+// shouldApplyExpectContinue reports whether the request is eligible for the "Expect: 100-continue"
+// header: it must have a non-nil body, and the request's known Content-Length must be at least
+// contentLengthThreshold. Requests with an unknown content length (chunked) are not eligible.
+func shouldApplyExpectContinue(req *policy.Request, contentLengthThreshold int64) bool {
+	if req == nil || req.Body() == nil {
+		return false
+	}
+	raw := req.Raw()
+	if raw == nil {
+		return false
+	}
+	if raw.ContentLength <= 0 {
+		return false
+	}
+	return raw.ContentLength >= contentLengthThreshold
+}

--- a/sdk/storage/azblob/internal/base/expect_continue_test.go
+++ b/sdk/storage/azblob/internal/base/expect_continue_test.go
@@ -1,0 +1,388 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package base
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
+	"github.com/stretchr/testify/require"
+)
+
+// newPipelineForPolicy wraps the given policy in a pipeline targeting the supplied mock server.
+// Retries are disabled so each pipeline invocation produces exactly one transport call, making
+// expectation checks against the mock server's response sequence deterministic.
+func newPipelineForPolicy(p policy.Policy, srv policy.Transporter) runtime.Pipeline {
+	return runtime.NewPipeline("test", "v0.0.0",
+		runtime.PipelineOptions{PerCall: []policy.Policy{p}},
+		&policy.ClientOptions{
+			Transport: srv,
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	)
+}
+
+// newRequestWithBody constructs a *policy.Request with the supplied body bytes attached and
+// the Content-Length populated. When body is nil the request has no body.
+func newRequestWithBody(t *testing.T, body []byte) *policy.Request {
+	t.Helper()
+	req, err := runtime.NewRequest(context.Background(), http.MethodPut, "https://localhost")
+	require.NoError(t, err)
+	if body != nil {
+		require.NoError(t, req.SetBody(streaming.NopCloser(bytes.NewReader(body)), "application/octet-stream"))
+	}
+	return req
+}
+
+// TestExpectContinuePolicyAddsHeaderOnContentBody verifies the Expect: 100-continue header is
+// set only when a non-empty body is present.
+func TestExpectContinuePolicyAddsHeaderOnContentBody(t *testing.T) {
+	for _, hasBody := range []bool{true, false} {
+		hasBody := hasBody
+		t.Run("", func(t *testing.T) {
+			srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+			defer closeSrv()
+			srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+
+			p := NewExpectContinuePolicy(&exported.ExpectContinueOptions{Mode: exported.ExpectContinueModeOn})
+			require.NotNil(t, p)
+			pl := newPipelineForPolicy(p, srv)
+
+			var body []byte
+			if hasBody {
+				body = []byte("foo")
+			}
+			req := newRequestWithBody(t, body)
+			_, err := pl.Do(req)
+			require.NoError(t, err)
+
+			if hasBody {
+				require.Equal(t, "100-continue", req.Raw().Header.Get("Expect"))
+			} else {
+				require.Empty(t, req.Raw().Header.Get("Expect"))
+			}
+		})
+	}
+}
+
+// TestExpectContinuePolicyRespectsThreshold verifies the header is applied only when the
+// request's Content-Length meets or exceeds ContentLengthThreshold.
+func TestExpectContinuePolicyRespectsThreshold(t *testing.T) {
+	cases := []struct {
+		threshold    int64
+		bodyLength   int
+		expectHeader bool
+	}{
+		{threshold: 1024, bodyLength: 2048, expectHeader: true},
+		{threshold: 2048, bodyLength: 1024, expectHeader: false},
+		{threshold: 1024, bodyLength: 1024, expectHeader: true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+			defer closeSrv()
+			srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+
+			p := NewExpectContinuePolicy(&exported.ExpectContinueOptions{
+				Mode:                   exported.ExpectContinueModeOn,
+				ContentLengthThreshold: to.Ptr(tc.threshold),
+			})
+			require.NotNil(t, p)
+			pl := newPipelineForPolicy(p, srv)
+
+			req := newRequestWithBody(t, bytes.Repeat([]byte("a"), tc.bodyLength))
+			_, err := pl.Do(req)
+			require.NoError(t, err)
+
+			if tc.expectHeader {
+				require.Equal(t, "100-continue", req.Raw().Header.Get("Expect"))
+			} else {
+				require.Empty(t, req.Raw().Header.Get("Expect"))
+			}
+		})
+	}
+}
+
+// TestExpectContinueOnThrottlePolicyAddsHeaderOnlyAfterError verifies that, in
+// ExpectContinueModeApplyOnThrottle mode, a 429/500/503 response opens a window during which
+// subsequent requests carry the header.
+func TestExpectContinueOnThrottlePolicyAddsHeaderOnlyAfterError(t *testing.T) {
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable} {
+		status := status
+		t.Run("", func(t *testing.T) {
+			srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+			defer closeSrv()
+			srv.AppendResponse(mock.WithStatusCode(http.StatusAccepted))
+			srv.AppendResponse(mock.WithStatusCode(status))
+			srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+
+			p := NewExpectContinuePolicy(&exported.ExpectContinueOptions{Mode: exported.ExpectContinueModeApplyOnThrottle})
+			require.NotNil(t, p)
+			pl := newPipelineForPolicy(p, srv)
+
+			// message 1 doesn't get expect header (no prior throttle)
+			req1 := newRequestWithBody(t, []byte("foo"))
+			_, err := pl.Do(req1)
+			require.NoError(t, err)
+			require.Empty(t, req1.Raw().Header.Get("Expect"))
+
+			// message 2 doesn't get expect header but triggers future messages
+			req2 := newRequestWithBody(t, []byte("foo"))
+			_, err = pl.Do(req2)
+			require.NoError(t, err)
+			require.Empty(t, req2.Raw().Header.Get("Expect"))
+
+			// message 3 gets expect header
+			req3 := newRequestWithBody(t, []byte("foo"))
+			_, err = pl.Do(req3)
+			require.NoError(t, err)
+			require.Equal(t, "100-continue", req3.Raw().Header.Get("Expect"))
+		})
+	}
+}
+
+// TestExpectContinueOnThrottlePolicyRespectsThreshold verifies that, in ApplyOnThrottle mode,
+// the header is applied only when the request's Content-Length meets or exceeds
+// ContentLengthThreshold.
+func TestExpectContinueOnThrottlePolicyRespectsThreshold(t *testing.T) {
+	cases := []struct {
+		threshold    int64
+		bodyLength   int
+		expectHeader bool
+	}{
+		{threshold: 1024, bodyLength: 2048, expectHeader: true},
+		{threshold: 2048, bodyLength: 1024, expectHeader: false},
+		{threshold: 1024, bodyLength: 1024, expectHeader: true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+			defer closeSrv()
+			srv.AppendResponse(mock.WithStatusCode(http.StatusTooManyRequests))
+			srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+
+			p := NewExpectContinuePolicy(&exported.ExpectContinueOptions{
+				Mode:                   exported.ExpectContinueModeApplyOnThrottle,
+				ContentLengthThreshold: to.Ptr(tc.threshold),
+			})
+			require.NotNil(t, p)
+			pl := newPipelineForPolicy(p, srv)
+
+			// message 1 doesn't get expect header but triggers future messages
+			req1 := newRequestWithBody(t, bytes.Repeat([]byte("a"), tc.bodyLength))
+			_, err := pl.Do(req1)
+			require.NoError(t, err)
+			require.Empty(t, req1.Raw().Header.Get("Expect"))
+
+			// message 2 may or may not get expect header depending on threshold
+			req2 := newRequestWithBody(t, bytes.Repeat([]byte("a"), tc.bodyLength))
+			_, err = pl.Do(req2)
+			require.NoError(t, err)
+
+			if tc.expectHeader {
+				require.Equal(t, "100-continue", req2.Raw().Header.Get("Expect"))
+			} else {
+				require.Empty(t, req2.Raw().Header.Get("Expect"))
+			}
+		})
+	}
+}
+
+// TestExpectContinueOnThrottlePolicyRevertsAfterBackoff verifies that, after the throttle window
+// elapses, the header is no longer applied. The throttle interval is overridden on the policy
+// struct so the test runs fast.
+func TestExpectContinueOnThrottlePolicyRevertsAfterBackoff(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusTooManyRequests))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+
+	backoff := 10 * time.Millisecond
+	throttlePolicy := &expectContinueOnThrottlePolicy{throttleInterval: backoff}
+	pl := newPipelineForPolicy(throttlePolicy, srv)
+
+	// message 1 doesn't get expect header but triggers future messages
+	req1 := newRequestWithBody(t, []byte("foo"))
+	_, err := pl.Do(req1)
+	require.NoError(t, err)
+	require.Empty(t, req1.Raw().Header.Get("Expect"))
+
+	// message 2 gets expect header
+	req2 := newRequestWithBody(t, []byte("foo"))
+	_, err = pl.Do(req2)
+	require.NoError(t, err)
+	require.Equal(t, "100-continue", req2.Raw().Header.Get("Expect"))
+
+	// wait out the throttle window
+	time.Sleep(2 * backoff)
+
+	// message 3 no longer gets expect header
+	req3 := newRequestWithBody(t, []byte("foo"))
+	_, err = pl.Do(req3)
+	require.NoError(t, err)
+	require.Empty(t, req3.Raw().Header.Get("Expect"))
+}
+
+// TestNewExpectContinuePolicyOffReturnsNil verifies that mode Off causes no policy to be added.
+func TestNewExpectContinuePolicyOffReturnsNil(t *testing.T) {
+	p := NewExpectContinuePolicy(&exported.ExpectContinueOptions{Mode: exported.ExpectContinueModeOff})
+	require.Nil(t, p)
+}
+
+// TestNewExpectContinuePolicyDefaultsToApplyOnThrottle verifies that nil options produces the
+// ApplyOnThrottle policy.
+func TestNewExpectContinuePolicyDefaultsToApplyOnThrottle(t *testing.T) {
+	p := NewExpectContinuePolicy(nil)
+	require.NotNil(t, p)
+	_, ok := p.(*expectContinueOnThrottlePolicy)
+	require.True(t, ok, "expected *expectContinueOnThrottlePolicy, got %T", p)
+}
+
+// TestNewExpectContinuePolicyEnvVarDisables verifies that setting the disable env var causes
+// no policy to be returned, regardless of supplied options.
+func TestNewExpectContinuePolicyEnvVarDisables(t *testing.T) {
+	for _, v := range []string{"1", "true", "True", "TRUE"} {
+		v := v
+		t.Run(v, func(t *testing.T) {
+			t.Setenv(DisableExpectContinueHeaderEnvVar, v)
+			resetExpectContinueEnvCacheForTest(t)
+			require.Nil(t, NewExpectContinuePolicy(nil))
+			require.Nil(t, NewExpectContinuePolicy(&exported.ExpectContinueOptions{Mode: exported.ExpectContinueModeOn}))
+			require.Nil(t, NewExpectContinuePolicy(&exported.ExpectContinueOptions{Mode: exported.ExpectContinueModeApplyOnThrottle}))
+		})
+	}
+}
+
+// TestNewExpectContinuePolicyEnvVarFalsyValuesEnable verifies that the policy is added when the
+// env var is unset or set to a falsy value.
+func TestNewExpectContinuePolicyEnvVarFalsyValuesEnable(t *testing.T) {
+	for _, v := range []string{"0", "false", "False", "not-a-bool"} {
+		v := v
+		t.Run(v, func(t *testing.T) {
+			t.Setenv(DisableExpectContinueHeaderEnvVar, v)
+			resetExpectContinueEnvCacheForTest(t)
+			require.NotNil(t, NewExpectContinuePolicy(nil))
+		})
+	}
+}
+
+// resetExpectContinueEnvCacheForTest discards the memoized env-var lookup so a subsequent call
+// to NewExpectContinuePolicy re-reads the current environment. The previous value is restored
+// when the test (or subtest) completes.
+func resetExpectContinueEnvCacheForTest(t *testing.T) {
+	t.Helper()
+	prev := envCheckExpectContinueDisabled
+	envCheckExpectContinueDisabled = newExpectContinueEnvCheck()
+	t.Cleanup(func() { envCheckExpectContinueDisabled = prev })
+}
+
+// TestExpectContinueEnvCacheIsMemoized verifies the env-var lookup is performed exactly once
+// per cache lifetime: a change to the env variable after the first read is not observed by
+// subsequent calls until the cache is reset.
+func TestExpectContinueEnvCacheIsMemoized(t *testing.T) {
+	resetExpectContinueEnvCacheForTest(t)
+
+	t.Setenv(DisableExpectContinueHeaderEnvVar, "true")
+	// Prime the cache while the variable is "true" - the policy must be disabled.
+	require.Nil(t, NewExpectContinuePolicy(nil))
+
+	// Change the env variable. The cache should not pick up the new value.
+	t.Setenv(DisableExpectContinueHeaderEnvVar, "false")
+	require.Nil(t, NewExpectContinuePolicy(nil), "cache should still report disabled until reset")
+
+	// Resetting the cache forces a re-read.
+	resetExpectContinueEnvCacheForTest(t)
+	require.NotNil(t, NewExpectContinuePolicy(nil))
+}
+
+// TestExpectContinuePolicyIgnoresUnknownContentLength verifies the header is not added when
+// content length is unknown (e.g. -1 from chunked encoding).
+func TestExpectContinuePolicyIgnoresUnknownContentLength(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+
+	p := NewExpectContinuePolicy(&exported.ExpectContinueOptions{Mode: exported.ExpectContinueModeOn})
+	require.NotNil(t, p)
+	pl := newPipelineForPolicy(p, srv)
+
+	req := newRequestWithBody(t, []byte("foo"))
+	// Simulate an unknown content length (chunked encoding).
+	req.Raw().ContentLength = -1
+	_, err := pl.Do(req)
+	require.NoError(t, err)
+	require.Empty(t, req.Raw().Header.Get("Expect"))
+}
+
+// TestNewExpectContinuePolicyDefaultThrottleIntervalIsOneMinute verifies that the default
+// throttle interval is one minute.
+func TestNewExpectContinuePolicyDefaultThrottleIntervalIsOneMinute(t *testing.T) {
+	p := NewExpectContinuePolicy(nil)
+	require.NotNil(t, p)
+	tp, ok := p.(*expectContinueOnThrottlePolicy)
+	require.True(t, ok, "expected *expectContinueOnThrottlePolicy, got %T", p)
+	require.Equal(t, time.Minute, tp.throttleInterval)
+}
+
+// TestNewExpectContinuePolicyHonorsAutoInterval verifies that a caller-supplied AutoInterval
+// overrides the default throttle interval.
+func TestNewExpectContinuePolicyHonorsAutoInterval(t *testing.T) {
+	custom := 250 * time.Millisecond
+	p := NewExpectContinuePolicy(&exported.ExpectContinueOptions{AutoInterval: &custom})
+	require.NotNil(t, p)
+	tp, ok := p.(*expectContinueOnThrottlePolicy)
+	require.True(t, ok, "expected *expectContinueOnThrottlePolicy, got %T", p)
+	require.Equal(t, custom, tp.throttleInterval)
+}
+
+// TestExpectContinueOnThrottlePolicyAutoIntervalEndToEnd verifies that the user-supplied
+// AutoInterval is observed end-to-end through the factory and the pipeline: the header is set
+// while the configured window is open and removed after it elapses.
+func TestExpectContinueOnThrottlePolicyAutoIntervalEndToEnd(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusTooManyRequests))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+
+	backoff := 10 * time.Millisecond
+	p := NewExpectContinuePolicy(&exported.ExpectContinueOptions{AutoInterval: &backoff})
+	require.NotNil(t, p)
+	pl := newPipelineForPolicy(p, srv)
+
+	// message 1 doesn't get expect header but triggers future messages
+	req1 := newRequestWithBody(t, []byte("foo"))
+	_, err := pl.Do(req1)
+	require.NoError(t, err)
+	require.Empty(t, req1.Raw().Header.Get("Expect"))
+
+	// message 2 gets expect header
+	req2 := newRequestWithBody(t, []byte("foo"))
+	_, err = pl.Do(req2)
+	require.NoError(t, err)
+	require.Equal(t, "100-continue", req2.Raw().Header.Get("Expect"))
+
+	// wait out the user-supplied window
+	time.Sleep(2 * backoff)
+
+	// message 3 no longer gets expect header
+	req3 := newRequestWithBody(t, []byte("foo"))
+	_, err = pl.Do(req3)
+	require.NoError(t, err)
+	require.Empty(t, req3.Raw().Header.Get("Expect"))
+}

--- a/sdk/storage/azblob/internal/exported/expect_continue.go
+++ b/sdk/storage/azblob/internal/exported/expect_continue.go
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package exported
+
+import "time"
+
+// ExpectContinueMode is the mode for applying the HTTP "Expect: 100-continue" header to PUT requests.
+type ExpectContinueMode int
+
+const (
+	// ExpectContinueModeApplyOnThrottle indicates that Expect-Continue will not be applied until
+	// specific errors are encountered from the service, at which point it will be applied for a
+	// fixed window of time after the last triggering error.
+	//
+	// Response codes that trigger this behavior are 429, 500, and 503. This is the default behavior.
+	ExpectContinueModeApplyOnThrottle ExpectContinueMode = 0
+
+	// ExpectContinueModeOn indicates Expect-Continue will be applied regardless of recent error status.
+	// The ContentLengthThreshold option still applies.
+	ExpectContinueModeOn ExpectContinueMode = 1
+
+	// ExpectContinueModeOff indicates Expect-Continue will never be applied.
+	ExpectContinueModeOff ExpectContinueMode = 2
+)
+
+// ExpectContinueOptions configures the behavior for applying the HTTP "Expect: 100-continue"
+// header to operations that include a request body.
+type ExpectContinueOptions struct {
+	// Mode controls when the Expect: 100-continue header is applied. The default value
+	// (ExpectContinueModeApplyOnThrottle) applies the header for a fixed time window after
+	// the service responds with a throttle/server-error status (429, 500, or 503).
+	Mode ExpectContinueMode
+
+	// ContentLengthThreshold is the minimum value of HTTP request Content-Length for applying
+	// the Expect: 100-continue header. The default is zero, meaning any request that has a
+	// non-empty body and a computable content length is eligible.
+	ContentLengthThreshold *int64
+
+	// AutoInterval is used in ExpectContinueModeApplyOnThrottle mode to set the time window
+	// during which the Expect: 100-continue header is applied after a triggering error response
+	// (429, 500, or 503) is observed. When nil, the default of one minute is used.
+	AutoInterval *time.Duration
+}

--- a/sdk/storage/azblob/pageblob/client.go
+++ b/sdk/storage/azblob/pageblob/client.go
@@ -37,6 +37,9 @@ func NewClient(blobURL string, cred azcore.TokenCredential, options *ClientOptio
 	conOptions := shared.GetClientOptions(options)
 	authPolicy := shared.NewStorageChallengePolicy(cred, audience, conOptions.InsecureAllowCredentialWithHTTP)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
@@ -51,8 +54,12 @@ func NewClient(blobURL string, cred azcore.TokenCredential, options *ClientOptio
 //   - options - client options; pass nil to accept the default values
 func NewClientWithNoCredential(blobURL string, options *ClientOptions) (*Client, error) {
 	conOptions := shared.GetClientOptions(options)
+	plOpts := runtime.PipelineOptions{}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
-	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -67,6 +74,9 @@ func NewClientWithSharedKeyCredential(blobURL string, cred *blob.SharedKeyCreden
 	authPolicy := exported.NewSharedKeyCredPolicy(cred)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {

--- a/sdk/storage/azblob/service/client.go
+++ b/sdk/storage/azblob/service/client.go
@@ -41,6 +41,9 @@ func NewClient(serviceURL string, cred azcore.TokenCredential, options *ClientOp
 	conOptions := shared.GetClientOptions(options)
 	authPolicy := shared.NewStorageChallengePolicy(cred, audience, conOptions.InsecureAllowCredentialWithHTTP)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
@@ -55,8 +58,12 @@ func NewClient(serviceURL string, cred azcore.TokenCredential, options *ClientOp
 //   - options - client options; pass nil to accept the default values
 func NewClientWithNoCredential(serviceURL string, options *ClientOptions) (*Client, error) {
 	conOptions := shared.GetClientOptions(options)
+	plOpts := runtime.PipelineOptions{}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
-	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, runtime.PipelineOptions{}, &conOptions.ClientOptions)
+	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +78,9 @@ func NewClientWithSharedKeyCredential(serviceURL string, cred *SharedKeyCredenti
 	authPolicy := exported.NewSharedKeyCredPolicy(cred)
 	conOptions := shared.GetClientOptions(options)
 	plOpts := runtime.PipelineOptions{PerRetry: []policy.Policy{authPolicy}}
+	if p := base.NewExpectContinuePolicy(conOptions.ExpectContinueBehavior); p != nil {
+		plOpts.PerRetry = append(plOpts.PerRetry, p)
+	}
 
 	azClient, err := azcore.NewClient(exported.ModuleName, exported.ModuleVersion, plOpts, &conOptions.ClientOptions)
 	if err != nil {

--- a/sdk/storage/azblob/service/models.go
+++ b/sdk/storage/azblob/service/models.go
@@ -22,6 +22,28 @@ func NewSharedKeyCredential(accountName, accountKey string) (*SharedKeyCredentia
 	return exported.NewSharedKeyCredential(accountName, accountKey)
 }
 
+// ExpectContinueMode is the mode for applying the HTTP "Expect: 100-continue" header to
+// operations that include a request body.
+type ExpectContinueMode = exported.ExpectContinueMode
+
+const (
+	// ExpectContinueModeApplyOnThrottle indicates that Expect-Continue will not be applied
+	// until specific errors are encountered from the service, at which point it will be
+	// applied for a fixed window of time after the last triggering error. This is the default.
+	ExpectContinueModeApplyOnThrottle = exported.ExpectContinueModeApplyOnThrottle
+
+	// ExpectContinueModeOn indicates Expect-Continue will be applied regardless of recent
+	// error status. The ContentLengthThreshold option still applies.
+	ExpectContinueModeOn = exported.ExpectContinueModeOn
+
+	// ExpectContinueModeOff indicates Expect-Continue will never be applied.
+	ExpectContinueModeOff = exported.ExpectContinueModeOff
+)
+
+// ExpectContinueOptions configures the behavior for applying the HTTP "Expect: 100-continue"
+// header to operations that include a request body.
+type ExpectContinueOptions = exported.ExpectContinueOptions
+
 // UserDelegationCredential contains an account's name and its user delegation key.
 type UserDelegationCredential = exported.UserDelegationCredential
 


### PR DESCRIPTION
**Summary**
A new ExpectContinueBehavior field on ClientOptions (exposed in azblob, service, container, and blob) controls how the header is applied:

```
type ExpectContinueOptions struct {
    Mode                   ExpectContinueMode // ApplyOnThrottle (default), On, Off
    ContentLengthThreshold *int64             // only attach when body size >= threshold
    AutoInterval           *time.Duration     // throttle window for ApplyOnThrottle (default 1 min)
}
```
Modes:

ApplyOnThrottle (default) — attaches the header only for a window (AutoInterval, default 1 * time.Minute) after the pipeline sees a throttling response (429, 500, 503). Matches .NET's AutoInterval default.
On — always attach the header on requests with a known content length above the threshold.
Off — never attach.

Behavior also honors the AZURE_STORAGE_DISABLE_EXPECT_CONTINUE_HEADER environment variable (same name as .NET) — when truthy, no policy is added regardless of options.

**Timeout for 100-continue**
go SDK: 1s ([source](https://github.com/Azure/azure-sdk-for-go/blob/31da55da5e493c5b7a076dac90e182257ab82ac7/sdk/azcore/runtime/transport_default_http_client.go#L29))
dot net SDK: 1s ([source](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler.expect100continuetimeout?view=net-10.0#:~:text=The-,timespan,-to%20wait%20for))


.NET SDK PR for reference: https://github.com/Azure/azure-sdk-for-net/pull/40611

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
