### PR TITLE
[storage] switch to recording.Sleep (cont.)

### DIFF
--- a/sdk/storage/azdatalake/directory/client_test.go
+++ b/sdk/storage/azdatalake/directory/client_test.go
@@ -674,7 +674,7 @@ func (s *RecordedTestSuite) TestCreateDirWithLease() {
 	_, err = dirClient.Create(context.Background(), createFileOpts)
 	_require.Error(err)
 
-	time.Sleep(time.Second * 15)
+	recording.Sleep(time.Second * 15)
 	resp, err = dirClient.Create(context.Background(), createFileOpts)
 	_require.NoError(err)
 	_require.NotNil(resp)

--- a/sdk/storage/azdatalake/file/client_test.go
+++ b/sdk/storage/azdatalake/file/client_test.go
@@ -587,7 +587,7 @@ func (s *RecordedTestSuite) TestCreateFileWithExpiryRelativeToNow() {
 	_require.NoError(err)
 	_require.NotNil(resp1.ExpiresOn)
 
-	time.Sleep(time.Second * 10)
+	recording.Sleep(time.Second * 10)
 	_, err = fClient.GetProperties(context.Background(), nil)
 	_require.Error(err)
 	testcommon.ValidateErrorCode(_require, err, datalakeerror.PathNotFound)
@@ -653,7 +653,7 @@ func (s *RecordedTestSuite) TestCreateFileWithLease() {
 	_, err = fClient.Create(context.Background(), createFileOpts)
 	_require.Error(err)
 
-	time.Sleep(time.Second * 15)
+	recording.Sleep(time.Second * 15)
 	resp, err = fClient.Create(context.Background(), createFileOpts)
 	_require.NoError(err)
 	_require.NotNil(resp)
@@ -1001,7 +1001,7 @@ func (s *RecordedTestSuite) TestFileSetExpiry() {
 	)
 	_require.NoError(err)
 
-	time.Sleep(time.Second * 12)
+	recording.Sleep(time.Second * 12)
 
 	_, err = fClient.GetProperties(context.Background(), nil)
 	testcommon.ValidateErrorCode(_require, err, datalakeerror.PathNotFound)
@@ -1037,7 +1037,7 @@ func (s *UnrecordedTestSuite) TestFileSetExpiryTypeAbsoluteTime() {
 		nil)
 	_require.NoError(err)
 
-	time.Sleep(time.Second * 7)
+	recording.Sleep(time.Second * 7)
 
 	_, err = fClient.GetProperties(context.Background(), nil)
 	testcommon.ValidateErrorCode(_require, err, datalakeerror.PathNotFound)
@@ -3790,7 +3790,7 @@ func (s *RecordedTestSuite) TestFileAppendDataWithAcquireLease() {
 	_require.NoError(err)
 	_require.Equal(lease.StateTypeLeased, *gResp2.LeaseState)
 
-	time.Sleep(time.Second * 15)
+	recording.Sleep(time.Second * 15)
 
 	// Check if the lease was acquired for the right duration
 	gResp, err := srcFClient.GetProperties(context.Background(), nil)
@@ -3829,7 +3829,7 @@ func (s *RecordedTestSuite) TestFileAppendDataWithRenewLease() {
 	_require.Equal(lease.StateTypeLeased, *gResp2.LeaseState)
 
 	// Wait for 15 seconds for lease to expire
-	time.Sleep(15 * time.Second)
+	recording.Sleep(15 * time.Second)
 
 	gResp, err := srcFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)

--- a/sdk/storage/azdatalake/service/client_test.go
+++ b/sdk/storage/azdatalake/service/client_test.go
@@ -305,7 +305,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicy() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	resp, err := svcClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -317,7 +317,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicy() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	resp, err = svcClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -336,7 +336,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicyEmpty() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	resp, err := svcClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -359,7 +359,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicyNil() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	resp, err := svcClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -370,7 +370,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountDeleteRetentionPolicyNil() {
 	_require.NoError(err)
 
 	// From FE, 30 seconds is guaranteed to be enough.
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	// If an element of service properties is not passed, the service keeps the current settings.
 	resp, err = svcClient.GetProperties(context.Background(), nil)

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -10,6 +10,16 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"hash/crc64"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -27,15 +37,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/share"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"hash/crc64"
-	"io"
-	"net/http"
-	"net/url"
-	"os"
-	"strings"
-	"sync/atomic"
-	"testing"
-	"time"
 )
 
 func Test(t *testing.T) {
@@ -1200,7 +1201,7 @@ func (f *FileRecordedTestsSuite) TestStartCopyDefault() {
 	_require.Equal(copyResp.Date.IsZero(), false)
 	_require.NotEqual(copyResp.CopyStatus, "")
 
-	time.Sleep(time.Duration(5) * time.Second)
+	recording.Sleep(time.Duration(5) * time.Second)
 
 	getResp, err := destFile.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1249,7 +1250,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyDestEmpty() {
 	_, err = copyFClient.StartCopyFromURL(context.Background(), fClient.URL(), nil)
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp, err := copyFClient.DownloadStream(context.Background(), nil)
 	_require.NoError(err)
@@ -1289,7 +1290,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyMetadata() {
 	_, err = copyFClient.StartCopyFromURL(context.Background(), fClient.URL(), &file.StartCopyFromURLOptions{Metadata: basicMetadata})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1328,7 +1329,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyMetadataNil() {
 	_, err = copyFClient.StartCopyFromURL(context.Background(), fClient.URL(), nil)
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1367,7 +1368,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyMetadataEmpty() {
 	_, err = copyFClient.StartCopyFromURL(context.Background(), fClient.URL(), &file.StartCopyFromURLOptions{Metadata: map[string]*string{}})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1440,7 +1441,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySourceCreationTime() {
 	})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1497,7 +1498,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySourceProperties() {
 	})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1558,7 +1559,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyDifferentProperties() {
 	})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1603,7 +1604,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyOverrideMode() {
 	})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1677,7 +1678,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySetArchiveAttributeTrue() {
 	})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1720,7 +1721,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopySetArchiveAttributeFalse() {
 	})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1765,7 +1766,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyDestReadOnly() {
 	})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp2, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -1850,7 +1851,7 @@ func (f *FileUnrecordedTestsSuite) TestFileStartCopyUsingSASSrc() {
 	_, err = copyFileClient.StartCopyFromURL(context.Background(), fileURLWithSAS, nil)
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	dResp, err := copyFileClient.DownloadStream(context.Background(), nil)
 	_require.NoError(err)
@@ -1908,7 +1909,7 @@ func (f *FileRecordedTestsSuite) TestFileStartCopyModeCopyModeNfs() {
 	})
 	_require.NoError(err)
 
-	time.Sleep(4 * time.Second)
+	recording.Sleep(4 * time.Second)
 
 	resp, err := copyFClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -4842,7 +4843,7 @@ func (f *FileUnrecordedTestsSuite) TestStartCopyTrailingDotOAuth() {
 	_require.NoError(err)
 	_require.NotEqual(copyResp.CopyStatus, "")
 
-	time.Sleep(time.Duration(5) * time.Second)
+	recording.Sleep(time.Duration(5) * time.Second)
 
 	getResp, err := destFileClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)

--- a/sdk/storage/azfile/lease/client_test.go
+++ b/sdk/storage/azfile/lease/client_test.go
@@ -5,6 +5,9 @@ package lease_test
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
@@ -13,8 +16,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/share"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
 )
 
 func Test(t *testing.T) {
@@ -288,7 +289,7 @@ func (l *LeaseRecordedTestsSuite) TestShareBreakLeaseNonDefault() {
 	_require.Error(err)
 
 	// wait for lease to expire
-	time.Sleep(6 * time.Second)
+	recording.Sleep(6 * time.Second)
 
 	_, err = shareClient.Delete(ctx, nil)
 	_require.NoError(err)

--- a/sdk/storage/azfile/service/client_test.go
+++ b/sdk/storage/azfile/service/client_test.go
@@ -206,7 +206,7 @@ func (s *ServiceRecordedTestsSuite) TestAccountProperties() {
 	_require.NoError(err)
 	_require.NotNil(setPropsResp.RequestID)
 
-	time.Sleep(time.Second * 30)
+	recording.Sleep(time.Second * 30)
 
 	getPropsResp, err := svcClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
@@ -433,7 +433,7 @@ func (s *ServiceUnrecordedTestsSuite) TestSASServiceClientRestoreShare() {
 	_require.NoError(err)
 
 	// wait for share deletion
-	time.Sleep(60 * time.Second)
+	recording.Sleep(60 * time.Second)
 
 	sharesCnt := 0
 	shareVersion := ""
@@ -570,7 +570,7 @@ func (s *ServiceRecordedTestsSuite) TestServiceCreateDeleteRestoreShare() {
 	_require.NoError(err)
 
 	// wait for share deletion
-	time.Sleep(60 * time.Second)
+	recording.Sleep(60 * time.Second)
 
 	sharesCnt := 0
 	shareVersion := ""

--- a/sdk/storage/azfile/share/client_test.go
+++ b/sdk/storage/azfile/share/client_test.go
@@ -6,6 +6,10 @@ package share_test
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
@@ -16,9 +20,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/share"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"strconv"
-	"testing"
-	"time"
 )
 
 func Test(t *testing.T) {
@@ -1441,7 +1442,7 @@ func (s *ShareUnrecordedTestsSuite) TestShareCreateSnapshotDefault() {
 	_, err = fClient.StartCopyFromURL(context.Background(), sourceURL, nil)
 	_require.NoError(err)
 
-	time.Sleep(2 * time.Second)
+	recording.Sleep(2 * time.Second)
 
 	// After restore
 	_, err = fClient.GetProperties(context.Background(), nil)
@@ -1644,7 +1645,7 @@ func (s *ShareRecordedTestsSuite) TestShareRestoreSuccess() {
 	_require.NoError(err)
 
 	// wait for share deletion
-	time.Sleep(60 * time.Second)
+	recording.Sleep(60 * time.Second)
 
 	pager := svcClient.NewListSharesPager(&service.ListSharesOptions{
 		Include: service.ListSharesInclude{Deleted: true},
@@ -1722,7 +1723,7 @@ func (s *ShareRecordedTestsSuite) TestShareRestoreWithSnapshotsAgain() {
 	_require.NoError(err)
 
 	// wait for share deletion
-	time.Sleep(60 * time.Second)
+	recording.Sleep(60 * time.Second)
 
 	pager := svcClient.NewListSharesPager(&service.ListSharesOptions{
 		Include: service.ListSharesInclude{Deleted: true},
@@ -1905,7 +1906,7 @@ func (s *ShareUnrecordedTestsSuite) TestShareSASUsingAccessPolicy() {
 	_require.NoError(err)
 	_require.Len(gResp.SignedIdentifiers, 1)
 
-	time.Sleep(30 * time.Second)
+	recording.Sleep(30 * time.Second)
 
 	sasQueryParams, err := sas.SignatureValues{
 		Protocol:   sas.ProtocolHTTPS,

--- a/sdk/storage/azqueue/queue_client_test.go
+++ b/sdk/storage/azqueue/queue_client_test.go
@@ -669,7 +669,7 @@ func (s *RecordedTestSuite) TestEnqueueMessageWithTimeToLiveExpired() {
 	_, err = queueClient.EnqueueMessage(context.Background(), testcommon.QueueDefaultData, &opts)
 	_require.NoError(err)
 
-	time.Sleep(time.Second * 2)
+	recording.Sleep(time.Second * 2)
 	resp, err := queueClient.DequeueMessage(context.Background(), nil)
 	_require.NoError(err)
 	_require.Equal(0, len(resp.Messages))
@@ -1286,7 +1286,7 @@ func (s *RecordedTestSuite) TestUpdateMessageWithVisibilityTimeout() {
 	opts := &azqueue.UpdateMessageOptions{VisibilityTimeout: to.Ptr(int32(1))}
 	_, err = queueClient.UpdateMessage(context.Background(), messageID, popReceipt, "new content", opts)
 	_require.NoError(err)
-	time.Sleep(time.Second * 2)
+	recording.Sleep(time.Second * 2)
 	resp1, err := queueClient.DequeueMessage(context.Background(), nil)
 	_require.NoError(err)
 	content := *resp1.Messages[0].MessageText
@@ -1614,7 +1614,7 @@ func (s *UnrecordedTestSuite) TestQueueSASUsingAccessPolicy() {
 	_require.NoError(err)
 	_require.Len(gResp.SignedIdentifiers, 1)
 
-	time.Sleep(30 * time.Second)
+	recording.Sleep(30 * time.Second)
 
 	sasQueryParams, err := sas.QueueSignatureValues{
 		Protocol:   sas.ProtocolHTTPS,
@@ -1674,7 +1674,7 @@ func (s *UnrecordedTestSuite) TestQueueClientGetPropertiesApproximateMessagesCou
 		_, err = queueClient.EnqueueMessage(context.Background(), fmt.Sprintf("msg-%d", i), nil)
 		_require.NoError(err)
 	}
-	time.Sleep(3 * time.Second)
+	recording.Sleep(3 * time.Second)
 	propsResp, err := queueClient.GetProperties(context.Background(), nil)
 	_require.NoError(err)
 


### PR DESCRIPTION
continuation of https://github.com/Azure/azure-sdk-for-go/pull/26667

Switching to `recording.Sleep` for the rest of the storage modules