### PR TITLE
Transition to GitHub App auth, remove azuresdk-github-pat usage

### DIFF
--- a/eng/pipelines/mgmt-auto-release.yml
+++ b/eng/pipelines/mgmt-auto-release.yml
@@ -41,9 +41,6 @@ extends:
                   version: '1.25.4'
 
               - template: /eng/common/pipelines/templates/steps/login-to-github.yml
-                parameters:
-                  TokenOwners:
-                    - azure
 
               - task: ShellScript@2
                 inputs:

--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -23,9 +23,6 @@ stages:
           os: linux
         steps:
           - template: /eng/common/pipelines/templates/steps/login-to-github.yml
-            parameters:
-              TokenOwners:
-                - azure
           - task: PowerShell@2
             name: Verify
             inputs:
@@ -127,6 +124,7 @@ stages:
               ReleaseSha: $(Build.SourceVersion)
               RepoId: Azure/azure-sdk-for-go
               WorkingDirectory: $(System.DefaultWorkingDirectory)
+              AuthToken: ''
           - download: current
             artifact: 'packages'
           - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -179,3 +177,4 @@ stages:
                 CommitMsg: "Increment package version after release of ${{ parameters.ServiceDirectory }}"
                 PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
                 CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
+                AuthToken: ''


### PR DESCRIPTION
This pull request updates the Azure DevOps pipeline templates to improve authentication handling, specifically for GitHub operations, and to standardize the use of authentication tokens across several pipeline steps. The changes ensure that the correct GitHub authentication is set up via a dedicated login step and that token usage is consistent and explicit throughout the release automation process.

Authentication and GitHub integration improvements:

* Added the `/eng/common/pipelines/templates/steps/login-to-github.yml` template to the `archetype-go-release.yml` and `mgmt-auto-release.yml` pipelines, ensuring a standardized GitHub login step is executed before any GitHub operations. [[1]](diffhunk://#diff-3923da3df8a4b616c2a71d874edcc06ba37682afe35cd7c87be072500a495196R25) [[2]](diffhunk://#diff-afc63a9e32f5671f5c9e177022c88bd6aafaa8e57938f906a3efe6e1dcd7ac8fR36-R42)
* Updated shell script arguments in `mgmt-auto-release.yml` to use the `GH_TOKEN` environment variable instead of `azuresdk-github-pat`, aligning with the new authentication flow.
* Removed the explicit setting of the `GH_TOKEN` environment variable in the `archetype-go-release.yml` pipeline, as authentication is now handled by the new login step.

Parameter and token handling standardization:

* Added an explicit `AuthToken: ''` parameter in multiple pipeline templates (`prepare-pipelines.yml`, `archetype-go-release.yml`) to clarify token usage and ensure consistency in parameter passing. [[1]](diffhunk://#diff-1e4452b8c2070017bf1bc0721fb4022b44de12dcd17387f03a3575e1f25cf77cR10) [[2]](diffhunk://#diff-3923da3df8a4b616c2a71d874edcc06ba37682afe35cd7c87be072500a495196R125) [[3]](diffhunk://#diff-3923da3df8a4b616c2a71d874edcc06ba37682afe35cd7c87be072500a495196R178)

Related to Azure/azure-sdk-tools#9842

[go - mgmt auto release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6369305&view=results) - Passed
[go - aztemplate](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6369308&view=results) - Passed
[prepare-pipelines](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6371870&view=results) - Passed