### PR TITLE
Fix armfileshare package release version

### DIFF
--- a/sdk/resourcemanager/fileshares/armfileshares/CHANGELOG.md
+++ b/sdk/resourcemanager/fileshares/armfileshares/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0 (2026-04-28)
+## 0.1.0 (2026-05-07)
 ### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fileshares/armfileshares` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).

--- a/sdk/resourcemanager/fileshares/armfileshares/version.go
+++ b/sdk/resourcemanager/fileshares/armfileshares/version.go
@@ -9,5 +9,5 @@ const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fileshares/armfileshares"
 
 	// moduleVersion is the semantic version (see http://semver.org) of this module.
-	moduleVersion = "v1.0.0"
+	moduleVersion = "v0.1.0"
 )


### PR DESCRIPTION
Original release request: https://github.com/Azure/azure-sdk-for-go/pull/26695. This release request is not generated by pipeline but generated in local from customer, the release version is incorrect. This service is first release for Go SDK, the sdk version should be first beta, 

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
