### PR TITLE
Added support for WASM compilation

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* Fixed WASM compilation by using heap-allocated buffers on JS targets.
+
 ### Other Changes
 
 ## 1.8.0-beta.1 (2026-05-05)

--- a/sdk/storage/azblob/internal/shared/mmf_js.go
+++ b/sdk/storage/azblob/internal/shared/mmf_js.go
@@ -5,15 +5,17 @@
 
 package shared
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+)
 
 // Mmb is a plain heap-allocated buffer used on platforms without mmap support (e.g. WASM).
 type Mmb []byte
 
 // NewMMB allocates a plain byte slice. No mmap is used.
 func NewMMB(size int64) (Mmb, error) {
-	maxInt := int64(^uint(0) >> 1)
-	if size < 0 || size > maxInt {
+	if size < 0 || size > math.MaxInt {
 		return nil, fmt.Errorf("size %d out of range", size)
 	}
 

--- a/sdk/storage/azblob/internal/shared/mmf_js.go
+++ b/sdk/storage/azblob/internal/shared/mmf_js.go
@@ -5,12 +5,19 @@
 
 package shared
 
+import "fmt"
+
 // Mmb is a plain heap-allocated buffer used on platforms without mmap support (e.g. WASM).
 type Mmb []byte
 
 // NewMMB allocates a plain byte slice. No mmap is used.
 func NewMMB(size int64) (Mmb, error) {
-	return make([]byte, size), nil
+	maxInt := int64(^uint(0) >> 1)
+	if size < 0 || size > maxInt {
+		return nil, fmt.Errorf("size %d out of range", size)
+	}
+
+	return make([]byte, int(size)), nil
 }
 
 // Delete is a no-op; GC handles reclamation.

--- a/sdk/storage/azblob/internal/shared/mmf_js.go
+++ b/sdk/storage/azblob/internal/shared/mmf_js.go
@@ -1,0 +1,19 @@
+//go:build js
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package shared
+
+// Mmb is a plain heap-allocated buffer used on platforms without mmap support (e.g. WASM).
+type Mmb []byte
+
+// NewMMB allocates a plain byte slice. No mmap is used.
+func NewMMB(size int64) (Mmb, error) {
+	return make([]byte, size), nil
+}
+
+// Delete is a no-op; GC handles reclamation.
+func (m *Mmb) Delete() {
+	*m = nil
+}

--- a/sdk/storage/azblob/internal/shared/mmf_js.go
+++ b/sdk/storage/azblob/internal/shared/mmf_js.go
@@ -1,4 +1,4 @@
-//go:build js
+//go:build js && wasm
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.


### PR DESCRIPTION
## Purpose

Adds a JS/WASM implementation of the azblob shared MMB type that uses a heap-allocated byte slice instead of memory mapping, allowing the package to compile on platforms without mmap support.

## Validation

- From : 

## Checklist

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go