### PR TITLE
feat(azcosmos): default HTTP/2 PING-based connection health checks

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+* Configured HTTP/2 PING-based connection health checks (`ReadIdleTimeout=1s`, `PingTimeout=2s`) on the SDK's default HTTP transport to detect broken connections more aggressively than the `azcore` baseline (`10s`/`5s`). This addresses the persistent unexplained 5xx errors caused by broken TCP connections being reused from Go's HTTP/2 connection pool ([golang/go#59690](https://github.com/golang/go/issues/59690)). Customers supplying their own `ClientOptions.Transport` are unaffected.
+
 ## 1.5.0-beta.5 (2026-03-09)
 
 ### Features Added

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -150,15 +150,13 @@ func NewClientFromConnectionString(connectionString string, o *ClientOptions) (*
 }
 
 func newClient(authPolicy policy.Policy, gem *globalEndpointManager, options *ClientOptions) (*azcore.Client, error) {
-	if options == nil {
-		options = &ClientOptions{}
-	}
+	localOptions := optionsWithDefaultTransport(options)
 	return azcore.NewClient(moduleName, serviceLibVersion,
 		azruntime.PipelineOptions{
 			AllowedHeaders: getAllowedHeaders(),
 			PerCall: []policy.Policy{
 				&headerPolicies{
-					enableContentResponseOnWrite: options.EnableContentResponseOnWrite,
+					enableContentResponseOnWrite: localOptions.EnableContentResponseOnWrite,
 				},
 				&globalEndpointManagerPolicy{gem: gem},
 			},
@@ -170,13 +168,11 @@ func newClient(authPolicy policy.Policy, gem *globalEndpointManager, options *Cl
 				Namespace: "Microsoft.DocumentDB",
 			},
 		},
-		&options.ClientOptions)
+		&localOptions.ClientOptions)
 }
 
 func newInternalPipeline(authPolicy policy.Policy, options *ClientOptions) azruntime.Pipeline {
-	if options == nil {
-		options = &ClientOptions{}
-	}
+	localOptions := optionsWithDefaultTransport(options)
 	return azruntime.NewPipeline(moduleName, serviceLibVersion,
 		azruntime.PipelineOptions{
 			AllowedHeaders: getAllowedHeaders(),
@@ -184,7 +180,24 @@ func newInternalPipeline(authPolicy policy.Policy, options *ClientOptions) azrun
 				authPolicy,
 			},
 		},
-		&options.ClientOptions)
+		&localOptions.ClientOptions)
+}
+
+// optionsWithDefaultTransport returns a shallow copy of options with the
+// Cosmos default HTTP client (HTTP/2 PING-based health checks) installed
+// when the caller did not supply their own Transport. The caller's options
+// struct is never mutated, so it is safe to reuse a single ClientOptions
+// value across multiple client constructions, including concurrently.
+// Customer-supplied transports are preserved unchanged.
+func optionsWithDefaultTransport(options *ClientOptions) ClientOptions {
+	var localOptions ClientOptions
+	if options != nil {
+		localOptions = *options
+	}
+	if localOptions.Transport == nil {
+		localOptions.Transport = defaultCosmosHTTPClient
+	}
+	return localOptions
 }
 
 func createScopeFromEndpoint(endpoint *url.URL) ([]string, error) {

--- a/sdk/data/azcosmos/go.mod
+++ b/sdk/data/azcosmos/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/net v0.52.0
 )
 
 require (
@@ -18,7 +19,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
-	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/sdk/data/azcosmos/transport_default_dialer_other.go
+++ b/sdk/data/azcosmos/transport_default_dialer_other.go
@@ -1,0 +1,15 @@
+//go:build !wasm
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"net"
+)
+
+func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return dialer.DialContext
+}

--- a/sdk/data/azcosmos/transport_default_dialer_wasm.go
+++ b/sdk/data/azcosmos/transport_default_dialer_wasm.go
@@ -1,0 +1,15 @@
+//go:build (js && wasm) || wasip1
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"net"
+)
+
+func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return nil
+}

--- a/sdk/data/azcosmos/transport_default_http_client.go
+++ b/sdk/data/azcosmos/transport_default_http_client.go
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+// defaultCosmosHTTPClient is the default HTTP client used by the Cosmos
+// SDK when the caller does not supply one via ClientOptions.Transport.
+//
+// It mirrors the default transport configured by sdk/azcore/runtime, but
+// uses more aggressive HTTP/2 PING-based health checks tuned for Cosmos
+// workloads. See https://github.com/golang/go/issues/59690 for the
+// underlying Go issue this works around.
+var defaultCosmosHTTPClient *http.Client
+
+func init() {
+	defaultCosmosHTTPClient, _ = newDefaultCosmosHTTPClient()
+}
+
+// newDefaultCosmosHTTPClient builds the Cosmos default *http.Client and
+// returns the configured *http2.Transport so callers (in particular tests)
+// can verify the HTTP/2 PING parameters.
+//
+// The returned *http2.Transport is nil when http2.ConfigureTransports
+// failed; the *http.Client is always usable in that case (HTTP/1.1).
+func newDefaultCosmosHTTPClient() (*http.Client, *http2.Transport) {
+	defaultTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: defaultTransportDialContext(&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}),
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: &tls.Config{
+			MinVersion:    tls.VersionTLS12,
+			Renegotiation: tls.RenegotiateFreelyAsClient,
+		},
+	}
+	// TODO: evaluate removing this once https://github.com/golang/go/issues/59690 has been fixed.
+	http2Transport, err := http2.ConfigureTransports(defaultTransport)
+	if err == nil {
+		// ReadIdleTimeout triggers an HTTP/2 PING frame if no data is received
+		// from the server within this duration. A value of 1s aggressively
+		// detects broken connections before they are reused.
+		http2Transport.ReadIdleTimeout = 1 * time.Second
+		// PingTimeout is how long to wait for a PING response before the
+		// connection is considered dead and closed.
+		http2Transport.PingTimeout = 2 * time.Second
+	} else {
+		http2Transport = nil
+	}
+	return &http.Client{Transport: defaultTransport}, http2Transport
+}

--- a/sdk/data/azcosmos/transport_default_http_client.go
+++ b/sdk/data/azcosmos/transport_default_http_client.go
@@ -21,8 +21,14 @@ import (
 // underlying Go issue this works around.
 var defaultCosmosHTTPClient *http.Client
 
+// defaultCosmosHTTP2Transport is the *http2.Transport captured at init()
+// time so tests can assert the production singleton (not just a freshly
+// built one) actually carries the configured PING values. It is nil when
+// http2.ConfigureTransports failed during init().
+var defaultCosmosHTTP2Transport *http2.Transport
+
 func init() {
-	defaultCosmosHTTPClient, _ = newDefaultCosmosHTTPClient()
+	defaultCosmosHTTPClient, defaultCosmosHTTP2Transport = newDefaultCosmosHTTPClient()
 }
 
 // newDefaultCosmosHTTPClient builds the Cosmos default *http.Client and

--- a/sdk/data/azcosmos/transport_default_http_client_test.go
+++ b/sdk/data/azcosmos/transport_default_http_client_test.go
@@ -6,6 +6,7 @@ package azcosmos
 import (
 	"crypto/tls"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +34,19 @@ func TestNewDefaultCosmosHTTPClient_HTTP2PingValues(t *testing.T) {
 
 	require.Equal(t, 1*time.Second, h2.ReadIdleTimeout, "Cosmos default ReadIdleTimeout must be 1s")
 	require.Equal(t, 2*time.Second, h2.PingTimeout, "Cosmos default PingTimeout must be 2s")
+}
+
+// TestSingleton_HasHTTP2PingsConfigured asserts the *http2.Transport captured
+// during init() — i.e. the transport that production traffic actually flows
+// through — has the expected PING values. The TestNewDefaultCosmosHTTPClient_*
+// tests above exercise a freshly built transport; this one closes the gap by
+// pinning the singleton itself, so a future drift between the helper and
+// init() (or a silent http2.ConfigureTransports failure on a new Go release)
+// surfaces here instead of in production.
+func TestSingleton_HasHTTP2PingsConfigured(t *testing.T) {
+	require.NotNil(t, defaultCosmosHTTP2Transport, "init() must capture the *http2.Transport")
+	require.Equal(t, 1*time.Second, defaultCosmosHTTP2Transport.ReadIdleTimeout, "singleton ReadIdleTimeout must be 1s")
+	require.Equal(t, 2*time.Second, defaultCosmosHTTP2Transport.PingTimeout, "singleton PingTimeout must be 2s")
 }
 
 func TestNewDefaultCosmosHTTPClient_TransportTuning(t *testing.T) {
@@ -112,4 +126,24 @@ func TestNewInternalPipeline_PreservesCustomerTransport(t *testing.T) {
 	_ = newInternalPipeline(fakePolicy{}, opts)
 
 	require.Same(t, custom, opts.Transport, "customer-supplied Transport must be preserved through newInternalPipeline")
+}
+
+// TestNewClient_ConcurrentSafe_SharedOptions exercises the property the PR
+// description sells: a single *ClientOptions reused across many concurrent
+// newClient calls is never mutated. Run under `go test -race` this also
+// catches any future regression that swaps the shallow-copy helper back to
+// in-place mutation.
+func TestNewClient_ConcurrentSafe_SharedOptions(t *testing.T) {
+	opts := &ClientOptions{} // no Transport set; helper must install the singleton without mutating opts
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			gem := &globalEndpointManager{preferredLocations: []string{}}
+			_, _ = newClient(fakePolicy{}, gem, opts)
+		}()
+	}
+	wg.Wait()
+	require.Nil(t, opts.Transport, "shared ClientOptions must not be mutated by concurrent newClient calls")
 }

--- a/sdk/data/azcosmos/transport_default_http_client_test.go
+++ b/sdk/data/azcosmos/transport_default_http_client_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePolicy is a no-op policy used to satisfy newClient/newInternalPipeline
+// signatures in tests that never dispatch a request through the pipeline.
+type fakePolicy struct{}
+
+func (fakePolicy) Do(req *policy.Request) (*http.Response, error) {
+	return req.Next()
+}
+
+func TestDefaultCosmosHTTPClient_IsConfigured(t *testing.T) {
+	require.NotNil(t, defaultCosmosHTTPClient, "package default HTTP client must be initialized")
+	require.IsType(t, &http.Transport{}, defaultCosmosHTTPClient.Transport, "default HTTP client transport must be *http.Transport")
+}
+
+func TestNewDefaultCosmosHTTPClient_HTTP2PingValues(t *testing.T) {
+	client, h2 := newDefaultCosmosHTTPClient()
+	require.NotNil(t, client)
+	require.NotNil(t, h2, "expected http2.ConfigureTransports to succeed on a freshly built transport")
+
+	require.Equal(t, 1*time.Second, h2.ReadIdleTimeout, "Cosmos default ReadIdleTimeout must be 1s")
+	require.Equal(t, 2*time.Second, h2.PingTimeout, "Cosmos default PingTimeout must be 2s")
+}
+
+func TestNewDefaultCosmosHTTPClient_TransportTuning(t *testing.T) {
+	client, _ := newDefaultCosmosHTTPClient()
+	tr, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "default client transport must be *http.Transport")
+
+	require.True(t, tr.ForceAttemptHTTP2, "ForceAttemptHTTP2 must be enabled so HTTP/2 ping settings take effect")
+	require.NotNil(t, tr.TLSClientConfig, "TLSClientConfig must be set")
+	require.Equal(t, uint16(tls.VersionTLS12), tr.TLSClientConfig.MinVersion, "MinVersion must be TLS 1.2")
+}
+
+func TestOptionsWithDefaultTransport_NilOptions_UsesDefault(t *testing.T) {
+	out := optionsWithDefaultTransport(nil)
+	require.Same(t, defaultCosmosHTTPClient, out.Transport, "nil options must yield the package default Transport")
+}
+
+func TestOptionsWithDefaultTransport_NilTransport_UsesDefault(t *testing.T) {
+	in := &ClientOptions{}
+	out := optionsWithDefaultTransport(in)
+	require.Same(t, defaultCosmosHTTPClient, out.Transport, "nil Transport must be replaced by the package default")
+	require.Nil(t, in.Transport, "caller-supplied options must not be mutated")
+}
+
+func TestOptionsWithDefaultTransport_PreservesCustomerTransport(t *testing.T) {
+	custom := &http.Client{Transport: http.DefaultTransport}
+	in := &ClientOptions{}
+	in.Transport = custom
+
+	out := optionsWithDefaultTransport(in)
+
+	require.Same(t, custom, out.Transport, "customer-supplied Transport must be preserved")
+	require.Same(t, custom, in.Transport, "caller-supplied options must not be mutated")
+}
+
+func TestNewClient_NilOptions_BuildsClient(t *testing.T) {
+	gem := &globalEndpointManager{preferredLocations: []string{}}
+
+	internal, err := newClient(fakePolicy{}, gem, nil)
+	require.NoError(t, err)
+	require.NotNil(t, internal)
+}
+
+func TestNewClient_NilTransportInOptions_DoesNotMutateCallerOptions(t *testing.T) {
+	gem := &globalEndpointManager{preferredLocations: []string{}}
+	opts := &ClientOptions{}
+
+	internal, err := newClient(fakePolicy{}, gem, opts)
+	require.NoError(t, err)
+	require.NotNil(t, internal)
+	require.Nil(t, opts.Transport, "newClient must not mutate the caller's ClientOptions when injecting the default Transport")
+}
+
+func TestNewClient_PreservesCustomerTransport(t *testing.T) {
+	gem := &globalEndpointManager{preferredLocations: []string{}}
+	custom := &http.Client{Transport: http.DefaultTransport}
+	opts := &ClientOptions{}
+	opts.Transport = custom
+
+	internal, err := newClient(fakePolicy{}, gem, opts)
+	require.NoError(t, err)
+	require.NotNil(t, internal)
+	require.Same(t, custom, opts.Transport, "customer-supplied Transport must be preserved through newClient")
+}
+
+func TestNewInternalPipeline_NilTransportInOptions_DoesNotMutateCallerOptions(t *testing.T) {
+	opts := &ClientOptions{}
+	_ = newInternalPipeline(fakePolicy{}, opts)
+	require.Nil(t, opts.Transport, "newInternalPipeline must not mutate the caller's ClientOptions when injecting the default Transport")
+}
+
+func TestNewInternalPipeline_PreservesCustomerTransport(t *testing.T) {
+	custom := &http.Client{Transport: http.DefaultTransport}
+	opts := &ClientOptions{}
+	opts.Transport = custom
+
+	_ = newInternalPipeline(fakePolicy{}, opts)
+
+	require.Same(t, custom, opts.Transport, "customer-supplied Transport must be preserved through newInternalPipeline")
+}


### PR DESCRIPTION
## Purpose

Make HTTP/2 PING-based connection health checks the **default** for the Cosmos client.

When the customer does not supply their own `Transport` via `ClientOptions`, `azcosmos` now installs an `*http.Client` whose underlying `*http2.Transport` is configured with:

```go
http2Transport.ReadIdleTimeout = 1 * time.Second
http2Transport.PingTimeout     = 2 * time.Second
```

`ReadIdleTimeout` triggers an HTTP/2 PING frame whenever no data has been received from the server for the configured duration. If no PING ACK comes back within `PingTimeout`, the connection is considered dead and closed, so the next request re-dials instead of hanging on a silently broken socket.

## Motivation

Long-lived idle HTTP/2 connections to Cosmos can be silently terminated by intermediaries (load balancers, NATs, firewalls, regional failover) without sending a TCP RST or HTTP/2 GOAWAY. When the client reuses such a connection for the next request the read can stall up to the full 30s connect timeout — see [golang/go#59690](https://github.com/golang/go/issues/59690).

`net/http2` ships PING-based liveness probes for exactly this case, but the default `ReadIdleTimeout` is `0` (disabled). Cosmos workloads are highly latency-sensitive and benefit from aggressive detection, so we set 1s/2s out of the box.

The shared `azcore` default (10s/5s) is intentionally **left unchanged** — this is a Cosmos-specific opinion layered on top.

## Scope

| Layer | Before | After |
| --- | --- | --- |
| `sdk/azcore/runtime/transport_default_http_client.go` | `ReadIdleTimeout=10s`, `PingTimeout=5s` | unchanged |
| `sdk/data/azcosmos` (new) | (uses azcore's default) | `ReadIdleTimeout=1s`, `PingTimeout=2s` |
| Customer-supplied `ClientOptions.Transport` | honored | honored (unchanged) |

## Implementation notes

- New `transport_default_http_client.go` defines a package-level `defaultCosmosHTTPClient` initialized once at process start. It mirrors the rest of azcore's transport tuning (proxy from environment, 30s dial timeout & keep-alive, `MaxIdleConnsPerHost=10`, `IdleConnTimeout=90s`, TLS 1.2+ with `RenegotiateFreelyAsClient`, `ForceAttemptHTTP2=true`) so behavior diverges from azcore in exactly one place: the two PING values.
- Inside `cosmos_client.go`, the new helper `optionsWithDefaultTransport` **shallow-copies** the caller's `*ClientOptions` and substitutes our default `*http.Client` only when `Transport` is nil. The customer's struct is never mutated, which avoids:
  - racy mutation if the same options struct is reused across multiple `NewClient*` calls,
  - leaking the singleton transport back into the customer's struct (which would otherwise let them call `CloseIdleConnections` on every other Cosmos client in the process).
- Both unexported funnels — `newClient` (used by `NewClient`, `NewClientWithKey`, `NewClientFromConnectionString`) and `newInternalPipeline` (used by GEM construction) — go through the same helper so the behavior is consistent on every code path.

### Why two `transport_default_dialer_*.go` files?

`*http.Transport.DialContext` requires a real `net.Dialer` on platforms with TCP. On WebAssembly targets (`js/wasm`, `wasip1/wasm`) raw sockets aren't available, so we leave `DialContext` as `nil` and let the runtime use its host-provided HTTP stack (browser `fetch`, WASI sockets, etc). This is the same build-tag split azcore uses for its own default transport.

## Trade-offs / risks

The 1s/2s settings are aggressive. Reviewers should consider:

- **Long-poll change feed** and large query continuations can naturally idle longer than 1s; expect more PING traffic on those connections. PINGs are cheap (`HTTP/2 frame, ~9 bytes`), so the bandwidth cost is negligible, but if the server is briefly back-pressured (>2s without acking the PING) we will close and re-dial, which can amplify the load.
- **PINGs only prove the peer's TCP/TLS stack is alive**, not that the backend service can serve a request. If the backend is slow but the frontend ACKs PINGs we won't detect the slowness via this mechanism (existing client retries / per-call timeouts still cover that).
- **Regional failover** during a 1–2s control-plane blip could close a wave of healthy connections and force re-dials. The retry policy will make calls succeed, but added connection setup latency may be visible to customers.

If the values turn out to be too aggressive in canary, easy follow-up to bump them — the values live in a single file.

## Testing

11 new unit tests in `transport_default_http_client_test.go`:

- The package singleton initializes successfully and is non-nil.
- `*http2.Transport` carries `ReadIdleTimeout=1s` and `PingTimeout=2s`.
- The shared `*http.Transport` retains the standard tuning (`MaxIdleConnsPerHost=10`, `IdleConnTimeout=90s`, `ForceAttemptHTTP2=true`, TLS 1.2 minimum, `RenegotiateFreelyAsClient`).
- `optionsWithDefaultTransport` handles `nil`, `&ClientOptions{}` (installs default and does not mutate caller), and an options struct with a customer-supplied `Transport` (preserved, not mutated).
- `newClient` and `newInternalPipeline` both install the default when `Transport` is nil and both preserve a customer-supplied `Transport`. Both code paths verify the caller's `*ClientOptions` is not mutated.

### Validation
- `gofmt -s -d ./sdk/data/azcosmos` — clean
- `go vet ./...` — clean
- `go build ./...` on `linux/amd64`, `js/wasm`, and `wasip1/wasm` — all pass
- `go test -short -count=1 ./sdk/data/azcosmos/...` — all green, 24s

## Checklist
- [x] The purpose of this PR is explained above.
- [x] The PR does not update generated files.
- [x] Tests are included for code changes.
- [x] Updates to module `CHANGELOG.md` are included.
- [x] MIT license headers are included in each new file.
